### PR TITLE
remove repetitive message in domain decomposition

### DIFF
--- a/starter/source/spmd/domdec2.F
+++ b/starter/source/spmd/domdec2.F
@@ -2952,9 +2952,9 @@ C
          WRITE(IOUT,*)
        END IF
        
-       DO P=1,NSPMD
-        WRITE(IOUT,*)
+       WRITE(IOUT,*)
      .  'PROC    NB OF ELTS    NB OF BOUND. NODES    NB OF BOUND. PROCS'
+       DO P=1,NSPMD
         WRITE(IOUT,1000) P,DDSTAT(2,P),DDSTAT(13,P),DDSTAT(12,P)
        ENDDO
 C


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
Annoying repetitive message about domain decomposition statistics in `*0.out` has been removed.

