### PR TITLE
Add Commit_id as build tag in Starter & Engine

### DIFF
--- a/Compiling_tools/script/or_compile_info2_cm.sh
+++ b/Compiling_tools/script/or_compile_info2_cm.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-echo "  char * btagfull=\" \";" 
-             
-

--- a/Compiling_tools/script/or_compile_info_cm.sh
+++ b/Compiling_tools/script/or_compile_info_cm.sh
@@ -2,7 +2,7 @@
 
 cd ..
 
-echo "       CHARACTER VERS*32, BDATE*32, BTIME*32,BTAG*2, MSGO*68,BNAME*32"
+echo "       CHARACTER VERS*32, BDATE*32, BTIME*32,BTAG*80, MSGO*68,BNAME*32"
 echo "       CHARACTER YEARSTRING*10"
 echo "       INTEGER LEN_VERS, LEN_BDATE, LEN_BTIME, PMSG,LEN_MSG,LENYS"
 echo "       INTEGER LENBNAM"
@@ -20,7 +20,12 @@ echo "       DATA BNAME/\"$5\"/"
 echo " "
 
 #Build Tag
-echo "       DATA BTAG/\"  \"/ "
+if [ -z "$GITHUB_SHA" ]
+then
+  echo "       DATA BTAG/\"  \"/ "
+else
+  echo "       DATA BTAG/'CommitID: $GITHUB_SHA'/ "
+fi
 
 if [ $2 = 1 ]; then
 echo "       PARAMETER (PMSG=1)"

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -219,11 +219,8 @@ add_custom_command(
          OUTPUT 
             ${Build_includes_directory}/__foo.inc 
             ${Build_includes_directory}/build_info.inc
-            ${Build_includes_directory}/btag.inc
          COMMAND 
             sh ../../Compiling_tools/script/or_compile_info_cm.sh linux64 0 e 0 linux64  > ${Build_includes_directory}/build_info.inc
-         COMMAND 
-            sh ../../Compiling_tools/script/or_compile_info2_cm.sh linux64 0 e 0 linux64  > ${Build_includes_directory}/btag.inc
          )
 
 
@@ -238,7 +235,7 @@ endif (NOT CMAKE_BUILD_TYPE)
 add_custom_target( alway_execute ALL DEPENDS ${Build_includes_directory}/__foo.inc )
 
 
-add_executable (${EXEC_NAME} ${source_files} ${source_files_common} ${c_source_files} ${cpp_source_files} ${Build_includes_directory}/engine_message_description.inc ${Build_includes_directory}/build_info.inc ${Build_includes_directory}/btag.inc )
+add_executable (${EXEC_NAME} ${source_files} ${source_files_common} ${c_source_files} ${cpp_source_files} ${Build_includes_directory}/engine_message_description.inc ${Build_includes_directory}/build_info.inc)
 
 target_include_directories(${EXEC_NAME} PRIVATE ${include_dir_list}  )
 target_link_libraries(${EXEC_NAME} ${LINK} )

--- a/engine/source/engine/radioss_title.F
+++ b/engine/source/engine/radioss_title.F
@@ -48,7 +48,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER LEN,LEN_RAD,LENBT,LENCPUNAM,LENARCHTIT,CT,LBT,
      *        LENGPU
-      CHARACTER RADVERS*68,BUILDTAG*256,COPYRIGHTLINE*68,
+      CHARACTER RADVERS*68,COPYRIGHTLINE*68,
      *          ARCH_TIT*66,GPUTITLE*66
 C-----------------------------------------------
        LENARCHTIT=LEN_TRIM(ARCHTITLE)
@@ -66,8 +66,7 @@ C-----------------------------------------------
           LEN = LEN_TRIM(RADVERS)
        ENDIF
 
-       WRITE(BUILDTAG,'(A,A,A,I2)') 'Build tag: ',BTAG(1:LBT)
-       LENBT = LEN_TRIM(BTAG)+12
+       LENBT = LEN_TRIM(BTAG)
        LENCPUNAM=LEN_TRIM(CPUNAM)
        LENARCHTIT=LEN_TRIM(ARCH_TIT)
 
@@ -97,7 +96,7 @@ C-----------------------------------------------
         CALL PRINTCENTER(" ",0,IOUT,0)
        ENDIF
        CALL PRINTCENTER(" ",0,IOUT,0)
-       CALL PRINTCENTER(" ",0,IOUT,0)
+       CALL PRINTCENTER(BTAG,LENBT,IOUT,3)
        CALL PRINTCENTER(" ",0,IOUT,1)
        CALL PRINTCENTER("OpenRadioss Software",20,IOUT,3)
        CALL PRINTCENTER(COPYRIGHTLINE,64,IOUT,3)

--- a/engine/source/system/mon_c.c
+++ b/engine/source/system/mon_c.c
@@ -21,7 +21,6 @@
 //Copyright>    software under a commercial license.  Contact Altair to discuss further if the 
 //Copyright>    commercial version may interest you: https://www.altair.com/radioss/.    
 #include "hardware.inc"
-#include "btag.inc"
 
 
 #if CPP_mach == CPP_w95 || CPP_mach == CPP_win64_spmd || CPP_mach == CPP_p4win64_spmd || CPP_mach == CPP_wnt || CPP_mach == CPP_wmr || CPP_mach == CPP_p4win64  || CPP_mach == CPP_p4win32

--- a/starter/CMakeLists.txt
+++ b/starter/CMakeLists.txt
@@ -200,9 +200,6 @@ add_custom_command(
          OUTPUT 
             ${Build_includes_directory}/__foo.inc 
             ${Build_includes_directory}/build_info.inc
-            ${Build_includes_directory}/btag.inc
-         COMMAND 
-            bash ../../Compiling_tools/script/or_compile_info2_cm.sh linux64 0 s 0 linux64  > ${Build_includes_directory}/btag.inc
          COMMAND
             bash ../../Compiling_tools/script/or_compile_info_cm.sh  linux64 0 s 0 linux64  > ${Build_includes_directory}/build_info.inc
          COMMAND
@@ -217,8 +214,6 @@ add_custom_command(
             ${Build_includes_directory}/build_info.inc
             ${Build_includes_directory}/btag.inc
          COMMAND 
-            bash ../../Compiling_tools/script/compile_info2_cm.sh linux64 0 s 0 linux64  > ${Build_includes_directory}/btag.inc
-         COMMAND
             bash ../../Compiling_tools/script/compile_info_cm.sh  linux64 0 s 0 linux64  > ${Build_includes_directory}/build_info.inc
          COMMAND
            ls  ${Build_includes_directory}
@@ -240,7 +235,7 @@ endif (NOT CMAKE_BUILD_TYPE)
 
 
 
-add_executable (${EXEC_NAME} ${source_files} ${sfullstarter_message_description.txtource_files_common} ${c_source_files} ${cpp_source_files} ${Build_includes_directory}/starter_message_description.inc ${Build_includes_directory}/btag.inc  ${Build_includes_directory}/build_info.inc)
+add_executable (${EXEC_NAME} ${source_files} ${sfullstarter_message_description.txtource_files_common} ${c_source_files} ${cpp_source_files} ${Build_includes_directory}/starter_message_description.inc   ${Build_includes_directory}/build_info.inc)
 
 target_include_directories(${EXEC_NAME} PRIVATE ${include_dir_list}  )
 target_link_libraries(${EXEC_NAME} ${LINK} )

--- a/starter/source/starter/radioss_title.F
+++ b/starter/source/starter/radioss_title.F
@@ -46,11 +46,10 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER LEN,LEN_RAD,LENBT,LENCPUNAM,LENARCHTIT,CT,RESC,LBT
-      CHARACTER RADVERS*68,BUILDTAG*256,COPYRIGHTLINE*68
+      INTEGER LEN,LEN_RAD,LENCPUNAM,LENARCHTIT,CT,RESC,LBT
+      CHARACTER RADVERS*68,COPYRIGHTLINE*68
 C-----------------------------------------------
        LEN=LEN_TRIM(VERS)
-       LBT=LEN_TRIM(BTAG)
 
        IF( GOT_INSPIRE_ALM == 1)THEN
          WRITE(RADVERS,'(A,A)') 'Altair Solver ',VERS
@@ -60,9 +59,7 @@ C-----------------------------------------------
          LEN = LEN_TRIM(RADVERS)
        ENDIF
  
-       WRITE(BUILDTAG,'(A,A,A,I2)') 'Build tag: ',BTAG(1:LBT)
-C
-       LENBT = LEN_TRIM(BTAG)+12
+       LBT=LEN_TRIM(BTAG)
        LENCPUNAM=LEN_TRIM(CPUNAM)
        LENARCHTIT=LEN_TRIM(ARCHTITLE)
 
@@ -92,7 +89,7 @@ C
          CALL PRINTCENTER(" ",0,IOUT,0)
        ENDIF
        CALL PRINTCENTER(" ",0,IOUT,0)
-       CALL PRINTCENTER(" ",0,IOUT,0)
+       CALL PRINTCENTER(BTAG,LBT,IOUT,3)
        CALL PRINTCENTER(" ",0,IOUT,1)
        CALL PRINTCENTER("OpenRadioss Software",20,IOUT,3)
        CALL PRINTCENTER(COPYRIGHTLINE,64,IOUT,3)

--- a/starter/source/system/mon_c.c
+++ b/starter/source/system/mon_c.c
@@ -21,7 +21,7 @@
 //Copyright>    software under a commercial license.  Contact Altair to discuss further if the 
 //Copyright>    commercial version may interest you: https://www.altair.com/radioss/.    
 #include "hardware.inc"
-#include "btag.inc"
+
 
 #if CPP_mach == CPP_w95 || CPP_mach == CPP_win64_spmd || CPP_mach == CPP_p4win64_spmd || CPP_mach == CPP_wnt || CPP_mach == CPP_wmr || CPP_mach == CPP_p4win64  || CPP_mach == CPP_p4win32
 


### PR DESCRIPTION
Remove obsolete build script & remove from source code

#### Prerequisites
<!--- Check [x] all boxes -->
- [X] Only one commit (please squash your commits) 
- [X] No merge commits (use git pull --rebase) 
- [X] The changes satisfy the DOS and DONTS of the CONTRIBUTING.md file

#### Description of the feature or the bug
Need to add traceability when executable is build with GitHub Workers, as those will be ued in the Binary release

#### Description of the changes
GITHUB_SHA is defined as environment variable
when scripts founds it, it applies...

<!--- If there is a design document, link to it here ->


