### PR TITLE
/MAT/LAW51:introduce mixture viscosity + source cleaning

### DIFF
--- a/engine/source/materials/mat/mat051/sigeps51.F
+++ b/engine/source/materials/mat/mat051/sigeps51.F
@@ -1,25 +1,25 @@
 Copyright>        OpenRadioss
 Copyright>        Copyright (C) 1986-2022 Altair Engineering Inc.
-Copyright>    
+Copyright>
 Copyright>        This program is free software: you can redistribute it and/or modify
 Copyright>        it under the terms of the GNU Affero General Public License as published by
 Copyright>        the Free Software Foundation, either version 3 of the License, or
 Copyright>        (at your option) any later version.
-Copyright>    
+Copyright>
 Copyright>        This program is distributed in the hope that it will be useful,
 Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
 Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 Copyright>        GNU Affero General Public License for more details.
-Copyright>    
+Copyright>
 Copyright>        You should have received a copy of the GNU Affero General Public License
 Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
-Copyright>    
-Copyright>    
-Copyright>        Commercial Alternative: Altair Radioss Software 
-Copyright>    
-Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss 
-Copyright>        software under a commercial license.  Contact Altair to discuss further if the 
-Copyright>        commercial version may interest you: https://www.altair.com/radioss/.    
+Copyright>
+Copyright>
+Copyright>        Commercial Alternative: Altair Radioss Software
+Copyright>
+Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
 Chd|====================================================================
 Chd|  SIGEPS51                      source/materials/mat/mat051/sigeps51.F
 Chd|-- called by -----------
@@ -34,7 +34,7 @@ Chd|        M51VOIS2                      source/materials/mat/mat051/m51vois2.F
 Chd|        M51VOIS3                      source/materials/mat/mat051/m51vois3.F
 Chd|        POLY51                        source/materials/mat/mat051/polynomial51.F
 Chd|        POLYUN51                      source/materials/mat/mat051/polynomial51.F
-Chd|        FINTER                        source/tools/curve/finter.F   
+Chd|        FINTER                        source/tools/curve/finter.F
 Chd|        ALE_CONNECTIVITY_MOD          ../common_source/modules/ale_connectivity_mod.F
 Chd|        ELBUFDEF_MOD                  ../common_source/modules/elbufdef_mod.F
 Chd|        I22BUFBRIC_MOD                ../common_source/modules/cut-cell-search_mod.F
@@ -43,7 +43,7 @@ Chd|====================================================================
       SUBROUTINE SIGEPS51 (
      1     NEL    ,NUPARAM,NUVAR   ,NFUNC   ,IFUNC    ,
      2     NPF    ,TF     ,TIME    ,TIMESTEP,UPARAM   ,NUMEL  ,
-     3     RHO0   ,RHO    ,VOLUME  ,EINT    ,SIGY     ,VEL_O  , 
+     3     RHO0   ,RHO    ,VOLUME  ,EINT    ,SIGY     ,VEL_O  ,
      4     EPSPXX ,EPSPYY ,EPSPZZ  ,EPSPXY  ,EPSPYZ   ,EPSPZX ,
      5     DEPSXX ,DEPSYY ,DEPSZZ  ,DEPSXY  ,DEPSYZ   ,DEPSZX ,
      6     EPSXX  ,EPSYY  ,EPSZZ   ,EPSXY   ,EPSYZ    ,EPSZX  ,
@@ -52,19 +52,19 @@ Chd|====================================================================
      9     SIGVXX ,SIGVYY ,SIGVZZ  ,SIGVXY  ,SIGVYZ   ,SIGVZX ,
      A     SOUNDSP,VISCMAX,UVAR    ,OFF     ,NFT      ,V      ,
      B     W      ,X      ,IX      ,N48     ,NIX      ,JTHE   ,
-     C     GEO    ,PID    ,ILAY    ,NG      ,ELBUF_TAB,PM     , 
+     C     GEO    ,PID    ,ILAY    ,NG      ,ELBUF_TAB,PM     ,
      D     IPARG  ,ALE_CONNECT  ,BUFVOIS ,IPM     ,BUFMAT   ,STIFN  ,
      E     VD2    ,VDX    ,VDY     ,VDZ     ,MAT      ,TAG22  ,
-     F     QVIS   , DDVOL ,QQOLD   ,NV46)  
+     F     QVIS   , DDVOL ,QQOLD   ,NV46)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
-      USE ELBUFDEF_MOD   
+      USE ELBUFDEF_MOD
       USE I22BUFBRIC_MOD
-      USE I22TRI_MOD       
+      USE I22TRI_MOD
       USE ALE_CONNECTIVITY_MOD
 ! ARTIFICIAL VISCO :  EPSPXX ,EPSPYY ,EPSPZZ  ,EPSPXY  ,EPSPYZ  ,EPSPZX ,
-! NON UTILISE      :  EPSXX  ,EPSYY  ,EPSZZ   ,EPSXY   ,EPSYZ   ,EPSZX  
+! NON UTILISE      :  EPSXX  ,EPSYY  ,EPSZZ   ,EPSXY   ,EPSYZ   ,EPSZX
 ! PLASTICITY       :  DEPSXX ,DEPSYY ,DEPSZZ  ,DEPSXY  ,DEPSYZ  ,DEPSZX ,
 !EINT    : BUFLY%LBUF
 !VOLUME  : BUFLY%LBUF
@@ -84,14 +84,14 @@ C-----------------------------------------------
 C---------+---------+---+---+--------------------------------------------
 C VAR     | SIZE    |TYP| RW| DEFINITION
 C---------+---------+---+---+--------------------------------------------
-C NEL     |  1      | I | R | SIZE OF THE ELEMENT GROUP NEL 
+C NEL     |  1      | I | R | SIZE OF THE ELEMENT GROUP NEL
 C NUPARAM |  1      | I | R | SIZE OF THE USER PARAMETER ARRAY
 C NUVAR   |  1      | I | R | NUMBER OF USER ELEMENT VARIABLES
 C---------+---------+---+---+--------------------------------------------
 C NFUNC   |  1      | I | R | NUMBER FUNCTION USED FOR THIS USER LAW
-C IFUNC   | NFUNC   | I | R | FUNCTION INDEX 
-C NPF     |  *      | I | R | FUNCTION ARRAY   
-C TF      |  *      | F | R | FUNCTION ARRAY 
+C IFUNC   | NFUNC   | I | R | FUNCTION INDEX
+C NPF     |  *      | I | R | FUNCTION ARRAY
+C TF      |  *      | F | R | FUNCTION ARRAY
 C---------+---------+---+---+--------------------------------------------
 C TIME    |  1      | F | R | CURRENT TIME
 C TIMESTEP|  1      | F | R | CURRENT TIME STEP
@@ -109,9 +109,9 @@ C ...     |         |   |   |
 C EPSXX   | NEL     | F | R | STRAIN XX
 C EPSYY   | NEL     | F | R | STRAIN YY
 C ...     |         |   |   |
-C SIGOXX  | NEL     | F | R | OLD ELASTO PLASTIC STRESS XX 
+C SIGOXX  | NEL     | F | R | OLD ELASTO PLASTIC STRESS XX
 C SIGOYY  | NEL     | F | R | OLD ELASTO PLASTIC STRESS YY
-C ...     |         |   |   |    
+C ...     |         |   |   |
 C---------+---------+---+---+--------------------------------------------
 C SIGNXX  | NEL     | F | W | NEW ELASTO PLASTIC STRESS XX
 C SIGNYY  | NEL     | F | W | NEW ELASTO PLASTIC STRESS YY
@@ -132,17 +132,17 @@ C          UVAR(2) = PLAS  !post
 C          UVAR(3) = BFRAC !post
 C phase k  dim=NVPHAS
 C          IAD = N0PHAS+(k-1)*NVPHAS
-c          UVAR(1 + IAD) = AVk                 (EV(NB10) +12k) 
-C          UVAR(2 + IAD) = SIGxk  
-C          UVAR(3 + IAD) = SIGyk 
-C          UVAR(4 + IAD) = SIGzk 
-C          UVAR(5 + IAD) = SIGxyk 
+c          UVAR(1 + IAD) = AVk                 (EV(NB10) +12k)
+C          UVAR(2 + IAD) = SIGxk
+C          UVAR(3 + IAD) = SIGyk
+C          UVAR(4 + IAD) = SIGzk
+C          UVAR(5 + IAD) = SIGxyk
 C          UVAR(6 + IAD) = SIGyzk
-C          UVAR(7 + IAD) = SIGzxk 
+C          UVAR(7 + IAD) = SIGzxk
 C          UVAR(8 + IAD) = EINTk              ! energie IN rho e OUT
 C          UVAR(9 + IAD) = RHOk0 * VOLUMk     ! masse IN rho OUT
 C          UVAR(10+ IAD) = Qk
-C          UVAR(11+ IAD) = VOLUMEk 
+C          UVAR(11+ IAD) = VOLUMEk
 C          UVAR(12+ IAD) = RHO
 C          UVAR(13+ IAD) = DDVOL
 C          UVAR(14+ IAD) = SSP
@@ -174,7 +174,7 @@ C
       INTEGER NEL, NUPARAM, NUVAR,NFT,N48,NIX,JTHE,NUMEL,
      .        IX(NIX,NUMEL), PID(NEL), ILAY, NG,IPARG(SIPARG),MAT(NEL),
      .        IPM(NPROPMI,NUMMAT),NV46
-      my_real 
+      my_real
      .   TIME,TIMESTEP,UPARAM(NUPARAM),SIGY(NEL),VK(NEL),PM(NPROPM,NUMMAT),
      .   RHO(NEL),RHO0(NEL),VOLUME(NEL),EINT(NEL),BUFVOIS(*),QVIS(NEL),DDVOL(NEL),QQOLD(NEL),
      .   EPSPXX(NEL),EPSPYY(NEL),EPSPZZ(NEL),
@@ -199,11 +199,11 @@ C-----------------------------------------------
      .    SIGVXY(NEL),SIGVYZ(NEL),SIGVZX(NEL),
      .    SOUNDSP(NEL),VISCMAX(NEL)
 C-----------------------------------------------
-C   I N P U T   O U T P U T   A r g u m e n t s 
+C   I N P U T   O U T P U T   A r g u m e n t s
 C-----------------------------------------------
       my_real UVAR(NEL,NUVAR), OFF(NEL)
 C-----------------------------------------------
-C   VARIABLES FOR FUNCTION INTERPOLATION 
+C   VARIABLES FOR FUNCTION INTERPOLATION
 C-----------------------------------------------
       INTEGER NPF(*), NFUNC, IFUNC(NFUNC)
       my_real FINTER ,TF(*)
@@ -220,18 +220,18 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER, PARAMETER :: IDBG = 0
       INTEGER I,J,K,KK,II,ITER,NITER,ibug,UNEPHASE
-      my_real 
-     .   P,VIS,VIS2,VIS3,VV,PMIN,PEXT,TFEXTT,P0_NRF,P0_NRFv(MVSIZ),DP0,
+      my_real
+     .   P,PEXT,TFEXTT,P0_NRF,P0_NRFv(MVSIZ),DP0,
      .   GG1,GG2,GG3,TC31,TC32,TC33,
      .   C11,C12,C13,C21,C22,C23,C31,C32,C33,C41,C42,C43,C51,C52,C53,
      .   AV1(MVSIZ),AV2(MVSIZ),AV3(MVSIZ),AV4(MVSIZ),RHO10,RHO20,RHO30,RHO40,RHO1,RHO2,RHO3,RHO4,
      .   RHO0E1,RHO0E2,RHO0E3,RHO0E4,RHO1OLD,RHO2OLD,RHO3OLD,RHO4OLD,
      .   MAS1,MAS2,MAS3,MAS4,EINT1,EINT2,EINT3,EINT4,EINT_NEW,EINT_k10,
      .   E1_INF, E2_INF, E3_INF, E4_INF,
-     .   DPDV1,DPDV2,DPDV3,DPDV4,VISV1,VISV2,VISV3,VISV4,
+     .   DPDV1,DPDV2,DPDV3,DPDV4,
      .   P1,P2,P3,P4,P1I,P2I,P3I,P4I,VQ0,VQ1,VQ2,VQ3,VQ4,
-     .   Q0, Q1,Q2,Q3,Q4,Q1OLD,Q2OLD,Q3OLD,Q4OLD,SSP1,SSP2,SSP3,SSP4,SSP(0:4),SSP0(MVSIZ),BETA,
-     .   MU1,MU2,MU3,MU4,MU1OLD,MU2OLD,MU3OLD,MU4OLD, LC(0:4), LC0(MVSIZ),
+     .   Q0, Q1,Q2,Q3,Q4,Q1OLD,Q2OLD,Q3OLD,Q4OLD,SSP1,SSP2,SSP3,SSP4,SSP(0:4),BETA,
+     .   MU1,MU2,MU3,MU4,
      .   MU1P1, MU2P1, MU3P1, MU4P1,
      .   DVDP1,DVDP2,DVDP3,DVDP4,DDVOL1,DDVOL2,DDVOL3,DDVOL4,
      .   V10,V20,V30,V40,V1,V2,V3,V4,V1OLD,V2OLD,V3OLD,V4OLD,
@@ -239,71 +239,67 @@ C-----------------------------------------------
      .   ECOLD1,ECOLD2,ECOLD3,ECOLD4,SPH1,SPH2,SPH3,SPH4,
      .   T10,T20,T30,T40,H1,H2,H3,H4,TEMP1,TEMP2,TEMP3,TEMP4,
      .   XL,QAL,QBL,Q,POLD,QOLD,MASS,
-     .   VISA1,VISB1,VISA2,VISB2,AA,BB,CC,DD,QA,QB,UNDT,
-     .   VOLD,DVOL,DVI,
+     .   VISA1,VISB1,AA,DD,QA,QB,UNDT,
+     .   VOLD,DVOL,
      .   C01,C02,C03,C04,ABCS,DYDX,EDIF1,EDIF2,EDIF3,EDIF4,
-     .   C0,C1,C2,C3,C4,C5,MU,MUOLD,V0,DPDMU,DE(NEL),
-     .   RHOA0,RHO0E,MASA,EINTA,DPDV,DVDP,PM_,GG,DP,AA1,AA2,AA3,
-     .   EEE,AAA,BBB,U,CC1,CC2,CC3,U2,
-     .   TBURN,ECOLD,TBURNI,T,
+     .   V0,DE(NEL),
+     .   AA1,AA2,AA3,
+     .   EEE,AAA,BBB,CC1,CC2,CC3,U2,
+     .   TBURN,ECOLD,T,
      .   VCRT1,VCRT2,VCRT3,U21,U22,U23,GV1,GV2,GV3,RV1,RV2,RV3,
      .   VN,X0,Y0,Z0,VX,VY,VZ,NX,NY,NZ,RHO1A,P1A,E01A,RHO2A,P2A,E02A,
-     .   RHO3A,P3A,E03A, AAA1,AAA2,AAA3,AAA4,FAC, P0(4,MVSIZ),PN, DU,LCAR
-      my_real 
+     .   RHO3A,P3A,E03A,FAC
+      my_real
      .   DEPS(6,MVSIZ),EPD(MVSIZ),
      .   P1OLD(MVSIZ),P2OLD(MVSIZ),P3OLD(MVSIZ),P4OLD(MVSIZ),
      .   SIGD(6,MVSIZ), EINT0(MVSIZ),PLAS1(MVSIZ),PLAS2(MVSIZ),PLAS3(MVSIZ),
-     .   PLA1, PLA2, PLA3,
      .   VOL(MVSIZ), TEMP(MVSIZ),
      .   EPSEQ1(MVSIZ), EPSEQ2(MVSIZ), EPSEQ3(MVSIZ),
-     .   PM5, BFRAC(MVSIZ), ALP(MVSIZ),
-     .   VEL_N(MVSIZ),VEL_O(MVSIZ), VEL(MVSIZ), 
-     .   EIV(0:4,MVSIZ), RHOV(0:4,MVSIZ), PV(0:4,MVSIZ), TV(0:4,MVSIZ),RHO0V(0:4,MVSIZ), 
-     .   AVV(0:4,MVSIZ), RHOC(0:4,MVSIZ),SSPv(0:4,MVSIZ),EPSPv(0:4,MVSIZ),
-     .   RHOC2(4),RHOC20,RHOC2_,ROC,RATIO,
-     .   myVol, alpha, myVAR, PP(MVSIZ), PP0(MVSIZ), PFAR, TAG22(MVSIZ), dbVOLD(4), dbVOLD_f(4), Tol51,
-     .   XL1,XL2,XL3,XL4,QAL1,QAL2,QAL3,QAL4,QBL1,QBL2,QBL3,QBL4,DD2,VISCMAX_tmp,
-     .   TOL, TOL2, ERROR, ERROR2, DRHO1, DRHO2, DRHO3, DRHO4, PII, COEF1, COEF2, COEF3, COEF4, 
-     .   STEP, SS, DPR1, DPR2, DPR3, DPR4,ERROR3,DV1, DV2, DV3, DV4,
-     .   GRUN1, GRUN2, GRUN3, GRUN4, DPR, DSS, DEINT1, DEINT2, DEINT3, DEINT4, DFVOL, 
-     .   DFEINT, DFP1, DFP2, DFP3, DFP4, DFS1, DFS2, DFS3, DFS4, A11,A12,A21,A22,
-     .   EINT1_INI, EINT2_INI, EINT3_INI, EINT4_INI, V1_INI, V2_INI, V3_INI, V4_INI, RHS1, RHS2, DET,
-     .   MATRI(9, 9), TMAT(9, 9), RHS(9), SOL(9), COMPA, ALPHA1OLD, ALPHA2OLD, ALPHA3OLD, ALPHA4OLD,
-     .   DERIVATIVE, RHOOLD, DEINT, SSP1_INI, SSP2_INI, SSP3_INI, SSP4_INI, VFRAC(MVSIZ), MACH,
+     .   PM5, BFRAC(MVSIZ),
+     .   VEL_N(MVSIZ),VEL_O(MVSIZ), VEL(MVSIZ),
+     .   EIV(0:4,MVSIZ), RHOV(0:4,MVSIZ), PV(0:4,MVSIZ), TV(0:4,MVSIZ),RHO0V(0:4,MVSIZ),
+     .   AVV(0:4,MVSIZ), SSPv(0:4,MVSIZ),EPSPv(0:4,MVSIZ),
+     .   RHOC2(4),RHOC20,ROC,
+     .   alpha, myVAR, PP(MVSIZ), PP0(MVSIZ), PFAR, TAG22(MVSIZ), dbVOLD(4), dbVOLD_f(4), Tol51,
+     .   XL1,XL2,XL3,XL4,QAL1,QAL2,QAL3,QAL4,QBL1,QBL2,QBL3,QBL4,DD2,
+     .   TOL, TOL2, ERROR, ERROR2, COEF1, COEF2, COEF3, COEF4,
+     .   STEP, DV1, DV2, DV3, DV4,
+     .   GRUN1, GRUN2, GRUN3, GRUN4,
+     .   EINT1_INI, EINT2_INI, EINT3_INI, EINT4_INI,
+     .   ALPHA1OLD, ALPHA2OLD, ALPHA3OLD, ALPHA4OLD,
+     .   RHOOLD, SSP1_INI, SSP2_INI, SSP3_INI, SSP4_INI, VFRAC(MVSIZ), MACH,
      .   E01f,E02f,E03f,E04f,RHO1f,RHO2f,RHO3f,RHO4f
       my_real :: VEL_IN, MOM
+      my_real :: VISC1, VISC2, VISC3,VISC4
       INTEGER :: IVEL
-      INTEGER :: IDX(9), CONT
+      INTEGER :: CONT
       INTEGER IFLG,IAV1,IAV2,IAV3,IRHO1,IRHO2,IRHO3,IE1,IE2,IE3,IEXP,
      .        IOPT, IPLA, IPLA1, IPLA2, IPLA3,
-     .        ITRIMAT, IOPT10, K1,K2,K3,K4, ISUPERSONIC, IVOI,ML,IFORM,IADBUF
+     .        K1,K2,K3,K4, ISUPERSONIC, IVOI,ML,IFORM,IADBUF
       INTEGER ::
      .   IX1,IX2,IX3,IX4
       my_real ::
-     .   X13, Y13, Z13, X24, Y24, Z24, XN, YN, ZN,  VN1, VN2,
-     .   VN3, VN4, VX1, VX2, VX3, VX4, VY1, VY2, VY3, VY4,
-     .   VZ1, VZ2, VZ3, VZ4  
-      character *10 NAN
-      INTEGER NPH,IPRINT,IBUG_ID(2),ICF3D(4,6), ICF2D(2,4), IAD2
+     .   X13, Y13, Z13, X24, Y24, Z24, XN, YN, ZN
+      INTEGER IBUG_ID(2),ICF3D(4,6), ICF2D(2,4), IAD2
       TYPE(G_BUFEL_)  ,POINTER :: GBUF
-      TYPE(L_BUFEL_)  ,POINTER :: LBUF      
-      TYPE(BUF_LAY_)  ,POINTER :: BUFLY      
+      TYPE(L_BUFEL_)  ,POINTER :: LBUF
+      TYPE(BUF_LAY_)  ,POINTER :: BUFLY
 C
       DATA ICF3D/1,4,3,2,3,4,8,7,5,6,7,8,1,2,6,5,2,3,7,6,1,5,8,4/
       DATA ICF2D/1,2,2,3,3,4,4,1/
 C
-      IF(TIMESTEP.GT.ZERO)THEN
+      IF(TIMESTEP > ZERO)THEN
         UNDT = UN/TIMESTEP
       ELSE
         UNDT = ZERO
       ENDIF
 C
       IBUG_ID(1:2) =  (/0, 0/)
-      
+
       IF(INT22==0)THEN
-        tol51   = EM10 
+        tol51   = EM10
       ELSE
-        tol51   = EM20 
+        tol51   = EM20
       ENDIF
       TOL51 = EM10
 C
@@ -311,12 +307,12 @@ C
       MU1P1  = UN
       MU2P1  = UN
       MU3P1  = UN
-      MU4P1  = UN   
-      
-      GBUF   => ELBUF_TAB(NG)%GBUF           
+      MU4P1  = UN
+
+      GBUF   => ELBUF_TAB(NG)%GBUF
       LBUF   => ELBUF_TAB(NG)%BUFLY(ILAY)%LBUF(1,1,1)
-      BUFLY  => ELBUF_TAB(NG)%BUFLY(ILAY)      
-C      
+      BUFLY  => ELBUF_TAB(NG)%BUFLY(ILAY)
+C
 
 CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 C===============================================================================C
@@ -324,26 +320,25 @@ C                                                                               
 C     LAW51 : TRI MATERIAL LAW & OPTIONNAL HIGH EXPLOSIVE MATERIAL              C
 C                                                                               C
 C      + SOLID, LIQUID, GAS, HE (IFLG==0.or.IFLG==1).and.(IEXP==0.or.IEXP==1)   C
-C      + INLET CONDITIONS (IFLG.EQ.2)                                           C
-C      + OUTLET CONDITIONS (IFLG.EQ.3)                                          C
+C      + INLET CONDITIONS (IFLG == 2)                                           C
+C      + OUTLET CONDITIONS (IFLG == 3)                                          C
 C      + INLET CONDITIONSFLUID STAGNATION PRESSURE   (IFLG == 4.or.IFLG == 5)   C
 C                                                                               C
 CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-C===============================================================================C   
+C===============================================================================C
 C
 C     |===========================================!
 C     | Reading Material Flags Through UPARAM()   !
-C     |===========================================! 
+C     |===========================================!
 
-      VISA1  = UPARAM(1)  !1st Viscosity coefficient : mu
-      VISB1  = UPARAM(3)  !2nd viscosity coeff: lambda    !VISB1 =(VISV1-2.VISA1)/3.
-      !Viscosity is global regarding the element.
-      !VISV1, VISV2, VISV3, VISV4 are currently not used.
-      VISV1  = ZERO
-      VISV2  = ZERO
-      VISV3  = ZERO
-      VISV4  = ZERO
-      
+      VISA1  = UPARAM(1)  !1st global Viscosity coefficient : mu
+      VISB1  = UPARAM(3)  !2nd vglobal iscosity coefficient : lambda    !VISB1 =(VISV1-2.VISA1)/3.
+
+      VISC1 = UPARAM(81) !law 6 paramter when law51 is defined from law6 (iform=12)
+      VISC2 = UPARAM(82)
+      VISC3 = UPARAM(83)
+      VISC4 = UPARAM(84)
+
       !INITIAL volume fraction (in case of inivol, it was updated in Starter)
       K=N0PHAS
       DO I=1,NEL
@@ -362,19 +357,19 @@ C     |===========================================!
         AV4(I)=UVAR(I,K+23)
       ENDDO
 
-      PFAR   = UPARAM(7)  
-      PEXT   = UPARAM(8) 
+      PFAR   = UPARAM(7)
+      PEXT   = UPARAM(8)
 
-      RHO10  = UPARAM(9)  
-      RHO20  = UPARAM(10) 
-      RHO30  = UPARAM(11) 
-      RHO40  = UPARAM(47) 
+      RHO10  = UPARAM(9)
+      RHO20  = UPARAM(10)
+      RHO30  = UPARAM(11)
+      RHO40  = UPARAM(47)
       !This avoid to divide by zero for empty phase
-      IF(RHO10.EQ.ZERO)RHO10=EM20
-      IF(RHO20.EQ.ZERO)RHO20=EM20
-      IF(RHO30.EQ.ZERO)RHO30=EM20
-      IF(RHO40.EQ.ZERO)RHO40=EM20 
-      
+      IF(RHO10 == ZERO)RHO10=EM20
+      IF(RHO20 == ZERO)RHO20=EM20
+      IF(RHO30 == ZERO)RHO30=EM20
+      IF(RHO40 == ZERO)RHO40=EM20
+
       RHO1   = RHO10
       RHO2   = RHO20
       RHO3   = RHO30
@@ -383,19 +378,19 @@ C     |===========================================!
       C11    = UPARAM(12)
       C12    = UPARAM(13)
       C13    = UPARAM(14)
-      
+
       C21    = UPARAM(15)
       C22    = UPARAM(16)
       C23    = UPARAM(17)
-      
+
       C31    = UPARAM(18)
       C32    = UPARAM(20)
       C33    = UPARAM(21)
-      
+
       C41    = UPARAM(22)
       C42    = UPARAM(23)
       C43    = UPARAM(24)
-      
+
       C51    = UPARAM(25)
       C52    = UPARAM(26)
       C53    = UPARAM(27)
@@ -404,88 +399,88 @@ C     |===========================================!
       GG2    = UPARAM(29)
       GG3    = UPARAM(30)
 
-      IFLG   = NINT(UPARAM(31)) 
-      IOPT   = NINT(UPARAM(61)) 
-      IEXP   = NINT(UPARAM(55)) 
-      ALPHA  = UPARAM(62)       
-      
-      IPLA   = NINT(UPARAM(63))      
-      IPLA1  = NINT(UPARAM(64)) 
-      IPLA2  = NINT(UPARAM(65)) 
-      IPLA3  = NINT(UPARAM(66))         
+      IFLG   = NINT(UPARAM(31))
+      IOPT   = NINT(UPARAM(61))
+      IEXP   = NINT(UPARAM(55))
+      ALPHA  = UPARAM(62)
 
-      E01    = UPARAM(32) 
+      IPLA   = NINT(UPARAM(63))
+      IPLA1  = NINT(UPARAM(64))
+      IPLA2  = NINT(UPARAM(65))
+      IPLA3  = NINT(UPARAM(66))
+
+      E01    = UPARAM(32)
       E02    = UPARAM(33)
-      E03    = UPARAM(34) 
-      E04    = UPARAM(48) 
-      
-      C01    = UPARAM(35) 
-      C02    = UPARAM(36) 
-      C03    = UPARAM(37) 
-      C04    = UPARAM(49)      
+      E03    = UPARAM(34)
+      E04    = UPARAM(48)
 
-      PM1    = UPARAM(39) 
-      PM2    = UPARAM(40) 
+      C01    = UPARAM(35)
+      C02    = UPARAM(36)
+      C03    = UPARAM(37)
+      C04    = UPARAM(49)
+
+      PM1    = UPARAM(39)
+      PM2    = UPARAM(40)
       PM3    = UPARAM(41)
       PM4    = UPARAM(56)
-      
+
       E1_INF = UPARAM(57) !E1_INF (t=0) Eint1_INF (t>0)
       E2_INF = UPARAM(58) !E2_INF (t=0) Eint2_INF (t>0)
       E3_INF = UPARAM(59) !E3_INF (t=0) Eint3_INF (t>0)
-      E4_INF = UPARAM(60) !E4_INF (t=0) Eint4_INF (t>0) 
-      
+      E4_INF = UPARAM(60) !E4_INF (t=0) Eint4_INF (t>0)
+
       SPH1   = UPARAM(112)
       SPH2   = UPARAM(162)
       SPH3   = UPARAM(212)
       SPH4   = UPARAM(262)
-      
-      T10    = UPARAM(113) 
-      T20    = UPARAM(163) 
-      T30    = UPARAM(213) 
-      T40    = UPARAM(263) 
+
+      T10    = UPARAM(113)
+      T20    = UPARAM(163)
+      T30    = UPARAM(213)
+      T40    = UPARAM(263)
 
       TC31   = TROIS*C31
       TC32   = TROIS*C32
       TC33   = TROIS*C33
 
       VEL_IN = UPARAM(75)
-            
+
 CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 C===========================================================================C
 C                                                                           C
-C     LAW51 : INLET CONDITIONS (IFLG.EQ.2)                                  C
+C     LAW51 : INLET CONDITIONS (IFLG == 2)                                  C
 C                                                                           C
 CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 C===========================================================================C
 
-      IF(IFLG.EQ.2)THEN
+      IF(IFLG == 2)THEN
         ABCS = TIME / UPARAM(38)
 
-        IAV1  = IFUNC(1) 
+        IAV1  = IFUNC(1)
         IRHO1 = IFUNC(2)
-        IE1   = IFUNC(3) 
-        IAV2  = IFUNC(4) 
-        IRHO2 = IFUNC(5) 
-        IE2   = IFUNC(6) 
-        IAV3  = IFUNC(7) 
-        IRHO3 = IFUNC(8) 
+        IE1   = IFUNC(3)
+        IAV2  = IFUNC(4)
+        IRHO2 = IFUNC(5)
+        IE2   = IFUNC(6)
+        IAV3  = IFUNC(7)
+        IRHO3 = IFUNC(8)
         IE3   = IFUNC(9)
-        IVEL  = IFUNC(10) 
+        IVEL  = IFUNC(10)
 
 
-        IF(IAV1.NE.0)THEN
+        IF(IAV1 /= 0)THEN
           myVAR = FINTER(IAV1,ABCS,NPF,TF,DYDX)
           AV1(1:NEL) = myVAR * AV1(1:NEL)
         ENDIF
-        IF(IAV2.NE.0)THEN
+        IF(IAV2 /= 0)THEN
           myVAR = FINTER(IAV2,ABCS,NPF,TF,DYDX)
           AV2(1:NEL) = myVAR * AV2(1:NEL)
         ENDIF
-        IF(IAV3.NE.0)THEN
+        IF(IAV3 /= 0)THEN
           myVAR = FINTER(IAV3,ABCS,NPF,TF,DYDX)
           AV3(1:NEL) = myVAR * AV3(1:NEL)
-        ENDIF                
-  
+        ENDIF
+
         !rho0,E0,P0,SSP0 in UVAR(20,21,22,24)
 
         !scale factors
@@ -497,40 +492,40 @@ C===========================================================================C
         E02  = UN
         E03  = UN
         E04  = UN
-        IF(IRHO1.NE.0)RHO1 = FINTER(IRHO1,ABCS,NPF,TF,DYDX)
-        IF(IRHO2.NE.0)RHO2 = FINTER(IRHO2,ABCS,NPF,TF,DYDX)
-        IF(IRHO3.NE.0)RHO3 = FINTER(IRHO3,ABCS,NPF,TF,DYDX)
-        IF(IE1.NE.0)E01 = FINTER(IE1,ABCS,NPF,TF,DYDX)
-        IF(IE2.NE.0)E02 = FINTER(IE2,ABCS,NPF,TF,DYDX)
-        IF(IE3.NE.0)E03 = FINTER(IE3,ABCS,NPF,TF,DYDX)
-        IF(IVEL.NE.0)VEL_IN = VEL_IN*FINTER(IVEL,ABCS,NPF,TF,DYDX)
+        IF(IRHO1 /= 0)RHO1 = FINTER(IRHO1,ABCS,NPF,TF,DYDX)
+        IF(IRHO2 /= 0)RHO2 = FINTER(IRHO2,ABCS,NPF,TF,DYDX)
+        IF(IRHO3 /= 0)RHO3 = FINTER(IRHO3,ABCS,NPF,TF,DYDX)
+        IF(IE1 /= 0)E01 = FINTER(IE1,ABCS,NPF,TF,DYDX)
+        IF(IE2 /= 0)E02 = FINTER(IE2,ABCS,NPF,TF,DYDX)
+        IF(IE3 /= 0)E03 = FINTER(IE3,ABCS,NPF,TF,DYDX)
+        IF(IVEL /= 0)VEL_IN = VEL_IN*FINTER(IVEL,ABCS,NPF,TF,DYDX)
 
 
         K1 = N0PHAS
         K2 = N0PHAS+NVPHAS
         K3 = N0PHAS+2*NVPHAS
         K4 = N0PHAS+3*NVPHAS
-        
+
         DO I=1,NEL
           P1=UVAR(I,4)
           P2=UVAR(I,4)
           P3=UVAR(I,4)
           MU1=UVAR(I,K1+20)*RHO1/RHO10 - UN
-          IF(UVAR(I,K1+20).NE.ZERO)THEN
+          IF(UVAR(I,K1+20) /= ZERO)THEN
             P1 = ( C01 + C11*MU1
      .      	   + MAX(MU1,ZERO)*(C21*MU1 + C31*MU1*MU1)
      .      	   + (C41 + C51*MU1)*E01*UVAR(I,K1+21)*RHO10/RHO1/UVAR(I,K1+20) )
           ENDIF
           P1 = MAX(P1,PM1)
           MU2=UVAR(I,K2+20)*RHO2/RHO20 - UN
-          IF(UVAR(I,K2+20).NE.ZERO)THEN
+          IF(UVAR(I,K2+20) /= ZERO)THEN
             P2 = ( C02 + C12*MU2
      .    	   + MAX(MU2,ZERO)*(C22*MU2 + C32*MU2*MU2)
      .    	   + (C42 + C52*MU2)*E02*UVAR(I,K2+21)*RHO20/RHO2/UVAR(I,K2+20) )
           ENDIF
           P2 = MAX(P2,PM2)
           MU3=UVAR(I,K3+20)*RHO3/RHO30 - UN
-          IF(UVAR(I,K3+20).NE.ZERO)THEN
+          IF(UVAR(I,K3+20) /= ZERO)THEN
             P3 = ( C03 + C13*MU3
      .    	   + MAX(MU3,ZERO)*(C23*MU3 + C33*MU3*MU3)
      .    	   + (C43 + C53*MU3)*E03*UVAR(I,K3+21)*RHO30/RHO3/UVAR(I,K3+20) )
@@ -540,128 +535,128 @@ C===========================================================================C
         ENDDO
 
         DO I=1,NEL
-          
+
           UVAR(I,1)  =  ZERO
           UVAR(I,2)  =  ZERO
           UVAR(I,3)  =  ZERO !BFRAC
 
 C         |====================!
 C         |     material 1     !
-C         |====================! 
+C         |====================!
           KK = N0PHAS
-          UVAR(I,1+KK)  = AV1(I)   
-          UVAR(I,2+KK)  = ZERO  
-          UVAR(I,3+KK)  = ZERO  
-          UVAR(I,4+KK)  = ZERO  
-          UVAR(I,5+KK)  = ZERO 
+          UVAR(I,1+KK)  = AV1(I)
+          UVAR(I,2+KK)  = ZERO
+          UVAR(I,3+KK)  = ZERO
+          UVAR(I,4+KK)  = ZERO
+          UVAR(I,5+KK)  = ZERO
           UVAR(I,6+KK)  = ZERO
-          UVAR(I,7+KK)  = ZERO 
-          UVAR(I,8+KK)  = E01*UVAR(I,K1+21)  !E0*AV1              
+          UVAR(I,7+KK)  = ZERO
+          UVAR(I,8+KK)  = E01*UVAR(I,K1+21)  !E0*AV1
           UVAR(I,9+KK)  = RHO1*UVAR(I,K1+20) !RHO1*V1
-          UVAR(I,10+KK) = ZERO     
+          UVAR(I,10+KK) = ZERO
           UVAR(I,11+KK) = VOLUME(I) * AV1(I)
-          UVAR(I,12+KK) = RHO1*UVAR(I,K1+20)  
-          !------------------!  
+          UVAR(I,12+KK) = RHO1*UVAR(I,K1+20)
+          !------------------!
           UVAR(I,13+KK) = ZERO
-          UVAR(I,14+KK) = ZERO 
+          UVAR(I,14+KK) = ZERO
           UVAR(I,15+KK) = ZERO
           UVAR(I,16+KK) = ZERO
-          UVAR(I,17+KK) = ZERO 
+          UVAR(I,17+KK) = ZERO
           UVAR(I,18+KK) = ZERO
-          UVAR(I,19+KK) = ZERO  
+          UVAR(I,19+KK) = ZERO
 
 C         |====================!
 C         |     material 2     !
-C         |====================! 
+C         |====================!
           KK = N0PHAS + NVPHAS
-          UVAR(I,1+KK)  = AV2(I)  
-          UVAR(I,2+KK)  = ZERO  
-          UVAR(I,3+KK)  = ZERO  
-          UVAR(I,4+KK)  = ZERO  
-          UVAR(I,5+KK)  = ZERO 
+          UVAR(I,1+KK)  = AV2(I)
+          UVAR(I,2+KK)  = ZERO
+          UVAR(I,3+KK)  = ZERO
+          UVAR(I,4+KK)  = ZERO
+          UVAR(I,5+KK)  = ZERO
           UVAR(I,6+KK)  = ZERO
-          UVAR(I,7+KK)  = ZERO 
-          UVAR(I,8+KK)  = E02*UVAR(I,K2+21)                
-          UVAR(I,9+KK)  = RHO2*UVAR(I,K2+20) 
-          UVAR(I,10+KK) = ZERO     
+          UVAR(I,7+KK)  = ZERO
+          UVAR(I,8+KK)  = E02*UVAR(I,K2+21)
+          UVAR(I,9+KK)  = RHO2*UVAR(I,K2+20)
+          UVAR(I,10+KK) = ZERO
           UVAR(I,11+KK) = VOLUME(I) * AV2(I)
           UVAR(I,12+KK) = RHO2*UVAR(I,K2+20)
-          !------------------!      
+          !------------------!
           UVAR(I,13+KK) = ZERO
-          UVAR(I,14+KK) = ZERO 
+          UVAR(I,14+KK) = ZERO
           UVAR(I,15+KK) = ZERO
           UVAR(I,16+KK) = ZERO
-          UVAR(I,17+KK) = ZERO 
-          UVAR(I,18+KK) = ZERO          
-          UVAR(I,19+KK) = ZERO  
+          UVAR(I,17+KK) = ZERO
+          UVAR(I,18+KK) = ZERO
+          UVAR(I,19+KK) = ZERO
 
 C         |====================!
 C         |     material 3     !
-C         |====================! 
+C         |====================!
           KK = N0PHAS + 2*NVPHAS
-          UVAR(I,1+KK)  = AV3(I)   
-          UVAR(I,2+KK)  = ZERO  
-          UVAR(I,3+KK)  = ZERO  
-          UVAR(I,4+KK)  = ZERO  
-          UVAR(I,5+KK)  = ZERO 
+          UVAR(I,1+KK)  = AV3(I)
+          UVAR(I,2+KK)  = ZERO
+          UVAR(I,3+KK)  = ZERO
+          UVAR(I,4+KK)  = ZERO
+          UVAR(I,5+KK)  = ZERO
           UVAR(I,6+KK)  = ZERO
-          UVAR(I,7+KK)  = ZERO 
-          UVAR(I,8+KK)  = E03*UVAR(I,K3+21)                
-          UVAR(I,9+KK)  = RHO3*UVAR(I,K3+20) 
-          UVAR(I,10+KK) = ZERO     
-          UVAR(I,11+KK) = VOLUME(I) * AV3(I) 
-          UVAR(I,12+KK) = RHO3*UVAR(I,K3+20) 
+          UVAR(I,7+KK)  = ZERO
+          UVAR(I,8+KK)  = E03*UVAR(I,K3+21)
+          UVAR(I,9+KK)  = RHO3*UVAR(I,K3+20)
+          UVAR(I,10+KK) = ZERO
+          UVAR(I,11+KK) = VOLUME(I) * AV3(I)
+          UVAR(I,12+KK) = RHO3*UVAR(I,K3+20)
           !------------------!
           UVAR(I,13+KK) = ZERO
-          UVAR(I,14+KK) = ZERO 
+          UVAR(I,14+KK) = ZERO
           UVAR(I,15+KK) = ZERO
           UVAR(I,16+KK) = ZERO
-          UVAR(I,17+KK) = ZERO 
+          UVAR(I,17+KK) = ZERO
           UVAR(I,18+KK) = ZERO
-          UVAR(I,19+KK) = ZERO             
+          UVAR(I,19+KK) = ZERO
 
 C         |====================!
 C         |     material 4     !
-C         |====================! 
+C         |====================!
           IF(TRIMAT == 4) THEN
-            KK = N0PHAS + 3*NVPHAS  
-            UVAR(I,1+KK)  = ZERO  
-            UVAR(I,2+KK)  = ZERO  
-            UVAR(I,3+KK)  = ZERO  
-            UVAR(I,4+KK)  = ZERO  
-            UVAR(I,5+KK)  = ZERO 
+            KK = N0PHAS + 3*NVPHAS
+            UVAR(I,1+KK)  = ZERO
+            UVAR(I,2+KK)  = ZERO
+            UVAR(I,3+KK)  = ZERO
+            UVAR(I,4+KK)  = ZERO
+            UVAR(I,5+KK)  = ZERO
             UVAR(I,6+KK)  = ZERO
-            UVAR(I,7+KK)  = ZERO 
-            UVAR(I,8+KK)  = ZERO             
-            UVAR(I,9+KK)  = ZERO 
-            UVAR(I,10+KK) = ZERO     
-            UVAR(I,11+KK) = ZERO 
-            UVAR(I,12+KK) = ZERO 
-            !------------------!    
+            UVAR(I,7+KK)  = ZERO
+            UVAR(I,8+KK)  = ZERO
+            UVAR(I,9+KK)  = ZERO
+            UVAR(I,10+KK) = ZERO
+            UVAR(I,11+KK) = ZERO
+            UVAR(I,12+KK) = ZERO
+            !------------------!
             UVAR(I,13+KK) = ZERO
-            UVAR(I,14+KK) = ZERO 
+            UVAR(I,14+KK) = ZERO
             UVAR(I,15+KK) = ZERO
             UVAR(I,16+KK) = ZERO
-            UVAR(I,17+KK) = ZERO 
+            UVAR(I,17+KK) = ZERO
             UVAR(I,18+KK) = ZERO
-            UVAR(I,19+KK) = ZERO       
+            UVAR(I,19+KK) = ZERO
           ENDIF
 
 C         |==================================!
-C         |     ELEMENT  OUTPUT  (IFLG.EQ.2) !
-C         |==================================!   
+C         |     ELEMENT  OUTPUT  (IFLG == 2) !
+C         |==================================!
           RHO(I) = RHO1*UVAR(I,K1+20) * AV1(I) + RHO2*UVAR(I,K2+20) * AV2(I) + RHO3*UVAR(I,K3+20) * AV3(I)
-          SOUNDSP(I) = EM20     
+          SOUNDSP(I) = EM20
           VISCMAX(I) = ZERO
           EEE        = VOLUME(I) * (E01*UVAR(I,K1+21) * AV1(I) + E02*UVAR(I,K2+21) * AV2(I) + E03*UVAR(I,K3+21) * AV3(I))
           TFEXTT      = ZERO !TFEXTT + EEE - EINT(I)
           EINT(I)    = EEE
           DD = -EPSPXX(I)-EPSPYY(I)-EPSPZZ(I)
-          SIGNXX(I) = -PP(I)              
-          SIGNYY(I) = -PP(I)              
-          SIGNZZ(I) = -PP(I) 
+          SIGNXX(I) = -PP(I)
+          SIGNYY(I) = -PP(I)
+          SIGNZZ(I) = -PP(I)
 
-          IF(VEL_IN.NE.ZERO .OR. IVEL.NE.0)THEN
+          IF(VEL_IN /= ZERO .OR. IVEL /= 0)THEN
             !normal face
             IF(N2D==0)THEN
                II     = I+NFT
@@ -670,10 +665,10 @@ C         |==================================!
                 IVOI  = ALE_CONNECT%ee_connect%connected(IAD2 + J - 1)
                 ML    = 51
                 IFORM = 1000
-                IF(IVOI.NE.0)            ML     = NINT(PM(19,IX(1,IVOI)))
-                IF(IVOI.NE.0)            IADBUF = IPM(7,IX(1,IVOI))
-                IF(IVOI.NE.0.AND.ML==51) IFORM  = BUFMAT(IADBUF+31-1)     
-                IF(ML==51.AND.IFORM<=1)  EXIT                             
+                IF(IVOI /= 0)            ML     = NINT(PM(19,IX(1,IVOI)))
+                IF(IVOI /= 0)            IADBUF = IPM(7,IX(1,IVOI))
+                IF(IVOI /= 0.AND.ML==51) IFORM  = BUFMAT(IADBUF+31-1)
+                IF(ML==51.AND.IFORM<=1)  EXIT
                ENDDO
                XN = ZERO
                YN = ZERO
@@ -704,9 +699,9 @@ C         |==================================!
                IVOI  =  ALE_CONNECT%ee_connect%connected(IAD2 + J - 1)
                ML    = 51
                IFORM = 1000
-               IF(IVOI.NE.0)            ML     = NINT(PM(19,IX(1,IVOI)))
-               IF(IVOI.NE.0)            IADBUF = IPM(7,IX(1,IVOI))
-               IF(IVOI.NE.0.AND.ML==51) IFORM  = BUFMAT(IADBUF+31-1)     !si voisin est materiau 51 alors on recupere UPARAM(31)=IFLG (IFLG=0,1 pour IFROM=0,1ou10)
+               IF(IVOI /= 0)            ML     = NINT(PM(19,IX(1,IVOI)))
+               IF(IVOI /= 0)            IADBUF = IPM(7,IX(1,IVOI))
+               IF(IVOI /= 0.AND.ML==51) IFORM  = BUFMAT(IADBUF+31-1)     !si voisin est materiau 51 alors on recupere UPARAM(31)=IFLG (IFLG=0,1 pour IFROM=0,1ou10)
                IF(ML==51.AND.IFORM<=1)  EXIT                             ! si materiau voisin est loi 51 Iform=1 ou 10 alors on a trouve
               ENDDO
               XN = ZERO
@@ -724,7 +719,7 @@ C         |==================================!
               ENDIF
             ENDIF
             ! sauvegarde de la quantite de mouvement imposee
-            IF(IALEFVM .NE. 0)THEN
+            IF(IALEFVM  /=  0)THEN
               MOM = RHO(I) * VEL_IN * VOLUME(I)
               GBUF%MOM(NEL*(1-1)+I) = -MOM * XN
               GBUF%MOM(NEL*(2-1)+I) = -MOM * YN
@@ -740,56 +735,56 @@ C         |==================================!
                 V(1:3,IX2) = VEL_IN * (/XN,YN,ZN/)
               ENDIF
             ENDIF
-          ENDIF 
-          
+          ENDIF
+
           VDX(I) = ZERO
           VDY(I) = ZERO
-          VDZ(I) = ZERO        
+          VDZ(I) = ZERO
 C
 c             TFEXTT      = TFEXTT - P * DD * VOLUME(I) * TIMESTEP
 cc            energie entrante
-cc             SIGNXX(I) = -P * UNDEMI             
-cc             SIGNYY(I) = -P * UNDEMI              
-cc             SIGNZZ(I) = -P * UNDEMI              
+cc             SIGNXX(I) = -P * UNDEMI
+cc             SIGNYY(I) = -P * UNDEMI
+cc             SIGNZZ(I) = -P * UNDEMI
 cc             TFEXTT      = TFEXTT - P * UNDEMI * DD * VOLUME(I) * TIMESTEP
 cd            enthalpie entrante
 cd             TFEXTT      = TFEXTT + P * DD * VOLUME(I) * TIMESTEP
 cd             EINT(I)    = EEE + P * DD * VOLUME(I) * TIMESTEP
 ce            enthalpie entrante
-ce             SIGNXX(I) = -P              
-ce             SIGNYY(I) = -P              
-ce             SIGNZZ(I) = -P              
+ce             SIGNXX(I) = -P
+ce             SIGNYY(I) = -P
+ce             SIGNZZ(I) = -P
 ce             EINT(I)    = EEE + P * DD * VOLUME(I) * TIMESTEP
 c3---
 C
         ENDDO
 C
 #if defined(_OPENMP)
-!$OMP ATOMIC 
+!$OMP ATOMIC
 #endif
         TFEXT = TFEXT + TFEXTT
 C
-        RETURN              
+        RETURN
 C
 CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 C===========================================================================C
 C                                                                           C
-C     LAW51 : OUTLET CONDITIONS (IFLG.EQ.3)                                 C
+C     LAW51 : OUTLET CONDITIONS (IFLG == 3)                                 C
 C                                                                           C
 C===========================================================================C
 CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 
-      ELSEIF(IFLG.EQ.3)THEN 
+      ELSEIF(IFLG == 3)THEN
 
         DO I=1,NEL
-          PP0(I) = C01 * AV1(I) + C02 * AV2(I) + C03 * AV3(I)        
+          PP0(I) = C01 * AV1(I) + C02 * AV2(I) + C03 * AV3(I)
         ENDDO
 
-        IF(TIME.EQ.0.0)THEN
+        IF(TIME == 0.0)THEN
           DO I=1,NEL
-            SIGOXX(I) = -PP0(I)             
-            SIGOYY(I) = -PP0(I)              
-            SIGOZZ(I) = -PP0(I)              
+            SIGOXX(I) = -PP0(I)
+            SIGOYY(I) = -PP0(I)
+            SIGOZZ(I) = -PP0(I)
             SIGOXY(I) = ZERO
             SIGOYZ(I) = ZERO
             SIGOZX(I) = ZERO
@@ -800,7 +795,7 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 
         DO I=1,NEL
           DD = -EPSPXX(I)-EPSPYY(I)-EPSPZZ(I)
-          BBB = UN - ALPHA          
+          BBB = UN - ALPHA
           IF(DD > ZERO)THEN
             SIGNXX(I) = SIGOXX(I)
             SIGNYY(I) = SIGOYY(I)
@@ -808,14 +803,14 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
             SIGNXY(I) = SIGOXY(I)
             SIGNYZ(I) = SIGOYZ(I)
             SIGNZX(I) = SIGOZX(I)
-            IF(IOPT==1)RHO(I) = 
+            IF(IOPT==1)RHO(I) =
      .        ALPHA*(RHO1 * AV1(I) + RHO2 * AV2(I) + RHO3 * AV3(I))+ BBB*RHO(I)
           ELSE
-            AAA = -ALPHA * PP0(I) 
-            SIGNXX(I) = BBB * SIGOXX(I) + AAA             
-            SIGNYY(I) = BBB * SIGOYY(I) + AAA              
-            SIGNZZ(I) = BBB * SIGOZZ(I) + AAA 
-            !IF(IOPT==0)BBB=ZERO  
+            AAA = -ALPHA * PP0(I)
+            SIGNXX(I) = BBB * SIGOXX(I) + AAA
+            SIGNYY(I) = BBB * SIGOYY(I) + AAA
+            SIGNZZ(I) = BBB * SIGOZZ(I) + AAA
+            !IF(IOPT==0)BBB=ZERO
             SIGNXY(I) = BBB * SIGOXY(I)
             SIGNYZ(I) = BBB * SIGOYZ(I)
             SIGNZX(I) = BBB * SIGOZX(I)
@@ -826,110 +821,110 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 
 C         |====================!
 C         |     material 1     !
-C         |====================! 
+C         |====================!
           KK = N0PHAS
-          UVAR(I,1+KK)  = AV1(I)   
-          UVAR(I,8+KK)  = E01               
+          UVAR(I,1+KK)  = AV1(I)
+          UVAR(I,8+KK)  = E01
           UVAR(I,9+KK)  = RHO1
-          UVAR(I,10+KK) = ZERO     
+          UVAR(I,10+KK) = ZERO
           UVAR(I,11+KK) = VOLUME(I) * AV1(I)
-          UVAR(I,12+KK) = RHO1                      
+          UVAR(I,12+KK) = RHO1
           !------------------!
           UVAR(I,13+KK) = ZERO
-          UVAR(I,14+KK) = ZERO 
+          UVAR(I,14+KK) = ZERO
           UVAR(I,15+KK) = ZERO
           UVAR(I,16+KK) = ZERO
           UVAR(I,17+KK) = ZERO
           UVAR(I,18+KK) = ZERO
-          UVAR(I,19+KK) = ZERO  
+          UVAR(I,19+KK) = ZERO
 
 C         |====================!
 C         |     material 2     !
-C         |====================! 
+C         |====================!
           KK = N0PHAS + NVPHAS
-          UVAR(I,1+KK)  = AV2(I)   
-          UVAR(I,8+KK)  = E02               
+          UVAR(I,1+KK)  = AV2(I)
+          UVAR(I,8+KK)  = E02
           UVAR(I,9+KK)  = RHO2
-          UVAR(I,10+KK) = ZERO     
-          UVAR(I,11+KK) = VOLUME(I) * AV2(I) 
-          UVAR(I,12+KK) = RHO2                     
+          UVAR(I,10+KK) = ZERO
+          UVAR(I,11+KK) = VOLUME(I) * AV2(I)
+          UVAR(I,12+KK) = RHO2
           !------------------!
           UVAR(I,13+KK) = ZERO
-          UVAR(I,14+KK) = ZERO 
+          UVAR(I,14+KK) = ZERO
           UVAR(I,15+KK) = ZERO
           UVAR(I,16+KK) = ZERO
-          UVAR(I,17+KK) = ZERO 
-          UVAR(I,18+KK) = ZERO            
+          UVAR(I,17+KK) = ZERO
+          UVAR(I,18+KK) = ZERO
           UVAR(I,19+KK) = ZERO
 
 C         |====================!
 C         |     material 3     !
-C         |====================! 
+C         |====================!
           KK = N0PHAS + 2*NVPHAS
-          UVAR(I,1+KK)  = AV3(I)   
+          UVAR(I,1+KK)  = AV3(I)
           UVAR(I,8+KK)  = E03
-          UVAR(I,9+KK)  = RHO3 
-          UVAR(I,10+KK) = ZERO     
+          UVAR(I,9+KK)  = RHO3
+          UVAR(I,10+KK) = ZERO
           UVAR(I,11+KK) = VOLUME(I) * AV3(I)
-          UVAR(I,12+KK) = RHO3 
+          UVAR(I,12+KK) = RHO3
           !------------------!
           UVAR(I,13+KK) = ZERO
-          UVAR(I,14+KK) = ZERO 
+          UVAR(I,14+KK) = ZERO
           UVAR(I,15+KK) = ZERO
           UVAR(I,16+KK) = ZERO
-          UVAR(I,17+KK) = ZERO 
+          UVAR(I,17+KK) = ZERO
           UVAR(I,18+KK) = ZERO
-          UVAR(I,19+KK) = ZERO                   
-     
+          UVAR(I,19+KK) = ZERO
+
 C         |====================!
 C         |     material 4     !
-C         |====================! 
+C         |====================!
           IF(TRIMAT == 4) THEN
-            KK = N0PHAS + 3*NVPHAS  
-            UVAR(I,1+KK)  = ZERO  
-            UVAR(I,2+KK)  = ZERO  
-            UVAR(I,3+KK)  = ZERO  
-            UVAR(I,4+KK)  = ZERO  
-            UVAR(I,5+KK)  = ZERO 
+            KK = N0PHAS + 3*NVPHAS
+            UVAR(I,1+KK)  = ZERO
+            UVAR(I,2+KK)  = ZERO
+            UVAR(I,3+KK)  = ZERO
+            UVAR(I,4+KK)  = ZERO
+            UVAR(I,5+KK)  = ZERO
             UVAR(I,6+KK)  = ZERO
-            UVAR(I,7+KK)  = ZERO 
-            UVAR(I,8+KK)  = ZERO             
-            UVAR(I,9+KK)  = ZERO 
-            UVAR(I,10+KK) = ZERO     
-            UVAR(I,11+KK) = ZERO 
-            UVAR(I,12+KK) = ZERO 
+            UVAR(I,7+KK)  = ZERO
+            UVAR(I,8+KK)  = ZERO
+            UVAR(I,9+KK)  = ZERO
+            UVAR(I,10+KK) = ZERO
+            UVAR(I,11+KK) = ZERO
+            UVAR(I,12+KK) = ZERO
             !------------------!
             UVAR(I,13+KK) = ZERO
-            UVAR(I,14+KK) = ZERO 
+            UVAR(I,14+KK) = ZERO
             UVAR(I,15+KK) = ZERO
             UVAR(I,16+KK) = ZERO
-            UVAR(I,17+KK) = ZERO 
-            UVAR(I,18+KK) = ZERO   
-            UVAR(I,19+KK) = ZERO     
+            UVAR(I,17+KK) = ZERO
+            UVAR(I,18+KK) = ZERO
+            UVAR(I,19+KK) = ZERO
           ENDIF
 
 C         |==================================!
-C         |     ELEMENT  OUTPUT  (IFLG.EQ.3) !
-C         |==================================!   
+C         |     ELEMENT  OUTPUT  (IFLG == 3) !
+C         |==================================!
           IF(IOPT==0)RHO(I) = RHO1 * AV1(I) + RHO2 * AV2(I) + RHO3 * AV3(I)
           EEE        = VOLUME(I) * (E01 * AV1(I) + E02 * AV2(I) + E03 * AV3(I))
           TFEXTT     = ZERO ! TFEXTT + EEE - EINT(I)
           EINT(I)    = EEE
-          SOUNDSP(I) = EM20     
+          SOUNDSP(I) = EM20
           VISCMAX(I) = ZERO
-          
+
           VDX(I) = ZERO
           VDY(I) = ZERO
-          VDZ(I) = ZERO 
-          
+          VDZ(I) = ZERO
+
         ENDDO
 C
 #if defined(_OPENMP)
-!$OMP ATOMIC 
+!$OMP ATOMIC
 #endif
         TFEXT = TFEXT + TFEXTT
 C
-        RETURN              
+        RETURN
 C
 CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 C===========================================================================C
@@ -943,27 +938,27 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
       ELSEIF(IFLG == 4.or.IFLG == 5)THEN
         ! Conditions d'arret pour gaz parfait ou liquide selon la phase
         ABCS  = TIME / UPARAM(38)
-        IAV1  = IFUNC(1) 
+        IAV1  = IFUNC(1)
         IRHO1 = IFUNC(2)
-        IE1   = IFUNC(3) 
-        IAV2  = IFUNC(4) 
-        IRHO2 = IFUNC(5) 
-        IE2   = IFUNC(6) 
-        IAV3  = IFUNC(7) 
-        IRHO3 = IFUNC(8) 
+        IE1   = IFUNC(3)
+        IAV2  = IFUNC(4)
+        IRHO2 = IFUNC(5)
+        IE2   = IFUNC(6)
+        IAV3  = IFUNC(7)
+        IRHO3 = IFUNC(8)
         IE3   = IFUNC(9)
-        IF(IAV1.NE.0)THEN
+        IF(IAV1 /= 0)THEN
           myVAR = FINTER(IAV1,ABCS,NPF,TF,DYDX)
           AV1(1:NEL) = myVAR * AV1(1:NEL)
         ENDIF
-        IF(IAV2.NE.0)THEN
+        IF(IAV2 /= 0)THEN
           myVAR = FINTER(IAV2,ABCS,NPF,TF,DYDX)
           AV2(1:NEL) = myVAR * AV2(1:NEL)
         ENDIF
-        IF(IAV3.NE.0)THEN
+        IF(IAV3 /= 0)THEN
           myVAR = FINTER(IAV3,ABCS,NPF,TF,DYDX)
           AV3(1:NEL) = myVAR * AV3(1:NEL)
-        ENDIF  
+        ENDIF
         K1 = N0PHAS
         K2 = N0PHAS+NVPHAS
         K3 = N0PHAS+2*NVPHAS
@@ -974,19 +969,19 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 	E01f  = UN
 	E02f  = UN
 	E03f  = UN
-        IF(IRHO1.NE.0)RHO1f = FINTER(IRHO1,ABCS,NPF,TF,DYDX)
-        IF(IRHO2.NE.0)RHO2f = FINTER(IRHO2,ABCS,NPF,TF,DYDX)
-        IF(IRHO3.NE.0)RHO3f = FINTER(IRHO3,ABCS,NPF,TF,DYDX)
-        IF(IE1.NE.0)E01f = FINTER(IE1,ABCS,NPF,TF,DYDX)
-        IF(IE2.NE.0)E02f = FINTER(IE2,ABCS,NPF,TF,DYDX)
-        IF(IE3.NE.0)E03f = FINTER(IE3,ABCS,NPF,TF,DYDX)
+        IF(IRHO1 /= 0)RHO1f = FINTER(IRHO1,ABCS,NPF,TF,DYDX)
+        IF(IRHO2 /= 0)RHO2f = FINTER(IRHO2,ABCS,NPF,TF,DYDX)
+        IF(IRHO3 /= 0)RHO3f = FINTER(IRHO3,ABCS,NPF,TF,DYDX)
+        IF(IE1 /= 0)E01f = FINTER(IE1,ABCS,NPF,TF,DYDX)
+        IF(IE2 /= 0)E02f = FINTER(IE2,ABCS,NPF,TF,DYDX)
+        IF(IE3 /= 0)E03f = FINTER(IE3,ABCS,NPF,TF,DYDX)
         DO I=1,NEL
           E01=E01f
           E02=E02f
           E03=E03f
-          RHO1=RHO1f                    
+          RHO1=RHO1f
           RHO2=RHO2f
-          RHO3=RHO3f                    
+          RHO3=RHO3f
           MU1=RHO1*UVAR(I,20+K1)/RHO10 - UN
           P1 = ( C01 + C11*MU1+ MAX(MU1,ZERO)*(C21*MU1 + C31*MU1*MU1) + (C41 + C51*MU1)*E01*UVAR(I,21+K1)*RHO10/RHO1/UVAR(I,20+K1) )
           P1 = MAX(P1,PM1)
@@ -1019,7 +1014,7 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
           ! vitesse critique calculee dans LECM11, ce qui est discutable (yann)
           VCRT1 = AA1*CC1
           VCRT2 = AA2*CC2
-          VCRT3 = AA3*CC3        
+          VCRT3 = AA3*CC3
           !------------
           UVAR(I,1:N0PHAS)  =  ZERO
           II = I + NFT
@@ -1053,8 +1048,8 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 
           !===============================!
           !     material 1 computation    !
-          !===============================! 
-          IF(AV1(I).GT.ZERO)THEN 
+          !===============================!
+          IF(AV1(I) > ZERO)THEN
             !---GAZ
             IF((IFLG == 4.and.C41 /= ZERO).or. (IFLG == 5.and.C41 /= ZERO.and.C11 == ZERO))THEN
               U21 = MIN(U2,VCRT1)
@@ -1075,45 +1070,45 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
             !---LIQUID
             ELSE
               FAC = (C11 + UNDEMI*RHO10*U2)
-              IF(FAC.NE.ZERO)THEN
+              IF(FAC /= ZERO)THEN
                 RHO1 = RHO1A*C11/FAC
                 P1   = P1A - UNDEMI*RHO1*U2
                 E01  = E01A + (UN - RHO1/RHO1A)*P1
               ENDIF
             ENDIF
-          ELSE  
+          ELSE
            !unused submaterial
-           RHO1 = RHO10 
-          ENDIF! (AV1(I).GT.ZERO)           
+           RHO1 = RHO10
+          ENDIF! (AV1(I) > ZERO)
           !================!
           !     output     !
           !================!
           KK = N0PHAS
-          UVAR(I,1+KK)  = AV1(I)   
-          UVAR(I,2+KK)  = ZERO  
-          UVAR(I,3+KK)  = ZERO  
-          UVAR(I,4+KK)  = ZERO  
-          UVAR(I,5+KK)  = ZERO 
+          UVAR(I,1+KK)  = AV1(I)
+          UVAR(I,2+KK)  = ZERO
+          UVAR(I,3+KK)  = ZERO
+          UVAR(I,4+KK)  = ZERO
+          UVAR(I,5+KK)  = ZERO
           UVAR(I,6+KK)  = ZERO
-          UVAR(I,7+KK)  = ZERO 
-          UVAR(I,8+KK)  = E01               
-          UVAR(I,9+KK)  = RHO1 
-          UVAR(I,10+KK) = ZERO     
+          UVAR(I,7+KK)  = ZERO
+          UVAR(I,8+KK)  = E01
+          UVAR(I,9+KK)  = RHO1
+          UVAR(I,10+KK) = ZERO
           UVAR(I,11+KK) = VOLUME(I) * AV1(I)
           UVAR(I,12+KK) = RHO1
           !------------------!
           UVAR(I,13+KK) = ZERO
-          UVAR(I,14+KK) = ZERO 
+          UVAR(I,14+KK) = ZERO
           UVAR(I,15+KK) = ZERO
           UVAR(I,16+KK) = ZERO
-          UVAR(I,17+KK) = ZERO 
+          UVAR(I,17+KK) = ZERO
           UVAR(I,18+KK) = ZERO
           UVAR(I,19+KK) = ZERO
-          
+
           !===============================!
           !     material 2 computation    !
-          !===============================! 
-          IF(AV2(I).GT.ZERO)THEN
+          !===============================!
+          IF(AV2(I) > ZERO)THEN
             IF((IFLG == 4.and.C42 /= ZERO).or. (IFLG == 5.and.C42 /= ZERO.and.C12 == ZERO))THEN
               U22 = MIN(U2,VCRT2)
               GV2 = C42/2/(C42+1)*RHO2A*U22/P2A
@@ -1131,7 +1126,7 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
               ENDIF
             ELSE
               FAC = (C12 + UNDEMI*RHO20*U2)
-              IF(FAC.NE.ZERO)THEN
+              IF(FAC /= ZERO)THEN
                 RHO2 = RHO2A*C12/FAC
                 P2   = P2A - UNDEMI*RHO2*U2
                 E02  = E02A + (UN - RHO2/RHO2A)*P2
@@ -1139,37 +1134,37 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
             ENDIF
           ELSE
            !unused submaterial
-           RHO2 = RHO20 
-          ENDIF! (AV2(I).GT.ZERO)          
+           RHO2 = RHO20
+          ENDIF! (AV2(I) > ZERO)
           !================!
           !     output     !
           !================!
           KK = N0PHAS + NVPHAS
-          UVAR(I,1+KK)  = AV2(I)   
-          UVAR(I,2+KK)  = ZERO  
-          UVAR(I,3+KK)  = ZERO  
-          UVAR(I,4+KK)  = ZERO  
-          UVAR(I,5+KK)  = ZERO 
+          UVAR(I,1+KK)  = AV2(I)
+          UVAR(I,2+KK)  = ZERO
+          UVAR(I,3+KK)  = ZERO
+          UVAR(I,4+KK)  = ZERO
+          UVAR(I,5+KK)  = ZERO
           UVAR(I,6+KK)  = ZERO
-          UVAR(I,7+KK)  = ZERO 
-          UVAR(I,8+KK)  = E02                
-          UVAR(I,9+KK)  = RHO2 
-          UVAR(I,10+KK) = ZERO     
+          UVAR(I,7+KK)  = ZERO
+          UVAR(I,8+KK)  = E02
+          UVAR(I,9+KK)  = RHO2
+          UVAR(I,10+KK) = ZERO
           UVAR(I,11+KK) = VOLUME(I) * AV2(I)
           UVAR(I,12+KK) = RHO2
           !------------------!
           UVAR(I,13+KK) = ZERO
-          UVAR(I,14+KK) = ZERO 
+          UVAR(I,14+KK) = ZERO
           UVAR(I,15+KK) = ZERO
           UVAR(I,16+KK) = ZERO
-          UVAR(I,17+KK) = ZERO 
+          UVAR(I,17+KK) = ZERO
           UVAR(I,18+KK) = ZERO
-          UVAR(I,19+KK) = ZERO  
-          
+          UVAR(I,19+KK) = ZERO
+
           !===============================!
           !     material 3 computation    !
-          !===============================! 
-          IF(AV3(I).GT.ZERO)THEN
+          !===============================!
+          IF(AV3(I) > ZERO)THEN
             IF((IFLG == 4.and.C43 /= ZERO).or. (IFLG == 5.and.C43 /= ZERO.and.C13 == ZERO))THEN
               U23 = MIN(U2,VCRT3)
               GV3 = C43/2/(C43+1)*RHO3A*U23/P3A
@@ -1187,72 +1182,72 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
               ENDIF
             ELSE
               FAC = (C13 + UNDEMI*RHO30*U2)
-              IF(FAC.NE.ZERO)THEN
+              IF(FAC /= ZERO)THEN
                 RHO3 = RHO3A*C13/FAC
                 P3   = P3A - UNDEMI*RHO3*U2
                 E03  = E03A + (UN - RHO3/RHO3A)*P3
               ENDIF
             ENDIF
           ELSE
-            !unused submaterial          
-            RHO3 = RHO30 
-          ENDIF! (AV3(I).GT.ZERO)                   
+            !unused submaterial
+            RHO3 = RHO30
+          ENDIF! (AV3(I) > ZERO)
           !================!
           !     output     !
           !================!
           KK = N0PHAS + 2*NVPHAS
-          UVAR(I,1+KK)  = AV3(I)   
-          UVAR(I,2+KK)  = ZERO  
-          UVAR(I,3+KK)  = ZERO  
-          UVAR(I,4+KK)  = ZERO  
-          UVAR(I,5+KK)  = ZERO 
+          UVAR(I,1+KK)  = AV3(I)
+          UVAR(I,2+KK)  = ZERO
+          UVAR(I,3+KK)  = ZERO
+          UVAR(I,4+KK)  = ZERO
+          UVAR(I,5+KK)  = ZERO
           UVAR(I,6+KK)  = ZERO
-          UVAR(I,7+KK)  = ZERO 
-          UVAR(I,8+KK)  = E03                
-          UVAR(I,9+KK)  = RHO3 
-          UVAR(I,10+KK) = ZERO     
+          UVAR(I,7+KK)  = ZERO
+          UVAR(I,8+KK)  = E03
+          UVAR(I,9+KK)  = RHO3
+          UVAR(I,10+KK) = ZERO
           UVAR(I,11+KK) = VOLUME(I) * AV3(I)
-          UVAR(I,12+KK) = RHO3 
+          UVAR(I,12+KK) = RHO3
 
           UVAR(I,13+KK) = ZERO
-          UVAR(I,14+KK) = ZERO 
+          UVAR(I,14+KK) = ZERO
           UVAR(I,15+KK) = ZERO
           UVAR(I,16+KK) = ZERO
-          UVAR(I,17+KK) = ZERO 
+          UVAR(I,17+KK) = ZERO
           UVAR(I,18+KK) = ZERO
-          UVAR(I,19+KK) = ZERO  
+          UVAR(I,19+KK) = ZERO
           !===============================!
           !     material 4 output         !
-          !===============================!  
+          !===============================!
           IF(TRIMAT == 4) THEN
-            KK = N0PHAS + 3*NVPHAS  
-            UVAR(I,1+KK)  = ZERO  
-            UVAR(I,2+KK)  = ZERO  
-            UVAR(I,3+KK)  = ZERO  
-            UVAR(I,4+KK)  = ZERO  
-            UVAR(I,5+KK)  = ZERO 
+            KK = N0PHAS + 3*NVPHAS
+            UVAR(I,1+KK)  = ZERO
+            UVAR(I,2+KK)  = ZERO
+            UVAR(I,3+KK)  = ZERO
+            UVAR(I,4+KK)  = ZERO
+            UVAR(I,5+KK)  = ZERO
             UVAR(I,6+KK)  = ZERO
-            UVAR(I,7+KK)  = ZERO 
-            UVAR(I,8+KK)  = ZERO             
-            UVAR(I,9+KK)  = ZERO 
-            UVAR(I,10+KK) = ZERO     
-            UVAR(I,11+KK) = ZERO 
-            UVAR(I,12+KK) = ZERO 
+            UVAR(I,7+KK)  = ZERO
+            UVAR(I,8+KK)  = ZERO
+            UVAR(I,9+KK)  = ZERO
+            UVAR(I,10+KK) = ZERO
+            UVAR(I,11+KK) = ZERO
+            UVAR(I,12+KK) = ZERO
             !------------------!
             UVAR(I,13+KK) = ZERO
-            UVAR(I,14+KK) = ZERO 
+            UVAR(I,14+KK) = ZERO
             UVAR(I,15+KK) = ZERO
             UVAR(I,16+KK) = ZERO
-            UVAR(I,17+KK) = ZERO 
-            UVAR(I,18+KK) = ZERO   
-            UVAR(I,19+KK) = ZERO    
+            UVAR(I,17+KK) = ZERO
+            UVAR(I,18+KK) = ZERO
+            UVAR(I,19+KK) = ZERO
           ENDIF
 
           !================================================!
           !     ELEMENT  OUTPUT  (IFLG == 4.or.IFLG == 5)  !
-          !================================================! 
+          !================================================!
           RHO(I) = RHO1 * AV1(I) + RHO2 * AV2(I) + RHO3 * AV3(I)
-          SOUNDSP(I) = EM20     
+          SOUNDSP(I) = EM20
           VISCMAX(I) = ZERO
           EEE        = VOLUME(I) * (E01 * AV1(I) + E02 * AV2(I) + E03 * AV3(I))
           TFEXTT     = ZERO !TFEXTT + EEE - EINT(I)
@@ -1261,36 +1256,36 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
           P2 = P2 - PEXT
           P3 = P3 - PEXT
           P  = P1 * AV1(I) + P2 * AV2(I) + P3 * AV3(I)
-          SIGNXX(I) = -P              
-          SIGNYY(I) = -P              
-          SIGNZZ(I) = -P 
-          
+          SIGNXX(I) = -P
+          SIGNYY(I) = -P
+          SIGNZZ(I) = -P
+
           VDX(I) = ZERO
           VDY(I) = ZERO
-          VDZ(I) = ZERO 
-  
+          VDZ(I) = ZERO
+
         ENDDO  !DO I=1,NEL
 
 #if defined(_OPENMP)
-!$OMP ATOMIC 
+!$OMP ATOMIC
 #endif
         TFEXT = TFEXT + TFEXTT
 
-        RETURN              
+        RETURN
 
 C
 CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 C===========================================================================C
 C                                                                           C
-C     LAW51 : GENERALIZED OUTLET CONDITIONS (IFLG.EQ.6)                     C
+C     LAW51 : GENERALIZED OUTLET CONDITIONS (IFLG == 6)                     C
 C                                                                           C
 C===========================================================================C
 CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 
-      ELSEIF(IFLG.EQ.6)THEN 
+      ELSEIF(IFLG == 6)THEN
 
-        IF(TIME.EQ.ZERO) THEN                                                                                              
-          DO I=1,NEL  
+        IF(TIME == ZERO) THEN
+          DO I=1,NEL
             P0_NRF = UVAR(I,4)
             !
             KK     = N0PHAS + 0*NVPHAS
@@ -1312,139 +1307,139 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
             RHO4   = UVAR(I,KK+20)
             E04    = UVAR(I,KK+21)
             SSP4   = UVAR(I,KK+22)
-            !----------------------!                                                                                       
-            SIGNXX(I)     = -P0_NRF                                                                                        
-            SIGNYY(I)     = -P0_NRF                                                                                        
-            SIGNZZ(I)     = -P0_NRF                                                                                        
-            SIGNXY(I)     = ZERO                                                                                            
-            SIGNYZ(I)     = ZERO                                                                                            
-            SIGNZX(I)     = ZERO                                                                                            
-            !----------------------!                                                                                       
-            SIGOXX(I)     = -P0_NRF                                                                                         
-            SIGOYY(I)     = -P0_NRF                                                                                         
-            SIGOZZ(I)     = -P0_NRF                                                                                         
-            SIGOXY(I)     = ZERO                                                                                            
-            SIGOYZ(I)     = ZERO                                                                                            
-            SIGOZX(I)     = ZERO                                                                                            
             !----------------------!
-            RHO(I)        = AV1(I)*RHO1+ AV2(I)*RHO2+ AV3(I)*RHO3                     !not relevant to add explosive here                                                                               
+            SIGNXX(I)     = -P0_NRF
+            SIGNYY(I)     = -P0_NRF
+            SIGNZZ(I)     = -P0_NRF
+            SIGNXY(I)     = ZERO
+            SIGNYZ(I)     = ZERO
+            SIGNZX(I)     = ZERO
+            !----------------------!
+            SIGOXX(I)     = -P0_NRF
+            SIGOYY(I)     = -P0_NRF
+            SIGOZZ(I)     = -P0_NRF
+            SIGOXY(I)     = ZERO
+            SIGOYZ(I)     = ZERO
+            SIGOZX(I)     = ZERO
+            !----------------------!
+            RHO(I)        = AV1(I)*RHO1+ AV2(I)*RHO2+ AV3(I)*RHO3                     !not relevant to add explosive here
             EINT(I)       = VOLUME(I) * (E01 * AV1(I) + E02 * AV2(I) + E03 * AV3(I))  !not relevant to add explosive here
 
             KK = N0PHAS
-            UVAR(I,1+KK)  = AV1(I)  
-            UVAR(I,8+KK)  = E01               
+            UVAR(I,1+KK)  = AV1(I)
+            UVAR(I,8+KK)  = E01
             UVAR(I,9+KK)  = RHO1
-            UVAR(I,10+KK) = ZERO     
+            UVAR(I,10+KK) = ZERO
             UVAR(I,11+KK) = VOLUME(I) * AV1(I)
-            UVAR(I,12+KK) = RHO1                      
+            UVAR(I,12+KK) = RHO1
             UVAR(I,13+KK) = ZERO
-            UVAR(I,14+KK) = SSP1 
+            UVAR(I,14+KK) = SSP1
             UVAR(I,15+KK) = ZERO
             UVAR(I,16+KK) = ZERO
             UVAR(I,17+KK) = ZERO
             UVAR(I,18+KK) = P0_NRF
-            UVAR(I,19+KK) = ZERO  
+            UVAR(I,19+KK) = ZERO
 
             KK = N0PHAS + NVPHAS
-            UVAR(I,1+KK)  = AV2(I) 
-            UVAR(I,8+KK)  = E02               
+            UVAR(I,1+KK)  = AV2(I)
+            UVAR(I,8+KK)  = E02
             UVAR(I,9+KK)  = RHO2
-            UVAR(I,10+KK) = ZERO     
-            UVAR(I,11+KK) = VOLUME(I) * AV2(I)   
-            UVAR(I,12+KK) = RHO2                     
+            UVAR(I,10+KK) = ZERO
+            UVAR(I,11+KK) = VOLUME(I) * AV2(I)
+            UVAR(I,12+KK) = RHO2
             UVAR(I,13+KK) = ZERO
-            UVAR(I,14+KK) = SSP2 
+            UVAR(I,14+KK) = SSP2
             UVAR(I,15+KK) = ZERO
             UVAR(I,16+KK) = ZERO
-            UVAR(I,17+KK) = ZERO 
-            UVAR(I,18+KK) = P0_NRF            
+            UVAR(I,17+KK) = ZERO
+            UVAR(I,18+KK) = P0_NRF
             UVAR(I,19+KK) = ZERO
 
             KK = N0PHAS + 2*NVPHAS
-            UVAR(I,1+KK)  = AV3(I) 
+            UVAR(I,1+KK)  = AV3(I)
             UVAR(I,8+KK)  = E03
-            UVAR(I,9+KK)  = RHO3 
-            UVAR(I,10+KK) = ZERO     
+            UVAR(I,9+KK)  = RHO3
+            UVAR(I,10+KK) = ZERO
             UVAR(I,11+KK) = VOLUME(I) *  AV3(I)
-            UVAR(I,12+KK) = RHO3 
+            UVAR(I,12+KK) = RHO3
             !------------------!
             UVAR(I,13+KK) = ZERO
-            UVAR(I,14+KK) = SSP3 
+            UVAR(I,14+KK) = SSP3
             UVAR(I,15+KK) = ZERO
             UVAR(I,16+KK) = ZERO
-            UVAR(I,17+KK) = ZERO 
+            UVAR(I,17+KK) = ZERO
             UVAR(I,18+KK) = P0_NRF
-            UVAR(I,19+KK) = ZERO      
-            
+            UVAR(I,19+KK) = ZERO
+
             KK = N0PHAS + 3*NVPHAS
-            UVAR(I,1+KK)  = AV4(I) 
+            UVAR(I,1+KK)  = AV4(I)
             UVAR(I,8+KK)  = E04
-            UVAR(I,9+KK)  = RHO4 
-            UVAR(I,10+KK) = ZERO     
+            UVAR(I,9+KK)  = RHO4
+            UVAR(I,10+KK) = ZERO
             UVAR(I,11+KK) = VOLUME(I) *  AV4(I)
-            UVAR(I,12+KK) = RHO4 
+            UVAR(I,12+KK) = RHO4
             !------------------!
             UVAR(I,13+KK) = ZERO
-            UVAR(I,14+KK) = SSP4 
+            UVAR(I,14+KK) = SSP4
             UVAR(I,15+KK) = ZERO
             UVAR(I,16+KK) = ZERO
-            UVAR(I,17+KK) = ZERO 
+            UVAR(I,17+KK) = ZERO
             UVAR(I,18+KK) = P0_NRF
-            UVAR(I,19+KK) = ZERO                         
+            UVAR(I,19+KK) = ZERO
 
-          ENDDO                                                                                       
-        ENDIF                                                                                                              
+          ENDDO
+        ENDIF
 
-        IF(TIMESTEP.GT.EM20)THEN
-          BETA   = TIMESTEP/MAX(UPARAM(71),TIMESTEP)   
+        IF(TIMESTEP > EM20)THEN
+          BETA   = TIMESTEP/MAX(UPARAM(71),TIMESTEP)
           IF(UPARAM(71)>=EP20)BETA=ZERO  ! default : Tcalpha=EP20 => BETA = 0
           ALPHA  = TIMESTEP/UPARAM(70)
         ELSE
           BETA   = UN
           ALPHA  = UN
-        ENDIF  
-       
+        ENDIF
+
         !RHOC2(1)  = MAX(RHO1*SSP1*SSP1,EM20)
         !RHOC2(2)  = MAX(RHO2*SSP2*SSP2,EM20)
         !RHOC2(3)  = MAX(RHO3*SSP3*SSP3,EM20)
-        !RHOC2(4)  = MAX(RHO4*SSP4*SSP4,EM20)       
+        !RHOC2(4)  = MAX(RHO4*SSP4*SSP4,EM20)
 
         STIFN(1:NEL) = ZERO
 
-        !     Recherche des quantits voisines                              
-        !     et calcul de la vitesse normale  la face.                    
-        IF(N2D==0)THEN                             
-          CALL M51VOIS3(PM   ,  IPARG  ,IX      ,ALE_CONNECT   ,ELBUF_TAB ,V    ,          
-     2                  X    ,  VEL_N  ,W       ,VEL     ,VD2  ,             
-     3                  MAT  ,  RHOV   ,PV      ,VDX     ,VDY       ,VDZ  ,                                 
-     4                  EIV  ,  TV     ,BUFVOIS ,IFLG    ,AVV       ,RHO0V,                    
+        !     Recherche des quantits voisines
+        !     et calcul de la vitesse normale  la face.
+        IF(N2D==0)THEN
+          CALL M51VOIS3(PM   ,  IPARG  ,IX      ,ALE_CONNECT   ,ELBUF_TAB ,V    ,
+     2                  X    ,  VEL_N  ,W       ,VEL     ,VD2  ,
+     3                  MAT  ,  RHOV   ,PV      ,VDX     ,VDY       ,VDZ  ,
+     4                  EIV  ,  TV     ,BUFVOIS ,IFLG    ,AVV       ,RHO0V,
      5                  IPM    ,BUFMAT  ,UVAR    ,NEL       ,NUVAR,
-     6                  NV46 ,  SSPv   ,EPSPv   ,P0_NRFv) 
+     6                  NV46 ,  SSPv   ,EPSPv   ,P0_NRFv)
         ELSE
-          CALL M51VOIS2(PM   ,  IPARG  ,IX      ,ALE_CONNECT   ,ELBUF_TAB ,V    ,          
-     2                  X    ,  VEL_N  ,W       ,VEL     ,VD2  ,             
-     3                  MAT  ,  RHOV   ,PV      ,VDX     ,VDY       ,VDZ  ,                                 
-     4                  EIV  ,  TV     ,BUFVOIS ,IFLG    ,AVV       ,RHO0V,                    
+          CALL M51VOIS2(PM   ,  IPARG  ,IX      ,ALE_CONNECT   ,ELBUF_TAB ,V    ,
+     2                  X    ,  VEL_N  ,W       ,VEL     ,VD2  ,
+     3                  MAT  ,  RHOV   ,PV      ,VDX     ,VDY       ,VDZ  ,
+     4                  EIV  ,  TV     ,BUFVOIS ,IFLG    ,AVV       ,RHO0V,
      5                  IPM    ,BUFMAT  ,UVAR    ,NEL       ,NUVAR,
-     6                  NV46 ,  SSPv   ,EPSPv   ,P0_NRFv)            
+     6                  NV46 ,  SSPv   ,EPSPv   ,P0_NRFv)
         ENDIF
 
-        IF(TIME.EQ.ZERO) THEN 
-         DO I=1,NEL                                                                                                         
+        IF(TIME == ZERO) THEN
+         DO I=1,NEL
            VEL_O(I)=VEL_N(I)
            P0_NRF = UVAR(I,4)
-           KK           = N0PHAS 
-           UVAR(I,1+KK) = AVV(1,I) 
-           AV1(I)       = AVV(1,I)                                                                      
+           KK           = N0PHAS
+           UVAR(I,1+KK) = AVV(1,I)
+           AV1(I)       = AVV(1,I)
            KK           = N0PHAS + NVPHAS
            UVAR(I,1+KK) = AVV(2,I)
-           AV2(I)       = AVV(2,I) 
+           AV2(I)       = AVV(2,I)
            KK           = N0PHAS + 2*NVPHAS
-           UVAR(I,1+KK) = AVV(3,I) 
+           UVAR(I,1+KK) = AVV(3,I)
            AV3(I)       = AVV(3,I)
            KK           = N0PHAS + 3*NVPHAS
            UVAR(I,1+KK) = AVV(4,I)
-           AV4(I)       = AVV(4,I) 
+           AV4(I)       = AVV(4,I)
            SIGOXX(I)    = -P0_NRF
            SIGOYY(I)    = -P0_NRF
            SIGOZZ(I)    = -P0_NRF
@@ -1453,29 +1448,29 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
            SIGOZX(I)    = ZERO
          ENDDO
         ENDIF
-        DO I=1,NEL                                                                                                         
-          P0_NRF = UVAR(I,4) 
-          !         
-          KK     = N0PHAS + 0*NVPHAS  
-          RHO1   = UVAR(I,KK+20)       
+        DO I=1,NEL
+          P0_NRF = UVAR(I,4)
+          !
+          KK     = N0PHAS + 0*NVPHAS
+          RHO1   = UVAR(I,KK+20)
           E01    = UVAR(I,KK+21)
-          SSP1   = UVAR(I,KK+22) 
-          !        
-          KK     = N0PHAS + 1*NVPHAS  
-          RHO2   = UVAR(I,KK+20)       
+          SSP1   = UVAR(I,KK+22)
+          !
+          KK     = N0PHAS + 1*NVPHAS
+          RHO2   = UVAR(I,KK+20)
           E02    = UVAR(I,KK+21)
-          SSP2   = UVAR(I,KK+22)  
-          !      
-          KK     = N0PHAS + 2*NVPHAS  
-          RHO3   = UVAR(I,KK+20)       
+          SSP2   = UVAR(I,KK+22)
+          !
+          KK     = N0PHAS + 2*NVPHAS
+          RHO3   = UVAR(I,KK+20)
           E03    = UVAR(I,KK+21)
-          SSP3   = UVAR(I,KK+22) 
-          !       
-          KK     = N0PHAS + 3*NVPHAS  
-          RHO4   = UVAR(I,KK+20)       
-          E04    = UVAR(I,KK+21)  
-          SSP4   = UVAR(I,KK+22)      
-          
+          SSP3   = UVAR(I,KK+22)
+          !
+          KK     = N0PHAS + 3*NVPHAS
+          RHO4   = UVAR(I,KK+20)
+          E04    = UVAR(I,KK+21)
+          SSP4   = UVAR(I,KK+22)
+
           IF( SUM(AVV(1:4,I)) == ZERO) THEN !corner element
             RHO(I)     = EM20
             SOUNDSP(I) = EM20
@@ -1487,24 +1482,24 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
             RHOC2(1)  = MAX(EM20,RHOV(1,I)*SSPV(1,I)*SSPV(1,I))
             RHOC2(2)  = MAX(EM20,RHOV(2,I)*SSPV(2,I)*SSPV(2,I))
             RHOC2(3)  = MAX(EM20,RHOV(3,I)*SSPV(3,I)*SSPV(3,I))
-            RHOC2(4)  = MAX(EM20,RHOV(4,I)*SSPV(4,I)*SSPV(4,I)) 
+            RHOC2(4)  = MAX(EM20,RHOV(4,I)*SSPV(4,I)*SSPV(4,I))
             RHOC20    = ZERO
-            IF(AVV(1,I).GT.EM06)RHOC20=RHOC20 + AVV(1,I)/RHOC2(1)
-            IF(AVV(2,I).GT.EM06)RHOC20=RHOC20 + AVV(2,I)/RHOC2(2)
-            IF(AVV(3,I).GT.EM06)RHOC20=RHOC20 + AVV(3,I)/RHOC2(3)
-            IF(AVV(4,I).GT.EM06)RHOC20=RHOC20 + AVV(4,I)/RHOC2(4)
+            IF(AVV(1,I) > EM06)RHOC20=RHOC20 + AVV(1,I)/RHOC2(1)
+            IF(AVV(2,I) > EM06)RHOC20=RHOC20 + AVV(2,I)/RHOC2(2)
+            IF(AVV(3,I) > EM06)RHOC20=RHOC20 + AVV(3,I)/RHOC2(3)
+            IF(AVV(4,I) > EM06)RHOC20=RHOC20 + AVV(4,I)/RHOC2(4)
             RHOC20=UN/RHOC20 !average stiffness
-            RHO(I) = AVV(1,I)*RHOV(1,I)+ AVV(2,I)*RHOV(2,I)+ AVV(3,I)*RHOV(3,I) + AVV(4,I)*RHOV(4,I)  
+            RHO(I) = AVV(1,I)*RHOV(1,I)+ AVV(2,I)*RHOV(2,I)+ AVV(3,I)*RHOV(3,I) + AVV(4,I)*RHOV(4,I)
             !RHOC2(1)  = MAX(EM20,RHOV(1,I)*SSPV(1,I)*SSPV(1,I))
             !RHOC2(2)  = MAX(EM20,RHOV(2,I)*SSPV(2,I)*SSPV(2,I))
             !RHOC2(3)  = MAX(EM20,RHOV(3,I)*SSPV(3,I)*SSPV(3,I))
-            !RHOC2(4)  = MAX(EM20,RHOV(4,I)*SSPV(4,I)*SSPV(4,I)) 
+            !RHOC2(4)  = MAX(EM20,RHOV(4,I)*SSPV(4,I)*SSPV(4,I))
             !RHOC2_    = UN/(AVV(1,I)/RHOC2(1)+AVV(2,I)/RHOC2(2)+AVV(3,I)/RHOC2(3)  + AVV(4,I)/RHOC2(4))
-            !SOUNDSP(I) = RHOC2_/RHO(I)                                                                                     
+            !SOUNDSP(I) = RHOC2_/RHO(I)
             SOUNDSP(I)  = SSPV(0,I)
             MACH        = VEL_N(I) / SOUNDSP(I)
             ISUPERSONIC = 0
-            IF(MACH.GE.UN .AND. VEL_N(I).GT.ZERO)THEN
+            IF(MACH >= UN .AND. VEL_N(I) > ZERO)THEN
              !vitesse sortante supersonique : etat = etat voisin
               ISUPERSONIC = 1
               P           = PV(0,I)
@@ -1517,108 +1512,108 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
               DP0   = (P0_NRF-P0_NRFv(I)) ! assuming rho0*g(t)*(z-zvois) = cst ; otherwise complicated: get g(t) and compute z-zvois
               P     = UN/(UN+ALPHA)*(POLD+ROC*(VEL_N(I)-VEL_O(I)))+ALPHA*(PV(0,I)+DP0)/(ALPHA + UN)
             ENDIF
-            
-            IF(VEL_N(I).LT.ZERO)THEN     !flux rentrant relaxation du pourcentage volumique  
-               KK = N0PHAS 
-               AVV(1,I)  = (UN-BETA)*UVAR(I,1+KK) + BETA* AV1(I)                                                                        
+
+            IF(VEL_N(I) < ZERO)THEN     !flux rentrant relaxation du pourcentage volumique
+               KK = N0PHAS
+               AVV(1,I)  = (UN-BETA)*UVAR(I,1+KK) + BETA* AV1(I)
                KK = N0PHAS + NVPHAS
-               AVV(2,I)  = (UN-BETA)*UVAR(I,1+KK) + BETA* AV2(I)                                                                        
+               AVV(2,I)  = (UN-BETA)*UVAR(I,1+KK) + BETA* AV2(I)
                KK = N0PHAS + 2*NVPHAS
-               AVV(3,I)  = (UN-BETA)*UVAR(I,1+KK) + BETA* AV3(I)                                                                        
+               AVV(3,I)  = (UN-BETA)*UVAR(I,1+KK) + BETA* AV3(I)
                KK = N0PHAS + 3*NVPHAS
                AVV(4,I)  = (UN-BETA)*UVAR(I,1+KK) + BETA* AV4(I)
-            ELSE  
-                        
-            ENDIF   
-          ENDIF 
+            ELSE
+
+            ENDIF
+          ENDIF
           EEE       = EIV(0,I) * VOLUME(I)
-          RHO(I)    = RHOV(0,I)         
+          RHO(I)    = RHOV(0,I)
           SIGNXX(I) = -P
-          SIGNYY(I) = SIGNXX(I)                                                                                                   
-          SIGNZZ(I) = SIGNXX(I)                                                                                                   
-          SIGNXY(I) = ZERO                                                                                                 
-          SIGNYZ(I) = ZERO                                                                                                 
-          SIGNZX(I) = ZERO                                                                                                 
-          VEL_O(I)  = VEL_N(I) 
-          SIGOXX(I) = SIGNXX(I)   
-          SIGOYY(I) = SIGNYY(I)   
-          SIGOZZ(I) = SIGNZZ(I)   
-          SIGOXY(I) = SIGNXY(I)   
-          SIGOYZ(I) = SIGNYZ(I)   
-          SIGOZX(I) = SIGNZX(I)   
+          SIGNYY(I) = SIGNXX(I)
+          SIGNZZ(I) = SIGNXX(I)
+          SIGNXY(I) = ZERO
+          SIGNYZ(I) = ZERO
+          SIGNZX(I) = ZERO
+          VEL_O(I)  = VEL_N(I)
+          SIGOXX(I) = SIGNXX(I)
+          SIGOYY(I) = SIGNYY(I)
+          SIGOZZ(I) = SIGNZZ(I)
+          SIGOXY(I) = SIGNXY(I)
+          SIGOYZ(I) = SIGNYZ(I)
+          SIGOZX(I) = SIGNZX(I)
 
           IF(BUFLY%L_PLA>0)THEN
             LBUF%PLA(I) = EPSPv(0,I)
             UVAR(I,1)  =  EPSPv(0,I)
           ENDIF
           UVAR(I,2)  =  ZERO
-          UVAR(I,3)  =  ZERO 
+          UVAR(I,3)  =  ZERO
 
 C         |====================!
 C         |     material 1     !
-C         |====================! 
+C         |====================!
           KK = N0PHAS
-          UVAR(I,1+KK)  = AVV(1,I)   
-          UVAR(I,8+KK)  = EIV(1,I)              
+          UVAR(I,1+KK)  = AVV(1,I)
+          UVAR(I,8+KK)  = EIV(1,I)
           UVAR(I,9+KK)  = RHOV(1,I)
-          UVAR(I,10+KK) = ZERO     
+          UVAR(I,10+KK) = ZERO
           UVAR(I,11+KK) = VOLUME(I) * AVV(1,I)
-          UVAR(I,12+KK) = RHOV(1,I)                      
+          UVAR(I,12+KK) = RHOV(1,I)
           !------------------!
           UVAR(I,13+KK) = ZERO
-          UVAR(I,14+KK) = SSPV(1,I) 
+          UVAR(I,14+KK) = SSPV(1,I)
           UVAR(I,15+KK) = EPSPv(1,I)
           UVAR(I,16+KK) = TV(1,I)
           UVAR(I,17+KK) = ZERO
           UVAR(I,18+KK) = P0_NRF
-          UVAR(I,19+KK) = ZERO  
+          UVAR(I,19+KK) = ZERO
 
 C         |====================!
 C         |     material 2     !
-C         |====================! 
+C         |====================!
           KK = N0PHAS + NVPHAS
-          UVAR(I,1+KK)  = AVV(2,I)   
-          UVAR(I,8+KK)  = EIV(2,I)              
+          UVAR(I,1+KK)  = AVV(2,I)
+          UVAR(I,8+KK)  = EIV(2,I)
           UVAR(I,9+KK)  = RHOV(2,I)
-          UVAR(I,10+KK) = ZERO     
-          UVAR(I,11+KK) = VOLUME(I) * AVV(2,I)   
-          UVAR(I,12+KK) = RHOV(2,I)                     
+          UVAR(I,10+KK) = ZERO
+          UVAR(I,11+KK) = VOLUME(I) * AVV(2,I)
+          UVAR(I,12+KK) = RHOV(2,I)
           !------------------!
           UVAR(I,13+KK) = ZERO
-          UVAR(I,14+KK) = SSPV(2,I) 
+          UVAR(I,14+KK) = SSPV(2,I)
           UVAR(I,15+KK) = EPSPv(2,I)
           UVAR(I,16+KK) = TV(2,I)
-          UVAR(I,17+KK) = ZERO 
-          UVAR(I,18+KK) = P0_NRF            
+          UVAR(I,17+KK) = ZERO
+          UVAR(I,18+KK) = P0_NRF
           UVAR(I,19+KK) = ZERO
 
 C         |====================!
 C         |     material 3     !
-C         |====================! 
+C         |====================!
           KK = N0PHAS + 2*NVPHAS
-          UVAR(I,1+KK)  = AVV(3,I)   
+          UVAR(I,1+KK)  = AVV(3,I)
           UVAR(I,8+KK)  = EIV(3,I)
           UVAR(I,9+KK)  = RHOV(3,I)
-          UVAR(I,10+KK) = ZERO     
+          UVAR(I,10+KK) = ZERO
           UVAR(I,11+KK) = VOLUME(I) * AVV(3,I)
           UVAR(I,12+KK) = RHOV(3,I)
           !------------------!
           UVAR(I,13+KK) = ZERO
-          UVAR(I,14+KK) = SSPV(3,I) 
+          UVAR(I,14+KK) = SSPV(3,I)
           UVAR(I,15+KK) = EPSPv(3,I)
           UVAR(I,16+KK) = TV(3,I)
-          UVAR(I,17+KK) = ZERO 
+          UVAR(I,17+KK) = ZERO
           UVAR(I,18+KK) = P0_NRF
-          UVAR(I,19+KK) = ZERO                   
+          UVAR(I,19+KK) = ZERO
 
 C         |====================!
 C         |     material 4     !
-C         |====================! 
+C         |====================!
           KK = N0PHAS + 3*NVPHAS
-          UVAR(I,1+KK)  = AVV(4,I)   
+          UVAR(I,1+KK)  = AVV(4,I)
           UVAR(I,8+KK)  = EIV(4,I)
-          UVAR(I,9+KK)  = RHOV(4,I) 
-          UVAR(I,10+KK) = ZERO     
+          UVAR(I,9+KK)  = RHOV(4,I)
+          UVAR(I,10+KK) = ZERO
           UVAR(I,11+KK) = VOLUME(I) * AVV(4,I)
           UVAR(I,12+KK) = RHOV(4,I)
           !------------------!
@@ -1626,27 +1621,27 @@ C         |====================!
           UVAR(I,14+KK) = SSPV(4,I)
           UVAR(I,15+KK) = ZERO          !no plasticity with detonation products
           UVAR(I,16+KK) = TV(4,I)
-          UVAR(I,17+KK) = ZERO 
+          UVAR(I,17+KK) = ZERO
           UVAR(I,18+KK) = P0_NRF
-          UVAR(I,19+KK) = ZERO       
+          UVAR(I,19+KK) = ZERO
 
-C         |==================================!   
-          
+C         |==================================!
+
           TFEXTT     = ZERO !TFEXTT + EEE - EINT(I)
           EINT(I)    = EEE
           VISCMAX(I) = ZERO
         ENDDO
 C
 #if defined(_OPENMP)
-!$OMP ATOMIC 
+!$OMP ATOMIC
 #endif
         TFEXT = TFEXT + TFEXTT
 C
-          
+
 C
-        RETURN  
-                    
-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC        
+        RETURN
+
+CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
       ENDIF ! IFLG
 
 
@@ -1658,7 +1653,7 @@ C     (IEXP == 0.or.IEXP == 1)                                              C
 C===========================================================================C
 CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 
-      IF (TIME .EQ. ZERO) THEN
+      IF (TIME  ==  ZERO) THEN
          DO I = 1, NEL
             KK = N0PHAS + 0 * NVPHAS
             V1OLD = AV1(I) * VOLUME(I)
@@ -1691,9 +1686,9 @@ C     TEMPERATURES
 C     T > 0
 C==========================================
       DO I=1,NEL
-           !---submaterial_1---!      
-           KK = N0PHAS + 0*NVPHAS 
-           EINT1   = UVAR(I,8 +KK) 
+           !---submaterial_1---!
+           KK = N0PHAS + 0*NVPHAS
+           EINT1   = UVAR(I,8 +KK)
            V1OLD   = UVAR(I,11+KK)
            RHO1OLD = UVAR(I,12+KK)
            ECOLD = -T10 * SPH1
@@ -1703,11 +1698,11 @@ C==========================================
            ECOLD1 = ECOLD*V1OLD*(UN+MU1)
            TEMP1 = (EINT1 - ECOLD1)/MAX(EM20,H1)
            UVAR(I,16+KK) = TEMP1
-           P1OLD(I) = UVAR(I,18+KK) 
-             
+           P1OLD(I) = UVAR(I,18+KK)
+
            !---submaterial_2---!
-           KK = N0PHAS + 1*NVPHAS 
-           EINT2   = UVAR(I,8 +KK) 
+           KK = N0PHAS + 1*NVPHAS
+           EINT2   = UVAR(I,8 +KK)
            V2OLD   = UVAR(I,11+KK)
            RHO2OLD = UVAR(I,12+KK)
            ECOLD = -T20 * SPH2
@@ -1716,12 +1711,12 @@ C==========================================
            IF(MU2 > ZERO) ECOLD = ECOLD * (UN+C52*MU2*(UN-MU2)) + UNDEMI*C22*MU2*MU2
            ECOLD2 = ECOLD*V2OLD*(UN+MU2)
            TEMP2 = (EINT2 - ECOLD2)/MAX(EM20,H2)
-           UVAR(I,16+KK) = TEMP2 
-           P2OLD(I) = UVAR(I,18+KK) 
-            
-           !---submaterial_3---!           
-           KK = N0PHAS + 2*NVPHAS 
-           EINT3   = UVAR(I,8 +KK) 
+           UVAR(I,16+KK) = TEMP2
+           P2OLD(I) = UVAR(I,18+KK)
+
+           !---submaterial_3---!
+           KK = N0PHAS + 2*NVPHAS
+           EINT3   = UVAR(I,8 +KK)
            V3OLD   = UVAR(I,11+KK)
            RHO3OLD = UVAR(I,12+KK)
            ECOLD = -T30 * SPH3
@@ -1730,13 +1725,13 @@ C==========================================
            IF(MU3 > ZERO) ECOLD = ECOLD * (UN+C53*MU3*(UN-MU3)) + UNDEMI*C23*MU3*MU3
            ECOLD3 = ECOLD*V3OLD*(UN+MU3)
            TEMP3 = (EINT3 - ECOLD3)/MAX(EM20,H3)
-           UVAR(I,16+KK) = TEMP3 
-           P3OLD(I) = UVAR(I,18+KK) 
-           
+           UVAR(I,16+KK) = TEMP3
+           P3OLD(I) = UVAR(I,18+KK)
+
            !---submaterial_4---!
-           IF(IEXP==1)THEN
-             KK = N0PHAS + 3*NVPHAS            
-             EINT4   = UVAR(I,8 +KK) 
+           IF(IEXP == 1)THEN
+             KK = N0PHAS + 3*NVPHAS
+             EINT4   = UVAR(I,8 +KK)
              V4OLD   = UVAR(I,11+KK)
              RHO4OLD = UVAR(I,12+KK)
              ECOLD = -T40 * SPH4
@@ -1744,19 +1739,19 @@ C==========================================
              H4 = SPH4*V4OLD*(UN+MU4)
              ECOLD4 = ECOLD*V4OLD*(UN+MU4)
              TEMP4 = (EINT4 - ECOLD4)/MAX(EM20,H4)
-             P4OLD(I) = UVAR(I,18+KK)  
+             P4OLD(I) = UVAR(I,18+KK)
            ELSE
-             V4OLD    = ZERO    
-             EINT4    = ZERO 
-             RHO4OLD  = EM20 
-             MU4      = ZERO 
-             TEMP4    = ZERO  
-             P4OLD(I) = ZERO   
-             ECOLD4   = ZERO  
-             H4       = ZERO           
-           ENDIF                             
-      ENDDO     
-            
+             V4OLD    = ZERO
+             EINT4    = ZERO
+             RHO4OLD  = EM20
+             MU4      = ZERO
+             TEMP4    = ZERO
+             P4OLD(I) = ZERO
+             ECOLD4   = ZERO
+             H4       = ZERO
+           ENDIF
+      ENDDO
+
 C==========================================
 C     PLASTICITY
 C     T > 0
@@ -1765,7 +1760,7 @@ C==========================================
       IF(IPLA > ZERO)THEN
         DO I=1,NEL
           !inter22
-          IF(VOLUME(I)==ZERO)CYCLE
+          IF(VOLUME(I) == ZERO)CYCLE
           !
           DE(I) = THIRD*(DEPSXX(I)+DEPSYY(I)+DEPSZZ(I))
           DEPS(1,I) = DEPSXX(I) !- DE
@@ -1775,9 +1770,9 @@ C==========================================
           DEPS(5,I) = DEPSYZ(I)
           DEPS(6,I) = DEPSZX(I)
           EPD(I)=OFF(I)*MAX(   ABS(EPSPXX(I)),   ABS(EPSPYY(I)),   ABS(EPSPZZ(I)),
-     .         UNDEMI*ABS(EPSPXY(I)),UNDEMI*ABS(EPSPYZ(I)),UNDEMI*ABS(EPSPZX(I))) 
+     .         UNDEMI*ABS(EPSPXY(I)),UNDEMI*ABS(EPSPYZ(I)),UNDEMI*ABS(EPSPZX(I)))
         ENDDO
-        IF(BUFLY%L_EPSD>0)THEN
+        IF(BUFLY%L_EPSD > 0)THEN
           DO I=1,NEL
            LBUF%EPSD(I) = EPD(I)
           ENDDO
@@ -1786,25 +1781,25 @@ C==========================================
 
       !===================================
       !       material 1 : PLASTICITY
-      !===================================  
+      !===================================
       IF(IPLA1 /= ZERO)THEN
         KK =  N0PHAS
-        DO I=1,NEL  
+        DO I=1,NEL
           !inter22
-          IF(VOLUME(I)==ZERO)CYCLE               
-           DO J=1,6                             
-             SIGD(J,I)  = UVAR(I,KK + J + 1)   
-           ENDDO  
+          IF(VOLUME(I) == ZERO)CYCLE
+           DO J=1,6
+             SIGD(J,I)  = UVAR(I,KK + J + 1)
+           ENDDO
 
            VFRAC(I)     = UVAR(I,1+KK)
-           PP(I)        = UVAR(I,18+KK)                                
-           PLAS1(I)     = UVAR(I,15+KK)             
-           TEMP(I)      = UVAR(I,16+KK)              
-           VOL(I)       = UVAR(I,11+KK)             
-           EINT0(I)     = UVAR(I,8 +KK) 
-           EPSEQ1(I)    = UVAR(I,19+KK)   ! Dprag  
+           PP(I)        = UVAR(I,18+KK)
+           PLAS1(I)     = UVAR(I,15+KK)
+           TEMP(I)      = UVAR(I,16+KK)
+           VOL(I)       = UVAR(I,11+KK)
+           EINT0(I)     = UVAR(I,8 +KK)
+           EPSEQ1(I)    = UVAR(I,19+KK)   ! Dprag
 
-        ENDDO                                   
+        ENDDO
         SELECT CASE (IPLA1)
            CASE (1)
              CALL JCOOK51 (NEL  ,SIGD     ,PLAS1       ,TEMP   ,VOL  ,
@@ -1812,7 +1807,7 @@ C==========================================
      .                     DE   ,TIMESTEP ,OFF         ,IX     ,NFT  ,
      .                     VFRAC)
            CASE (2)
-              CALL DPRAG51 
+              CALL DPRAG51
      .            (NEL    ,SIGD   ,TEMP       ,VOL     ,EPSEQ1  ,
      .             DEPS   ,EPD    ,UPARAM(101),VOLUME  ,EINT0   ,PLAS1 ,
      .             UVAR   ,NUVAR  ,KK         ,RHO10   ,
@@ -1820,49 +1815,49 @@ C==========================================
      .             SIGOXX ,SIGOYY ,SIGOZZ     ,SIGOXY  ,SIGOYZ  ,SIGOZX,
      .             SIGNXX ,SIGNYY ,SIGNZZ     ,SIGNXY  ,SIGNYZ  ,SIGNZX,
      .             OFF    ,PEXT   ,TIMESTEP   ,DE)
-        END SELECT     
-        DO I=1,NEL                           
+        END SELECT
+        DO I=1,NEL
 
           !inter22
-          IF(VOLUME(I)==ZERO)CYCLE
-                        
+          IF(VOLUME(I) == ZERO)CYCLE
+
              UVAR(I,KK + 1 + 1)= SIGD(1,I)
-             UVAR(I,KK + 2 + 1)= SIGD(2,I) 
-             UVAR(I,KK + 3 + 1)= SIGD(3,I) 
-             UVAR(I,KK + 4 + 1)= SIGD(4,I)                   
-             UVAR(I,KK + 5 + 1)= SIGD(5,I)  
-             UVAR(I,KK + 6 + 1)= SIGD(6,I)                            
-                                   
-             UVAR(I,15+KK) = PLAS1(I)         
-             UVAR(I,16+KK) = TEMP(I)          
-             UVAR(I,11+KK) = VOL(I)            
+             UVAR(I,KK + 2 + 1)= SIGD(2,I)
+             UVAR(I,KK + 3 + 1)= SIGD(3,I)
+             UVAR(I,KK + 4 + 1)= SIGD(4,I)
+             UVAR(I,KK + 5 + 1)= SIGD(5,I)
+             UVAR(I,KK + 6 + 1)= SIGD(6,I)
+
+             UVAR(I,15+KK) = PLAS1(I)
+             UVAR(I,16+KK) = TEMP(I)
+             UVAR(I,11+KK) = VOL(I)
              UVAR(I,8 +KK) = EINT0(I)
-             UVAR(I,19+KK) = EPSEQ1(I)   ! Dprag  
-             
+             UVAR(I,19+KK) = EPSEQ1(I)   ! Dprag
+
              !total stress is set before  returning from sigeps51.F
-                 
-        ENDDO                                
+
+        ENDDO
       ENDIF
 
       !===================================
       !        material 2 : PLASTICITY
-      !===================================  
+      !===================================
       IF(IPLA2 /= ZERO)THEN
         KK = N0PHAS + NVPHAS
-        DO I=1,NEL                              
+        DO I=1,NEL
           !inter22
-          IF(VOLUME(I)==ZERO)CYCLE
-          DO J=1,6                              
-            SIGD(J,I)   = UVAR(I,KK + J + 1)     
-          ENDDO 
+          IF(VOLUME(I) == ZERO)CYCLE
+          DO J=1,6
+            SIGD(J,I)   = UVAR(I,KK + J + 1)
+          ENDDO
            VFRAC(I)     = UVAR(I,1+KK)
-           PP(I)        = UVAR(I,18+KK) 
-           PLAS2(I)     = UVAR(I,15+KK)             
-           TEMP(I)      = UVAR(I,16+KK)              
-           VOL(I)       = UVAR(I,11+KK)             
-           EINT0(I)     = UVAR(I,8 +KK) 
-           EPSEQ2(I)    = UVAR(I,19+KK)   ! Dprag                             
-        ENDDO                                  
+           PP(I)        = UVAR(I,18+KK)
+           PLAS2(I)     = UVAR(I,15+KK)
+           TEMP(I)      = UVAR(I,16+KK)
+           VOL(I)       = UVAR(I,11+KK)
+           EINT0(I)     = UVAR(I,8 +KK)
+           EPSEQ2(I)    = UVAR(I,19+KK)   ! Dprag
+        ENDDO
         SELECT CASE (IPLA2)
            CASE (1)
              CALL JCOOK51 (NEL  ,SIGD     ,PLAS2       ,TEMP   ,VOL  ,
@@ -1870,7 +1865,7 @@ C==========================================
      .                     DE   ,TIMESTEP ,OFF         ,IX     ,NFT  ,
      .                     VFRAC)
            CASE (2)
-             CALL DPRAG51 
+             CALL DPRAG51
      .            (NEL    ,SIGD   ,TEMP       ,VOL     ,EPSEQ2  ,
      .             DEPS   ,EPD    ,UPARAM(151),VOLUME  ,EINT0   ,PLAS2 ,
      .             UVAR   ,NUVAR  ,KK         ,RHO20   ,
@@ -1878,46 +1873,46 @@ C==========================================
      .             SIGOXX ,SIGOYY ,SIGOZZ     ,SIGOXY  ,SIGOYZ  ,SIGOZX,
      .             SIGNXX ,SIGNYY ,SIGNZZ     ,SIGNXY  ,SIGNYZ  ,SIGNZX,
      .             OFF    ,PEXT   ,TIMESTEP   ,DE)
-        END SELECT    
-        DO I=1,NEL                           
+        END SELECT
+        DO I=1,NEL
          !inter22
-         IF(VOLUME(I)==ZERO)CYCLE
-         
-           UVAR(I,KK + 1 + 1) = SIGD(1,I) 
-           UVAR(I,KK + 2 + 1) = SIGD(2,I) 
-           UVAR(I,KK + 3 + 1) = SIGD(3,I)                                    
-           UVAR(I,KK + 4 + 1) = SIGD(4,I)                  
-           UVAR(I,KK + 5 + 1) = SIGD(5,I) 
-           UVAR(I,KK + 6 + 1) = SIGD(6,I) 
-                                     
-           UVAR(I,15+KK)      = PLAS2(I)           
-           UVAR(I,16+KK)      = TEMP(I)            
-           UVAR(I,11+KK)      = VOL(I)              
-           UVAR(I,8+KK)       = EINT0(I) 
-           UVAR(I,19+KK)      = EPSEQ2(I)   ! Dprag  
-                           
-        ENDDO                
+         IF(VOLUME(I) == ZERO)CYCLE
+
+           UVAR(I,KK + 1 + 1) = SIGD(1,I)
+           UVAR(I,KK + 2 + 1) = SIGD(2,I)
+           UVAR(I,KK + 3 + 1) = SIGD(3,I)
+           UVAR(I,KK + 4 + 1) = SIGD(4,I)
+           UVAR(I,KK + 5 + 1) = SIGD(5,I)
+           UVAR(I,KK + 6 + 1) = SIGD(6,I)
+
+           UVAR(I,15+KK)      = PLAS2(I)
+           UVAR(I,16+KK)      = TEMP(I)
+           UVAR(I,11+KK)      = VOL(I)
+           UVAR(I,8+KK)       = EINT0(I)
+           UVAR(I,19+KK)      = EPSEQ2(I)   ! Dprag
+
+        ENDDO
       ENDIF
 
       !===================================
       !        material 3 : PLASTICITY
-      !===================================  
+      !===================================
       IF(IPLA3 /= ZERO)THEN
-        KK = N0PHAS + 2*NVPHAS 
-        DO I=1,NEL                              
+        KK = N0PHAS + 2*NVPHAS
+        DO I=1,NEL
           !inter22
-          IF(VOLUME(I)==ZERO)CYCLE
-           DO J=1,6                           
-             SIGD(J,I)  = UVAR(I,KK + J + 1)  
-           ENDDO 
+          IF(VOLUME(I) == ZERO)CYCLE
+           DO J=1,6
+             SIGD(J,I)  = UVAR(I,KK + J + 1)
+           ENDDO
            VFRAC(I)     = UVAR(I,1+KK)
-           PP(I)        = UVAR(I,18+KK)                               
-           PLAS3(I)     = UVAR(I,15+KK)             
-           TEMP(I)      = UVAR(I,16+KK)              
-           VOL(I)       = UVAR(I,11+KK)             
-           EINT0(I)     = UVAR(I,8 +KK) 
-           EPSEQ3(I)    = UVAR(I,19+KK)   ! Dprag  
-        ENDDO                                   
+           PP(I)        = UVAR(I,18+KK)
+           PLAS3(I)     = UVAR(I,15+KK)
+           TEMP(I)      = UVAR(I,16+KK)
+           VOL(I)       = UVAR(I,11+KK)
+           EINT0(I)     = UVAR(I,8 +KK)
+           EPSEQ3(I)    = UVAR(I,19+KK)   ! Dprag
+        ENDDO
         SELECT CASE (IPLA3)
            CASE (1)
              CALL JCOOK51 (NEL  ,SIGD    ,PLAS3       ,TEMP   ,VOL  ,
@@ -1925,7 +1920,7 @@ C==========================================
      .                     DE   ,TIMESTEP,OFF         ,IX     ,NFT  ,
      .                     VFRAC)
            CASE (2)
-             CALL DPRAG51 
+             CALL DPRAG51
      .            (NEL    ,SIGD   ,TEMP       ,VOL     ,EPSEQ3  ,
      .             DEPS   ,EPD    ,UPARAM(201),VOLUME  ,EINT0   ,PLAS3 ,
      .             UVAR   ,NUVAR  ,KK         ,RHO30   ,
@@ -1933,26 +1928,26 @@ C==========================================
      .             SIGOXX ,SIGOYY ,SIGOZZ     ,SIGOXY  ,SIGOYZ  ,SIGOZX,
      .             SIGNXX ,SIGNYY ,SIGNZZ     ,SIGNXY  ,SIGNYZ  ,SIGNZX,
      .             OFF    ,PEXT   ,TIMESTEP   ,DE)
-        END SELECT 
-        DO I=1,NEL                          
+        END SELECT
+        DO I=1,NEL
          !inter22
-         IF(VOLUME(I)==ZERO)CYCLE
-         
-            UVAR(I,KK + 1 + 1)= SIGD(1,I) 
-            UVAR(I,KK + 2 + 1)= SIGD(2,I) 
-            UVAR(I,KK + 3 + 1)= SIGD(3,I)                                       
-            UVAR(I,KK + 4 + 1)= SIGD(4,I)                   
-            UVAR(I,KK + 5 + 1)= SIGD(5,I)  
-            UVAR(I,KK + 6 + 1)= SIGD(6,I) 
-                                       
-            UVAR(I,15+KK) = PLAS3(I)        
-            UVAR(I,16+KK) = TEMP(I)         
-            UVAR(I,11+KK) = VOL(I)           
+         IF(VOLUME(I) == ZERO)CYCLE
+
+            UVAR(I,KK + 1 + 1)= SIGD(1,I)
+            UVAR(I,KK + 2 + 1)= SIGD(2,I)
+            UVAR(I,KK + 3 + 1)= SIGD(3,I)
+            UVAR(I,KK + 4 + 1)= SIGD(4,I)
+            UVAR(I,KK + 5 + 1)= SIGD(5,I)
+            UVAR(I,KK + 6 + 1)= SIGD(6,I)
+
+            UVAR(I,15+KK) = PLAS3(I)
+            UVAR(I,16+KK) = TEMP(I)
+            UVAR(I,11+KK) = VOL(I)
             UVAR(I,8+KK)  = EINT0(I)
-            UVAR(I,19+KK) = EPSEQ3(I)   ! Dprag   
+            UVAR(I,19+KK) = EPSEQ3(I)   ! Dprag
             !total stress is set before  returning from sigeps51.F
-                             
-        ENDDO                               
+
+        ENDDO
       ENDIF
 
 
@@ -1960,18 +1955,18 @@ C==========================================
 C==========================================
 C     THERMODYNAMICAL STATE
 C==========================================
-      DO I=1,NEL       
+      DO I=1,NEL
 
           !inter22
-          IF(VOLUME(I)==ZERO)CYCLE
+          IF(VOLUME(I) == ZERO)CYCLE
 
         !===================================
         ! material 1 : THERMODYNAMICAL STATE
-        !===================================   
+        !===================================
         KK = N0PHAS
-        EINT1   = UVAR(I,8+KK)    ! energie IN rho e OUT 
+        EINT1   = UVAR(I,8+KK)    ! energie IN rho e OUT
         MAS1    = UVAR(I,9+KK)    ! masse IN rho OUT
-        Q1OLD   = UVAR(I,10+KK)   
+        Q1OLD   = UVAR(I,10+KK)
         V1OLD   = UVAR(I,11+KK)
         RHO1OLD = UVAR(I,12+KK)   ! rho_old IN rho OUT
         DDVOL1  = UVAR(I,13+KK)
@@ -1980,7 +1975,7 @@ C==========================================
         TEMP1   = UVAR(I,16+KK)   ! temperature
         EDIF1   = UVAR(I,17+KK)   ! chaleur diffusee
         P1OLD(I)= UVAR(I,18+KK)   ! Pressure
-!        EPSEQ1(I)= UVAR(I,19+KK)   ! Dprag    
+!        EPSEQ1(I)= UVAR(I,19+KK)   ! Dprag
         ECOLD = -T10 * SPH1
         MU1 = (RHO1OLD/RHO10 - UN)
         H1 = SPH1*V1OLD*(UN+MU1)
@@ -1994,7 +1989,7 @@ C==========================================
         ! material 2 : THERMODYNAMICAL STATE
         !===================================
         KK = N0PHAS + NVPHAS
-        EINT2   = UVAR(I,8+KK)    ! energie IN rho e OUT                          
+        EINT2   = UVAR(I,8+KK)    ! energie IN rho e OUT
         MAS2    = UVAR(I,9+KK)    ! masse IN rho OUT
         Q2OLD   = UVAR(I,10+KK)
         V2OLD   = UVAR(I,11+KK)
@@ -2003,9 +1998,9 @@ C==========================================
         SSP2    = UVAR(I,14+KK)   ! sound speed
         PLAS2(I)= UVAR(I,15+KK)   ! Eps plastique
         TEMP2   = UVAR(I,16+KK)   ! temperature
-        EDIF2   = UVAR(I,17+KK)   ! chaleur diffusee 
+        EDIF2   = UVAR(I,17+KK)   ! chaleur diffusee
         P2OLD(I)= UVAR(I,18+KK)   ! Pressure
-!        EPSEQ2(I)= UVAR(I,19+KK)   ! Dprag 
+!        EPSEQ2(I)= UVAR(I,19+KK)   ! Dprag
         ECOLD = -T20 * SPH2
         MU2 = (RHO2OLD/RHO20 - UN)
         H2 = SPH2*V2OLD*(UN+MU2)
@@ -2014,12 +2009,12 @@ C==========================================
         ECOLD2 = ECOLD*V2OLD*(UN+MU2)
         TEMP2 = (EINT2 - ECOLD2)/MAX(H2,EM20)
 
-    
+
         !===================================
         ! material 3 : THERMODYNAMICAL STATE
-        !===================================           
+        !===================================
         KK = N0PHAS + 2*NVPHAS
-        EINT3   = UVAR(I,8+KK)    ! energie IN rho e OUT                          
+        EINT3   = UVAR(I,8+KK)    ! energie IN rho e OUT
         MAS3    = UVAR(I,9+KK)    ! masse IN rho OUT
         Q3OLD   = UVAR(I,10+KK)
         V3OLD   = UVAR(I,11+KK)
@@ -2028,9 +2023,9 @@ C==========================================
         SSP3    = UVAR(I,14+KK)   ! sound speed
         PLAS3(I)= UVAR(I,15+KK)   ! Eps plastique
         TEMP3   = UVAR(I,16+KK)   ! temperature
-        EDIF3   = UVAR(I,17+KK)   ! chaleur diffusee 
+        EDIF3   = UVAR(I,17+KK)   ! chaleur diffusee
         P3OLD(I)= UVAR(I,18+KK)   ! Pressure
-!        EPSEQ3(I)= UVAR(I,19+KK)   ! Dprag 
+!        EPSEQ3(I)= UVAR(I,19+KK)   ! Dprag
         ECOLD   = -T30 * SPH3
         MU3     = (RHO3OLD/RHO30 - UN)
         H3      = SPH3*V3OLD*(UN+MU3)
@@ -2042,9 +2037,9 @@ C==========================================
 
         !===================================
         ! H.Explosive : THERMODYNAMICAL STATE
-        !===================================   
+        !===================================
         IF(IEXP == 0)THEN
-          EINT4   = ZERO                       
+          EINT4   = ZERO
           MAS4    = ZERO
           Q4OLD   = ZERO
           V4OLD   = ZERO
@@ -2060,13 +2055,13 @@ C==========================================
           P4OLD(I)= ZERO
         ELSE
           KK = N0PHAS + 3*NVPHAS
-          EINT4   = UVAR(I,8+KK)                       
+          EINT4   = UVAR(I,8+KK)
           MAS4    = UVAR(I,9+KK)
           Q4OLD   = UVAR(I,10+KK)
           V4OLD   = UVAR(I,11+KK)
           RHO4OLD = UVAR(I,12+KK)
           DDVOL4  = UVAR(I,13+KK)
-          SSP4    = UVAR(I,14+KK)   ! sound speed  
+          SSP4    = UVAR(I,14+KK)   ! sound speed
           TEMP4   = UVAR(I,16+KK)
           TBURN =  UVAR(I, 15+KK)
           EDIF4   = UVAR(I,17+KK)   ! chaleur diffusee
@@ -2076,23 +2071,23 @@ C==========================================
           H4 = SPH4*V4OLD*(UN+MU4)
           ECOLD4 = ECOLD*V4OLD*(UN+MU4)
           TEMP4 = (EINT4 - ECOLD4)/MAX(H4,EM20)
-          BFRAC(I) = GBUF%BFRAC(I)          
-          
+          BFRAC(I) = GBUF%BFRAC(I)
+
         ENDIF
 
         !===================================
         ! GLOBAL PRESSURE IN ELEMENT
-        !===================================   
+        !===================================
         POLD = P1OLD(I)*V1OLD + P2OLD(I)*V2OLD+ P3OLD(I)*V3OLD + P4OLD(I)*V4OLD
         POLD = POLD / (V1OLD + V2OLD + V3OLD + V4OLD)
 
 !         if(int22>0)then
 !           if (ibug22_dvol==-1 .or . ibug22_dvol==ix(11,I+nft))then
 !                   write (*,FMT='(A,I10,5(A,F24.16))' )
-!     .             "  *inter22, cell_id=", ix(11,I+nft), "   SUMdv =",TIMESTEP*(DDVOL1+DDVOL2+DDVOL3+DDVOL4), 
-!     .             "   DDVOL1=",TIMESTEP*DDVOL1, 
-!     .             "   DDVOL2=",TIMESTEP*DDVOL2, 
-!     .             "   DDVOL3=",TIMESTEP*DDVOL3, 
+!     .             "  *inter22, cell_id=", ix(11,I+nft), "   SUMdv =",TIMESTEP*(DDVOL1+DDVOL2+DDVOL3+DDVOL4),
+!     .             "   DDVOL1=",TIMESTEP*DDVOL1,
+!     .             "   DDVOL2=",TIMESTEP*DDVOL2,
+!     .             "   DDVOL3=",TIMESTEP*DDVOL3,
 !     .             "   DDVOL4=",TIMESTEP*DDVOL4
 !           endif
 !         endif
@@ -2102,7 +2097,7 @@ c              SPH     =PM(69,MAT(I))
 c              EINT0   =PM(23,MAT(I))
 c              THETA(I)=PM(79,MAT(I))
 c              PLIM    =PC(I)-C0(I)-PSH(I)
-c              IF(C1(I).GT.ABS(PLIM/1.E36))THEN
+c              IF(C1(I) > ABS(PLIM/1.E36))THEN
 c              DMU = MIN(AMU(I)-PLIM/C1(I),ZERO)
 c              ELSE
 c              DMU =0.
@@ -2112,7 +2107,7 @@ c                   +0.5*DMU*(C0(I)+PSH(I)+C1(I)*AMU(I)-PC(I))
 c                   +EINT0
 c              THETA(I)=THETA(I) + (EINT(I)*DF(I)-ECOLD)/SPH
 Cmtemp.fc               ECOLD=-300.*SPH(I)
-c              IF(AMU(I).GT.0.) ECOLD=ECOLD*(1.+C4(I)*AMU(I)*(1-AMU(I)))
+c              IF(AMU(I) > 0.) ECOLD=ECOLD*(1.+C4(I)*AMU(I)*(1-AMU(I)))
 c             1                         +0.5*C1(I)*AMU2(I)
 c              THETA(I)=(EINT(I)-ECOLD)/SPH(I)
 C
@@ -2124,17 +2119,17 @@ C============================================
         IF(JTHE == 1)THEN
          IF(V1OLD+V2OLD+V3OLD > EM03)THEN
          ! chaleur in
-          T = ( EINT1 - ECOLD1 + EINT2 - ECOLD2 + EINT3 - ECOLD3 + UVAR(I,2)) / (H1 + H2 + H3)                      
+          T = ( EINT1 - ECOLD1 + EINT2 - ECOLD2 + EINT3 - ECOLD3 + UVAR(I,2)) / (H1 + H2 + H3)
           !--------material_1---------!
           AAA   = (T-TEMP1)*H1        ! 'TdH'
-          EDIF1   = EDIF1 + AAA       ! -> Heat 'Q' 
+          EDIF1   = EDIF1 + AAA       ! -> Heat 'Q'
           EINT1   = EINT1 + AAA       ! -> E(k)=E(k)+ TdH (non adiabatique => energy correction)
           !--------material_2---------!
-          AAA   = (T-TEMP2)*H2 
+          AAA   = (T-TEMP2)*H2
           EDIF2   = EDIF2 + AAA
-          EINT2   = EINT2 + AAA     
+          EINT2   = EINT2 + AAA
           !--------material_3---------!
-          AAA   = (T-TEMP3)*H3  
+          AAA   = (T-TEMP3)*H3
           EDIF3   = EDIF3 + AAA
           EINT3   = EINT3 + AAA
           !--------output-------------!
@@ -2145,12 +2140,11 @@ C============================================
           EINT1=max(EINT1,MAS1/MAX(RHO10,EM20)*E1_INF)
           EINT2=max(EINT2,MAS2/MAX(RHO20,EM20)*E2_INF)
           EINT3=max(EINT3,MAS3/MAX(RHO30,EM20)*E3_INF)
-          EINT4=max(EINT4,MAS4/MAX(RHO40,EM20)*E4_INF)  
-         END IF 
+          EINT4=max(EINT4,MAS4/MAX(RHO40,EM20)*E4_INF)
+         END IF
         ECOLD4 = ZERO
-        AAA4 = ZERO
         END IF
-        IF (TIME .EQ. ZERO) THEN
+        IF (TIME  ==  ZERO) THEN
            EINT(I)= EINT1 + EINT2 + EINT3 + EINT4
         ENDIF
 C============================================
@@ -2164,21 +2158,21 @@ C============================================
         dbVOLD(1) = V1OLD
         dbVOLD(2) = V2OLD
         dbVOLD(3) = V3OLD
-        dbVOLD(4) = V4OLD  
-        
+        dbVOLD(4) = V4OLD
+
         !inter22 : Polyhedra strain rate trace estimation
 !        IF(INT22>0)THEN
-!          IF(TAG22(I).GT.ZERO)THEN
+!          IF(TAG22(I) > ZERO)THEN
 !            VOLD = BRICK_LIST(1,NINT(TAG22(I)))%Vold_SCell
 !            VOLD = SUM(dbVOLD(:))
-!            DD   = VOLUME(I)**THIRD 
+!            DD   = VOLUME(I)**THIRD
 !            DD   = (DD - VOLD**THIRD) / DD
 !            DD   = -TROIS*DD*UNDT
 !          ENDIF
 !        ENDIF
 
-        IF(INT22>0)DD=ZERO
-        
+        IF(INT22 > 0)DD=ZERO
+
         QA   = GEO(14,PID(I)) !1.225D00
         QB   = GEO(15,PID(I)) !0.06D00
         XL   = VOLUME(I)**THIRD
@@ -2187,13 +2181,13 @@ C============================================
 
 
 
-        VQ0  = RHO(I)*QAL*MAX(ZERO,DD) 
+        VQ0  = RHO(I)*QAL*MAX(ZERO,DD)
         VQ0  = VQ0 + (RHO1OLD*SSP1*V1OLD+RHO2OLD*SSP2*V2OLD+RHO3OLD*SSP3*V3OLD+RHO4OLD*SSP4*V4OLD)*QBL/(V1OLD+V2OLD+V3OLD+V4OLD)
         VQ1  = VQ0
         VQ2  = VQ0
         VQ3  = VQ0
         VQ4  = VQ0
-        
+
         Q0   = VQ0*MAX(ZERO,DD)
         Q1   = Q0
         Q2   = Q0
@@ -2209,17 +2203,17 @@ C============================================
         QAL2 = (QA*XL2)**2
         QAL3 = (QA*XL3)**2
         QAL4 = (QA*XL4)**2
-                                
+
         QBL1 = QB*XL1
         QBL2 = QB*XL2
         QBL3 = QB*XL3
         QBL4 = QB*XL4
-        
-        IF(DD.GT.ZERO)THEN
+
+        IF(DD > ZERO)THEN
           DD2  = DD * DD
           VQ1  = RHO1OLD*(QAL1*DD2 + SSP1*QBL1*DD)
           VQ2  = RHO2OLD*(QAL2*DD2 + SSP2*QBL2*DD)
-          VQ3  = RHO3OLD*(QAL3*DD2 + SSP3*QBL3*DD)                                                
+          VQ3  = RHO3OLD*(QAL3*DD2 + SSP3*QBL3*DD)
           VQ4  = RHO4OLD*(QAL4*DD2 + SSP4*QBL4*DD)
         ELSE
           VQ1  = ZERO
@@ -2227,15 +2221,15 @@ C============================================
           VQ3  = ZERO
           VQ4  = ZERO
         ENDIF
-        
+
         Q1   = VQ1
         Q2   = VQ2
         Q3   = VQ3
-        Q4   = VQ4 
-        
-Cts        if     (ix(11,I+NFT).EQ.ibug_id(1))then
+        Q4   = VQ4
+
+Cts        if     (ix(11,I+NFT) == ibug_id(1))then
 Cts          write (*,FMT='(A,5E30.16)')"Q1,Q2,Q3,Q4, Q0 =", Q1,Q2,Q3,Q4,Q0
-Cts        endif   
+Cts        endif
 
         SSP1 = ZERO
         SSP2 = ZERO
@@ -2274,14 +2268,14 @@ c   MATERIAL PRESENCE (INTEGER UNEPHASE)
 C============================================
         UNEPHASE=0
         MASS = MAS1 + MAS2 + MAS3 + MAS4
-        VOLD = V1OLD + V2OLD + V3OLD + V4OLD        
+        VOLD = V1OLD + V2OLD + V3OLD + V4OLD
 
-        IF (MAS1 / MASS .GT. TOL51 .AND. MAS1/RHO10/VOLD.GT.Tol51) THEN
+        IF (MAS1 / MASS  >  TOL51 .AND. MAS1/RHO10/VOLD > Tol51) THEN
            UNEPHASE=UNEPHASE + 1
            V10 = MAS1 / RHO10
            RHO0E1 = EINT1/V10
            ALPHA1OLD = V1OLD / VOLD
-           !IF (ALPHA1OLD .GT. UN + EM14) THEN
+           !IF (ALPHA1OLD  >  UN + EM14) THEN
            !   PRINT*, "ALPHA1OLD",ALPHA1OLD
            !ENDIF
            V1 = V1OLD - TIMESTEP*DDVOL1 + ALPHA1OLD * DDVOL(I)
@@ -2292,12 +2286,12 @@ C============================================
            V10   = ZERO
            ALPHA1OLD = ZERO
         ENDIF
-        IF (MAS2 / MASS .GT. TOL51 .AND. MAS2/RHO20/VOLD.GT.Tol51) THEN
+        IF (MAS2 / MASS  >  TOL51 .AND. MAS2/RHO20/VOLD > Tol51) THEN
            UNEPHASE=UNEPHASE + 2
            V20 = MAS2 / RHO20
            RHO0E2 = EINT2/V20
            ALPHA2OLD = V2OLD / VOLD
-           !IF (ALPHA2OLD .GT. UN + EM14) THEN
+           !IF (ALPHA2OLD  >  UN + EM14) THEN
            !   PRINT*, "ALPHA2OLD",ALPHA2OLD
            !ENDIF
            V2 = V2OLD - TIMESTEP*DDVOL2 + ALPHA2OLD * DDVOL(I)
@@ -2305,16 +2299,16 @@ C============================================
         ELSE
            MAS2  = ZERO
            V2 = ZERO
-           V20   = ZERO 
+           V20   = ZERO
            ALPHA2OLD = ZERO
         ENDIF
-        
-        IF (MAS3 / MASS .GT. TOL51 .AND. MAS3/RHO30/VOLD.GT.Tol51) THEN
+
+        IF (MAS3 / MASS  >  TOL51 .AND. MAS3/RHO30/VOLD > Tol51) THEN
            UNEPHASE=UNEPHASE + 4
            V30 = MAS3 / RHO30
            RHO0E3 = EINT3/V30
            ALPHA3OLD = V3OLD / VOLD
-           !IF (ALPHA3OLD .GT. UN + EM14) THEN
+           !IF (ALPHA3OLD  >  UN + EM14) THEN
            !   PRINT*, "ALPHA3OLD",ALPHA3OLD
            !ENDIF
            V3 = V3OLD - TIMESTEP*DDVOL3 + ALPHA3OLD * DDVOL(I)
@@ -2322,28 +2316,28 @@ C============================================
         ELSE
           MAS3  = ZERO
           V3 = ZERO
-          V30   = ZERO    
+          V30   = ZERO
           ALPHA3OLD = ZERO
         ENDIF
 
-        IF (MAS4 / MASS .GT. TOL51 .AND. MAS4/RHO40/VOLD.GT.Tol51) THEN
+        IF (MAS4 / MASS  >  TOL51 .AND. MAS4/RHO40/VOLD > Tol51) THEN
            UNEPHASE=UNEPHASE + 8
            V40 = MAS4 / RHO40
            ALPHA4OLD = V4OLD / VOLD
-           !IF (ALPHA4OLD .GT. UN + EM14) THEN
+           !IF (ALPHA4OLD  >  UN + EM14) THEN
            !   PRINT*, "ALPHA4OLD",ALPHA4OLD
            !ENDIF
            V4 = V4OLD - TIMESTEP*DDVOL4 + ALPHA4OLD * DDVOL(I)
-           V4 = MAX(ZERO,V4)   
+           V4 = MAX(ZERO,V4)
         ELSE
            MAS4  = ZERO
            V4 = ZERO
-           V40   = ZERO     
+           V40   = ZERO
            ALPHA4OLD = ZERO
         ENDIF
         ! SANITY CHECK
         AA = (V1 + V2 + V3 + V4) / VOLUME(I)
-        IF(AA.GT.EM06)THEN
+        IF(AA > EM06)THEN
          V1 = V1 / AA
          V2 = V2 / AA
          V3 = V3 / AA
@@ -2358,16 +2352,16 @@ C============================================
         MASS = MAS1 + MAS2 + MAS3 + MAS4
         RHO(I) = MASS / VOLUME(I)
 
-        RHOOLD = ALPHA1OLD * RHO1OLD + ALPHA2OLD * RHO2OLD + 
+        RHOOLD = ALPHA1OLD * RHO1OLD + ALPHA2OLD * RHO2OLD +
      .       ALPHA3OLD * RHO3OLD + ALPHA4OLD * RHO4OLD
 
         dbVOLD_f(1) = V1OLD
         dbVOLD_f(2) = V2OLD
         dbVOLD_f(3) = V3OLD
-        dbVOLD_f(4) = V4OLD 
+        dbVOLD_f(4) = V4OLD
 
 C===================================================
-C IF ONLY ONE MATERIAL IN ELEMENT     
+C IF ONLY ONE MATERIAL IN ELEMENT
 C      MAT1 : (UNEPHASE=1) => Polynomial EOS
 C   or MAT2 : (UNEPHASE=2) => Polynomial EOS
 C   or MAT3 : (UNEPHASE=4) => Polynomial EOS
@@ -2387,7 +2381,7 @@ C===================================================
           V2    = ZERO
           V3    = ZERO
           V4    = ZERO
-          
+
          !==========================================
          ! The only material is MAT1 (sol, liq, gas)
          !==========================================
@@ -2404,7 +2398,7 @@ C===================================================
      .            RHO0E1,EINT1 ,SOUNDSP(I),VISCMAX(I),XL ,SSP1,
      .            QA,QB, E1_INF,IPLA1,UPARAM(101),PLAS1(I))
 
-	     
+
          !==========================================
          ! The only material is MAT2 (sol, liq, gas)
          !==========================================
@@ -2434,10 +2428,10 @@ C===================================================
      .           RHO(I),MAS3 ,RHO30,RHO3,DD,MU3,MU3P1,
      .           POLD,PEXT,P3,PM3,P,Q3,QOLD,Q,
      .           RHO0E3,EINT3 ,SOUNDSP(I),VISCMAX(I),XL ,SSP3,
-     .           QA,QB, E3_INF,IPLA3,UPARAM(201),PLAS3(I)) 
+     .           QA,QB, E3_INF,IPLA3,UPARAM(201),PLAS3(I))
          !===========================================
          ! The only material is MAT4 (High Explosive)
-         !===========================================   
+         !===========================================
          ELSEIF(UNEPHASE == 8)THEN
             EINT4 = EINT4  - (PEXT + POLD + QQOLD(I)) * DDVOL(I)
             EINT(I) = EINT4
@@ -2448,12 +2442,12 @@ C     Computation of burnt fraction
 C---------------------------------------------------
             CALL JWLUN51 (TIME,XL,TBURN,UPARAM,DD,MU4,MU4P1,
      .           VOLUME(I),DVOL, V4OLD,EINT4,VISCMAX(I),
-     .           P4OLD(I),Q4,Q4OLD,PEXT,P4,PM4,     
+     .           P4OLD(I),Q4,Q4OLD,PEXT,P4,PM4,
      .           RHO(I),RHO40,MAS4,SOUNDSP(I),
      .           P,Q,RHO4,V4,SSP4,
      .           QA,QB,BFRAC(I))
            ENDIF
-          
+
 C===================================================
 C MORE THAN ONE MATERIAL IN ELEMENT
 C    UNEPHASE /= 1,2,4,8
@@ -2466,7 +2460,7 @@ C     New solver
 C===================================================
 C===================================================
 C---------------------------------------------------
-C     Submaterial energies evolve according to 
+C     Submaterial energies evolve according to
 C     dEi / dt + div(Ei u) + alpha_i p_i div(u) = 0
 C     with a fraction of the global pseudo-viscosity
 C     coefficient
@@ -2484,8 +2478,8 @@ C     Pseudo viscosity pondarated by old massic fractions
 C---------------------------------------------------
 C     Global energy evolution
 C     d(E) / dt + div(Eu) +  P div(u) = 0
-C     with contribution of pseudo viscosity and 
-C     pressure at time t^n. 
+C     with contribution of pseudo viscosity and
+C     pressure at time t^n.
 C     However, since EINT1 ... EINT4 have received
 C     plasticity contributions, we directly set
 C     EINT(I) = EINT1 + EINT2 + EINT3 + EINT4
@@ -2507,10 +2501,10 @@ C---------------------------------------------------
           V2I   = V2
           V3I   = V3
           V4I   = V4
-          IF (V1 .GT. ZERO) RHO1 = MAS1 / V1
-          IF (V2 .GT. ZERO) RHO2 = MAS2 / V2
-          IF (V3 .GT. ZERO) RHO3 = MAS3 / V3
-          IF (V4 .GT. ZERO) RHO4 = MAS4 / V4
+          IF (V1  >  ZERO) RHO1 = MAS1 / V1
+          IF (V2  >  ZERO) RHO2 = MAS2 / V2
+          IF (V3  >  ZERO) RHO3 = MAS3 / V3
+          IF (V4  >  ZERO) RHO4 = MAS4 / V4
 C---------------------------------------------------
 C     COMPUTE PRESSURE FOR EACH SUBMATERIAL
 C---------------------------------------------------
@@ -2521,7 +2515,7 @@ C     Gruneisen coefficient : GRUN = 1 / RHO * Dp / De (cst rho)
           GRUN3 = ZERO
           GRUN4 = ZERO
 C     MAT1
-          IF (V1 .GT. ZERO) THEN
+          IF (V1  >  ZERO) THEN
              CALL POLY51 (C01,C11,C21,C31,C41,C51,GG1,
      .            VOLUME(I),V10,V1,V1I,MU1,MU1P1,EINT1,
      .            P1OLD(I),Q1,Q1OLD,PEXT,P1,PM1,P1I,
@@ -2529,7 +2523,7 @@ C     MAT1
      .            IPLA1,UPARAM(101),PLAS1(I), 0, GRUN1)
           ENDIF
 C     MAT2
-          IF (V2 .GT. ZERO) THEN
+          IF (V2  >  ZERO) THEN
              CALL POLY51 (C02,C12,C22,C32,C42,C52,GG2,
      .            VOLUME(I),V20,V2,V2I,MU2,MU2P1,EINT2,
      .            P2OLD(I),Q2,Q2OLD,PEXT,P2,PM2,P2I,
@@ -2537,7 +2531,7 @@ C     MAT2
      .            IPLA2,UPARAM(151),PLAS2(I), 0, GRUN2)
           ENDIF
 C     MAT3
-          IF (V3 .GT. ZERO) THEN
+          IF (V3  >  ZERO) THEN
              CALL POLY51 (C03,C13,C23,C33,C43,C53,GG3,
      .            VOLUME(I),V30,V3,V3I,MU3,MU3P1,EINT3,
      .            P3OLD(I),Q3,Q3OLD,PEXT,P3,PM3,P3I,
@@ -2545,7 +2539,7 @@ C     MAT3
      .            IPLA3,UPARAM(201),PLAS3(I), 0, GRUN3)
           ENDIF
 C     MAT4 : High Explosive
-          IF (V4 .GT. ZERO) THEN
+          IF (V4  >  ZERO) THEN
 C---------------------------------------------------
 C     Computation of burnt fraction
 C---------------------------------------------------
@@ -2588,23 +2582,23 @@ C---------------------------------------------------
           ERROR2 = ERROR
           STEP = UN
           CONT = 1
-          DO WHILE(ITER .LE. NITER .AND. CONT .EQ. 1)
+          DO WHILE(ITER <= NITER .AND. CONT  ==  1)
              ITER = ITER + 1
 
              COEF1 = ZERO
-             IF (V1 .GT. ZERO .AND. SSP1 .GT. ZERO) THEN
+             IF (V1  >  ZERO .AND. SSP1  >  ZERO) THEN
                 COEF1 = V1 / RHO1 / SSP1 / SSP1
              ENDIF
              COEF2 = ZERO
-             IF (V2 .GT. ZERO .AND. SSP2 .GT. ZERO) THEN
+             IF (V2  >  ZERO .AND. SSP2  >  ZERO) THEN
                 COEF2 = V2 / RHO2 / SSP2 / SSP2
              ENDIF
              COEF3 = ZERO
-             IF (V3 .GT. ZERO .AND. SSP3 .GT. ZERO) THEN
+             IF (V3  >  ZERO .AND. SSP3  >  ZERO) THEN
                 COEF3 = V3 / RHO3 / SSP3 / SSP3
              ENDIF
              COEF4 = ZERO
-             IF (V4 .GT. ZERO .AND. SSP4 .GT. ZERO) THEN
+             IF (V4  >  ZERO .AND. SSP4  >  ZERO) THEN
                 COEF4 = V4 / RHO4 / SSP4 / SSP4
              ENDIF
              !!! Relaxation pressure
@@ -2617,37 +2611,37 @@ C---------------------------------------------------
              DV3 = COEF3 * (P3 - P)
              DV4 = COEF4 * (P4 - P)
 
-             !!! Compute a step less or equal that one to ensure 
+             !!! Compute a step less or equal that one to ensure
              !!! that volume does not decrease of more than half
              !!! of its previous value
 
              STEP = UN
-             IF (DV1 .LT. ZERO) THEN
+             IF (DV1  <  ZERO) THEN
                 STEP = MIN(STEP, -UNDEMI * V1 / DV1)
              ENDIF
-             IF (DV2 .LT. ZERO) THEN
+             IF (DV2  <  ZERO) THEN
                 STEP = MIN(STEP, -UNDEMI * V2 / DV2)
              ENDIF
-             IF (DV3 .LT. ZERO) THEN
+             IF (DV3  <  ZERO) THEN
                 STEP = MIN(STEP, -UNDEMI * V3 / DV3)
              ENDIF
-             IF (DV4 .LT. ZERO) THEN
+             IF (DV4  <  ZERO) THEN
                 STEP = MIN(STEP, -UNDEMI * V4 / DV4)
              ENDIF
              !!! Also ensure energy positivity
-c$$$             IF (P * DV1 .GT. ZERO) THEN
+c$$$             IF (P * DV1  >  ZERO) THEN
 c$$$                STEP = MIN(STEP, UNDEMI * EINT1 / (P * DV1))
 c$$$             ENDIF
-c$$$             IF (P * DV2 .GT. ZERO) THEN
+c$$$             IF (P * DV2  >  ZERO) THEN
 c$$$                STEP = MIN(STEP, UNDEMI * EINT2 / (P * DV2))
 c$$$             ENDIF
-c$$$             IF (P * DV3 .GT. ZERO) THEN
+c$$$             IF (P * DV3  >  ZERO) THEN
 c$$$                STEP = MIN(STEP, UNDEMI * EINT3 / (P * DV3))
 c$$$             ENDIF
-c$$$             IF (P * DV4 .GT. ZERO) THEN
+c$$$             IF (P * DV4  >  ZERO) THEN
 c$$$                STEP = MIN(STEP, UNDEMI * EINT4 / (P * DV4))
 c$$$             ENDIF
-            
+
              DV1 = STEP * DV1
              DV2 = STEP * DV2
              DV3 = STEP * DV3
@@ -2657,16 +2651,16 @@ c$$$             ENDIF
 
              !!! Update submaterial internal energies in a thermodynamically consistent way
              !!! only if this has a sense (GRUN /= 0)
-             IF (V1 .GT. ZERO) THEN
+             IF (V1  >  ZERO) THEN
                 EINT1 = EINT1 - (P + PEXT) * DV1
              ENDIF
-             IF (V2 .GT. ZERO) THEN
+             IF (V2  >  ZERO) THEN
                 EINT2 = EINT2 - (P + PEXT) * DV2
              ENDIF
-             IF (V3 .GT. ZERO) THEN
+             IF (V3  >  ZERO) THEN
                 EINT3 = EINT3 - (P + PEXT) * DV3
              ENDIF
-             IF (V4 .GT. ZERO) THEN
+             IF (V4  >  ZERO) THEN
                 EINT4 = EINT4 - (P + PEXT) * DV4
              ENDIF
 
@@ -2683,22 +2677,22 @@ c$$$             ENDIF
              V4 = V4 / AA
 
              !!! Update densities
-             IF (V1 .GT. ZERO) RHO1 = MAS1 / V1
-             IF (V2 .GT. ZERO) RHO2 = MAS2 / V2
-             IF (V3 .GT. ZERO) RHO3 = MAS3 / V3
-             IF (V4 .GT. ZERO) RHO4 = MAS4 / V4
-            
+             IF (V1  >  ZERO) RHO1 = MAS1 / V1
+             IF (V2  >  ZERO) RHO2 = MAS2 / V2
+             IF (V3  >  ZERO) RHO3 = MAS3 / V3
+             IF (V4  >  ZERO) RHO4 = MAS4 / V4
+
              !!! Update submaterial pressures
              PM5 = -EP20
-             IF (V1 .GT. ZERO) PM5 = max(PM5,PM1)
-             IF (V2 .GT. ZERO) PM5 = max(PM5,PM2)
-             IF (V3 .GT. ZERO) PM5 = max(PM5,PM3)
-             IF (V4 .GT. ZERO) PM5 = max(PM5,PM4) 
+             IF (V1  >  ZERO) PM5 = max(PM5,PM1)
+             IF (V2  >  ZERO) PM5 = max(PM5,PM2)
+             IF (V3  >  ZERO) PM5 = max(PM5,PM3)
+             IF (V4  >  ZERO) PM5 = max(PM5,PM4)
 
             !===========================================
             !       material 1 - Polynomial EOS
             !===========================================
-            IF (V1 .GT. ZERO) THEN
+            IF (V1  >  ZERO) THEN
                 CALL POLY51 (C01,C11,C21,C31,C41,C51,GG1,
      .                        VOLUME(I),V10,V1,V1I,MU1,MU1P1,EINT1,
      .                        P1OLD(I),Q1,Q1OLD,PEXT,P1,PM5,P1I,
@@ -2708,7 +2702,7 @@ c$$$             ENDIF
             !===========================================
             !       material 2 - Polynomial EOS
             !===========================================
-            IF (V2 .GT. ZERO) THEN
+            IF (V2  >  ZERO) THEN
                 CALL POLY51 (C02,C12,C22,C32,C42,C52,GG2,
      .                        VOLUME(I),V20,V2,V2I,MU2,MU2P1,EINT2,
      .                        P2OLD(I),Q2,Q2OLD,PEXT,P2,PM5,P2I,
@@ -2718,7 +2712,7 @@ c$$$             ENDIF
             !===========================================
             !       material 3 - Polynomial EOS
             !===========================================
-            IF (V3 .GT. ZERO) THEN
+            IF (V3  >  ZERO) THEN
                 CALL POLY51 (C03,C13,C23,C33,C43,C53,GG3,
      .                        VOLUME(I),V30,V3,V3I,MU3,MU3P1,EINT3,
      .                        P3OLD(I),Q3,Q3OLD,PEXT,P3,PM5,P3I,
@@ -2728,22 +2722,22 @@ c$$$             ENDIF
             !===========================================
             !       material 4 - Polynomial EOS
             !===========================================
-            IF (V4 .GT. ZERO)THEN
+            IF (V4  >  ZERO)THEN
                 CALL JWL51 (TIME,XL,TBURN,UPARAM,
      .                      VOLUME(I),V4,V4I,MU4,MU4P1,EINT4,
      .                      P4OLD(I),Q4,Q4OLD,PEXT,P4,PM5,P4I,
      .                      RHO4,RHO40,MAS4,SSP4,DVDP4,DPDV4,
      .                      BFRAC(I),V40, 0, GRUN4)
             ENDIF
-            
+
             !!! Check convergence
             ERROR = ZERO
-            IF (V1 .GT. ZERO) ERROR = ERROR + ABS(DV1) / V1
-            IF (V2 .GT. ZERO) ERROR = ERROR + ABS(DV2) / V2
-            IF (V3 .GT. ZERO) ERROR = ERROR + ABS(DV3) / V3
-            IF (V4 .GT. ZERO) ERROR = ERROR + ABS(DV4) / V4
+            IF (V1  >  ZERO) ERROR = ERROR + ABS(DV1) / V1
+            IF (V2  >  ZERO) ERROR = ERROR + ABS(DV2) / V2
+            IF (V3  >  ZERO) ERROR = ERROR + ABS(DV3) / V3
+            IF (V4  >  ZERO) ERROR = ERROR + ABS(DV4) / V4
 
-            IF (ERROR .LT. TOL) THEN
+            IF (ERROR  <  TOL) THEN
                CONT = 0
             ENDIF
 
@@ -2752,8 +2746,8 @@ c$$$             ENDIF
 C---------------------------------------------------
 C     CONVERGENCE TEST
 C---------------------------------------------------
-          IF (CONT .EQ. 1) THEN
-             IF (IDBG .EQ. 1) THEN
+          IF (CONT  ==  1) THEN
+             IF (IDBG  ==  1) THEN
                 PRINT*, "*** Non convergence of LAW51 EOS in elem", IX(NIX, I + NFT), ERROR, ERROR2
              ENDIF
 c$$$             P1 = P1I
@@ -2776,13 +2770,13 @@ c$$$             P = V1 * P1 + V2 * P2 + V3 * P3 + V4 * P4
 c$$$             P = P / VOLUME(I)
           ENDIF
           AA = (V1 + V2 + V3 + V4) / VOLUME(I)
-          
-          IF (IDBG.EQ.1 .AND. ABS(AA - UN) .GT. EM14) THEN
+
+          IF (IDBG == 1 .AND. ABS(AA - UN)  >  EM14) THEN
              PRINT*, "**WARNING : CONVERGENCE ISSUE", AA
           ENDIF
 C     Sanity check
           ERROR2 = ABS(EINT(I) - EINT1 - EINT2 - EINT3 - EINT4)
-          IF (IDBG.EQ.1 .AND. ERROR2 .GT. EM13 * (UN + ABS(EINT(I)))) THEN
+          IF (IDBG == 1 .AND. ERROR2  >  EM13 * (UN + ABS(EINT(I)))) THEN
              PRINT*, "**Warning : Conversgence Issue", ERROR2
           ENDIF
           Q1 = Q1OLD
@@ -2796,81 +2790,89 @@ C===================================================
 C     END New solver
 C===================================================
 C===================================================
-               
-          
-        ELSEIF(UNEPHASE.EQ.0) THEN
+
+
+        ELSEIF(UNEPHASE == 0) THEN
           !! This case should not occur.It means that MASS.LE.ZERO
           !print *, "Warning, empty element"
            SOUNDSP(I)=EM20
-          
+
         ENDIF
-        RHO(I) = MASS / VOLUME(I)          
+        RHO(I) = MASS / VOLUME(I)
 
         SOUNDSP(I) = ZERO
-        IF (MAS1 / MASS .GT. TOL51) THEN
+        VISA1 = ZERO
+
+        IF (MAS1 / MASS  >  TOL51) THEN
            SOUNDSP(I) = SOUNDSP(I) + MAS1 / MASS * SSP1 * SSP1
+           VISA1 = VISA1 + V1*RHO1 * VISC1
         ENDIF
-        IF (MAS2 / MASS .GT. TOL51) THEN
+        IF (MAS2 / MASS  >  TOL51) THEN
            SOUNDSP(I) = SOUNDSP(I) + MAS2 / MASS * SSP2 * SSP2
+           VISA1 = VISA1 + V2*RHO2 * VISC2
         ENDIF
-        IF (MAS3 / MASS .GT. TOL51) THEN
+        IF (MAS3 / MASS  >  TOL51) THEN
            SOUNDSP(I) = SOUNDSP(I) + MAS3 / MASS * SSP3 * SSP3
+           VISA1 = VISA1 + V3*RHO3 * VISC3
         ENDIF
-        IF (MAS4 / MASS .GT. TOL51) THEN
+        IF (MAS4 / MASS  >  TOL51) THEN
            SOUNDSP(I) = SOUNDSP(I) + MAS4 / MASS * SSP4 * SSP4
+           VISA1 = VISA1 + V4*RHO4 * VISC4
         ENDIF
+
+        VISA1 = VISA1 / VOLUME(I) / RHO(I)
+
         SOUNDSP(I) = SQRT(SOUNDSP(I))
-        VISCMAX(I)=VQ0
+        VISCMAX(I) = VQ0
         VISCMAX(I) = VISCMAX(I)/DEUX
         VISCMAX(I) = VISCMAX(I) + RHO(I)*(DEUX*VISA1 + VISB1)/TROIS
-
 !
 C===================================================
-C CALCULTATION OF CONSISTENT DENSITY WITH PRESSURE 
+C CALCULTATION OF CONSISTENT DENSITY WITH PRESSURE
 C IF ONE MATERIAL IS NOT PRESENT
 C===================================================
 C----------------------------
 C       phases vide calcul de rho consistant avec p
 c
-c     dP/drho = C1/rho0 + max(mu,0)(2 C2 + 3 C3 mu)/rho0 
+c     dP/drho = C1/rho0 + max(mu,0)(2 C2 + 3 C3 mu)/rho0
 c            + (C4 + C5 mu)  (P+Q) /(1+mu)^2 /rho0
 c            + C5 e
 C----------------------------
 c 1-  mu=0 e = E0/rho0
 c     dP/drho = (C1 + C4 (P+Q) + C5 E0 ) /rho0
-c     drho/dP = rho0/(C1 + C4 (P+Q) + C5 E0 ) 
-c     drho = dP rho0/(C1 + C4 (P+Q) + C5 E0 ) 
+c     drho/dP = rho0/(C1 + C4 (P+Q) + C5 E0 )
+c     drho = dP rho0/(C1 + C4 (P+Q) + C5 E0 )
 C----------------------------
-c 2-  mu=rho/rho0 - 1 
+c 2-  mu=rho/rho0 - 1
 c     e = E /rho0
 c     d(rho0e)V0 = -P DV
 c     d(rho0e) = -P DV/V0 = -P (V/VO - V_/V0) = -P(rho0/rho-rho0/rho_)
 c     d(rho0e) = -P rho0/rho(1-rho/rho_)
 c     rho0e = rho0e + P rho0/rho a      a = rho/rho_ -1
 c     a = drho/rho
-c     dP/drho = C1/rho0 + max(mu,0)(2 C2 + 3 C3 mu)/rho0 
+c     dP/drho = C1/rho0 + max(mu,0)(2 C2 + 3 C3 mu)/rho0
 c            + (C4 + C5 mu)  (P+Q) /(1+mu)^2 /rho0
 c            + C5 rho0e/rho0
-c     drho/dP = rho0 / [C1 + max(mu,0)(2 C2 + 3 C3 mu) 
-c            + (C4 + C5 mu)  (P+Q) /(1+mu)^2 
+c     drho/dP = rho0 / [C1 + max(mu,0)(2 C2 + 3 C3 mu)
+c            + (C4 + C5 mu)  (P+Q) /(1+mu)^2
 c            + C5 rho0e]
-c     drho = rho0 dP/ [C1 + max(mu,0)(2 C2 + 3 C3 mu) 
-c            + (C4 + C5 mu)  (P+Q) /(1+mu)^2 
+c     drho = rho0 dP/ [C1 + max(mu,0)(2 C2 + 3 C3 mu)
+c            + (C4 + C5 mu)  (P+Q) /(1+mu)^2
 c            + C5 rho0e]
-c     drho/rho = rho0/rho dP/ [C1 + max(mu,0)(2 C2 + 3 C3 mu) 
-c            + (C4 + C5 mu)  (P+Q) /(1+mu)^2 
+c     drho/rho = rho0/rho dP/ [C1 + max(mu,0)(2 C2 + 3 C3 mu)
+c            + (C4 + C5 mu)  (P+Q) /(1+mu)^2
 c            + C5 rho0e]
-c     a = rho0/rho dP/ [C1 + max(mu,0)(2 C2 + 3 C3 mu) 
-c            + (C4 + C5 mu)  (P+Q) /(1+mu)^2 
+c     a = rho0/rho dP/ [C1 + max(mu,0)(2 C2 + 3 C3 mu)
+c            + (C4 + C5 mu)  (P+Q) /(1+mu)^2
 c            + C5 rho0e]
 c     rho0e = rho0e + P rho0/rho a
 c     rho   = rho  (1+a)
 C----------------------------
 !
 C===================================================
-C  OUTPUT : STRESS TENSOR 
+C  OUTPUT : STRESS TENSOR
 C           VISCOUS STRESS
-C===================================================       
+C===================================================
 
         !----------------------------------------------------------------------------------!
         !SUBATERIAL INTERNAL ENERGY HAS TO BE BOUNDED : EINT1+EINT2+EINT3+EINT4 = EINT(new)
@@ -2878,19 +2880,19 @@ C===================================================
         !----------------------------------------------------------------------------------!
         !EINT_NEW = EINT(I) -(POLD+P+PEXT+PEXT+QOLD+Q)*DVOL*UNDEMI
         !EINT_k10 = EINT1+EINT2+EINT3+EINT4
-        !IF(ABS(EINT_k10).GE.EM06)THEN
+        !IF(ABS(EINT_k10) >= EM06)THEN
         !  ALP   = EINT_NEW / EINT_k10
         !  EINT1 = ALP * EINT1
         !  EINT2 = ALP * EINT2
         !  EINT3 = ALP * EINT3
-        !  EINT4 = ALP * EINT4                              
+        !  EINT4 = ALP * EINT4
         !ENDIF
 
-        !---------------------------------------------------------------------------------------------!        
+        !---------------------------------------------------------------------------------------------!
         !ENERGY INTEGRATION WITH PRESSURE CONTRIBUTION IS DONE AT ENT OF MULAW SUBROUTINE             !
-        !---------------------------------------------------------------------------------------------!        
+        !---------------------------------------------------------------------------------------------!
         !EINT(I) = EINT(I) - (PEXT+PEXT+QOLD+Q)*DVOL*UNDEMI !Attention : Q est retranche ici car stocke dans Svis pour mulaw et sfint
-     
+
         !---------------------------!
         !   TOTAL STRESS TENSOR     !
         !---------------------------!
@@ -2912,51 +2914,51 @@ C===================================================
          SIGNXY(I) = SIGNXY(I) + UVAR(I,5+K4) * V4
          SIGNYZ(I) = SIGNYZ(I) + UVAR(I,6+K4) * V4
          SIGNZX(I) = SIGNZX(I) + UVAR(I,7+K4) * V4
-        ENDIF 
+        ENDIF
 
         SIGNXX(I) = SIGNXX(I) / VOLUME(I)
         SIGNYY(I) = SIGNYY(I) / VOLUME(I)
-        SIGNZZ(I) = SIGNZZ(I) / VOLUME(I) 
+        SIGNZZ(I) = SIGNZZ(I) / VOLUME(I)
         SIGNXY(I) = SIGNXY(I) / VOLUME(I)
         SIGNYZ(I) = SIGNYZ(I) / VOLUME(I)
-        SIGNZX(I) = SIGNZX(I) / VOLUME(I) 
-        
+        SIGNZX(I) = SIGNZX(I) / VOLUME(I)
+
         SIGNXX(I) = SIGNXX(I) - P
         SIGNYY(I) = SIGNYY(I) - P
-        SIGNZZ(I) = SIGNZZ(I) - P  
+        SIGNZZ(I) = SIGNZZ(I) - P
 
         !---------------------------!
         !   VISCOUS STRESS TENSOR   !
         !---------------------------!
-        SIGVXX(I) = DEUX*RHO(I)*VISA1*EPSPXX(I) + RHO(I)*VISB1*(EPSPXX(I)+EPSPYY(I)+EPSPZZ(I))      
-        SIGVYY(I) = DEUX*RHO(I)*VISA1*EPSPYY(I) + RHO(I)*VISB1*(EPSPXX(I)+EPSPYY(I)+EPSPZZ(I))              
-        SIGVZZ(I) = DEUX*RHO(I)*VISA1*EPSPZZ(I) + RHO(I)*VISB1*(EPSPXX(I)+EPSPYY(I)+EPSPZZ(I))              
+        SIGVXX(I) = DEUX*RHO(I)*VISA1*EPSPXX(I) + RHO(I)*VISB1*(EPSPXX(I)+EPSPYY(I)+EPSPZZ(I))
+        SIGVYY(I) = DEUX*RHO(I)*VISA1*EPSPYY(I) + RHO(I)*VISB1*(EPSPXX(I)+EPSPYY(I)+EPSPZZ(I))
+        SIGVZZ(I) = DEUX*RHO(I)*VISA1*EPSPZZ(I) + RHO(I)*VISB1*(EPSPXX(I)+EPSPYY(I)+EPSPZZ(I))
         SIGVXY(I) = RHO(I)* VISA1 * EPSPXY(I)
         SIGVYZ(I) = RHO(I)* VISA1 * EPSPYZ(I)
         SIGVZX(I) = RHO(I)* VISA1 * EPSPZX(I)
-        
+
 C===========================================================C
 C  OUTPUT : UVAR(,) SUBMATERIAL OUTPUTS                     C
 C===========================================================C
 C     DC : supress this. Really dangerous, since modification of
-C     volume should me followed by modification of density, 
+C     volume should me followed by modification of density,
 C     energy and pressure ...
-        !IF(V1.EQ.ZERO.AND.MAS1.GT.ZERO)V1 = Tol51*VOLUME(I)
-        !IF(V2.EQ.ZERO.AND.MAS2.GT.ZERO)V2 = Tol51*VOLUME(I)
-        !IF(V3.EQ.ZERO.AND.MAS3.GT.ZERO)V3 = Tol51*VOLUME(I)
-        !IF(V4.EQ.ZERO.AND.MAS4.GT.ZERO)V4 = Tol51*VOLUME(I)
+        !IF(V1 == ZERO.AND.MAS1 > ZERO)V1 = Tol51*VOLUME(I)
+        !IF(V2 == ZERO.AND.MAS2 > ZERO)V2 = Tol51*VOLUME(I)
+        !IF(V3 == ZERO.AND.MAS3 > ZERO)V3 = Tol51*VOLUME(I)
+        !IF(V4 == ZERO.AND.MAS4 > ZERO)V4 = Tol51*VOLUME(I)
 C     DC : same comment
-        !IF (MAS1.GT.ZERO .AND. V1/VOLUME(I).LT.EM20)V1 = EM20*VOLUME(I)                
-        !IF (MAS2.GT.ZERO .AND. V2/VOLUME(I).LT.EM20)V2 = EM20*VOLUME(I)
-        !IF (MAS3.GT.ZERO .AND. V3/VOLUME(I).LT.EM20)V3 = EM20*VOLUME(I)
-        !IF (MAS4.GT.ZERO .AND. V4/VOLUME(I).LT.EM20)V4 = EM20*VOLUME(I)                        
+        !IF (MAS1 > ZERO .AND. V1/VOLUME(I) < EM20)V1 = EM20*VOLUME(I)
+        !IF (MAS2 > ZERO .AND. V2/VOLUME(I) < EM20)V2 = EM20*VOLUME(I)
+        !IF (MAS3 > ZERO .AND. V3/VOLUME(I) < EM20)V3 = EM20*VOLUME(I)
+        !IF (MAS4 > ZERO .AND. V4/VOLUME(I) < EM20)V4 = EM20*VOLUME(I)
         !===================================================C
         !        material 1 : THERMODYNAMICAL STATE OUTPUT  C
         !===================================================C
         KK = N0PHAS
-        IF(V1 .GT. ZERO)THEN          
+        IF(V1  >  ZERO)THEN
             UVAR(I,1+KK)  = V1 / VOLUME(I)
-            !deviator stress already updated in plasticity subroutines 
+            !deviator stress already updated in plasticity subroutines
             UVAR(I,18+KK) =   P1
             UVAR(I,14+KK) = SSP1
             UVAR(I,15+KK) = PLAS1(I)     ! Eps plastique
@@ -2966,42 +2968,42 @@ C     DC : same comment
             UVAR(I,16+KK) = TEMP1
             UVAR(I,8+KK)  = EINT1 / V1 ! energie IN rho e OUT
             UVAR(I,9+KK)  = RHO1       ! masse IN rho OUT
-            UVAR(I,10+KK) = Q1     
-            UVAR(I,11+KK) = V1  
+            UVAR(I,10+KK) = Q1
+            UVAR(I,11+KK) = V1
             UVAR(I,12+KK) = RHO1       ! rho_old IN rho OUT
             UVAR(I,17+KK) = EDIF1 / V1 ! energie diffusee IN spec OUT
 !           UVAR(I,19+KK) = EPSEQ1(I)
         ELSE
-            UVAR(I,1+KK)  = ZERO   
-            UVAR(I,2+KK)  = ZERO  
-            UVAR(I,3+KK)  = ZERO 
+            UVAR(I,1+KK)  = ZERO
+            UVAR(I,2+KK)  = ZERO
+            UVAR(I,3+KK)  = ZERO
             UVAR(I,4+KK)  = ZERO
-            UVAR(I,5+KK)  = ZERO 
+            UVAR(I,5+KK)  = ZERO
             UVAR(I,6+KK)  = ZERO
             UVAR(I,7+KK)  = ZERO
             UVAR(I,8+KK)  = ZERO
-            UVAR(I,9+KK)  = ZERO       
-            UVAR(I,10+KK) = ZERO   
+            UVAR(I,9+KK)  = ZERO
+            UVAR(I,10+KK) = ZERO
             UVAR(I,11+KK) = ZERO
-            UVAR(I,12+KK) = RHO10 
+            UVAR(I,12+KK) = RHO10
             UVAR(I,14+KK) = ZERO
             UVAR(I,15+KK) = ZERO
             UVAR(I,16+KK) = T10
             TEMP1         = T10
             UVAR(I,17+KK) = ZERO ! energie diffusee IN spec OUT
-            UVAR(I,18+KK) =  P              
+            UVAR(I,18+KK) =  P
             UVAR(I,19+KK) = ZERO
-            EPSEQ1(I)     = ZERO    
+            EPSEQ1(I)     = ZERO
         ENDIF
-C        IF(V1/VOLUME(I) .LT. EM03)UVAR(I,14+KK)=ZERO
-        
+C        IF(V1/VOLUME(I)  <  EM03)UVAR(I,14+KK)=ZERO
+
         !===================================================C
         !        material 2 : THERMODYNAMICAL STATE OUTPUT  C
         !===================================================C
         KK = N0PHAS + NVPHAS
-        IF(V2 .GT. ZERO)THEN
-            UVAR(I,1+KK)  = V2  / VOLUME(I) 
-            !deviator stress already updated in plasticity subroutines 
+        IF(V2  >  ZERO)THEN
+            UVAR(I,1+KK)  = V2  / VOLUME(I)
+            !deviator stress already updated in plasticity subroutines
             UVAR(I,18+KK) = P2
             UVAR(I,14+KK) = SSP2
             UVAR(I,15+KK) = PLAS2(I)   ! Eps plastique
@@ -3010,43 +3012,43 @@ C        IF(V1/VOLUME(I) .LT. EM03)UVAR(I,14+KK)=ZERO
             TEMP2         = (EINT2/V2/(MU2P1) - ECOLD) / SPH2
             UVAR(I,16+KK) = TEMP2
             UVAR(I,8+KK)  = EINT2 / V2
-            UVAR(I,9+KK)  = RHO2   
-            UVAR(I,10+KK) = Q2     
-            UVAR(I,11+KK) = V2 
+            UVAR(I,9+KK)  = RHO2
+            UVAR(I,10+KK) = Q2
+            UVAR(I,11+KK) = V2
             UVAR(I,12+KK) = RHO2
             UVAR(I,17+KK) = EDIF2 / V2 ! energie diffusee IN spec OUT
-!           UVAR(I,19+KK) = EPSEQ2(I)    
+!           UVAR(I,19+KK) = EPSEQ2(I)
         ELSE
-            UVAR(I,1+KK)  = ZERO   
-            UVAR(I,2+KK)  = ZERO 
-            UVAR(I,3+KK)  = ZERO 
-            UVAR(I,4+KK)  = ZERO 
-            UVAR(I,5+KK)  = ZERO 
+            UVAR(I,1+KK)  = ZERO
+            UVAR(I,2+KK)  = ZERO
+            UVAR(I,3+KK)  = ZERO
+            UVAR(I,4+KK)  = ZERO
+            UVAR(I,5+KK)  = ZERO
             UVAR(I,6+KK)  = ZERO
-            UVAR(I,7+KK)  = ZERO 
-            UVAR(I,8+KK)  = ZERO 
-            UVAR(I,9+KK)  = ZERO       
+            UVAR(I,7+KK)  = ZERO
+            UVAR(I,8+KK)  = ZERO
+            UVAR(I,9+KK)  = ZERO
             UVAR(I,10+KK) = ZERO
             UVAR(I,11+KK) = ZERO
-            UVAR(I,12+KK) = RHO20      
+            UVAR(I,12+KK) = RHO20
             UVAR(I,14+KK) = ZERO
             UVAR(I,15+KK) = ZERO
             UVAR(I,16+KK) = T20
             TEMP2         = T20
             UVAR(I,17+KK) = ZERO ! energie diffusee IN spec OUT
-            UVAR(I,18+KK) =   P            
+            UVAR(I,18+KK) =   P
             UVAR(I,19+KK) = ZERO
-            EPSEQ2(I)     = ZERO    
+            EPSEQ2(I)     = ZERO
         ENDIF
-C        IF(V2/VOLUME(I) .LT. EM03)UVAR(I,14+KK)=ZERO
-        
+C        IF(V2/VOLUME(I)  <  EM03)UVAR(I,14+KK)=ZERO
+
         !===================================================C
         !        material 3 : THERMODYNAMICAL STATE OUTPUT  C
         !===================================================C
         KK = N0PHAS + 2*NVPHAS
-        IF(V3 .GT. ZERO)THEN
+        IF(V3  >  ZERO)THEN
             UVAR(I,1+KK)  = V3  / VOLUME(I)
-            !deviator stress already updated in plasticity subroutines                     
+            !deviator stress already updated in plasticity subroutines
             UVAR(I,18+KK) =   P3
             UVAR(I,14+KK) = SSP3
             UVAR(I,15+KK) = PLAS3(I)   ! Eps plastique
@@ -3054,148 +3056,146 @@ C        IF(V2/VOLUME(I) .LT. EM03)UVAR(I,14+KK)=ZERO
             IF(MU3 > ZERO) ECOLD = ECOLD * (UN+C53*MU3*(UN-MU3)) + UNDEMI*C23*MU3*MU3
             TEMP3         = (EINT3/V3/MU3P1 - ECOLD) / SPH3
             UVAR(I,16+KK) = TEMP3
-            UVAR(I,8+KK)  = EINT3 / V3 
-            UVAR(I,9+KK)  = RHO3   
-            UVAR(I,10+KK) = Q3     
-            UVAR(I,11+KK) = V3  
+            UVAR(I,8+KK)  = EINT3 / V3
+            UVAR(I,9+KK)  = RHO3
+            UVAR(I,10+KK) = Q3
+            UVAR(I,11+KK) = V3
             UVAR(I,12+KK) = RHO3
             UVAR(I,17+KK) = EDIF3 / V3 ! energie diffusee IN spec OUT
-!           UVAR(I,19+KK) = EPSEQ3(I)    
+!           UVAR(I,19+KK) = EPSEQ3(I)
         ELSE
-            UVAR(I,1+KK)  = ZERO 
+            UVAR(I,1+KK)  = ZERO
             UVAR(I,2+KK)  = ZERO
-            UVAR(I,3+KK)  = ZERO 
-            UVAR(I,4+KK)  = ZERO 
-            UVAR(I,5+KK)  = ZERO 
+            UVAR(I,3+KK)  = ZERO
+            UVAR(I,4+KK)  = ZERO
+            UVAR(I,5+KK)  = ZERO
             UVAR(I,6+KK)  = ZERO
-            UVAR(I,7+KK)  = ZERO 
-            UVAR(I,8+KK)  = ZERO 
-            UVAR(I,9+KK)  = ZERO     
-            UVAR(I,10+KK) = ZERO  
+            UVAR(I,7+KK)  = ZERO
+            UVAR(I,8+KK)  = ZERO
+            UVAR(I,9+KK)  = ZERO
+            UVAR(I,10+KK) = ZERO
             UVAR(I,11+KK) = ZERO
-            UVAR(I,12+KK) = RHO30     
+            UVAR(I,12+KK) = RHO30
             UVAR(I,14+KK) = ZERO
             UVAR(I,15+KK) = ZERO
             UVAR(I,16+KK) = T30
             UVAR(I,17+KK) = ZERO ! energie diffusee IN spec OUT
-            UVAR(I,18+KK) =   P            
+            UVAR(I,18+KK) =   P
             TEMP3         = T30
             UVAR(I,19+KK) = ZERO
-            EPSEQ3(I)     = ZERO    
+            EPSEQ3(I)     = ZERO
         ENDIF
-C        IF(V3/VOLUME(I) .LT. EM03)UVAR(I,14+KK)=ZERO
+C        IF(V3/VOLUME(I)  <  EM03)UVAR(I,14+KK)=ZERO
 
         !===================================================C
         !        material 4 : THERMODYNAMICAL STATE OUTPUT  C
         !===================================================C
         IF(IEXP/=0)THEN
-        KK = N0PHAS + 3*NVPHAS         
-         IF(V4 .GT. ZERO)THEN
-            UVAR(I,1+KK)  = V4 / VOLUME(I)           
+        KK = N0PHAS + 3*NVPHAS
+         IF(V4  >  ZERO)THEN
+            UVAR(I,1+KK)  = V4 / VOLUME(I)
             UVAR(I,18+KK) = P4
             UVAR(I,14+KK) = SSP4
             UVAR(I,15+KK) = ZERO      ! Eps plastique
             UVAR(I,8+KK)  = EINT4 / V4 ! energie IN rho e OUT
             UVAR(I,9+KK)  = RHO4       ! masse IN rho OUT
-            UVAR(I,10+KK) = Q4     
-            UVAR(I,11+KK) = V4  
+            UVAR(I,10+KK) = Q4
+            UVAR(I,11+KK) = V4
             UVAR(I,12+KK) = RHO4       ! rho_old IN rho OUT
             UVAR(I,15+KK) = TBURN   ! -burn time ou burn fraction
             UVAR(I,17+KK) = EDIF4 / V4 ! energie diffusee IN spec OUT
             TEMP4 = T40
-            UVAR(I,19+KK) = ZERO    
+            UVAR(I,19+KK) = ZERO
          ELSE
-            UVAR(I,1+KK)  = ZERO   
+            UVAR(I,1+KK)  = ZERO
             UVAR(I,2+KK)  = ZERO
-            UVAR(I,3+KK)  = ZERO 
+            UVAR(I,3+KK)  = ZERO
             UVAR(I,4+KK)  = ZERO
             UVAR(I,18+KK) = P
-            UVAR(I,5+KK)  = ZERO 
+            UVAR(I,5+KK)  = ZERO
             UVAR(I,6+KK)  = ZERO
             UVAR(I,7+KK)  = ZERO
-            UVAR(I,8+KK)  = ZERO 
-            UVAR(I,9+KK)  = ZERO       
-            UVAR(I,10+KK) = ZERO   
+            UVAR(I,8+KK)  = ZERO
+            UVAR(I,9+KK)  = ZERO
+            UVAR(I,10+KK) = ZERO
             UVAR(I,11+KK) = ZERO
             UVAR(I,12+KK) = RHO40
             UVAR(I,14+KK) = ZERO
             UVAR(I,16+KK) = T40
             UVAR(I,17+KK) = ZERO ! energie diffusee IN spec OUT
             TEMP4 = T40
-            UVAR(I,19+KK) = ZERO    
+            UVAR(I,19+KK) = ZERO
          ENDIF
-C         IF(V4/VOLUME(I) .LT. EM03)UVAR(I,14+KK)=ZERO
+C         IF(V4/VOLUME(I)  <  EM03)UVAR(I,14+KK)=ZERO
         END IF
         !===================================================
-        !               UVAR(I,1) : PLAS                    
+        !               UVAR(I,1) : PLAS
         !===================================================
         IF(IPLA1 == 2)PLAS1(I)=EPSEQ1(I)
         IF(IPLA2 == 2)PLAS2(I)=EPSEQ2(I)
         IF(IPLA3 == 2)PLAS3(I)=EPSEQ3(I)
         UVAR(I,1) = (PLAS1(I) * V1 + PLAS2(I) * V2 + PLAS3(I) * V3) / VOLUME(I)
         IF(BUFLY%L_PLA>0)LBUF%PLA(I) = UVAR(I,1)
-        
+
         !===================================================
-        !               UVAR(I,2)    : TEMP                 
+        !               UVAR(I,2)    : TEMP
         !===================================================
         H1 = SPH1*V1*(MU1P1)
         H2 = SPH2*V2*(MU2P1)
         H3 = SPH3*V3*(MU3P1)
         H4 = SPH4*V4*(MU4P1)
         ! temperature out ! chaleur     in
-        UVAR(I,2) = (TEMP1*H1 + TEMP2*H2 + TEMP3*H3 + TEMP4*H4)  / (H1 + H2 + H3 + H4)  
-        IF(BUFLY%L_TEMP>0)LBUF%TEMP(I) = UVAR(I,2)      
+        UVAR(I,2) = (TEMP1*H1 + TEMP2*H2 + TEMP3*H3 + TEMP4*H4)  / (H1 + H2 + H3 + H4)
+        IF(BUFLY%L_TEMP>0)LBUF%TEMP(I) = UVAR(I,2)
         !===================================================
-        !               UVAR(I,3) : BFRAC                   
+        !               UVAR(I,3) : BFRAC
         !===================================================
-        IF(V4.GT.ZERO)THEN 
+        IF(V4 > ZERO)THEN
           UVAR(I,3) = BFRAC(I)
         ELSE
           UVAR(I,3) = ZERO
-        END IF  
-        IF(BUFLY%L_BFRAC>0)LBUF%BFRAC(I) = UVAR(I,3)            
+        END IF
+        IF(BUFLY%L_BFRAC>0)LBUF%BFRAC(I) = UVAR(I,3)
         !===================================================
         !               EPSEQ (DPrag)
         !===================================================
         IF(BUFLY%L_EPSQ>0)THEN
-          LBUF%EPSQ(I) = ZERO 
+          LBUF%EPSQ(I) = ZERO
           IF(IPLA1==2)LBUF%EPSQ(I) = LBUF%EPSQ(I) + V1*EPSEQ1(I)
           IF(IPLA2==2)LBUF%EPSQ(I) = LBUF%EPSQ(I) + V2*EPSEQ2(I)
-          IF(IPLA3==2)LBUF%EPSQ(I) = LBUF%EPSQ(I) + V3*EPSEQ3(I)                    
+          IF(IPLA3==2)LBUF%EPSQ(I) = LBUF%EPSQ(I) + V3*EPSEQ3(I)
           LBUF%EPSQ(I) = LBUF%EPSQ(I) / VOLUME(I)
         ENDIF
 
        IF(JTHE == 1 ) THEN
          GBUF%TEMP(I) = TROIS100 + EM03
        ELSE
-         GBUF%TEMP(I) = UVAR(I,2) 
+         GBUF%TEMP(I) = UVAR(I,2)
        ENDIF
 
 
        !provisoire : tracking mat 1 | mat B in animation files
         !IF(INT22>0)THEN
-        !  GBUF  => ELBUF_TAB(NG)%GBUF          
+        !  GBUF  => ELBUF_TAB(NG)%GBUF
         !  UVAR(I,1)=GBUF%TAG22(I)
         !ENDIF
-        
+
         QVIS(I) = QQOLD(I)
-        
+
         !===================================================
         !               POST-TREATMENT (DEBUG)
         !     must be commented in official releases
         !===================================================
-Cts        IF(IX(11,I+NFT)==ibug_ID(1) .OR. IX(11,I+NFT)==ibug_ID(2)) THEN            
+Cts        IF(IX(11,I+NFT)==ibug_ID(1) .OR. IX(11,I+NFT)==ibug_ID(2)) THEN
 Cts          CALL WRITE_BUF_LAW51(IX    , NFT     , NUVAR    , NEL      , UVAR     ,
 Cts     .                         I     , UNEPHASE, DD       , dbVOLD   , dbVOLD_f ,
 Cts     .                         VOLUME, VOLD    , EPSPXX   , EPSPYY   , EPSPZZ   ,
 Cts     .                         TAG22 ,BFRAC(I) , RHO10    , RHO20    , RHO30    ,
-Cts     .                         RHO40) 
+Cts     .                         RHO40)
 Cts        ENDIF
 
 
       ENDDO  !DO I=1,NEL
-      
+
       RETURN
       END
-
-

--- a/starter/source/materials/mat/mat051/fill_buffer_51.F
+++ b/starter/source/materials/mat/mat051/fill_buffer_51.F
@@ -30,7 +30,7 @@ Chd|        FREERR                        source/starter/freform.F
 Chd|        NINTRI                        source/system/nintrr.F        
 Chd|        MESSAGE_MOD                   share/message_module/message_mod.F
 Chd|====================================================================
-      SUBROUTINE FILL_BUFFER_51( IPM, PM, UPARAM, BUFMAT, USER_ID, TITR, INTERNAL_ID) 
+      SUBROUTINE FILL_BUFFER_51( IPM, PM, UPARAM, BUFMAT, USER_ID, TITR, INTERNAL_ID)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -39,10 +39,10 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C This subroutine is filling law51 material buffer UPARAM(:)
-C from material identifiers which were provided in input 
+C from material identifiers which were provided in input
 C format related to IFLG=12
 C
-C It is done here and not in lecm51 because we need all 
+C It is done here and not in lecm51 because we need all
 C material cards and eos card to be treated before.
 C
 C you need yield criteria and eos to be defined for each submaterial.
@@ -52,8 +52,8 @@ C bijective app is in UPARAM(277:280) to get corresponding ids
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
-#include      "implicit_f.inc"     
-C-----------------------------------------------    
+#include      "implicit_f.inc"
+C-----------------------------------------------
 C   C o m m o n   B l o c k s
 C-----------------------------------------------
 #include "param_c.inc"
@@ -71,7 +71,7 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER          :: IDX_AV, IDX_RHO, IDX_C1, IDX_C2, IDX_C3(3), IDX_C4, IDX_C5, IDX_G
-      INTEGER          :: IDX_E0, IDX_C0, IDX_PM, IDX_IPLA, IDX_EINF
+      INTEGER          :: IDX_E0, IDX_C0, IDX_PM, IDX_IPLA, IDX_EINF, IDX_VISC
       INTEGER          :: IDX_YIELD(4)
       INTEGER          :: MID(4),MID_VALID(4),IEXP,NPAR,IADBUF,IDX_PSH_TAB
       INTEGER          :: IMID, MLN, EOS_TYPE, I, J, NJWL, COUNT_VALID_MAT, COUNT_NONEXPLO, ID,  NBMAT, TAG(4),IPLA,NITER
@@ -81,11 +81,11 @@ C-----------------------------------------------
       my_real, POINTER, DIMENSION(:) :: PM_
       my_real, EXTERNAL              :: IE_BOUND
       my_real, DIMENSION(:), POINTER :: UPARAM_
-     
+
       CHARACTER*nchartitle :: chain1
 
       !====================================POLYNOMIAL EOS
-      my_real :: RHO,C0,C1,C2,C3,C4,C5,E0,PSH,P0,DPDMU,SSP   
+      my_real :: RHO,C0,C1,C2,C3,C4,C5,E0,PSH,P0,DPDMU,SSP
 
       !====================================LAW05 - PARAMETERS
       my_real :: VDET,PCJ,VCJ,B1,B2,R1,R2,W,
@@ -95,10 +95,13 @@ C-----------------------------------------------
       INTEGER :: IBFRAC,QOPT,NEXPLO,IMIN
 
       !====================================LAW03 - PARAMETERS
-      my_real :: YOUNG,ANU,G,BULK,PMIN,CA,CB,CN,EPSM,SIGM,GG 
+      my_real :: YOUNG,ANU,G,BULK,PMIN,CA,CB,CN,EPSM,SIGM,GG
 
       !====================================LAW04 - PARAMETERS
       my_real :: CC,EPS0,M,TMELT,TMAX,CS,SPH,T0
+
+      !====================================LAW06 - PARAMETERS
+      my_real :: VISC
 
       !====================================LAW10 - PARAMETERS
       my_real :: A0,A1,A2,AMX,PSTAR
@@ -123,6 +126,7 @@ C-----------------------------------------------
       IDX_PM       = 038
       IDX_EINF     = 056
       IDX_IPLA     = 063
+      IDX_VISC     = 080
       IDX_YIELD(1) = 100
       IDX_YIELD(2) = 150
       IDX_YIELD(3) = 200
@@ -137,8 +141,8 @@ C-----------------------------------------------
       COUNT_VALID_MAT = 0
       COUNT_NONEXPLO = 0
 
-      !pointers 
-      NULLIFY(PM_)  
+      !pointers
+      NULLIFY(PM_)
 
       !PSTAR INIT
       UPARAM(123)=-INFINITY
@@ -158,7 +162,7 @@ C-----------------------------------------------
 
       G  = ZERO
       GG = ZERO
-      
+
       PSH_TAB(1:4)=ZERO
       IDX_PSH_TAB = 0
       PEXT = ZERO
@@ -166,34 +170,34 @@ C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
         DO I=1,4
-          IF(MID(I).EQ.0)EXIT !if defined
+          IF(MID(I) == 0)EXIT !if defined
           IMID     = NINTRI(MID(I),IPM,NPROPMI,NUMMAT,1) !internal ID
           MLN      = 0
           ID       = 0
           EOS_TYPE = 0
-          IF(IMID.NE.0)THEN
+          IF(IMID /= 0)THEN
             MLN      = IPM(2,IMID)
             ID       = IPM(1,IMID)
             EOS_TYPE = IPM(4,IMID)
           ENDIF
-          IF(MLN.EQ.5)NJWL=NJWL+1
-          IF(IMID.EQ.0)THEN
+          IF(MLN == 5)NJWL=NJWL+1
+          IF(IMID == 0)THEN
               chain1='NON EXISTING SUBMATERIAL IDENTIFIER:          '
               write(chain1(37:46),'(i10)')MID(I)
-              IF(MID(I).GT.0) THEN
+              IF(MID(I) > 0) THEN
                 CALL ANCMSG(MSGID=99,
-     .                    MSGTYPE=MSGERROR,       
-     .                    ANMODE=ANINFO,  
-     .                    I1=USER_ID,                  
-     .                    C1=TITR,                
+     .                    MSGTYPE=MSGERROR,
+     .                    ANMODE=ANINFO,
+     .                    I1=USER_ID,
+     .                    C1=TITR,
      .                    C2=chain1)
               ELSE
                 !already checked in hm_read_mat51 (MID(I)=0 or MID(I) <0)
-              ENDIF 
+              ENDIF
           ELSE
-            IF(MLN.EQ.3 .OR. MLN.EQ.4 .OR. MLN.EQ.5 .OR. MLN.EQ.6 .OR. MLN.EQ.10 .OR. MLN.EQ.102)THEN
-              IF(MLN.NE.5)THEN
-                IF(EOS_TYPE.EQ.0 .OR. EOS_TYPE.EQ.1 .OR. EOS_TYPE.EQ.7 .OR. EOS_TYPE.EQ.10)THEN
+            IF(MLN == 3 .OR. MLN == 4 .OR. MLN == 5 .OR. MLN == 6 .OR. MLN == 10 .OR. MLN == 102)THEN
+              IF(MLN /= 5)THEN
+                IF(EOS_TYPE == 0 .OR. EOS_TYPE == 1 .OR. EOS_TYPE == 7 .OR. EOS_TYPE == 10)THEN
                 ELSE
                 chain1='SUBMATERIAL COMPATIBLE EOS:POLYNOMIAL, IDEAL-GAS, STIFFENED-GAS'
                 CALL ANCMSG(MSGID=99,
@@ -201,17 +205,17 @@ C-----------------------------------------------
      .                      ANMODE=ANINFO,
      .                      I1=ID,
      .                      C1=TITR,
-     .                      C2=chain1) 
+     .                      C2=chain1)
                 ENDIF
               ELSE
                 IEXP=1
                 NEXPLO=NEXPLO+1
               ENDIF
-              IF(IMID.GT.0)THEN
+              IF(IMID > 0)THEN
                 COUNT_VALID_MAT = COUNT_VALID_MAT + 1    !take into account only line with MID>0
                 MID_VALID(COUNT_VALID_MAT) = IMID
                 !--UPARAM(276:280) isBIJECTION TO RETRIVE PHASE ORDER FROM USER
-                IF(MLN.NE.5)THEN
+                IF(MLN /= 5)THEN
                   COUNT_NONEXPLO=COUNT_NONEXPLO + 1
                   UPARAM(276+COUNT_VALID_MAT)=MINLOC(TAG(1:4),1)
                   TAG(COUNT_NONEXPLO)=1
@@ -228,10 +232,10 @@ C-----------------------------------------------
      .                    I1=ID,
      .                    C1=TITR,
      .                    C2=chain1)
-            ENDIF             
+            ENDIF
            ENDIF
        ENDDO !next I
-       
+
        ! fill missing phases if user defines less 1,2,or 3 ; (ie, user did not defined all 4)
        !  example UPARAM(276+4)=0 if user defines only 3 submaterial, then output related to phase 4 has wrond index : memory corruption)
        ! (/1,2,4,0/) -> (/1,2,4,3/)
@@ -252,389 +256,395 @@ C-----------------------------------------------
          !  UPARAM(55) = 0
          !ENDIF
         UPARAM(55)=1
-        
+
        IF(NEXPLO>1)THEN
-          chain1='ONLY ONE EXPLOSIVE SUBMATERIAL CAN BE DEFINED'      
-          CALL ANCMSG(MSGID=99,                                                         
-     .                MSGTYPE=MSGERROR,                                                 
-     .                ANMODE=ANINFO,                                                    
-     .                I1=ID,                                                            
-     .                C1=TITR,                                                  
-     .                C2=chain1)                                                        
+          chain1='ONLY ONE EXPLOSIVE SUBMATERIAL CAN BE DEFINED'
+          CALL ANCMSG(MSGID=99,
+     .                MSGTYPE=MSGERROR,
+     .                ANMODE=ANINFO,
+     .                I1=ID,
+     .                C1=TITR,
+     .                C2=chain1)
        ENDIF
 
-!ALREADY CHEKED IN LECM51       
+!ALREADY CHEKED IN LECM51
 !       IF(NBMAT==0)THEN
-!          chain1='AT LEAST ONE SUBMATERIAL MUST BE DEFINED'      
-!          CALL ANCMSG(MSGID=99,                                                         
-!     .                MSGTYPE=MSGERROR,                                                 
-!     .                ANMODE=ANINFO,                                                    
-!     .                I1=ID,                                                            
-!     .                C1=TITR,                                                  
-!     .                C2=chain1) 
-!             J = 1                           
-!             UPARAM(IDX_AV      +J) = 1.0              
-!             UPARAM(IDX_RHO     +J) = EM20   
-!             RETURN                                                                    
+!          chain1='AT LEAST ONE SUBMATERIAL MUST BE DEFINED'
+!          CALL ANCMSG(MSGID=99,
+!     .                MSGTYPE=MSGERROR,
+!     .                ANMODE=ANINFO,
+!     .                I1=ID,
+!     .                C1=TITR,
+!     .                C2=chain1)
+!             J = 1
+!             UPARAM(IDX_AV      +J) = 1.0
+!             UPARAM(IDX_RHO     +J) = EM20
+!             RETURN
 !       ENDIF
-       
+
        IF(NBMAT>4)THEN
-          chain1='LAW51 IS COMPATBILE WITH UP TO 4 SUBMATERIAL ONLY'      
-          CALL ANCMSG(MSGID=99,                                                         
-     .                MSGTYPE=MSGERROR,                                                 
-     .                ANMODE=ANINFO,                                                    
-     .                I1=ID,                                                            
-     .                C1=TITR,                                                  
-     .                C2=chain1)                                                        
+          chain1='LAW51 IS COMPATBILE WITH UP TO 4 SUBMATERIAL ONLY'
+          CALL ANCMSG(MSGID=99,
+     .                MSGTYPE=MSGERROR,
+     .                ANMODE=ANINFO,
+     .                I1=ID,
+     .                C1=TITR,
+     .                C2=chain1)
        ENDIF
-     
+
        IPM(5,INTERNAL_ID)=COUNT_VALID_MAT  !storing NUMBER OF SUBMATERIALS
        PM(27,INTERNAL_ID) = ZERO
 
        RHO_MAX=ZERO
-       DO I=1,COUNT_VALID_MAT                                                                       
-         IMID     = NINTRI(MID(I),IPM,NPROPMI,NUMMAT,1)                                             
-         IPM(20+I,INTERNAL_ID)=IMID        !storing internal material IDs                           
-         IPM(50+I,INTERNAL_ID)=UPARAM(276+I)        !storing bijective order of submaterial   
-         MLN      = IPM(2,IMID)                                                                     
-         EOS_TYPE = IPM(4,IMID)                                                                     
-         PM_      => PM(1:,IMID)   
-         RHO_MAX=MAX(RHO_MAX,PM(1,IMID))                                                                 
-         IF(MLN.NE.5)THEN                                                                           
-           SELECT CASE(EOS_TYPE)                                                                    
-               !EOS PARAMETERS DEPENDS ON 'EOS_TYPE'                                                
-               CASE(0,1)                   !0:/EOS/LINEAR                                           
-                 RHO    = PM_(1)           !1:/EOS/POLYNOMIAL                                       
-                 E0     = PM_(23)                                                                   
+       DO I=1,COUNT_VALID_MAT
+         IMID     = NINTRI(MID(I),IPM,NPROPMI,NUMMAT,1)
+         IPM(20+I,INTERNAL_ID)=IMID        !storing internal material IDs
+         IPM(50+I,INTERNAL_ID)=UPARAM(276+I)        !storing bijective order of submaterial
+         MLN      = IPM(2,IMID)
+         EOS_TYPE = IPM(4,IMID)
+         PM_      => PM(1:,IMID)
+         RHO_MAX=MAX(RHO_MAX,PM(1,IMID))
+         IF(MLN /= 5)THEN
+           SELECT CASE(EOS_TYPE)
+               !EOS PARAMETERS DEPENDS ON 'EOS_TYPE'
+               CASE(0,1)                   !0:/EOS/LINEAR
+                 RHO    = PM_(1)           !1:/EOS/POLYNOMIAL
+                 E0     = PM_(23)
                  C0     = PM_(104)   !C0-PSH
-                 C1     = PM_(32)                                                                   
-                 C2     = PM_(33)                                                                   
-                 C3     = PM_(34)                                                                   
-                 C4     = PM_(35)                                                                   
-                 C5     = PM_(36)                                                                   
-                 PSH    = PM_(88)                                                                   
-                 T0     = PM_(35)                                                                 
-               CASE(7)                     !07:/EOS/IDEAL-GAS                                       
-                 RHO    = PM_(1)                                                                    
-                 E0     = PM_(23)                                                                   
-                 C0     = -PM_(88)                                                                      
-                 C1     = ZERO                                                                      
-                 C2     = ZERO                                                                      
-                 C3     = ZERO                                                                      
-                 C4     = PM_(32)-UN                                                                
-                 C5     = PM_(32)-UN                                                                
-                 PSH    = PM_(88)                                                                   
-                 T0     = PM_(35)                                                                   
-               CASE(10)                    !10:/EOS/STIFF-GAS                                       
-                 RHO    = PM_(1)                                                                    
-                 E0     = PM_(23)                                                                   
-                 C0     = -PM_(34)*PM_(35)-PM_(88)  !-gamma*P_star  - PSH                                        
-                 C1     = ZERO                                                                      
-                 C2     = ZERO                                                                      
-                 C3     = ZERO                                                                      
-                 C4     = PM_(34)-UN                                                                
-                 C5     = PM_(34)-UN                                                                
-                 PSH    = PM_(88)                                                                   
-                 T0     = PM_(35)                                                                   
-               CASE DEFAULT                                                                         
-            END SELECT  
+                 C1     = PM_(32)
+                 C2     = PM_(33)
+                 C3     = PM_(34)
+                 C4     = PM_(35)
+                 C5     = PM_(36)
+                 PSH    = PM_(88)
+                 T0     = PM_(35)
+               CASE(7)                     !07:/EOS/IDEAL-GAS
+                 RHO    = PM_(1)
+                 E0     = PM_(23)
+                 C0     = -PM_(88)
+                 C1     = ZERO
+                 C2     = ZERO
+                 C3     = ZERO
+                 C4     = PM_(32)-UN
+                 C5     = PM_(32)-UN
+                 PSH    = PM_(88)
+                 T0     = PM_(35)
+               CASE(10)                    !10:/EOS/STIFF-GAS
+                 RHO    = PM_(1)
+                 E0     = PM_(23)
+                 C0     = -PM_(34)*PM_(35)-PM_(88)  !-gamma*P_star  - PSH
+                 C1     = ZERO
+                 C2     = ZERO
+                 C3     = ZERO
+                 C4     = PM_(34)-UN
+                 C5     = PM_(34)-UN
+                 PSH    = PM_(88)
+                 T0     = PM_(35)
+               CASE DEFAULT
+            END SELECT
             !----update PSH
             IDX_PSH_TAB = IDX_PSH_TAB + 1
             PSH_TAB(IDX_PSH_TAB)=PSH
-            !no yield                                                                               
-            PMIN   = PM_(37)                                                                        
-            SPH    = PM_(69)                                                                        
-            P0     = C0+C4*E0  
-            G      =  PM_(22)                                                                     
-            DPDMU  = (C1+C5*E0) + C4*(P0)                                                           
+            !no yield
+            IF(MLN == 6)THEN
+              VISC = PM_(24) !use submaterial viscosity (if defined with /MAT/LAW6)
+            ELSE
+              VISC = UPARAM(1) !use global viscosity otherwise (if defined with /MAT/LAW51)
+            ENDIF
+            PMIN   = PM_(37)
+            SPH    = PM_(69)
+            P0     = C0+C4*E0
+            G      =  PM_(22)
+            DPDMU  = (C1+C5*E0) + C4*(P0)
             SSP    = SQRT( (DPDMU + DTIERS*G) / RHO )
             PM(27,INTERNAL_ID) = MAX( PM(27,INTERNAL_ID), SSP  )
-            !---WRITING LAW51 SUBMATERIAL BUFFER FOR EOS                                            
-            J = UPARAM(276+I)                                                                       
-            UPARAM(IDX_AV      +J) = AV(I)                                                          
-            UPARAM(IDX_RHO     +J) = RHO                                                            
-            UPARAM(IDX_C0      +J) = C0                                                             
-            UPARAM(IDX_C1      +J) = C1                                                             
-            UPARAM(IDX_C2      +J) = C2                                                             
-            UPARAM(IDX_C3(J))      = C3                                                             
-            UPARAM(IDX_C4      +J) = C4                                                             
-            UPARAM(IDX_C5      +J) = C5                                                             
-            UPARAM(IDX_E0      +J) = E0                                                             
-            UPARAM(IDX_YIELD(J)+13)= T0                                                             
-            UPARAM(IDX_PM      +J) = PMIN                                                           
-            UPARAM(IDX_YIELD(J)+12)= SPH                                                            
-            UPARAM(IDX_YIELD(J)+24) = SSP                                                           
-            UPARAM(IDX_YIELD(J)+26) = RHO*SSP*SSP                                                   
-         ENDIF !(MLN.NE.5)                                                                          
+            !---WRITING LAW51 SUBMATERIAL BUFFER FOR EOS
+            J = UPARAM(276+I)
+            UPARAM(IDX_AV      +J) = AV(I)
+            UPARAM(IDX_RHO     +J) = RHO
+            UPARAM(IDX_C0      +J) = C0
+            UPARAM(IDX_C1      +J) = C1
+            UPARAM(IDX_C2      +J) = C2
+            UPARAM(IDX_C3(J))      = C3
+            UPARAM(IDX_C4      +J) = C4
+            UPARAM(IDX_C5      +J) = C5
+            UPARAM(IDX_E0      +J) = E0
+            UPARAM(IDX_YIELD(J)+13)= T0
+            UPARAM(IDX_PM      +J) = PMIN
+            UPARAM(IDX_YIELD(J)+12)= SPH
+            UPARAM(IDX_YIELD(J)+24) = SSP
+            UPARAM(IDX_YIELD(J)+26) = RHO*SSP*SSP
+            UPARAM(IDX_VISC+J) = VISC
+         ENDIF !(MLN /= 5)
 
-         SELECT CASE(MLN)                                                                           
-           CASE (5)                                                                                 
-              !---READING MATERIAL LAW5 BUFFER                                                      
-              VDET           = PM_(38)                                                              
-              PCJ            = PM_(39)                                                              
-              B1             = PM_(33)                                                              
-              B2             = PM_(34)                                                              
-              R1             = PM_(35)                                                              
-              R2             = PM_(36)                                                              
-              W              = PM_(45)                                                              
-              IBFRAC         = NINT(PM_(41))                                                        
-              QOPT           = NINT(PM_(42))                                                        
-              PSH            = PM_(88)                                                              
-              PM4            = -PSH                                                                 
-              AV4            = AV(I)                                                                
-              RHO40          = PM_(1)                                                               
-              E04            = PM_(23)                                                              
-              C04            = PM_(43)-PM_(88)                                                             
-              C14            = PM_(44)                                                              
-              TMELT4         = INFINITY                                                             
-              THETL4         = INFINITY                                                             
-              SPH4           = UN                                                                   
-              T40            = TROIS100                                                             
-              XKA4           = EM20                                                                 
-              XKB4           = ZERO                                                                 
-              SSP4           = VDET                                                                 
-              EADD           = PM_(160)                                                             
-              TBEGIN         = PM_(161)                                                             
-              TEND           = PM_(162)                                                             
-              REACTION_RATE  = PM_(163)                                                             
-              A_MIL          = PM_(164)                                                             
-              M_MIL          = PM_(165)                                                             
-              N_MIL          = PM_(166)                                                             
-              REACTION_RATE2 = PM_(167)                                                             
-              ALPHA_UNIT     = PM_(168)                                                             
-              !---WRITING LAW51 SUBMATERIAL BUFFER                                                  
-              UPARAM(42) = VDET                                                                     
-              UPARAM(43) = PCJ                                                                      
-              IF(PCJ.GT.EM20)THEN                                                                   
-                UPARAM(44) = RHO40 * VDET**2 / PCJ                                                  
-              ELSE                                                                                  
-                UPARAM(44) = INFINITY                                                               
-              END IF                                                                                
-              UPARAM(45)  = B1                                                                      
-              VCJ   = UN  - UN/UPARAM(44)                                                           
-              UPARAM(46)  = AV4                                                                     
-              UPARAM(47)  = RHO40                                                                   
-              IF(UPARAM(47)==ZERO) UPARAM(47) = EM20                                                
-              UPARAM(48)  = E04                                                                     
-              UPARAM(49)  = C04                                                                     
-              UPARAM(50)  = C14                                                                     
-              UPARAM(51)  = B2                                                                      
-              UPARAM(52)  = R1                                                                      
-              UPARAM(53)  = R2                                                                      
-              UPARAM(54)  = W                                                                       
-              UPARAM(55)  = IEXP                                                                    
-              IF(PM4==ZERO)PM4=-INFINITY                                                            
-              UPARAM(56)  = PM4                                                                     
-              UPARAM(68)  = IBFRAC                                                                  
-              UPARAM(258) = TMELT4                                                                  
-              UPARAM(259) = THETL4                                                                  
-              UPARAM(262) = SPH4                                                                    
-              UPARAM(263) = T40                                                                     
-              UPARAM(264) = XKA4                                                                    
-              UPARAM(265) = XKB4                                                                    
-              UPARAM(273) = SSP4                                                                    
-              UPARAM(274) = ZERO                                                                    
-              UPARAM(275) = RHO40*SSP4*SSP4                                                         
-              UPARAM(276) = ZERO       
-              
-              IDX_PSH_TAB = IDX_PSH_TAB + 1                                                                        
-              PSH_TAB(IDX_PSH_TAB) = PSH 
+         SELECT CASE(MLN)
+           CASE (5)
+              !---READING MATERIAL LAW5 BUFFER
+              VDET           = PM_(38)
+              PCJ            = PM_(39)
+              B1             = PM_(33)
+              B2             = PM_(34)
+              R1             = PM_(35)
+              R2             = PM_(36)
+              W              = PM_(45)
+              IBFRAC         = NINT(PM_(41))
+              QOPT           = NINT(PM_(42))
+              PSH            = PM_(88)
+              PM4            = -PSH
+              AV4            = AV(I)
+              RHO40          = PM_(1)
+              E04            = PM_(23)
+              C04            = PM_(43)-PM_(88)
+              C14            = PM_(44)
+              TMELT4         = INFINITY
+              THETL4         = INFINITY
+              SPH4           = UN
+              T40            = TROIS100
+              XKA4           = EM20
+              XKB4           = ZERO
+              SSP4           = VDET
+              EADD           = PM_(160)
+              TBEGIN         = PM_(161)
+              TEND           = PM_(162)
+              REACTION_RATE  = PM_(163)
+              A_MIL          = PM_(164)
+              M_MIL          = PM_(165)
+              N_MIL          = PM_(166)
+              REACTION_RATE2 = PM_(167)
+              ALPHA_UNIT     = PM_(168)
+              !---WRITING LAW51 SUBMATERIAL BUFFER
+              UPARAM(42) = VDET
+              UPARAM(43) = PCJ
+              IF(PCJ > EM20)THEN
+                UPARAM(44) = RHO40 * VDET**2 / PCJ
+              ELSE
+                UPARAM(44) = INFINITY
+              END IF
+              UPARAM(45)  = B1
+              VCJ   = UN  - UN/UPARAM(44)
+              UPARAM(46)  = AV4
+              UPARAM(47)  = RHO40
+              IF(UPARAM(47)==ZERO) UPARAM(47) = EM20
+              UPARAM(48)  = E04
+              UPARAM(49)  = C04
+              UPARAM(50)  = C14
+              UPARAM(51)  = B2
+              UPARAM(52)  = R1
+              UPARAM(53)  = R2
+              UPARAM(54)  = W
+              UPARAM(55)  = IEXP
+              IF(PM4==ZERO)PM4=-INFINITY
+              UPARAM(56)  = PM4
+              UPARAM(68)  = IBFRAC
+              UPARAM(258) = TMELT4
+              UPARAM(259) = THETL4
+              UPARAM(262) = SPH4
+              UPARAM(263) = T40
+              UPARAM(264) = XKA4
+              UPARAM(265) = XKB4
+              UPARAM(273) = SSP4
+              UPARAM(274) = ZERO
+              UPARAM(275) = RHO40*SSP4*SSP4
+              UPARAM(276) = ZERO
+
+              IDX_PSH_TAB = IDX_PSH_TAB + 1
+              PSH_TAB(IDX_PSH_TAB) = PSH
               PM(27,INTERNAL_ID) = MAX( PM(27,INTERNAL_ID), SSP4  )
-                                                                                                    
-              !MSG - specific case of law5 when used with law 51 (new input format iform=12)        
-              IF(C14.LE.ZERO)THEN                                                                   
-                chain1='BULK MODULUS OF LAW5 (JWL) MUST BE PROVIDED FOR UNREACTED EXPLOSIVE'        
-                CALL ANCMSG(MSGID=99,                                                               
-     .                      MSGTYPE=MSGERROR,                                                       
-     .                      ANMODE=ANINFO,                                                          
-     .                      I1=USER_ID,                                                             
-     .                      C1=TITR,                                                                
-     .                      C2=chain1)                                                              
-              ENDIF                                                                                 
-           CASE(3,4)                                                                                
-             !yield criteria                                                                        
-             YOUNG  =  PM_(20)                                                                      
-             ANU    =  ZEP2 !PM_(21)                                                                
-             G      =  PM_(22)                                                                      
-             BULK   =  PM_(32)                                                                      
-             PMIN   =  PM_(37)                                                                      
-             CA     =  PM_(38)                                                                      
-             CB     =  PM_(39)                                                                      
-             CN     =  PM_(40)                                                                      
-             EPSM   =  PM_(41)                                                                      
-             SIGM   =  PM_(42)                                                                      
-             CC     =  PM_(43)                                                                      
-             EPS0   =  PM_(44)                                                                      
-             M      =  PM_(45)                                                                      
-             TMELT  =  PM_(46)                                                                      
-             TMAX   =  PM_(47)                                                                      
-             CS     =  PM_(48)                                                                      
-             SPH    =  PM_(69)                                                                      
-             T0     =  PM_(79)                                                                      
-             GG     =  DEUX*G                                                                       
-             SSP    = SQRT( (DPDMU + DTIERS*G) / RHO )                                              
-             !---WRITING LAW51 SUBMATERIAL BUFFER                                                   
-             J = UPARAM(276+I)                                                                      
-             UPARAM(IDX_IPLA    +J)  = 1                                                            
-             IPLA                    = 1                                                            
-             UPARAM(IDX_G       +J)  = GG                                                           
-             UPARAM(IDX_YIELD(J)+01) = G                                                            
-             UPARAM(IDX_YIELD(J)+02) = CA                                                           
-             UPARAM(IDX_YIELD(J)+03) = CB                                                           
-             UPARAM(IDX_YIELD(J)+04) = CN                                                           
-             !specific law4 subcase                                                                 
-             UPARAM(IDX_YIELD(J)+05:IDX_YIELD(J)+13)=ZERO                                           
-             IF(MLN.EQ.4)THEN                                                                       
-             UPARAM(IDX_YIELD(J)+05) = CC                                                           
-             UPARAM(IDX_YIELD(J)+06) = EPS0                                                         
-             UPARAM(IDX_YIELD(J)+07) = M                                                            
-             UPARAM(IDX_YIELD(J)+08) = TMELT                                                        
-             UPARAM(IDX_YIELD(J)+09) = TMAX                                                         
-             UPARAM(IDX_YIELD(J)+12) = SPH                                                          
-             UPARAM(IDX_YIELD(J)+13) = T0                                                           
-             ENDIF                                                                                  
-             UPARAM(IDX_YIELD(J)+10) = EPSM                                                         
-             UPARAM(IDX_YIELD(J)+11) = SIGM                                                         
-             UPARAM(IDX_YIELD(J)+14) = ZERO                                                         
-             UPARAM(IDX_YIELD(J)+15) = ZERO                                                         
-             UPARAM(IDX_YIELD(J)+16) = ZERO                                                         
-             UPARAM(IDX_YIELD(J)+17) = ZERO                                                         
-             UPARAM(IDX_YIELD(J)+18) = ZERO                                                         
-             UPARAM(IDX_YIELD(J)+19) = ZERO                                                         
-             UPARAM(IDX_YIELD(J)+20) = ZERO                                                         
-             UPARAM(IDX_YIELD(J)+21) = ZERO                                                         
-             UPARAM(IDX_YIELD(J)+22) = ANU                                                          
-             UPARAM(IDX_YIELD(J)+23) = -INFINITY                                                    
-             UPARAM(IDX_YIELD(J)+24) = SSP                                                          
-             UPARAM(IDX_YIELD(J)+25) = ZERO                                                         
-             UPARAM(IDX_YIELD(J)+26) = RHO*SSP*SSP                                                  
 
-           CASE(6)                                                                                  
-             !no yield criteria                                                                     
-             T0    = TROIS100                                                                       
-             G     = ZERO                                                                           
-             GG    = ZERO                                                                           
-             EPSM  = ZERO                                                                           
-             SIGM  = ZERO                                                                           
-             CA    = ZERO                                                                           
-             CB    = ZERO                                                                           
-             CN    = ZERO                                                                           
-             CC    = ZERO                                                                           
-             EPS0  = ZERO                                                                           
-             M     = ZERO                                                                           
-             TMELT = ZERO                                                                           
-             TMAX  = ZERO                                                                           
-             SPH   = ZERO                                                                           
-             ANU   = ZERO                                                                           
-             AMX   = ZERO                                                                           
-             PSTAR = ZERO                                                                           
-             YOUNG = ZERO                                                                           
-             A0    = ZERO                                                                           
-             A1    = ZERO                                                                           
-             A2    = ZERO                                                                           
-             AMX   = ZERO                                                                           
-             SSP   = SQRT( (DPDMU + ZERO) / RHO )                                                   
-             !---WRITING LAW51 SUBMATERIAL BUFFER                                                   
-             J = UPARAM(276+I)                                                                      
-             UPARAM(IDX_IPLA    +J)  = 0                                                            
-             UPARAM(IDX_G       +J)  = GG                                                           
-             UPARAM(IDX_YIELD(J)+01) = G                                                            
-             UPARAM(IDX_YIELD(J)+02) = YOUNG                                                        
-             UPARAM(IDX_YIELD(J)+05) = CC                                                           
-             UPARAM(IDX_YIELD(J)+06) = EPS0                                                         
-             UPARAM(IDX_YIELD(J)+07) = M                                                            
-             UPARAM(IDX_YIELD(J)+08) = TMELT                                                        
-             UPARAM(IDX_YIELD(J)+09) = TMAX                                                         
-             UPARAM(IDX_YIELD(J)+12) = SPH                                                          
-             UPARAM(IDX_YIELD(J)+13) = T0                                                           
-             UPARAM(IDX_YIELD(J)+14) = ZERO                                                         
-             UPARAM(IDX_YIELD(J)+15) = ZERO                                                         
-             UPARAM(IDX_YIELD(J)+16) = A0                                                           
-             UPARAM(IDX_YIELD(J)+17) = A1                                                           
-             UPARAM(IDX_YIELD(J)+18) = A2                                                           
-             UPARAM(IDX_YIELD(J)+19) = AMX                                                          
-             UPARAM(IDX_YIELD(J)+20) = ZERO                                                         
-             UPARAM(IDX_YIELD(J)+21) = ZERO                                                         
-             UPARAM(IDX_YIELD(J)+22) = ANU                                                          
-             UPARAM(IDX_YIELD(J)+23) = PSTAR                                                        
-             UPARAM(IDX_YIELD(J)+24) = SSP                                                          
-             UPARAM(IDX_YIELD(J)+25) = ZERO                                                         
-             UPARAM(IDX_YIELD(J)+26) = RHO*SSP*SSP                                                  
+              !MSG - specific case of law5 when used with law 51 (new input format iform=12)
+              IF(C14 <= ZERO)THEN
+                chain1='BULK MODULUS OF LAW5 (JWL) MUST BE PROVIDED FOR UNREACTED EXPLOSIVE'
+                CALL ANCMSG(MSGID=99,
+     .                      MSGTYPE=MSGERROR,
+     .                      ANMODE=ANINFO,
+     .                      I1=USER_ID,
+     .                      C1=TITR,
+     .                      C2=chain1)
+              ENDIF
+           CASE(3,4)
+             !yield criteria
+             YOUNG  =  PM_(20)
+             ANU    =  ZEP2 !PM_(21)
+             G      =  PM_(22)
+             BULK   =  PM_(32)
+             PMIN   =  PM_(37)
+             CA     =  PM_(38)
+             CB     =  PM_(39)
+             CN     =  PM_(40)
+             EPSM   =  PM_(41)
+             SIGM   =  PM_(42)
+             CC     =  PM_(43)
+             EPS0   =  PM_(44)
+             M      =  PM_(45)
+             TMELT  =  PM_(46)
+             TMAX   =  PM_(47)
+             CS     =  PM_(48)
+             SPH    =  PM_(69)
+             T0     =  PM_(79)
+             GG     =  DEUX*G
+             SSP    = SQRT( (DPDMU + DTIERS*G) / RHO )
+             !---WRITING LAW51 SUBMATERIAL BUFFER
+             J = UPARAM(276+I)
+             UPARAM(IDX_IPLA    +J)  = 1
+             IPLA                    = 1
+             UPARAM(IDX_G       +J)  = GG
+             UPARAM(IDX_YIELD(J)+01) = G
+             UPARAM(IDX_YIELD(J)+02) = CA
+             UPARAM(IDX_YIELD(J)+03) = CB
+             UPARAM(IDX_YIELD(J)+04) = CN
+             !specific law4 subcase
+             UPARAM(IDX_YIELD(J)+05:IDX_YIELD(J)+13)=ZERO
+             IF(MLN == 4)THEN
+             UPARAM(IDX_YIELD(J)+05) = CC
+             UPARAM(IDX_YIELD(J)+06) = EPS0
+             UPARAM(IDX_YIELD(J)+07) = M
+             UPARAM(IDX_YIELD(J)+08) = TMELT
+             UPARAM(IDX_YIELD(J)+09) = TMAX
+             UPARAM(IDX_YIELD(J)+12) = SPH
+             UPARAM(IDX_YIELD(J)+13) = T0
+             ENDIF
+             UPARAM(IDX_YIELD(J)+10) = EPSM
+             UPARAM(IDX_YIELD(J)+11) = SIGM
+             UPARAM(IDX_YIELD(J)+14) = ZERO
+             UPARAM(IDX_YIELD(J)+15) = ZERO
+             UPARAM(IDX_YIELD(J)+16) = ZERO
+             UPARAM(IDX_YIELD(J)+17) = ZERO
+             UPARAM(IDX_YIELD(J)+18) = ZERO
+             UPARAM(IDX_YIELD(J)+19) = ZERO
+             UPARAM(IDX_YIELD(J)+20) = ZERO
+             UPARAM(IDX_YIELD(J)+21) = ZERO
+             UPARAM(IDX_YIELD(J)+22) = ANU
+             UPARAM(IDX_YIELD(J)+23) = -INFINITY
+             UPARAM(IDX_YIELD(J)+24) = SSP
+             UPARAM(IDX_YIELD(J)+25) = ZERO
+             UPARAM(IDX_YIELD(J)+26) = RHO*SSP*SSP
 
-           CASE(10,102)                                                                             
-             !yield criteria                                                                        
-             IF(MLN.EQ.10)THEN                                                                      
-               YOUNG  =  PM_(20)                                                                    
-               ANU    =  PM_(21)                                                                    
-               G      =  PM_(22)                                                                    
-               BULK   =  PM_(32)                                                                    
-               PMIN   =  PM_(37)                                                                    
-               A0     =  PM_(38)                                                                    
-               A1     =  PM_(39)                                                                    
-               A2     =  PM_(40)                                                                    
-               AMX    =  PM_(41)                                                                    
-               PSTAR  =  PM_(44)                                                                    
-             ELSEIF(MLN.EQ.102)THEN                                                                 
-               NPAR   = IPM(9,IMID)                                                                 
-               IADBUF = IPM(7,IMID)                                                                 
-               IADBUF = MAX(1,IADBUF)                                                               
-               UPARAM_ => BUFMAT(IADBUF:IADBUF+NPAR)                                                
-               YOUNG  =  UPARAM_(10)                                                                
-               ANU    =  UPARAM_(11)                                                                
-               G      =  UPARAM_(08)                                                                
-               BULK   =  PM_(32)                                                                    
-               IF(BULK.EQ.ZERO)BULK=TIERS*YOUNG/(UN-DEUX*ANU)                                       
-               PMIN   =  PM_(37)                                                                    
-               A0     =  UPARAM_(04)                                                                
-               A1     =  UPARAM_(05)                                                                
-               A2     =  UPARAM_(06)                                                                
-               AMX    =  UPARAM_(07)                                                                
-               PSTAR  =  UPARAM_(03)                                                                
-             ENDIF                                                                                  
-             GG     =  DEUX*G                                                                       
-             SSP    = SQRT( (DPDMU + DTIERS*G) / RHO )                                              
-             !---WRITING LAW51 SUBMATERIAL BUFFER                                                   
-             J = UPARAM(276+I)                                                                      
-             UPARAM(IDX_IPLA    +J)  = 2                                                            
-             IPLA                    = 1                                                            
-             UPARAM(IDX_G       +J)  = GG                                                           
-             UPARAM(IDX_YIELD(J)+01) = G                                                            
-             UPARAM(IDX_YIELD(J)+02) = YOUNG                                                        
-             UPARAM(IDX_YIELD(J)+14) = ZERO                                                         
-             UPARAM(IDX_YIELD(J)+15) = ZERO                                                         
-             UPARAM(IDX_YIELD(J)+16) = A0                                                           
-             UPARAM(IDX_YIELD(J)+17) = A1                                                           
-             UPARAM(IDX_YIELD(J)+18) = A2                                                           
-             UPARAM(IDX_YIELD(J)+19) = AMX                                                          
-             UPARAM(IDX_YIELD(J)+20) = ZERO                                                         
-             UPARAM(IDX_YIELD(J)+21) = ZERO                                                         
-             UPARAM(IDX_YIELD(J)+22) = ANU                                                          
-             UPARAM(IDX_YIELD(J)+23) = PSTAR                                                        
-             UPARAM(IDX_YIELD(J)+24) = SSP                                                          
-             UPARAM(IDX_YIELD(J)+25) = ZERO                                                         
-             UPARAM(IDX_YIELD(J)+26) = RHO*SSP*SSP                                                  
+           CASE(6)
+             !no yield criteria
+             T0    = TROIS100
+             G     = ZERO
+             GG    = ZERO
+             EPSM  = ZERO
+             SIGM  = ZERO
+             CA    = ZERO
+             CB    = ZERO
+             CN    = ZERO
+             CC    = ZERO
+             EPS0  = ZERO
+             M     = ZERO
+             TMELT = ZERO
+             TMAX  = ZERO
+             SPH   = ZERO
+             ANU   = ZERO
+             AMX   = ZERO
+             PSTAR = ZERO
+             YOUNG = ZERO
+             A0    = ZERO
+             A1    = ZERO
+             A2    = ZERO
+             AMX   = ZERO
+             SSP   = SQRT( (DPDMU + ZERO) / RHO )
+             !---WRITING LAW51 SUBMATERIAL BUFFER
+             J = UPARAM(276+I)
+             UPARAM(IDX_IPLA    +J)  = 0
+             UPARAM(IDX_G       +J)  = GG
+             UPARAM(IDX_YIELD(J)+01) = G
+             UPARAM(IDX_YIELD(J)+02) = YOUNG
+             UPARAM(IDX_YIELD(J)+05) = CC
+             UPARAM(IDX_YIELD(J)+06) = EPS0
+             UPARAM(IDX_YIELD(J)+07) = M
+             UPARAM(IDX_YIELD(J)+08) = TMELT
+             UPARAM(IDX_YIELD(J)+09) = TMAX
+             UPARAM(IDX_YIELD(J)+12) = SPH
+             UPARAM(IDX_YIELD(J)+13) = T0
+             UPARAM(IDX_YIELD(J)+14) = ZERO
+             UPARAM(IDX_YIELD(J)+15) = ZERO
+             UPARAM(IDX_YIELD(J)+16) = A0
+             UPARAM(IDX_YIELD(J)+17) = A1
+             UPARAM(IDX_YIELD(J)+18) = A2
+             UPARAM(IDX_YIELD(J)+19) = AMX
+             UPARAM(IDX_YIELD(J)+20) = ZERO
+             UPARAM(IDX_YIELD(J)+21) = ZERO
+             UPARAM(IDX_YIELD(J)+22) = ANU
+             UPARAM(IDX_YIELD(J)+23) = PSTAR
+             UPARAM(IDX_YIELD(J)+24) = SSP
+             UPARAM(IDX_YIELD(J)+25) = ZERO
+             UPARAM(IDX_YIELD(J)+26) = RHO*SSP*SSP
 
-           CASE DEFAULT                                                                             
-             !not expected, pre-condition test done in lecm51, error message if MLN is not relevant 
+           CASE(10,102)
+             !yield criteria
+             IF(MLN == 10)THEN
+               YOUNG  =  PM_(20)
+               ANU    =  PM_(21)
+               G      =  PM_(22)
+               BULK   =  PM_(32)
+               PMIN   =  PM_(37)
+               A0     =  PM_(38)
+               A1     =  PM_(39)
+               A2     =  PM_(40)
+               AMX    =  PM_(41)
+               PSTAR  =  PM_(44)
+             ELSEIF(MLN == 102)THEN
+               NPAR   = IPM(9,IMID)
+               IADBUF = IPM(7,IMID)
+               IADBUF = MAX(1,IADBUF)
+               UPARAM_ => BUFMAT(IADBUF:IADBUF+NPAR)
+               YOUNG  =  UPARAM_(10)
+               ANU    =  UPARAM_(11)
+               G      =  UPARAM_(08)
+               BULK   =  PM_(32)
+               IF(BULK == ZERO)BULK=TIERS*YOUNG/(UN-DEUX*ANU)
+               PMIN   =  PM_(37)
+               A0     =  UPARAM_(04)
+               A1     =  UPARAM_(05)
+               A2     =  UPARAM_(06)
+               AMX    =  UPARAM_(07)
+               PSTAR  =  UPARAM_(03)
+             ENDIF
+             GG     =  DEUX*G
+             SSP    = SQRT( (DPDMU + DTIERS*G) / RHO )
+             !---WRITING LAW51 SUBMATERIAL BUFFER
+             J = UPARAM(276+I)
+             UPARAM(IDX_IPLA    +J)  = 2
+             IPLA                    = 1
+             UPARAM(IDX_G       +J)  = GG
+             UPARAM(IDX_YIELD(J)+01) = G
+             UPARAM(IDX_YIELD(J)+02) = YOUNG
+             UPARAM(IDX_YIELD(J)+14) = ZERO
+             UPARAM(IDX_YIELD(J)+15) = ZERO
+             UPARAM(IDX_YIELD(J)+16) = A0
+             UPARAM(IDX_YIELD(J)+17) = A1
+             UPARAM(IDX_YIELD(J)+18) = A2
+             UPARAM(IDX_YIELD(J)+19) = AMX
+             UPARAM(IDX_YIELD(J)+20) = ZERO
+             UPARAM(IDX_YIELD(J)+21) = ZERO
+             UPARAM(IDX_YIELD(J)+22) = ANU
+             UPARAM(IDX_YIELD(J)+23) = PSTAR
+             UPARAM(IDX_YIELD(J)+24) = SSP
+             UPARAM(IDX_YIELD(J)+25) = ZERO
+             UPARAM(IDX_YIELD(J)+26) = RHO*SSP*SSP
 
-         END SELECT                                                                                 
+           CASE DEFAULT
+             !not expected, pre-condition test done in lecm51, error message if MLN is not relevant
+
+         END SELECT
 
        ENDDO! next SUBMAT
-       
+
        PM(91,INTERNAL_ID)=RHO_MAX
-        
-       !CHECK CONSISTENCY OF PSH PARAMETERS 
+
+       !CHECK CONSISTENCY OF PSH PARAMETERS
        IF(IDX_PSH_TAB > 0)THEN
-         TMP1=MINVAL(PSH_TAB(1:IDX_PSH_TAB))                                                    
-         TMP2=MAXVAL(PSH_TAB(1:IDX_PSH_TAB))                                                  
-         IF(TMP1 == TMP2)THEN                                                
-           PEXT = TMP1                                                                          
-         ELSE                                           
-           chain1='SUBMATERIAL EOS MUST HAVE CONSISTENT PSH PARAMETERS'                        
-           CALL ANCMSG(MSGID=99,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=USER_ID,C1=TITR,C2=chain1)   
-         ENDIF                                                                                 
-         UPARAM(8) = PEXT   
-       ENDIF                                                                   
+         TMP1=MINVAL(PSH_TAB(1:IDX_PSH_TAB))
+         TMP2=MAXVAL(PSH_TAB(1:IDX_PSH_TAB))
+         IF(TMP1 == TMP2)THEN
+           PEXT = TMP1
+         ELSE
+           chain1='SUBMATERIAL EOS MUST HAVE CONSISTENT PSH PARAMETERS'
+           CALL ANCMSG(MSGID=99,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=USER_ID,C1=TITR,C2=chain1)
+         ENDIF
+         UPARAM(8) = PEXT
+       ENDIF
 C-----------------------------------------------
 C   Default
 C-----------------------------------------------
@@ -697,8 +707,8 @@ C-----------------------------------------------
       !IF(UPARAM(272)==ZERO)    UPARAM(272)=ZEP2
       !Drucker-Prager unload modulus
       IF(UPARAM(121) == ZERO)  UPARAM(121) = UPARAM(12)
-      IF(UPARAM(171) == ZERO)  UPARAM(171) = UPARAM(13)  
-      IF(UPARAM(221) == ZERO)  UPARAM(221) = UPARAM(14)  
+      IF(UPARAM(171) == ZERO)  UPARAM(171) = UPARAM(13)
+      IF(UPARAM(221) == ZERO)  UPARAM(221) = UPARAM(14)
 
       !E_INF
       PEXT   = ZERO
@@ -710,34 +720,34 @@ C-----------------------------------------------
       UPARAM(58) = E2_INF
       UPARAM(59) = E3_INF
       UPARAM(60) = E4_INF
-      
+
 
 
       !GLOBAL PARAMETERS
        !IF(UPARAM(30)==ZERO)    UPARAM(30)=ZEP2
        UPARAM(62) = EM03
-       UPARAM(69) = UPARAM(9)*UPARAM(4) + UPARAM(10)*UPARAM(5) + UPARAM(11)*UPARAM(6) + UPARAM(47)*UPARAM(46)   
-       UPARAM(31) = 1 
+       UPARAM(69) = UPARAM(9)*UPARAM(4) + UPARAM(10)*UPARAM(5) + UPARAM(11)*UPARAM(6) + UPARAM(47)*UPARAM(46)
+       UPARAM(31) = 1
        UPARAM(72) = INFINITY
-       IF(UPARAM(43).LE.EM20) UPARAM(44)=INFINITY
+       IF(UPARAM(43) <= EM20) UPARAM(44)=INFINITY
        IF(UPARAM(47)==ZERO) UPARAM(47) = EM20
        IF(UPARAM(56)==ZERO) UPARAM(56)=-INFINITY
        UPARAM(63) = IPLA
 
        RATIO=UPARAM(74)
-       IF(RATIO.LE.ZERO)THEN
+       IF(RATIO <= ZERO)THEN
          RATIO = 0.25D00   !UN is for previous formulation (permitted large volume change)
          UPARAM(74)=RATIO
        ENDIF
 
        NITER=UPARAM(73)
-       IF(NITER.EQ.0)THEN
+       IF(NITER == 0)THEN
          NITER=10
          UPARAM(73)=NITER
        ENDIF
 C-----------------------------------------------
 
 
-      RETURN 
+      RETURN
   999 CALL FREERR(3)
       END SUBROUTINE

--- a/starter/source/materials/mat/mat051/hm_read_mat51.F
+++ b/starter/source/materials/mat/mat051/hm_read_mat51.F
@@ -42,7 +42,7 @@ Chd|        MESSAGE_MOD                   share/message_module/message_mod.F
 Chd|        SUBMODEL_MOD                  share/modules1/submodel_mod.F 
 Chd|====================================================================
       SUBROUTINE HM_READ_MAT51(UPARAM ,MAXUPARAM,NUPARAM  ,ISRATE   , IMATVIS  ,
-     .                         NUVAR  ,IFUNC    ,MAXFUNC  ,NFUNC    , PARMAT   , 
+     .                         NUVAR  ,IFUNC    ,MAXFUNC  ,NFUNC    , PARMAT   ,
      .                         UNITAB ,MAT_ID   ,TITR     ,MTAG     , LSUBMODEL,
      .                         PM     ,IPM      )
 C-----------------------------------------------
@@ -53,7 +53,7 @@ C
 C   DUMMY ARGUMENTS DESCRIPTION:
 C   ===================
 C
-C     NAME            DESCRIPTION                         
+C     NAME            DESCRIPTION
 C
 C     PM              MATERIAL ARRAY(REAL)
 C     IPM             MATERIAL ARRAY(INTEGER)
@@ -62,19 +62,19 @@ C     IMATVIS         FLAG FOR VISCOSITY
 C     UNITAB          UNITS ARRAY
 C     MAT_ID          MATERIAL ID(INTEGER)
 C     TITR            MATERIAL TITLE
-C     LSUBMODEL       SUBMODEL STRUCTURE  
+C     LSUBMODEL       SUBMODEL STRUCTURE
 C     UPARAM          MATERIAL BUFFER
-C     PARMAT          ADDITIONAL PARAMETER FOR MATERIALS 
+C     PARMAT          ADDITIONAL PARAMETER FOR MATERIALS
 C
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE UNITAB_MOD
-      USE ELBUFTAG_MOD            
-      USE MESSAGE_MOD      
+      USE ELBUFTAG_MOD
+      USE MESSAGE_MOD
       USE SUBMODEL_MOD
-      USE MATPARAM_DEF_MOD   
-      USE MATPARAM_DEF_MOD         
+      USE MATPARAM_DEF_MOD
+      USE MATPARAM_DEF_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -97,7 +97,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      TYPE (UNIT_TYPE_),INTENT(IN) ::UNITAB 
+      TYPE (UNIT_TYPE_),INTENT(IN) ::UNITAB
       my_real, INTENT(INOUT)                :: PM(NPROPM),PARMAT(100),UPARAM(MAXUPARAM)
       INTEGER, INTENT(INOUT)                :: IPM(NPROPMI),ISRATE,IFUNC(MAXFUNC),NFUNC,MAXFUNC,MAXUPARAM,NUPARAM, NUVAR,IMATVIS
       TYPE(MLAW_TAG_),INTENT(INOUT)         :: MTAG
@@ -114,35 +114,35 @@ C-----------------------------------------------
       my_real      :: RHO0, RHOR, DPDMU(4)
       my_real      :: AV(4), RHO0_(4),C0(4),C1(4), E0(4),PMIN_(4),T0(4),C2(4),C3(4),C4(4),C5(4), GG(4)
       my_real      :: B1,B2,R1,R2,W,VDET,PCJ,VCJ, P0_GLOB
-      !---constitutive model  
-      !------ Johnson-Cook       
+      !---constitutive model
+      !------ Johnson-Cook
       my_real      :: Y(4),BB(4),N(4),CC(4),EPDR(4),CM(4),TMELT(4),THETL(4),PLAMX(4),SIGMX(4),SPH(4), XKA(4),XKB(4)
       !------ units
       my_real      :: FAC_UNIT_TIME, FAC_UNIT_SPH
-      !------ Drucker-PRager  
-      my_real      :: NU(4),A0(4),A1(4),A2(4),AMX(4),BUNL(4),MUMX(4),PSTAR(4),DET,DELTA,PTOT           
+      !------ Drucker-PRager
+      my_real      :: NU(4),A0(4),A1(4),A2(4),AMX(4),BUNL(4),MUMX(4),PSTAR(4),DET,DELTA,PTOT
       !---NRF
-      my_real      :: P0(4),SSP(4),LC(4),TCARP,TCAR,ABCS 
+      my_real      :: P0(4),SSP(4),LC(4),TCARP,TCAR,ABCS
       !---INLET/OUTLET
       INTEGER      :: IOPT,IAV(4),IRHO(4),IE(4)
       INTEGER      :: I,J,IFLG,io,IERROR
       INTEGER      :: JTHE, NITER
       INTEGER      :: IEXP, N_LC, IPLA_, IPLA(4), IBFRAC
       INTEGER      :: IVEL, IMID, NJWL, EOS_TYPE
-      INTEGER      :: tMID(4),SUM_MID   
+      INTEGER      :: tMID(4),SUM_MID
       !---temporary working arrays
       my_real      :: tAV(4),tR0(4),tC0(4),tC1(4),tC2(4),tC3(4),tC4(4),tC5(4),tE0(4)
       my_real      :: tPM(4), EINF(4),tA0(4),tA1(4),tA2(4),tPL(4),Pfar,Pini(4)
       my_real      :: IE_BOUND, RATIO, SumVF,VEL
       !---messages/output
       CHARACTER*64 :: chain,chain1
-      CHARACTER*32 :: CAV(4),CRHO0(34),CE0(4),CPM(4),CC0(4),CSSP(4) 
-      CHARACTER*32 :: CPEXT,CTCARP,CTCAR             
+      CHARACTER*32 :: CAV(4),CRHO0(34),CE0(4),CPM(4),CC0(4),CSSP(4)
+      CHARACTER*32 :: CPEXT,CTCARP,CTCAR
       !---booleans
       LOGICAL      :: IS_AVAILABLE,IS_CRYPTED, IFLG6_SUBMAT_DEFINED(4)
 C-----------------------------------------------
-C   S o u r c e   L i n e s 
-C-----------------------------------------------      
+C   S o u r c e   L i n e s
+C-----------------------------------------------
       IS_CRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
       ISRATE=0
@@ -154,14 +154,14 @@ C-----------------------------------------------
       MTAG%G_EINS = 1
       MTAG%L_EINT = 1
       MTAG%G_EINT = 1
-      MTAG%G_TEMP = 1    
-      MTAG%L_TEMP = 1       
-      MTAG%L_VK   = 1 
+      MTAG%G_TEMP = 1
+      MTAG%L_TEMP = 1
+      MTAG%L_VK   = 1
       NUPARAM = 280
       NFUNC = 10
       UPARAM(1:NUPARAM) = ZERO
       IFUNC(1:NFUNC)    = 0
-      IF (IALEMUSCl .GT. 0) I_LAW = 51  ! Communicate LAW to ALEMUSC_MOD 
+      IF (IALEMUSCl  >  0) I_LAW = 51  ! Communicate LAW to ALEMUSC_MOD
       IFLG6_SUBMAT_DEFINED(1:4)=.TRUE.
       !----------------!
       NITER  = 10
@@ -191,10 +191,10 @@ C-----------------------------------------------
       SSP(1:4)= ZERO
       LC(1:4) = ZERO
       TCARP   = ZERO
-      TCAR    = ZERO            
+      TCAR    = ZERO
       ABCS    = 0
       IAV(1:4)=0
-      IRHO(1:4)=0 
+      IRHO(1:4)=0
       IE(1:4)=0
       IVEL    = 0
       VEL     = ZERO
@@ -226,7 +226,7 @@ C-----------------------------------------------
       IBFRAC = 0
       !----------------!
       XKA(1:4)  = ZERO
-      XKB(1:4)  = ZERO 
+      XKB(1:4)  = ZERO
       A0(1:4)   = ZERO
       A1(1:4)   = ZERO
       A2(1:4)   = ZERO
@@ -238,49 +238,49 @@ C-----------------------------------------------
       EINF(1:4) =-INFINITY
       !==========================================!
       ! IFLG == ALL (0,1,2,3,4,5,10,11,12)       !
-      !==========================================!       
+      !==========================================!
       CALL HM_OPTION_IS_CRYPTED(IS_CRYPTED)
       !line-1
       CALL HM_GET_FLOATV('MAT_RHO'    ,RHO0        ,IS_AVAILABLE, LSUBMODEL, UNITAB)
       CALL HM_GET_FLOATV('Refer_Rho'  ,RHOR        ,IS_AVAILABLE, LSUBMODEL, UNITAB)
       !line-2
-      IPLA_     = 0  !Plasticity Flag > 0 means that at least one plastic submaterial. 
+      IPLA_     = 0  !Plasticity Flag > 0 means that at least one plastic submaterial.
       IPLA(1:4) = 0  !1:JCOOK, 2:DPRAG
       CALL HM_GET_INTV  ('MAT_Iflag'  ,IFLG        ,IS_AVAILABLE, LSUBMODEL)
             IFLAG_BAK=IFLG
-      IF(IFLG.EQ.11)THEN
+      IF(IFLG == 11)THEN
         CALL HM_GET_INTV  ('Mach1'      ,IPLA(1)     ,IS_AVAILABLE, LSUBMODEL)
         CALL HM_GET_INTV  ('Mach2'      ,IPLA(2)     ,IS_AVAILABLE, LSUBMODEL)
-        CALL HM_GET_INTV  ('Mach3'      ,IPLA(3)     ,IS_AVAILABLE, LSUBMODEL) 
-      ENDIF      
-      IF(IFLG.NE.11)THEN
+        CALL HM_GET_INTV  ('Mach3'      ,IPLA(3)     ,IS_AVAILABLE, LSUBMODEL)
+      ENDIF
+      IF(IFLG /= 11)THEN
         IPLA(1:4)=0
-      ENDIF  
+      ENDIF
       DO I=1,3
-        IF(IPLA(I).LT.0 .OR. IPLA(I).GT.2)IPLA(I)=0
-      ENDDO 
+        IF(IPLA(I) < 0 .OR. IPLA(I) > 2)IPLA(I)=0
+      ENDDO
       !----------------!
-      SELECT CASE(IFLG)         
+      SELECT CASE(IFLG)
       !============================!
       ! IFLG == 0                  !
-      !============================! 
+      !============================!
       CASE(0)
         !line-3
         CALL HM_GET_FLOATV('PEXT'       ,PEXT   ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         CALL HM_GET_FLOATV('MAT_NU'     ,VIS    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         CALL HM_GET_FLOATV('MAT_Lamda'  ,VISV   ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         DO I=1,3
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_ALPHA_Iflg0_phas'    ,AV(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_RHO_Iflg0_phas'      ,RHO0_(I) ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_E_Iflg0_phas'        ,E0(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_P_Iflg0_phas'        ,PMIN_(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C0_Iflg0_phas'       ,C0(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C1_Iflg0_phas'       ,C1(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C2_Iflg0_phas'       ,C2(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C3_Iflg0_phas'       ,C3(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C4_Iflg0_phas'       ,C4(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C5_Iflg0_phas'       ,C5(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_G_Iflg0_phas'        ,GG(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_ALPHA_Iflg0_phas'    ,AV(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_RHO_Iflg0_phas'      ,RHO0_(I) ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_E_Iflg0_phas'        ,E0(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_P_Iflg0_phas'        ,PMIN_(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C0_Iflg0_phas'       ,C0(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C1_Iflg0_phas'       ,C1(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C2_Iflg0_phas'       ,C2(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C3_Iflg0_phas'       ,C3(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C4_Iflg0_phas'       ,C4(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C5_Iflg0_phas'       ,C5(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_G_Iflg0_phas'        ,GG(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         ENDDO
         CALL HM_GET_FLOAT_ARRAY_INDEX_DIM('MAT_P_Iflg0_phas' ,FAC_UNIT_SPH   ,1 ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         IF(GG(1)+GG(2)+GG(3)==ZERO)THEN
@@ -289,11 +289,11 @@ C-----------------------------------------------
           IPLA_=1
           IF(GG(1)>ZERO)IPLA(1)=1
           IF(GG(2)>ZERO)IPLA(2)=1
-          IF(GG(3)>ZERO)IPLA(3)=1                    
+          IF(GG(3)>ZERO)IPLA(3)=1
         ENDIF
       !============================!
       ! IFLG == 1                  !
-      !============================! 
+      !============================!
       CASE(1)
         IFLG = 0
         !line-3
@@ -301,31 +301,31 @@ C-----------------------------------------------
         CALL HM_GET_FLOATV('MAT_NU'     ,VIS    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         CALL HM_GET_FLOATV('MAT_Lamda'  ,VISV   ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         DO I=1,3
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_ALPHA_Iflg1_phas'    ,AV(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_RHO_Iflg1_phas'      ,RHO0_(I) ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_E_Iflg1_phas'        ,E0(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_P_Iflg1_phas'        ,PMIN_(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C0_Iflg1_phas'       ,C0(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C1_Iflg1_phas'       ,C1(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C2_Iflg1_phas'       ,C2(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C3_Iflg1_phas'       ,C3(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C4_Iflg1_phas'       ,C4(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C5_Iflg1_phas'       ,C5(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_ALPHA_Iflg1_phas'    ,AV(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_RHO_Iflg1_phas'      ,RHO0_(I) ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_E_Iflg1_phas'        ,E0(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_P_Iflg1_phas'        ,PMIN_(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C0_Iflg1_phas'       ,C0(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C1_Iflg1_phas'       ,C1(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C2_Iflg1_phas'       ,C2(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C3_Iflg1_phas'       ,C3(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C4_Iflg1_phas'       ,C4(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C5_Iflg1_phas'       ,C5(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
           CALL HM_GET_FLOAT_ARRAY_INDEX('MLAW51_G1'               ,GG(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
-          CALL HM_GET_FLOAT_ARRAY_INDEX('Sigma_Y1'                ,Y(I)     ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('BB1'                     ,BB(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)  
-          CALL HM_GET_FLOAT_ARRAY_INDEX('LAW51_N1'                ,N(I)     ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('CC1'                     ,CC(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('e01'                     ,EPDR(I)  ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('CM1'                     ,CM(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('T10'                     ,T0(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('T_melt1'                 ,TMELT(I) ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('T_limit1'                ,THETL(I) ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('Rhocv'                   ,SPH(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('E_max1'                  ,PLAMX(I) ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('sigma_max1'              ,SIGMX(I) ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('K_A1'                    ,XKA(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('K_B1'                    ,XKB(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
+          CALL HM_GET_FLOAT_ARRAY_INDEX('Sigma_Y1'                ,Y(I)     ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('BB1'                     ,BB(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('LAW51_N1'                ,N(I)     ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('CC1'                     ,CC(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('e01'                     ,EPDR(I)  ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('CM1'                     ,CM(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('T10'                     ,T0(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('T_melt1'                 ,TMELT(I) ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('T_limit1'                ,THETL(I) ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('Rhocv'                   ,SPH(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('E_max1'                  ,PLAMX(I) ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('sigma_max1'              ,SIGMX(I) ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('K_A1'                    ,XKA(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('K_B1'                    ,XKB(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         ENDDO
         CALL HM_GET_FLOAT_ARRAY_INDEX_DIM('Rhocv' ,FAC_UNIT_SPH   ,1 ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         IF(GG(1)+GG(2)+GG(3)==ZERO)THEN
@@ -334,11 +334,11 @@ C-----------------------------------------------
           IPLA_=1
           IF(GG(1)>ZERO)IPLA(1)=1
           IF(GG(2)>ZERO)IPLA(2)=1
-          IF(GG(3)>ZERO)IPLA(3)=1                    
+          IF(GG(3)>ZERO)IPLA(3)=1
         ENDIF
       !============================!
       ! IFLG == 2                  !
-      !============================! 
+      !============================!
       CASE(2)
         IS_BOUNDARY_MATERIAL = .TRUE.
         CALL HM_GET_FLOATV('SCALE'       ,ABCS        ,IS_AVAILABLE, LSUBMODEL, UNITAB)
@@ -346,122 +346,122 @@ C-----------------------------------------------
         CALL HM_GET_FLOATV('VEL_in'      ,VEL         ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         CALL HM_GET_INTV  ('Fct_ID_vel'  ,IVEL        ,IS_AVAILABLE, LSUBMODEL)
         DO I=1,3
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_ALPHA_Iflg2_phas'     ,AV(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_RHO_Iflg2_phas'       ,RHO0_(I),I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_E_Iflg2_phas'         ,E0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_INT_ARRAY_INDEX  ('ABG_N1'                   ,IAV(I)  ,I ,IS_AVAILABLE, LSUBMODEL) 
-          CALL HM_GET_INT_ARRAY_INDEX  ('ABG_N2'                   ,IRHO(I) ,I ,IS_AVAILABLE, LSUBMODEL) 
-          CALL HM_GET_INT_ARRAY_INDEX  ('ABG_N3'                   ,IE(I)   ,I ,IS_AVAILABLE, LSUBMODEL) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C1_Iflg2_phas'        ,C1(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C2_Iflg2_phas'        ,C2(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C3_Iflg2_phas'        ,C3(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C4_Iflg2_phas'        ,C4(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C5_Iflg2_phas'        ,C5(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_P_Iflg2_phas'         ,PMIN_(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C0_Iflg2_phas'        ,C0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_ALPHA_Iflg2_phas'     ,AV(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_RHO_Iflg2_phas'       ,RHO0_(I),I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_E_Iflg2_phas'         ,E0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_INT_ARRAY_INDEX  ('ABG_N1'                   ,IAV(I)  ,I ,IS_AVAILABLE, LSUBMODEL)
+          CALL HM_GET_INT_ARRAY_INDEX  ('ABG_N2'                   ,IRHO(I) ,I ,IS_AVAILABLE, LSUBMODEL)
+          CALL HM_GET_INT_ARRAY_INDEX  ('ABG_N3'                   ,IE(I)   ,I ,IS_AVAILABLE, LSUBMODEL)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C1_Iflg2_phas'        ,C1(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C2_Iflg2_phas'        ,C2(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C3_Iflg2_phas'        ,C3(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C4_Iflg2_phas'        ,C4(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C5_Iflg2_phas'        ,C5(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_P_Iflg2_phas'         ,PMIN_(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C0_Iflg2_phas'        ,C0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         ENDDO
         CALL HM_GET_FLOAT_ARRAY_INDEX_DIM('MAT_P_Iflg2_phas' ,FAC_UNIT_SPH   ,1 ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         CALL HM_GET_FLOATV_DIM('SCALE'   ,FAC_UNIT_TIME  ,IS_AVAILABLE, LSUBMODEL, UNITAB)
       !============================!
       ! IFLG == 3                  !
-      !============================! 
+      !============================!
       CASE(3)
         !OBSOLETE use IFLG=6 instead
-        IS_BOUNDARY_MATERIAL = .TRUE.        
+        IS_BOUNDARY_MATERIAL = .TRUE.
         CALL ANCMSG(MSGID   = 75              ,
      .              MSGTYPE = MSGWARNING      ,
      .              ANMODE  = ANINFO_BLIND_1
-     .              )   
+     .              )
         DO I=1,3
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_ALPHA_Iflg3_phas'     ,AV(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_RHO_Iflg3_phas'       ,RHO0_(I),I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_E_Iflg3_phas'         ,E0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_P_Iflg3_phas'         ,PMIN_(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C0_Iflg3_phas'        ,C0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_ALPHA_Iflg3_phas'     ,AV(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_RHO_Iflg3_phas'       ,RHO0_(I),I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_E_Iflg3_phas'         ,E0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_P_Iflg3_phas'         ,PMIN_(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C0_Iflg3_phas'        ,C0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         ENDDO
         CALL HM_GET_FLOAT_ARRAY_INDEX_DIM('MAT_P_Iflg3_phas' ,FAC_UNIT_SPH   ,1 ,IS_AVAILABLE, LSUBMODEL, UNITAB)
       !============================!
       ! IFLG == 4                  !
-      !============================! 
+      !============================!
       CASE(4)
-        IS_BOUNDARY_MATERIAL = .TRUE.      
+        IS_BOUNDARY_MATERIAL = .TRUE.
         CALL HM_GET_FLOATV('SCALE'       ,ABCS        ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         CALL HM_GET_FLOATV('PEXT'        ,PEXT        ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         DO I=1,3
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_ALPHA_Iflg2_phas'     ,AV(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_RHO_Iflg2_phas'       ,RHO0_(I),I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_E_Iflg2_phas'         ,E0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_INT_ARRAY_INDEX  ('ABG_N1'                   ,IAV(I)  ,I ,IS_AVAILABLE, LSUBMODEL) 
-          CALL HM_GET_INT_ARRAY_INDEX  ('ABG_N2'                   ,IRHO(I) ,I ,IS_AVAILABLE, LSUBMODEL) 
-          CALL HM_GET_INT_ARRAY_INDEX  ('ABG_N3'                   ,IE(I)   ,I ,IS_AVAILABLE, LSUBMODEL) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C0_Iflg2_phas'        ,C0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C1_Iflg2_phas'        ,C1(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C4_Iflg2_phas'        ,C4(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          C5(I)=C4(I) ! no need to enter C5 (=C4) since 14.0   
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_ALPHA_Iflg2_phas'     ,AV(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_RHO_Iflg2_phas'       ,RHO0_(I),I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_E_Iflg2_phas'         ,E0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_INT_ARRAY_INDEX  ('ABG_N1'                   ,IAV(I)  ,I ,IS_AVAILABLE, LSUBMODEL)
+          CALL HM_GET_INT_ARRAY_INDEX  ('ABG_N2'                   ,IRHO(I) ,I ,IS_AVAILABLE, LSUBMODEL)
+          CALL HM_GET_INT_ARRAY_INDEX  ('ABG_N3'                   ,IE(I)   ,I ,IS_AVAILABLE, LSUBMODEL)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C0_Iflg2_phas'        ,C0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C1_Iflg2_phas'        ,C1(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C4_Iflg2_phas'        ,C4(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          C5(I)=C4(I) ! no need to enter C5 (=C4) since 14.0
         ENDDO
         CALL HM_GET_FLOAT_ARRAY_INDEX_DIM('MAT_C0_Iflg2_phas' ,FAC_UNIT_SPH   ,1 ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         CALL HM_GET_FLOATV_DIM('SCALE'            ,FAC_UNIT_TIME  ,IS_AVAILABLE, LSUBMODEL, UNITAB)
       !============================!
       ! IFLG == 5                  !
-      !============================! 
+      !============================!
       CASE(5)
-        IS_BOUNDARY_MATERIAL = .TRUE.      
+        IS_BOUNDARY_MATERIAL = .TRUE.
         CALL HM_GET_FLOATV('SCALE'       ,ABCS        ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         CALL HM_GET_FLOATV('PEXT'        ,PEXT        ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         DO I=1,3
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_ALPHA_Iflg2_phas'     ,AV(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_RHO_Iflg2_phas'       ,RHO0_(I),I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_E_Iflg2_phas'         ,E0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_INT_ARRAY_INDEX  ('ABG_N1'                   ,IAV(I)  ,I ,IS_AVAILABLE, LSUBMODEL) 
-          CALL HM_GET_INT_ARRAY_INDEX  ('ABG_N2'                   ,IRHO(I) ,I ,IS_AVAILABLE, LSUBMODEL) 
-          CALL HM_GET_INT_ARRAY_INDEX  ('ABG_N3'                   ,IE(I)   ,I ,IS_AVAILABLE, LSUBMODEL) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C0_Iflg2_phas'        ,C0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C1_Iflg2_phas'        ,C1(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_P_Iflg2_phas'         ,PMIN_(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)  
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_ALPHA_Iflg2_phas'     ,AV(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_RHO_Iflg2_phas'       ,RHO0_(I),I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_E_Iflg2_phas'         ,E0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_INT_ARRAY_INDEX  ('ABG_N1'                   ,IAV(I)  ,I ,IS_AVAILABLE, LSUBMODEL)
+          CALL HM_GET_INT_ARRAY_INDEX  ('ABG_N2'                   ,IRHO(I) ,I ,IS_AVAILABLE, LSUBMODEL)
+          CALL HM_GET_INT_ARRAY_INDEX  ('ABG_N3'                   ,IE(I)   ,I ,IS_AVAILABLE, LSUBMODEL)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C0_Iflg2_phas'        ,C0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C1_Iflg2_phas'        ,C1(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_P_Iflg2_phas'         ,PMIN_(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         ENDDO
         CALL HM_GET_FLOAT_ARRAY_INDEX_DIM('MAT_P_Iflg2_phas' ,FAC_UNIT_SPH   ,1 ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         CALL HM_GET_FLOATV_DIM('SCALE'  ,FAC_UNIT_TIME  ,IS_AVAILABLE, LSUBMODEL, UNITAB)
       !============================!
       ! IFLG == 6                  !
-      !============================! 
+      !============================!
       CASE(6)
-        IS_BOUNDARY_MATERIAL = .TRUE.      
+        IS_BOUNDARY_MATERIAL = .TRUE.
         M51_IFLG6 = 1
         IERROR = 0
         CALL HM_GET_FLOATV('PEXT'        ,PEXT         ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         CALL HM_GET_FLOATV('MAT_TCP'     ,TCARP        ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         CALL HM_GET_FLOATV('MAT_TCALPHA' ,TCAR         ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         DO I=1,3
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_ALPHA_Iflg0_phas'     ,AV(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_RHO_Iflg0_phas'       ,RHO0_(I),I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_E_Iflg0_phas'         ,E0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_P_Iflg0_phas'         ,PMIN_(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_P0_Iflg0_phas'        ,C0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_SSP0_Iflg0_phas'      ,SSP(I)  ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB) 
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_ALPHA_Iflg0_phas'     ,AV(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_RHO_Iflg0_phas'       ,RHO0_(I),I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_E_Iflg0_phas'         ,E0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_P_Iflg0_phas'         ,PMIN_(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_P0_Iflg0_phas'        ,C0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_SSP0_Iflg0_phas'      ,SSP(I)  ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
           IF(AV(I)==ZERO .AND. RHO0_(I)==ZERO .AND. E0(I)==ZERO .AND. PMIN_(I)==ZERO .AND. C0(I)==ZERO .AND. SSP(I)==ZERO )THEN
             IFLG6_SUBMAT_DEFINED(I)=.FALSE.
           ENDIF
         ENDDO
         CALL HM_GET_FLOAT_ARRAY_INDEX_DIM('MAT_P0_Iflg0_phas' ,FAC_UNIT_SPH   ,1 ,IS_AVAILABLE, LSUBMODEL, UNITAB)
-       IF(TCAR.EQ.ZERO)TCAR=INFINITY
+       IF(TCAR == ZERO)TCAR=INFINITY
        CPEXT (1:32) = '  auto                          ' ;
-       IF (PEXT  /= ZERO) WRITE(CPEXT  ,FMT='(E12.4)')PEXT
-       CTCARP(1:32) = '  auto                          ' ; 
-       IF (TCARP /= ZERO) WRITE(CTCARP ,FMT='(E12.4)')TCARP     
-       CTCAR (1:32) = '  auto                          ' ; 
-       IF (TCAR  /= ZERO) WRITE(CTCAR  ,FMT='(E12.4)')TCAR  
-       DO I=1,3         
-         CAV  (I)= '  auto                          ' ;IF (AV(I)   /= ZERO) WRITE(CAV(I)   ,FMT='(E12.4)')AV(I)          
-         CRHO0(I)= '  auto                          ' ;IF (RHO0_(I)/= ZERO)  WRITE(CRHO0(I) ,FMT='(E12.4)')RHO0_(I)         
-         CE0  (I)= '  auto                          ' ;IF (E0(I)   /= ZERO) WRITE(CE0(I)   ,FMT='(E12.4)')E0(I)
-         CPM  (I)= '  auto                          ' ;IF (PMIN_(I)   /= ZERO) WRITE(CPM(I)   ,FMT='(E12.4)')PMIN_(I)        
-         CC0  (I)= '  auto                          ' ;IF (C0(I)   /= ZERO) WRITE(CC0(I)   ,FMT='(E12.4)')C0(I)      
-         CSSP (I)= '  auto                          ' ;IF (SSP(I)  /= ZERO) WRITE(CSSP(I)  ,FMT='(E12.4)')SSP(I) 
+       IF (PEXT /= ZERO) WRITE(CPEXT  ,FMT='(E12.4)')PEXT
+       CTCARP(1:32) = '  auto                          ' ;
+       IF (TCARP /= ZERO) WRITE(CTCARP ,FMT='(E12.4)')TCARP
+       CTCAR (1:32) = '  auto                          ' ;
+       IF (TCAR /= ZERO) WRITE(CTCAR  ,FMT='(E12.4)')TCAR
+       DO I=1,3
+         CAV  (I)= '  auto                          ' ;IF (AV(I) /= ZERO) WRITE(CAV(I)   ,FMT='(E12.4)')AV(I)
+         CRHO0(I)= '  auto                          ' ;IF (RHO0_(I)/= ZERO)  WRITE(CRHO0(I) ,FMT='(E12.4)')RHO0_(I)
+         CE0  (I)= '  auto                          ' ;IF (E0(I) /= ZERO) WRITE(CE0(I)   ,FMT='(E12.4)')E0(I)
+         CPM  (I)= '  auto                          ' ;IF (PMIN_(I) /= ZERO) WRITE(CPM(I)   ,FMT='(E12.4)')PMIN_(I)
+         CC0  (I)= '  auto                          ' ;IF (C0(I) /= ZERO) WRITE(CC0(I)   ,FMT='(E12.4)')C0(I)
+         CSSP (I)= '  auto                          ' ;IF (SSP(I) /= ZERO) WRITE(CSSP(I)  ,FMT='(E12.4)')SSP(I)
        ENDDO
 
       !============================!
       ! IFLG == 10                 !
-      !============================! 
+      !============================!
       CASE(10)
         IFLG=1
         IEXP=1
@@ -469,59 +469,59 @@ C-----------------------------------------------
         CALL HM_GET_FLOATV('MAT_NU'     ,VIS          ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         CALL HM_GET_FLOATV('MAT_Lamda'  ,VISV         ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         DO I=1,3
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_ALPHA_Iflg10_phas' ,AV(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_RHO_Iflg10_phas'   ,RHO0_(I),I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_E_Iflg10_phas'     ,E0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_P_Iflg10_phas'     ,PMIN_(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C0_Iflg10_phas'    ,C0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C1_Iflg10_phas'    ,C1(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C2_Iflg10_phas'    ,C2(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C3_Iflg10_phas'    ,C3(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C4_Iflg10_phas'    ,C4(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C5_Iflg10_phas'    ,C5(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('MLAW51_G10'            ,GG(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('Sigma_Y10'             ,Y(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('BB10'                  ,BB(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('LAW51_N10'             ,N(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('CC10'                  ,CC(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('e010'                  ,EPDR(I) ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('CM10'                  ,CM(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('T10_10'                ,T0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('T_melt10'              ,TMELT(I),I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('T_limit10'             ,THETL(I),I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('Rhocv10'               ,SPH(I)  ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-          CALL HM_GET_FLOAT_ARRAY_INDEX('E_max10'               ,PLAMX(I) ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)     
-          CALL HM_GET_FLOAT_ARRAY_INDEX('sigma_max10'           ,SIGMX(I) ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)     
-          CALL HM_GET_FLOAT_ARRAY_INDEX('K_A1'                  ,XKA(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)     
-          CALL HM_GET_FLOAT_ARRAY_INDEX('K_B1'                  ,XKB(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)     
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_ALPHA_Iflg10_phas' ,AV(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_RHO_Iflg10_phas'   ,RHO0_(I),I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_E_Iflg10_phas'     ,E0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_P_Iflg10_phas'     ,PMIN_(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C0_Iflg10_phas'    ,C0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C1_Iflg10_phas'    ,C1(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C2_Iflg10_phas'    ,C2(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C3_Iflg10_phas'    ,C3(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C4_Iflg10_phas'    ,C4(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MAT_C5_Iflg10_phas'    ,C5(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('MLAW51_G10'            ,GG(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('Sigma_Y10'             ,Y(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('BB10'                  ,BB(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('LAW51_N10'             ,N(I)    ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('CC10'                  ,CC(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('e010'                  ,EPDR(I) ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('CM10'                  ,CM(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('T10_10'                ,T0(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('T_melt10'              ,TMELT(I),I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('T_limit10'             ,THETL(I),I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('Rhocv10'               ,SPH(I)  ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('E_max10'               ,PLAMX(I) ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('sigma_max10'           ,SIGMX(I) ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('K_A1'                  ,XKA(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+          CALL HM_GET_FLOAT_ARRAY_INDEX('K_B1'                  ,XKB(I)   ,I ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         ENDDO
         CALL HM_GET_FLOAT_ARRAY_INDEX_DIM('Rhocv10' ,FAC_UNIT_SPH   ,1 ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         !High Explosive
-        CALL HM_GET_FLOATV('MLAW51_ALPHA'            ,AV(4)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-        CALL HM_GET_FLOATV('MLAW51_Rho'              ,RHO0_(4) ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-        CALL HM_GET_FLOATV('MLAW51_E0'               ,E0(4)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-        CALL HM_GET_FLOATV('MLAW51_Pmin'             ,PMIN_(4) ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-        CALL HM_GET_FLOATV('MLAW51_C0'               ,C0(4)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-        CALL HM_GET_FLOATV('MLAW51_B1'               ,B1       ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-        CALL HM_GET_FLOATV('MLAW51_B2'               ,B2       ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-        CALL HM_GET_FLOATV('MLAW51_R1'               ,R1       ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-        CALL HM_GET_FLOATV('MLAW51_R2'               ,R2       ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-        CALL HM_GET_FLOATV('MLAW51_W'                ,W        ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-        CALL HM_GET_FLOATV('MLAW51_D'                ,VDET     ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-        CALL HM_GET_FLOATV('MLAW51_PCJ'              ,PCJ      ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-        CALL HM_GET_FLOATV('MLAW51_C14'              ,C1(4)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)      
-        CALL HM_GET_INTV('MAT_IBFRAC'              ,IBFRAC   ,IS_AVAILABLE, LSUBMODEL)              
+        CALL HM_GET_FLOATV('MLAW51_ALPHA'            ,AV(4)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+        CALL HM_GET_FLOATV('MLAW51_Rho'              ,RHO0_(4) ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+        CALL HM_GET_FLOATV('MLAW51_E0'               ,E0(4)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+        CALL HM_GET_FLOATV('MLAW51_Pmin'             ,PMIN_(4) ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+        CALL HM_GET_FLOATV('MLAW51_C0'               ,C0(4)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+        CALL HM_GET_FLOATV('MLAW51_B1'               ,B1       ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+        CALL HM_GET_FLOATV('MLAW51_B2'               ,B2       ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+        CALL HM_GET_FLOATV('MLAW51_R1'               ,R1       ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+        CALL HM_GET_FLOATV('MLAW51_R2'               ,R2       ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+        CALL HM_GET_FLOATV('MLAW51_W'                ,W        ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+        CALL HM_GET_FLOATV('MLAW51_D'                ,VDET     ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+        CALL HM_GET_FLOATV('MLAW51_PCJ'              ,PCJ      ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+        CALL HM_GET_FLOATV('MLAW51_C14'              ,C1(4)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+        CALL HM_GET_INTV('MAT_IBFRAC'              ,IBFRAC   ,IS_AVAILABLE, LSUBMODEL)
         IF(GG(1)+GG(2)+GG(3)==ZERO)THEN
           IPLA_=0
         ELSE
           IPLA_=1
           IF(GG(1)>ZERO)IPLA(1)=1
           IF(GG(2)>ZERO)IPLA(2)=1
-          IF(GG(3)>ZERO)IPLA(3)=1                    
+          IF(GG(3)>ZERO)IPLA(3)=1
         ENDIF
       !============================!
       ! IFLG == 11                 !
-      !============================! 
+      !============================!
       CASE(11)
         IFLG=1
         IEXP=1
@@ -532,26 +532,26 @@ C-----------------------------------------------
      .        CC     , EPDR      ,CM       ,  T0      , TMELT   ,
      .        THETL  , SPH       ,PLAMX    ,  SIGMX   , XKA     ,
      .        XKB    , NU        ,A0       ,  A1      , A2      ,
-     .        AMX    , BUNL      ,MUMX     ,  
+     .        AMX    , BUNL      ,MUMX     ,
      .        B1     , B2        ,R1       ,  R2,       W,
-     .        VDET   , PCJ       ,IBFRAC   ,  PEXT,     VIS,  
-     .        VISV   , IS_CRYPTED,LSUBMODEL,  UNITAB)  
-        CALL HM_GET_FLOAT_ARRAY_INDEX_DIM('DAMP1' ,FAC_UNIT_SPH   ,1 ,IS_AVAILABLE, LSUBMODEL, UNITAB)         
+     .        VDET   , PCJ       ,IBFRAC   ,  PEXT,     VIS,
+     .        VISV   , IS_CRYPTED,LSUBMODEL,  UNITAB)
+        CALL HM_GET_FLOAT_ARRAY_INDEX_DIM('DAMP1' ,FAC_UNIT_SPH   ,1 ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         !Shear Modulus for DPRAG input
         IF(GG(1)==ZERO.AND.IPLA(1)==2)GG(1)=Y(1)/DEUX/(UN+NU(1))
         IF(GG(2)==ZERO.AND.IPLA(2)==2)GG(2)=Y(2)/DEUX/(UN+NU(2))
         IF(GG(3)==ZERO.AND.IPLA(3)==2)GG(3)=Y(3)/DEUX/(UN+NU(3))
         !Plasticity flags
         IPLA_=0
-        IF(GG(1)+GG(2)+GG(3)/=ZERO)THEN
+        IF(GG(1)+GG(2)+GG(3) /= ZERO)THEN
           IPLA_=1
           IF(GG(1)==ZERO)IPLA(1)=0
           IF(GG(2)==ZERO)IPLA(2)=0
-          IF(GG(3)==ZERO)IPLA(3)=0 
-        ENDIF 
+          IF(GG(3)==ZERO)IPLA(3)=0
+        ENDIF
       !============================!
       ! IFLG == 12                 !
-      !============================! 
+      !============================!
       CASE(12)
         IFLG  = 12
         IEXP  = 1
@@ -561,7 +561,7 @@ C-----------------------------------------------
         CALL HM_GET_FLOATV('MAT_NU'     ,VIS          ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         CALL HM_GET_FLOATV('MAT_Lamda'  ,VISV         ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         CALL HM_GET_INTV  ('MIP'       ,MIP        ,IS_AVAILABLE, LSUBMODEL)
-        IMID            = 0 
+        IMID            = 0
         SUMVF           = ZERO
         DO I=1,MIP
           CALL HM_GET_INT_ARRAY_INDEX  ('materialIds'               ,tMID(I)   ,I,IS_AVAILABLE, LSUBMODEL)
@@ -576,10 +576,10 @@ C-----------------------------------------------
      .                    ANMODE=ANINFO,
      .                    I1=MAT_ID,
      .                    C1=TITR,
-     .                    C2=chain1) 
+     .                    C2=chain1)
         ENDIF
         DO I=1,MIP
-          IF(tAV(I).LT.ZERO .OR. tAV(I).GT.UN)THEN
+          IF(tAV(I) < ZERO .OR. tAV(I) > UN)THEN
               chain(1:20)='                    '
               write(chain(1:20),'(e20.14)')tAV(I)
               chain1='VOLUME FRACTION MUST BE BETWEEN 0.0 AND 1.0 , READ VALUE IS '// chain(1:20)
@@ -588,9 +588,9 @@ C-----------------------------------------------
      .                    ANMODE=ANINFO,
      .                    I1=MAT_ID,
      .                    C1=TITR,
-     .                    C2=chain1) 
+     .                    C2=chain1)
           ENDIF
-          IF(tMID(I).LE.0)THEN
+          IF(tMID(I)  <= 0)THEN
               chain(1:10)='          '
               write(chain(1:10),'(i10)')tMID(I)
               chain1='INCORRECT MATERIAL IDENTIFIER '//chain(1:10)
@@ -599,25 +599,25 @@ C-----------------------------------------------
      .                    ANMODE=ANINFO,
      .                    I1=MAT_ID,
      .                    C1=TITR,
-     .                    C2=chain1) 
+     .                    C2=chain1)
               tMID(I)=0
           ENDIF
         ENDDO
         SUMVF = SUM(tAV(1:4))
-        IF(SUMVF.GT.UN)THEN
+        IF(SUMVF > UN)THEN
             chain(1:20)='                    '
             write(chain(1:20),'(F20.8)')SUMVF
             chain1='SUM OF VOLUME FRACTION MUST BE EQUAL TO 1.0, CURRENT SUM IS '// chain(1:20)
-            CALL ANCMSG(MSGID=99,                                  
-     .                  MSGTYPE=MSGERROR,                          
-     .                  ANMODE=ANINFO,                     
-     .                  I1=MAT_ID,                                     
-     .                  C1=TITR,                                   
-     .                  C2=chain1)                                 
+            CALL ANCMSG(MSGID=99,
+     .                  MSGTYPE=MSGERROR,
+     .                  ANMODE=ANINFO,
+     .                  I1=MAT_ID,
+     .                  C1=TITR,
+     .                  C2=chain1)
         ENDIF
       !============================!
       ! IFLG == NOT VALID          !
-      !============================! 
+      !============================!
       CASE DEFAULT
        !not correct iform value
            chain1='INCORRECT IFORM VALUE '
@@ -626,54 +626,54 @@ C-----------------------------------------------
      .                 ANMODE=ANINFO_BLIND_1,
      .                 I1=MAT_ID,
      .                 C1=TITR,
-     .                 C2=chain1)           
+     .                 C2=chain1)
       END SELECT
       !============================!
       ! PLASTICITY DEFAULT         !
-      !============================! 
-      IF(RATIO.LE.ZERO)THEN
+      !============================!
+      IF(RATIO  <= ZERO)THEN
         RATIO = 0.25D00   !UN is for previous formulation (permitted large volume change)
       ENDIF
       IF(IPLA_>0)THEN
         MTAG%G_EPSD  = 1
         MTAG%L_EPSD  = 1
         MTAG%G_PLA   = 1
-        MTAG%L_PLA   = 1  
+        MTAG%L_PLA   = 1
         IF(IPLA(1) == 2 .OR. IPLA(2) == 2 .OR. IPLA(3) == 2)THEN
           MTAG%G_EPSQ = 1
           MTAG%L_EPSQ = 1
-        ENDIF        
-      ENDIF       
+        ENDIF
+      ENDIF
       IF(IEXP>0)THEN
-        MTAG%G_BFRAC = 1       
-        MTAG%L_BFRAC = 1  
-      ENDIF 
-      IF(IFLG.EQ.12)THEN
+        MTAG%G_BFRAC = 1
+        MTAG%L_BFRAC = 1
+      ENDIF
+      IF(IFLG == 12)THEN
           MTAG%G_EPSD  = 1
           MTAG%L_EPSD  = 1
           MTAG%G_PLA   = 1
-          MTAG%L_PLA   = 1  
+          MTAG%L_PLA   = 1
           MTAG%G_EPSQ  = 1
           MTAG%L_EPSQ  = 1
-          MTAG%G_BFRAC = 1       
-          MTAG%L_BFRAC = 1  
+          MTAG%G_BFRAC = 1
+          MTAG%L_BFRAC = 1
       ENDIF
       DO I=1,3
-        IF(IPLA(I) == 2)THEN 
-          IF(A2(I)==ZERO.AND.A1(I)/=ZERO)THEN   !(A21=A11=ZERO => error message)
-            PSTAR(I)=-A0(I)/A1(I) 
-          ELSEIF(A2(I).NE.ZERO)THEN
+        IF(IPLA(I) == 2)THEN
+          IF(A2(I) == ZERO .AND. A1(I) /= ZERO)THEN   !(A21=A11=ZERO => error message)
+            PSTAR(I)=-A0(I)/A1(I)
+          ELSEIF(A2(I) /= ZERO)THEN
             DELTA = A1(I)*A1(I)-QUATRE*A0(I)*A2(I)
             !Si intersection avec l'axe
-            IF(DELTA .GE. ZERO)THEN
+            IF(DELTA  >=  ZERO)THEN
               DELTA=SQRT(DELTA)
               PSTAR(I) = (-A1(I)+DELTA)/DEUX/A2(I)
-            
+
             ELSE
-            !  PSTAR(I) = -A1(I)/DEUX/A2(I) !no let user do what he wants 
+            !  PSTAR(I) = -A1(I)/DEUX/A2(I) !no let user do what he wants
               PSTAR(I) = -INFINITY
-              chain='SUBMAT-0 : YIELD SURFACE HAS NO ROOT.                          '  
-              write(chain(8:8),'(i1.1)')I    
+              chain='SUBMAT-0 : YIELD SURFACE HAS NO ROOT.                          '
+              write(chain(8:8),'(i1.1)')I
               CALL ANCMSG(MSGID=829,
      .                    MSGTYPE=MSGWARNING,
      .                    ANMODE=ANINFO,
@@ -681,27 +681,27 @@ C-----------------------------------------------
      .                    I2=MAT_ID,
      .                    C1='WARNING',
      .                    C2=TITR,
-     .                    C3=chain)               
+     .                    C3=chain)
             ENDIF
           ELSE
             !do nothing let user do what he wants
-          ENDIF       
+          ENDIF
         ENDIF
       ENDDO
 C     |============================!
 C     | DEFAULT FLAGS              !
-C     !============================! 
-      IF(IOPT.LT.0)IOPT=0 !check possible values otherwise set to debaut one. 
-      !IF(IOPT.GE.4)IOPT=0 ! does not exist
-      IF (N_LC.LE.0)THEN
+C     !============================!
+      IF(IOPT < 0)IOPT=0 !check possible values otherwise set to debaut one.
+      !IF(IOPT >= 4)IOPT=0 ! does not exist
+      IF (N_LC  <= 0)THEN
         IF(IOPT==1)THEN
           N_LC=100
         ELSE
           N_LC=1000
         ENDIF
-      ENDIF       
-      IF(ABCS.EQ.ZERO) ABCS=  UN*FAC_UNIT_TIME
-      PMIN = -PEXT  
+      ENDIF
+      IF(ABCS == ZERO) ABCS=  UN*FAC_UNIT_TIME
+      PMIN = -PEXT
       DO I=1,4
         ! RhoCp
         IF(SPH(I) == ZERO) SPH(I) = UN * FAC_UNIT_SPH
@@ -718,7 +718,7 @@ C     !============================!
         !Limit Temperature
         IF(THETL(I) == ZERO) THETL(I) = INFINITY
         !Thermal condictivity
-        IF(XKA(I) == ZERO)  XKA(I) = EM20                  
+        IF(XKA(I) == ZERO)  XKA(I) = EM20
         !Johnson-Cook parameters
         IF(EPDR(I) == ZERO)  EPDR(I) = UN
         !Drucker-Prager maximum values
@@ -728,10 +728,10 @@ C     !============================!
       ENDDO
       !Drucker-Prager \B5max1, \B5max2, \B5max3
       DO I=1,3
-        IF(MUMX(I).EQ.ZERO.AND.BUNL(I).NE.ZERO)THEN
-         IF(C3(I).EQ.ZERO)THEN
-          IF(C2(I).EQ.ZERO)THEN
-           MUMX(I)=INFINITY 
+        IF(MUMX(I) == ZERO .AND. BUNL(I) /= ZERO)THEN
+         IF(C3(I) == ZERO)THEN
+          IF(C2(I) == ZERO)THEN
+           MUMX(I)=INFINITY
           ELSE
            MUMX(I)=(BUNL(I)-C1(I))/(DEUX*C2(I))
           ENDIF
@@ -746,23 +746,23 @@ C     !============================!
         IF(BUNL(I) == ZERO)  BUNL(I) = C1(I)
       ENDDO
       !Minimum Pressure (GGi must be calculated whatever is yield criteria)
-      IF(IFLG.LE.1.OR.IFLG.EQ.11)THEN
+      IF(IFLG  <= 1.OR.IFLG == 11)THEN
        DO I=1,3
-        IF (PMIN_(I).EQ.ZERO) THEN
-          IF(GG(I).EQ.ZERO)THEN
+        IF (PMIN_(I) == ZERO) THEN
+          IF(GG(I) == ZERO)THEN
             PMIN_(I) = -PEXT
           ELSE
             PMIN_(I) = -INFINITY
           ENDIF
         ENDIF
        ENDDO
-       IF (PMIN_(4).EQ.ZERO) THEN
+       IF (PMIN_(4) == ZERO) THEN
          PMIN_(4) = -INFINITY
-       ENDIF       
-      ENDIF  
+       ENDIF
+      ENDIF
       !EXPLOSIVE C14
-      IF(RHO0_(4).GT.ZERO)THEN
-        IF(C1(4).LE.ZERO)THEN
+      IF(RHO0_(4) > ZERO)THEN
+        IF(C1(4)  <= ZERO)THEN
            chain1='BULK MODULUS C14 MUST BE PROVIDED FOR UNREACTED EXPLOSIVE'
            CALL ANCMSG(MSGID=99,
      .                 MSGTYPE=MSGERROR,
@@ -771,24 +771,24 @@ C     !============================!
      .                 C1=TITR,
      .                 C2=chain1)
         ENDIF
-        IF(VDET.LE.ZERO)THEN                                                     
-          chain1='DETONATION VELOCITY MUST BE INPUT FOR EXPLOSIVE SUBMATERIAL'   
-          CALL ANCMSG(MSGID=99,                                                  
-     .                MSGTYPE=MSGERROR,                                          
-     .                ANMODE=ANINFO,                                     
-     .                I1=MAT_ID,                                                 
-     .                C1=TITR,                                                   
-     .                C2=chain1)                                                 
-        ENDIF                                                                    
-      ENDIF  
+        IF(VDET  <= ZERO)THEN
+          chain1='DETONATION VELOCITY MUST BE INPUT FOR EXPLOSIVE SUBMATERIAL'
+          CALL ANCMSG(MSGID=99,
+     .                MSGTYPE=MSGERROR,
+     .                ANMODE=ANINFO,
+     .                I1=MAT_ID,
+     .                C1=TITR,
+     .                C2=chain1)
+        ENDIF
+      ENDIF
       !============================!
       ! CHECKING INITIAL STATE     !
       !   *INITIAL PRESSURE        !
       !   *DENSITIES               !
       !   *VOLUMETRIC FRACTION     !
-      !============================!      
+      !============================!
       !Check is done only for multimaterial law (iflg=0|1), inlet/outlet are skipped.
-      IF (IFLG.NE.12) THEN       
+      IF (IFLG /= 12) THEN
         CALL LECM51__CHECK_INITIAL_STATE(
      .   AV, RHO0_,  C0,  C1,  C2, C3, C4,  C5,
      .   E0, PM, RHO0, RHOR, IEXP, JTHE,PEXT, IFLG,
@@ -809,19 +809,19 @@ C     !============================!
         EINF(4)=ZERO
       END IF
       !initialisation vitesse du son, loi51
-      IF(IFLG.EQ.0 .OR. IFLG.EQ.1)THEN
+      IF(IFLG == 0 .OR. IFLG == 1)THEN
         DO I=1,3
           P0(I)    = C0(I)+C4(I)*E0(I)
-          DPDMU(I) = (C1(I)+C5(I)*E0(I)) + C4(I)*(PEXT+P0(I)) 
-          IF(RHO0_(I) .NE. ZERO) SSP(I)  = SQRT( (DPDMU(I) + DTIERS*GG(I)) / RHO0_(I) )   !achtung GG = 2*G   =>  DTIERS*GG = QTIERS*G
+          DPDMU(I) = (C1(I)+C5(I)*E0(I)) + C4(I)*(PEXT+P0(I))
+          IF(RHO0_(I) /=  ZERO) SSP(I)  = SQRT( (DPDMU(I) + DTIERS*GG(I)) / RHO0_(I) )   !achtung GG = 2*G   =>  DTIERS*GG = QTIERS*G
         ENDDO
         P0(4)  = C0(4)
-        SSP(4) = VDET 
+        SSP(4) = VDET
       ENDIF
       !============================!
       ! Output through UPARAM(*)   !
-      !============================! 
-      UPARAM(1)  = VIS   
+      !============================!
+      UPARAM(1)  = VIS
       UPARAM(2)  = DEUX*VIS
       UPARAM(3)  = (VISV-UPARAM(2))*THIRD
       UPARAM(4)  = AV(1)
@@ -833,8 +833,8 @@ C     !============================!
       UPARAM(55) = IEXP
       UPARAM(31) = IFLG
       UPARAM(73) = NITER
-      UPARAM(74) = RATIO 
-      IF (IFLG.NE.12) THEN  
+      UPARAM(74) = RATIO
+      IF (IFLG /= 12) THEN
         UPARAM(9)  = RHO0_(1)
         UPARAM(10) = RHO0_(2)
         UPARAM(11) = RHO0_(3)
@@ -870,7 +870,7 @@ C     !============================!
         UPARAM(41) = PMIN_(3)
         UPARAM(42) = VDET
         UPARAM(43) = PCJ
-        IF(PCJ.GT.EM20)THEN
+        IF(PCJ > EM20)THEN
           UPARAM(44) = RHO0_(4) * VDET**2 / PCJ
         ELSE
           UPARAM(44) = INFINITY
@@ -879,7 +879,7 @@ C     !============================!
         IF(RHO0_(4)==ZERO) UPARAM(47) = EM20 !RHO0_(4)
         UPARAM(48) = E0(4)
         UPARAM(49) = C0(4)
-        UPARAM(50) = C1(4) 
+        UPARAM(50) = C1(4)
         UPARAM(45) = B1
         UPARAM(51) = B2
         UPARAM(52) = R1
@@ -890,20 +890,24 @@ C     !============================!
         UPARAM(57) = EINF(1)
         UPARAM(58) = EINF(2)
         UPARAM(59) = EINF(3)
-        UPARAM(60) = EINF(4)               
-        UPARAM(61) = IOPT  
+        UPARAM(60) = EINF(4)
+        UPARAM(61) = IOPT
         UPARAM(62) = UN/N_LC
         UPARAM(63) = IPLA_
         UPARAM(64) = IPLA(1)
         UPARAM(65) = IPLA(2)
-        UPARAM(66) = IPLA(3)       
-        UPARAM(67) = IPLA(4) 
+        UPARAM(66) = IPLA(3)
+        UPARAM(67) = IPLA(4)
         UPARAM(68) = IBFRAC
-        UPARAM(69) = RHO0_(1) * AV(1) + RHO0_(2) * AV(2) + RHO0_(3) * AV(3) + RHO0_(4) * AV(4)   
+        UPARAM(69) = RHO0_(1) * AV(1) + RHO0_(2) * AV(2) + RHO0_(3) * AV(3) + RHO0_(4) * AV(4)
         UPARAM(70) = TCARP
         UPARAM(71) = TCAR
         UPARAM(72) = INFINITY    !P0_NRF
         UPARAM(75) = VEL
+        UPARAM(81) = ZERO !visc1
+        UPARAM(82) = ZERO !visc2
+        UPARAM(83) = ZERO !visc3
+        UPARAM(84) = ZERO !visc4
         IDX=100
         DO I=1,3
           UPARAM(IDX+01) = GG(I)
@@ -928,12 +932,12 @@ C     !============================!
           UPARAM(IDX+20) = MUMX(I)
           UPARAM(IDX+21) = BUNL(I)
           UPARAM(IDX+22) = NU(I)
-          UPARAM(IDX+23) = PSTAR(I) 
+          UPARAM(IDX+23) = PSTAR(I)
           UPARAM(IDX+24) = SSP(I)
-          UPARAM(IDX+25) = LC(I)           
+          UPARAM(IDX+25) = LC(I)
           UPARAM(IDX+26) = RHO0_(I)*SSP(I)*SSP(I)
-          IDX=IDX+50  
-        ENDDO 
+          IDX=IDX+50
+        ENDDO
         !I=4
         UPARAM(258) = TMELT(4)
         UPARAM(259) = THETL(4)
@@ -942,15 +946,15 @@ C     !============================!
         UPARAM(264) = XKA(4)
         UPARAM(265) = XKB(4)
         UPARAM(273) = SSP(4)
-        UPARAM(274) = LC(4)      
-        UPARAM(275) = RHO0_(4)*SSP(4)*SSP(4)  
-        UPARAM(276) = ZERO          
+        UPARAM(274) = LC(4)
+        UPARAM(275) = RHO0_(4)*SSP(4)*SSP(4)
+        UPARAM(276) = ZERO
         !bijective application (in case of new input you must retrieve phase order in legacy buffer)
         ! example jwl is necessarily id 4 in legacy buffer, but not necessarily in user input (iform=12)
         UPARAM(277) = 1
         UPARAM(278) = 2
         UPARAM(279) = 3
-        UPARAM(280) = 4     
+        UPARAM(280) = 4
         !functions
         IFUNC(01) = IAV(1)
         IFUNC(02) = IRHO(1)
@@ -968,27 +972,27 @@ C     !============================!
       PM(27) = MAXVAL(SSP(1:4))
       !============================!
       ! Starter Listing File       !
-      !============================! 
+      !============================!
       WRITE(IOUT,997) TRIM(TITR),MAT_ID,51
       WRITE(IOUT,998)
       IF(IS_CRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        IF(IFLG.NE.12)THEN     
+        IF(IFLG /= 12)THEN
           WRITE(IOUT, 900)RHO0,RHOR
           WRITE(iOUT,5002)IFLAG_BAK
           WRITE(IOUT,5001)PEXT,VIS,VISV,AV(1),AV(2),AV(3),AV(4)
         ENDIF
         !============================!
         ! IFLG == 0,1,10,11          !
-        !============================!    
-          IF(IFLG.LE.1)THEN
+        !============================!
+          IF(IFLG <= 1)THEN
             P0_GLOB = P0(1)*AV(1)+P0(2)*AV(2)+P0(3)*AV(3)+P0(4)*AV(4)
             DO I=1,3
              WRITE(IOUT,5005)I
              WRITE(IOUT,5010)
              WRITE(IOUT,5011)C0(I),C1(I),C2(I),C3(I),C4(I),C5(I),E0(I),RHO0_(I),PMIN_(I),P0_GLOB
-             IF(Y(I).EQ.ZERO)IPLA(I)=0
+             IF(Y(I) == ZERO)IPLA(I)=0
              SELECT CASE(IPLA(I))
                CASE(0)
                  IF(GG(I)>ZERO)THEN
@@ -1000,94 +1004,94 @@ C     !============================!
                  WRITE(IOUT,5021)Y(I),BB(I),N(I),CC(I),EPDR(I),CM(I),T0(I),TMELT(I),THETL(I),SPH(I),PLAMX(I),SIGMX(I),XKA(I),XKB(I)
                CASE(2)
                  WRITE(IOUT,5025)
-                 WRITE(IOUT,5026)A0(I),A1(I),A2(I),AMX(I),Y(I),NU(I),T0(I),TMELT(I),THETL(I),SPH(I),PLAMX(I),SIGMX(I),XKA(I),XKB(I) 
-             END SELECT 
+                 WRITE(IOUT,5026)A0(I),A1(I),A2(I),AMX(I),Y(I),NU(I),T0(I),TMELT(I),THETL(I),SPH(I),PLAMX(I),SIGMX(I),XKA(I),XKB(I)
+             END SELECT
            ENDDO
            I=4
            WRITE(IOUT,5005)I
            WRITE(IOUT,5030)
            WRITE(IOUT,5031)RHO0_(4),E0(4),PMIN_(4),C0(4),C1(4),B1,B2,R1,R2,W,VDET,PCJ,VCJ,IBFRAC
-        !============================!                                                                             
-        ! IFLG == 2                  !                                                                             
-        !============================!                                                                             
-        ELSEIF(IFLG.EQ.2)THEN                                                                                      
-          WRITE(IOUT,1200)ABCS,VEL,IVEL,                                                                           
-     &                    AV(1),RHO0_(1),E0(1),IAV(1),IRHO(1),IE(1),PMIN_(1),C0(1),C1(1),C2(1),C3(1),C4(1),C5(1),  
-     &                    AV(2),RHO0_(2),E0(2),IAV(2),IRHO(2),IE(2),PMIN_(2),C0(2),C1(2),C2(2),C3(2),C4(2),C5(2),  
-     &                    AV(3),RHO0_(3),E0(3),IAV(3),IRHO(3),IE(3),PMIN_(3),C0(3),C1(3),C2(3),C3(3),C4(3),C5(3)   
+        !============================!
+        ! IFLG == 2                  !
+        !============================!
+        ELSEIF(IFLG == 2)THEN
+          WRITE(IOUT,1200)ABCS,VEL,IVEL,
+     &                    AV(1),RHO0_(1),E0(1),IAV(1),IRHO(1),IE(1),PMIN_(1),C0(1),C1(1),C2(1),C3(1),C4(1),C5(1),
+     &                    AV(2),RHO0_(2),E0(2),IAV(2),IRHO(2),IE(2),PMIN_(2),C0(2),C1(2),C2(2),C3(2),C4(2),C5(2),
+     &                    AV(3),RHO0_(3),E0(3),IAV(3),IRHO(3),IE(3),PMIN_(3),C0(3),C1(3),C2(3),C3(3),C4(3),C5(3)
 
-        !============================!                                                                             
-        ! IFLG == 3                  !                                                                             
-        !============================!                                                                             
-        ELSEIF(IFLG.EQ.3)THEN                                                                                      
-          IF(IOPT==1)THEN                                                                                          
-            WRITE(IOUT,1299)IOPT                                                                                   
-          ELSE                                                                                                     
-            WRITE(IOUT,1298)                                                                                       
-          ENDIF                                                                                                    
-          WRITE(IOUT,1300)AV(1),RHO0_(1),E0(1),C0(1),                                                              
-     &                    AV(2),RHO0_(2),E0(2),C0(2),                                                              
-     &                    AV(3),RHO0_(3),E0(3),C0(3)                                                               
-     
-        !============================!                                                                             
-        ! IFLG == 4                  !                                                                             
-        !============================!                                                                             
-        ELSEIF(IFLG.EQ.4)THEN                                                                                      
-          WRITE(IOUT,1400)ABCS,                                                                                    
-     &          AV(1),RHO0_(1),E0(1),IAV(1),IRHO(1),IE(1),PMIN_(1),C0(1),C1(1),C4(1),                              
-     &          AV(2),RHO0_(2),E0(2),IAV(2),IRHO(2),IE(2),PMIN_(2),C0(2),C1(2),C4(2),                              
-     &          AV(3),RHO0_(3),E0(3),IAV(3),IRHO(3),IE(3),PMIN_(3),C0(3),C1(3),C4(3)                               
+        !============================!
+        ! IFLG == 3                  !
+        !============================!
+        ELSEIF(IFLG == 3)THEN
+          IF(IOPT == 1)THEN
+            WRITE(IOUT,1299)IOPT
+          ELSE
+            WRITE(IOUT,1298)
+          ENDIF
+          WRITE(IOUT,1300)AV(1),RHO0_(1),E0(1),C0(1),
+     &                    AV(2),RHO0_(2),E0(2),C0(2),
+     &                    AV(3),RHO0_(3),E0(3),C0(3)
 
-        !============================!                                                                             
-        ! IFLG == 5                  !                                                                             
-        !============================!                                                                             
-        ELSEIF(IFLG.EQ.5)THEN                                                                                      
-          WRITE(IOUT,1500)ABCS,                                                                                    
-     &                    AV(1),RHO0_(1),E0(1),IAV(1),IRHO(1),IE(1),PMIN_(1),C0(1),C1(1),                          
-     &                    AV(2),RHO0_(2),E0(2),IAV(2),IRHO(2),IE(2),PMIN_(2),C0(2),C1(2),                          
-     &                    AV(3),RHO0_(3),E0(3),IAV(3),IRHO(3),IE(3),PMIN_(3),C0(3),C1(3)                           
-        !============================!                                                                             
-        ! IFLG == 6                  !                                                                             
-        !============================!                                                                             
-        ELSEIF(IFLG.EQ.6)THEN                                                                                      
-          WRITE(IOUT,1700)CPEXT,CTCARP,CTCAR                                                                       
-          IF(IFLG6_SUBMAT_DEFINED(1) .OR. IFLG6_SUBMAT_DEFINED(2) .OR. IFLG6_SUBMAT_DEFINED(3))                    
-     &    WRITE(IOUT,1701)CAV(1) ,CRHO0(1),CE0(1) ,CPM(1) ,CC0(1) ,CSSP(1),                                        
-     &                    CAV(2) ,CRHO0(2),CE0(2) ,CPM(2) ,CC0(2) ,CSSP(2),                                        
-     &                    CAV(3) ,CRHO0(3),CE0(3) ,CPM(3) ,CC0(3) ,CSSP(3)                                         
-        !============================!                                                                             
-        ! IFLG == 12                  !                                                                            
-        !============================!                                                                             
-        ELSEIF(IFLG==12)THEN   
-          WRITE(IOUT,5002)12                                                                                        
-          WRITE(IOUT,4003)VIS,VISV 
-          WRITE(IOUT,4004)                                                                                  
-          DO I=1,MIP                                                                                               
-            WRITE(IOUT,4001)I,tMID(I)                                                                                
-          ENDDO  
-          WRITE(IOUT,4004)                                                                                                  
-          DO I=1,MIP                                                                                               
-            WRITE(IOUT,4002)I,tAV(I)                                                                                 
-          ENDDO                                                                                                    
-        ENDIF                                                                                                      
-        !============================! 
-        IF(NITER.NE.10)THEN
+        !============================!
+        ! IFLG == 4                  !
+        !============================!
+        ELSEIF(IFLG == 4)THEN
+          WRITE(IOUT,1400)ABCS,
+     &          AV(1),RHO0_(1),E0(1),IAV(1),IRHO(1),IE(1),PMIN_(1),C0(1),C1(1),C4(1),
+     &          AV(2),RHO0_(2),E0(2),IAV(2),IRHO(2),IE(2),PMIN_(2),C0(2),C1(2),C4(2),
+     &          AV(3),RHO0_(3),E0(3),IAV(3),IRHO(3),IE(3),PMIN_(3),C0(3),C1(3),C4(3)
+
+        !============================!
+        ! IFLG == 5                  !
+        !============================!
+        ELSEIF(IFLG == 5)THEN
+          WRITE(IOUT,1500)ABCS,
+     &                    AV(1),RHO0_(1),E0(1),IAV(1),IRHO(1),IE(1),PMIN_(1),C0(1),C1(1),
+     &                    AV(2),RHO0_(2),E0(2),IAV(2),IRHO(2),IE(2),PMIN_(2),C0(2),C1(2),
+     &                    AV(3),RHO0_(3),E0(3),IAV(3),IRHO(3),IE(3),PMIN_(3),C0(3),C1(3)
+        !============================!
+        ! IFLG == 6                  !
+        !============================!
+        ELSEIF(IFLG == 6)THEN
+          WRITE(IOUT,1700)CPEXT,CTCARP,CTCAR
+          IF(IFLG6_SUBMAT_DEFINED(1) .OR. IFLG6_SUBMAT_DEFINED(2) .OR. IFLG6_SUBMAT_DEFINED(3))
+     &    WRITE(IOUT,1701)CAV(1) ,CRHO0(1),CE0(1) ,CPM(1) ,CC0(1) ,CSSP(1),
+     &                    CAV(2) ,CRHO0(2),CE0(2) ,CPM(2) ,CC0(2) ,CSSP(2),
+     &                    CAV(3) ,CRHO0(3),CE0(3) ,CPM(3) ,CC0(3) ,CSSP(3)
+        !============================!
+        ! IFLG == 12                  !
+        !============================!
+        ELSEIF(IFLG == 12)THEN
+          WRITE(IOUT,5002)12
+          WRITE(IOUT,4003)VIS,VISV
+          WRITE(IOUT,4004)
+          DO I=1,MIP
+            WRITE(IOUT,4001)I,tMID(I)
+          ENDDO
+          WRITE(IOUT,4004)
+          DO I=1,MIP
+            WRITE(IOUT,4002)I,tAV(I)
+          ENDDO
+        ENDIF
+        !============================!
+        IF(NITER  /= 10)THEN
           WRITE(IOUT,901)NITER
-        ENDIF   
-      ENDIF  
-      
-      PM(38)=VDET    
-      IF(IFLG.EQ.12)RHO0=UN    
-      IF(RHOR.EQ.ZERO)RHOR=RHO0
+        ENDIF
+      ENDIF
+
+      PM(38)=VDET
+      IF(IFLG == 12)RHO0=UN
+      IF(RHOR == ZERO)RHOR=RHO0
       PM(1) =RHOR
-      PM(89)=RHO0 
+      PM(89)=RHO0
       PM(91)=MAXVAL(RHO0_(1:4))
-          
+
 
       RETURN
-      
+
   999 CALL FREERR(3)
-      
+
 C======================================================================|
   900 FORMAT(
      & 5X,'INITIAL DENSITY . . . . . . . . . . . .=',1PG20.13/,
@@ -1238,34 +1242,34 @@ C======================================================================|
      & 5X,'SUBMAT-1 AV10 VOLUME FRACTION. . . . . .=',A    /
      & 5X,'SUBMAT-1 RHO10 REFERENCE DENSITY . . . .=',A    /
      & 5X,'SUBMAT-1 E01 VOLUMETRIC ENERGY . . . . .=',A    /
-     & 5X,'SUBMAT-1 PM1 CUT OFF PRESSURE. . . . . .=',A    /     
+     & 5X,'SUBMAT-1 PM1 CUT OFF PRESSURE. . . . . .=',A    /
      & 5X,'SUBMAT-1 P01 INITIAL PRESSURE. . . . . .=',A    /
      & 5X,'SUBMAT-1 SSP1 SOUND SPEED. . . . . . . .=',A    /
      & 5X,'SUBMAT-2 AV20 VOLUME FRACTION. . . . . .=',A    /
      & 5X,'SUBMAT-2 RHO20 REFERENCE DENSITY . . . .=',A    /
      & 5X,'SUBMAT-2 E02 VOLUMETRIC ENERGY . . . . .=',A    /
-     & 5X,'SUBMAT-2 PM2 CUT OFF PRESSURE. . . . . .=',A    /     
+     & 5X,'SUBMAT-2 PM2 CUT OFF PRESSURE. . . . . .=',A    /
      & 5X,'SUBMAT-2 P02 INITIAL PRESSURE. . . . . .=',A    /
      & 5X,'SUBMAT-2 SSP2 SOUND SPEED. . . . . . . .=',A    /
      & 5X,'SUBMAT-3 AV30 VOLUME FRACTION. . . . . .=',A    /
      & 5X,'SUBMAT-3 RHO30 REFERENCE DENSITY . . . .=',A    /
      & 5X,'SUBMAT-3 E03 VOLUMETRIC ENERGY . . . . .=',A    /
-     & 5X,'SUBMAT-3 PM3 CUT OFF PRESSURE. . . . . .=',A    /     
+     & 5X,'SUBMAT-3 PM3 CUT OFF PRESSURE. . . . . .=',A    /
      & 5X,'SUBMAT-3 P03 INITIAL PRESSURE. . . . . .=',A    /
-     & 5X,'SUBMAT-3 SSP3 SOUND SPEED. . . . . . . .=',A    //)         
+     & 5X,'SUBMAT-3 SSP3 SOUND SPEED. . . . . . . .=',A    //)
  2000 FORMAT(
-     & 5X,'Minimum Energies                      ',/     
-     & 5X,'(Computed for Numerical Stability)    ',/       
+     & 5X,'Minimum Energies                      ',/
+     & 5X,'(Computed for Numerical Stability)    ',/
      & 5X,'SUBMAT-1 Minimum ENERGY. . . . . . . . .=',E12.4/
      & 5X,'SUBMAT-2 Minimum ENERGY. . . . . . . . .=',E12.4/
      & 5X,'SUBMAT-3 Minimum ENERGY. . . . . . . . .=',E12.4//)
  4001 FORMAT(
-     & 5X,'SUBMATERIAL-',I1,' ID =   ',I10)  
+     & 5X,'SUBMATERIAL-',I1,' ID =   ',I10)
  4002 FORMAT(
-     & 5X,'SUBMATERIAL-',I1,' Volume Fraction = ',F12.10)  
+     & 5X,'SUBMATERIAL-',I1,' Volume Fraction = ',F12.10)
  4003 FORMAT(
      & 5X,'SHEAR KINEMATIC VISCOSITY. . . . . . . =',E12.4/
-     & 5X,'SPHERICAL KINEMATIC VISCOSITY. . . . . =',E12.4) 
+     & 5X,'SPHERICAL KINEMATIC VISCOSITY. . . . . =',E12.4)
  4004 FORMAT(
      & 5X,'____________________________________________________')
  5001 FORMAT(
@@ -1280,10 +1284,10 @@ C======================================================================|
  5002 FORMAT(
      & 5X,'FORMULATION FLAG . . . . . . . . . . . =  ',I2)
  5005 FORMAT(
-     & 5X,'__________________________',/, 
+     & 5X,'__________________________',/,
      & 5X,'+S U B M A T E R I A L - ',I1)
  5010 FORMAT(
-     & 5X,'|',/, 
+     & 5X,'|',/,
      & 5X,'+----POLYNOMIAL EoS',/,
      & 5X,'|    --------------')
  5011 FORMAT(
@@ -1296,18 +1300,18 @@ C======================================================================|
      & 5X,'|    E0. . . . . . . . . . . . . . . . =',1PG20.13/,
      & 5X,'|    RHO0. . . . . . . . . . . . . . . =',1PG20.13/,
      & 5X,'|    PMIN. . . . . . . . . . . . . . . =',1PG20.13/,
-     & 5X,'|    INITIAL PRESSURE (COMPUTED) . . . =',1PG20.13)  
+     & 5X,'|    INITIAL PRESSURE (COMPUTED) . . . =',1PG20.13)
  5015 FORMAT(
-     & 5X,'|',/, 
+     & 5X,'|',/,
      & 5X,'+----ELASTIC SOLID',/,
      & 5X,'|    -------------')
- 5016 FORMAT(     
-     & 5X,'|    G SHEAR MODULUS . . . . . . . . . =',E12.4) 
+ 5016 FORMAT(
+     & 5X,'|    G SHEAR MODULUS . . . . . . . . . =',E12.4)
  5020 FORMAT(
-     & 5X,'|',/, 
+     & 5X,'|',/,
      & 5X,'+----JOHNSON-COOK YIELD CRITERIA',/,
-     & 5X,'|    ---------------------------')     
- 5021 FORMAT(     
+     & 5X,'|    ---------------------------')
+ 5021 FORMAT(
      & 5X,'|    G      SHEAR MODULUS. . . . . . . =',E12.4/
      & 5X,'|    A      YIELD STRESS . . . . . . . =',E12.4/
      & 5X,'|    B      YIELD FACTOR . . . . . . . =',E12.4/
@@ -1322,18 +1326,18 @@ C======================================================================|
      & 5X,'|    MAXIMUM PLASTIC STRAIN. . . . . . =',E12.4/
      & 5X,'|    MAXIMUM STRESS. . . . . . . . . . =',E12.4/
      & 5X,'|    KA  . . . . . . . . . . . . . . . =',E12.4/
-     & 5X,'|    KB  . . . . . . . . . . . . . . . =',E12.4) 
+     & 5X,'|    KB  . . . . . . . . . . . . . . . =',E12.4)
  5025 FORMAT(
-     & 5X,'|',/, 
+     & 5X,'|',/,
      & 5X,'+----DRUCKER-PRAGER YIELD CRITERIA     ',/,
-     & 5X,'|    -----------------------------     ')     
- 5026 FORMAT(     
+     & 5X,'|    -----------------------------     ')
+ 5026 FORMAT(
      & 5X,'|    A0     YIELD COEFFICIENT 1. . . . =',E12.4/
      & 5X,'|    A1     YIELD COEFFICIENT 2. . . . =',E12.4/
-     & 5X,'|    A2     YIELD COEFFICIENT 3. . . . =',E12.4/     
-     & 5X,'|    A-MAX  MAXIMUM YIELD VALUE. . . . =',E12.4/ 
+     & 5X,'|    A2     YIELD COEFFICIENT 3. . . . =',E12.4/
+     & 5X,'|    A-MAX  MAXIMUM YIELD VALUE. . . . =',E12.4/
      & 5X,'|    E      YOUNG MODULUS. . . . . . . =',E12.4/
-     & 5X,'|    NU     YOUNG MODULUS. . . . . . . =',E12.4/       
+     & 5X,'|    NU     YOUNG MODULUS. . . . . . . =',E12.4/
      & 5X,'|    T0     INITIAL TEMPERATURE. . . . =',E12.4/
      & 5X,'|    TMELT  MELTING TEMPERATURE. . . . =',E12.4/
      & 5X,'|    TLIM   TEMPERATURE LIMIT. . . . . =',E12.4/
@@ -1341,9 +1345,9 @@ C======================================================================|
      & 5X,'|    MAXIMUM PLASTIC STRAIN. . . . . . =',E12.4/
      & 5X,'|    MAXIMUM STRESS. . . . . . . . . . =',E12.4/
      & 5X,'|    KA  . . . . . . . . . . . . . . . =',E12.4/
-     & 5X,'|    KB  . . . . . . . . . . . . . . . =',E12.4)   
+     & 5X,'|    KB  . . . . . . . . . . . . . . . =',E12.4)
  5030 FORMAT(
-     & 5X,'|',/, 
+     & 5X,'|',/,
      & 5X,'+----JWL EoS',/,
      & 5X,'|    -------')
  5031 FORMAT(
@@ -1360,10 +1364,6 @@ C======================================================================|
      & 5X,'|    VDET DETONATION VELOCITY. . . . . =',E12.4/
      & 5X,'|    PCJ  PRESSURE AT C-J STATE . . . .=',E12.4/
      & 5X,'|    VCJ  VOLUME AT C-J STATE . . . . .=',E12.4/
-     & 5X,'|    FLAG FOR BURN FRACTION METHOD . . =',I10) 
+     & 5X,'|    FLAG FOR BURN FRACTION METHOD . . =',I10)
       END
 C======================================================================|
-
-
-
-


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [x] Only one commit (please squash your commits) 
- [x] No merge commits (use git pull --rebase) 
- [x] The changes satisfy the DOS and DONTS of the CONTRIBUTING.md file

<!------ Provide a general summary of your changes in the Title above -->
#### /MAT/LAW51:mixture viscosity
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Viscosity of the mixture is calculated. If submaterial is based on a law6 then its viscosity parameter is used. Otherwise submaterial is using law51 viscosity parameter (which is 0.0 by default). Source cleaning was also done (unused parameters, obsolete operators, ...)
<!--- If there is a design document, link to it here ->


