### PR TITLE
add compatibility of Ilen=1 to spings within /INISPRI

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2020/TABLE/inispri.cfg
+++ b/hm_cfg_files/config/CFG/radioss2020/TABLE/inispri.cfg
@@ -1,0 +1,121 @@
+//Copyright>    CFG Files and Library ("CFG")
+//Copyright>    Copyright (C) 1986-2022 Altair Engineering Inc.
+//Copyright>
+//Copyright>    Altair Engineering Inc. grants to third parties limited permission to 
+//Copyright>    use and modify CFG solely in connection with OpenRadioss software, provided 
+//Copyright>    that any modification to CFG by a third party must be provided back to 
+//Copyright>    Altair Engineering Inc. and shall be deemed a Contribution under and therefore
+//Copyright>    subject to the CONTRIBUTOR LICENSE AGREEMENT for OpenRadioss software. 
+//Copyright>  
+//Copyright>    CFG IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
+//Copyright>    INCLUDING, BUT NOT LIMITED TO, THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR 
+//Copyright>    A PARTICULAR PURPOSE, AND NONINFRINGEMENT.  IN NO EVENT SHALL ALTAIR ENGINEERING
+//Copyright>    INC. OR ITS AFFILIATES BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, 
+//Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
+//Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
+//
+// /INISPRI/FULL
+//
+
+ATTRIBUTES(COMMON)
+{
+    // INPUT ATTRIBUTES
+    prop_type                               = VALUE(INT, "Property set");
+    size_spring                             = SIZE("The initial state for spring");
+    INISPRI_FULL_SUBOBJ_TYPE_4_12           = ARRAY[size_spring](SUBOBJECT, "List of keys/items"); // If prop_type = 4, 12 
+    INISPRI_FULL_SUBOBJ_TYPE_26             = ARRAY[size_spring](SUBOBJECT, "List of keys/items"); // If prop_type = 26 
+    INISPRI_FULL_SUBOBJ_TYPE_8_13_25        = ARRAY[size_spring](SUBOBJECT, "List of keys/items"); // If prop_type = 8, 13, 25
+    INISPRI_FULL_SUBOBJ_OTHER_TYPES         = ARRAY[size_spring](SUBOBJECT, "List of keys/items"); // If prop_type = 29, 30, 31, 32, 33, 35, 36, 44, 45, 46
+
+    //HM INTERNAL
+    KEYWORD_STR                             = VALUE(STRING, "Solver Keyword");
+    IO_FLAG                                 = VALUE(INT,    "IO_FLAG");
+}
+
+SKEYWORDS_IDENTIFIER(COMMON)
+{
+    //INPUT ATTRIBUTES
+    prop_type                               = -1;
+    size_spring                             = -1;
+    INISPRI_FULL_SUBOBJ_TYPE_4_12           = -1;
+    INISPRI_FULL_SUBOBJ_TYPE_26             = -1;
+    INISPRI_FULL_SUBOBJ_TYPE_8_13_25        = -1;
+    INISPRI_FULL_SUBOBJ_OTHER_TYPES         = -1;
+
+    //HM INTERNAL
+    KEYWORD_STR                            = 9000;
+    IO_FLAG                                = -1;
+}
+
+GUI(COMMON)
+{
+    ASSIGN(KEYWORD_STR, "/INISPRI/FULL");
+
+    RADIO(prop_type,"prop_type")
+    {
+        ADD(4,  "Property Type 4");
+        ADD(8,  "Property Type 8");
+        ADD(12, "Property Type 12");
+        ADD(13, "Property Type 13");
+        ADD(23, "Property Type 23");
+        ADD(25, "Property Type 25");
+        ADD(26, "Property Type 26");
+        ADD(29, "Property Type 29");
+        ADD(30, "Property Type 30");
+        ADD(31, "Property Type 31");
+        ADD(32, "Property Type 32");
+        ADD(33, "Property Type 33");
+        ADD(35, "Property Type 35");
+        ADD(36, "Property Type 36");
+        ADD(44, "Property Type 44");
+        ADD(45, "Property Type 45");
+        ADD(46, "Property Type 46");
+    }
+
+    if(prop_type == 4 || prop_type == 12)
+    {
+        SUBOBJECT(INISPRI_FULL_SUBOBJ_TYPE_4_12) {SUBTYPES = (/SUBOBJECT/INISPRI_FULL_SUBOBJ_TYPE_4_12);}
+    }
+    else if(prop_type == 26)
+    {
+        SUBOBJECT(INISPRI_FULL_SUBOBJ_TYPE_26) {SUBTYPES = (/SUBOBJECT/INISPRI_FULL_SUBOBJ_TYPE_26);}
+    }
+    else if(prop_type == 8 || prop_type == 13 || prop_type == 23 || prop_type == 25)
+    {
+        SUBOBJECT(INISPRI_FULL_SUBOBJ_TYPE_8_13_25) {SUBTYPES = (/SUBOBJECT/INISPRI_FULL_SUBOBJ_TYPE_8_13_25);}
+    }
+    else if(prop_type == 29 || prop_type == 30 || prop_type == 31 || prop_type == 32 || prop_type == 33 || 
+            prop_type == 35 || prop_type == 36 || prop_type == 44 || prop_type == 45 || prop_type == 46 )
+    {
+        SUBOBJECT(INISPRI_FULL_SUBOBJ_OTHER_TYPES) {SUBTYPES = (/SUBOBJECT/INISPRI_FULL_SUBOBJ_OTHER_TYPES);}
+    }
+}
+
+// File format
+FORMAT(radioss2018)
+{
+    ASSIGN(IO_FLAG,0,EXPORT);
+    ASSIGN(IO_FLAG,1,IMPORT);
+    HEADER("/INISPRI/FULL");
+    if(IO_FLAG == 1)
+    {
+        CARD_PREREAD("%10s%10d",_BLANK_,prop_type);
+    }
+    if(prop_type == 4 || prop_type == 12)
+    {
+        SUBOBJECTS(INISPRI_FULL_SUBOBJ_TYPE_4_12,/SUBOBJECT/INISPRI_FULL_SUBOBJ_TYPE_4_12);
+    }
+    else if(prop_type == 26)
+    {
+        SUBOBJECTS(INISPRI_FULL_SUBOBJ_TYPE_26,/SUBOBJECT/INISPRI_FULL_SUBOBJ_TYPE_26);
+    }
+    else if(prop_type == 8 || prop_type == 13 || prop_type == 23 || prop_type == 25)
+    {
+        SUBOBJECTS(INISPRI_FULL_SUBOBJ_TYPE_8_13_25,/SUBOBJECT/INISPRI_FULL_SUBOBJ_TYPE_8_13_25);
+    }
+    else if(prop_type == 29 || prop_type == 30 || prop_type == 31 || prop_type == 32 || prop_type == 33 || 
+            prop_type == 35 || prop_type == 36 || prop_type == 44 || prop_type == 45 || prop_type == 46 )
+    {
+        SUBOBJECTS(INISPRI_FULL_SUBOBJ_OTHER_TYPES,/SUBOBJECT/INISPRI_FULL_SUBOBJ_OTHER_TYPES);
+    }
+}

--- a/starter/source/elements/spring/rinit3.F
+++ b/starter/source/elements/spring/rinit3.F
@@ -472,8 +472,13 @@ C-            inertia of element is automaically computed acording to moment of 
               GBUF%MASS(I) = GEO(1,I0)*RHO
             ENDIF
 C
-           XM  = GBUF%MASS(I)
-           XINE= GEO(2,I0)            
+          IF (ILENG > 0) THEN
+            XM=GBUF%MASS(I)*XL(I)
+            XINE=GEO(2,I0)*XL(I)
+          ELSE
+            XM=GBUF%MASS(I)
+            XINE=GEO(2,I0)
+          ENDIF           
 C
           RATIO = XM * LENGTH * LENGTH
           IF( MTN == 113) THEN

--- a/starter/source/elements/spring/rmass.F
+++ b/starter/source/elements/spring/rmass.F
@@ -204,7 +204,7 @@ C----------------------------------------------
 C     MASSE ELEMENT /2
 C----------------------------------------------
        DO I=LFT,LLT
-         EMS(I)=HALF*MASS(I)
+         EMS(I)=HALF*MASS(I)*XL(I)
        ENDDO
 C
       IF(IREST_MSELT/=0)THEN


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [x] Only one commit (please squash your commits) 
- [x] No merge commits (use git pull --rebase) 
- [x] The changes satisfy the DOS and DONTS of the CONTRIBUTING.md file

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

/INISPRI option does not work if Ilen = 1, for spring TYPE4, TYPE13, TYPE25 and /MAT/LAW113

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Improvement for the spring types 4, 13, 25 and material /MAT/LAW113 initialisation with the option Ilen = 1. The mass and inertia was not correct.


<!--- If there is a design document, link to it here ->


