### PR TITLE
Correction of merging CNODE to CNODE

### DIFF
--- a/starter/source/model/submodel/merge_cnod_cnod.F
+++ b/starter/source/model/submodel/merge_cnod_cnod.F
@@ -408,7 +408,7 @@ C--------------------------------------------------
       NM = NMERGED_OLD
 !
       DO I= 1,NUMCNOD 
-        IF (IMERGETMP(I) > 0) THEN
+        IF (IMERGETMP(I) > 0 .AND. IMERGE0(I) == 0) THEN
           NM = NM+1                     
           IMERGE(NMERGE_TOT+NM) = USRTOSC(IMERGETMP(I),ITABM1)
           IMERGE(NM)         = USRTOSC(ITABC(I) ,ITABM1)


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [x] Only one commit (please squash your commits) 
- [x] No merge commits (use git pull --rebase) 
- [x] The changes satisfy the DOS and DONTS of the README.md file

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug

Wrong merging of /CNODE to /CNODE.
Once /CNODE are merged to /NODE, the already merged /CNODE are continuing searching to merge again to /CNODE, even if they are already merged to /NODE. The already merged /CNODE must be excluded from the next merge /CNODE to /CNODE.

<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes

A conditioning was put in place to avoid remerging of already merged /CNODE (to /NODE)

<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

<!--- If there is a design document, link to it here ->


