### PR TITLE
Fix a dimension issue of TEMP array

### DIFF
--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -1201,6 +1201,7 @@ C-------------------------------------------------------------------------------
         LOGICAL :: BOOL_RESTART
 
         INTEGER :: NATIV_SMS_SIZ ! size of NATIV_SMS array
+        INTEGER :: TEMP_SIZ      ! size of TEMP
       DATA IUN/1/
 C-----------------------------------------------------------------------------------       
 C Uncomment for Debug - ITAB is copied in Debug Module.
@@ -1230,6 +1231,12 @@ C-------------------------------------------------------------------------------
       NELTST  = 0
       ITYPTST = 0
       DT2T    = 0
+
+      IF(ITHERM_FE>0) THEN
+        TEMP_SIZ = NUMNOD
+      ELSE
+        TEMP_SIZ = 0
+      ENDIF
 
 C initialize int24 presence flag
       INT24USE = 0
@@ -3349,7 +3356,7 @@ C===============================================================================
      L     MULTI_FVM,IPARG  ,ELBUF_TAB, H3D_DATA, T2MAIN_SMS,
      M     LSKYI_SMS_NEW    ,FORNEQS  ,INT7ITIED,IDEL7NOK_SAV,MAXDGAP,
      N     T2FAC_SMS,ICODT,ISKEW ,FSKYN25  ,ADDCSRECT,PROCNOR,
-     O     INTER_STRUCT,SORT_COMM,RNUM_SIZ,NATIV_SMS_SIZ)
+     O     INTER_STRUCT,SORT_COMM,RNUM_SIZ,NATIV_SMS_SIZ,TEMP_SIZ)
 C
 #include "lockon.inc"
         IF(DT2TT.LT.DT2T)THEN

--- a/engine/source/interfaces/generic/inter_prepare_sort.F
+++ b/engine/source/interfaces/generic/inter_prepare_sort.F
@@ -29,7 +29,8 @@ Chd|====================================================================
         SUBROUTINE INTER_PREPARE_SORT( ITASK,NB_INTER_SORTED,LIST_INTER_SORTED,ISENDTO,IRECVFROM,
      .                                 IPARI,IAD_ELEM,FR_ELEM,X,V,
      .                                 MS,TEMP,KINET,NODNX_SMS,ITAB,
-     .                                 WEIGHT,INTBUF_TAB,INTER_STRUCT,SORT_COMM,NODNX_SMS_SIZ )
+     .                                 WEIGHT,INTBUF_TAB,INTER_STRUCT,SORT_COMM,NODNX_SMS_SIZ,
+     .                                 TEMP_SIZ )
 
 !$COMMENT
 !       INTER_PREPARE_SORT description
@@ -81,13 +82,15 @@ C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
         INTEGER, INTENT(in) :: ITASK    !   omp thread ID
         INTEGER, INTENT(in) :: NB_INTER_SORTED        !   number of interfaces that need to be sorted
-        INTEGER, INTENT(in) :: NODNX_SMS_SIZ
+        INTEGER, INTENT(in) :: NODNX_SMS_SIZ! size of NODNX_SMS
+        INTEGER, INTENT(in) :: TEMP_SIZ     ! size of TEMP
         INTEGER, DIMENSION(NB_INTER_SORTED), INTENT(in) :: LIST_INTER_SORTED   !   list of interfaces that need to be sorted
         INTEGER, DIMENSION(NINTER+1,NSPMD+1), INTENT(in) :: ISENDTO,IRECVFROM ! array for S and R : isendto = nsn ; ircvfrom = nmn
         INTEGER,DIMENSION(NPARI,NINTER), INTENT(inout) :: IPARI
         my_real, DIMENSION(3*NUMNOD), INTENT(in) :: X   !   position
         my_real, DIMENSION(3*NUMNOD), INTENT(in) :: V   !   velocity
-        my_real, DIMENSION(NUMNOD), INTENT(in) :: MS,TEMP   !   mass & temperature
+        my_real, DIMENSION(NUMNOD), INTENT(in) :: MS    !   mass
+        my_real, DIMENSION(TEMP_SIZ), INTENT(in) :: TEMP   !   temperature
         INTEGER, DIMENSION(NUMNOD), INTENT(in) :: WEIGHT ! weight : 1 if current proc computes the node
         INTEGER, DIMENSION(NUMNOD), INTENT(in) :: ITAB   ! global node ID
         INTEGER, DIMENSION(NUMNOD), INTENT(in) :: KINET  ! k energy & 
@@ -210,7 +213,7 @@ C-----------------------------------------------
                     CALL SPMD_CELL_LIST_EXCHANGE(IRECVFROM,ISENDTO,1,WEIGHT,IAD_ELEM,
      .                 FR_ELEM,X,V,MS,TEMP,
      .                 KINET,NODNX_SMS,ITAB,INTBUF_TAB,IPARI,
-     .                 N,INTER_STRUCT,SORT_COMM,NODNX_SMS_SIZ)   !   size of cell list
+     .                 N,INTER_STRUCT,SORT_COMM,NODNX_SMS_SIZ,TEMP_SIZ)   !   size of cell list
                 ENDIF
                 CALL MY_BARRIER()
             ENDIF
@@ -225,7 +228,7 @@ C-----------------------------------------------
                     CALL SPMD_CELL_LIST_EXCHANGE(IRECVFROM,ISENDTO,2,WEIGHT,IAD_ELEM,
      .                 FR_ELEM,X,V,MS,TEMP,
      .                 KINET,NODNX_SMS,ITAB,INTBUF_TAB,IPARI,
-     .                 N,INTER_STRUCT,SORT_COMM,NODNX_SMS_SIZ) !   mpi wait size of cell list
+     .                 N,INTER_STRUCT,SORT_COMM,NODNX_SMS_SIZ,TEMP_SIZ) !   mpi wait size of cell list
 
                 ENDIF
                 CALL MY_BARRIER()
@@ -243,7 +246,7 @@ C-----------------------------------------------
                     CALL SPMD_CELL_LIST_EXCHANGE(IRECVFROM,ISENDTO,3,WEIGHT,IAD_ELEM,
      .                 FR_ELEM,X,V,MS,TEMP,
      .                 KINET,NODNX_SMS,ITAB,INTBUF_TAB,IPARI,
-     .                 N,INTER_STRUCT,SORT_COMM,NODNX_SMS_SIZ)
+     .                 N,INTER_STRUCT,SORT_COMM,NODNX_SMS_SIZ,TEMP_SIZ)
 
                 ENDIF
                 CALL MY_BARRIER()
@@ -263,7 +266,7 @@ C-----------------------------------------------
                     CALL SPMD_CELL_LIST_EXCHANGE(IRECVFROM,ISENDTO,4,WEIGHT,IAD_ELEM,
      .                 FR_ELEM,X,V,MS,TEMP,
      .                 KINET,NODNX_SMS,ITAB,INTBUF_TAB,IPARI,
-     .                 N,INTER_STRUCT,SORT_COMM,NODNX_SMS_SIZ)
+     .                 N,INTER_STRUCT,SORT_COMM,NODNX_SMS_SIZ,TEMP_SIZ)
                     ! wait "number of secondary nodes needed by remote proc"
                     CALL SPMD_WAIT_NB(IRECVFROM,ISENDTO,N,SORT_COMM)    
                 ENDIF

--- a/engine/source/interfaces/intsort/inttri.F
+++ b/engine/source/interfaces/intsort/inttri.F
@@ -110,7 +110,7 @@ Chd|====================================================================
      L       MULTI_FVM,IPARG  ,ELBUF_TAB, H3D_DATA ,T2MAIN_SMS,
      M       LSKYI_SMS_NEW,FORNEQS,INT7ITIED,IDEL7NOK_SAV,MAXDGAP,
      N       T2FAC_SMS,ICODT,ISKEW,FSKYN25,ADDCSRECT,PROCNOR,
-     O       INTER_STRUCT,SORT_COMM,RENUM_SIZ,NODNX_SMS_SIZ)
+     O       INTER_STRUCT,SORT_COMM,RENUM_SIZ,NODNX_SMS_SIZ,TEMP_SIZ)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -187,10 +187,11 @@ C-----------------------------------------------
 !                 INT7ITIED = 1 type 7 + ITIED/=0 used
       INTEGER, INTENT(IN) :: INT7ITIED
       INTEGER, DIMENSION(*), TARGET :: KINET
+      INTEGER, INTENT(in) :: TEMP_SIZ
       TYPE(INTSTAMP_DATA) INTSTAMP(*)
       my_real 
      .   WAG(*),
-     .   VR(3,*),IN(*),DT2T,DIST, DRETRI(*), TEMP(*), EMINX(*),
+     .   VR(3,*),IN(*),DT2T,DIST, DRETRI(*), TEMP(TEMP_SIZ), EMINX(*),
      .        THKNOD(*),DELTA_PMAX_GAP(NINTER),
      .        XSLV(18,NINTER),XMSR(12,NINTER),X21MSR(3,NINTSTAMP),
      .        VSLV(6,NINTER),VMSR(6,NINTER),V21MSR(3,NINTSTAMP),
@@ -674,7 +675,8 @@ C Fin Partie non parallele smt
             CALL INTER_PREPARE_SORT( ITASK,NB_INTER_SORTED,LIST_INTER_SORTED,ISENDTO,IRECVFROM,
      .                               IPARI,IAD_ELEM,FR_ELEM,X,V,
      .                               MS,TEMP,KINET,NODNX_SMS,ITAB,
-     .                               WEIGHT,INTBUF_TAB,INTER_STRUCT,SORT_COMM,NODNX_SMS_SIZ )
+     .                               WEIGHT,INTBUF_TAB,INTER_STRUCT,SORT_COMM,NODNX_SMS_SIZ,
+     .                               TEMP_SIZ )
             ! -----------
             ! sorting computation
             CALL INTER_SORT( ITASK,NB_INTER_SORTED,LIST_INTER_SORTED,RETRI,IPARI,

--- a/engine/source/mpi/interfaces/spmd_cell_list_exchange.F
+++ b/engine/source/mpi/interfaces/spmd_cell_list_exchange.F
@@ -32,7 +32,7 @@ Chd|====================================================================
         SUBROUTINE SPMD_CELL_LIST_EXCHANGE(IRCVFROM,ISENDTO,MODE,WEIGHT,IAD_ELEM,
      .             FR_ELEM,X,V,MS,TEMP,
      .             KINET,NODNX_SMS,ITAB,INTBUF_TAB,IPARI,
-     .             NIN,INTER_STRUCT,SORT_COMM,NODNX_SMS_SIZ)
+     .             NIN,INTER_STRUCT,SORT_COMM,NODNX_SMS_SIZ,TEMP_SIZE)
 !$COMMENT
 !       SPMD_CELL_LIST_EXCHANGE description :
 !       exchange of remote cell and preparation of comm "send/rcv the data of remote nodes"
@@ -88,13 +88,15 @@ C-----------------------------------------------
         INTEGER, INTENT(in) :: NIN
         INTEGER, INTENT(in) :: MODE
         INTEGER, INTENT(in) :: NODNX_SMS_SIZ ! size of NODNX_SMS
+        INTEGER, INTENT(in) :: TEMP_SIZE     ! size of TEMP
         INTEGER, DIMENSION(NINTER+1,NSPMD+1), INTENT(in) :: ISENDTO,IRCVFROM
         INTEGER, DIMENSION(NPARI,NINTER), INTENT(in) ::  IPARI
         INTEGER, DIMENSION(NUMNOD), INTENT(inout) :: WEIGHT
         INTEGER, DIMENSION(2,NSPMD+1), INTENT(in) :: IAD_ELEM ! connectivity array iad(P+1)-iad(P) = nb of frontier node
         INTEGER, DIMENSION(SFR_ELEM), INTENT(in) :: FR_ELEM ! frontier node ID
         my_real, DIMENSION(3,NUMNOD), INTENT(in) :: X,V !   position & velocity
-        my_real, DIMENSION(NUMNOD), INTENT(in) :: MS,TEMP !   mass & temperature
+        my_real, DIMENSION(NUMNOD), INTENT(in) :: MS   !   mass 
+        my_real, DIMENSION(TEMP_SIZE), INTENT(in) :: TEMP !   temperature
         INTEGER, DIMENSION(NUMNOD), INTENT(in) :: ITAB ! global node ID
         INTEGER, DIMENSION(NUMNOD), INTENT(in) :: KINET ! k energy 
         INTEGER, DIMENSION(NODNX_SMS_SIZ), INTENT(in) :: NODNX_SMS ! SMS array
@@ -334,7 +336,7 @@ C-----------------------------------------------
                     !   prepare the S buffer of secondary nodes (x, v, temp ...)
                     CALL SPMD_CELL_SIZE_EXCHANGE(IRCVFROM,ISENDTO,WEIGHT,
      .                IAD_ELEM,FR_ELEM,X,V,MS,TEMP,KINET,NODNX_SMS,ITAB,INTBUF_TAB,IPARI,NIN,REMOTE_PROC,
-     .                ALREADY_SEND,INDEX_ALREADY_SEND,SORT_COMM,NODNX_SMS_SIZ)
+     .                ALREADY_SEND,INDEX_ALREADY_SEND,SORT_COMM,NODNX_SMS_SIZ,TEMP_SIZE)
                 ENDIF
                 !   ------------------------- 
             ENDDO

--- a/engine/source/mpi/interfaces/spmd_cell_size_exchange.F
+++ b/engine/source/mpi/interfaces/spmd_cell_size_exchange.F
@@ -28,7 +28,7 @@ Chd|-- calls ---------------
 Chd|====================================================================
         SUBROUTINE SPMD_CELL_SIZE_EXCHANGE(IRCVFROM,ISENDTO,WEIGHT,
      .                    IAD_ELEM,FR_ELEM,X,V,MS,TEMP,KINET,NODNX_SMS,ITAB,INTBUF_TAB,IPARI,NIN,REMOTE_PROC_ID,
-     .                    ALREADY_SEND,INDEX_ALREADY_SEND,SORT_COMM,NODNX_SMS_SIZ)
+     .                    ALREADY_SEND,INDEX_ALREADY_SEND,SORT_COMM,NODNX_SMS_SIZ,TEMP_SIZE)
 !$COMMENT
 !       SPMD_CELL_SIZE_EXCHANGE description :
 !       check if the remote processor need some secondary nodes
@@ -85,13 +85,15 @@ C-----------------------------------------------
         INTEGER, INTENT(in) :: NIN
         INTEGER,INTENT(in) :: REMOTE_PROC_ID
         INTEGER, INTENT(in) :: NODNX_SMS_SIZ ! size of NODNX_SMS
+        INTEGER, INTENT(in) :: TEMP_SIZE     ! size of TEMP
         INTEGER, DIMENSION(NPARI,NINTER), INTENT(in) ::  IPARI
         INTEGER, DIMENSION(NINTER+1,NSPMD+1), INTENT(in) :: ISENDTO,IRCVFROM
         INTEGER, DIMENSION(NUMNOD), INTENT(inout) :: WEIGHT
         INTEGER, DIMENSION(2,NSPMD+1), INTENT(in) :: IAD_ELEM
         INTEGER, DIMENSION(SFR_ELEM), INTENT(in) :: FR_ELEM
         my_real, DIMENSION(3,NUMNOD), INTENT(in) :: X,V
-        my_real, DIMENSION(NUMNOD), INTENT(in) :: MS,TEMP
+        my_real, DIMENSION(NUMNOD), INTENT(in) :: MS
+        my_real, DIMENSION(TEMP_SIZE), INTENT(in) :: TEMP
         INTEGER, DIMENSION(NUMNOD), INTENT(in) :: ITAB
         INTEGER, DIMENSION(NUMNOD), INTENT(in) :: KINET ! k energy 
         INTEGER, DIMENSION(NODNX_SMS_SIZ), INTENT(in) :: NODNX_SMS ! SMS array


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [x] Only one commit (please squash your commits) 
- [x] No merge commits (use git pull --rebase) 
- [x] The changes satisfy the DOS and DONTS of the CONTRIBUTING.md file

<!------ Provide a general summary of your changes in the Title above -->
Fix a size issue of TEMP array
<!--- Describe the problem, ideally from the user viewpoint -->
The size of TEMP array can be 0 or NUMNOD (according to the temperature option usage). 
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
The size of TEMP (TEMP_SIZ) is now an argument of INTTRI routine
<!--- If there is a design document, link to it here ->


