### PR TITLE
section issue in engine ( spmd only) : bad initialisation that leads to potential overflow in case 2.rad & SC02 file used 

### DIFF
--- a/engine/source/tools/sect/sectio.F
+++ b/engine/source/tools/sect/sectio.F
@@ -4024,7 +4024,7 @@ C-----------------------------------------------
         ENDDO
       ENDIF
 C-----------------------------------------------
-C READ FILE dans l'ordre des sections lues sur le fichier
+C READ FILE dans l ordre des sections lues sur le fichier
 C  T = TT + DT2
 C-----------------------------------------------
        IF(NSPMD.EQ.1) THEN
@@ -4950,6 +4950,7 @@ C
         IF(ISPMD.EQ.0) THEN
           CALL CUR_FIL_C(4)
         END IF
+        L = 0
         DO WHILE(TT2.LE.TTT)
           IFRL1=IFRL2
           IFRL2=MOD(IFRL1+1,2)
@@ -5029,13 +5030,13 @@ C
             NSTRF(5) = IR2
 C
             CALL READ_R_C(R4,1)
+            IF(R4 .NE. ZERO) L = 0
             TT1=TT2
             TT2=R4
           ENDIF          
 C-----------------------------------------------
           CALL READ_I_C(LL,1)
           CALL READ_I_C(NSECR,1)
-          L = 0
           DO NR=1,NSECR
             CALL READ_I_C(ID_SEC,1)
             K0  = NSTRF(25)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->
section issue in engine: bad initialisation of temp array for spmd computation

<!--- Describe the problem, ideally from the user viewpoint -->
corrected bug leads to potential overflow when using 2.rad file & SC02 file

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
initialisation of targeted temporary array at t=0 if first run of at t = tstart for other runs

<!--- If there is a design, link to it here ->

<!- Here is what the maintainer will check:>
<!- *  The PR contains only one commit (please squash your commits), unless the developer explicitely states the need for multiple commits>
<!- *  The linear history is preserved (no merge commits)>
<!- *  The changes satisfy the DOS and DONTS of the README.md file>
<!- *  The copyright header is added to new source files>
