### PR TITLE
Fix a mpi hang in the collision detection algo

### DIFF
--- a/engine/source/mpi/interfaces/spmd_cell_list_exchange.F
+++ b/engine/source/mpi/interfaces/spmd_cell_list_exchange.F
@@ -56,6 +56,7 @@ C-----------------------------------------------
         USE INTBUFDEF_MOD  
         USE INTER_SORTING_MOD
         USE INTER_STRUCT_MOD
+        USE TRI7BOX
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -138,6 +139,7 @@ C-----------------------------------------------
         !   mode = 1
         !   send & rcv the number of cell & prepare the array for the next comm
         IF(MODE==1) THEN
+            NSNFI(NIN)%P(1:NSPMD) = 0
             IF(IRCVFROM(NIN,LOC_PROC).EQ.0.AND.ISENDTO(NIN,LOC_PROC).EQ.0) RETURN !CYCLE
             IF(.NOT.ALLOCATED(SORT_COMM(NIN)%NB_CELL_PROC)) THEN
                 SIZE_ = SORT_COMM(NIN)%PROC_NUMBER


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
A hang was found in the new collision detection algorithm
<!--- Describe the problem, ideally from the user viewpoint -->
When all elements are deleted on a processor, a potential hang can occurred in a mpi routine. The NSNFI array must be always flush to 0 at the beginning of the algorithm.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->


