### PR TITLE
RWALL:fixing signal floating point exception during Engine

### DIFF
--- a/engine/source/constraints/general/rwall/rgwal0.F
+++ b/engine/source/constraints/general/rwall/rgwal0.F
@@ -23,9 +23,9 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 Chd|====================================================================
 Chd|  RGWAL0                        source/constraints/general/rwall/rgwal0.F
 Chd|-- called by -----------
-Chd|        RESOL                         source/engine/resol.F         
+Chd|        RESOL                         source/engine/resol.F
 Chd|-- calls ---------------
-Chd|        MY_BARRIER                    source/system/machine.F       
+Chd|        MY_BARRIER                    source/system/machine.F
 Chd|        RGWALC                        source/constraints/general/rwall/rgwalc.F
 Chd|        RGWALL                        source/constraints/general/rwall/rgwall.F
 Chd|        RGWALP                        source/constraints/general/rwall/rgwalp.F
@@ -33,7 +33,7 @@ Chd|        RGWALS                        source/constraints/general/rwall/rgwal
 Chd|        RGWALT                        source/constraints/general/rwall/rgwal0.F
 Chd|        SPMD_EXCH_FR6                 source/mpi/kinematic_conditions/spmd_exch_fr6.F
 Chd|====================================================================
-      SUBROUTINE RGWAL0(X      ,A      ,V      ,RWBUF   ,LPRW  ,   
+      SUBROUTINE RGWAL0(X      ,A      ,V      ,RWBUF   ,LPRW  ,
      2                  NPRW   ,MS     ,FSAV   ,FR_WALL ,FOPT  ,
      3                  RWSAV  ,WEIGHT ,FRWL6 ,NODNX_SMS,WEIGHT_MD,
      4                  DIMFB  , FBSAV6,STABSEN,TABSENSOR )
@@ -59,13 +59,10 @@ C-----------------------------------------------
       INTEGER LPRW(*), NPRW(*), FR_WALL(NSPMD+2,*), WEIGHT(*),
      .        IBID, NODNX_SMS(*),WEIGHT_MD(*),
      .        DIMFB,STABSEN,TABSENSOR(*)
-      my_real
-     .   X(3,*), A(3,*), V(3,*),RWBUF(NRWLP,*),RWSAV(*),MS(*),
-     .   FSAV(NTHVKI,*), FOPT(6,*)
-      DOUBLE PRECISION
-     .        FRWL6(7,6,NRWALL)
-      DOUBLE PRECISION
-     .        FBSAV6(12,6,DIMFB),RBID(12,6)
+      my_real X(3,NUMNOD), A(3,NUMNOD), V(3,NUMNOD),RWBUF(NRWLP,*),RWSAV(*),MS(*),
+     .        FSAV(NTHVKI,*), FOPT(6,*)
+      DOUBLE PRECISION FRWL6(7,6,NRWALL)
+      DOUBLE PRECISION FBSAV6(12,6,DIMFB),RBID(12,6)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -76,7 +73,7 @@ C-----------------------------------------------
 C Init global result to 0
 
 !$OMP DO
-          DO N = 1, NRWALL          
+          DO N = 1, NRWALL
             DO K = 1, 6
               FRWL6(1,K,N) = ZERO
               FRWL6(2,K,N) = ZERO
@@ -102,27 +99,27 @@ C Init global result to 0
 C
             ITYP= NPRW(N4)
             ILAGM= 0
-            IF (NPRW(N6).EQ.1) ILAGM=1
-            IF(ITYP.EQ.1.AND.ILAGM.EQ.0)THEN
+            IF (NPRW(N6) == 1) ILAGM=1
+            IF(ITYP == 1.AND.ILAGM == 0)THEN
               CALL RGWALL(
-     +          X       ,A         ,V           ,RWBUF(1,N),LPRW(K), 
+     +          X       ,A         ,V           ,RWBUF(1,N),LPRW(K),
      +          NPRW(N) ,NPRW(N2)  ,NPRW(N3)    ,MS        ,WEIGHT ,
      +          NPRW(N5),RWSAV(ISL),FRWL6(1,1,N),IMP       ,IBID   ,
      +          IBID    ,IBID      ,IBID        ,NODNX_SMS ,WEIGHT_MD)
-            ELSEIF(ITYP.EQ.2)THEN
+            ELSEIF(ITYP == 2)THEN
               CALL RGWALC(
      +          X       ,A           ,V       ,RWBUF(1,N) ,LPRW(K),
      +          NPRW(N) ,NPRW(N2)    ,NPRW(N3),MS         ,WEIGHT ,
      +          NPRW(N5),FRWL6(1,1,N),IMP     ,IBID       ,IBID   ,
      +          IBID    ,IBID        ,NODNX_SMS , WEIGHT_MD)
 C
-            ELSEIF(ITYP.EQ.3)THEN
+            ELSEIF(ITYP == 3)THEN
               CALL RGWALS(
      +          X       ,A           ,V       ,RWBUF(1,N),LPRW(K),
      +          NPRW(N) ,NPRW(N2)    ,NPRW(N3),MS        ,WEIGHT ,
      +          NPRW(N5),FRWL6(1,1,N),IMP     ,IBID      ,IBID   ,
      +          IBID    ,IBID        ,NODNX_SMS ,WEIGHT_MD)
-            ELSEIF(ITYP.EQ.4)THEN
+            ELSEIF(ITYP == 4)THEN
               CALL RGWALP(
      +          X       ,A           ,V       ,RWBUF(1,N),LPRW(K),
      +          NPRW(N) ,NPRW(N2)    ,NPRW(N3),MS        ,WEIGHT ,
@@ -131,14 +128,18 @@ C
             ENDIF
             K=K+NPRW(N)
             IFQ = NINT(RWBUF(15,N))
-            IF (SMINVER.LT.9.OR.IFQ.GT.0) ISL=ISL+NPRW(N)*3
-            IF(NPRW(N4).EQ.-1)K=K+NINT(RWBUF(8,N))
+            IF (SMINVER < 9.OR.IFQ > 0) THEN
+              ISL=ISL+NPRW(N)*3
+            ENDIF
+            IF(NPRW(N4) == -1)THEN
+              K=K+NINT(RWBUF(8,N))
+            ENDIF
           END DO
 
 C Explicit barrier required before communication
- 
+
           CALL MY_BARRIER
-          
+
 !$OMP SINGLE
 
 C
@@ -155,7 +156,7 @@ C
               IF(NPRW(N3) /= 0) THEN
                 IF(NSPMD > 1) THEN
 Cel si proc concerne par le rgwall
-                  IF(FR_WALL(ISPMD+1,N).NE.0) THEN
+                  IF(FR_WALL(ISPMD+1,N) /= 0) THEN
                     CALL SPMD_EXCH_FR6(FR_WALL(1,N),FRWL6(1,1,N),7*6)
                   ENDIF
                   PMAIN = FR_WALL(NSPMD+2,N)
@@ -168,8 +169,9 @@ Cel si proc concerne par le rgwall
 C
               IPARSENS=0
               ISECT=0
-              IF(STABSEN/=0) ISECT=TABSENSOR(N+NSECT+NINTSUB+NINTER+1)-
-     .                             TABSENSOR(N+NSECT+NINTSUB+NINTER)
+              IF(STABSEN/=0) THEN
+                ISECT=TABSENSOR(N+NSECT+NINTSUB+NINTER+1)-TABSENSOR(N+NSECT+NINTSUB+NINTER)
+              ENDIF
               IF(ISECT/=0) THEN
                 IPARSENS=1
                 CALL RGWALT(
@@ -190,21 +192,21 @@ C
 Chd|====================================================================
 Chd|  RGWAL0_IMP                    source/constraints/general/rwall/rgwal0.F
 Chd|-- called by -----------
-Chd|        IMP_BUCK                      source/implicit/imp_buck.F    
-Chd|        IMP_CHKM                      source/implicit/imp_solv.F    
-Chd|        IMP_SOLV                      source/implicit/imp_solv.F    
+Chd|        IMP_BUCK                      source/implicit/imp_buck.F
+Chd|        IMP_CHKM                      source/implicit/imp_solv.F
+Chd|        IMP_SOLV                      source/implicit/imp_solv.F
 Chd|-- calls ---------------
 Chd|        FV_RWL                        source/constraints/general/rwall/srw_imp.F
-Chd|        GETDYNA_A                     source/implicit/imp_dyna.F    
+Chd|        GETDYNA_A                     source/implicit/imp_dyna.F
 Chd|        RGWALC                        source/constraints/general/rwall/rgwalc.F
 Chd|        RGWALL                        source/constraints/general/rwall/rgwall.F
 Chd|        RGWALP                        source/constraints/general/rwall/rgwalp.F
 Chd|        RGWALS                        source/constraints/general/rwall/rgwals.F
 Chd|        RGWALT                        source/constraints/general/rwall/rgwal0.F
 Chd|        SPMD_EXCH_FR6                 source/mpi/kinematic_conditions/spmd_exch_fr6.F
-Chd|        ZEROR                         source/system/zero.F          
+Chd|        ZEROR                         source/system/zero.F
 Chd|====================================================================
-      SUBROUTINE RGWAL0_IMP(X      ,D      ,V      ,RWBUF   ,LPRW   ,   
+      SUBROUTINE RGWAL0_IMP(X      ,D      ,V      ,RWBUF   ,LPRW   ,
      1                  NPRW   ,MS     ,FSAV   ,FR_WALL ,FOPT   ,
      2                  RWSAV  ,WEIGHT ,FSAVD   ,NT_RW  ,
      3                  IDDL   ,IKC    ,ICOMV  ,NDOF  ,FRWL6 ,WEIGHT_MD,
@@ -232,9 +234,8 @@ C-----------------------------------------------
       INTEGER LPRW(*), NPRW(*), FR_WALL(NSPMD+2,*), WEIGHT(*),
      .        NT_RW,IDDL(*),IKC(*),NDOF(*),ICOMV,WEIGHT_MD(*),
      .        DIMFB,STABSEN,TABSENSOR(*)
-      my_real
-     .   X(3,*), D(3,*), V(3,*),RWBUF(NRWLP,*),RWSAV(*),MS(*),
-     .   FSAV(NTHVKI,*), FOPT(6,*),FSAVD(NTHVKI,*)
+      my_real X(3,NUMNOD), D(3,NUMNOD), V(3,NUMNOD),RWBUF(NRWLP,*),RWSAV(*),MS(*),
+     .        FSAV(NTHVKI,*), FOPT(6,*),FSAVD(NTHVKI,*)
       DOUBLE PRECISION
      .        FRWL6(7,6,NRWALL)
       DOUBLE PRECISION
@@ -244,15 +245,14 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER K, N, N2, N3, N4, N5, N6, ITYP, ISL, IFQ, ILAGM,
      .        NDS,IMP, PMAIN, IBID,IPARSENS,ISECT
-      my_real
-     .        A(3,NUMNOD),BID,DTI
+      my_real A(3,NUMNOD),BID,DTI
 C-----------------------------------------------
           RBID = ZERO
 C Init global result to 0
 
 C for the moment RGWAL0 is called in monoprocessor, so no need of // do loop
 c!$OMP DO
-          DO N = 1, NRWALL          
+          DO N = 1, NRWALL
             DO K = 1, 6
               FRWL6(1,K,N) = ZERO
               FRWL6(2,K,N) = ZERO
@@ -267,19 +267,19 @@ c!$OMP END DO
 
           NDS=0
           IMP=1
-	      IF (IDYNA.GT.0) THEN
+	      IF (IDYNA > 0) THEN
 	        CALL GETDYNA_A(1  ,NUMNOD   ,A )
 	      ELSE
             CALL ZEROR(A,NUMNOD)
 	      END IF
-          IF (ICOMV.EQ.1) THEN
+          IF (ICOMV == 1) THEN
            DTI = UN/DT2
            DO N=1,NUMNOD
             V(1,N)=D(1,N)*DTI
             V(2,N)=D(2,N)*DTI
             V(3,N)=D(3,N)*DTI
            ENDDO
-          ENDIF 
+          ENDIF
           ISL = 1
           K=1
           DO N=1,NRWALL
@@ -291,39 +291,39 @@ c!$OMP END DO
 
             ITYP= NPRW(N4)
             ILAGM= 0
-            IF (CODVERS.GE.44) THEN
-              IF (NPRW(N6).EQ.1) ILAGM=1
+            IF (CODVERS >= 44) THEN
+              IF (NPRW(N6) == 1) ILAGM=1
             ENDIF
-            IF(ITYP.EQ.1.AND.ILAGM.EQ.0)THEN
+            IF(ITYP == 1.AND.ILAGM == 0)THEN
               CALL RGWALL(
-     +          X       ,A         ,V           ,RWBUF(1,N),LPRW(K), 
+     +          X       ,A         ,V           ,RWBUF(1,N),LPRW(K),
      +          NPRW(N) ,NPRW(N2)  ,NPRW(N3)    ,MS        ,WEIGHT ,
      +          NPRW(N5),RWSAV(ISL),FRWL6(1,1,N),IMP       ,NT_RW  ,
      +          IDDL    ,IKC       ,NDOF        ,IBID      ,WEIGHT_MD)
-            ELSEIF(ITYP.EQ.2)THEN
+            ELSEIF(ITYP == 2)THEN
               CALL RGWALC(
      +          X       ,A           ,V       ,RWBUF(1,N),LPRW(K),
      +          NPRW(N) ,NPRW(N2)    ,NPRW(N3),MS        ,WEIGHT ,
      +          NPRW(N5),FRWL6(1,1,N),IMP     ,NT_RW     ,IDDL   ,
      +          IKC     ,NDOF        ,IBID    ,WEIGHT_MD)
-            ELSEIF(ITYP.EQ.3)THEN
+            ELSEIF(ITYP == 3)THEN
               CALL RGWALS(
      +          X       ,A           ,V       ,RWBUF(1,N),LPRW(K),
      +          NPRW(N) ,NPRW(N2)    ,NPRW(N3),MS        ,WEIGHT ,
      +          NPRW(N5),FRWL6(1,1,N),IMP     ,NT_RW     ,IDDL   ,
      +          IKC     ,NDOF        ,IBID    ,WEIGHT_MD)
-            ELSEIF(ITYP.EQ.4)THEN
+            ELSEIF(ITYP == 4)THEN
               CALL RGWALP(
      +          X       ,A           ,V       ,RWBUF(1,N),LPRW(K),
      +          NPRW(N) ,NPRW(N2)    ,NPRW(N3),MS        ,WEIGHT ,
      +          NPRW(N5),FRWL6(1,1,N),IMP     ,NT_RW     ,IDDL   ,
      +          IKC     ,NDOF        ,IBID    ,WEIGHT_MD)
             ENDIF
-            
+
             K=K+NPRW(N)
             IFQ = NINT(RWBUF(15,N))
-            IF (SMINVER.LT.9.OR.IFQ.GT.0) ISL=ISL+NPRW(N)*3
-            IF(NPRW(N4).EQ.-1)K=K+NINT(RWBUF(8,N))
+            IF (SMINVER < 9.OR.IFQ > 0) ISL=ISL+NPRW(N)*3
+            IF(NPRW(N4) == -1)K=K+NINT(RWBUF(8,N))
           END DO
 
 C
@@ -340,7 +340,7 @@ C
               IF(NPRW(N3) /= 0) THEN
                 IF(NSPMD > 1) THEN
 Cel si proc concerne par le rgwall
-                  IF(FR_WALL(ISPMD+1,N).NE.0) THEN
+                  IF(FR_WALL(ISPMD+1,N) /= 0) THEN
                     CALL SPMD_EXCH_FR6(FR_WALL(1,N),FRWL6(1,1,N),7*6)
                   ENDIF
                   PMAIN = FR_WALL(NSPMD+2,N)
@@ -368,8 +368,8 @@ C
             END DO
           END IF
 
-          IF (NT_RW.GT.0) THEN
-           CALL FV_RWL(IDDL   ,IKC   ,NDOF  ,D    ,V    ,A     )         
+          IF (NT_RW > 0) THEN
+           CALL FV_RWL(IDDL   ,IKC   ,NDOF  ,D    ,V    ,A     )
           ENDIF
 
       RETURN
@@ -378,7 +378,7 @@ C
 Chd|====================================================================
 Chd|  RGWALF                        source/constraints/general/rwall/rgwal0.F
 Chd|-- called by -----------
-Chd|        RESOL                         source/engine/resol.F         
+Chd|        RESOL                         source/engine/resol.F
 Chd|-- calls ---------------
 Chd|====================================================================
       SUBROUTINE RGWALF(A      ,RWBUF   ,NPRW   ,MS    )
@@ -401,14 +401,12 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER NPRW(*)
-      my_real
-     .        A(3,*),RWBUF(NRWLP,*),MS(*)
+      my_real A(3,NUMNOD),RWBUF(NRWLP,*),MS(*)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER N,N2,N3,N4,N5,N6, MSR, ITYP, ILAGM
-      my_real
-     .        DM
+      my_real DM
 C-----------------------------------------------
 C
 C RWL(17) = Fx
@@ -424,10 +422,10 @@ C
         N6=N5+NRWALL
         ITYP= NPRW(N4)
         ILAGM= 0
-        IF (NPRW(N6).EQ.1) ILAGM=1
-        IF(ITYP.GE.1.AND.ITYP.LE.4.AND.ILAGM.EQ.0)THEN
+        IF (NPRW(N6) == 1) ILAGM=1
+        IF(ITYP >= 1.AND.ITYP <= 4.AND.ILAGM == 0)THEN
           MSR = NPRW(N3)
-          IF(MSR.NE.0)THEN
+          IF(MSR /= 0)THEN
             DM = MS(MSR)+ RWBUF(20,N)
             IF(DM /= ZERO) THEN
               DM = MS(MSR) / DM
@@ -470,19 +468,13 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER MSR, PMAIN, IPARSENS, I
-C     REAL ou REAL*8
-      my_real
-     .   RWL(*), FSAV(*),FOPT(6)
-      DOUBLE PRECISION
-     .   FRWL6(7,6)
-      DOUBLE PRECISION 
-     .   FBSAV6(12,6)
+      my_real RWL(*), FSAV(*),FOPT(6),DIVDT12
+      DOUBLE PRECISION FRWL6(7,6)
+      DOUBLE PRECISION FBSAV6(12,6)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-C     REAL ou REAL*8
-      my_real
-     .   FXN, FYN, FZN, FXT, FYT, FZT, XMT
+      my_real FXN, FYN, FZN, FXT, FYT, FZT, XMT
 C-----------------------------------------------
       FXN = FRWL6(1,1)+FRWL6(1,2)+FRWL6(1,3)+
      .      FRWL6(1,4)+FRWL6(1,5)+FRWL6(1,6)
@@ -499,22 +491,28 @@ C-----------------------------------------------
       FZT = FRWL6(7,1)+FRWL6(7,2)+FRWL6(7,3)+
      .      FRWL6(7,4)+FRWL6(7,5)+FRWL6(7,6)
 C
-      IF (IPARSENS .NE. 0)THEN
+      IF(DT12 /= ZERO)THEN
+        DIVDT12 = UN / DT12
+      ELSE
+        DIVDT12 = ZERO
+      ENDIF
+
+      IF (IPARSENS  /= 0)THEN
         DO I=1,6
-          FBSAV6(1,I) = FRWL6(1,I)/DT12
-          FBSAV6(2,I) = FRWL6(2,I)/DT12
-          FBSAV6(3,I) = FRWL6(3,I)/DT12
-          FBSAV6(4,I) = FRWL6(5,I)/DT12
-          FBSAV6(5,I) = FRWL6(6,I)/DT12
-          FBSAV6(6,I) = FRWL6(7,I)/DT12
+          FBSAV6(1,I) = FRWL6(1,I)*DIVDT12
+          FBSAV6(2,I) = FRWL6(2,I)*DIVDT12
+          FBSAV6(3,I) = FRWL6(3,I)*DIVDT12
+          FBSAV6(4,I) = FRWL6(5,I)*DIVDT12
+          FBSAV6(5,I) = FRWL6(6,I)*DIVDT12
+          FBSAV6(6,I) = FRWL6(7,I)*DIVDT12
         ENDDO
       ENDIF
 C
-      IF(IDTMINS==0.AND.IDTMINS_INT==0)THEN 
+      IF(IDTMINS==0.AND.IDTMINS_INT==0)THEN
 Cel changement formulation F et XMT stockoques dans RWL et appliques debut cycle suivant
-         RWL(17)=(FXN+FXT)/DT12
-         RWL(18)=(FYN+FYT)/DT12
-         RWL(19)=(FZN+FZT)/DT12
+         RWL(17)=(FXN+FXT)*DIVDT12
+         RWL(18)=(FYN+FYT)*DIVDT12
+         RWL(19)=(FZN+FZT)*DIVDT12
          RWL(20)=XMT
 C test  pour ne cummuler qu'une fois en multiprocessors dans le cas moving
         IF(ISPMD+1 == PMAIN.OR. MSR == 0) THEN
@@ -529,9 +527,9 @@ C test  pour ne cummuler qu'une fois en multiprocessors dans le cas moving
           FOPT(3)=FOPT(3)+RWL(19)
         END IF
       ELSE
-        RWL(17)=RWL(17)+(FXN+FXT)/DT12
-        RWL(18)=RWL(18)+(FYN+FYT)/DT12
-        RWL(19)=RWL(19)+(FZN+FZT)/DT12
+        RWL(17)=RWL(17)+(FXN+FXT)*DIVDT12
+        RWL(18)=RWL(18)+(FYN+FYT)*DIVDT12
+        RWL(19)=RWL(19)+(FZN+FZT)*DIVDT12
         RWL(20)=RWL(20)+XMT
 C test pour ne cummuler qu'une fois en multiprocessors dans le cas moving
         IF(ISPMD+1 == PMAIN.OR. MSR == 0) THEN
@@ -541,9 +539,9 @@ C test pour ne cummuler qu'une fois en multiprocessors dans le cas moving
          FSAV(4)=FSAV(4)+FXT
          FSAV(5)=FSAV(5)+FYT
          FSAV(6)=FSAV(6)+FZT
-         FOPT(1)=FOPT(1)+(FXN+FXT)/DT12
-         FOPT(2)=FOPT(2)+(FYN+FYT)/DT12
-         FOPT(3)=FOPT(3)+(FZN+FZT)/DT12
+         FOPT(1)=FOPT(1)+(FXN+FXT)*DIVDT12
+         FOPT(2)=FOPT(2)+(FYN+FYT)*DIVDT12
+         FOPT(3)=FOPT(3)+(FZN+FZT)*DIVDT12
         END IF
       END IF
 C

--- a/engine/source/constraints/general/rwall/rgwall.F
+++ b/engine/source/constraints/general/rwall/rgwall.F
@@ -55,27 +55,20 @@ C-----------------------------------------------
       INTEGER NSN, ITIED, MSR,ICONT,IMP_S,NT_RW
       INTEGER NSW(*), WEIGHT(*),IDDL(*),IKC(*),NDOF(*), NODNX_SMS(*)
       INTEGER WEIGHT_MD(*)
-C     REAL ou REAL*8
-      my_real
-     .   X(*), A(*), V(*), RWL(*), MS(*), RWSAV(*)
-      DOUBLE PRECISION 
-     .   FRWL6(7,6)
+      my_real X(*), A(*), V(*), RWL(*), MS(*), RWSAV(*)
+      DOUBLE PRECISION FRWL6(7,6)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER M3, M2, M1, I, N, N3, N2, N1,NINDEX, IFQ, J, K, JJ,
      .        INDEX(NSN)
-
-C     REAL ou REAL*8
-      my_real
-     .   XWL, YWL, ZWL, VXW, VYW, VZW, TFXTN, FACT,
+      my_real XWL, YWL, ZWL, VXW, VYW, VZW, TFXTN, FACT,
      .   TFXT, VX, VY, VZ, UX, UY, UZ, XC, YC, ZC, DP, DV, DA, DVT,
      .   FNXN, FNYN, FNZN, FNXT, FNYT, FNZT, FNDFN, FTDFT, FRIC, FRIC2,
      .   FCOE,MSW,FAC,ALPHA,ALPHI,
      .   F1(NSN), F2(NSN), F3(NSN), F4(NSN), F5(NSN), F6(NSN), F7(NSN),
      .   TFXT2, TFXTN2, WEWE2
-      DOUBLE PRECISION 
-     .   FRWL6_L(7,6)
+      DOUBLE PRECISION FRWL6_L(7,6)
 C-----------------------------------------------
       IF(IDTMINS==0.AND.IDTMINS_INT==0)THEN
 C-------------
@@ -90,7 +83,7 @@ C------------
 !       ICONT to 0
 !       ICONT is a shared variable 
 C
-        IF(MSR.EQ.0)THEN
+        IF(MSR == 0)THEN
          XWL=RWL(4)
          YWL=RWL(5)
          ZWL=RWL(6)
@@ -141,9 +134,10 @@ C
               CYCLE              
             END IF
             ICONT=1
-C---        test pour noeuds penetres
-            IF((VX-VXW)*RWL(1)+(VY-VYW)*RWL(2)+(VZ-VZW)*RWL(3) > ZERO)
-     .        CYCLE
+C---        test for penetrated nodes
+            IF((VX-VXW)*RWL(1)+(VY-VYW)*RWL(2)+(VZ-VZW)*RWL(3) > ZERO)THEN
+              CYCLE
+            ENDIF
             NINDEX = NINDEX+1
             INDEX(NINDEX) = I
           END DO
@@ -168,8 +162,9 @@ C---        test pour noeuds penetres
             IF(DP > ZERO) CYCLE
             ICONT=1
 C---        test pour noeuds penetres
-            IF((VX-VXW)*RWL(1)+(VY-VYW)*RWL(2)+(VZ-VZW)*RWL(3) > ZERO)
-     .        CYCLE
+            IF((VX-VXW)*RWL(1)+(VY-VYW)*RWL(2)+(VZ-VZW)*RWL(3) > ZERO)THEN
+              CYCLE
+            ENDIF
             NINDEX = NINDEX+1
             INDEX(NINDEX) = I
           END DO
@@ -187,7 +182,7 @@ C-----------------
 !       ICONT to 0
 !       ICONT is a shared variable 
 C
-        IF(MSR.EQ.0)THEN
+        IF(MSR == 0)THEN
          XWL=RWL(4)
          YWL=RWL(5)
          ZWL=RWL(6)
@@ -241,8 +236,9 @@ C
             ENDIF
             ICONT=1
 C---        test pour noeuds penetres
-            IF((VX-VXW)*RWL(1)+(VY-VYW)*RWL(2)+(VZ-VZW)*RWL(3) > ZERO)
-     .        CYCLE
+            IF((VX-VXW)*RWL(1)+(VY-VYW)*RWL(2)+(VZ-VZW)*RWL(3) > ZERO)THEN
+              CYCLE
+            ENDIF
             NINDEX = NINDEX+1
             INDEX(NINDEX) = I
           END DO
@@ -266,22 +262,28 @@ C
             YC=UY-YWL
             ZC=UZ-ZWL
             DP=XC*RWL(1)+YC*RWL(2)+ZC*RWL(3)
-            IF(DP.GT.ZERO) CYCLE
+            IF(DP > ZERO) CYCLE
             ICONT=1
 C---        test pour noeuds penetres
-            IF((VX-VXW)*RWL(1)+(VY-VYW)*RWL(2)+(VZ-VZW)*RWL(3) > ZERO)
-     .        CYCLE
+            IF((VX-VXW)*RWL(1)+(VY-VYW)*RWL(2)+(VZ-VZW)*RWL(3) > ZERO)THEN
+              CYCLE
+            ENDIF
             NINDEX = NINDEX+1
             INDEX(NINDEX) = I
           END DO
 !$OMP END DO
         ENDIF
       ENDIF
-C-----------------     
-      FACT=UN/DT12
-      IF(ITIED.EQ.0)THEN
+C-----------------
+      IF(DT12 /= ZERO)THEN
+        FACT=UN/DT12
+      ELSE
+        FACT = ZERO
+      ENDIF
+      
+      IF(ITIED == 0)THEN
 C
-       DO 40 J = 1,NINDEX
+       DO J = 1,NINDEX
         I = INDEX(J)
         N=NSW(I)
         N3=3*N
@@ -296,11 +298,9 @@ C
         FNXN=DVT*RWL(1)
         FNYN=DVT*RWL(2)
         FNZN=DVT*RWL(3)
-        TFXTN = TFXTN - WEIGHT_MD(N)*FACT*
-     .  ((V(N1)-VXW)*FNXN+(V(N2)-VYW)*FNYN+(V(N3)-VZW)*FNZN)
+        TFXTN = TFXTN - WEIGHT_MD(N)*FACT*((V(N1)-VXW)*FNXN+(V(N2)-VYW)*FNYN+(V(N3)-VZW)*FNZN)
         WEWE2 = (1-WEIGHT_MD(N))*WEIGHT(N)     
-        TFXTN2 = TFXTN2 - WEWE2*FACT*
-     .  ((V(N1)-VXW)*FNXN+(V(N2)-VYW)*FNYN+(V(N3)-VZW)*FNZN)        
+        TFXTN2 = TFXTN2 - WEWE2*FACT*((V(N1)-VXW)*FNXN+(V(N2)-VYW)*FNYN+(V(N3)-VZW)*FNZN)        
         F1(J) = FNXN*WEIGHT_MD(N)
         F2(J) = FNYN*WEIGHT_MD(N)
         F3(J) = FNZN*WEIGHT_MD(N)
@@ -314,12 +314,12 @@ C
         V(N1)=V(N1)-DV*RWL(1)
         V(N2)=V(N2)-DV*RWL(2)
         V(N3)=V(N3)-DV*RWL(3)
-        IF(IMP_S.EQ.1) V(N1) = -DV
- 40    CONTINUE
+        IF(IMP_S == 1) V(N1) = -DV
+       ENDDO
 C
-      ELSEIF(ITIED.EQ.1)THEN
+      ELSEIF(ITIED == 1)THEN
 C
-       DO 60 J = 1,NINDEX
+       DO J = 1,NINDEX
         I = INDEX(J)
         N=NSW(I)
         N3=3*N
@@ -334,11 +334,9 @@ C
         FNXN=DVT*RWL(1)
         FNYN=DVT*RWL(2)
         FNZN=DVT*RWL(3)
-        TFXTN = TFXTN - WEIGHT_MD(N)*FACT*
-     .  ((V(N1)-VXW)*FNXN+(V(N2)-VYW)*FNYN+(V(N3)-VZW)*FNZN)
+        TFXTN = TFXTN - WEIGHT_MD(N)*FACT*((V(N1)-VXW)*FNXN+(V(N2)-VYW)*FNYN+(V(N3)-VZW)*FNZN)
         WEWE2 = (1-WEIGHT_MD(N))*WEIGHT(N)
-        TFXTN2 = TFXTN2 - WEWE2*FACT*
-     .  ((V(N1)-VXW)*FNXN+(V(N2)-VYW)*FNYN+(V(N3)-VZW)*FNZN)        
+        TFXTN2 = TFXTN2 - WEWE2*FACT*((V(N1)-VXW)*FNXN+(V(N2)-VYW)*FNYN+(V(N3)-VZW)*FNZN)        
            F1(J) = FNXN*WEIGHT_MD(N)
            F2(J) = FNYN*WEIGHT_MD(N)
            F3(J) = FNZN*WEIGHT_MD(N)
@@ -356,15 +354,15 @@ C
         F5(J) = FNXT*WEIGHT_MD(N)
         F6(J) = FNYT*WEIGHT_MD(N)
         F7(J) = FNZT*WEIGHT_MD(N)
- 60    CONTINUE
+       ENDDO
 C
       ELSE
 C
-       IF (IFQ.GT.0.) THEN
+       IF (IFQ > 0.) THEN
 C---     friction filtering
          FRIC = RWL(13)
          ALPHA= RWL(14)
-         IF (IFQ.EQ.3) ALPHA = ALPHA * DT12
+         IF (IFQ == 3) ALPHA = ALPHA * DT12
          ALPHI = UN - ALPHA
          FRIC2 = FRIC**2
          DO J = 1,NINDEX
@@ -380,11 +378,9 @@ C---     friction filtering
            FNXN=DVT*RWL(1)
            FNYN=DVT*RWL(2)
            FNZN=DVT*RWL(3)
-           TFXTN = TFXTN - WEIGHT_MD(N)*FACT*
-     .     ((V(N1)-VXW)*FNXN+(V(N2)-VYW)*FNYN+(V(N3)-VZW)*FNZN)
+           TFXTN = TFXTN - WEIGHT_MD(N)*FACT*((V(N1)-VXW)*FNXN+(V(N2)-VYW)*FNYN+(V(N3)-VZW)*FNZN)
            WEWE2 = (1-WEIGHT_MD(N))*WEIGHT(N)
-           TFXTN2 = TFXTN2 - WEWE2*FACT*
-     .     ((V(N1)-VXW)*FNXN+(V(N2)-VYW)*FNYN+(V(N3)-VZW)*FNZN)           
+           TFXTN2 = TFXTN2 - WEWE2*FACT*((V(N1)-VXW)*FNXN+(V(N2)-VYW)*FNYN+(V(N3)-VZW)*FNZN)           
            F1(J) = FNXN*WEIGHT_MD(N)
            F2(J) = FNYN*WEIGHT_MD(N)
            F3(J) = FNZN*WEIGHT_MD(N)
@@ -400,7 +396,7 @@ C---       filter
 C---
            FNDFN=FNXN**2+FNYN**2+FNZN**2
            FTDFT=FNXT**2+FNYT**2+FNZT**2
-           IF (FNDFN.EQ.0) THEN
+           IF (FNDFN == 0) THEN
              RWSAV(K)   = ZERO
              RWSAV(K+1) = ZERO
              RWSAV(K+2) = ZERO
@@ -413,22 +409,23 @@ C---
            FNXT=FCOE*FNXT
            FNYT=FCOE*FNYT
            FNZT=FCOE*FNZT
-           FAC=1./(DT12*MS(N))
+           FAC = DT12*MS(N)
+           IF(FAC /= ZERO)THEN
+             FAC=UN/FAC
+           ENDIF
            A(N1)=A(N1)-(DA*RWL(1)+FNXT*FAC)
            A(N2)=A(N2)-(DA*RWL(2)+FNYT*FAC)
            A(N3)=A(N3)-(DA*RWL(3)+FNZT*FAC)
            V(N1)=V(N1)-DV*RWL(1)
            V(N2)=V(N2)-DV*RWL(2)
            V(N3)=V(N3)-DV*RWL(3)
-           TFXT = TFXT - WEIGHT_MD(N)*
-     .     ((V(N1)-VXW)*FNXT+(V(N2)-VYW)*FNYT+(V(N3)-VZW)*FNZT)
+           TFXT = TFXT - WEIGHT_MD(N)*((V(N1)-VXW)*FNXT+(V(N2)-VYW)*FNYT+(V(N3)-VZW)*FNZT)
            WEWE2 = (1-WEIGHT_MD(N))*WEIGHT(N)
-           TFXT2 = TFXT2 - WEWE2*
-     .     ((V(N1)-VXW)*FNXT+(V(N2)-VYW)*FNYT+(V(N3)-VZW)*FNZT)           
+           TFXT2 = TFXT2 - WEWE2*((V(N1)-VXW)*FNXT+(V(N2)-VYW)*FNYT+(V(N3)-VZW)*FNZT)           
            F5(J) = FNXT*WEIGHT_MD(N)
            F6(J) = FNYT*WEIGHT_MD(N)
            F7(J) = FNZT*WEIGHT_MD(N)
-           IF(IMP_S.EQ.1) V(N1) = -DV
+           IF(IMP_S == 1) V(N1) = -DV
          ENDDO
        ELSE
 C---     no friction filtering
@@ -447,14 +444,12 @@ C---     no friction filtering
            FNXN=DVT*RWL(1)
            FNYN=DVT*RWL(2)
            FNZN=DVT*RWL(3)
-           TFXTN = TFXTN - WEIGHT_MD(N)*FACT*
-     .     ((V(N1)-VXW)*FNXN+(V(N2)-VYW)*FNYN+(V(N3)-VZW)*FNZN)
+           TFXTN = TFXTN - WEIGHT_MD(N)*FACT*((V(N1)-VXW)*FNXN+(V(N2)-VYW)*FNYN+(V(N3)-VZW)*FNZN)
            WEWE2 = (1-WEIGHT_MD(N))*WEIGHT(N) 
            FNXT=((V(N1)-VXW)+A(N1)*DT12)*MS(N)-FNXN
            FNYT=((V(N2)-VYW)+A(N2)*DT12)*MS(N)-FNYN
            FNZT=((V(N3)-VZW)+A(N3)*DT12)*MS(N)-FNZN  
-           TFXTN2 = TFXTN2 - WEWE2*
-     .     ((V(N1)-VXW)*FNXT+(V(N2)-VYW)*FNYT+(V(N3)-VZW)*FNZT)
+           TFXTN2 = TFXTN2 - WEWE2*((V(N1)-VXW)*FNXT+(V(N2)-VYW)*FNYT+(V(N3)-VZW)*FNZT)
            F1(J) = FNXN*WEIGHT_MD(N)
            F2(J) = FNYN*WEIGHT_MD(N)
            F3(J) = FNZN*WEIGHT_MD(N)
@@ -462,7 +457,7 @@ C---     no friction filtering
            FNDFN=FNXN**2+FNYN**2+FNZN**2
            FTDFT=FNXT**2+FNYT**2+FNZT**2
 C
-           IF(FTDFT.LE.FRIC2*FNDFN) THEN
+           IF(FTDFT <= FRIC2*FNDFN) THEN
 C---         tied secnd point
              A(N1)=ZERO
              A(N2)=ZERO
@@ -470,12 +465,12 @@ C---         tied secnd point
              V(N1)=VXW
              V(N2)=VYW
              V(N3)=VZW
-            IF (IMP_S.EQ.1) THEN
-               IF (NDOF(N).GT.0) THEN
+            IF (IMP_S == 1) THEN
+               IF (NDOF(N) > 0) THEN
                  JJ=IDDL(N)+1
-                 IF (IKC(JJ).EQ.0)IKC(JJ)=3
-                 IF (IKC(JJ+1).EQ.0)IKC(JJ+1)=3
-                 IF (IKC(JJ+2).EQ.0)IKC(JJ+2)=3
+                 IF (IKC(JJ) == 0)IKC(JJ)=3
+                 IF (IKC(JJ+1) == 0)IKC(JJ+1)=3
+                 IF (IKC(JJ+2) == 0)IKC(JJ+2)=3
                ENDIF
             ENDIF 
            ELSE
@@ -485,27 +480,26 @@ C---         sliding secnd point
              FNYT=FCOE*FNYT
              FNZT=FCOE*FNZT
              FAC=UN/(DT12*MS(N))
+             
              A(N1)=A(N1)-(DA*RWL(1)+FNXT*FAC)
              A(N2)=A(N2)-(DA*RWL(2)+FNYT*FAC)
              A(N3)=A(N3)-(DA*RWL(3)+FNZT*FAC)
              V(N1)=V(N1)-DV*RWL(1)
              V(N2)=V(N2)-DV*RWL(2)
              V(N3)=V(N3)-DV*RWL(3)
-             IF (IMP_S.EQ.1) THEN
-              IF (NDOF(N).GT.0) THEN
+             IF (IMP_S == 1) THEN
+              IF (NDOF(N) > 0) THEN
                 V(N1)=-DV
                 A(N1)=RWL(1)
                 A(N2)=RWL(2)
                 A(N3)=RWL(3)    
                 JJ=IDDL(N)+1
-                IF (IKC(JJ).EQ.0)IKC(JJ)=10
+                IF (IKC(JJ) == 0)IKC(JJ)=10
               ENDIF
              ENDIF 
-             TFXT = TFXT - WEIGHT_MD(N)*
-     .        ((V(N1)-VXW)*FNXT+(V(N2)-VYW)*FNYT+(V(N3)-VZW)*FNZT)
+             TFXT = TFXT - WEIGHT_MD(N)*((V(N1)-VXW)*FNXT+(V(N2)-VYW)*FNYT+(V(N3)-VZW)*FNZT)
              WEWE2 = (1-WEIGHT_MD(N))*WEIGHT(N)
-             TFXT2 = TFXT2 - WEWE2*
-     .        ((V(N1)-VXW)*FNXT+(V(N2)-VYW)*FNYT+(V(N3)-VZW)*FNZT)
+             TFXT2 = TFXT2 - WEWE2*((V(N1)-VXW)*FNXT+(V(N2)-VYW)*FNYT+(V(N3)-VZW)*FNZT)
            ENDIF
            F5(J) = FNXT*WEIGHT_MD(N)
            F6(J) = FNYT*WEIGHT_MD(N)
@@ -514,7 +508,7 @@ C---         sliding secnd point
        ENDIF
       ENDIF
 C
-      IF(IMCONV.EQ.1)THEN
+      IF(IMCONV == 1)THEN
           TFXT=TFXT+UNDEMI*DT1*TFXTN
           TFXT2=TFXT2+UNDEMI*DT1*TFXTN2
 #include "atomic.inc"
@@ -551,23 +545,23 @@ C
 #include "lockoff.inc"
       ENDIF
 C  
-      IF (IMP_S.EQ.1) THEN
-        IF(ITIED.EQ.1)THEN
+      IF (IMP_S == 1) THEN
+        IF(ITIED == 1)THEN
           DO J=1,NINDEX
            I = INDEX(J)
            N=NSW(I)
-           IF (NDOF(N).GT.0) THEN
+           IF (NDOF(N) > 0) THEN
            JJ=IDDL(N)+1
-           IF (IKC(JJ).EQ.0)IKC(JJ)=3
-           IF (IKC(JJ+1).EQ.0)IKC(JJ+1)=3
-           IF (IKC(JJ+2).EQ.0)IKC(JJ+2)=3
+           IF (IKC(JJ) == 0)IKC(JJ)=3
+           IF (IKC(JJ+1) == 0)IKC(JJ+1)=3
+           IF (IKC(JJ+2) == 0)IKC(JJ+2)=3
            ENDIF 
           ENDDO
-        ELSEIF(ITIED.EQ.0.OR.IFQ.GT.0)THEN
+        ELSEIF(ITIED == 0.OR.IFQ > 0)THEN
           DO J=1,NINDEX
            I = INDEX(J)
            N=NSW(I)
-           IF (NDOF(N).GT.0) THEN
+           IF (NDOF(N) > 0) THEN
            N3=3*N
            N2=N3-1
            N1=N2-1
@@ -575,7 +569,7 @@ C
            A(N2)=RWL(2)
            A(N3)=RWL(3)    
            JJ=IDDL(N)+1
-           IF (IKC(JJ).EQ.0)IKC(JJ)=10
+           IF (IKC(JJ) == 0)IKC(JJ)=10
            ENDIF 
           ENDDO
         ELSE
@@ -584,7 +578,7 @@ C--------c'est fait avant-------
           DO J=1,NINDEX
            I = INDEX(J)
            N=NSW(I)
-           IF (NDOF(N).GT.0) THEN
+           IF (NDOF(N) > 0) THEN
 C to be uncommented the day it is parallel in implicit
 #include "atomic.inc"
              NT_RW = NT_RW + 1


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [x] Only one commit (please squash your commits) 
- [x] No merge commits (use git pull --rebase) 
- [x] The changes satisfy the DOS and DONTS of the README.md file

<!------ Provide a general summary of your changes in the Title above -->
#### RWALL:Fixing SIGFPE during Engine
<!--- Describe the problem, ideally from the user viewpoint -->


#### Floating point exceptions occured during engine at cycle 0 were fixed (occured with "debug" compiling).  It was related to DT12 value which was 0.0 and was used to divide in rigid walls subroutines. A conditionnal test was introduced to prevent from any division by zero. "/DT12" was replaced with "*DIVDT12"
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

<!--- If there is a design document, link to it here ->


