### PR TITLE
Fix uninitialized variables for LAW 110 reader

### DIFF
--- a/starter/source/materials/mat/mat110/hm_read_mat110.F
+++ b/starter/source/materials/mat/mat110/hm_read_mat110.F
@@ -76,7 +76,7 @@ C-----------------------------------------------
       my_real, DIMENSION(100),INTENT(OUT) :: PARMAT
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
       TYPE(MLAW_TAG_), INTENT(OUT) :: MTAG
-      TYPE(MATPARAM_STRUCT_) ,INTENT(OUT) :: MATPARAM
+      TYPE(MATPARAM_STRUCT_),INTENT(INOUT) :: MATPARAM
 C     
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
@@ -213,6 +213,7 @@ card7 - Yield criterion parameters
         IF (.NOT.ALLOCATED(fUN))   ALLOCATE(fUN(NANGLE,2))
         IF (.NOT.ALLOCATED(fSH))   ALLOCATE(fSH(NANGLE,2))
         IF (.NOT.ALLOCATED(fPS))   ALLOCATE(fPS(NANGLE,2))
+        fPS(1:NANGLE,1:2) = ZERO
         IF (.NOT.ALLOCATED(ALPS))  ALLOCATE(ALPS(NANGLE))
         IF (.NOT.ALLOCATED(rLank)) ALLOCATE(rLank(NANGLE))
         ! Loop over angles (must be equally distributed between 0 and pi/2)


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [ ] Only one commit (please squash your commits) 
- [ ] No merge commits (use git pull --rebase) 
- [ ] The changes satisfy the DOS and DONTS of the CONTRIBUTING.md file

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Some variables were not initialized but used in hm_read_mat110.F creating Valgrind issue. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Add the initialization of the concerned variables (fPS and MATPARAM%NTABLE). 

<!--- If there is a design document, link to it here ->


