### PR TITLE
Itetra4+/INIBRI/EREF (bugfixing)

### DIFF
--- a/engine/source/output/sta/stat_s_eref.F
+++ b/engine/source/output/sta/stat_s_eref.F
@@ -80,7 +80,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I,N,J,K,II,JJ,LEN,NLAY,NPTR,NPTS,NPTT,
+      INTEGER I,N,J,K,II,JJ,LEN,NLAY,NPTR,NPTS,NPTT,ISOLNOD0,
      .   ISOLNOD,ISTRAIN,NG, NEL, MLW, ID, IPRT0, IPRT,IE, 
      .   NPG,IPG,IPT,IL,IR,IS,IT,IPID,PID,IOFF,KK(8),NC(20),NN1
       INTEGER PTWA(STAT_NUMELS), PTWA_P0(0:MAX(1,STAT_NUMELS_G))
@@ -124,6 +124,8 @@ C----- not output all solid element
      6          IREP    ,IINT    ,IGTYP   ,ISRAT   ,ISROT   ,  
      7          ICSEN   ,ISORTH  ,ISORTHG ,IFAILURE,JSMS    )
           IF (JHBE==17.AND.IINT==2) JHBE = 18
+          ISOLNOD0 = ISOLNOD
+          IF (ISOLNOD0==4 .AND. ISROT>0) ISOLNOD=10
           GBUF => ELBUF_TAB(NG)%GBUF
           IPRT=IPARTS(LFT+NFT)
           PID = IPART(2,IPRT)
@@ -148,7 +150,7 @@ c------
 	             DO J = 1,ISOLNOD
 	               NC(J) = IXS(J+1,N)
                  ENDDO
-                ELSEIF(ISOLNOD == 4)THEN
+                ELSEIF(ISOLNOD0== 4)THEN
                   NC(1)=IXS(2,N)
                   NC(2)=IXS(4,N)
                   NC(3)=IXS(7,N)
@@ -160,7 +162,7 @@ c------
                   NC(4)=IXS(6,N)
                   NC(5)=IXS(7,N)
                   NC(6)=IXS(8,N)
-                ELSEIF(ISOLNOD == 10)THEN
+                ELSEIF(ISOLNOD0== 10)THEN
                   NC(1)=IXS(2,N)
                   NC(2)=IXS(4,N)
                   NC(3)=IXS(7,N)

--- a/starter/source/elements/initia/initia.F
+++ b/starter/source/elements/initia/initia.F
@@ -383,7 +383,7 @@ C remove automatic allocation to reduce stack consumption
       my_real, DIMENSION(:,:), ALLOCATABLE :: DIS
       my_real
      .    ADDEDMS(NPART), MST3(MVSIZ),PTTRIA(MVSIZ)
-      INTEGER ID,ISTOT, NF1,ICUMU,I15_,SIPHASE, NUMEL_TOT
+      INTEGER ID,ISTOT, NF1,ICUMU,I15_,SIPHASE, NUMEL_TOT,NNOD
       CHARACTER*nchartitle,
      .   TITR
       LOGICAL :: ERROR_THROWN
@@ -1019,7 +1019,8 @@ C-----Case total strain
      C         STRSGLOB(NF1),STRAGLOB(NF1),FAIL_INI,ILOADP ,FACLOAD    ,
      D         PERTURB     ,RNOISE    )
               IF (NSIGI > 0 ) THEN
-                 CALL SGSAVINIEREFQ(ISOLNOD,STRAGLOB(NF1),SIGSP,NSIGI,PTSOL(NF1),
+                 NNOD = 10
+                 CALL SGSAVINIEREFQ(NNOD,STRAGLOB(NF1),SIGSP,NSIGI,PTSOL(NF1),
      .                              GBUF%SMSTR,GBUF%OFF,NEL)
               END IF
          ELSEIF(ITY.EQ.1.AND.ISOLNOD.EQ.20)THEN

--- a/starter/source/elements/initia/lec_inistate_d00_brick-check.F
+++ b/starter/source/elements/initia/lec_inistate_d00_brick-check.F
@@ -60,7 +60,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER IPIDD00, JJHBED00, NPTD00, NPTF, NPTR, NPTS, NPTT, ICSTR, IINT, NLY
+      INTEGER IPIDD00, JJHBED00, NPTD00, NPTF, NPTR, NPTS, NPTT, ICSTR, IINT, NLY,NNOD
 C-----------------------------------------------
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7----+----8----+----9----+----A----+----B----+----C----+----D--
 C-----------------------------------------
@@ -96,7 +96,9 @@ C
 C
 C  Number of nodes
 C
-      IF (ISOLNODD00(IE) .NE.ISOLNOD) THEN
+      NNOD = ISOLNOD
+      IF (ISOLNOD==10 .AND. ISROT==1) NNOD=4
+      IF (ISOLNODD00(IE) .NE.NNOD) THEN
           CALL ANCMSG(MSGID=695,
      .                MSGTYPE=MSGERROR,
      .                ANMODE=ANINFO,


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [ ] Only one commit (please squash your commits) 
- [ ] No merge commits (use git pull --rebase) 
- [ ] The changes satisfy the DOS and DONTS of the README.md file

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
When /INIBRI/EREF using Itetra4=1 of tetra4 element (/PROP/SOLID) the initial state (reference configuation) did'nt work
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
output /STATE/SOLID/EREF with nnod=10 instead of 4 when Itetra4=1 

<!--- If there is a design document, link to it here ->


