### PR TITLE
Force strain rate computation in law2

### DIFF
--- a/engine/source/materials/mat/mat002/m2law.F
+++ b/engine/source/materials/mat/mat002/m2law.F
@@ -201,23 +201,23 @@ c     --  storing elastic predictors for stiffness computation
 C-------------
 C     STRAIN RATE (JOHNSON-COOK, ZERILLI-ARMSTRONG)
 C-------------
-      IF(EPIF.NE.0.0)THEN
-
+      IF (ISRATE > 0) THEN
         DO I=LFT,LLT
-          IF(ISRATE.GE.1)THEN
-
-            EPD(I) = UNDEMI*((D1(I)+DAV(I))**2+(D2(I)+DAV(I))**2
-     .                                    +(D3(I)+DAV(I))**2) 
-     .             + QUART*(D4(I)**2+D5(I)**2+D6(I)**2)
-            EPD(I) = SQRT(TROIS*EPD(I))/TDEMI
-            EPSD(I) = ASRATE*EPD(I) + (UN -ASRATE)*EPSD(I)
-          ELSE
-            EPSD(I)=OFF(I)* MAX( ABS(D1(I)), ABS(D2(I)), ABS(D3(I)),
-     .   UNDEMI*ABS(D4(I)),UNDEMI*ABS(D5(I)),UNDEMI*ABS(D6(I)))
-          ENDIF !..israte
-C
-          EPSP(I) =EPSD(I)                   
+          EPD(I) = UNDEMI*((D1(I)+DAV(I))**2+(D2(I)+DAV(I))**2
+     .                                  +(D3(I)+DAV(I))**2) 
+     .           + QUART*(D4(I)**2+D5(I)**2+D6(I)**2)
+          EPD(I) = SQRT(TROIS*EPD(I))/TDEMI
+          EPSD(I) = ASRATE*EPD(I) + (UN -ASRATE)*EPSD(I)
         ENDDO
+      ELSE
+        DO I=LFT,LLT
+          EPSD(I)=OFF(I)* MAX( ABS(D1(I)), ABS(D2(I)), ABS(D3(I)),
+     .      UNDEMI*ABS(D4(I)),UNDEMI*ABS(D5(I)),UNDEMI*ABS(D6(I)))
+        ENDDO
+      ENDIF   ! israte
+      EPSP(1:NEL) = EPSD(1:NEL)                   
+c
+      IF (EPIF.NE.0.0)THEN
         DO I=LFT,LLT
            EPD(I)= MAX(EPSD(I),EM15)
            EPD(I)= LOG(EPD(I)/EPDR)
@@ -229,7 +229,7 @@ C
             T(I) = T(I) +CP*EINT(I)/MAX(EM15,VOL(I))
             TSTAR(I)=MIN(UN,MAX(ZERO,(T(I)-T_1)/(TM-T_1))) 
           ENDDO
-        ENDIF
+        ENDIF  
   
         IF(NPIF.EQ.ZERO)THEN
           DO I=LFT,LLT

--- a/starter/source/materials/mat/mat002/hm_read_mat02.F
+++ b/starter/source/materials/mat/mat002/hm_read_mat02.F
@@ -119,7 +119,6 @@ C-----------------------------------------------
       CC      = ZERO
       EPS0    = ZERO
       ICC     = 0
-      ISRATE  = 0
       FCUT    = ZERO
       FISOKIN = ZERO
       C3      = ZERO
@@ -356,7 +355,6 @@ C-----
      .                 I1=ID, 
      .                 C1=TITR)
       ENDIF
-      ISRATE = 1
       !FCUT = FCUT / FAC_T
       IF (FCUT == ZERO) FCUT=EP20
       IF(RHOR.EQ.ZERO) RHOR=RHO0
@@ -367,7 +365,12 @@ C
 C
       IF(EPSM == ZERO) EPSM  = EP20
       IF(SIGM == ZERO) SIGM  = EP20
-      IF(CC == ZERO)   EPS0  = UN
+      IF (CC == ZERO)   THEN
+        EPS0   = UN
+        ISRATE = 0
+      ELSE
+        ISRATE = 1
+      END IF
       IF(ANU.LE.-UN)  THEN       
         CALL ANCMSG(MSGID=300,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=2,I2=ID,C1=TITR)
       ENDIF


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [ ] Only one commit (please squash your commits) 
- [ ] No merge commits (use git pull --rebase) 
- [ ] The changes satisfy the DOS and DONTS of the README.md file

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Correct a problem of non-initialized strain rate values when it is not activated in the input cards, but a failure model depending on strain rate is applied to material.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Strain rate is now always calculated in law2. Filtering of strain rate depends on ISRATE parameter, which is desactivaded when Johnson-Cook strain parameters are not present in the input.

<!--- If there is a design document, link to it here ->


