### PR TITLE
Better differenciate ARM & X64 / Gfortran for find executable

### DIFF
--- a/engine/share/spe_inc/abfname.inc
+++ b/engine/share/spe_inc/abfname.inc
@@ -4,7 +4,7 @@
 char * ABFPLATTTF = "macosx64";
 
 #elif CPP_mach==CPP_p4linux964
-#ifdef ARCH_CPU
+#ifdef __aarch64__
 char * ABFPLATTTF = "linuxa64";
 #elif 1
 char * ABFPLATTTF = "linux64";


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [x] Only one commit (please squash your commits) 
- [x] No merge commits (use git pull --rebase) 
- [x] The changes satisfy the DOS and DONTS of the CONTRIBUTING.md file

<!------ Provide a general summary of your changes in the Title above -->
Need to differenciate better call to ABF_CONVERTER between X64 & ARM
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Modified the #ifdef
<!--- If there is a design document, link to it here ->


