### PR TITLE
rwall representation correction both in h3d & anim

### DIFF
--- a/engine/source/output/anim/generate/dxwall.F
+++ b/engine/source/output/anim/generate/dxwall.F
@@ -78,17 +78,29 @@ C
       DZ = ZMAX - ZMIN
 C
       R = ZEP707*MAX(DX,DY,DZ)
-      V1 = ZERO
-      V2 = ZEP707
-      V3 = ZEP707
+      IF (XN == ZERO .AND. YN == ZERO .AND. ZN .NE. ZERO ) THEN
+        V1 = ZEP707
+        V2 = ZEP707
+        V3 = ZERO
+      ELSE
+        V1 = ZERO
+        V2 = ZEP707
+        V3 = ZEP707
+      ENDIF
       VV1 = V2 * ZN - V3 * YN
       VV2 = V3 * XN - V1 * ZN
       VV3 = V1 * YN - V2 * XN
       VV = SQRT(VV1*VV1 + VV2*VV2 + VV3*VV3)
       IF(VV.LE.HALF)THEN
-        V1 = ZERO
-        V2 = -ZEP707
-        V3 = ZEP707        
+        IF (XN == ZERO .AND. YN == ZERO .AND. ZN .NE. ZERO ) THEN
+          V1 = -ZEP707
+          V2 = ZEP707
+          V3 = ZERO        
+        ELSE 
+          V1 = ZERO
+          V2 = -ZEP707
+          V3 = ZEP707  
+        ENDIF      
         VV1 = V2 * ZN - V3 * YN
         VV2 = V3 * XN - V1 * ZN
         VV3 = V1 * YN - V2 * XN

--- a/engine/source/output/h3d/h3d_build_fortran/h3d_dxyz_rwall.F
+++ b/engine/source/output/h3d/h3d_build_fortran/h3d_dxyz_rwall.F
@@ -109,24 +109,35 @@ C
           XN =RWBUF(1,N)
           YN =RWBUF(2,N)
           ZN =RWBUF(3,N)
-
           IF (ISPMD.EQ.0) THEN
             DX = XMAX - XMIN
             DY = YMAX - YMIN
             DZ = ZMAX - ZMIN
 C
             R = ZEP707*MAX(DX,DY,DZ)
-            V1 = ZERO
-            V2 = ZEP707
-            V3 = ZEP707
+            IF (XN == ZERO .AND. YN == ZERO .AND. ZN .NE. ZERO ) THEN
+              V1 = ZEP707
+              V2 = ZEP707
+              V3 = ZERO
+            ELSE
+              V1 = ZERO
+              V2 = ZEP707
+              V3 = ZEP707
+            ENDIF
             VV1 = V2 * ZN - V3 * YN
             VV2 = V3 * XN - V1 * ZN
             VV3 = V1 * YN - V2 * XN
             VV = SQRT(VV1*VV1 + VV2*VV2 + VV3*VV3)
             IF(VV.LE.HALF)THEN
-              V1 = ZERO
-              V2 = -ZEP707
-              V3 = ZEP707        
+              IF (XN == ZERO .AND. YN == ZERO .AND. ZN .NE. ZERO ) THEN
+                V1 = -ZEP707
+                V2 = ZEP707
+                V3 = ZERO        
+              ELSE 
+                V1 = ZERO
+                V2 = -ZEP707
+                V3 = ZEP707 
+              ENDIF      
               VV1 = V2 * ZN - V3 * YN
               VV2 = V3 * XN - V1 * ZN
               VV3 = V1 * YN - V2 * XN


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
some issue in representation of rwalls both in h3d & anim , in case in place (XoZ)
(unexpected 45 deg rotation)


#### Description of the changes
add some specific correction to output correctly rwalls ( h3d + anim) in this case

![image](https://user-images.githubusercontent.com/100404030/179756459-f38f963d-4ced-48a4-bb16-8148354f03d1.png)
