### PR TITLE
Update gauss point failure output for /FAIL/ORTHSTRAIN and /FAIL/GENE1

### DIFF
--- a/engine/source/materials/fail/gene1/fail_gene1_s.F
+++ b/engine/source/materials/fail/gene1/fail_gene1_s.F
@@ -566,7 +566,7 @@ c
       ! Case of under-integrated solids
       IF (NPG == 1) THEN 
         DO I = 1,NEL
-          IF ((UVAR(I,5) == ZERO).AND.(OFF(I) /= 0)) THEN 
+          IF ((UVAR(I,5) == ZERO).AND.(OFF(I) /= ZERO)) THEN 
             NINDX2        = NINDX2 + 1
             INDX2(NINDX2) = I
             DFMAX(I)      = ONE 
@@ -730,9 +730,9 @@ c------------------------
         END DO
       END IF     
 c------------------------
- 1000 FORMAT(1X,'>> FOR SOLID ELEMENT NUMBER (GENE1) el#',I10,', GAUSS POINT #',I3,
+ 1000 FORMAT(1X,'>> FOR SOLID ELEMENT NUMBER (GENE1) el#',I10,', GAUSS POINT # ',I5,
      .          ', FAILURE START AT TIME: ',1PE12.4,', ',I3,' CRITERION HAS BEEN REACHED:')     
- 1001 FORMAT(1X,'>> FOR SOLID ELEMENT NUMBER (GENE1) el#',I10,', GAUSS POINT #',I3,
+ 1001 FORMAT(1X,'>> FOR SOLID ELEMENT NUMBER (GENE1) el#',I10,', GAUSS POINT # ',I5,
      .          ', FAILURE START AT TIME: ',1PE12.4,', ',I3,' CRITERIA HAVE BEEN REACHED:')
  1002 FORMAT(1X,'HYDROSTATIC PRESSURE VALUE:  ',1PE12.4,' > CRITICAL VALUE: ',1PE12.4) 
  1003 FORMAT(1X,'HYDROSTATIC PRESSURE VALUE:  ',1PE12.4,' < CRITICAL VALUE: ',1PE12.4) 

--- a/engine/source/materials/fail/orthstrain/fail_orthstrain_s.F
+++ b/engine/source/materials/fail/orthstrain/fail_orthstrain_s.F
@@ -727,9 +727,9 @@ c------------------------
         END DO
       END IF              
 c-----------------------------------------------------------------------
- 1000 FORMAT(1X,'FAILURE (ORTHSTR) OF SOLID ELEMENT ',I10,1X,',GAUSS PT',I2,
+ 1000 FORMAT(1X,'FAILURE (ORTHSTR) OF SOLID ELEMENT ',I10,1X,',GAUSS PT ',I5,
      .       1X,'MODE',1X,I2)
- 2000 FORMAT(1X,'FAILURE (ORTHSTR) OF SOLID ELEMENT ',I10,1X,',GAUSS PT',I2,
+ 2000 FORMAT(1X,'FAILURE (ORTHSTR) OF SOLID ELEMENT ',I10,1X,',GAUSS PT ',I5,
      .       1X,'MODE',1X,I2,1X,'STRAIN RATE',1PE12.4)
  3000 FORMAT(1X,'RUPTURE OF ELEMENT #',I10,1X,'AT TIME # ',1PE12.4)    
 c-----------------------------------------------------------------------


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [x] Only one commit (please squash your commits) 
- [x] No merge commits (use git pull --rebase) 
- [x] The changes satisfy the DOS and DONTS of the CONTRIBUTING.md file

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

For solids, and more precisely for thickshell, the maximum number of Gauss point is written on 5 digits. In /FAIL/ORTHSTRAIN + /FAIL/GENE1 the output of Gauss point failure message was not correct. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Fix the number of digits for the number of Gauss points.

<!--- If there is a design document, link to it here ->


