### PR TITLE
Add CRITICAL to EBCS

### DIFF
--- a/starter/source/restart/ddsplit/ddsplit.F
+++ b/starter/source/restart/ddsplit/ddsplit.F
@@ -958,6 +958,8 @@ C--------------------------------------
       ALLOCATE(IEBCS_LISTDP0_L(0))
       EBCS_TAB_LOC%nebcs_fvm = 0
       IF (NEBCS .GT. 0) THEN
+! Workaround for isses with Polymorphic types with some compilers
+!$OMP CRITICAL
          NEBCS_FVM = 0
          DO II = 1, NEBCS
             IF (EBCS_TAB%tab(II)%poly%is_multifluid) THEN
@@ -1038,6 +1040,7 @@ C        FILL IEBCS_LISTELEM_L and LISTFAC_L
 
             ENDIF
          ENDDO
+!$OMP END CRITICAL
       ENDIF
 
 


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [X] Only one commit (please squash your commits) 
- [X] No merge commits (use git pull --rebase) 
- [X] The changes satisfy the DOS and DONTS of the CONTRIBUTING.md file

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
EBCS uses Polymorphic types.
Issue with Polymorphic types in SMP / Starter writing Restart files
Some compilers cause random failure when likely 2 threads access to Polymorphic types in the same time.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
I add CRITICAL section around EBCS writing to ensure only one thread acesses at a time.
<!--- If there is a design document, link to it here ->


