### PR TITLE
uninitialized surface buffer variable for isogeo

### DIFF
--- a/starter/source/groups/hm_read_surf.F
+++ b/starter/source/groups/hm_read_surf.F
@@ -277,6 +277,7 @@ C=======================================================================
               IGRSURF(IGS)%ID = 0
               IGRSURF(IGS)%NSEG = 0
               IGRSURF(IGS)%NSEG_IGE = 0
+              IGRSURF(IGS)%IAD_IGE = 0
               IGRSURF(IGS)%TYPE = 0
               IGRSURF(IGS)%ID_MADYMO = 0
               IGRSURF(IGS)%IAD_BUFR = 0


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [x] Only one commit (please squash your commits) 
- [x] No merge commits (use git pull --rebase) 
- [x] The changes satisfy the DOS and DONTS of the CONTRIBUTING.md file

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Gfortran compile identified an uninitialized variable within surface buffer definition, for isogeometric elements.


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

A missing surface buffer variable was initialized.

<!--- If there is a design document, link to it here ->


