### PR TITLE
/DFS/WAV_SHAPER : optionnal detpoint velocity to lighten screen points

### DIFF
--- a/starter/source/initial_conditions/detonation/ecran1.F
+++ b/starter/source/initial_conditions/detonation/ecran1.F
@@ -31,7 +31,7 @@ Chd|        IOMBR                         source/initial_conditions/detonation/i
 Chd|        DETONATORS_MOD                share/modules1/detonators_mod.F
 Chd|        MESSAGE_MOD                   share/message_module/message_mod.F
 Chd|====================================================================
-      SUBROUTINE ECRAN1(DETONATORS,N1,NP1,X)
+      SUBROUTINE ECRAN1(DETONATORS,N1,NP1,X,VDET)
 C-----------------------------------------------
       USE MESSAGE_MOD
       USE DETONATORS_MOD
@@ -43,6 +43,7 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       my_real X(3,NUMNOD)
+      my_real,INTENT(IN)::VDET
       TYPE(DETONATOR_STRUCT_),TARGET ::DETONATORS
 C-----------------------------------------------
 C   C o m m o n   B l o c k s
@@ -89,7 +90,7 @@ C---------------------------------------
         II=IECR(I)
         YL=X(2,II)
         ZL=X(3,II)
-        IF(IOMBR(DETONATORS,X,IECR,DDMX) == 0)THEN
+        IF(IOMBR(DETONATORS,X,IECR,DDMX,VDET) == 0)THEN   !Vdet is optionnal velocity from origin (default is material velocity VDTO)
           DTIME(I)=DTO !DT0 is lightening time from function IOMBR
           IF(DTIME(I) <= DTOMIN)THEN
             IORDR(1)=I
@@ -129,7 +130,7 @@ C-----------------------------------------
             D2 =(YD-YL)**2+(ZD-ZL)**2
             DTO=DTO0+SQRT(D2)/VDTO
             DTIME(I)= MIN(DTIME(I),DTO)
-          ELSEIF(IOMBR(DETONATORS,X,IECR,DDMX) == 0)THEN
+          ELSEIF(IOMBR(DETONATORS,X,IECR,DDMX,VDTO) == 0)THEN
             DTIME(I)= MIN(DTIME(I),DTO)
           ENDIF
           IF(DTIME(I) <= DTOMIN)THEN

--- a/starter/source/initial_conditions/detonation/ecran2.F
+++ b/starter/source/initial_conditions/detonation/ecran2.F
@@ -29,7 +29,7 @@ Chd|-- calls ---------------
 Chd|        IOMBR                         source/initial_conditions/detonation/iombr.F
 Chd|        DETONATORS_MOD                share/modules1/detonators_mod.F
 Chd|====================================================================
-      SUBROUTINE ECRAN2(DETONATORS,N1,NP1,X)
+      SUBROUTINE ECRAN2(DETONATORS,N1,NP1,X,VDET)
 C-----------------------------------------------
       USE DETONATORS_MOD
 C-----------------------------------------------
@@ -40,6 +40,7 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       my_real  X(3,NUMNOD)
+      my_real,INTENT(IN)::VDET
       TYPE(DETONATOR_STRUCT_),TARGET ::DETONATORS
       INTEGER,INTENT(IN) :: N1,NP1
 C-----------------------------------------------
@@ -70,9 +71,12 @@ C---------------------------------------
 C     COMPUTING DETONATION:TIME FOR ONE ELEMENT (CENTROID)
 C---------------------------------------
 C     1) DETONATION ORIGIN: USER DETONATION POINT
+C         check if the target can be directly lightened from detonation origin.
+C            yes if no crossing with the screen (IOMBR returns 0)
+C             no otherwise (IOMBR return 1)
 C---------------------------------------
       DDMX=EP20
-      IF(IOMBR(DETONATORS,X,IECR,DDMX) == 0)RETURN
+      IF(IOMBR(DETONATORS,X,IECR,DDMX,VDET) == 0)RETURN   !Vdet is optionnal velocity from origin (default is material velocity VDTO)
 
 C-----------------------------------------
 C     2) DETONATION ORIGIN:EACH POINT OF THE SCREEN PATH
@@ -86,7 +90,7 @@ C-----------------------------------------
         YD=X(2,II)
         ZD=X(3,II)
         DTO0=DTIME(I)
-        IF(IOMBR(DETONATORS,X,IECR,DDMX) == 0)THEN
+        IF(IOMBR(DETONATORS,X,IECR,DDMX,VDTO) == 0)THEN
           DTOS= MIN(DTOS,DTO) !keep minimum value (first arrival time)
         ENDIF
       END DO !J=1,NPE

--- a/starter/source/initial_conditions/detonation/iombr.F
+++ b/starter/source/initial_conditions/detonation/iombr.F
@@ -28,7 +28,7 @@ Chd|        ECRAN2                        source/initial_conditions/detonation/e
 Chd|-- calls ---------------
 Chd|        DETONATORS_MOD                share/modules1/detonators_mod.F
 Chd|====================================================================
-      INTEGER FUNCTION IOMBR(DETONATORS,X,IECR,DDMX)
+      INTEGER FUNCTION IOMBR(DETONATORS,X,IECR,DDMX,VDET_ARG)
       USE DETONATORS_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
@@ -40,6 +40,7 @@ C-----------------------------------------------
       my_real DDMX
       INTEGER IECR(*)
       my_real X(3,NUMNOD)
+      my_real VDET_ARG
       TYPE(DETONATOR_STRUCT_) :: DETONATORS
 C-----------------------------------------------
 C   C o m m o n   B l o c k s
@@ -138,7 +139,7 @@ C-----------------------------------------------
       IF(JOMBR+KOMBR == 2)THEN
         IOMBR=1
       ELSE
-        DTO=DTO0+SQRT(DD)/VDTO
+        DTO=DTO0+SQRT(DD)/VDET_ARG
       ENDIF
 
  999  CONTINUE

--- a/starter/source/initial_conditions/detonation/m5in2.F
+++ b/starter/source/initial_conditions/detonation/m5in2.F
@@ -203,6 +203,7 @@ C     Getting rid of equivalences
           DO N=NDETPS+NDETSG+1,NDETPS+NDETSG+NECRAN
             ALT=DETONATORS%BURN(1,N)
             MTL=NINT(DETONATORS%BURN(2,N))
+            VDET =DETONATORS%BURN(3,N)
             YD =DETONATORS%BURN(4,N)
             ZD =DETONATORS%BURN(5,N)
             NPE=NINT(DETONATORS%BURN(6,N))
@@ -210,18 +211,20 @@ C     Getting rid of equivalences
             DTO0=ALT
             MT  =MTL
             IF(MT == 0)MT=MAT(1)
-            VDTO=PM(38,MT)
+            VDTO=PM(38,MT) 
+            IF(VDET == ZERO)VDET=PM(38,MT) !optional detonation velocity
             !---detonation time for screen points
-            CALL ECRAN1(DETONATORS,N1,NP1,X)
+            CALL ECRAN1(DETONATORS,N1,NP1,X,VDET)
             !---detonation times for elements
             DO I=LFT,LLT
             IF(MTL /= MAT(I).AND.MTL /= 0) CYCLE
+              VDET = DETONATORS%BURN(3,N)
               YD =DETONATORS%BURN(4,N)
-              ZD =DETONATORS%BURN(5,N)
+              ZD =DETONATORS%BURN(5,N)            
               DTO0=ALT
               YL=YC(I)
               ZL=ZC(I)
-              CALL ECRAN2(DETONATORS,N1,NP1,X)
+              CALL ECRAN2(DETONATORS,N1,NP1,X,VDET)
               BT(I) =DTO
               IF(BT(I) < ABS(TB(I))) TB(I)=-BT(I)
               JJ(I)=JJ(I)-1

--- a/starter/source/initial_conditions/detonation/m5in2t.F
+++ b/starter/source/initial_conditions/detonation/m5in2t.F
@@ -189,11 +189,12 @@ C     Getting rid of equivalences
         !---------------------------------! 
         ! LIGHTING TIME FOR /DFS/WAV_SHA  !
         !---------------------------------!
-        IF(DETONATORS%NECRAN > 0) THEN
+        IF(NECRAN > 0) THEN
           N1=1
           DO N=NDETPS+NDETSG+1,NDETPS+NDETSG+NECRAN
             ALT=DETONATORS%BURN(1,N)
             MTL=NINT(DETONATORS%BURN(2,N))
+            VDET =DETONATORS%BURN(3,N)
             YD =DETONATORS%BURN(4,N)
             ZD =DETONATORS%BURN(5,N)
             NPE=NINT(DETONATORS%BURN(6,N))
@@ -201,16 +202,20 @@ C     Getting rid of equivalences
             DTO0=ALT
             MT  =MTL
             IF(MT == 0)MT=MAT(1)
-            VDTO=PM(38,MT)
-            CALL ECRAN1(DETONATORS,N1,NP1,X)
+            VDTO=PM(38,MT) 
+            IF(VDET == ZERO)VDET=PM(38,MT) !optional detonation velocity
+            !---detonation time for screen points
+            CALL ECRAN1(DETONATORS,N1,NP1,X,VDET)
+            !---detonation times for elements
             DO I=LFT,LLT
             IF(MTL /= MAT(I).AND.MTL /= 0) CYCLE
+              VDET = DETONATORS%BURN(3,N)
               YD =DETONATORS%BURN(4,N)
-              ZD =DETONATORS%BURN(5,N)
+              ZD =DETONATORS%BURN(5,N)            
               DTO0=ALT
               YL=YC(I)
               ZL=ZC(I)
-              CALL ECRAN2(DETONATORS,N1,NP1,X)
+              CALL ECRAN2(DETONATORS,N1,NP1,X,VDET)
               BT(I) =DTO
               IF(BT(I) < ABS(TB(I))) TB(I)=-BT(I)
               JJ(I)=JJ(I)-1

--- a/starter/source/initial_conditions/detonation/read_dfs_wave_shaper.F
+++ b/starter/source/initial_conditions/detonation/read_dfs_wave_shaper.F
@@ -88,7 +88,7 @@ C-----------------------------------------------
       INTEGER              :: IBID,  NODE_ID1, NODE_ID2,uID1,uID2, IOPT, IUNIT, UID
       INTEGER              :: FLAG_FMT,IMAT,IFLAGUNIT,UNUSED
       INTEGER              :: STAT,NPE
-      my_real              :: XC, YC, ZC, ALT, XC1, YC1, ZC1, XC2, YC2, ZC2, NX, NY, NZ, BID, VCJ
+      my_real              :: XC, YC, ZC, ALT, XC1, YC1, ZC1, XC2, YC2, ZC2, NX, NY, NZ, BID, VCJ, VDET
       CHARACTER*40         :: MESS
       CHARACTER*64         :: chain1,chain2
       CHARACTER*nchartitle :: TITR
@@ -120,7 +120,7 @@ C-----------------------------------------------
       !---------------------------------!                                                    
       !             READING             !                                                    
       !---------------------------------!                                                    
-      CALL HM_GET_FLOATV('rad_det_locationA_X', XC1, IS_AVAILABLE, LSUBMODEL, UNITAB)       
+      CALL HM_GET_FLOATV('rad_det_locationA_X', VDET, IS_AVAILABLE, LSUBMODEL, UNITAB)       
       CALL HM_GET_FLOATV('rad_det_locationA_Y', YC1, IS_AVAILABLE, LSUBMODEL, UNITAB)       
       CALL HM_GET_FLOATV('rad_det_locationA_Z', ZC1, IS_AVAILABLE, LSUBMODEL, UNITAB)       
       CALL HM_GET_FLOATV('rad_det_time', ALT, IS_AVAILABLE, LSUBMODEL,UNITAB)              
@@ -158,7 +158,7 @@ C-----------------------------------------------
      .              MSGTYPE=MSGERROR,                                                        
      .              ANMODE=ANINFO,                                                           
      .              I1=DET_ID,                                                                   
-     .              C1='DETONATOR MUST REFER TO A JWL MATERIAL LAW (LAWS 5 OR 51)',          
+     .              C1='DETONATOR MUST REFER TO A JWL MATERIAL LAW (LAWS 5, 51, 97, 151)',          
      .              C2='/DFS/WAV_SHAPER',                                                    
      .              I2=MDET)                                                                 
       ELSE                                                                                   
@@ -170,7 +170,7 @@ C-----------------------------------------------
               !Nodes in group are ordered from 1 to NPE. last point is the nearest from the detonation origin. Points are composing the screen lines (guard lines). Screen lines is the boundary of the obstacle (shadow area)
         DETONATORS%NPE=NPE   
         IF(IS_ENCRYPTED) WRITE(IOUT,1001)                    
-        IF(.NOT.IS_ENCRYPTED)WRITE(IOUT,1550) DET_ID,XC1,YC1,ZC1,ALT,MDET,IGU,NPE                                     
+        IF(.NOT.IS_ENCRYPTED)WRITE(IOUT,1550) DET_ID,VDET,YC1,ZC1,ALT,MDET,IGU,NPE                                     
         NPEM=MAX0(NPE,NPEM)                                                                  
         IF(.NOT.IS_ENCRYPTED)WRITE(IOUT,FMT=FMW_10I) (ITAB(IECRAN(I)),I=N1,N1+NPE-1)                              
         DO I=N1,N1+NPE-1                                                                     
@@ -178,7 +178,7 @@ C-----------------------------------------------
         END DO                                                                               
         DETONATORS%BURN(1,I3) = ALT                                                                        
         DETONATORS%BURN(2,I3) = MAT                                                                        
-        DETONATORS%BURN(3,I3) = XC1                                                                        
+        DETONATORS%BURN(3,I3) = VDET                                                                        
         DETONATORS%BURN(4,I3) = YC1                                                                        
         DETONATORS%BURN(5,I3) = ZC1                                                                        
         DETONATORS%BURN(6,I3) = NPE                                                                        
@@ -195,7 +195,7 @@ C-----------------------------------------------
      &          'CONFIDENTIAL DATA')    
  1550 FORMAT(///'SHADOW LINE DETONATION    =',I10,/5X,
      &          '----------------------     ',/5X,
-     &          'X-COORDINATE              =',1PG20.13,/5X,
+     &          'OPTIONAL VELOCITY         =',1PG20.13,/5X,
      &          'Y-COORDINATE              =',1PG20.13,/5X,
      &          'Z-COORDINATE              =',1PG20.13,/5X,
      &          'LIGHTING TIME             =',1PG20.13,/5X,


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [x] Only one commit (please squash your commits) 
- [x] No merge commits (use git pull --rebase) 
- [x] The changes satisfy the DOS and DONTS of the CONTRIBUTING.md file

<!------ Provide a general summary of your changes in the Title above -->
#### /DFS/WAV_SHAPER : new option to lighten screen point using a specific detonation velocty
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
A new parameter is introduced (1st line 1 column). It is the detonation velocity which will be use to detonate the screen point if a direct path does exist. Otherwise material velocity is used (taken from mat_id) as usually. Backward compatibility is ensured by defining Vdet=0.0
<!--- If there is a design document, link to it here ->


