### PR TITLE
Fix /FAIL/TENSSTRAIN principal strain computation

### DIFF
--- a/engine/source/materials/fail/tensstrain/fail_tensstrain_c.F
+++ b/engine/source/materials/fail/tensstrain/fail_tensstrain_c.F
@@ -190,7 +190,7 @@ c
           IF (STRFLAG == 1 .or. STRFLAG == 4) THEN
             DO I=1,NEL          
               EPST_A = HALF*(EPSXX(I)+EPSYY(I))
-              EPST_B = SQRT( (HALF*(EPSXX(I)-EPSYY(I)))**2 + (EPSXY(I)**2) )
+              EPST_B = SQRT( (HALF*(EPSXX(I)-EPSYY(I)))**2 + (HALF*EPSXY(I))**2)
               EPST1(I)  = EPST_A + EPST_B
               EPST2(I)  = EPST_A - EPST_B
             ENDDO
@@ -205,7 +205,7 @@ c
         CASE (3)      ! max tensile principal strain criterion
           DO I=1,NEL          
             EPST_A = HALF*(EPSXX(I)+EPSYY(I))
-            EPST_B = SQRT( (HALF*(EPSXX(I)-EPSYY(I)))**2 + (EPSXY(I)**2) )
+            EPST_B = SQRT((HALF*(EPSXX(I)-EPSYY(I)))**2 + (HALF*EPSXY(I))**2)
             EPST1(I)  = EPST_A + EPST_B
             EPST2(I)  = EPST_A - EPST_B
             IF (EPST1(I) > -EPST2(I)) THEN

--- a/engine/source/materials/fail/tensstrain/fail_tensstrain_s.F
+++ b/engine/source/materials/fail/tensstrain/fail_tensstrain_s.F
@@ -194,8 +194,8 @@ c           transform total grad def strain to engineering
               EPS22(I)  = MFYY(I)
               EPS33(I)  = MFZZ(I)
               EPS12(I)  = MFXY(I) + MFYX(I)
-              EPS23(I)  = MFXZ(I) + MFZX(I)
-              EPS31(I)  = MFZY(I) + MFYZ(I)
+              EPS23(I)  = MFZY(I) + MFYZ(I)
+              EPS31(I)  = MFXZ(I) + MFZX(I)
             END DO          
           ELSE IF (STRFLAG == 2) THEN     
 c           transform engineering strain to true
@@ -232,7 +232,7 @@ c           transform total grad def strain to true
             EPS22(1:NEL)  = EPSYY(1:NEL)
             EPS33(1:NEL)  = EPSZZ(1:NEL)
             EPS12(1:NEL)  = EPSXY(1:NEL)
-            EPS23(1:NEL)  = EPSXY(1:NEL)
+            EPS23(1:NEL)  = EPSYZ(1:NEL)
             EPS31(1:NEL)  = EPSZX(1:NEL)
           END IF
 c         calculate max strain


### PR DESCRIPTION
Fix /FAIL/TENSSTRAIN principal strain computation

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Fix principal strain computation for shells when using /FAIL/TENSSTRAIN. The factor 2 included in the shear components was not taken into account. There were a few mistakes for solids too. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Add the "HALF" factor needed in 2D principal strain computation + fix the mistakes for SOLIDS. 
