### PR TITLE
Igap=3 for e2e contact /INTER/TYPE25 : missing compuation Gap for pen…

### DIFF
--- a/engine/source/interfaces/int25/i25cor3e.F
+++ b/engine/source/interfaces/int25/i25cor3e.F
@@ -44,7 +44,8 @@ Chd|====================================================================
      E      VTX_BISECTOR,IGAP0,
      F      IAM    ,JAM    ,IBM    ,JBM    ,IAS    ,
      G      JAS    ,IBS    ,JBS    ,ITAB   , EDGE_ID,
-     H      INTFRIC,IPARTFRIC_E,IPARTFRICSI,IPARTFRICMI)
+     H      INTFRIC,IPARTFRIC_E,IPARTFRICSI,IPARTFRICMI,
+     I      IGAP   ,GAP_E_L)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -73,7 +74,7 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER LEDGE(NLEDGE,*), IRECT(4,*), CAND_M(*), CAND_S(*), ADMSR(4,*),
-     .        LBOUND(*), JLT, NRTS, NIN, IEDGE, IGAP0,INTFRIC,
+     .        LBOUND(*), JLT, NRTS, NIN, IEDGE, IGAP0,INTFRIC,IGAP,
      .        N1(MVSIZ), N2(MVSIZ), 
      .        M1(MVSIZ), M2(MVSIZ), 
      .        NODNX_SMS(*), NSMS(MVSIZ), 
@@ -94,7 +95,8 @@ C     REAL ou REAL*8
      .        VYM1(*), VYM2(*), VZM1(*), VZM2(*),
      .        MS1(*),  MS2(*),  MM1(*),  MM2(*),
      .        STIF(*), STFAC, STS, STM, GAPVE(*),
-     .        EX(*), EY(*), EZ(*), FX(*), FY(*), FZ(*)
+     .        EX(*), EY(*), EZ(*), FX(*), FY(*), FZ(*),
+     .        GAP_E_L(NEDGE)
       REAL*4 EDG_BISECTOR(3,4,*), VTX_BISECTOR(3,2,*)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
@@ -308,6 +310,15 @@ C
         DEBUG_E2E(EDGE_ID(1,I) ==  D_EM .AND. EDGE_ID(2,I) == D_ES,GAPE_S(I))
         GAPVE(I)=GAPE_M(I)+GAPE_S(I)
       END DO
+      IF(IGAP == 3) THEN
+        DO I=1,JLT
+          IF(CAND_S(I).LE.NEDGE) THEN
+             GAPVE(I)=MIN(GAP_E_L(CAND_M(I))+GAP_E_L(CAND_S(I)),GAPVE(I)) 
+          ELSE
+             GAPVE(I)=MIN(GAP_E_L(CAND_M(I))+GAPE_L_FIE(NIN)%P(CAND_S(I) - NEDGE),GAPVE(I)) 
+          ENDIF
+        ENDDO
+      ENDIF
 C
 C     Always shift MAIN edge toward inner side
       DO I=1,JLT

--- a/engine/source/interfaces/int25/i25mainf.F
+++ b/engine/source/interfaces/int25/i25mainf.F
@@ -850,7 +850,8 @@ C         preparation candidats retenus
      E INTBUF_TAB%VTX_BISECTOR ,IGAP0,
      F IAM          ,JAM          ,IBM          ,JBM          ,IAS     ,
      G JAS          ,IBS          ,JBS          ,ITAB         ,EDGE_ID ,
-     H INTFRIC      ,INTBUF_TAB%IPARTFRIC_E     ,IPARTFRICSI  ,IPARTFRICMI)
+     H INTFRIC      ,INTBUF_TAB%IPARTFRIC_E     ,IPARTFRICSI  ,IPARTFRICMI,
+     I IGAP         ,INTBUF_TAB%GAP_E_L)
           CALL I_COR_EPFIT3(
      1               JLT      ,INTBUF_TAB%STFE,STIF    ,CS_LOC ,CM_LOC ,
      2               NEDGE    ,NIN     ,INACTI  ,IPARI(40,NIN),TNCY) 

--- a/starter/source/interfaces/inter3d1/i25cor3e.F
+++ b/starter/source/interfaces/inter3d1/i25cor3e.F
@@ -34,10 +34,11 @@ Chd|====================================================================
      5      XZS2   ,XXM1   ,XXM2   ,XYM1   ,XYM2   ,
      6      XZM1   ,XZM2   ,EX     ,EY     ,EZ     ,
      7      FX     ,FY     ,FZ     ,
-     8      N1     ,N2     ,M1     ,M2     ,NRTS   ,
+     8      N1     ,N2     ,M1     ,M2     ,NEDGE  ,
      9      GAPE   ,GAPVE  ,
      A      IEDGE  ,ADMSR  ,LBOUND ,EDG_BISECTOR   ,
-     B      VTX_BISECTOR,ITAB   ,IGAP0)
+     B      VTX_BISECTOR   ,ITAB   ,IGAP0  ,IGAP   ,
+     C      GAP_E_L )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -63,7 +64,7 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER LEDGE(NLEDGE,*), IRECT(4,*), CAND_M(*), CAND_S(*), ADMSR(4,*),
-     .        LBOUND(*), JLT, NRTS, IEDGE, ITAB(*), IGAP0,
+     .        LBOUND(*), JLT, NEDGE, IEDGE, ITAB(*), IGAP0, IGAP, 
      .        N1(MVSIZ), N2(MVSIZ), 
      .        M1(MVSIZ), M2(MVSIZ)
 C     REAL ou REAL*8
@@ -72,7 +73,7 @@ C     REAL ou REAL*8
      .        XXS1(MVSIZ), XXS2(MVSIZ), XYS1(MVSIZ), XYS2(MVSIZ),
      .        XZS1(MVSIZ), XZS2(MVSIZ), XXM1(MVSIZ), XXM2(MVSIZ),
      .        XYM1(MVSIZ), XYM2(MVSIZ), XZM1(MVSIZ), XZM2(MVSIZ),
-     .        GAPE(*),GAPVE(MVSIZ),
+     .        GAPE(*),GAPVE(MVSIZ),GAP_E_L(NEDGE),
      .        EX(MVSIZ), EY(MVSIZ), EZ(MVSIZ), FX(MVSIZ), FY(MVSIZ), FZ(MVSIZ)
       REAL*4 EDG_BISECTOR(3,4,*), VTX_BISECTOR(3,2,*)
 C-----------------------------------------------
@@ -84,7 +85,7 @@ C-----------------------------------------------
      .   AAA, DX, DY, DZ, DD, NNI, NI2, INVCOS, GAPE_M(MVSIZ), GAPE_S(MVSIZ)
 C-----------------------------------------------
       DO I=1,JLT
-        IF(CAND_S(I).LE.NRTS) THEN
+        IF(CAND_S(I).LE.NEDGE) THEN
 
           I1=LEDGE(1,CAND_S(I))
           J1=LEDGE(2,CAND_S(I))
@@ -131,12 +132,19 @@ C-----------------------------------------------
 
       DO I=1,JLT
         GAPE_M(I)=GAPE(CAND_M(I))
-	IF(CAND_S(I).LE.NRTS) THEN
+	IF(CAND_S(I).LE.NEDGE) THEN
           GAPE_S(I)=GAPE(CAND_S(I))
         ELSE ! TBD
 	END IF
         GAPVE(I)=GAPE_M(I)+GAPE_S(I)
       END DO
+      IF(IGAP==3) THEN
+        DO I=1,JLT
+	   IF(CAND_S(I).LE.NEDGE) THEN
+              GAPVE(I)=MIN(GAP_E_L(CAND_M(I))+GAP_E_L(CAND_S(I)),GAPVE(I))
+           ENDIF
+        ENDDO
+      ENDIF
 C
       SOL_EDGE=IEDGE/10 ! solids
       SH_EDGE =IEDGE-10*SOL_EDGE ! shells

--- a/starter/source/interfaces/inter3d1/inint3.F
+++ b/starter/source/interfaces/inter3d1/inint3.F
@@ -2231,8 +2231,9 @@ C
      7         FX         ,FY           ,FZ           ,
      8         N1           ,N2           ,M1           ,M2           ,NEDGE   ,
      9         INTBUF_TAB%GAPE,GAPVE,
-     A         IEDGE        ,INTBUF_TAB%ADMSR,INTBUF_TAB%LBOUND,INTBUF_TAB%EDGE_BISECTOR,
-     B         INTBUF_TAB%VTX_BISECTOR,ITAB   ,IGAP0 )
+     A         IEDGE       ,INTBUF_TAB%ADMSR,INTBUF_TAB%LBOUND,INTBUF_TAB%EDGE_BISECTOR,
+     B         INTBUF_TAB%VTX_BISECTOR       ,ITAB        ,IGAP0    ,IGAP        ,
+     C         INTBUF_TAB%GAP_E_L)
 
               CALL I25PEN3E(
      1         LLT    ,IEDGE ,INTBUF_TAB%CANDS_E2E(1+NFT) ,INTBUF_TAB%CANDM_E2E(1+NFT) ,


### PR DESCRIPTION
…etration computation

#### Prerequisites
<!--- Check [x] all boxes -->
- [x] Only one commit (please squash your commits) 
- [x] No merge commits (use git pull --rebase) 
- [x] The changes satisfy the DOS and DONTS of the README.md file

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
Igap=3 option is now working for E2E contact


#### Description of the changes
Correction of the computation of Gap for penetration computation in case of Igap=3 


