### PR TITLE
Fix SIGEQ ouput issue for shells in anim and h3d

### DIFF
--- a/engine/source/output/anim/generate/dfuncc.F
+++ b/engine/source/output/anim/generate/dfuncc.F
@@ -492,12 +492,32 @@ c----           USER VARIABLES from 6 to 60
                ENDIF                                                                          
 !---
             ELSEIF (IFUNC == 10677) THEN  !  /ANIM/ELEM/SIGEQ
-            !  equivalent stress - other then VON MISES
+            !  equivalent stress - other than VON MISES
               IF (GBUF%G_SEQ > 0) THEN
+C------------------
+                ! Total number of integration points
+                NPGT = 0
+                DO IL=1,NLAY
+                  BUFLY => ELBUF_TAB(NG)%BUFLY(IL)
+                  NPGT = NPGT + BUFLY%NPTT*NPTR*NPTS
+                ENDDO
+                ! Average equivalent stress on integration points
                 DO I=LFT,LLT
-                  FUNC(EL2FA(NN3+NFT+I)) = GBUF%SEQ(I)
-                ENDDO ! DO I=LFT,LLT
-!---
+                  EVAR_TMP = ZERO
+                  DO IL=1,NLAY
+                    BUFLY => ELBUF_TAB(NG)%BUFLY(IL)
+                    DO IT=1,BUFLY%NPTT
+                      DO IR=1,NPTR
+                        DO IS=1,NPTS
+                          LBUF => ELBUF_TAB(NG)%BUFLY(IL)%LBUF(IR,IS,IT)        
+                          EVAR_TMP = EVAR_TMP + LBUF%SEQ(I)/NPGT
+                        ENDDO
+                      ENDDO
+                    ENDDO
+                  ENDDO
+                  FUNC(EL2FA(NN3+NFT+I)) = EVAR_TMP
+                ENDDO
+C------------------
               ELSE  ! VON MISES
                 DO I=LFT,LLT
                   P = - (GBUF%SIG(JJ(1) + I)
@@ -2403,14 +2423,33 @@ C-------------------------------------
               ENDDO  
 C-------------------------------------
             ELSEIF (IFUNC == 10677) THEN  !  /ANIM/SHELL/SIGEQ
-            !  equivalent stress - other then VON MISES
+            !  equivalent stress - other than VON MISES
 C-------------------------------------
               IF (GBUF%G_SEQ > 0) THEN
-!!!!!!
-                DO I = LFT, LLT
-                  EVAR(I) = GBUF%SEQ(I)
+C------------------
+                ! Total number of integration points
+                NPGT = 0
+                DO IL=1,NLAY
+                  BUFLY => ELBUF_TAB(NG)%BUFLY(IL)
+                  NPGT = NPGT + BUFLY%NPTT*NPTR*NPTS
                 ENDDO
-!!!!!!
+                ! Average equivalent stress on integration points
+                DO I=LFT,LLT
+                  EVAR_TMP = ZERO
+                  DO IL=1,NLAY
+                    BUFLY => ELBUF_TAB(NG)%BUFLY(IL)
+                    DO IT=1,BUFLY%NPTT
+                      DO IR=1,NPTR
+                        DO IS=1,NPTS
+                          LBUF => ELBUF_TAB(NG)%BUFLY(IL)%LBUF(IR,IS,IT)        
+                          EVAR_TMP = EVAR_TMP + LBUF%SEQ(I)/NPGT
+                        ENDDO
+                      ENDDO
+                    ENDDO
+                  ENDDO
+                  EVAR(I) = EVAR_TMP
+                ENDDO
+C------------------
               ELSE  !  VON MISES
                 DO I=LFT,LLT
                   S1 = GBUF%FOR(JJ(1)+I)

--- a/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
@@ -2976,14 +2976,32 @@ C--------------------------------------------------
               ENDDO   
 C--------------------------------------------------
             ELSEIF (KEYWORD == 'SIGEQ') THEN  ! equiv stress (mid layer : npt/2 + 1)
-C  equivalent stress - other then VON MISES
+C  equivalent stress - other than VON MISES
 C--------------------------------------------------
               IF (GBUF%G_SEQ > 0) THEN
 C------------------
-                DO I=1,NEL
-                  VALUE(I) = GBUF%SEQ(I)
-                  IS_WRITTEN_VALUE(I) = 1   
-                ENDDO ! DO I=1,NEL  
+                ! Total number of integration points
+                NPGT = 0
+                DO IL=1,NLAY
+                  BUFLY => ELBUF_TAB(NG)%BUFLY(IL)
+                  NPGT = NPGT + BUFLY%NPTT*NPTR*NPTS
+                ENDDO
+                ! Average equivalent stress on integration points
+                VALUE(1:NEL) = ZERO
+                DO IL=1,NLAY
+                  BUFLY => ELBUF_TAB(NG)%BUFLY(IL)
+                  DO IT=1,BUFLY%NPTT
+                    DO IR=1,NPTR
+                      DO IS=1,NPTS
+                        LBUF => ELBUF_TAB(NG)%BUFLY(IL)%LBUF(IR,IS,IT)     
+                        DO I=1,NEL   
+                          VALUE(I) = VALUE(I) + LBUF%SEQ(I)/NPGT
+                          IS_WRITTEN_VALUE(I) = 1  
+                        ENDDO
+                      ENDDO
+                    ENDDO 
+                  ENDDO 
+                ENDDO 
 C------------------
               ELSE  !  VON MISES
                 DO I=1,NEL


### PR DESCRIPTION
Fix SIGEQ ouput issue for shells in anim and h3d

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

/H3D/SHELL/SIGEQ and /ANIM/SHELL/SIGEQ were not working when the number of thickness integration points was higher than 1 for some material laws. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Instead of using GBUF%SEQ, the average of SIGEQ on integration points has been added in the output source code (as it is the case for many other outputs). 



