### PR TITLE
Add maximal and minimal failure displacement for /PROP/TYPE26 (SPR_TAB)

### DIFF
--- a/engine/source/elements/spring/r26def3.F
+++ b/engine/source/elements/spring/r26def3.F
@@ -73,7 +73,7 @@ C-----------------------------------------------
 C     REAL
       my_real
      .   DLOLD(MVSIZ),DMN(MVSIZ),DMX(MVSIZ),XL0(MVSIZ),
-     .   DV(MVSIZ),DMAX(MVSIZ),ALPHA(MVSIZ)
+     .   DV(MVSIZ),ALPHA(MVSIZ)
       my_real
      .    DT11, BID, SUM
       DOUBLE PRECISION EXDP(MVSIZ),EYDP(MVSIZ),EZDP(MVSIZ),ALDP(MVSIZ),
@@ -87,7 +87,6 @@ c
         XM(I)   =GEO(1,PID)
         XK(I)   =GEO(2,PID)
         XC(I)   =ZERO
-        DMAX(I) =GEO(3,PID)
         ALPHA(I)=GEO(4,PID)
         DMN(I)  =GEO(15,PID)
         DMX(I)  =GEO(16,PID)
@@ -138,15 +137,15 @@ C
       ENDDO
 C
 C-----
-      CALL R26SIG(F       ,XK       ,DL        ,DLOLD    ,DMAX     ,
+      CALL R26SIG(F       ,XK       ,DL        ,DLOLD    ,
      .            E       ,OFF      ,XL0       ,TF       ,NPF      , 
      .            ANIM    ,ANIM_FE(11),FR_WAVE ,DMN      ,DMX      , 
      .            IGEO     ,GEO       ,MGN     ,DV0      ,ALPHA    )                    
 C-----
       NINDX = 0
       DO I=LFT,LLT
-        IF (OFF(I) == ONE .AND. DMX(I) /= ZERO .AND. DMN(I) /= ZERO) THEN
-          IF (DL(I) > DMX(I) .OR. DL(I) < DMN(I)) THEN
+        IF (OFF(I) == ONE) THEN
+          IF (DL(I) > DMX(I)*XL0(I) .OR. DL(I) < DMN(I)*XL0(I)) THEN
             OFF(I)=ZERO
             NINDX = NINDX + 1
             INDX(NINDX) = I

--- a/engine/source/elements/spring/r26sig.F
+++ b/engine/source/elements/spring/r26sig.F
@@ -27,7 +27,7 @@ Chd|        R26DEF3                       source/elements/spring/r26def3.F
 Chd|-- calls ---------------
 Chd|        FINTER                        source/tools/curve/finter.F   
 Chd|====================================================================
-      SUBROUTINE R26SIG(FX     ,XK     ,DX     ,DXOLD  ,DMAX   ,
+      SUBROUTINE R26SIG(FX     ,XK     ,DX     ,DXOLD  ,
      .                  E      ,OFF    ,XL0    ,TF     ,NPF    , 
      .                  ANIM   ,IANI   ,FR_WAVE,DMN    ,DMX    , 
      .                  IGEO   ,GEO    ,PID    ,DV0    ,ALPHA  )                 
@@ -48,7 +48,7 @@ C-----------------------------------------------
 C     REAL
       my_real
      .   GEO(NPROPG,*),FX(*),XK(*),DX(*),DXOLD(*),TF(*),XL0(*),E(*),
-     .   OFF(*), DMN(*), DMX(*), ANIM(*),FR_WAVE(*),DMAX(*),DV0(*),
+     .   OFF(*), DMN(*), DMX(*), ANIM(*),FR_WAVE(*),DV0(*),
      .   ALPHA(*)
 C-----------------------------------------------
 C   C o m m o n   B l o c k s
@@ -81,7 +81,6 @@ C=======================================================================
         E(I)    =E(I)/XL0(I)
         DX(I)   =DX(I)/XL0(I)
         DXOLD(I)=DXOLD(I)/XL0(I)
-        DMAX(I) =DMAX(I)/XL0(I)
       ENDDO
 C
       DO I=LFT,LLT
@@ -175,14 +174,12 @@ c          FMIN(I) = -MAX(Y2 + FAC*(Y1-Y2), EM20)
             FMIN(I) =  -YFAC1(I)*FINTER(FUNC1(I),DL(I)/XFAC(I),NPF,TF,DF1)  
           ENDIF                                                    
 C--------------
-          IF (DX(I) < ZERO) THEN        
-            IF (DL(I) < DMAX(I)) THEN      
-              IF (FX(I) > FMIN(I)) THEN    
-                FX(I) = FMIN(I)            
-              ELSEIF (FX(I) < FMAX(I) )THEN
-                FX(I) = FMAX(I)            
-              ENDIF                        
-            ENDIF                          
+          IF (DX(I) < ZERO) THEN             
+            IF (FX(I) > FMIN(I)) THEN    
+              FX(I) = FMIN(I)            
+            ELSEIF (FX(I) < FMAX(I) )THEN
+              FX(I) = FMAX(I)            
+            ENDIF                                                
           ENDIF                            
         ELSE
           FX(I) = ZERO

--- a/hm_cfg_files/config/CFG/radioss2022/PROP/prop_p26_spr_tab.cfg
+++ b/hm_cfg_files/config/CFG/radioss2022/PROP/prop_p26_spr_tab.cfg
@@ -1,0 +1,321 @@
+//Copyright>    CFG Files and Library ("CFG")
+//Copyright>    Copyright (C) 1986-2022 Altair Engineering Inc.
+//Copyright>
+//Copyright>    Altair Engineering Inc. grants to third parties limited permission to 
+//Copyright>    use and modify CFG solely in connection with OpenRadioss software, provided 
+//Copyright>    that any modification to CFG by a third party must be provided back to 
+//Copyright>    Altair Engineering Inc. and shall be deemed a Contribution under and therefore
+//Copyright>    subject to the CONTRIBUTOR LICENSE AGREEMENT for OpenRadioss software. 
+//Copyright>  
+//Copyright>    CFG IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
+//Copyright>    INCLUDING, BUT NOT LIMITED TO, THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR 
+//Copyright>    A PARTICULAR PURPOSE, AND NONINFRINGEMENT.  IN NO EVENT SHALL ALTAIR ENGINEERING
+//Copyright>    INC. OR ITS AFFILIATES BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, 
+//Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
+//Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
+// Property SPR_TAB Type26
+
+ATTRIBUTES(COMMON)
+{
+    m_coeff                                 = VALUE(FLOAT,  " Mass");
+    ISENSOR                                 = VALUE(SENSOR,  " Sensor Identifier") {SUBTYPES=(/SENSOR/SENSOR_DEFINE);}
+    ISFLAG                                  = VALUE(INT,  " Sensor Flag");
+    Ileng                                   = VALUE(INT,  " Flag for Input Per Unit Length");
+    NFUNC                                   = SIZE(" Number of Loading Curves");
+    NRATEN                                  = SIZE(" Number of Unloading Curves");
+    SCALE                                   = VALUE(FLOAT,  " Scale Factor for Abscissa of Loading and Unloading Functions");
+    STIFF0                                  = VALUE(FLOAT,  " Maximum Stiffness");
+    DMAX                                    = VALUE(FLOAT,  " Failure Displacement in Tension");
+    DMIN                                    = VALUE(FLOAT,  " Failure Displacement in Compression");
+    ALPHA1                                  = VALUE(FLOAT,  " Strain Rate Filtering Factor");
+    FUN_LOAD                                = ARRAY[NFUNC](FUNCT,  " Function identifier defining f(delta)");
+    SCALE_LOAD                              = ARRAY[NFUNC](FLOAT,  " Scale Factor for Loading Function and unloading functions ");
+    STRAINRATE_LOAD                         = ARRAY[NFUNC](FLOAT,  "  delta or epsilon Corresponding to a Loading Function or unloading function");
+    FUN_UNLOAD                              = ARRAY[NRATEN](FUNCT,  " Function identifier defining f(delta)");
+    SCALE_UNLOAD                            = ARRAY[NRATEN](FLOAT,  " Scale Factor for loading Function and unloading functions");
+    STRAINRATE_UNLOAD                       = ARRAY[NRATEN](FLOAT,  " delta or epsilon Corresponding to a loading Function or unloading function ");
+    
+    //Atrributes for HM usage
+    KEYWORD_STR                             = VALUE(STRING, "Solver Keyword");
+    NUM_COMMENTS                            = SIZE("NUM_COMMENTS");
+    COMMENTS                                = ARRAY[NUM_COMMENTS](STRING,  "Entity_Comments");
+    CommentEnumField                        = VALUE(INT,  "User Comments");
+    Prop_Name_OR_Type                       = VALUE(INT, "");
+    IO_FLAG                                 = VALUE(INT, "");
+    TYPE_NO                                 = VALUE(STRING, "");
+    TITLE                                   = VALUE(STRING, "");
+}
+
+SKEYWORDS_IDENTIFIER(COMMON)
+{
+    KEYWORD_STR                             = 9000;
+    NUM_COMMENTS                            = 5110;
+    COMMENTS                                = 5109;
+    CommentEnumField                        = 7951;
+    FUN_LOAD                                = 4234;
+    FUN_UNLOAD                              = 4239;
+    ISENSOR                                 = 5157;
+    ISFLAG                                  = 5158;
+    Ileng                                   =  999;
+    ALPHA1                                  = 6145;
+    NFUNC                                   = 5093;
+    NRATEN                                  = 4233;
+    SCALE                                   =   13;
+    SCALE_LOAD                              = 4236;
+    SCALE_UNLOAD                            = 4238;
+    STIFF0                                  =  831;
+    DMAX                                    = 9059;
+    DMIN                                    =   -1;
+    STRAINRATE_LOAD                         = 4235;
+    STRAINRATE_UNLOAD                       = 4237;
+    m_coeff                                 = 4203;
+    Prop_Name_OR_Type                       = 4537;
+    TITLE                                   =   -1;
+    TYPE_NO                                 =   -1;
+    IO_FLAG                                 =   -1;
+}
+
+CHECK(COMMON)
+{
+    ALPHA1                                   >=   0;
+    ALPHA1                                   <= 1.0;
+    NFUNC                                    >    0;
+    NFUNC                                    <= 100;
+    NRATEN                                   >    0;
+    NRATEN                                   <= 100;
+}
+
+DEFAULTS(COMMON)
+{
+    ALPHA1                                   = 1.0;
+    NFUNC                                    =   1;
+    NRATEN                                   =   1;
+    SCALE                                    = 1.0;
+    STIFF0                                   = 1.0;
+    Prop_Name_OR_Type                        = 0;
+
+}
+
+GUI(COMMON)
+{
+    RADIO(CommentEnumField)
+    {
+       ENUM_VALUE_FLAG=TRUE;
+       ADD(1, "1:Hide in Menu/Export");
+       ADD(2, "2:Show in Menu/Export");
+       ADD(3, "3:Do Not Export");
+    }
+    if(CommentEnumField == 2)
+    {  
+        SIZE(NUM_COMMENTS);
+        ARRAY(NUM_COMMENTS,"")
+        {
+            SCALAR(COMMENTS);
+        }   
+    }
+    if( Prop_Name_OR_Type == 2)
+    {
+        ASSIGN(KEYWORD_STR, "/PROP");
+        ASSIGN(KEYWORD_STR, "/TYPE26/");
+
+    }
+    else
+    {
+        ASSIGN(KEYWORD_STR, "/PROP");
+        ASSIGN(KEYWORD_STR, "/SPR_TAB/");
+    }
+    SCALAR(m_coeff) { if (Ileng==0) { DIMENSION="m"; } else { DIMENSION="lineic_mass"; } }
+    DATA(ISENSOR) {SUBTYPES=(/SENSOR/SENSOR_DEFINE);}
+    RADIO(ISFLAG)
+    {
+        ADD(0, "0:Spring Element Activated.");
+        ADD(1, "1:Spring Element Deactivated.");
+        ADD(2, "2:Spring Element Activated or Deactivated.");
+    }
+    RADIO(Ileng)
+    {
+        ADD(0, "0:The Force in the Spring is Computed as Previously Detailed Formula.");
+        ADD(1, "1:All Inputs are Per Unit Length.");
+    }
+    SIZE(NFUNC);
+    SIZE(NRATEN);
+    SCALAR(SCALE) { if(Ileng==0) { DIMENSION="l"; } else { DIMENSION="DIMENSIONLESS"; } }
+    SCALAR(STIFF0) { if (Ileng==0) { DIMENSION="translation_stiffness"; } else { DIMENSION="force"; } }
+    SCALAR(DMAX) { if(Ileng==0) { DIMENSION="l"; } else { DIMENSION="DIMENSIONLESS"; }  }
+    SCALAR(DMIN) { if(Ileng==0) { DIMENSION="l"; } else { DIMENSION="DIMENSIONLESS"; }  }
+    SCALAR(ALPHA1);
+    ARRAY(NFUNC, "Loading Functions")
+    {
+        FUNCTION(FUN_LOAD) {
+        if (Ileng==0)
+        {
+          X_TITLE="dl";    X_DIMENSION="l";
+          Y_TITLE="f";     Y_DIMENSION="force";    
+        }
+        if (Ileng==1)
+        {
+          X_TITLE="Strain";    X_DIMENSION="DIMENSIONLESS";
+          Y_TITLE="f";         Y_DIMENSION="force";    
+        }
+        /FILTER/groupEnumField/1/EQ;
+        }
+        SCALAR(SCALE_LOAD)      { DIMENSION="force"; }
+        SCALAR(STRAINRATE_LOAD) { DIMENSION="f"; }
+    }
+    ARRAY(NRATEN, "Unloading Functions")
+    {
+        FUNCTION(FUN_UNLOAD) {
+        if (Ileng==0)
+        {
+          X_TITLE="dl";    X_DIMENSION="l";
+          Y_TITLE="f";     Y_DIMENSION="force";    
+        }
+        if (Ileng==1)
+        {
+          X_TITLE="Strain";    X_DIMENSION="DIMENSIONLESS";
+          Y_TITLE="f";     Y_DIMENSION="force";    
+        }
+        }
+        SCALAR(SCALE_UNLOAD)        { DIMENSION="force"; }
+        SCALAR(STRAINRATE_UNLOAD)   { DIMENSION="f"; }
+    }
+}
+
+// File format for Radioss 110
+FORMAT(radioss110) 
+{
+    ASSIGN(IO_FLAG, 0, EXPORT);
+    ASSIGN(IO_FLAG, 1, IMPORT);
+    if(IO_FLAG == 1)
+    {
+        HEADER("/PROP/%4s",TYPE_NO);
+        if(TYPE_NO == "TYPE" )
+        {
+            ASSIGN(Prop_Name_OR_Type,2);
+        }
+    }
+    else if(IO_FLAG == 0 && Prop_Name_OR_Type == 2)
+    {
+        HEADER("/PROP/TYPE26/%d",_ID_);
+    }
+    else
+    {
+        HEADER("/PROP/SPR_TAB/%d",_ID_);
+    }
+    CARD("%-100s", TITLE);
+    COMMENT("#                  M                                 sens_ID    Isflag     Ileng");
+    CARD("%20lg                              %10d%10d%10d",m_coeff,ISENSOR,ISFLAG,Ileng);
+    //
+    COMMENT("#    Nfunc     Nfund              Lscale                Kmax                                   Alpha");
+    CARD("%10d%10d%20lg%20lg%20s%20lg",NFUNC,NRATEN,SCALE,STIFF0,_BLANK_,ALPHA1);
+    //
+    if(NFUNC > 0)
+    {
+        COMMENT("#  fct_ID1              Fscale         Strain_rate");
+        CARD_LIST(NFUNC)
+        {
+            CARD("%10d%20lg%20lg",FUN_LOAD,SCALE_LOAD,STRAINRATE_LOAD);
+        }
+    }
+    //
+    if(NRATEN > 0)
+    {
+        COMMENT("#  fct_ID1              Fscale         Strain_rate");
+        CARD_LIST(NRATEN)
+        {
+            CARD("%10d%20lg%20lg",FUN_UNLOAD,SCALE_UNLOAD,STRAINRATE_UNLOAD);
+        }
+    }
+}
+
+FORMAT(radioss2020) 
+{
+    ASSIGN(IO_FLAG, 0, EXPORT);
+    ASSIGN(IO_FLAG, 1, IMPORT);
+    if(IO_FLAG == 1)
+    {
+        HEADER("/PROP/%4s",TYPE_NO);
+        if(TYPE_NO == "TYPE" )
+        {
+            ASSIGN(Prop_Name_OR_Type,2);
+        }
+    }
+    else if(IO_FLAG == 0 && Prop_Name_OR_Type == 2)
+    {
+        HEADER("/PROP/TYPE26/%d",_ID_);
+    }
+    else
+    {
+        HEADER("/PROP/SPR_TAB/%d",_ID_);
+    }
+    CARD("%-100s", TITLE);
+    COMMENT("#                  M                                 sens_ID    Isflag     Ileng");
+    CARD("%20lg                              %10d%10d%10d",m_coeff,ISENSOR,ISFLAG,Ileng);
+    //
+    COMMENT("#    Nfunc     Nfund              Lscale                Kmax                Dmax               Alpha");
+    CARD("%10d%10d%20lg%20lg%20lg%20lg",NFUNC,NRATEN,SCALE,STIFF0,DMAX,ALPHA1);
+    //
+    if(NFUNC > 0)
+    {
+        COMMENT("#  fct_ID1              Fscale         Strain_rate");
+        CARD_LIST(NFUNC)
+        {
+            CARD("%10d%20lg%20lg",FUN_LOAD,SCALE_LOAD,STRAINRATE_LOAD);
+        }
+    }
+    //
+    if(NRATEN > 0)
+    {
+        COMMENT("#  fct_ID1              Fscale         Strain_rate");
+        CARD_LIST(NRATEN)
+        {
+            CARD("%10d%20lg%20lg",FUN_UNLOAD,SCALE_UNLOAD,STRAINRATE_UNLOAD);
+        }
+    }
+}
+
+FORMAT(radioss2022) 
+{
+    ASSIGN(IO_FLAG, 0, EXPORT);
+    ASSIGN(IO_FLAG, 1, IMPORT);
+    if(IO_FLAG == 1)
+    {
+        HEADER("/PROP/%4s",TYPE_NO);
+        if(TYPE_NO == "TYPE" )
+        {
+            ASSIGN(Prop_Name_OR_Type,2);
+        }
+    }
+    else if(IO_FLAG == 0 && Prop_Name_OR_Type == 2)
+    {
+        HEADER("/PROP/TYPE26/%d",_ID_);
+    }
+    else
+    {
+        HEADER("/PROP/SPR_TAB/%d",_ID_);
+    }
+    CARD("%-100s", TITLE);
+    COMMENT("#                  M                                 sens_ID    Isflag     Ileng                Dmin");
+    CARD("%20lg                              %10d%10d%10d%20lg",m_coeff,ISENSOR,ISFLAG,Ileng,DMIN);
+    //
+    COMMENT("#    Nfunc     Nfund              Lscale                Kmax                Dmax               Alpha");
+    CARD("%10d%10d%20lg%20lg%20lg%20lg",NFUNC,NRATEN,SCALE,STIFF0,DMAX,ALPHA1);
+    //
+    if(NFUNC > 0)
+    {
+        COMMENT("#  fct_ID1              Fscale         Strain_rate");
+        CARD_LIST(NFUNC)
+        {
+            CARD("%10d%20lg%20lg",FUN_LOAD,SCALE_LOAD,STRAINRATE_LOAD);
+        }
+    }
+    //
+    if(NRATEN > 0)
+    {
+        COMMENT("#  fct_ID1              Fscale         Strain_rate");
+        CARD_LIST(NRATEN)
+        {
+            CARD("%10d%20lg%20lg",FUN_UNLOAD,SCALE_UNLOAD,STRAINRATE_UNLOAD);
+        }
+    }
+}

--- a/starter/source/properties/spring/hm_read_prop26.F
+++ b/starter/source/properties/spring/hm_read_prop26.F
@@ -80,8 +80,8 @@ C-----------------------------------------------
        INTEGER I,J,NFUNC,NFUND,IFUN,IAD,ISENS,IFL,ILENG,IRTYP
 C     REAL
       my_real
-     .   MASS,KMAX,DMAX,XFAC,YFAC,RATE,ALPHA,
-     .   PUN,YFAC_DIM,RATE_DIM,XFAC_DIM,DMAX_DIM
+     .   MASS,KMAX,DMAX,XFAC,YFAC,RATE,ALPHA,DMIN,
+     .   PUN,YFAC_DIM,XFAC_DIM
       CHARACTER*nchartitle,
      .   TITR
       LOGICAL IS_AVAILABLE, IS_CRYPTED
@@ -108,6 +108,7 @@ C--------------------------------------------------
 
       CALL HM_GET_INTV('NFUNC',NFUNC,IS_AVAILABLE,LSUBMODEL)
       CALL HM_GET_INTV('NRATEN',NFUND,IS_AVAILABLE,LSUBMODEL)
+      CALL HM_GET_FLOATV('DMIN',DMIN,IS_AVAILABLE,LSUBMODEL,UNITAB)
 C--------------------------------------------------
 C EXTRACT DATAS (REAL VALUES)
 C--------------------------------------------------
@@ -116,21 +117,18 @@ C--------------------------------------------------
       CALL HM_GET_FLOATV_DIM('SCALE',XFAC_DIM,IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('STIFF0',KMAX,IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('DMAX',DMAX,IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_FLOATV_DIM('DMAX',DMAX_DIM,IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('ALPHA1',ALPHA,IS_AVAILABLE,LSUBMODEL,UNITAB)
 C----
       IRTYP = 7                                                       
       CALL FRETITL2(TITR,IGEO(NPROPGI-LTITR+1),LTITR)
 c
-      IF (ALPHA == ZERO)  ALPHA = ONE                                   
-      IF (XFAC == ZERO) XFAC = ONE * XFAC_DIM
-      IF (ILENG == 0) THEN
-        DMAX = DMAX * XFAC / DMAX_DIM  
-      ELSE
-        DMAX = DMAX * XFAC 
-        XFAC = ONE              
-      ENDIF                     
-      IF (DMAX == ZERO) DMAX = EP20 * DMAX_DIM
+      IF (ALPHA == ZERO) ALPHA = ONE                                   
+      IF (XFAC == ZERO)  XFAC  = ONE * XFAC_DIM    
+      DMIN = -ABS(DMIN)
+      DMAX = ABS(DMAX)
+      IF (DMIN == ZERO)  DMIN  = -INFINITY              
+      IF (DMAX == ZERO)  DMAX  =  INFINITY
+      IF (ILENG == 1)    XFAC  = ONE
 c
 C---  courbes de charge                                                  
       IAD = 100                                                       
@@ -139,7 +137,6 @@ C---  courbes de charge
         CALL HM_GET_FLOAT_ARRAY_INDEX('SCALE_LOAD',YFAC,I,IS_AVAILABLE,LSUBMODEL,UNITAB)
         CALL HM_GET_FLOAT_ARRAY_INDEX('STRAINRATE_LOAD',RATE,I,IS_AVAILABLE,LSUBMODEL,UNITAB)
         CALL HM_GET_FLOAT_ARRAY_INDEX_DIM('SCALE_LOAD',YFAC_DIM,I,IS_AVAILABLE,LSUBMODEL,UNITAB)
-        CALL HM_GET_FLOAT_ARRAY_INDEX_DIM('STRAINRATE_LOAD',RATE_DIM,I,IS_AVAILABLE,LSUBMODEL,UNITAB)
 C
         IF (IFUN <= 0) THEN
           CALL ANCMSG(MSGID=862,
@@ -170,7 +167,6 @@ C---  courbes de decharge
         CALL HM_GET_FLOAT_ARRAY_INDEX('SCALE_UNLOAD',YFAC,I,IS_AVAILABLE,LSUBMODEL,UNITAB)
         CALL HM_GET_FLOAT_ARRAY_INDEX('STRAINRATE_UNLOAD',RATE,I,IS_AVAILABLE,LSUBMODEL,UNITAB)
         CALL HM_GET_FLOAT_ARRAY_INDEX_DIM('SCALE_UNLOAD',YFAC_DIM,I,IS_AVAILABLE,LSUBMODEL,UNITAB)
-        CALL HM_GET_FLOAT_ARRAY_INDEX_DIM('STRAINRATE_UNLOAD',RATE_DIM,I,IS_AVAILABLE,LSUBMODEL,UNITAB)
 C
         IF (IFUN <= 0) THEN
           CALL ANCMSG(MSGID=862,
@@ -197,12 +193,13 @@ C
 C
       IGEO(20) = NFUNC                                             
       IGEO(21) = NFUND
-      GEO(1) = MASS                                                   
-      GEO(2) = KMAX                                                   
-      GEO(3) = DMAX                                                   
-      GEO(4) = ALPHA   
-      GEO(5) = XFAC                                               
-      GEO(8) = IRTYP + EM20                                           
+      GEO(1)   = MASS                                                   
+      GEO(2)   = KMAX                                                   
+      GEO(4)   = ALPHA   
+      GEO(5)   = XFAC                                               
+      GEO(8)   = IRTYP + EM20   
+      GEO(15)  = DMIN                          
+      GEO(16)  = DMAX                                        
 C
       IF (MASS < EM15)THEN                                            
          CALL ANCMSG(MSGID=229,
@@ -224,7 +221,7 @@ C
       IF(IS_CRYPTED)THEN
         WRITE(IOUT,1000)IG
       ELSE
-        WRITE(IOUT,1500)IG,MASS,KMAX,NFUNC,NFUND,DMAX,ALPHA,XFAC,ILENG
+        WRITE(IOUT,1500)IG,MASS,KMAX,NFUNC,NFUND,DMIN,DMAX,ALPHA,XFAC,ILENG
         IAD = 100                                                       
         DO I=1,NFUNC
           WRITE(IOUT,1700) IGEO(IAD+I),GEO(IAD+200+I),GEO(IAD+100+I)
@@ -261,7 +258,8 @@ C-----------
      & 5X,'MAXIMUM STIFFNESS . . . . . . . . . . .=',1PG20.13/,
      & 5X,'NUMBER OF LOADING CURVES  . . . . . . .=',I10/,
      & 5X,'NUMBER OF UNLOADING CURVES. . . . . . .=',I10/,
-     & 5X,'FAILURE DISPLACEMENT          . . . . .=',1PG20.13/,
+     & 5X,'FAILURE DISPLACEMENT IN COMPRESSION . .=',1PG20.13/,
+     & 5X,'FAILURE DISPLACEMENT IN TENSION . . . .=',1PG20.13/,
      & 5X,'STRAIN RATE FILTERING FACTOR  . . . . .=',1PG20.13/,
      & 5X,'ABSCISSA SCALE FACTOR         . . . . .=',1PG20.13/,
      & 5X,'UNIT LENGTH FLAG. . . . . . . . . . . .=',I10/,


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

The SPRING TYPE 26 had the possibility to define a maximal displacement but this parameter had no effect at all. More over, it was not possible to fail under compressive loadings because no minimal displacement was defined in the input card. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

I have added the possibility to define a compressive minimal displacement and now minimal and maximal displacement trigger properly the element deletion. New radioss 2022 format for this property has been defined in the .cfg file to take Dmin into account. 
