### PR TITLE
bug of npt w/ thick-shell composite(type22) when law1 is used in /PART

### DIFF
--- a/starter/source/elements/initia/initia.F
+++ b/starter/source/elements/initia/initia.F
@@ -3555,6 +3555,8 @@ C-------this is done in ENGINE, should be done in Starter
            ENDIF  
 c-----          
            IF (IGTYP==22.AND.IHBE==14 ) THEN
+C------  IPARG(6,NG)= NPG after elbuf_ini          
+             NPT =MAX(NPT,IGEO(4,IPID))
              ICSTR = IPARG(17,NG)
              SELECT CASE (ICSTR)
               CASE(100)                                             

--- a/starter/source/elements/solid/solide/sgrtails.F
+++ b/starter/source/elements/solid/solide/sgrtails.F
@@ -693,7 +693,7 @@ c
             IF(NPT ==  0) NPT = 3
             IF(MLN == 1 .AND. NPT /= 1) NPT = 2
           ENDIF
-          IF(JHBE==14 .AND. MLN==1) NPT = 222
+          IF(JHBE==14 .AND. MLN==1.AND.IGT /= 22) NPT = 222
 C
           JALE=NINT(PM(72,MID))
           JLAG=0


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [x] Only one commit (please squash your commits) 
- [x] No merge commits (use git pull --rebase) 
- [x] The changes satisfy the DOS and DONTS of the README.md file

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
when law1 is defined in /PART with thick-shell composite(TYPE22), npt is wrongly fixed to 2x2x2 for Isolid=14
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

<!--- If there is a design document, link to it here ->


