### PR TITLE
Fix element deletion trigger for /FAIL/RTCL

### DIFF
--- a/engine/source/materials/fail/rtcl/fail_rtcl_c.F
+++ b/engine/source/materials/fail/rtcl/fail_rtcl_c.F
@@ -31,8 +31,7 @@ Chd|====================================================================
      1     NEL      ,NUPARAM  ,NUVAR    ,TIME     ,TIMESTEP ,UPARAM   ,
      2     SIGNXX   ,SIGNYY   ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,NPTOT    ,
      3     NGL      ,DPLA     ,UVAR     ,OFF      ,DFMAX    ,TDELE    ,
-     4     AREA     ,FOFF     ,IGTYP    ,OFFL     ,NOFF     ,IPT      ,
-     5     THK0     )
+     4     AREA     ,FOFF     ,IGTYP    ,OFFL     ,IPT      ,THK0     )
 C!-----------------------------------------------
 C!   I m p l i c i t   T y p e s
 C!-----------------------------------------------
@@ -45,7 +44,7 @@ C!---------+---------+---+---+-------------------
 #include "param_c.inc"
 #include "impl1_c.inc"
 C!-----------------------------------------------
-      INTEGER NEL, NUPARAM, NUVAR,NGL(NEL),IGTYP,NOFF(NEL),IPT,
+      INTEGER NEL, NUPARAM, NUVAR,NGL(NEL),IGTYP,IPT,
      .        NPTOT
       my_real TIME,TIMESTEP,UPARAM(*),
      .   SIGNXX(NEL),SIGNYY(NEL),OFFL(NEL),
@@ -55,9 +54,9 @@ C!-----------------------------------------------
 C!-----------------------------------------------
 C!   L o c a l   V a r i a b l e s
 C!-----------------------------------------------
-      INTEGER I,J,INDX(NEL),NINDX,CONDITION1(NEL),CONDITION2(NEL),INST
+      INTEGER I,J,INDX(NEL),NINDX,CONDITION(NEL),INST
       my_real 
-     .        NHARD,EPSCAL,P,triaxs,vmises,hydros,EPS_CR,F_RTCL,PTHK
+     .        NHARD,EPSCAL,P,triaxs,vmises,hydros,EPS_CR,F_RTCL
 C!--------------------------------------------------------------
       !=======================================================================
       ! - INITIALISATION OF COMPUTATION ON TIME STEP
@@ -66,7 +65,6 @@ C!--------------------------------------------------------------
       EPSCAL = UPARAM(1)
       INST   = NINT(UPARAM(2))
       NHARD  = UPARAM(3)
-      PTHK   = UPARAM(4)
 c
       ! Store initial element size
       IF (UVAR(1,1) == ZERO) THEN 
@@ -75,17 +73,6 @@ c
           UVAR(I,2) = THK0(I)
         ENDDO
       ENDIF
-
-      ! Checking element failure and recovering user variable
-      DO I = 1,NEL
-        IF (DFMAX(I) >= UN .AND. PTHK > ZERO .AND. OFF(I) == UN) THEN
-          SIGNXX(I) = ZERO
-          SIGNYY(I) = ZERO
-          SIGNXY(I) = ZERO
-          SIGNYZ(I) = ZERO
-          SIGNZX(I) = ZERO           
-        ENDIF
-      ENDDO
 C
       ! Initialization of variable
       NINDX = 0  
@@ -128,21 +115,11 @@ c
 c
           ! Checking element failure using global damage
           IF (OFFL(I) == UN .AND. DFMAX(I) >= UN) THEN
-            OFFL(I) = ZERO
-            NOFF(I) = NOFF(I) + 1
-            IF (PTHK < ZERO) FOFF(I) = 0
-            IF (IGTYP == 10 .OR. IGTYP == 11 .OR. IGTYP == 51 .OR. IGTYP == 52) FOFF(I) = 0
-            NINDX = NINDX + 1
-            INDX(NINDX) = I  
-            CONDITION1(NINDX) = IPT
-            IF (IGTYP /= 51 .AND. IGTYP /= 52) THEN
-              IF (NOFF(I) >= (ABS(PTHK)*REAL(NPTOT)) .AND. PTHK > ZERO) THEN
-                TDELE(I) = TIME
-                OFF(I)   = ZERO
-                IDEL7NOK = 1
-                CONDITION2(NINDX) = 1
-              ENDIF
-            ENDIF
+            OFFL(I)          = ZERO
+            FOFF(I)          = 0
+            NINDX            = NINDX + 1
+            INDX(NINDX)      = I  
+            CONDITION(NINDX) = IPT
           ENDIF
         ENDIF 
       ENDDO
@@ -152,21 +129,14 @@ c------------------------
         DO J=1,NINDX             
           I = INDX(J)         
 #include "lockon.inc"
-         IF(CONDITION1(J) >= 1)  THEN         
-           WRITE(IOUT, 2000) NGL(I),CONDITION1(J),TIME
-           WRITE(ISTDO,2000) NGL(I),CONDITION1(J),TIME
-         ENDIF      
-         IF(CONDITION2(J)==1) THEN
-           WRITE(ISTDO,2200) NGL(I),TIME
-           WRITE(IOUT, 2200) NGL(I),TIME
-         ENDIF          
+          IF(CONDITION(J) >= 1)  THEN         
+            WRITE(IOUT, 2000) NGL(I),CONDITION(J),TIME
+            WRITE(ISTDO,2000) NGL(I),CONDITION(J),TIME
+          ENDIF
 #include "lockoff.inc" 
         END DO                   
       END IF   ! NINDX         
 c------------------------
  2000 FORMAT(1X,'FOR SHELL ELEMENT (RTCL)',I10,1X,'LAYER',I3,':',/,
      .       1X,'STRESS TENSOR SET TO ZERO',1X,'AT TIME :',1PE12.4)
-
- 2200 FORMAT(1X,' *** RUPTURE OF SHELL ELEMENT (RTCL)',I10,1X,
-     . ' AT TIME :',1PE12.4)
       END

--- a/engine/source/materials/mat_share/mulawc.F
+++ b/engine/source/materials/mat_share/mulawc.F
@@ -2125,8 +2125,7 @@ c
      1            JLT      ,NUPAR    ,NVARF    ,TT       ,DT1C     ,UPARAMF  ,
      2            SIGNXX   ,SIGNYY   ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,MPT      ,
      3            NGL      ,DPLA     ,UVARF    ,OFF      ,DFMAX    ,TDEL     ,
-     4            AREA     ,FOFF     ,IGTYP    ,OFFL     ,GBUF%NOFF,IPT      ,
-     5            THK0     )
+     4            AREA     ,FOFF     ,IGTYP    ,OFFL     ,IPT      ,THK0     )
 
 c-------------
               END SELECT

--- a/hm_cfg_files/config/CFG/radioss2022/FAIL/fail_rtcl.cfg
+++ b/hm_cfg_files/config/CFG/radioss2022/FAIL/fail_rtcl.cfg
@@ -1,5 +1,5 @@
 //
-// Failure model, GENE1 Setup File
+// Failure model, RTCL Setup File
 // 
 
 ATTRIBUTES(COMMON){ 
@@ -11,7 +11,6 @@ ATTRIBUTES(COMMON){
         MAT_EPSCAL                      = VALUE(FLOAT,"Simple tension failure strain calibrated at the reference element size");
         Inst   		                = VALUE(INT,  "Flags for taking into account mesh sensitivity effect on necking for shells") ;
         MAT_N                           = VALUE(FLOAT,"Hardening exponent");
-	Pthk   		                = VALUE(FLOAT,"Element suppression criterion (for shells only) :% of thickness in normal direction to delete the element");
         //	
 	ID_CARD_EXIST	 		= VALUE(BOOL, "Give an Id");
 }
@@ -26,13 +25,12 @@ mandatory:
     SCALAR(MAT_EPSCAL)                { DIMENSION="DIMENSIONLESS";    } 
     SCALAR(Inst)                      { DIMENSION="DIMENSIONLESS";    }
     SCALAR(MAT_N)                     { DIMENSION="DIMENSIONLESS";    }        
-    SCALAR(Pthk)                      { DIMENSION="DIMENSIONLESS";    }  
 }
 
 FORMAT(radioss2022) {
 	HEADER("/FAIL/RTCL/%d",mat_id);
-	COMMENT("#             EPScal      Inst                   N                Pthk");
-	CARD("%20lg%10d%20lg%20lg",MAT_EPSCAL,Inst,MAT_N,Pthk);
+	COMMENT("#             EPScal      Inst                   N");
+	CARD("%20lg%10d%20lg",MAT_EPSCAL,Inst,MAT_N);
 	if (ID_CARD_EXIST==TRUE)
 	{
 	 COMMENT("#  FAIL_ID") ;

--- a/starter/source/materials/fail/rtcl/hm_read_fail_rtcl.F
+++ b/starter/source/materials/fail/rtcl/hm_read_fail_rtcl.F
@@ -70,7 +70,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER Inst
       my_real 
-     .        N,EPSCAL,Pthk
+     .        N,EPSCAL
       LOGICAL :: IS_AVAILABLE,IS_CRYPTED
 C=======================================================================
       IS_CRYPTED   = .FALSE.
@@ -85,7 +85,6 @@ C===============================================================================
       CALL HM_GET_FLOATV ('MAT_EPSCAL' ,EPSCAL    ,IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_INTV   ('Inst'       ,Inst      ,IS_AVAILABLE,LSUBMODEL)
       CALL HM_GET_FLOATV ('MAT_N'      ,N         ,IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_FLOATV ('Pthk'       ,Pthk      ,IS_AVAILABLE,LSUBMODEL,UNITAB)
 C======================================================================================
 C DEFAULT VALUES
 C======================================================================================
@@ -93,20 +92,16 @@ C===============================================================================
       IF (EPSCAL == ZERO) EPSCAL = 0.3D0
       ! Flag for mesh sensitivity in shells
       IF (Inst == 0) Inst = 2
-      ! Default percentage
-      IF (Pthk == ZERO) Pthk = UN
-      Pthk = MAX(MIN(Pthk,UN),ZERO)
 C======================================================================================
 c     Filling buffer tables
 C======================================================================================
       ! -> Number of parameters
-      NUPARAM    = 4
+      NUPARAM    = 3
       ! -> Number of user variables
       NUVAR      = 2   
       UPARAM(1)  = EPSCAL
       UPARAM(2)  = Inst
       UPARAM(3)  = N
-      UPARAM(4)  = Pthk
 C======================================================================================
 c--------------------------
 c     Printout data
@@ -115,7 +110,7 @@ c--------------------------
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
         WRITE(IOUT,1000)
-        WRITE(IOUT,1100) EPSCAL,Inst,N,Pthk
+        WRITE(IOUT,1100) EPSCAL,Inst,N
         WRITE(IOUT,1200)
       ENDIF
 c-----------------------------------------------------
@@ -130,8 +125,7 @@ c-----------------------------------------------------
      & 5X,'FLAG FOR REGULARIZATION OF MESH SENSITIVITY. . . . .=',I10,/,
      & 5X,'     = 1 : MESH REGULARIZATION NOT ACTIVATED         ',/,
      & 5X,'     = 2 : MESH REGULARIZATION ACTIVATED             ',/, 
-     & 5X,'HARDENING EXPONENT FOR REGULARIZATION. . . . . . . .=',1PG20.13,/,
-     & 5X,'RATIO OF DAMAGED INTEGRATION POINTS. . . . . . . . .=',1PG20.13,/)
+     & 5X,'HARDENING EXPONENT FOR REGULARIZATION. . . . . . . .=',1PG20.13,/)
  1200 FORMAT(
      & 5X,' ----------------------------------------------------',//)
 c----------- 


### PR DESCRIPTION
Element deletion for /FAIL/RTCL was badly triggered. This modification leads to a code and a unified way of element deletion with the other failure criteria.
