### PR TITLE
Fix an issue in the old candidate treatment

### DIFF
--- a/engine/source/mpi/interfaces/spmd_cell_list_exchange.F
+++ b/engine/source/mpi/interfaces/spmd_cell_list_exchange.F
@@ -140,7 +140,6 @@ C-----------------------------------------------
         !   mode = 1
         !   send & rcv the number of cell & prepare the array for the next comm
         IF(MODE==1) THEN
-            NSNFI(NIN)%P(1:NSPMD) = 0
             IF(IRCVFROM(NIN,LOC_PROC).EQ.0.AND.ISENDTO(NIN,LOC_PROC).EQ.0) RETURN !CYCLE
             IF(.NOT.ALLOCATED(SORT_COMM(NIN)%NB_CELL_PROC)) THEN
                 SIZE_ = SORT_COMM(NIN)%PROC_NUMBER
@@ -322,7 +321,7 @@ C-----------------------------------------------
             !   -------------------------
             !   wait the previous comm
             CALL SPMD_CELL_SIZE_EXCHANGE_INIT(IRCVFROM,ISENDTO,IPARI,NIN,INTER_STRUCT,SORT_COMM)  
-
+            NSNFI(NIN)%P(1:NSPMD) = 0
             IF(IRCVFROM(NIN,LOC_PROC).EQ.0.AND.ISENDTO(NIN,LOC_PROC).EQ.0) RETURN
 
             ITIED = IPARI(85,NIN)


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
A bug was introduced in a previous commit : the list of old candidates (for the collision detection algorithm) was flush to 0 
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
The current number of candidate is now flush to 0 after the old candidate number saving

