### PR TITLE
fix for MPI user-function used in reduction: they should be subroutines

### DIFF
--- a/engine/source/mpi/generic/glob_min.F
+++ b/engine/source/mpi/generic/glob_min.F
@@ -27,7 +27,7 @@ Chd|  GLOB_MIN                      source/mpi/generic/glob_min.F
 Chd|-- called by -----------
 Chd|-- calls ---------------
 Chd|====================================================================
-      INTEGER FUNCTION GLOB_MIN(RIN,RINOUT,LEN,TYPE)
+      SUBROUTINE GLOB_MIN(RIN,RINOUT,LEN,TYPE)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -77,7 +77,6 @@ C          RINOUT(L+(I-1)*VLEN) = MAX(RINOUT(L+(I-1)*VLEN),RIN(L+(I-1)*VLEN))
 C        END DO
       ENDDO
       
-      GLOB_MIN = 0
 C
 #endif
       RETURN

--- a/engine/source/mpi/generic/glob_minv.F
+++ b/engine/source/mpi/generic/glob_minv.F
@@ -26,7 +26,7 @@ Chd|  GLOB_MINV                     source/mpi/generic/glob_minv.F
 Chd|-- called by -----------
 Chd|-- calls ---------------
 Chd|====================================================================
-      INTEGER FUNCTION GLOB_MINV(RIN,RINOUT,LEN,TYPE)
+      SUBROUTINE GLOB_MINV(RIN,RINOUT,LEN,TYPE)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -68,7 +68,6 @@ C-----------------------------------------------
           RINOUT(L+(I-1)*VLEN) = RINOUT(L+(I-1)*VLEN)+RIN(L+(I-1)*VLEN)
         END DO
       ENDDO
-      GLOB_MINV = 0
 C
 #endif
       RETURN

--- a/engine/source/mpi/interfaces/reduce_mmx.F
+++ b/engine/source/mpi/interfaces/reduce_mmx.F
@@ -26,7 +26,7 @@ Chd|  REDUCE_MMX                    source/mpi/interfaces/reduce_mmx.F
 Chd|-- called by -----------
 Chd|-- calls ---------------
 Chd|====================================================================
-      INTEGER FUNCTION REDUCE_MMX(RIN,RINOUT,LEN,TYPE)
+      SUBROUTINE REDUCE_MMX(RIN,RINOUT,LEN,TYPE)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -127,8 +127,6 @@ C T25 main gap changes with thickness change
         RINOUT(L) = MAX(RINOUT(L),RIN(L))              
         L = L + 1
       END DO
-C
-      REDUCE_MMX = 0
 C
 #endif
       RETURN

--- a/engine/source/mpi/interfaces/spmd_exch_nor.F
+++ b/engine/source/mpi/interfaces/spmd_exch_nor.F
@@ -125,7 +125,7 @@ c                  print *,'recoit siz',ispmd+1,i,siz
               NBIRECV = NBIRECV + 1
               IRINDEX(NBIRECV) = I
               CALL MPI_IRECV(
-     S          RBUF(L0),SIZ,MPI_FLOAT,IT_SPMD(I),MSGTYP,
+     S          RBUF(L0),SIZ,MPI_REAL4,IT_SPMD(I),MSGTYP,
      G          MPI_COMM_WORLD,REQ_R(NBIRECV),IERROR)
             ENDIF
           ENDIF
@@ -194,7 +194,7 @@ c                  print *,'envoi siz',ispmd+1,i,siz
               NBISEND = NBISEND + 1
               ISINDEX(NBISEND)=I
               CALL MPI_ISEND(
-     S        SBUF(L0),SIZ,MPI_FLOAT,IT_SPMD(I),MSGTYP,
+     S        SBUF(L0),SIZ,MPI_REAL4,IT_SPMD(I),MSGTYP,
      G        MPI_COMM_WORLD,REQ_S(I),IERROR)
             ENDIF
           END IF

--- a/engine/source/mpi/interfaces/spmd_i25front.F
+++ b/engine/source/mpi/interfaces/spmd_i25front.F
@@ -451,7 +451,7 @@ C           CALL FLUSH(6)
               CALL MPI_IRECV(
      .          BUFFERS(NI25)%RECV_BUF(L),
      .          RECV_SIZE,
-     .          MPI_FLOAT,
+     .          MPI_REAL4,
      .          IT_SPMD(P),
      .          MSGTYP,
      .          MPI_COMM_WORLD,
@@ -725,7 +725,7 @@ C           CALL FLUSH(6)
               CALL MPI_ISEND(
      .          BUFFERS(NI25)%SEND_BUF(L),
      .          SEND_SIZE,
-     .          MPI_FLOAT,
+     .          MPI_REAL4,
      .          IT_SPMD(P),
      .          MSGTYP,
      .          MPI_COMM_WORLD,

--- a/engine/source/mpi/sph/spmd_spamaj.F
+++ b/engine/source/mpi/sph/spmd_spamaj.F
@@ -65,10 +65,9 @@ C-----------------------------------------------
      .        STATUS(MPI_STATUS_SIZE),MSGOFF
       INTEGER :: type_reduc,myop,I_LEN
 
-      INTEGER REDUCE_IMAX_MIN
-      EXTERNAL REDUCE_IMAX_MIN
        my_real, DIMENSION(2) :: SBUF,RBUF
        DATA MSGOFF/2007/
+       EXTERNAL REDUCE_IMAX_MIN
 C-----------------------------------------------
 C   S o u r c e  L i n e s
 C-----------------------------------------------
@@ -114,7 +113,7 @@ Chd|  REDUCE_IMAX_MIN               source/mpi/sph/spmd_spamaj.F
 Chd|-- called by -----------
 Chd|-- calls ---------------
 Chd|====================================================================
-      INTEGER FUNCTION REDUCE_IMAX_MIN(RIN,RINOUT)
+      SUBROUTINE REDUCE_IMAX_MIN(RIN,RINOUT)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -145,8 +144,6 @@ C   S o u r c e  L i n e s
 C-----------------------------------------------
       RINOUT(1)   = MAX( NINT(RINOUT(1)), NINT(RIN(1)) )
       RINOUT(2)   = MIN(RINOUT(2),RIN(2))
-C
-      REDUCE_IMAX_MIN = 0
 C
 #endif
       RETURN


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [x] Only one commit (please squash your commits) 
- [x] No merge commits (use git pull --rebase) 
- [x] The changes satisfy the DOS and DONTS of the CONTRIBUTING.md file

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
MPI_User_Function (used  as user-defined operators in reductions should be `SUBROUTINE`  instead of `FUNCTION`
<!--- Describe the problem, ideally from the user viewpoint -->



