### PR TITLE
back to a mass averaged temperature in finite volume airbags

### DIFF
--- a/engine/source/airbag/fv_up_switch.F
+++ b/engine/source/airbag/fv_up_switch.F
@@ -1511,7 +1511,6 @@ C
       FSAV(14) = NPOLH
       RGAS_AV = CP_AV - CV_AV
       RHO_AV = AMTOT / VOLPH
-      FSAV(5) = PRES_AV / (RHO_AV * RGAS_AV)
 
       IF(IVOLU(39) == 0) THEN
         FSAV(6) =ZERO

--- a/engine/source/airbag/fvbag.F
+++ b/engine/source/airbag/fvbag.F
@@ -1932,7 +1932,6 @@ C
       FSAV(14) = NPOLH
       RGAS_AV = CP_AV - CV_AV
       RHO_AV = AMTOT / VOLPH
-      FSAV(5) = PRES_AV / (RHO_AV * RGAS_AV)
 
       IF(IVOLU(39) == 0) THEN
         FSAV(6) =ZERO


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
Temperature in finite volume airbags is based on mass average 
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here ->


