### PR TITLE
Fix SEQ computation for /MAT/LAW87

### DIFF
--- a/engine/source/materials/mat/mat087/mat87c_hansel.F
+++ b/engine/source/materials/mat/mat087/mat87c_hansel.F
@@ -703,7 +703,7 @@ c
       DO I=1,NEL
         UVAR(I,10) = TEMP(I)
         UVAR(I,2)  = YLD(I)
-        SEQ(I)     = SIG(I)
+        SEQ(I)     = SIG(I)/NORM_SP
         DEELZZ(I ) = -NU*(SIGNXX(I)-SIGOXX(I)+SIGNYY(I)-SIGOYY(I))/E
         IF (INLOC > 0) THEN
           NORMSIG = SIGNXX(I)*SIGNXX(I) + SIGNYY(I)*SIGNYY(I) 

--- a/engine/source/materials/mat/mat087/mat87c_swift_voce.F
+++ b/engine/source/materials/mat/mat087/mat87c_swift_voce.F
@@ -661,7 +661,7 @@ C=======================================================================
 c
       DO I=1,NEL
         UVAR(I,2)  = YLD(I)
-        SEQ(I)     = SIG(I)
+        SEQ(I)     = SIG(I)/NORM_SP
         DEELZZ(I ) = -NU*(SIGNXX(I)-SIGOXX(I)+SIGNYY(I)-SIGOYY(I))/E
         IF (INLOC > 0) THEN
           NORMSIG = SIGNXX(I)*SIGNXX(I) + SIGNYY(I)*SIGNYY(I) 

--- a/engine/source/materials/mat/mat087/mat87c_tabulated_plas_sr.F
+++ b/engine/source/materials/mat/mat087/mat87c_tabulated_plas_sr.F
@@ -650,7 +650,7 @@ C-------------------------------------------------------------------------
 c
       DO I=1,NEL
         UVAR(I,2)  = YLD(I)
-        SEQ(I)     = SIG(I)
+        SEQ(I)     = SIG(I)/NORM_SP
         DEELZZ(I ) = -NU*(SIGNXX(I)-SIGOXX(I)+SIGNYY(I)-SIGOYY(I))/E
         IF (INLOC > 0) THEN
           NORMSIG = SIGNXX(I)*SIGNXX(I) + SIGNYY(I)*SIGNYY(I) 

--- a/engine/source/materials/mat/mat087/mat87c_tabulated_totalsr.F
+++ b/engine/source/materials/mat/mat087/mat87c_tabulated_totalsr.F
@@ -663,7 +663,7 @@ C=======================================================================
           ETSE(I) = ONE 
         ENDIF        
         UVAR(I,2)  = YLD(I)
-        SEQ(I)     = SIG(I)
+        SEQ(I)     = SIG(I)/NORM_SP
         DEELZZ(I ) = -NU*(SIGNXX(I)-SIGOXX(I)+SIGNYY(I)-SIGOYY(I))/E
         IF (INLOC > 0) THEN
           NORMSIG = SIGNXX(I)*SIGNXX(I) + SIGNYY(I)*SIGNYY(I) 


### PR DESCRIPTION
Fix SEQ computation for /MAT/LAW87

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

SEQ computation for /MAT/LAW87 was not taking into account the normalization realized above. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Remove the normalization from the value of SIG. 
Note that SIG must be normalized by YOUNG/1000, however NORM_SP = 1000/YOUNG. Thus the multiply SIG by NORM_SP to normalize, and we divide SIG by NORM_SP (for SEQ computation) to get back the regular value. 
