### PR TITLE
Improve build scripts :

### DIFF
--- a/.github/workflows/developer_ci.yml
+++ b/.github/workflows/developer_ci.yml
@@ -76,7 +76,7 @@ jobs:
             mpi_opts="-mpi=${{ matrix.mpi }}"
           fi
 
-          cmd="./build_script.sh -arch=${{ matrix.os }}_gf -prec=${{ matrix.precision }} -nt=${{ env.BUILD_NB_THREAD }} $mpi_opts"
+          cmd="./build_script.sh -arch=${{ matrix.os }}_gf -prec=${{ matrix.precision }} -nt=${{ env.BUILD_NB_THREAD }} -static-link $mpi_opts"
           echo "========================================="
           echo "--  BUILD ${{ matrix.build }} --"   
           echo "--  $cmd --"   

--- a/.github/workflows/prmerge_ci_main.yml
+++ b/.github/workflows/prmerge_ci_main.yml
@@ -96,7 +96,7 @@ jobs:
             mpi_opts="-mpi=${{ matrix.mpi }}"
           fi
 
-          cmd="./build_script.sh -arch=${{ matrix.os }}_gf -prec=${{ matrix.precision }} -nt=${{ env.BUILD_NB_THREAD }} $mpi_opts"
+          cmd="./build_script.sh -arch=${{ matrix.os }}_gf -prec=${{ matrix.precision }} -nt=${{ env.BUILD_NB_THREAD }} -static-link $mpi_opts"
           echo "========================================="
           echo "--  BUILD ${{ matrix.build }} --"   
           echo "--  $cmd --"   

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -134,6 +134,13 @@ list(REMOVE_ITEM include_dir_list ${precision_include_remove})
 # using "arch" Variable 
 # ----------------------------------------------------------
 
+#
+# additional build flags from command line
+# -----------------------------------------
+if (DEFINED  ENV{ADFL})
+  set ( ADF "$ENV{ADFL}"  )
+endif()
+
 if (NOT DEFINED arch)
    set (arch "linux64_gf")
 endif ()
@@ -174,8 +181,15 @@ message (STATUS "C Compiler: ${CMAKE_C_COMPILER}")
 message (STATUS "CPP Compiler: ${CMAKE_CPP_COMPILER}")
 message (STATUS "Exec name: ${EXEC_NAME} ")
 message (STATUS "MPI: ${mpiver} ")
+if ( mpi_os STREQUAL "1")
+   message (STATUS "MPI in default OS installation : ${mpi_os} ")
+endif()
+message (STATUS "MPI libraries : ${mpi_lib} ")
+message (STATUS "MPI include directory : ${mpi_inc} ")
+
 message (STATUS "Flags release: ${CMAKE_Fortran_FLAGS_RELEASE} ")
 message (STATUS "Precision: ${precision} ")
+message (STATUS "Runtime Static link : ${static_link} ")
 message (STATUS "debug: ${debug} ")
 if ( DEFINED ADF )
    message (STATUS "Addflag : ${ADF} ")

--- a/engine/CMake_Compilers/cmake_linux64_gf.txt
+++ b/engine/CMake_Compilers/cmake_linux64_gf.txt
@@ -20,9 +20,34 @@ if ( DEFINED MPI )
   if ( mpiver STREQUAL "smp")
      set (mpi_suf "" )
   elseif ( mpiver STREQUAL "ompi")
-     set (mpi_suf "_${mpiver}" )
-    set (mpi_flag "-DMPI -I/opt/openmpi-4.1.1/include/ ")
-    set (mpi_lib "-L/opt/openmpi-4.1.1/lib -lmpi -lmpi_mpifh" )
+
+      set (mpi_inc "-I/opt/openmpi/include/")
+      set (mpi_lib "-L/opt/openmpi/lib -lmpi -lmpi_mpifh" )
+
+    if (mpi_os STREQUAL "1")
+      
+      set (mpi_inc " ")
+      set (mpi_lib "-lmpi -lmpi_mpifh" )
+    else()
+      if ( DEFINED mpi_root )
+        set (mpi_inc "-I${mpi_root}/include/")
+        set (mpi_lib "-L${mpi_root}/lib -lmpi -lmpi_mpifh" )        
+      else()
+        set (mpi_inc "-I/opt/openmpi/include/")
+        set (mpi_lib "-L/opt/openmpi/lib -lmpi -lmpi_mpifh" )
+
+        if ( DEFINED mpi_includes )
+            set (mpi_inc "-I${mpi_includes}")
+        endif()
+        if ( DEFINED mpi_libdir )
+            set (mpi_lib "-I${mpi_libdir} -lmpi -lmpi_mpifh")
+        endif()
+
+      endif()
+    endif()
+
+    set (mpi_suf "_${mpiver}" )
+    set (mpi_flag "-DMPI ${mpi_inc}")
   else()
     message( FATAL_ERROR "\n ERROR : -mpi=${mpiver} not available for this platform\n\n" )
   endif()
@@ -99,8 +124,11 @@ endif()
 set (CMAKE_EXE_LINKER_FLAGS " ${mpi_lib} -fopenmp  -ldl -lrt -lstdc++ " )
 
 #Libraries
-set (LINK "rt  -ldl -static-libgfortran -static-libstdc++ -static-libgcc -Wunused-function"  )
-
+if ( static_link STREQUAL "1" )
+  set (LINK "rt  -ldl -static-libgfortran -static-libstdc++ -static-libgcc -Wunused-function"  )
+else()
+  set (LINK "rt  -ldl -Wunused-function"  )
+endif()
 
 # -------------------------------------------------------------------------------------------------------------------------------------------
 # Specific set of compilation flag

--- a/starter/CMakeLists.txt
+++ b/starter/CMakeLists.txt
@@ -121,6 +121,13 @@ list(REMOVE_ITEM include_dir_list ${precision_include_remove})
 # using "arch" Variable 
 # ----------------------------------------------------------
 
+#
+# additional build flags from command line
+# -----------------------------------------
+if (DEFINED  ENV{ADFL})
+  set ( ADF "$ENV{ADFL}"  )
+endif()
+
 if (NOT DEFINED arch)
    set (arch "linux64_gf")
 endif ()
@@ -153,6 +160,7 @@ message (STATUS "CPP Compiler: ${CMAKE_CPP_COMPILER}")
 message (STATUS "Exec name: ${EXEC_NAME} ")
 message (STATUS "Flags release: ${CMAKE_Fortran_FLAGS_RELEASE} ")
 message (STATUS "Precision: ${precision} ")
+message (STATUS "Runtime Static link : ${static_link} ")
 message (STATUS "debug: ${debug} ")
 if ( DEFINED ADF )
    message (STATUS "Addflag : ${ADF} ")

--- a/starter/CMake_Compilers/cmake_linux64_gf.txt
+++ b/starter/CMake_Compilers/cmake_linux64_gf.txt
@@ -83,8 +83,11 @@ endif()
 set (CMAKE_EXE_LINKER_FLAGS " -rdynamic -no-pie -O2 -fopenmp " )
 
 #Libraries
+if ( static_link STREQUAL "1" )
 set (LINK "dl  ${flexpipe_lib} ${metis_lib} ${reader_lib}  ${lapack_lib} -ldl -static-libgfortran -static-libstdc++ -static-libgcc -Wunused-function"  )
-
+else()
+set (LINK "dl  ${flexpipe_lib} ${metis_lib} ${reader_lib}  ${lapack_lib} -ldl -Wunused-function"  )
+endif()
 
 # -------------------------------------------------------------------------------------------------------------------------------------------
 # Specific set of compilation flag


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [X] Only one commit (please squash your commits) 
- [X] No merge commits (use git pull --rebase) 
- [X] The changes satisfy the DOS and DONTS of the CONTRIBUTING.md file

<!------ Provide a general summary of your changes in the Title above -->
build scripts improvments

add some options for

1/ linux64_gf get openmpi per default from /opt/openmpi
    user can download & build wit differrent OpenMPI

2/ Choose OpenMPI directories
    
3/ Have a dynamic link from runtimes

4/ Add verbose mode to see build options

5/ Clean build directory

6/ review addflag
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

<!--- If there is a design document, link to it here ->


