### PR TITLE
Correction bug  /DT/THERM : need to stop computation at Tstop exactly 

### DIFF
--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -962,7 +962,7 @@ C----
      .     LBUFSEGLO
       my_real
      .   DT2T,
-     .   DT2SAVE, INER, MAS, BB, TFEXC,
+     .   DT2SAVE, INER, MAS, BB, TFEXC,TREST,DTREST,
      .   DMAST, DINERT,DTU, RFACTOR, RFMAX,FACTB,DAMPT,
      .   DTFNOD, DTMNOD, XSENS(12,NSENSOR),DAMPA3
       my_real
@@ -5983,7 +5983,15 @@ C     IF(IDTMINS==0.AND.IDTMINS_INT==0)THEN
       DINER = DINER + DINERT
       IF(IDT_THERM == 1)THEN    
         IF(DT2TT.LE.DT2T)THEN
-          DT2T = DT2TT 
+C---------Check remaing time for end simulation and correct time step----
+C------------Need to stop computation at Tstop for /DT/THERM----------
+          TREST=MAX(TSTOP-TT,ZERO)  
+          DTREST = TREST*(UN+EM10)
+          IF(DTREST.LT.DT2T) THEN
+             ILASTANIM = 1 
+             ILASTH3D = 1 
+          ENDIF     
+          DT2T = MIN(DT2TT,DTREST) 
           NELTST = NELTSTT
           ITYPTST= ITYPTSTT
         ENDIF


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [x] Only one commit (please squash your commits) 
- [x] No merge commits (use git pull --rebase) 
- [x] The changes satisfy the DOS and DONTS of the README.md file

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Using /DT/THERM, computation is stopped at T=Tstop

#### Description of the changes
Adding a check of remaining time (Trest) to insure that end time of simulation equal to Tstop. The last time step is computed using Trest


