### PR TITLE
Fix element deletion output issue for BIQUAD, ORTHBIQUAD and GENE1

### DIFF
--- a/engine/source/materials/fail/biquad/fail_biquad_c.F
+++ b/engine/source/materials/fail/biquad/fail_biquad_c.F
@@ -32,9 +32,10 @@ Chd|====================================================================
      1           NEL      ,NUVAR    ,
      2           TIME     ,UPARAM   ,NGL      ,IPT      ,NPTOT    ,
      3           SIGNXX   ,SIGNYY   ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,
-     4           DPLA     ,EPSP     ,UVAR     ,NOFF     ,UEL1     ,
+     4           DPLA     ,EPSP     ,UVAR     ,PTHKF    ,UEL1     ,
      5           OFF      ,OFFL     ,DFMAX    ,TDEL     ,NFUNC    ,
-     6           IFUNC    ,NPF      ,TF       ,ALDT     ,FOFF     ,IGTYP )
+     6           IFUNC    ,NPF      ,TF       ,ALDT     ,FOFF     ,
+     7           IPG      )
 C-----------------------------------------------
 C    Biquadratic failure model
 C-----------------------------------------------
@@ -84,10 +85,10 @@ C IGTYP                       PROPERTY TYPE
 C-----------------------------------------------
 C   I N P U T   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER NEL,NUVAR,IPT,NPTOT,NFUNC,IGTYP
-      INTEGER NGL(NEL),NOFF(NEL),IFUNC(NFUNC)
+      INTEGER NEL,NUVAR,IPT,NPTOT,NFUNC,IPG
+      INTEGER NGL(NEL),IFUNC(NFUNC)
       my_real TIME,UPARAM(*),DPLA(NEL),EPSP(NEL),
-     .   UEL1(NEL),ALDT(NEL)
+     .   UEL1(NEL),ALDT(NEL),PTHKF
 C-----------------------------------------------
 C   I N P U T   O U T P U T   A r g u m e n t s 
 C-----------------------------------------------
@@ -113,12 +114,12 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
        my_real hydros, vmises, triaxs,REF_EL_LEN
-       INTEGER I,J,L,NINDX,FLAG_PERTURB,SEL
+       INTEGER I,J,L,NINDX1,NINDX2,FLAG_PERTURB,SEL
        INTEGER FAIL_COUNT,IT
-       INTEGER, DIMENSION(MVSIZ) :: INDX , CONDITION1, CONDITION2,CONDITION3
+       INTEGER, DIMENSION(MVSIZ) :: INDX1,INDX2
 
        my_real  X_1(3) , X_2(3),c3,DYDX
-       my_real  EPS_FAIL, EPS_FAIL2, DAMAGE, d1, INST
+       my_real  EPS_FAIL, EPS_FAIL2, DAMAGE, INST
        my_real  P1X,P1Y,S1X,S1Y,S2Y, A1, A2, B1, B2, C1, C2,FAC,LAMBDA
 C-----------------------------------------------
 c! UVAR1 = damage due to instability (triax between 1/3 and 2/3)
@@ -132,19 +133,17 @@ C-----------------------------------------------
        X_2(1)       = UPARAM(4)
        X_2(2)       = UPARAM(5)
        X_2(3)       = UPARAM(6)
-       d1           = UPARAM(7)
+       PTHKF        = UPARAM(7)
        FLAG_PERTURB = UPARAM(8)
        c3           = UPARAM(9)
        L            = INT(UPARAM(10)+0.0001)
        SEL          = INT(UPARAM(11)+0.0001)
        INST         = UPARAM(12)
        REF_EL_LEN   = UPARAM(13)
-       NINDX        = 0  
+       NINDX1       = 0  
+       NINDX2       = 0
        EPS_FAIL     = ZERO
        EPS_FAIL2    = ZERO
-       CONDITION1(1:MVSIZ)   = 0
-       CONDITION2(1:MVSIZ)   = 0
-       CONDITION3(1:MVSIZ)   = 0
 C
 C!  Initialization
        IF (TIME == ZERO .AND. NFUNC > 0) THEN
@@ -162,17 +161,6 @@ C!  Initialization
           ENDIF
         ENDDO
        ENDIF
-       
-       DO I=1,NEL
-         IF (DFMAX(I) .GE. UN .AND. d1 .GT. ZERO .AND. OFF(I) == UN) THEN
-           SIGNXX(I) = ZERO
-           SIGNYY(I) = ZERO
-           SIGNXY(I) = ZERO
-           SIGNYZ(I) = ZERO
-           SIGNZX(I) = ZERO           
-         ENDIF
-       ENDDO
-      
 C-----------------------------------------------
        IF(FLAG_PERTURB == 0) THEN
          DO I =1,NEL
@@ -256,42 +244,25 @@ C-----------------------------------------------
              DFMAX(I) = MIN(UN,DFMAX(I))
            
            IF (OFFL(I).EQ.1. .AND. DFMAX(I).GE.1.0) THEN
-             OFFL(I) = ZERO
-             NOFF(I) = NOFF(I) + 1
-             IF (d1 < ZERO ) FOFF(I) = 0
-             IF (IGTYP == 10 .or. IGTYP == 11 .or. IGTYP == 51 .or. IGTYP == 52) FOFF(I) = 0
-             NINDX = NINDX + 1
-             INDX(NINDX) = I  
-             CONDITION1(NINDX) = IPT
-             IF (IGTYP /= 51 .and. IGTYP /= 52) THEN
-               IF (NOFF(I) .GE. (ABS(d1)*REAL(NPTOT)) .AND. d1 .GT. ZERO) THEN
-                 TDEL(I)= TIME
-                 OFF(I) = ZERO
-                 IDEL7NOK = 1
-                 CONDITION2(NINDX) = 1
-               ENDIF
-             ENDIF
+             FOFF(I)       = 0
+             NINDX1        = NINDX1 + 1
+             INDX1(NINDX1) = I  
            ENDIF
            
-           IF (DAMAGE .GT. UN .AND. UVAR(I,2) .EQ. ZERO .AND. OFFL(I) .EQ. UN) THEN
-             UVAR(I,2) = UN   
-             FOFF(I) = 0
-             UEL1(I) = UEL1(I) + UN
+           IF (DAMAGE .GE. UN .AND. UVAR(I,2) .EQ. ZERO .AND. OFFL(I) .EQ. UN) THEN
+             UVAR(I,2) = UN  
+             UEL1(I)   = UEL1(I) + UN
              IF (INT(UEL1(I)) == NPTOT) THEN
-               SIGNXX(I) = ZERO
-        	   SIGNYY(I) = ZERO
-        	   SIGNXY(I) = ZERO
-        	   SIGNYZ(I) = ZERO
-        	   SIGNZX(I) = ZERO
-               NINDX = NINDX + 1
-               INDX(NINDX) = I  
-               TDEL(I)= TIME
-        	      OFF(I) = 0.0
-               IDEL7NOK = 1
-               CONDITION2(NINDX) = 1
-               CONDITION3(NINDX) = 1
+               NINDX2        = NINDX2 + 1
+               INDX2(NINDX2) = I
+               TDEL(I)       = TIME
+               OFF(I)        = ZERO
+               SIGNXX(I)     = ZERO
+               SIGNYY(I)     = ZERO
+               SIGNXY(I)     = ZERO
+               SIGNYZ(I)     = ZERO
+               SIGNZX(I)     = ZERO
              ENDIF
-
            ENDIF
          ENDIF
          ENDDO
@@ -377,43 +348,25 @@ C-----------------------------------------------
              DFMAX(I) = MIN(UN,DFMAX(I))
              
            IF (OFFL(I).EQ.1. .AND. DFMAX(I).GE.1.0) THEN
-             OFFL(I) = ZERO
-             NOFF(I) = NOFF(I) + 1
-             IF (d1 < ZERO ) FOFF(I) = 0
-             IF (IGTYP == 10 .or. IGTYP == 11 .or. IGTYP == 51 .or. IGTYP == 52) FOFF(I) = 0
-             NINDX = NINDX + 1
-             INDX(NINDX) = I  
-             CONDITION1(NINDX) = IPT
-             IF (IGTYP /= 51 .and. IGTYP /= 52) THEN
-               IF (NOFF(I) .GE. (ABS(d1)*REAL(NPTOT)) .AND. d1 .GT. ZERO) THEN
-                 TDEL(I)= TIME
-                 OFF(I) = ZERO
-                 IDEL7NOK = 1
-                 CONDITION2(NINDX) = 1
-               ENDIF
-             ENDIF
+             FOFF(I)       = 0
+             NINDX1        = NINDX1 + 1
+             INDX1(NINDX1) = I  
            ENDIF
            
            IF (DAMAGE .GT. UN .AND. UVAR(I,2) .EQ. ZERO .AND. OFFL(I) .EQ. UN) THEN
              UVAR(I,2) = UN   
-             FOFF(I) = 0
-             UEL1(I) = UEL1(I) + UN
+             UEL1(I)   = UEL1(I) + UN
              IF (INT(UEL1(I)) == NPTOT) THEN
-               SIGNXX(I) = 0.
-        	   SIGNYY(I) = 0.
-        	   SIGNXY(I) = 0.
-        	   SIGNYZ(I) = 0.
-        	   SIGNZX(I) = 0.
-               NINDX = NINDX + 1
-               INDX(NINDX) = I  
-               TDEL(I)= TIME
-        	      OFF(I) = 0.0
-               IDEL7NOK = 1
-               FOFF(I) = 0
-               CONDITION2(NINDX) = 1
-               CONDITION3(NINDX) = 1
+               NINDX2        = NINDX2 + 1
+               INDX2(NINDX2) = I
+               TDEL(I)       = TIME
+               OFF(I)        = ZERO
+               SIGNXX(I)     = ZERO
+               SIGNYY(I)     = ZERO
+               SIGNXY(I)     = ZERO
+               SIGNYZ(I)     = ZERO
+               SIGNZX(I)     = ZERO
              ENDIF
-
            ENDIF
          ENDIF
          ENDDO
@@ -424,30 +377,31 @@ c------------------------
 c------------------------
 c------------------------
 c------------------------
-      IF (NINDX > 0) THEN        
-        DO J=1,NINDX             
-          I = INDX(J)         
+      IF (NINDX1 > 0) THEN        
+        DO J=1,NINDX1             
+          I = INDX1(J)         
 #include "lockon.inc"
-         IF(CONDITION1(J) >= 1)  THEN         
-           WRITE(IOUT, 2000) NGL(I),CONDITION1(J),TIME
-           WRITE(ISTDO,2000) NGL(I),CONDITION1(J),TIME
-         ENDIF
-         IF(CONDITION3(J)==1) THEN
-           WRITE(ISTDO,3000) NGL(I)
-           WRITE(IOUT, 3000) NGL(I)
-         ENDIF          
-         IF(CONDITION2(J)==1) THEN
-           WRITE(ISTDO,2200) NGL(I), TIME
-           WRITE(IOUT, 2200) NGL(I), TIME
-         ENDIF          
+          WRITE(IOUT, 2000) NGL(I),IPG,IPT,TIME
+          WRITE(ISTDO,2000) NGL(I),IPG,IPT,TIME
+#include "lockoff.inc" 
+        ENDDO
+      ENDIF
+      IF (NINDX2 > 0) THEN        
+        DO J=1,NINDX2            
+          I = INDX2(J)         
+#include "lockon.inc"
+          WRITE(IOUT, 3000) NGL(I)
+          WRITE(IOUT, 2200) NGL(I), TIME
+          WRITE(ISTDO,3000) NGL(I)
+          WRITE(ISTDO,2200) NGL(I), TIME                 
 #include "lockoff.inc" 
         END DO                   
       END IF   ! NINDX             
 c------------------------
 C---------Damage for output  0 < DFMAX < 1 --------------------
- 2000 FORMAT(1X,'FOR SHELL ELEMENT (BIQUAD)',I10,1X,'LAYER',I3,':',/,
+ 2000 FORMAT(1X,'FOR SHELL ELEMENT (BIQUAD)',I10,1X,'GAUSS POINT',I3,
+     .       1X,'LAYER',I3,':',/,
      .       1X,'STRESS TENSOR SET TO ZERO',1X,'AT TIME :',1PE12.4)
-
  2200 FORMAT(1X,' *** RUPTURE OF SHELL ELEMENT (BIQUAD)',I10,1X,
      . ' AT TIME :',1PE12.4)
  3000 FORMAT(1X,'FOR SHELL ELEMENT (BIQUAD)',I10,

--- a/engine/source/materials/fail/gene1/fail_gene1_c.F
+++ b/engine/source/materials/fail/gene1/fail_gene1_c.F
@@ -40,7 +40,7 @@ Chd|====================================================================
      4     EPSXX    ,EPSYY    ,EPSXY    ,EPSYZ    ,EPSZX    ,AREA     ,
      5     SIGNXX   ,SIGNYY   ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,THKN     ,
      6     TEMP     ,DFMAX    ,TDELE    ,ALDT     ,TABLE    ,IRUPT    ,
-     7     THK0     ,ELBUF_TAB,IPT      ,MPT      ,NOFF     ,FOFF     ,
+     7     THK0     ,ELBUF_TAB,IPT      ,MPT      ,PTHKF    ,FOFF     ,
      8     IGTYP    ,THKLYL   ,ILAY1    )
 C-----------------------------------------------
 C   M o d u l e s
@@ -65,7 +65,7 @@ C-----------------------------------------------
 #include      "com01_c.inc"
 C!-----------------------------------------------
       INTEGER NEL, NUPARAM, NUVAR,NGL(NEL),IPG,
-     .        NPG,IRUPT,IPT,MPT,NOFF(NEL),IGTYP,ILAY1
+     .        NPG,IRUPT,IPT,MPT,IGTYP,ILAY1
       my_real TIME,TIMESTEP,UPARAM(*),
      .   EPSXX(NEL),EPSYY(NEL),EPSXY(NEL),
      .   EPSYZ(NEL),EPSZX(NEL),SIGNXX(NEL),
@@ -73,7 +73,7 @@ C!-----------------------------------------------
      .   SIGNZX(NEL),UVAR(NEL,NUVAR),DT(NEL),
      .   EPSP(NEL),OFF(NEL),DFMAX(NEL),TDELE(NEL),
      .   ALDT(NEL),TEMP(NEL),LOFF(NEL),AREA(NEL),
-     .   THKN(NEL),THK0(NEL),THKLYL(NEL)
+     .   THKN(NEL),THK0(NEL),THKLYL(NEL),PTHKF
       TYPE (TTABLE), DIMENSION(NTABLE) :: TABLE
       TYPE (ELBUF_STRUCT_), TARGET :: ELBUF_TAB
       INTEGER, DIMENSION(NEL), INTENT(INOUT) :: FOFF
@@ -93,19 +93,19 @@ C!        NPF,TF  : FUNCTION PARAMETER
 C!-----------------------------------------------
 C!   L o c a l   V a r i a b l e s
 C!-----------------------------------------------
-      INTEGER I,K,J,INDX(MVSIZ),NINDX,IREG,NSTEP,tab_IDfld,Itab,NCS,
+      INTEGER I,K,J,INDX1(MVSIZ),NINDX1,INDX2(MVSIZ),NINDX2,IREG,NSTEP,
      .        ISM,IPS,IG12,IG13,IE1C,IFLD,fct_IDg12,fct_IDg13,fct_IDe1c,
      .        NCRIT,fct_IDel,IPOS(NEL,2),Ismooth,Istrain,IR,IS,IT,ILAY,
-     .        CONDITION1(NEL),CONDITION2(NEL),CONDITION3(NEL),CONDITION4(NEL)
+     .        tab_IDfld,Itab,NCS
       my_real 
      .        MINPRES,MAXPRES,SIGP1,TMAX,DTMIN,EPSDOT_SM,SIGVM,SIGTH,
      .        KF,EPSDOT_PS,MAXEPS,EFFEPS,VOLEPS,MINEPS,EPSSH,EPSDOT_FLD,
-     .        THIN,VOLFRAC,PTHK,MAXTEMP,Fscale_el,El_ref,LAMBDA,FAC,DF
+     .        THIN,VOLFRAC,MAXTEMP,Fscale_el,El_ref,LAMBDA,FAC,DF
       my_real 
      .        E12,P(NEL),SXX,SYY,SZZ,SVM(NEL),SH12,SH13,E1C,XVEC(NEL,2),
      .        Q,R,R_INTER,E11(NEL),E22(NEL),VOL_STRAIN(NEL),DAV,E1D,
      .        E2D,E3D,E4D,S11(NEL),S22(NEL),EFF_STRAIN(NEL),S1,S2,
-     .        EPSMAX,SIGMAX,FACL(NEL),FACS(NEL),FACV(NEL),
+     .        EPSMAX,SIGMAX,FACL(NEL),FACS(NEL),FACV(NEL),VFAIL(NEL),
      .        E1FLD(NEL),DFLD(NEL),HARDR(NEL),VTOT,VDAM,DENOM
       TYPE(BUF_FAIL_) ,POINTER :: FBUF
 C!--------------------------------------------------------------
@@ -134,7 +134,7 @@ C!--------------------------------------------------------------
       NSTEP      = NINT(UPARAM(19))
       THIN       = UPARAM(20)
       VOLFRAC    = UPARAM(21)
-      PTHK       = UPARAM(22)
+      PTHKF      = UPARAM(22)
       NCS        = NINT(UPARAM(23))
       MAXTEMP    = UPARAM(24)
       Fscale_el  = UPARAM(25)
@@ -415,52 +415,33 @@ c
       ! - LOOKING FOR ELEMENT DELETION
       !====================================================================  
       ! Initialization of variable
-      NINDX = 0
-      INDX(1:NEL) = 0
-      CONDITION1(1:NEL) = 0
-      CONDITION2(1:NEL) = 0 
-      CONDITION3(1:NEL) = 0
-      CONDITION4(1:NEL) = 0
+      NINDX1 = 0
+      NINDX2 = 0
+      INDX1(1:NEL) = 0
+      INDX2(1:NEL) = 0
+      VFAIL(1:NEL) = ZERO
       ! Case of under-integrated shells
       IF ((ELBUF_TAB%NPTR == 1).AND.(ELBUF_TAB%NPTS == 1)) THEN       
         DO I = 1,NEL
           ! Checking element failure using global damage
-          IF ((UVAR(I,5) == ZERO).AND.(OFF(I) /= ZERO)) THEN
-            NOFF(I) = NOFF(I) + 1
-            IF (PTHK < ZERO) FOFF(I) = 0
-            IF (IGTYP == 10 .OR. IGTYP == 11 .OR. IGTYP == 51 .OR. IGTYP == 52) FOFF(I) = 0
-            NINDX = NINDX + 1
-            INDX(NINDX) = I  
-            IF (LOFF(I) == UN) THEN
-              CONDITION1(NINDX) = IPT
-              LOFF(I) = ZERO
-            ENDIF
-            DFMAX(I) = UN
-            IF (IGTYP /= 51 .AND. IGTYP /= 52) THEN
-              IF (NOFF(I) >= (ABS(PTHK)*REAL(MPT)) .AND. PTHK > ZERO) THEN
-                TDELE(I)  = TIME
-                OFF(I)    = ZERO
-                IDEL7NOK  = 1
-                CONDITION2(NINDX) = 1
-              ENDIF
-            ENDIF
+          IF ((UVAR(I,5) == ZERO).AND.(FOFF(I) /= 0)) THEN
+            FOFF(I)       = 0
+            NINDX1        = NINDX1 + 1
+            INDX1(NINDX1) = I  
+            DFMAX(I)      = UN
           ENDIF
         ENDDO
       ELSE
         DO I = 1,NEL
           ! Checking element failure using global damage
-          IF ((UVAR(I,5) == ZERO).AND.(OFF(I) /= ZERO)) THEN
-            NINDX = NINDX + 1
-            INDX(NINDX) = I  
-            IF (LOFF(I) == UN) THEN
-              CONDITION3(NINDX) = IPG
-              CONDITION4(NINDX) = IPT
-              LOFF(I) = ZERO
-            ENDIF
-            DFMAX(I) = UN
+          IF ((UVAR(I,5) == ZERO).AND.(LOFF(I) /= ZERO)) THEN
+            NINDX1        = NINDX1 + 1
+            INDX1(NINDX1) = I  
+            IF (LOFF(I) == UN) LOFF(I) = ZERO
+            DFMAX(I)      = UN
           ENDIF
           IF ((IPG == NPG).AND.(IPT == ELBUF_TAB%NPTT)
-     .         .AND.(OFF(I) /= ZERO).AND.(ILAY1 == ELBUF_TAB%NLAY)) THEN      
+     .         .AND.(OFF(I) /= ZERO).AND.(ILAY1 == ELBUF_TAB%NLAY)) THEN  
             ! Initialization of volumes computation
             VTOT = ZERO
             VDAM = ZERO
@@ -471,19 +452,26 @@ c
                   DO IT = 1, ELBUF_TAB%NPTT
                     FBUF => ELBUF_TAB%BUFLY(ILAY)%FAIL(IR,IS,IT)
                     ! Compute total volume of the element
-                    VTOT = VTOT + FBUF%FLOC(IRUPT)%VAR(3+NEL*(I-1))
+                    VTOT = VTOT + FBUF%FLOC(IRUPT)%VAR(2*NEL+I)
                     ! Compute damaged volume of the element
-                    VDAM = VDAM + FBUF%FLOC(IRUPT)%VAR(4+NEL*(I-1))
+                    VDAM = VDAM + FBUF%FLOC(IRUPT)%VAR(3*NEL+I)
                   ENDDO
                 ENDDO
               ENDDO
             ENDDO
             ! Checking volume fraction criterion
             IF (((VDAM/VTOT) >= VOLFRAC)) THEN
-              TDELE(I) = TIME
-              OFF(I)   = ZERO
-              IDEL7NOK = 1
-              CONDITION2(NINDX) = 1
+              TDELE(I)      = TIME
+              OFF(I)        = ZERO
+              IDEL7NOK      = 1
+              NINDX2        = NINDX2 + 1
+              INDX2(NINDX2) = I 
+              VFAIL(I)      = VDAM/VTOT
+              SIGNXX(I)     = ZERO
+              SIGNYY(I)     = ZERO
+              SIGNXY(I)     = ZERO
+              SIGNYZ(I)     = ZERO
+              SIGNZX(I)     = ZERO
             ENDIF
           ENDIF
         ENDDO
@@ -491,31 +479,28 @@ c
 c
 c------------------------
 c------------------------
-      IF (NINDX > 0) THEN
-        DO J = 1,NINDX
-         I = INDX(J)
+      IF (NINDX1 > 0) THEN
+        DO J = 1,NINDX1
+          I = INDX1(J)
 #include "lockon.inc"
-         IF (CONDITION1(J) >= 1)  THEN         
-           WRITE(IOUT, 2000) NGL(I),CONDITION1(J),TIME
-           WRITE(ISTDO,2000) NGL(I),CONDITION1(J),TIME
-         ENDIF  
-         IF (CONDITION3(J) >= 1) THEN
-           WRITE(ISTDO,2100) NGL(I),CONDITION3(J),CONDITION4(J),TIME
-           WRITE(IOUT, 2100) NGL(I),CONDITION3(J),CONDITION4(J),TIME
-         ENDIF      
-         IF (CONDITION2(J) == 1) THEN
-           WRITE(ISTDO,2200) NGL(I), TIME
-           WRITE(IOUT, 2200) NGL(I), TIME
-         ENDIF
+          WRITE(IOUT, 2100) NGL(I),IPG,IPT,TIME
+          WRITE(ISTDO,2100) NGL(I),IPG,IPT,TIME
+#include "lockoff.inc"
+        END DO
+      END IF          
+      IF (NINDX2 > 0) THEN
+        DO J = 1,NINDX2
+          I = INDX2(J)
+#include "lockon.inc"          
+          WRITE(IOUT, 2200) NGL(I),VFAIL(I),TIME
+          WRITE(ISTDO,2200) NGL(I),VFAIL(I),TIME
 #include "lockoff.inc"
         END DO
       END IF         
 c------------------------
- 2000 FORMAT(1X,'FOR SHELL ELEMENT (GENE1)',I10,1X,'LAYER',I3,':',/,
-     .       1X,'STRESS TENSOR SET TO ZERO',1X,'AT TIME :',1PE12.4)
  2100 FORMAT(1X,'FOR SHELL ELEMENT (GENE1)',I10,1X,'GAUSS POINT',I10,1X,
      .       'LAYER',I3,':',/,
      .       1X,'STRESS TENSOR SET TO ZERO',1X,'AT TIME :',1PE12.4)
- 2200 FORMAT(1X,' *** RUPTURE OF SHELL ELEMENT (GENE1)',I10,1X,
-     . ' AT TIME :',1PE12.4)
+ 2200 FORMAT(1X,' *** RUPTURE OF SHELL ELEMENT (GENE1)',I10,
+     .       ' DAMAGED VOLUME FRACTION :',1PE12.4,' AT TIME :',1PE12.4)
       END

--- a/engine/source/materials/fail/gene1/fail_gene1_s.F
+++ b/engine/source/materials/fail/gene1/fail_gene1_s.F
@@ -90,9 +90,10 @@ C!        NPF,TF  : FUNCTION PARAMETER
 C!-----------------------------------------------
 C!   L o c a l   V a r i a b l e s
 C!-----------------------------------------------
-      INTEGER I,K,J,INDX(MVSIZ),NINDX,IREG,NSTEP,tab_IDfld,Itab,NCS,
+      INTEGER I,K,J,INDX(MVSIZ),NINDX,INDX2(MVSIZ),NINDX2,IREG,NSTEP,
      .        ISM,IPS,IG12,IG13,IE1C,IFLD,fct_IDg12,fct_IDg13,fct_IDe1c,
-     .        NCRIT,fct_IDel,IPOS(NEL,2),Ismooth,Istrain,IR,IS,IT,ILAY
+     .        NCRIT,fct_IDel,IPOS(NEL,2),Ismooth,Istrain,IR,IS,IT,ILAY,
+     .        tab_IDfld,Itab,NCS,INDX3(MVSIZ),NINDX3
       my_real 
      .        MINPRES,MAXPRES,SIGP1,TMAX,DTMIN,EPSDOT_SM,SIGVM,SIGTH,
      .        KF,EPSDOT_PS,MAXEPS,EFFEPS,VOLEPS,MINEPS,EPSSH,EPSDOT_FLD,
@@ -102,7 +103,7 @@ C!-----------------------------------------------
      .        Q,R,R_INTER,PHI,E11(NEL),E22(NEL),E33(NEL),VOL_STRAIN(NEL),DAV,E1D,
      .        E2D,E3D,E4D,E5D,E6D,S11(NEL),S22(NEL),S33(NEL),EFF_STRAIN(NEL),PSI,
      .        EPSMAX,SIGMAX,FACL(NEL),FACS(NEL),FACV(NEL),SH12,SH13,E1C,XVEC(NEL,2),
-     .        E1FLD(NEL),DFLD(NEL),HARDR(NEL),VTOT,VDAM,DENOM
+     .        E1FLD(NEL),DFLD(NEL),HARDR(NEL),VTOT,VDAM,DENOM,VFAIL(NEL)
       TYPE(BUF_FAIL_) ,POINTER :: FBUF
 C!--------------------------------------------------------------
       !=======================================================================
@@ -142,6 +143,14 @@ C!--------------------------------------------------------------
       Ismooth    = NINT(UPARAM(31))
       Istrain    = NINT(UPARAM(32))
 c
+      ! Initialization of variable
+      NINDX  = 0 
+      NINDX2 = 0
+      NINDX3 = 0
+      INDX(1:NEL)  = 0
+      INDX2(1:NEL) = 0 
+      INDX3(1:NEL) = 0 
+      VFAIL(1:NEL) = ZERO
       ! Recovering functions
       ! -> equivalent stress VS strain-rate
       ISM  = 0
@@ -195,19 +204,29 @@ c
       ! Checking element failure and recovering user variable
       DO I=1,NEL
        ! Integration point failure
-       IF (LOFF(I) < UN .AND. LOFF(I) >= EM08) THEN 
-         LOFF(I)   = UVAR(I,5)
-         LOFF(I)   = LOFF(I) - UN/NSTEP
-         IF (LOFF(I) <= EM08) LOFF(I) = ZERO
-         UVAR(I,5) = LOFF(I)
+       IF (TIME == ZERO) UVAR(I,5) = UN
+       IF (UVAR(I,5) < UN .AND. UVAR(I,5) > ZERO) THEN 
+         UVAR(I,5) = UVAR(I,5) - UN/NSTEP
+         IF (UVAR(I,5) <= EM08) THEN 
+           UVAR(I,5) = ZERO
+           IF (NPG > 1) THEN 
+             NINDX2        = NINDX2 + 1
+             INDX2(NINDX2) = I
+           ELSE
+             NINDX       = NINDX + 1
+             INDX(NINDX) = I
+             IDEL7NOK    = 1   
+             TDELE(I)    = TIME
+             OFF(I)      = ZERO
+           ENDIF
+         ENDIF
        ENDIF
-       IF (LOFF(I) < EM08) LOFF(I) = ZERO
-       SIGNXX(I) = SIGNXX(I)*LOFF(I)
-       SIGNYY(I) = SIGNYY(I)*LOFF(I)
-       SIGNZZ(I) = SIGNZZ(I)*LOFF(I)
-       SIGNXY(I) = SIGNXY(I)*LOFF(I)
-       SIGNYZ(I) = SIGNYZ(I)*LOFF(I)
-       SIGNZX(I) = SIGNZX(I)*LOFF(I)
+       SIGNXX(I) = SIGNXX(I)*UVAR(I,5)
+       SIGNYY(I) = SIGNYY(I)*UVAR(I,5)
+       SIGNZZ(I) = SIGNZZ(I)*UVAR(I,5)
+       SIGNXY(I) = SIGNXY(I)*UVAR(I,5)
+       SIGNYZ(I) = SIGNYZ(I)*UVAR(I,5)
+       SIGNZX(I) = SIGNZX(I)*UVAR(I,5)
        ! Regularization factors for length, surface and volume
        FACL(I) = UVAR(I,1)
        FACS(I) = UVAR(I,1)**2
@@ -215,7 +234,7 @@ c
        ! Storage of integration point volume
        IF (NPG > 1) THEN
          UVAR(I,3) = VOLN(I)
-         IF (LOFF(I) == ZERO) UVAR(I,4) = VOLN(I)
+         IF (UVAR(I,5) == ZERO) UVAR(I,4) = VOLN(I)
        ENDIF
       ENDDO
 c      
@@ -368,7 +387,7 @@ c
       ! - LOOP OVER THE ELEMENT TO CHECK THE EROSION CRITERIA
       !====================================================================    
       DO I = 1,NEL
-        IF ((LOFF(I) == UN).AND.(OFF(I)==UN)) THEN
+        IF ((UVAR(I,5) == UN).AND.(OFF(I)==UN)) THEN
           NCRIT = 0
           !  -> maximum pressure
           IF (P(I) >= MAXPRES*FACS(I)) NCRIT = NCRIT + 1
@@ -452,8 +471,20 @@ c
           !  -> Checking failure
           DFMAX(I) = REAL(NCRIT)/REAL(NCS)
           IF (NCRIT >= NCS) THEN 
-            LOFF(I)   = LOFF(I) - UN/NSTEP
-            UVAR(I,5) = LOFF(I)
+            UVAR(I,5) = UVAR(I,5) - UN/NSTEP
+            DFMAX(I)  = UN
+            IF (NSTEP == 1) THEN 
+              IF (NPG > 1) THEN 
+                NINDX2        = NINDX2 + 1
+                INDX2(NINDX2) = I
+              ELSE
+                NINDX       = NINDX + 1
+                INDX(NINDX) = I
+                IDEL7NOK    = 1   
+                TDELE(I)    = TIME
+                OFF(I)      = ZERO
+              ENDIF
+            ENDIF
           ENDIF
         ENDIF
 c
@@ -461,59 +492,42 @@ c
 c
       !====================================================================
       ! - LOOKING FOR ELEMENT DELETION
-      !====================================================================  
-      ! Initialization of variable
-      NINDX = 0        
+      !====================================================================      
       ! Fully integrated element
       IF (NPG > 1) THEN 
         IF ((IPG == NPG).AND.(ILAY1 == ELBUF_TAB%NLAY)) THEN 
           DO I = 1,NEL       
-            ! Initialization of volumes computation
-            VTOT = ZERO
-            VDAM = ZERO
-            ! Loop over integration points
-            DO ILAY = 1, ELBUF_TAB%NLAY
-              DO IR = 1, ELBUF_TAB%NPTR
-                DO IS = 1, ELBUF_TAB%NPTS
-                  DO IT = 1, ELBUF_TAB%NPTT
-                    FBUF => ELBUF_TAB%BUFLY(ILAY)%FAIL(IR,IS,IT)
-                    ! Compute total volume of the element
-                    VTOT = VTOT + FBUF%FLOC(IRUPT)%VAR(3+NEL*(I-1))
-                    ! Compute damaged volume of the element
-                    VDAM = VDAM + FBUF%FLOC(IRUPT)%VAR(4+NEL*(I-1))
+            IF (OFF(I) == UN) THEN 
+              ! Initialization of volumes computation
+              VTOT = ZERO
+              VDAM = ZERO
+              ! Loop over integration points
+              DO ILAY = 1, ELBUF_TAB%NLAY
+                DO IR = 1, ELBUF_TAB%NPTR
+                  DO IS = 1, ELBUF_TAB%NPTS
+                    DO IT = 1, ELBUF_TAB%NPTT
+                      FBUF => ELBUF_TAB%BUFLY(ILAY)%FAIL(IR,IS,IT)
+                      ! Compute total volume of the element
+                      VTOT = VTOT + FBUF%FLOC(IRUPT)%VAR(2*NEL+I)
+                      ! Compute damaged volume of the element
+                      VDAM = VDAM + FBUF%FLOC(IRUPT)%VAR(3*NEL+I)
+                    ENDDO
                   ENDDO
                 ENDDO
               ENDDO
-            ENDDO
-            ! Checking volume fraction criterion
-            IF (((VDAM/VTOT) >= VOLFRAC).AND.(OFF(I) == UN)) THEN
-              DFMAX(I)    = UN
-              NINDX       = NINDX + 1
-              INDX(NINDX) = I
-              IDEL7NOK    = 1   
-              TDELE(I)    = TIME
-              OFF(I)      = ZERO
+              ! Checking volume fraction criterion
+              IF ((VDAM/VTOT) >= VOLFRAC) THEN
+                DFMAX(I)      = UN
+                NINDX3        = NINDX3 + 1
+                INDX3(NINDX3) = I
+                VFAIL(I)      = VDAM/VTOT
+                IDEL7NOK      = 1   
+                TDELE(I)      = TIME
+                OFF(I)        = ZERO
+              ENDIF
             ENDIF
           ENDDO
         ENDIF
-      ! Under-integrated element
-      ELSE
-        DO I = 1,NEL
-          !Initialization for checking complete failure of the shell (all integration points)
-          IF (IPG == 1) THEN
-            OFF(I) = ZERO
-          ENDIF
-          !If one integration points is not fully broken, the brick remains
-          IF (LOFF(I)>ZERO) OFF(I) = UN
-          ! Integration point failure
-          IF (LOFF(I) == UN - UN/NSTEP) THEN
-            DFMAX(I)    = UN
-            NINDX       = NINDX + 1
-            INDX(NINDX) = I
-            IDEL7NOK    = 1   
-            TDELE(I)    = TIME
-          ENDIF
-        ENDDO
       ENDIF
 c------------------------
 c------------------------
@@ -522,13 +536,33 @@ c------------------------
           I = INDX(J)     
 #include "lockon.inc"
           WRITE(IOUT, 1000) NGL(I),TIME
-          WRITE(ISTDO,1100) NGL(I),TIME
+          WRITE(ISTDO,1000) NGL(I),TIME
 #include "lockoff.inc"
         END DO
-      END IF         
+      END IF    
+      IF (NINDX2 > 0) THEN
+        DO J=1,NINDX2
+          I = INDX2(J)     
+#include "lockon.inc"
+          WRITE(IOUT, 2000) NGL(I),IPG,TIME
+          WRITE(ISTDO,2000) NGL(I),IPG,TIME
+#include "lockoff.inc"
+        END DO
+      END IF      
+      IF (NINDX3 > 0) THEN
+        DO J=1,NINDX3
+          I = INDX3(J)     
+#include "lockon.inc"
+          WRITE(IOUT, 3000) NGL(I),VFAIL(I),TIME
+          WRITE(ISTDO,3000) NGL(I),VFAIL(I),TIME
+#include "lockoff.inc"
+        END DO
+      END IF     
 c------------------------
  1000 FORMAT(1X,'DELETE SOLID ELEMENT NUMBER (GENE1) el#',I10,
-     .          ' AT TIME :',1PE12.4)     
- 1100 FORMAT(1X,'DELETE SOLID ELEMENT NUMBER (GENE1) el#',I10,
-     .          ' AT TIME :',1PE12.4)
+     .          ' AT TIME :',1PE12.4)    
+ 2000 FORMAT(1X,'FOR SOLID ELEMENT (GENE1)',I10,1X,'GAUSS POINT',I10,':'
+     .       ,/,1X,'FAILURE',1X,'AT TIME :',1PE12.4) 
+ 3000 FORMAT(1X,'DELETE SOLID ELEMENT NUMBER (GENE1) el#',I10,
+     .          ' DAMAGED VOLUME FRACTION :',1PE12.4,' AT TIME :',1PE12.4)    
       END

--- a/engine/source/materials/fail/orthbiquad/fail_orthbiquad_c.F
+++ b/engine/source/materials/fail/orthbiquad/fail_orthbiquad_c.F
@@ -32,10 +32,10 @@ Chd|====================================================================
      1           NEL      ,NUVAR    ,
      2           TIME     ,UPARAM   ,NGL      ,IPT      ,NPTOT    ,
      3           SIGNXX   ,SIGNYY   ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,
-     4           DPLA     ,EPSP     ,UVAR     ,NOFF     ,UEL1     ,
+     4           DPLA     ,EPSP     ,UVAR     ,PTHKF    ,UEL1     ,
      5           OFF      ,OFFL     ,DFMAX    ,TDEL     ,NFUNC    ,
      6           IFUNC    ,NPF      ,TF       ,ALDT     ,FOFF     ,
-     7           IGTYP    )
+     7           IPG      )
 C-----------------------------------------------
 C    ORTHOTROPIC BIQUADRATIC FAILURE MODEL
 C-----------------------------------------------
@@ -85,10 +85,10 @@ C IGTYP                       PROPERTY TYPE
 C-----------------------------------------------
 C   I N P U T   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER NEL,NUVAR,IPT,NPTOT,NFUNC,IGTYP
-      INTEGER NGL(NEL),NOFF(NEL),IFUNC(NFUNC)
+      INTEGER NEL,NUVAR,IPT,NPTOT,NFUNC,IPG
+      INTEGER NGL(NEL),IFUNC(NFUNC)
       my_real TIME,UPARAM(*),DPLA(NEL),EPSP(NEL),
-     .   UEL1(NEL),ALDT(NEL)
+     .   UEL1(NEL),ALDT(NEL),PTHKF
 C-----------------------------------------------
 C   I N P U T   O U T P U T   A r g u m e n t s 
 C-----------------------------------------------
@@ -114,11 +114,11 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       my_real hydros,vmises,triaxs,REF_EL_LEN
-      INTEGER I,J,K,L,NINDX,SEL,NANGLE
+      INTEGER I,J,K,L,NINDX1,NINDX2,SEL,NANGLE
       INTEGER FAIL_COUNT,IT,IREG,IRATE
-      INTEGER, DIMENSION(MVSIZ) :: INDX,CONDITION1,CONDITION2,CONDITION3
+      INTEGER, DIMENSION(MVSIZ) :: INDX1,INDX2
       my_real X_1(3),X_2(3),c3,DYDX,COS2(10,10),EPSD0,CJC,RATE_SCALE,FRATE
-      my_real EPS_FAIL,EPS_FAIL2,DAMAGE,d1,INST,FSCALE_LEN,MOHR_RADIUS
+      my_real EPS_FAIL,EPS_FAIL2,DAMAGE,INST,FSCALE_LEN,MOHR_RADIUS
       my_real P1X,P1Y,S1X,S1Y,S2Y,A1,A2,B1,B2,C1,C2,FAC,LAMBDA,COS2THETA(NEL)
       my_real, DIMENSION(:), ALLOCATABLE :: Q_X11,Q_X12,Q_X13,Q_X21,Q_X22,Q_X23,Q_INST
 C
@@ -143,7 +143,7 @@ c
       ! - INITIALISATION OF COMPUTATION ON TIME STEP
       !=======================================================================
       ! Recovering model parameters
-      d1         = UPARAM(1)
+      PTHKF      = UPARAM(1)
       SEL        = INT(UPARAM(2))
       REF_EL_LEN = UPARAM(3)
       EPSD0      = UPARAM(4)
@@ -194,23 +194,10 @@ c
           UVAR(I,3) = FAC
         ENDDO
       ENDIF
-c
-      ! Checking element failure and recovering user variable
-      DO I = 1,NEL
-        IF (DFMAX(I) >= UN .AND. d1 > ZERO .AND. OFF(I) == UN) THEN
-          SIGNXX(I) = ZERO
-          SIGNYY(I) = ZERO
-          SIGNXY(I) = ZERO
-          SIGNYZ(I) = ZERO
-          SIGNZX(I) = ZERO           
-        ENDIF
-      ENDDO
 C
       ! Initialization of variable
-      NINDX     = 0
-      CONDITION1(1:MVSIZ) = 0
-      CONDITION2(1:MVSIZ) = 0
-      CONDITION3(1:MVSIZ) = 0
+      NINDX1 = 0
+      NINDX2 = 0
 c      
       !====================================================================
       ! - LOOP OVER THE ELEMENT TO COMPUTE THE DAMAGE VARIABLE
@@ -348,41 +335,25 @@ c
 c
           ! Checking element failure using global damage
           IF (OFFL(I) == UN .AND. DFMAX(I) >= UN) THEN
-            OFFL(I) = ZERO
-            NOFF(I) = NOFF(I) + 1
-            IF (d1 < ZERO) FOFF(I) = 0
-            IF (IGTYP == 10 .OR. IGTYP == 11 .OR. IGTYP == 51 .OR. IGTYP == 52) FOFF(I) = 0
-            NINDX = NINDX + 1
-            INDX(NINDX) = I  
-            CONDITION1(NINDX) = IPT
-            IF (IGTYP /= 51 .AND. IGTYP /= 52) THEN
-              IF (NOFF(I) >= (ABS(d1)*REAL(NPTOT)) .AND. d1 > ZERO) THEN
-                TDEL(I)  = TIME
-                OFF(I)   = ZERO
-                IDEL7NOK = 1
-                CONDITION2(NINDX) = 1
-              ENDIF
-            ENDIF
+            FOFF(I)       = 0
+            NINDX1        = NINDX1 + 1
+            INDX1(NINDX1) = I  
           ENDIF
 c
           ! Checking element failure using instability damage
           IF (DAMAGE > UN .AND. UVAR(I,2) == ZERO .AND. OFFL(I) == UN) THEN
             UVAR(I,2) = UN   
-            FOFF(I) = 0
-            UEL1(I) = UEL1(I) + UN
+            UEL1(I)   = UEL1(I) + UN
             IF (INT(UEL1(I)) == NPTOT) THEN
-              SIGNXX(I) = ZERO
-              SIGNYY(I) = ZERO
-              SIGNXY(I) = ZERO
-              SIGNYZ(I) = ZERO
-              SIGNZX(I) = ZERO
-              NINDX     = NINDX + 1
-              INDX(NINDX) = I  
-              TDEL(I)   = TIME
-              OFF(I)    = ZERO
-              IDEL7NOK  = 1
-              CONDITION2(NINDX) = 1
-              CONDITION3(NINDX) = 1
+              NINDX2        = NINDX2 + 1
+              INDX2(NINDX2) = I
+              TDEL(I)       = TIME
+              OFF(I)        = ZERO
+              SIGNXX(I)     = ZERO
+              SIGNYY(I)     = ZERO
+              SIGNXY(I)     = ZERO
+              SIGNYZ(I)     = ZERO
+              SIGNZX(I)     = ZERO
             ENDIF
           ENDIF
         ENDIF
@@ -399,29 +370,30 @@ c------------------------
       IF (ALLOCATED(Q_INST)) DEALLOCATE(Q_INST)
 c------------------------
 c------------------------
-      IF (NINDX > 0) THEN        
-        DO J=1,NINDX             
-          I = INDX(J)         
-#include "lockon.inc"
-         IF(CONDITION1(J) >= 1)  THEN         
-           WRITE(IOUT, 2000) NGL(I),CONDITION1(J),TIME
-           WRITE(ISTDO,2000) NGL(I),CONDITION1(J),TIME
-         ENDIF
-         IF(CONDITION3(J)==1) THEN
-           WRITE(ISTDO,3000) NGL(I)
-           WRITE(IOUT, 3000) NGL(I)
-         ENDIF          
-         IF(CONDITION2(J)==1) THEN
-           WRITE(ISTDO,2200) NGL(I), TIME
-           WRITE(IOUT, 2200) NGL(I), TIME
-         ENDIF          
+      IF (NINDX1 > 0) THEN        
+        DO J=1,NINDX1             
+          I = INDX1(J)         
+#include "lockon.inc"         
+          WRITE(IOUT, 2000) NGL(I),IPG,IPT,TIME
+          WRITE(ISTDO,2000) NGL(I),IPG,IPT,TIME
 #include "lockoff.inc" 
         END DO                   
-      END IF   ! NINDX             
+      END IF 
+      IF (NINDX2 > 0) THEN        
+        DO J=1,NINDX2             
+          I = INDX2(J)         
+#include "lockon.inc"
+          WRITE(IOUT, 3000) NGL(I)
+          WRITE(IOUT, 2200) NGL(I), TIME
+          WRITE(ISTDO,3000) NGL(I)
+          WRITE(ISTDO,2200) NGL(I), TIME          
+#include "lockoff.inc" 
+        END DO                   
+      END IF           
 c------------------------
- 2000 FORMAT(1X,'FOR SHELL ELEMENT (ORTHBIQUAD)',I10,1X,'LAYER',I3,':',/,
+ 2000 FORMAT(1X,'FOR SHELL ELEMENT (ORTHBIQUAD)',I10,1X,'GAUSS POINT',I3,
+     .       1X,'LAYER',I3,':',/,
      .       1X,'STRESS TENSOR SET TO ZERO',1X,'AT TIME :',1PE12.4)
-
  2200 FORMAT(1X,' *** RUPTURE OF SHELL ELEMENT (ORTHBIQUAD)',I10,1X,
      . ' AT TIME :',1PE12.4)
  3000 FORMAT(1X,'FOR SHELL ELEMENT (ORTHBIQUAD)',I10,

--- a/engine/source/materials/mat_share/mulawc.F
+++ b/engine/source/materials/mat_share/mulawc.F
@@ -2017,9 +2017,9 @@ c
      1          JLT      ,NVARF   ,
      2          TT       ,UPARAMF ,NGL      ,IPT      ,MPT      ,
      3          SIGNXX   ,SIGNYY  ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,
-     4          DPLA     ,EPSPL   ,UVARF    ,GBUF%NOFF,UELR1    ,
+     4          DPLA     ,EPSPL   ,UVARF    ,PTHKF(ILAYER,IFL)  ,UELR1    ,
      5          OFF      ,OFFL    ,DFMAX    ,TDEL     ,NFUNC1   ,
-     6          IFUNC1   ,NPF     ,TF       ,ALDT     ,FOFF     , IGTYP)
+     6          IFUNC1   ,NPF     ,TF       ,ALDT     ,FOFF     ,IPG      )
 c
               CASE (31)     !    Anisotropic fabric failure model
 c
@@ -2102,10 +2102,9 @@ c
      1            JLT      ,NVARF   ,
      2            TT       ,UPARAMF ,NGL      ,IPT      ,MPT      ,
      3            SIGNXX   ,SIGNYY  ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,
-     4            DPLA     ,EPSPL   ,UVARF    ,GBUF%NOFF,UELR1    ,
+     4            DPLA     ,EPSPL   ,UVARF    ,PTHKF(ILAYER,IFL)  ,UELR1  ,
      5            OFF      ,OFFL    ,DFMAX    ,TDEL     ,NFUNC1   ,
-     6            IFUNC1   ,NPF     ,TF       ,ALDT     ,FOFF     , 
-     7            IGTYP    )
+     6            IFUNC1   ,NPF     ,TF       ,ALDT     ,FOFF     ,IPG    )
 c
               CASE (39)     !    GENE1
 c
@@ -2116,7 +2115,7 @@ c
      4            EPSXX    ,EPSYY    ,EPSXY    ,EPSYZ    ,EPSZX    ,AREA     ,            
      5            SIGNXX   ,SIGNYY   ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,THKN     , 
      6            TEMPEL   ,DFMAX    ,TDEL     ,ALDT     ,TABLE    ,IFL      ,
-     7            THK0     ,ELBUF_STR,IPT      ,MPT      ,GBUF%NOFF,FOFF     ,
+     7            THK0     ,ELBUF_STR,IPT      ,MPT      ,PTHKF(ILAYER,IFL),FOFF,
      8            IGTYP    ,THKLYL   ,ILAY     )
 c
               CASE (40)     !    RTCL

--- a/starter/source/materials/fail/biquad/hm_read_fail_biquad.F
+++ b/starter/source/materials/fail/biquad/hm_read_fail_biquad.F
@@ -124,7 +124,9 @@ c---------------------------------------------------
       CALL HM_GET_FLOATV ('R4'          ,E3          ,IS_AVAILABLE,LSUBMODEL,UNITAB)  
       CALL HM_GET_FLOATV ('R5'          ,E4          ,IS_AVAILABLE,LSUBMODEL,UNITAB)  
 c---------------------------------------------------
-      IF (PTHK  == ZERO) PTHK  = -UN
+      IF (PTHK  == ZERO) PTHK  = UN
+      PTHK = MIN(PTHK,UN)
+      PTHK = MAX(ZERO,PTHK)
       IF (SFLAG == 0)    SFLAG = 1
 c---------------------------------------------------
 c     pre definition for user-input data when only 
@@ -163,7 +165,7 @@ c---------------------------------------------------
       UPARAM(4)  = X_2(1)
       UPARAM(5)  = X_2(2)
       UPARAM(6)  = X_2(3)
-      UPARAM(7)  = PTHK-EM6
+      UPARAM(7)  = PTHK
       UPARAM(8)  = 0
       UPARAM(11) = SFLAG
       UPARAM(12) = INST

--- a/starter/source/materials/fail/gene1/hm_read_fail_gene1.F
+++ b/starter/source/materials/fail/gene1/hm_read_fail_gene1.F
@@ -39,7 +39,7 @@ Chd|====================================================================
        SUBROUTINE HM_READ_FAIL_GENE1(
      .            UPARAM  ,MAXUPARAM ,NUPARAM ,NUVAR   ,IFUNC    ,
      .            MAXFUNC ,NFUNC     ,UNITAB  ,FAIL_ID ,MAT_ID   ,
-     .            TABLE   ,TITR    ,LSUBMODEL )
+     .            TABLE   ,TITR      ,LSUBMODEL)
 C-----------------------------------------------
 c    Orthotropic strain  failure model
 C-----------------------------------------------
@@ -256,7 +256,11 @@ C===============================================================================
       IF (THIN    == ZERO) THIN    = -INFINITY
       ! Card 6 
       IF (VOLFRAC == ZERO) VOLFRAC = UNDEMI
+      VOLFRAC = MIN(VOLFRAC,UN)
+      VOLFRAC = MAX(ZERO,VOLFRAC)
       IF (PTHK    == ZERO) PTHK    = UN
+      PTHK = MIN(PTHK,UN)
+      PTHK = MAX(ZERO,PTHK)
       IF (NCS     == 0   ) NCS     = 1
       IF (NCS > NCRIT_MAX) THEN
         CALL ANCMSG(MSGID=2043,MSGTYPE=MSGWARNING,
@@ -330,7 +334,7 @@ C===============================================================================
       UPARAM(19) = NSTEP
       UPARAM(20) = THIN
       UPARAM(21) = VOLFRAC
-      UPARAM(22) = PTHK-EM6
+      UPARAM(22) = PTHK
       UPARAM(23) = NCS
       UPARAM(24) = MAXTEMP
       UPARAM(25) = Fscale_el

--- a/starter/source/materials/fail/orthbiquad/hm_read_fail_orthbiquad.F
+++ b/starter/source/materials/fail/orthbiquad/hm_read_fail_orthbiquad.F
@@ -158,7 +158,9 @@ C===============================================================================
       CALL HM_GET_INTV   ('fct_IDel' ,REG_FUNC    ,IS_AVAILABLE,LSUBMODEL)
       CALL HM_GET_FLOATV ('EI_ref'   ,REF_SIZ     ,IS_AVAILABLE,LSUBMODEL,UNITAB)
 ! Default values      
-      IF (PTHK  == ZERO) PTHK  = -UN
+      IF (PTHK  == ZERO) PTHK  = UN
+      PTHK = MIN(PTHK,UN)
+      PTHK = MAX(ZERO,PTHK)
       IF (SFLAG == 0)    SFLAG = 2
 ! Units
       IF ((REF_SIZ == ZERO).AND.(REG_FUNC > 0)) THEN
@@ -481,7 +483,7 @@ C===============================================================================
       ! -> Number of user variables
       NUVAR = 3   
 c-----------------------------------------------------    
-      UPARAM(1) = PTHK-EM6
+      UPARAM(1) = PTHK
       UPARAM(2) = SFLAG
       UPARAM(3) = REF_SIZ
       UPARAM(4) = EPSD0


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

/FAIL/BIQUAD, /FAIL/ORTHBIQUAD and /FAIL/GENE1 had element deletion triggering that is not in agreement with the common framework leading to output issue when element is deleted. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Revise element deletion for these 3 failures criteria.

<!--- If there is a design, link to it here ->

<!- Here is what the maintainer will check:>
<!- *  The PR contains only one commit (please squash your commits), unless the developer explicitely states the need for multiple commits>
<!- *  The linear history is preserved (no merge commits)>
<!- *  The changes satisfy the DOS and DONTS of the README.md file>
<!- *  The copyright header is added to new source files>
