### PR TITLE
/EBCS/NRF : initializing default value for EBCS%NBMAT

### DIFF
--- a/common_source/modules/ebcs_mod.F
+++ b/common_source/modules/ebcs_mod.F
@@ -271,7 +271,7 @@ Chd|====================================================================
 !     type = 10 /EBCS/NRF
 !     ----------------------
       type, public, extends(t_ebcs) :: t_ebcs_nrf
-      integer :: nbmat
+      integer :: nbmat=21
       my_real :: tcar_p = 0., tcar_vf = 1E20
       !my_real, dimension(:,:), allocatable :: phase_alpha      
       type(fvm_inlet_data_struct) :: fvm_inlet_data    


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [x] Only one commit (please squash your commits) 
- [x] No merge commits (use git pull --rebase) 
- [x] The changes satisfy the DOS and DONTS of the CONTRIBUTING.md file

<!------ Provide a general summary of your changes in the Title above -->
#### /EBCS/NRF:initialize defaut value for EBCS%NBMAT to 21 (static max value)
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Buffer maximum size is 21. This value is reached with material law 151 since this law cannot have more than 21 submaterials.
<!--- If there is a design document, link to it here ->


