### PR TITLE
Fix default value of Pthickfail in /FAIL/BIQUAD

### DIFF
--- a/starter/source/materials/fail/biquad/hm_read_fail_biquad.F
+++ b/starter/source/materials/fail/biquad/hm_read_fail_biquad.F
@@ -124,7 +124,6 @@ c---------------------------------------------------
       CALL HM_GET_FLOATV ('R4'          ,E3          ,IS_AVAILABLE,LSUBMODEL,UNITAB)  
       CALL HM_GET_FLOATV ('R5'          ,E4          ,IS_AVAILABLE,LSUBMODEL,UNITAB)  
 c---------------------------------------------------
-      IF (PTHK  == ZERO) PTHK  = UN
       PTHK = MIN(PTHK,UN)
       PTHK = MAX(ZERO,PTHK)
       IF (SFLAG == 0)    SFLAG = 1


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [ ] Only one commit (please squash your commits) 
- [ ] No merge commits (use git pull --rebase) 
- [ ] The changes satisfy the DOS and DONTS of the README.md file

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Wrong default value for PTHK parameter in BIQUAD reader code, not in agreement with documentation and generating QA 8.0 returns. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Change the default value from 1 to 0.

<!--- If there is a design document, link to it here ->


