### PR TITLE
INTER18:error message if GRNOD used with LAW151, instead of GRBRIC

### DIFF
--- a/starter/source/interfaces/int18/hm_read_inter_type18.F
+++ b/starter/source/interfaces/int18/hm_read_inter_type18.F
@@ -37,7 +37,7 @@ Chd|====================================================================
       SUBROUTINE HM_READ_INTER_TYPE18(
      1          IPARI      ,STFAC      ,FRIGAP     ,NOINT     ,NI       ,
      3          IGRNOD     ,IGRSURF    ,IGRBRIC    ,XFILTR    ,FRIC_P   ,
-     3          IDDLEVEL   ,TITR, UNITAB, LSUBMODEL)
+     3          IDDLEVEL   ,TITR, UNITAB, LSUBMODEL,MULTI_FVM)
 C============================================================================
 C-----------------------------------------------
 C   M o d u l e s
@@ -46,6 +46,7 @@ C-----------------------------------------------
       USE GROUPDEF_MOD
       USE SUBMODEL_MOD
       USE UNITAB_MOD
+      USE MULTI_FVM_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -68,6 +69,7 @@ C-----------------------------------------------
       my_real
      .   FRIGAP(*),FRIC_P(*),STFAC,XFILTR
       CHARACTER,INTENT(IN) :: TITR*nchartitle
+      TYPE(MULTI_FVM_STRUCT), INTENT(INOUT) :: MULTI_FVM      
 C-----------------------------------------------
       TYPE (GROUP_)  ,TARGET, DIMENSION(NGRNOD)  :: IGRNOD
       TYPE (SURF_)   ,TARGET , DIMENSION(NSURF)   :: IGRSURF
@@ -189,7 +191,7 @@ C------------------------------------------------------------
       IF(ISTIFF == 2) INTER18_AUTOPARAM = 1
       
 !===CHECK STRUCTURE:ISU2=SURF_ID                                                                                                      
-       IF(ISU2.EQ.0) THEN 
+       IF(ISU2 == 0) THEN 
              MSGTITL='LAGRANGIAN SURFACE IS EMPTY (SURF_ID)'
              !IF(IDDLEVEL==1)CALL ANCMSG(MSGID=1115,MSGTYPE=MSGERROR,ANMODE=ANINFO, I1=NOINT,C1=TITR,C2=MSGTITL)
              CALL ANCMSG(MSGID=1115,MSGTYPE=MSGERROR,ANMODE=ANINFO, I1=NOINT,C1=TITR,C2=MSGTITL)                
@@ -199,13 +201,19 @@ C------------------------------------------------------------
             INGR2USR => IGRSURF(1:NSURF)%ID  
             ISU2=NGR2USR(ISU2,INGR2USR,NSURF) 
             MSGTITL='SURFACE CANNOT BE FOUND (SURF_ID)' 
-            !IF(ISU2.EQ.0 .AND. IDDLEVEL==1)CALL ANCMSG(MSGID=1115, MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=NOINT,C1=TITR,C2=MSGTITL) 
-            IF(ISU2.EQ.0)CALL ANCMSG(MSGID=1115, MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=NOINT,C1=TITR,C2=MSGTITL)             
+            !IF(ISU2 == 0 .AND. IDDLEVEL==1)CALL ANCMSG(MSGID=1115, MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=NOINT,C1=TITR,C2=MSGTITL) 
+             IF(ISU1 == 0)THEN
+               MSGTITL='GROUP OF NODES CANNOT BE FOUND (GRNOD_ID)'
+               CALL ANCMSG(MSGID=1115,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=NOINT,C1=TITR,C2=MSGTITL)
+             ELSEIF(MULTI_FVM%IS_USED)THEN            
+               MSGTITL='GRBRIC_id (COLUMN 3) MUST BE PROVIDED INSTEAD OF GRNOD_id (COLUMN 1)' 
+               CALL ANCMSG(MSGID=1115,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=NOINT,C1=TITR,C2=MSGTITL)
+             ENDIF            
        ENDIF       
 !===CHECK ALE CELLS:ISU1=GRNOD_ID (old format) otherwise use Group of solids (GRBRIC_ID,GRQUAD_ID,GRTRIA_ID                           
           
-       IF(ISU1.NE.0 .AND. GRBRIC_ID.NE.0)GRBRIC_ID=0 ! Possible Istf flag defined in input (was removed from manuabecause Istf is always 1) 
-c          IF(ISU1.NE.0 .AND. GRBRIC_ID.NE.0)THEN                                                                          
+       IF(ISU1 /= 0 .AND. GRBRIC_ID /= 0)GRBRIC_ID=0 ! Possible Istf flag defined in input (was removed from manuabecause Istf is always 1) 
+c          IF(ISU1 /= 0 .AND. GRBRIC_ID /= 0)THEN                                                                          
 c             MSGTITL='YOU CANNOT DEFINE BOTH GRNOD_ID and GRBRIC_ID'                                                                       
 c             CALL ANCMSG(MSGID=1115,                                                                                                    
 c     .                   MSGTYPE=MSGERROR,  
@@ -214,21 +222,21 @@ c     .                   I1=NOINT,
 c     .                   C1=TITR,                                         
 c     .                   C2=MSGTITL)                                      
 c          ENDIF                                                           
-        IF(ISU1.NE.0)THEN                                                  
+        IF(ISU1 /= 0)THEN                                                  
             INGR2USR => IGRNOD(1:NGRNOD)%ID                                
             ISU1=NGR2USR(ISU1,INGR2USR,NGRNOD)                             
             IS1 =2  
              MSGTITL='GROUP OF NODES CANNOT BE FOUND (GRNOD_ID)' 
-             !IF(ISU1.EQ.0 .AND. IDDLEVEL==1)CALL ANCMSG(MSGID=1115,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=NOINT,C1=TITR,C2=MSGTITL)
-             IF(ISU1.EQ.0)CALL ANCMSG(MSGID=1115,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=NOINT,C1=TITR,C2=MSGTITL)             
+             !IF(ISU1 == 0 .AND. IDDLEVEL==1)CALL ANCMSG(MSGID=1115,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=NOINT,C1=TITR,C2=MSGTITL)
+             IF(ISU1 == 0)CALL ANCMSG(MSGID=1115,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=NOINT,C1=TITR,C2=MSGTITL)             
         ELSE                                                               
             !GRBRIC_ID,GRQUAD_ID,GRTRIA_ID                                 
-            IF(GRBRIC_ID.NE.0)THEN                                         
+            IF(GRBRIC_ID /= 0)THEN                                         
               INGR2USR => IGRBRIC(1:NGRBRIC)%ID                            
               GRBRIC_ID = NGR2USR(GRBRIC_ID,INGR2USR,NGRBRIC)              
               IS1 = 5                                                      
             ENDIF                                                          
-            IF(GRBRIC_ID.EQ.0) THEN                                        
+            IF(GRBRIC_ID == 0) THEN                                        
              MSGTITL='GROUP OF ALE CELLS IS EMPTY (GRBRIC_ID)'             
              !IF(IDDLEVEL==1)CALL ANCMSG(MSGID=1115,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=NOINT,C1=TITR,C2=MSGTITL)
              CALL ANCMSG(MSGID=1115,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=NOINT,C1=TITR,C2=MSGTITL)             
@@ -237,7 +245,7 @@ c          ENDIF
             ENDIF                                              
         ENDIF                                                  
 !===CHECK STFAC                                                
-        IF(STFAC.LE.ZERO .AND. ISTIFF==1)THEN                                  
+        IF(STFAC <= ZERO .AND. ISTIFF==1)THEN                                  
              MSGTITL='STIFFNESS VALUE MUST BE DEFINED (STFVAL)'
              !IF(IDDLEVEL==1)CALL ANCMSG(MSGID=1115,MSGTYPE=MSGERROR, ANMODE=ANINFO,I1=NOINT,C1=TITR,C2=MSGTITL)  
              CALL ANCMSG(MSGID=1115,MSGTYPE=MSGERROR, ANMODE=ANINFO,I1=NOINT,C1=TITR,C2=MSGTITL)                          
@@ -253,9 +261,9 @@ c          ENDIF
       ENDIF
       
 !===DEFAULT
-        IF(IBAG.LE.-1 .OR. IBAG.GE.4)IBAG=1
-        IF(IDEL7N.LE.-1 .OR. IDEL7N.GE.3)IDEL7N=0
-        IF(STFAC.EQ.ZERO)STFAC=ONE
+        IF(IBAG <= -1 .OR. IBAG >= 4)IBAG=1
+        IF(IDEL7N <= -1 .OR. IDEL7N >= 3)IDEL7N=0
+        IF(STFAC == ZERO)STFAC=ONE
         STFAC=-STFAC 
           
 !===STORAGE  
@@ -302,7 +310,7 @@ C------------------------------------------------------------
         FRIGAP(3)=STARTT
         FRIGAP(11)=STOPT
 
-        IF(BUMULT.EQ.ZERO)  BUMULT = BMUL0
+        IF(BUMULT == ZERO)  BUMULT = BMUL0
         FRIGAP(4)=BUMULT
 
 C FRIGAP(10) is initialized but used only in engine for storing number of couples candidates  
@@ -330,7 +338,7 @@ C
 
         !==OUTPUTS USER IDS FOR MAIN/SECONDARY DEFINITION
         WRITE(IOUT,3017)  
-        IF(GRBRIC_ID.GT.0)THEN
+        IF(GRBRIC_ID > 0)THEN
             WRITE(IOUT,6002)ISU3_user  !SECONDARY side from grbrick_id
         ELSE
             WRITE(IOUT,6001)ISU1_user  !SECONDARY side from grnod_id
@@ -347,7 +355,7 @@ C
           IF(STFAC > ZERO)WRITE(IOUT,3020)GAP                                                    
         ENDIF
         
-        IF(IDEL7N.NE.0) THEN
+        IF(IDEL7N /= 0) THEN
            WRITE(IOUT,'(A,A,I5/)')'    DELETION FLAG ON FAILURE OF MAIN ELEMENT','  (1:YES-ALL/2:YES-ANY) : ',IDEL7N
            IF(IDELKEEP == 1)THEN
              WRITE(IOUT,'(A)')    '    IDEL: DO NOT REMOVE NON-CONNECTED NODES FROM SECONDARY SURFACE'

--- a/starter/source/interfaces/reader/hm_read_inter_fsi.F
+++ b/starter/source/interfaces/reader/hm_read_inter_fsi.F
@@ -41,7 +41,7 @@ Chd|====================================================================
      2        IGRNOD      ,IGRSURF    ,ILAGM          ,UNITAB   , NI       ,
      3        NOM_OPT     ,TITR       ,IGRBRIC        ,IGRSH3N  , IGRTRUSS ,      
      4        IDDLEVEL    ,NOINT      ,KEY            ,LSUBMODEL, ITAB     ,
-     5        ITABM1      ,ISKN)
+     5        ITABM1      ,ISKN       ,MULTI_FVM)
 C============================================================================
 
 C-----------------------------------------------
@@ -51,6 +51,7 @@ C-----------------------------------------------
       USE MESSAGE_MOD
       USE GROUPDEF_MOD
       USE SUBMODEL_MOD
+      USE MULTI_FVM_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -80,6 +81,7 @@ C-----------------------------------------------
      .   FRIGAP(*),FRIC_P(*)
       CHARACTER TITR*nchartitle
       TYPE(SUBMODEL_DATA), DIMENSION(NSUBMOD), INTENT(IN) :: LSUBMODEL
+      TYPE(MULTI_FVM_STRUCT), INTENT(INOUT) :: MULTI_FVM      
 C-----------------------------------------------
       TYPE (GROUP_)  ,TARGET, DIMENSION(NGRNOD)  :: IGRNOD
       TYPE (GROUP_)  ,TARGET, DIMENSION(NGRBRIC) :: IGRBRIC
@@ -152,7 +154,7 @@ C--------------------------------------------------
              CALL HM_READ_INTER_TYPE18(
      1            IPARI      ,STFAC      ,FRIGAP     ,NOINT     ,NI       ,
      2            IGRNOD     ,IGRSURF    ,IGRBRIC    ,XFILTR    ,FRIC_P   ,
-     3            IDDLEVEL   ,TITR, UNITAB, LSUBMODEL)  
+     3            IDDLEVEL   ,TITR, UNITAB, LSUBMODEL,MULTI_FVM)  
 
          CASE ('TYPE12')
 C--------------------------------------------------

--- a/starter/source/interfaces/reader/hm_read_interfaces.F
+++ b/starter/source/interfaces/reader/hm_read_interfaces.F
@@ -157,7 +157,7 @@ C--------------------------------------------------
 
          NB = NB+1
 C----------Multidomaines --> on ignore les interfaces et sous-interfaces non tagees--- 
-         IF (NSUBDOM.GT.0) THEN
+         IF (NSUBDOM > 0) THEN
            IF(TAGINT(NB)==0) CALL HM_SZ_R2R(TAGINT,NB,LSUBMODEL)
          ENDIF
 c
@@ -177,7 +177,7 @@ C--------------------------------------------------
 C--------------------------------------------------
 C CHECK IF READ OPTION IS /INTER/SUB
 C--------------------------------------------------
-        IF(KEY(1:LEN_TRIM(KEY)).EQ.'SUB') CYCLE 
+        IF(KEY(1:LEN_TRIM(KEY)) == 'SUB') CYCLE 
 C--------------------------------------------------
          NI=NI+1
 C                                      
@@ -195,7 +195,7 @@ C--------------------------------------------------
             EXIT
           ENDIF
       ENDDO
-      IF (UID.NE.0.AND.IFLAGUNIT.EQ.0) THEN
+      IF (UID /= 0.AND.IFLAGUNIT == 0) THEN
            CALL ANCMSG(MSGID=659,ANMODE=ANINFO,MSGTYPE=MSGERROR,
      .  	       I2=UID,I1=NOINT,C1='INTERFACE',
      .  	       C2='INTERFACE',
@@ -218,7 +218,7 @@ C--------------------------------------------------
      2          IGRNOD      ,IGRSURF   ,ILAGM        ,UNITAB    ,NI          ,
      3          NOM_OPT     ,TITR      ,IGRBRIC      ,IGRSH3N   ,IGRTRUSS    ,       
      4          IDDLEVEL    ,NOINT     ,KEY          ,LSUBMODEL ,ITAB        ,
-     5          ITABM1      ,ISKN)
+     5          ITABM1      ,ISKN      ,MULTI_FVM)
 
         CASE ('LAGMUL')
 C---------------------------------------------------------------
@@ -254,7 +254,7 @@ C---------------------------------------------------------------
         END SELECT
 
          NOINT  = IPARI(15,NI)
-         IF (IPARI(71,NI).LE.0) THEN
+         IF (IPARI(71,NI) <= 0) THEN
            DO K=1,NI-1
              IF (NOINT == IPARI(15,K)) THEN
                  CALL ANCMSG(MSGID=117,


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [x] Only one commit (please squash your commits) 
- [x] No merge commits (use git pull --rebase) 
- [x] The changes satisfy the DOS and DONTS of the CONTRIBUTING.md file

<!------ Provide a general summary of your changes in the Title above -->
#### /INTER/TYPE18:error message introduced GRNOD+LAW151
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Interface 18, when used with Law151 must use a GRBRIC_id and not a GRNOD_id. Input is checked and an error message is printed if GRNOD_id is provided (column 1) instead of GRBRIC (columun 3). User then knows how to fix the input file (otherwise program stops during Engine).
<!--- If there is a design document, link to it here ->


