### PR TITLE
Dev CI - make workflow compatible with public repo + protect against …

### DIFF
--- a/.github/workflows/developer_ci.yml
+++ b/.github/workflows/developer_ci.yml
@@ -3,7 +3,13 @@ name: Developer CI
 on:
   
   pull_request:
+    paths:    
+      - '.github/workflows/*.yml'
 
+  pull_request_target:
+    paths-ignore:    
+      - '.github/workflows/*.yml'
+      
 env:
   QA_TIMEOUT_PER_TEST: 150
 


### PR DESCRIPTION
#### Prerequisites
<!--- Check [x] all boxes -->
- [x] Only one commit (please squash your commits) 
- [x] No merge commits (use git pull --rebase) 
- [x] The changes satisfy the DOS and DONTS of the CONTRIBUTING.md file

#### Description of the feature or the bug
Dev CI - make workflow compatible with public repo + protect against workflow hack tentative


#### Description of the changes
Modification of the developer workflow to ensure that it will run correctly (accessing secret variables) even when repository will be public (using event  pull_request_target).
Protect workflow modification by outside collaborator by restricting any worklow modification to the pull_request event (the secret variables won't be found in an external branch).
In addition we can notice that a workflow modification in an external branch is blocked and maintainer is aked before running. BUT OUR POLICY is to decline any PR (from outside collaborator) including any workflow changes.

