### PR TITLE
Add new /TH/SPRING option "LENGTH" to output the absolute total length of a spring

### DIFF
--- a/engine/source/output/abf/abfhist2.F
+++ b/engine/source/output/abf/abfhist2.F
@@ -597,7 +597,7 @@ C-------------------------------------------------------
         !   initialization of local array
         WA_SPRING(ID_HIST)%WA_REAL( 1:WA_SPRING_SIZE(ID_HIST) ) = ZERO
         CALL THRES(IPARG,ITHBUF,ELBUF_TAB,WA_SPRING(ID_HIST)%WA_REAL,IGEO,
-     .                  IXR,NTHGRP2,ITHGRP)
+     .                  IXR,NTHGRP2,ITHGRP,X)
         IF(NSPMD>1) THEN
             !   send WA_SPRING to PROC0
             CALL SPMD_GATHERV(WA_SPRING(ID_HIST)%WA_REAL,WA_SPRING_P0(ID_HIST)%WA_REAL,0,

--- a/engine/source/output/th/hist2.F
+++ b/engine/source/output/th/hist2.F
@@ -686,7 +686,7 @@ C-------------------------------------------------------
         !   initialization of local array
         WA_SPRING(ID_HIST)%WA_REAL( 1:WA_SPRING_SIZE(ID_HIST) ) = ZERO
         CALL THRES(IPARG,ITHBUF,ELBUF_TAB,WA_SPRING(ID_HIST)%WA_REAL,IGEO,
-     .                  IXR,NTHGRP2,ITHGRP)
+     .                  IXR,NTHGRP2,ITHGRP,X)
         IF(NSPMD>1) THEN
             !   send WA_SPRING to PROC0
             CALL SPMD_GATHERV(WA_SPRING(ID_HIST)%WA_REAL,WA_SPRING_P0(ID_HIST)%WA_REAL,0,

--- a/engine/source/output/th/thres.F
+++ b/engine/source/output/th/thres.F
@@ -29,7 +29,7 @@ Chd|-- calls ---------------
 Chd|        ELBUFDEF_MOD                  ../common_source/modules/elbufdef_mod.F
 Chd|====================================================================
       SUBROUTINE THRES(IPARG,ITHBUF,ELBUF_TAB,WA,IGEO,
-     .                      IXR,NTHGRP2,ITHGRP)
+     .                      IXR,NTHGRP2,ITHGRP,X)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -55,7 +55,7 @@ C-----------------------------------------------
       INTEGER IPARG(NPARG,*),ITHBUF(*),IXR(NIXR,*),
      .   IGEO(NPROPGI,*)
       my_real
-     .   WA(*)
+     .   WA(*),X(3,NUMNOD)
 C
       TYPE (ELBUF_STRUCT_), TARGET, DIMENSION(NGROUP) :: ELBUF_TAB
 !       -*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-**-*-*-*-*-*-*-*-*-*-*-*-*
@@ -67,7 +67,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER :: II,I,N,IH,NG,ITY,MTE,K,IP,L
       INTEGER :: IJK,LWA,NEL,NFT,IPROP,IGTYP,J,JJ(6)
-      INTEGER :: NITER,IAD,NN,IADV,NVAR,ITYP
+      INTEGER :: NITER,IAD,NN,IADV,NVAR,ITYP,NODE1,NODE2,NODE3
       my_real
      . WWA(100)
       my_real
@@ -127,6 +127,8 @@ C
                             N=I+NFT
                             K=ITHBUF(IH)
                             IP=ITHBUF(IH+NN)
+                            NODE1 = IXR(2,N)
+                            NODE2 = IXR(3,N)
 C
                             IF (K == N) THEN
                                 IH=IH+1
@@ -160,6 +162,10 @@ C
                                 DO L=17,64
                                     WWA(L)= ZERO
                                 ENDDO
+                                ! Absolute spring length
+                                WWA(65)= SQRT((X(1,NODE2)-X(1,NODE1))**2 +
+     .                                        (X(2,NODE2)-X(2,NODE1))**2 + 
+     .                                        (X(3,NODE2)-X(3,NODE1))**2)   
                                 DO L=IADV,IADV+NVAR-1
                                     K=ITHBUF(L)
                                     IJK=IJK+1
@@ -174,6 +180,8 @@ C
                             N=I+NFT
                             K=ITHBUF(IH)
                             IP=ITHBUF(IH+NN)
+                            NODE1 = IXR(2,N)
+                            NODE2 = IXR(3,N)
 C
                             IF (K == N) THEN
                                 IH=IH+1
@@ -206,6 +214,10 @@ C
                                 DO L=17,64
                                     WWA(L)= ZERO
                                 ENDDO
+                                ! Absolute spring length
+                                WWA(65)= SQRT((X(1,NODE2)-X(1,NODE1))**2 +
+     .                                        (X(2,NODE2)-X(2,NODE1))**2 + 
+     .                                        (X(3,NODE2)-X(3,NODE1))**2)   
                                 DO L=IADV,IADV+NVAR-1
                                     K=ITHBUF(L)
                                     IJK=IJK+1
@@ -220,6 +232,8 @@ C
                             N=I+NFT
                             K=ITHBUF(IH)
                             IP=ITHBUF(IH+NN)
+                            NODE1 = IXR(2,N)
+                            NODE2 = IXR(3,N)
 C
                             IF (K == N) THEN
                                 IH=IH+1
@@ -252,6 +266,10 @@ C
                                 DO L=17,64
                                     WWA(L)= ZERO
                                 ENDDO
+                                ! Absolute spring length
+                                WWA(65)= SQRT((X(1,NODE2)-X(1,NODE1))**2 +
+     .                                        (X(2,NODE2)-X(2,NODE1))**2 + 
+     .                                        (X(3,NODE2)-X(3,NODE1))**2)   
                                 DO L=IADV,IADV+NVAR-1
                                     K=ITHBUF(L)
                                     IJK=IJK+1
@@ -266,6 +284,9 @@ C
                             N=I+NFT
                             K=ITHBUF(IH)
                             IP=ITHBUF(IH+NN)
+                            NODE1 = IXR(2,N)
+                            NODE2 = IXR(3,N)
+                            NODE3 = IXR(4,N)
 C
                             IF (K == N) THEN
                                 IH=IH+1
@@ -297,6 +318,13 @@ C
                                 DO L=17,64
                                     WWA(L)= ZERO
                                 ENDDO
+                                ! Absolute spring length
+                                WWA(65)= SQRT((X(1,NODE2)-X(1,NODE1))**2 +
+     .                                        (X(2,NODE2)-X(2,NODE1))**2 + 
+     .                                        (X(3,NODE2)-X(3,NODE1))**2) 
+     .                                 + SQRT((X(1,NODE3)-X(1,NODE2))**2 +
+     .                                        (X(2,NODE3)-X(2,NODE2))**2 + 
+     .                                        (X(3,NODE3)-X(3,NODE2))**2) 
                                 DO L=IADV,IADV+NVAR-1
                                     K=ITHBUF(L)
                                     IJK=IJK+1
@@ -312,6 +340,8 @@ C
                             N=I+NFT
                             K=ITHBUF(IH)
                             IP=ITHBUF(IH+NN)
+                            NODE1 = IXR(2,N)
+                            NODE2 = IXR(3,N)
 C
                             IF (K == N) THEN
                                 IH=IH+1
@@ -345,6 +375,10 @@ C
                                 DO L=17,64
                                     WWA(L)= ZERO 
                                 ENDDO
+                                ! Absolute spring length
+                                WWA(65)= SQRT((X(1,NODE2)-X(1,NODE1))**2 +
+     .                                        (X(2,NODE2)-X(2,NODE1))**2 + 
+     .                                        (X(3,NODE2)-X(3,NODE1))**2)   
                                 DO L=IADV,IADV+NVAR-1
                                     K=ITHBUF(L)
                                     IJK=IJK+1
@@ -361,6 +395,8 @@ C
                                     N=I+NFT
                                     K=ITHBUF(IH)
                                     IP=ITHBUF(IH+NN)
+                                    NODE1 = IXR(2,N)
+                                    NODE2 = IXR(3,N)
 C
                                     IF (K == N) THEN
                                         IH=IH+1
@@ -471,7 +507,11 @@ C---            rotation locale Noeud2
 C---            rotation globale Noeud2                    
                                         WWA(56)=-V1*E1X+V2*E1Y+V3*E1Z              
                                         WWA(57)=-V1*E2X+V2*E2Y+V3*E2Z              
-                                        WWA(58)=-V1*E3X+V2*E3Y+V3*E3Z              
+                                        WWA(58)=-V1*E3X+V2*E3Y+V3*E3Z  
+C---            absolute spring length
+                                        WWA(65)= SQRT((X(1,NODE2)-X(1,NODE1))**2 +
+     .                                                (X(2,NODE2)-X(2,NODE1))**2 + 
+     .                                                (X(3,NODE2)-X(3,NODE1))**2)            
 c
                                         DO L=IADV,IADV+NVAR-1
                                             K=ITHBUF(L)
@@ -487,6 +527,8 @@ c
                                     N=I+NFT
                                     K=ITHBUF(IH)
                                     IP=ITHBUF(IH+NN)
+                                    NODE1 = IXR(2,N)
+                                    NODE2 = IXR(3,N)
 C
                                     IF (K == N) THEN
                                         IH=IH+1
@@ -520,6 +562,10 @@ C
                                         DO L=17,64
                                             WWA(L)= ZERO
                                         ENDDO
+                                        ! Absolute spring length
+                                        WWA(65)= SQRT((X(1,NODE2)-X(1,NODE1))**2 +
+     .                                                (X(2,NODE2)-X(2,NODE1))**2 + 
+     .                                                (X(3,NODE2)-X(3,NODE1))**2)   
                                         DO L=IADV,IADV+NVAR-1
                                             K=ITHBUF(L)
                                             IJK=IJK+1
@@ -534,6 +580,8 @@ C
                                     N=I+NFT
                                     K=ITHBUF(IH)
                                     IP=ITHBUF(IH+NN)
+                                    NODE1 = IXR(2,N)
+                                    NODE2 = IXR(3,N)
 C
                                     IF (K == N) THEN
                                         IH=IH+1
@@ -567,6 +615,10 @@ C
                                         DO L=17,64
                                             WWA(L)= ZERO
                                         ENDDO
+                                        ! Absolute spring length
+                                        WWA(65)= SQRT((X(1,NODE2)-X(1,NODE1))**2 +
+     .                                                (X(2,NODE2)-X(2,NODE1))**2 + 
+     .                                                (X(3,NODE2)-X(3,NODE1))**2)   
                                         DO L=IADV,IADV+NVAR-1
                                             K=ITHBUF(L)
                                             IJK=IJK+1

--- a/starter/source/output/th/hm_read_thgrou.F
+++ b/starter/source/output/th/hm_read_thgrou.F
@@ -148,7 +148,7 @@ C
       CHARACTER*10 VARRIV(NVARRIV),VARRIVG(NVARRIVG)
 C-----------------------------------------------
       PARAMETER (NVARN = 637,NVARS =239552 ,NVARC = 37854,NVART = 6)
-      PARAMETER (NVARP = 8,NVARR = 64,NVARUR = 12)
+      PARAMETER (NVARP = 8,NVARR = 65,NVARUR = 12)
       PARAMETER (NVARNS = 4,NVARSPH = 41)
       PARAMETER (NVARIN = 28,NVARRW = 6,NVARRB =15,NVARFX =4)
       PARAMETER (NVARFXM = 3)
@@ -907,7 +907,7 @@ C   springs
      . 'D2G_Z   ','D1L_X   ','D1L_Y   ','D1L_Z   ','D2L_X   ',
      . 'D2L_Y   ','D2L_Z   ','R1G_X   ','R1G_Y   ','R1G_Z   ',
      . 'R2G_X   ','R2G_Y   ','R2G_Z   ','R1L_X   ','R1L_Y   ',
-     . 'G1L_Z   ','G2L_X   ','G2L_Y   ','G2L_Z   '/
+     . 'G1L_Z   ','G2L_X   ','G2L_Y   ','G2L_Z   ','LENGTH  '/
 
       DATA VARNS/
      . 'OFF     ','FX      ','LX      ','IE      '/
@@ -1305,7 +1305,7 @@ c VARCG = VARCG1 + VARCG2+ VARCG3
      .         / 1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0/
       DATA VARRG/'DEF     '/
       DATA IVARRG
-     .         / 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14, 0, 0, 0, 0/
+     .         / 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,65, 0, 0, 0/
       DATA VARURG/'DEF     '/
       DATA IVARURG
      .         / 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12, 0, 0, 0, 0, 0, 0/


### PR DESCRIPTION
Add new /TH/SPRING option "LENGTH" to output the absolute total length of a spring

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Add new option for /TH/SPRING "LENGTH" 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

New TH has been added for springs