### PR TITLE
Fix /FAIL/COCKROFT equivalent strain computation

### DIFF
--- a/engine/source/materials/fail/cockroft_latham/fail_cockroft_c.F
+++ b/engine/source/materials/fail/cockroft_latham/fail_cockroft_c.F
@@ -110,8 +110,8 @@ C L o c a l V a r i a b l e s
 C-----------------------------------------------
        INTEGER I,J,NINDX,LEN
        INTEGER, DIMENSION(NEL) :: INDX
-       my_real   E_HYD,E_11,E_22,E_33,EEQ,D_EEQ,
-     .           SIG_11,SIG_A,SIG_B
+       my_real   E_HYD,E_11,E_22,E_33,E_12,E_23,E_13,
+     .           EEQ,D_EEQ,SIG_11,SIG_A,SIG_B
 C-----------------------------------------------
 C Ex : ELEMENT IS OFF iF COLA > C0
 C-----------------------------------------------
@@ -138,9 +138,12 @@ c! equivalent strain calculation (negative = total strain ; positive = plastic s
             E_11  = EPSXX(I) - E_HYD
             E_22  = EPSYY(I) - E_HYD
             E_33  =  -E_HYD
+            E_12  = HALF*EPSXY(I)
+            E_23  = HALF*EPSYZ(I)
+            E_13  = HALF*EPSZX(I)
             
             EEQ   = E_11**2 + E_22**2 + E_33**2
-            EEQ   = EEQ + TWO * EPSXY(I)**2 + TWO * EPSYZ(I)**2 + TWO * EPSZX(I)**2
+            EEQ   = EEQ + TWO * (E_12**2) + TWO * (E_23**2) + TWO * (E_13**2)
             EEQ   = 0.8164965809 * SQRT(EEQ) ! sqrt (2/3)*sqrt(...)
             
             D_EEQ = EEQ - UVAR(I,1)

--- a/engine/source/materials/fail/cockroft_latham/fail_cockroft_s.F
+++ b/engine/source/materials/fail/cockroft_latham/fail_cockroft_s.F
@@ -110,7 +110,8 @@ C-----------------------------------------------
 C L o c a l V a r i a b l e s
 C-----------------------------------------------
         INTEGER I,J,LENG,NINDX,INDX(NEL),NCYC
-        my_real C0,EMA,E_HYD,E_11,E_22,E_33,EEQ,D_EEQ
+        my_real C0,EMA,E_HYD,E_11,E_22,E_33,E_12,E_23,
+     .          E_13,EEQ,D_EEQ
         my_real I1,I2,I3,S11,S22,S33,
      .                   Q,R,R_INTER,PHI,LOCKROFT
 
@@ -177,9 +178,12 @@ c! equivalent strain calculation (negative = total strain ; positive = plastic s
             E_11  = EPSXX(I) - E_HYD
             E_22  = EPSYY(I) - E_HYD
             E_33  = EPSZZ(I) - E_HYD
+            E_12  = HALF*EPSXY(I)
+            E_23  = HALF*EPSYZ(I)
+            E_13  = HALF*EPSZX(I)
           
             EEQ   = E_11**2 + E_22**2 + E_33**2
-            EEQ   = EEQ + TWO * EPSXY(I)**2 + TWO * EPSYZ(I)**2 + TWO * EPSZX(I)**2
+            EEQ   = EEQ + TWO * (E_12**2) + TWO * (E_23**2) + TWO * (E_13**2)
             EEQ   = 0.8164965809 * SQRT(EEQ) ! sqrt (2/3)*sqrt(...)
 
             D_EEQ = EEQ - UVAR(I,1)
@@ -228,7 +232,7 @@ c!   principal stress calculation
             S11       = S11 * EMA + (ONE-EMA)* UVAR(I,3)
             UVAR(I,3) = S11
 
-            UVAR(I,2) = UVAR(I,2) + S11 * D_EEQ
+            UVAR(I,2) = UVAR(I,2) + MAX(S11,ZERO) * D_EEQ
           ENDIF 
           
           DFMAX(I) = UVAR(I,2) / MAX(ABS(C0),EM20)

--- a/engine/source/materials/mat_share/mulawc.F
+++ b/engine/source/materials/mat_share/mulawc.F
@@ -509,7 +509,7 @@ c
             DO IFL = 1, NFAIL      ! loop over fail models in current layer
               IRUPT  =  FBUF%FLOC(IFL)%ILAWF
               IF(IRUPT== 4.OR.IRUPT== 5.OR.IRUPT== 6.OR.IRUPT==7.OR.
-     .           IRUPT==10.OR.IRUPT==24) FLAG_EPS=.TRUE.
+     .           IRUPT==10.OR.IRUPT==24.OR.IRUPT==34) FLAG_EPS=.TRUE.
 
               IF(IRUPT== 4.OR.IRUPT== 5.OR.IRUPT== 6.OR.
      .           IRUPT==14.OR.IRUPT==24) FLAG_EPSP=.TRUE.

--- a/engine/source/materials/mat_share/usermat_shell.F
+++ b/engine/source/materials/mat_share/usermat_shell.F
@@ -450,7 +450,7 @@ c
             DO IFL = 1, NFAIL      ! loop over fail models in current layer
               IRUPT  =  FBUF%FLOC(IFL)%ILAWF
               IF(IRUPT== 4.OR.IRUPT== 5.OR.IRUPT== 6.OR.IRUPT==7.OR.
-     .           IRUPT==10.OR.IRUPT==24) FLAG_EPS=.TRUE.
+     .           IRUPT==10.OR.IRUPT==24.OR.IRUPT==34) FLAG_EPS=.TRUE.
 
               IF(IRUPT== 4.OR.IRUPT== 5.OR.IRUPT== 6.OR.
      .           IRUPT==14.OR.IRUPT==24) FLAG_EPSP=.TRUE.


### PR DESCRIPTION
Fix /FAIL/COCKROFT equivalent strain computation

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Equivalent strain computation was not correct for /FAIL/COCKROFT. The factor 2 included in the shear components was not taken into account. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Introduce a HALF factor to fix the problem. 
