### PR TITLE
Add failure criteria parameters scaling with LE_MAX non-local parameter

### DIFF
--- a/engine/source/elements/forintc.F
+++ b/engine/source/elements/forintc.F
@@ -379,7 +379,7 @@ C
      M          IADC_CRK   ,ELCUTC(1,NF1),CRKSKY ,
      N          LSENSOR    ,SENSOR     ,IXEL     ,
      O          ISUBSTACK  ,UXINT_MEAN ,UYINT_MEAN,UZINT_MEAN,NLEVXF      ,
-     P          NODEDGE    ,CRKEDGE    ,STACK    ,DRAPE_Q4  )
+     P          NODEDGE    ,CRKEDGE    ,STACK    ,DRAPE_Q4  ,NLOC_DMG    )
           ENDDO
             ENDIF
 c
@@ -435,7 +435,7 @@ c
      M ELCUTC(1,NF1),
      N LSENSOR     ,SENSOR      ,IXEL      ,STACK       ,
      O ISUBSTACK   ,UXINT_MEAN  ,UYINT_MEAN  ,UZINT_MEAN,NLEVXF      ,
-     P NODEDGE     ,CRKEDGE     ,DRAPE_Q4   ,IPRI  )
+     P NODEDGE     ,CRKEDGE     ,DRAPE_Q4   ,IPRI       ,NLOC_DMG    )
           ENDDO
             END IF
           ENDIF
@@ -571,7 +571,8 @@ C----6---------------------------------------------------------------7--
      H     LSENSOR     ,SENSOR      ,PTG(1,NF1)  ,IXFEM       ,INOD_CRK    ,
      I     IEL_CRK(ITG3),IADC_CRK(ITG1),ELCUTC(1,NF1+ITG3-1)  ,IXEL        ,
      J     STACK       ,ISUBSTACK   ,UXINT_MEAN  ,UYINT_MEAN  ,UZINT_MEAN  ,
-     K     NLEVXF      ,NODEDGE     ,CRKEDGE     ,DRAPE_T3    ,IPRI        )
+     K     NLEVXF      ,NODEDGE     ,CRKEDGE     ,DRAPE_T3    ,IPRI        ,
+     L     NLOC_DMG    )
         ENDDO
         ENDIF
        ENDIF

--- a/engine/source/elements/sh3n/coque3n/c3forc3.F
+++ b/engine/source/elements/sh3n/coque3n/c3forc3.F
@@ -491,7 +491,7 @@ C--------------------------
      M   DIR1_CRK  ,DIR2_CRK  ,ALDT      ,
      N   ISMSTR    ,IR        ,IS        ,NLAY      ,NPT       ,
      O   IXLAY     ,IXEL      ,ISUBSTACK ,STACK     ,
-     P   F_DEF     ,ITASK     ,DRAPE_T3  ,VAR_REG   )
+     P   F_DEF     ,ITASK     ,DRAPE_T3  ,VAR_REG   ,NLOC_DMG  )
 C--------------------------
       IF ((IMON_MAT==1).AND.ITASK == 0)CALL STOPTIME(35,1)
 C--------------------------

--- a/engine/source/elements/sh3n/coquedk/cdkforc3.F
+++ b/engine/source/elements/sh3n/coquedk/cdkforc3.F
@@ -391,7 +391,7 @@ C----------------------------------------------------------------------------
      M     BID       ,BID       ,ALDT      ,
      N     ISMSTR    ,IR        ,IS        ,NLAY      ,NPT       ,
      O     IBID      ,IBID      ,ISUBSTACK ,STACK     ,
-     R     BID       ,ITASK     ,DRAPE_T3  ,VAR_REG   )
+     R     BID       ,ITASK     ,DRAPE_T3  ,VAR_REG   ,NLOC_DMG  )
 C----------------------------------------------------------------------------
 C     THICKNESS CORRECTION 
 C----------------------------

--- a/engine/source/elements/sh3n/coquedk6/cdk6forc3.F
+++ b/engine/source/elements/sh3n/coquedk6/cdk6forc3.F
@@ -337,9 +337,9 @@ C----------------------------------------------------------------------------
      K   R32       ,R33       ,NG        ,TABLE     ,IBID       ,
      L   BID       ,LSENSOR   ,SENSOR    ,BID       ,IBID       ,
      M   BID       ,BID       ,ALDT      ,
-     N   ISMSTR    ,IR        ,IS        ,NLAY      ,NPT       ,
+     N   ISMSTR    ,IR        ,IS        ,NLAY      ,NPT        ,
      O   IBID      ,IBID      ,ISUBSTACK ,STACK     ,
-     R   BID       ,ITASK     ,DRAPE_T3  ,VAR_REG   )
+     R   BID       ,ITASK     ,DRAPE_T3  ,VAR_REG   ,NLOC_DMG   )
 C----------------------------------------------------------------------------
 C     FORCES VISCOCITE 
 C----------------------------

--- a/engine/source/elements/shell/coque/cforc3.F
+++ b/engine/source/elements/shell/coque/cforc3.F
@@ -487,7 +487,7 @@ C-----------------------------
      M  DIR1_CRK    ,DIR2_CRK    ,ALDT        ,
      N  ISMSTR      ,IR          ,IS          ,NLAY       ,NPT        ,
      O  IXLAY       ,IXEL        ,ISUBSTACK   ,STACK      ,
-     P  F_DEF       ,ITASK       ,DRAPE_Q4    ,VAR_REG    )
+     P  F_DEF       ,ITASK       ,DRAPE_Q4    ,VAR_REG    ,NLOC_DMG   )
 C-----------------------------
       IF ((IMON_MAT==1).AND. ITASK == 0)CALL STOPTIME(35,1)
 C-----------------------------

--- a/engine/source/elements/shell/coqueba/cbaforc3.F
+++ b/engine/source/elements/shell/coqueba/cbaforc3.F
@@ -746,7 +746,7 @@ C-----------------
      M    DIR1_CRK  ,DIR2_CRK  ,LC        ,
      N    ISMSTR    ,IR        ,IS        ,NLAY      ,NPT       ,
      O    IBID      ,IBID      ,ISUBSTACK ,STACK     ,
-     P    F_DEF(1,1,NG),ITASK  ,DRAPE_Q4     ,VAR_REG(1,1))        
+     P    F_DEF(1,1,NG),ITASK  ,DRAPE_Q4     ,VAR_REG(1,1),NLOC_DMG)        
         ENDIF
 
 C-----------------

--- a/engine/source/elements/shell/coquez/czforc3.F
+++ b/engine/source/elements/shell/coquez/czforc3.F
@@ -518,9 +518,9 @@ C-----------------------------------------------
      K      R32       ,R33       ,NG        ,TABLE     ,IXFEM      ,
      L      BID       ,LSENSOR   ,SENSOR    ,BID       ,ELCRKINI   ,
      M      DIR1_CRK  ,DIR2_CRK  ,LL        ,
-     N      ISMSTR    ,IR        ,IS        ,NLAY      ,NPT       ,
+     N      ISMSTR    ,IR        ,IS        ,NLAY      ,NPT        ,
      O      IXLAY     ,IXEL      ,ISUBSTACK ,STACK     ,
-     P      F_DEF     ,ITASK     ,DRAPE_Q4  ,VAR_REG   )
+     P      F_DEF     ,ITASK     ,DRAPE_Q4  ,VAR_REG   ,NLOC_DMG   )
 C-----------------------------------------------
 c        
       IF ((ITASK==0).AND.(IMON_MAT==1)) CALL STOPTIME(35,1)

--- a/engine/source/elements/xfem/c3forc3_crk.F
+++ b/engine/source/elements/xfem/c3forc3_crk.F
@@ -78,7 +78,8 @@ Chd|====================================================================
      H            PTG    ,IXFEM  ,INOD_CRK,IEL_CRK,IADTG_CRK,
      I            ELCUTC ,IXEL   ,STACK  ,ISUBSTACK ,
      R            UXINT_MEAN,UYINT_MEAN  ,UZINT_MEAN,NLEVXF  ,
-     S            NODEDGE,CRKEDGE ,DRAPE_T3   ,IPRI      )
+     S            NODEDGE,CRKEDGE ,DRAPE_T3   ,IPRI          ,
+     T            NLOC_DMG)
 C-----------------------------------------------
       USE TABLE_MOD
       USE CRACKXFEM_MOD
@@ -86,7 +87,8 @@ C-----------------------------------------------
       USE STACK_MOD
       USE FAILWAVE_MOD
       USE MATPARAM_DEF_MOD  
-      USE DRAPE_MOD           
+      USE DRAPE_MOD 
+      USE NLOCAL_REG_MOD          
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -146,6 +148,7 @@ C-----------------------------------------------
       TYPE (GRP_PARAM_STRUCT_) :: GROUP_PARAM 
       TYPE(DRAPE_) :: DRAPE_T3
       TYPE (MATPARAM_STRUCT_) , DIMENSION(NUMMAT) :: MATPARAM_TAB
+      TYPE (NLOCAL_STR_) :: NLOC_DMG 
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -435,7 +438,7 @@ C--------------------------
      M   DIR1_CRK  ,DIR2_CRK  ,ALDT      ,
      P   ISMSTR    ,IR        ,IS        ,NLAYER    ,NPTT      ,
      Q   IXLAY     ,IXEL      ,ISUBSTACK ,STACK     ,
-     R   BID    ,ITASK        ,DRAPE_T3  ,VARNL     )
+     R   BID    ,ITASK        ,DRAPE_T3  ,VARNL     ,NLOC_DMG  )
 
 C--------------------------
         IF ((ITASK==0).AND.(IMON_MAT==1)) CALL STOPTIME(35,1)

--- a/engine/source/elements/xfem/cforc3_crk.F
+++ b/engine/source/elements/xfem/cforc3_crk.F
@@ -77,7 +77,7 @@ Chd|====================================================================
      L            IEL_CRK,IADC_CRK,ELCUTC,
      M            LSENSOR,SENSOR ,IXEL ,STACK   ,
      N            ISUBSTACK,UXINT_MEAN,UYINT_MEAN,UZINT_MEAN,NLEVXF,
-     O            NODEDGE,CRKEDGE,DRAPE_Q4,IPRI  )
+     O            NODEDGE,CRKEDGE,DRAPE_Q4,IPRI  ,NLOC_DMG)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -87,7 +87,8 @@ C-----------------------------------------------
       USE STACK_MOD
       USE FAILWAVE_MOD
       USE MATPARAM_DEF_MOD           
-      USE DRAPE_MOD    
+      USE DRAPE_MOD  
+      USE NLOCAL_REG_MOD  
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -149,6 +150,7 @@ C     REAL
       TYPE (GRP_PARAM_STRUCT_) :: GROUP_PARAM
       TYPE (DRAPE_) :: DRAPE_Q4
       TYPE (MATPARAM_STRUCT_) , DIMENSION(NUMMAT) :: MATPARAM_TAB
+      TYPE (NLOCAL_STR_) :: NLOC_DMG 
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -443,7 +445,7 @@ C-----------------------------
      M    DIR1_CRK  ,DIR2_CRK  ,ALDT      ,
      N    ISMSTR    ,IR        ,IS        ,NLAYER    ,NPTT      ,
      O    IXLAY     ,IXEL      ,ISUBSTACK ,STACK     ,
-     R    BID       ,ITASK     ,DRAPE_Q4  ,VARNL     )
+     R    BID       ,ITASK     ,DRAPE_Q4  ,VARNL     ,NLOC_DMG  )
 C-----------------------------
         IF ((ITASK==0).AND.(IMON_MAT==1)) CALL STOPTIME(35,1)
 C-----------------------------

--- a/engine/source/elements/xfem/czforc3_crk.F
+++ b/engine/source/elements/xfem/czforc3_crk.F
@@ -78,7 +78,7 @@ Chd|====================================================================
      M            IADC_CRK,ELCUTC,CRKSKY,
      N            LSENSOR,SENSOR ,IXEL    ,
      K            ISUBSTACK,UXINT_MEAN,UYINT_MEAN,UZINT_MEAN,NLEVXF,
-     L            NODEDGE,CRKEDGE, STACK ,DRAPE_Q4)
+     L            NODEDGE,CRKEDGE, STACK ,DRAPE_Q4,NLOC_DMG)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -88,7 +88,8 @@ C-----------------------------------------------
       USE STACK_MOD
       USE FAILWAVE_MOD
       USE MATPARAM_DEF_MOD  
-      USE DRAPE_MOD          
+      USE DRAPE_MOD 
+      USE NLOCAL_REG_MOD         
 C-----------------------------------------------
 C   I M P L I C I T   T Y P E S
 C-----------------------------------------------
@@ -147,6 +148,7 @@ C     REAL OU REAL*8
       TYPE (GRP_PARAM_STRUCT_) :: GROUP_PARAM
       TYPE (DRAPE_) :: DRAPE_Q4
       TYPE (MATPARAM_STRUCT_) , DIMENSION(NUMMAT) :: MATPARAM_TAB
+      TYPE (NLOCAL_STR_) :: NLOC_DMG 
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7--
 C   L O C A L   V A R I A B L E S
 C--------------------------------
@@ -465,7 +467,7 @@ C-----------------------------
      M       DIR1_CRK  ,DIR2_CRK  ,LL        ,
      N       ISMSTR    ,IR        ,IS        ,NLAYER    ,NPTT    ,
      O       IXLAY     ,IXEL      ,ISUBSTACK ,STACK     ,
-     R       BID       ,ITASK     ,DRAPE_Q4  ,VARNL     )
+     R       BID       ,ITASK     ,DRAPE_Q4  ,VARNL     ,NLOC_DMG)
 C-----------------------------
         IF ((ITASK==0).AND.(IMON_MAT==1)) CALL STOPTIME(35,1)
 C--------------------------

--- a/engine/source/materials/fail/cockroft_latham/fail_cockroft_c.F
+++ b/engine/source/materials/fail/cockroft_latham/fail_cockroft_c.F
@@ -34,7 +34,7 @@ Chd|====================================================================
      4     SIGNXX ,SIGNYY ,SIGNXY ,
      5     EPSXX  ,EPSYY  ,EPSXY  ,EPSYZ  ,EPSZX  ,
      6     DPLA   ,UVAR   ,UEL    ,FOFF   ,
-     7     OFF    ,LENGTH ,AREA   ,DFMAX  ,TDEL)
+     7     OFF    ,DFMAX  ,TDEL   )
 C--------------------------------------------------------------------
 C   /FAIL/COCKROFT - Cockroft-Latham failure criteria for shells and solids
 C--------------------------------------------------------------------
@@ -94,7 +94,7 @@ C-----------------------------------------------
        my_real TIME,TIMESTEP(NEL),UPARAM(*),DPLA(NEL),
      .   EPSXX(NEL) ,EPSYY(NEL) ,EPSXY(NEL),
      .   EPSYZ(NEL) ,EPSZX(NEL),
-     .   LENGTH,AREA,DFMAX(NEL),TDEL(NEL)
+     .   DFMAX(NEL) ,TDEL(NEL)
 
 C
 C-----------------------------------------------

--- a/engine/source/materials/fail/cockroft_latham/fail_cockroft_s.F
+++ b/engine/source/materials/fail/cockroft_latham/fail_cockroft_s.F
@@ -36,7 +36,7 @@ Chd|====================================================================
      5     EPSXX ,EPSYY ,EPSZZ ,EPSXY ,EPSYZ ,EPSZX ,
      6     SIGNXX ,SIGNYY ,SIGNZZ ,SIGNXY ,SIGNYZ ,SIGNZX ,
      7     PLA ,DPLA ,EPSP ,UVAR ,OFF ,
-     8     DELTAX,VOLN,DFMAX,TDELE )
+     8     DFMAX,TDELE )
 
 C--------------------------------------------------------------------
 C   /FAIL/COCKROFT - Cockroft-Latham failure criteria for solids
@@ -98,8 +98,7 @@ C
      .   EPSPXY(NEL),EPSPYZ(NEL),EPSPZX(NEL),
      .   EPSXX(NEL) ,EPSYY(NEL) ,EPSZZ(NEL) ,
      .   EPSXY(NEL) ,EPSYZ(NEL) ,EPSZX(NEL) ,
-     .   DELTAX(NEL),VOLN(NEL),TDELE(NEL),
-     .   DFMAX(NEL)     
+     .   TDELE(NEL) ,DFMAX(NEL)     
 C-----------------------------------------------
 C I N P U T O U T P U T A r g u m e n t s
 C-----------------------------------------------

--- a/engine/source/materials/mat_share/cmain3.F
+++ b/engine/source/materials/mat_share/cmain3.F
@@ -73,9 +73,9 @@ Chd|====================================================================
      K           E3Y       ,E3Z       ,NG        ,TABLE     ,IXFEM      ,
      L           OFFI      ,LSENSOR   ,SENSOR    ,A11_IPLY  ,ELCRKINI   ,
      M           DIR1_CRK  ,DIR2_CRK  ,ALDT      ,
-     N           ISMSTR    ,IR        ,IS        ,NLAY      ,NPT       ,
+     N           ISMSTR    ,IR        ,IS        ,NLAY      ,NPT        ,
      O           IXLAY     ,IXEL      ,ISUBSTACK ,STACK     ,
-     P           F_DEF     ,ITASK     ,DRAPE     ,VARNL     )
+     P           F_DEF     ,ITASK     ,DRAPE     ,VARNL     ,NLOC_DMG   )
 C-----------------------------------------------
 C   M o d u l e s
 C----------------------------------------------- 
@@ -85,6 +85,7 @@ C-----------------------------------------------
       USE FAILWAVE_MOD
       USE MATPARAM_DEF_MOD
       USE DRAPE_MOD 
+      USE NLOCAL_REG_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -139,6 +140,7 @@ C-----------------------------------------------
       TYPE (GRP_PARAM_STRUCT_) :: GROUP_PARAM
       TYPE (DRAPE_) :: DRAPE
       TYPE (MATPARAM_STRUCT_) , DIMENSION(NUMMAT) :: MATPARAM_TAB
+      TYPE (NLOCAL_STR_) :: NLOC_DMG 
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -255,7 +257,7 @@ c
      G       IXEL    ,ITHK    ,F_DEF   ,ISHPLYXFEM,
      H       ITASK   ,STACK%PM ,ISUBSTACK,STACK ,TSTAR   ,ALPE    ,
      I       PLY_EXX ,PLY_EYY ,PLY_EXY ,PLY_EXZ ,PLY_EYZ ,PLY_F   ,
-     J       VARNL   )
+     J       VARNL   ,NLOC_DMG)
 cc----------------------------
       ELSE   ! User-type Radioss laws , NPT > 0
 c----------------------------
@@ -287,7 +289,7 @@ c
      G       IXEL    ,ITHK    ,F_DEF   ,ISHPLYXFEM,
      H       ITASK   ,STACK%PM ,ISUBSTACK,STACK ,TSTAR   ,ALPE    ,
      I       PLY_EXX ,PLY_EYY ,PLY_EXY ,PLY_EXZ ,PLY_EYZ ,PLY_F   ,
-     J       VARNL   ,ETIMP  )
+     J       VARNL   ,ETIMP   ,NLOC_DMG)
       ENDIF ! IF (NPT == 0) 
 C----------------------------------------------------------------------
       IF (IEXPAN > 0 .AND. JTHE > 0. AND.IDT_THERM==0) THEN

--- a/engine/source/materials/mat_share/mmain.F
+++ b/engine/source/materials/mat_share/mmain.F
@@ -239,7 +239,7 @@ C-----------  R4_FREE is replaced by R3_AMU (no more free)
      .   FQVIS(*),FVD2(*),FSSP(*),FDELTAX(*),CONDE(*)
       TYPE(TTABLE) TABLE(*)
       TYPE (ELBUF_STRUCT_), TARGET, DIMENSION(NGROUP) :: ELBUF_TAB
-      TYPE (NLOCAL_STR_)  , TARGET :: NLOC_DMG 
+      TYPE (NLOCAL_STR_) :: NLOC_DMG 
       TYPE(t_ale_connectivity), INTENT(IN) :: ALE_CONNECT
       TYPE(MATPARAM_STRUCT_)  , DIMENSION(NUMMAT) :: MATPARAM_TAB
 C-----------------------------------------------
@@ -281,13 +281,15 @@ C-----------------------------------------------
      .   HEAT_MECA_L
       my_real
      .   Q1,Q2,Q3,STR1,STR2,STR3,STR4,STR5,STR6,WXXF,WYYF,WZZF
-      my_real, DIMENSION(:) ,POINTER :: STRD1,STRD2
+      my_real, DIMENSION(NEL), TARGET :: LE_MAX
+      my_real, DIMENSION(:) ,POINTER :: STRD1,STRD2,EL_LEN
      .  
        LOGICAL :: LOGICAL_USERL_AVAIL, l_MULAW_CALLED
 !
       CHARACTER OPTION*256
       INTEGER SIZE
       CHARACTER IUSER_KEY*ncharline
+      TARGET   :: DELTAX
 C--------------------------------------------    
        my_real
      .  FINTER 
@@ -1301,7 +1303,7 @@ c
      T      CONDE       ,ITASK      ,IEXPAN      ,VOL_AVG   ,AMU      ,
      U      EPSTH       ,LBUF%FORTH ,LBUF%VISC   ,NEL       ,GBUF%ETOTSH,
      V      ISELECT     ,TSTAR      ,LBUF%MU     ,AMU2      ,DPDM     ,
-     W      RHOREF      ,RHOSP      )
+     W      RHOREF      ,RHOSP      ,NLOC_DMG    )
 c
       ELSE   ! 'user type' Radioss material laws 
 C---
@@ -1340,7 +1342,7 @@ c
      U      EPSTH       ,LBUF%FORTH ,LBUF%VISC   ,NEL       ,GBUF%ETOTSH,
      V      ISELECT     ,TSTAR      ,LBUF%MU     ,DPDM     ,
      W      RHOREF      ,RHOSP      ,NVARTMP     ,MBUF%VARTMP,LBUF%EINTTH,
-     X      MATPARAM_TAB)
+     X      MATPARAM_TAB,NLOC_DMG   )
 
       ENDIF 
 C-----------------------------------
@@ -1535,12 +1537,19 @@ C------------------------------------------------------------
 C     Recovering non-local variable
 C------------------------------------------------------------
         INLOC = IPARG(78,NG)
-        IF (INLOC > 0) THEN 
+        IF (INLOC > 0) THEN
+          ! -> Length used for failure criterion parameters scaling is LE_MAX
+          LE_MAX(1:NEL) = NLOC_DMG%LE_MAX(IPM(1,MAT(1)))
+          EL_LEN => LE_MAX(1:NEL) 
+          ! -> Copying the non-local plastic strain increment
           IF (ELBUF_TAB(NG)%BUFLY(ILAY)%L_PLA > 0) THEN 
             DO I = LFT,LLT
               DPLA(I) = MAX(VARNL(I),ZERO)
             ENDDO
           ENDIF
+        ELSE
+          ! -> Length used for failure criterion parameters scaling is the element length
+          EL_LEN => DELTAX(1:NEL)
         ENDIF
 c---
         DO IR = 1,NFAIL 
@@ -1827,8 +1836,8 @@ c --- ladeveze delamination damage model
 c ---   tabulated failure model
               CALL FAIL_TAB_S(
      1        LLT      ,NVARF    ,NPF      ,TF       ,TT       ,         
-     2        BUFMAT(IADBUF)     ,NGL      ,IPM      ,MAT      ,DELTAX   ,         
-     3        SS1      ,SS2      ,SS3      ,SS4      ,SS5      ,SS6  ,    
+     2        BUFMAT(IADBUF)     ,NGL      ,IPM      ,MAT      ,EL_LEN  ,         
+     3        SS1      ,SS2      ,SS3      ,SS4      ,SS5      ,SS6     ,    
      4        DEFP     ,DPLA     ,EPSP     ,TSTAR    ,UVARF    ,           
      5        OFF      ,IP       ,TABLE    ,DFMAX    ,TDEL     ,
      6        NFUNC    ,IFUNC )                                       
@@ -1867,7 +1876,7 @@ C  --- Biquadratic failure model
      3        NGL     ,IPM       ,MAT      ,                   
      4        SS1     ,SS2       ,SS3      ,SS4      ,SS5      ,SS6 ,
      5        DPLA    ,EPSP      ,TSTAR    ,UVARF    ,OFF      ,IP  ,
-     6        DFMAX   ,TDEL      ,DELTAX)                     
+     6        DFMAX   ,TDEL      ,EL_LEN   )                     
           ELSEIF (IRUPT == 34) THEN                                      
 C  --- Cockroft-Latham failure model             
               CALL FAIL_COCKROFT_S(LLT ,NPARAM,NVARF,
@@ -1877,7 +1886,7 @@ C  --- Cockroft-Latham failure model
      5        ES1     ,ES2       ,ES3      ,ES4      ,ES5           ,ES6 ,
      6        SS1     ,SS2       ,SS3      ,SS4      ,SS5           ,SS6 ,    
      7        DEFP    ,DPLA      ,EPSP     ,UVARF    ,OFF           ,
-     8        DELTAX  ,VOLN      ,DFMAX    ,TDEL) 
+     8        DFMAX   ,TDEL) 
           ELSEIF (IRUPT == 36) THEN                                      
 C  --- VISUAL failure model             
               CALL FAIL_VISUAL_S(
@@ -1890,8 +1899,8 @@ c
 c ---       tabulated failure model (old, obsolete version)
               CALL FAIL_TAB_OLD_S(
      1        LLT      ,NVARF    ,NPF      ,TF       ,TT       ,         
-     2        BUFMAT(IADBUF)     ,NGL      ,IPM      ,MAT      ,DELTAX   ,         
-     3        SS1      ,SS2      ,SS3      ,SS4      ,SS5      ,SS6  ,    
+     2        BUFMAT(IADBUF)     ,NGL      ,IPM      ,MAT      ,EL_LEN   ,         
+     3        SS1      ,SS2      ,SS3      ,SS4      ,SS5      ,SS6      ,    
      4        DEFP     ,DPLA     ,EPSP     ,TSTAR    ,UVARF    ,           
      5        OFF      ,IP       ,DFMAX    ,TDEL     ,
      6        NFUNC    ,IFUNC )   
@@ -1903,7 +1912,7 @@ C  --- Orthotropic biquadratic failure model
      2          NPF      ,TF       ,TT       ,DT1      ,BUFMAT(IADBUF),
      3          NGL      ,DPLA     ,EPSP     ,UVARF    ,OFF      ,                   
      4          SS1      ,SS2      ,SS3      ,SS4      ,SS5      ,SS6      ,
-     5          DFMAX    ,TDEL     ,DELTAX) 
+     5          DFMAX    ,TDEL     ,EL_LEN   ) 
 c
           ELSEIF (IRUPT == 39) THEN                                      
 c  --- GENE1 failure model                                  

--- a/engine/source/materials/mat_share/mulaw.F
+++ b/engine/source/materials/mat_share/mulaw.F
@@ -158,7 +158,7 @@ Chd|====================================================================
      U                  EPSTH3  ,EPSTH   ,SVISC    ,NEL     ,ETOTSH ,
      V                  ISELECT ,TSTAR   ,MUOLD    ,DPDM   ,
      W                  RHOREF  ,RHOSP   ,NVARTMP  ,VARTMP  ,EINTTH ,
-     X                  MATPARAM_TAB)
+     X                  MATPARAM_TAB     ,NLOC_DMG )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -167,6 +167,7 @@ C-----------------------------------------------
       USE ALE_CONNECTIVITY_MOD
       USE MATPARAM_DEF_MOD
       USE MESSAGE_MOD
+      USE NLOCAL_REG_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -221,7 +222,7 @@ C
      .   AL_IMP(MVSIZ),SIGNOR(MVSIZ,6),VDX(NEL),VDY(NEL),VDZ(NEL),EINTTH(MVSIZ),
      .   SVISC(NEL,6),AMU(MVSIZ),DPDM(MVSIZ),VOL_AVG(MVSIZ),EPSTH(NEL),EPSTH3(MVSIZ),
      .   ETOTSH(NEL,6),TSTAR(MVSIZ),MUOLD(NEL),CONDE(NEL), RHOREF(MVSIZ), RHOSP(MVSIZ)
-      TARGET :: BUFMAT
+      TARGET :: BUFMAT,DELTAX
       my_real, TARGET, DIMENSION(NUVAR*NEL)   :: UVAR
       my_real, TARGET, DIMENSION(NVARTMP*NEL) :: VARTMP
       my_real, TARGET, DIMENSION(NEL)       :: UVARF1,LTEMP,TEMPEL,SCALE1
@@ -231,6 +232,7 @@ C
       TYPE (ELBUF_STRUCT_), TARGET, DIMENSION(NGROUP) :: ELBUF_TAB
       TYPE(t_ale_connectivity), INTENT(IN) :: ALE_CONNECT
       TYPE(MATPARAM_STRUCT_), DIMENSION(NUMMAT),TARGET :: MATPARAM_TAB
+      TYPE (NLOCAL_STR_) :: NLOC_DMG 
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -264,9 +266,10 @@ C-----------------------------------------------
       my_real 
      .   RHO0(MVSIZ),BIDON1,BIDON2,BIDON3,BIDON4,BIDON5,POLD
       my_real TT_LOCAL
+      my_real, DIMENSION(NEL), TARGET  :: LE_MAX
 C----
       my_real, DIMENSION(:), POINTER   :: UPARAM,UPARAMF,UVARF,DFMAX,TDEL,EL_TEMP, 
-     .                                   YLDFAC,DAM
+     .                                    YLDFAC,DAM,EL_LEN
       TYPE(L_BUFEL_)  ,POINTER         :: LBUF
       TYPE(G_BUFEL_)  ,POINTER         :: GBUF      
       TYPE(MATPARAM_STRUCT_) , POINTER :: MATPARAM
@@ -291,6 +294,12 @@ C=======================================================================
       ENDIF
       ISEQ   = ELBUF_TAB(NG)%BUFLY(ILAY)%L_SEQ
       INLOC  = IPARG(78,NG)
+      ! Make sure that the non-local variable increment is positive
+      IF (INLOC > 0) THEN 
+        DO I = 1,NEL
+          VARNL(I) = MAX(VARNL(I),ZERO)
+        ENDDO
+      ENDIF
       ! needed in mqviscb
       FACQ0  = ONE                          
       MX     = MAT(1)                      
@@ -1649,6 +1658,17 @@ C                  FAILURE MODEL
 C=======================================================================
       IF ((ITASK==0).AND.(IMON_MAT==1))CALL STARTIME(121,1)
       IF (NFAIL > 0) THEN
+c
+        ! Failure criterion parameters scaling
+        IF (INLOC > 0) THEN
+          ! -> Length used for failure criterion parameters scaling is LE_MAX
+          LE_MAX(1:NEL) = NLOC_DMG%LE_MAX(IPM(1,MAT(1)))
+          EL_LEN => LE_MAX(1:NEL) 
+        ELSE
+          ! -> Length used for failure criterion parameters scaling is LE_MAX
+          EL_LEN => DELTAX(1:NEL) 
+        ENDIF
+c
         IF (ELBUF_TAB(NG)%BUFLY(ILAY)%L_PLA > 0) THEN
 C for non-local plastic law
           IF (INLOC > 0) THEN 
@@ -1853,11 +1873,11 @@ C---- energy failure
 C---- tabulated failure model
                CALL FAIL_TAB_S(
      1         NEL      ,NVARF    ,NPF      ,TF       ,TT       ,        
-     2         UPARAMF     ,NGL      ,IPM      ,MAT      ,DELTAX   ,        
-     3         S1       ,S2       ,S3       ,S4       ,S5       ,S6,    
-     4         DEFP     ,DPLA     ,EPSP1    ,TSTAR    ,UVARF ,             
-     5         OFF      ,IP       ,TABLE    ,DFMAX    ,TDEL  ,
-     6         NFUNC    ,IFUNC )                                      
+     2         UPARAMF  ,NGL      ,IPM      ,MAT      ,EL_LEN   ,         
+     3         S1       ,S2       ,S3       ,S4       ,S5       ,S6      ,    
+     4         DEFP     ,DPLA     ,EPSP1    ,TSTAR    ,UVARF    ,             
+     5         OFF      ,IP       ,TABLE    ,DFMAX    ,TDEL     ,
+     6         NFUNC    ,IFUNC    )                                      
           ELSEIF (IRUPT == 24) THEN                                      
 c   --- Orthotropic strain failure
               CALL FAIL_ORTHSTRAIN(
@@ -1893,7 +1913,7 @@ c  --- Biquadratic failure model
      3        NGL      ,IPM      ,MAT      ,                   
      4        S1       ,S2       ,S3       ,S4       ,S5       ,S6 ,
      5        DPLA     ,EPSP1    ,TSTAR    ,UVARF    ,OFF,IP   ,
-     6        DFMAX    ,TDEL     ,DELTAX)    
+     6        DFMAX    ,TDEL     ,EL_LEN   )    
           ELSEIF (IRUPT == 33. AND . MTN /= 100 .AND. MTN /= 95 ) THEN                                
 c  --- Mullins Ogden-Roxburgh dammage model                                  
               CALL FAIL_MULLINS_OR_S(
@@ -1911,7 +1931,7 @@ C  --- Cockroft-Latham failure model
      4        ES1     ,ES2       ,ES3      ,ES4      ,ES5           ,ES6 ,
      5        S1      ,S2        ,S3       ,S4       ,S5            ,S6  ,
      6        DEFP    ,DPLA      ,EPSP     ,UVARF    ,OFF           ,
-     7        DELTAX  ,VOLN      ,DFMAX    ,TDEL) 
+     7        DFMAX   ,TDEL      ) 
           ELSEIF (IRUPT == 36) THEN                                           
 C  --- VISUAL failure model             
               CALL FAIL_VISUAL_S(
@@ -1923,11 +1943,11 @@ C  --- VISUAL failure model
 c ---       tabulated failure model (old, obsolete version)
               CALL FAIL_TAB_OLD_S(
      1         NEL      ,NVARF    ,NPF      ,TF       ,TT       ,        
-     2         UPARAMF     ,NGL      ,IPM      ,MAT      ,DELTAX   ,        
-     3         S1       ,S2       ,S3       ,S4       ,S5       ,S6,    
-     4         DEFP     ,DPLA     ,EPSP1    ,TSTAR    ,UVARF ,             
+     2         UPARAMF  ,NGL      ,IPM      ,MAT      ,EL_LEN   ,
+     3         S1       ,S2       ,S3       ,S4       ,S5       ,S6    ,    
+     4         DEFP     ,DPLA     ,EPSP1    ,TSTAR    ,UVARF    ,             
      5         OFF      ,IP       ,DFMAX    ,TDEL     ,
-     6         NFUNC    ,IFUNC )     
+     6         NFUNC    ,IFUNC    )     
 c
           ELSEIF (IRUPT == 38) THEN                                      
 c  --- Orthotropic biquadratic failure model                                  
@@ -1936,7 +1956,7 @@ c  --- Orthotropic biquadratic failure model
      2          NPF      ,TF       ,TT       ,DT1      ,UPARAMF  ,
      3          NGL      ,DPLA     ,EPSP1    ,UVARF    ,OFF      ,                
      4          S1       ,S2       ,S3       ,S4       ,S5       ,S6       ,
-     5          DFMAX    ,TDEL     ,DELTAX   )    
+     5          DFMAX    ,TDEL     ,EL_LEN   )    
 c
           ELSEIF (IRUPT == 39) THEN                                      
 c  --- GENE1 failure model                                  

--- a/engine/source/materials/mat_share/mulawc.F
+++ b/engine/source/materials/mat_share/mulawc.F
@@ -143,7 +143,7 @@ Chd|====================================================================
      G       IXEL     ,ITHK     ,F_DEF    ,ISHPLYXFEM,
      H       ITASK    ,PM_STACK , ISUBSTACK,STACK    ,TSTAR    ,ALPE     ,
      I       PLY_EXX  ,PLY_EYY  ,PLY_EXY  ,PLY_EXZ   ,PLY_EYZ  ,PLY_F    ,
-     J       VARNL    ,ETIMP    )
+     J       VARNL    ,ETIMP    ,NLOC_DMG )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -154,6 +154,7 @@ C-----------------------------------------------
       USE FAILWAVE_MOD
       USE MESSAGE_MOD
       USE MATPARAM_DEF_MOD
+      USE NLOCAL_REG_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -207,6 +208,7 @@ C-----------------------------------------------
       TYPE (STACK_PLY) :: STACK
       TYPE (FAILWAVE_STR_) ,TARGET :: FAILWAVE 
       TYPE (MATPARAM_STRUCT_) , DIMENSION(NUMMAT) ,TARGET :: MATPARAM_TAB
+      TYPE (NLOCAL_STR_) :: NLOC_DMG 
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -242,8 +244,9 @@ c
      .   T1,T2,T3,PHI,SUM1,SUM2,FACT,R3R3,S3S3, 
      .   BIDON1,BIDON2,BIDON3,BIDON4,BIDON5,RATIO,VV,AA,TRELAX
       my_real  SCALE1(NEL)
+      my_real ,DIMENSION(NEL), TARGET :: LE_MAX
       my_real TT_LOCAL
-      my_real, DIMENSION(:) ,POINTER  :: EL_TEMP,YLDFAC,CRKLEN,CRKDIR,DADV,TFAIL
+      my_real, DIMENSION(:) ,POINTER  :: EL_TEMP,YLDFAC,CRKLEN,CRKDIR,DADV,TFAIL,EL_LEN
       my_real, DIMENSION(NLAY,10)  :: PTHKF
       TARGET :: TEMPEL,BUFMAT,EPSXX,EPSYY,DEPSXX,DEPSYY,SCALE1,POSLY,THKLY
 c----
@@ -544,6 +547,13 @@ c
           UVARV => BUFLY%VISC(IR,IS,IT)%VAR
           VARTMP=> BUFLY%MAT(IR,IS,IT)%VARTMP
           DIRDMG => LBUF%DMG(1:L_DMG*NEL)
+c
+          ! -> Make sure the non-local increment is positive
+          IF (INLOC > 0) THEN 
+            DO I = JFT,JLT
+              VARNL(I,IT) = MAX(VARNL(I,IT),ZERO)
+            ENDDO 
+          ENDIF
 c
           IF (JTHE == 0 .and. BUFLY%L_TEMP > 0) THEN        
              EL_TEMP => LBUF%TEMP(1:NEL)
@@ -1676,7 +1686,18 @@ C
             DMG_LOC_SCALE(1:NEL) = ONE  ! local dmg scale by integration point and failure model
 c                                        
             MPT  = NPTTOT * MAX(1,NPG)
-            FBUF => BUFLY%FAIL(IR,IS,IT)                   
+            FBUF => BUFLY%FAIL(IR,IS,IT)  
+c
+            ! Length used for regularization (failure criterion parameters scaling)
+            !  -> If non-local, criterion parameters are scaled with LE_MAX parameter
+            IF (INLOC > 0) THEN 
+              LE_MAX(1:NEL) = NLOC_DMG%LE_MAX(IPM(1,MAT(1)))
+              EL_LEN => LE_MAX(1:NEL)
+            !  -> If not, criterion parameters are scaled with the element characteristic length
+            ELSE
+              EL_LEN => ALDT(1:NEL)
+            ENDIF
+c
 C           plastic strain increment for all plastic laws                   
             IF (BUFLY%L_PLA > 0) THEN
               ! Non-local material
@@ -1977,7 +1998,7 @@ c
      2                NFUNC1    ,IFUNC1    ,TABLE     ,NPF       ,TF        ,
      3                TT        ,NGL       ,IPG       ,ILAYER    ,IT        , 
      4                SIGNXX    ,SIGNYY    ,SIGNXY    ,SIGNYZ    ,SIGNZX    ,      
-     5                DPLA      ,EPSPL     ,THKN      ,ALDT      ,TSTAR     ,
+     5                DPLA      ,EPSPL     ,THKN      ,EL_LEN    ,TSTAR     ,
      6                PTHKF(ILAYER,IFL),DMG_FLAG,DMG_LOC_SCALE ,OFF  ,FOFF      ,
      7                DFMAX     ,TDEL      ,IGTYP     )
                 ELSE
@@ -2050,7 +2071,7 @@ c
      3          SIGNXX   ,SIGNYY  ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,
      4          DPLA     ,EPSPL   ,UVARF    ,PTHKF(ILAYER,IFL)  ,UELR1    ,
      5          OFF      ,OFFL    ,DFMAX    ,TDEL     ,NFUNC1   ,
-     6          IFUNC1   ,NPF     ,TF       ,ALDT     ,FOFF     ,IPG      )
+     6          IFUNC1   ,NPF     ,TF       ,EL_LEN   ,FOFF     ,IPG      )
 c
               CASE (31)     !    Anisotropic fabric failure model
 c
@@ -2090,7 +2111,7 @@ c
      4           SIGNXX   ,SIGNYY   ,SIGNXY   ,
      5           EPSXX    ,EPSYY    ,EPSXY    ,EPSYZ    ,EPSZX     ,
      6           DPLA     ,UVARF    ,UELR1    ,FOFF     ,
-     7           OFF      ,ALDT     ,AREA     ,DFMAX    ,TDEL   )
+     7           OFF      ,DFMAX    ,TDEL   )
 c
               CASE (36)     !    Visual failure model
                 IF (ILAW == 2) THEN
@@ -2113,7 +2134,7 @@ c
      2                NFUNC1    ,IFUNC1    ,NPF       ,TF        ,
      3                TT        ,NGL       ,IPG       ,ILAYER    ,IT        , 
      4                SIGNXX    ,SIGNYY    ,SIGNXY    ,SIGNYZ    ,SIGNZX    ,      
-     5                DPLA      ,EPSPL     ,THKN      ,ALDT      ,TSTAR     ,
+     5                DPLA      ,EPSPL     ,THKN      ,EL_LEN    ,TSTAR     ,
      6                PTHKF(ILAYER,IFL)    ,OFF       ,FOFF      ,
      7                DFMAX     ,TDEL      ,IGTYP     )
                 ELSE
@@ -2135,7 +2156,7 @@ c
      3            SIGNXX   ,SIGNYY  ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,
      4            DPLA     ,EPSPL   ,UVARF    ,PTHKF(ILAYER,IFL)  ,UELR1  ,
      5            OFF      ,OFFL    ,DFMAX    ,TDEL     ,NFUNC1   ,
-     6            IFUNC1   ,NPF     ,TF       ,ALDT     ,FOFF     ,IPG    )
+     6            IFUNC1   ,NPF     ,TF       ,EL_LEN   ,FOFF     ,IPG    )
 c
               CASE (39)     !    GENE1
 c

--- a/engine/source/materials/mat_share/usermat_shell.F
+++ b/engine/source/materials/mat_share/usermat_shell.F
@@ -101,7 +101,7 @@ Chd|====================================================================
      G       IXEL     ,ITHK     ,F_DEF    ,ISHPLYXFEM,
      H       ITASK    ,PM_STACK , ISUBSTACK,STACK    ,TSTAR    ,ALPE     ,
      I       PLY_EXX  ,PLY_EYY  ,PLY_EXY  ,PLY_EXZ   ,PLY_EYZ  ,PLY_F    ,
-     J       VARNL    )
+     J       VARNL    ,NLOC_DMG )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -111,6 +111,7 @@ C-----------------------------------------------
       USE STACK_MOD
       USE FAILWAVE_MOD
       USE MESSAGE_MOD
+      USE NLOCAL_REG_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -163,6 +164,7 @@ C-----------------------------------------------
       TARGET :: ALDT, IPM
       TYPE (STACK_PLY) :: STACK
       TYPE (FAILWAVE_STR_) ,TARGET :: FAILWAVE 
+      TYPE (NLOCAL_STR_) :: NLOC_DMG 
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -210,8 +212,9 @@ c
       my_real COPY_PLA(MVSIZ)
       my_real, DIMENSION(MVSIZ) :: DT_INV
       my_real  SCALE1(NEL)
+      my_real ,DIMENSION(NEL), TARGET :: LE_MAX
       my_real TT_LOCAL
-      my_real, DIMENSION(:) ,POINTER  :: EL_TEMP,YLDFAC,CRKLEN,CRKDIR,DADV,TFAIL
+      my_real, DIMENSION(:) ,POINTER  :: EL_TEMP,YLDFAC,CRKLEN,CRKDIR,DADV,TFAIL,EL_LEN
       my_real, DIMENSION(NLAY,10)  :: PTHKF
       TARGET :: TEMPEL,BUFMAT,EPSXX,EPSYY,DEPSXX,DEPSYY,SCALE1,POSLY,THKLY
 C
@@ -485,6 +488,13 @@ c
           UVARV => BUFLY%VISC(IR,IS,IT)%VAR
           VARTMP=> BUFLY%MAT(IR,IS,IT)%VARTMP
           DIRDMG => LBUF%DMG(1:L_DMG*NEL)
+c
+          ! -> Make sure the non-local increment is positive
+          IF (INLOC > 0) THEN 
+            DO I = JFT,JLT
+              VARNL(I,IT) = MAX(VARNL(I,IT),ZERO)
+            ENDDO 
+          ENDIF
 c
           IF (JTHE == 0 .and. BUFLY%L_TEMP > 0) THEN        
              EL_TEMP => LBUF%TEMP(1:NEL)
@@ -1192,7 +1202,18 @@ C
             DMG_LOC_SCALE(1:NEL) = ONE
 c                                        
             MPT  = NPTTOT * MAX(1,NPG)
-            FBUF => BUFLY%FAIL(IR,IS,IT)                   
+            FBUF => BUFLY%FAIL(IR,IS,IT)   
+c
+            ! Length used for regularization (failure criterion parameters scaling)
+            !  -> If non-local, criterion parameters are scaled with LE_MAX parameter
+            IF (INLOC > 0) THEN 
+              LE_MAX(1:NEL) = NLOC_DMG%LE_MAX(IPM(1,MAT(1)))
+              EL_LEN => LE_MAX(1:NEL)
+            !  -> If not, criterion parameters are scaled with the element characteristic length
+            ELSE
+              EL_LEN => ALDT(1:NEL)
+            ENDIF
+c            
 C           plastic strain increment for all plastic laws                   
             IF (BUFLY%L_PLA > 0) THEN
               ! Non-local material
@@ -1493,7 +1514,7 @@ c
      2                NFUNC1    ,IFUNC1    ,TABLE     ,NPF       ,TF        ,
      3                TT        ,NGL       ,IPG       ,ILAYER    ,IT        , 
      4                SIGNXX    ,SIGNYY    ,SIGNXY    ,SIGNYZ    ,SIGNZX    ,      
-     5                DPLA      ,EPSPL     ,THKN      ,ALDT      ,TSTAR     ,
+     5                DPLA      ,EPSPL     ,THKN      ,EL_LEN    ,TSTAR     ,
      6                PTHKF(ILAYER,IFL),DMG_FLAG,DMG_LOC_SCALE ,OFF  ,FOFF      ,
      7                DFMAX     ,TDEL      ,IGTYP     )
                 ELSE
@@ -1566,7 +1587,7 @@ c
      3          SIGNXX   ,SIGNYY  ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,
      4          DPLA     ,EPSPL   ,UVARF    ,GBUF%NOFF,UELR1    ,
      5          OFF      ,OFFL    ,DFMAX    ,TDEL     ,NFUNC1   ,
-     6          IFUNC1   ,NPF     ,TF       ,ALDT     ,FOFF     , IGTYP)
+     6          IFUNC1   ,NPF     ,TF       ,EL_LEN   ,FOFF     , IGTYP)
 c
               CASE (31)     !    Anisotropic fabric failure model
 c
@@ -1606,7 +1627,7 @@ c
      4           SIGNXX   ,SIGNYY   ,SIGNXY   ,
      5           EPSXX    ,EPSYY    ,EPSXY    ,EPSYZ    ,EPSZX     ,
      6           DPLA     ,UVARF    ,UELR1    ,FOFF     ,
-     7           OFF      ,ALDT     ,AREA     ,DFMAX    ,TDEL   )
+     7           OFF      ,DFMAX    ,TDEL   )
 c
               CASE (36)     !    Visual failure model
                 CALL FAIL_VISUAL_C(                                           
@@ -1621,7 +1642,7 @@ c
      2                NFUNC1    ,IFUNC1    ,NPF       ,TF        ,
      3                TT        ,NGL       ,IPG       ,ILAYER    ,IT        , 
      4                SIGNXX    ,SIGNYY    ,SIGNXY    ,SIGNYZ    ,SIGNZX    ,      
-     5                DPLA      ,EPSPL     ,THKN      ,ALDT      ,TSTAR     ,
+     5                DPLA      ,EPSPL     ,THKN      ,EL_LEN    ,TSTAR     ,
      6                PTHKF(ILAYER,IFL)    ,OFF       ,FOFF      ,
      7                DFMAX     ,TDEL      ,IGTYP     )
                 ELSE
@@ -1643,7 +1664,7 @@ c
      3            SIGNXX   ,SIGNYY  ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,
      4            DPLA     ,EPSPL   ,UVARF    ,GBUF%NOFF,UELR1    ,
      5            OFF      ,OFFL    ,DFMAX    ,TDEL     ,NFUNC1   ,
-     6            IFUNC1   ,NPF     ,TF       ,ALDT     ,FOFF     , 
+     6            IFUNC1   ,NPF     ,TF       ,EL_LEN   ,FOFF     , 
      7            IGTYP    )
 c
               CASE (39)     !    GENE1

--- a/engine/source/materials/mat_share/usermat_solid.F
+++ b/engine/source/materials/mat_share/usermat_solid.F
@@ -101,7 +101,7 @@ Chd|====================================================================
      T                  CONDE   ,ITASK   ,IEXPAN   ,VOL_AVG ,AMU      ,
      U                  EPSTH3  ,EPSTH   ,SVISC    ,NEL     ,ETOTSH   ,
      V                  ISELECT ,TSTAR   ,MUOLD    ,AMU2    ,DPDM     ,
-     W                  RHOREF  ,RHOSP   )
+     W                  RHOREF  ,RHOSP   ,NLOC_DMG )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -109,6 +109,7 @@ C-----------------------------------------------
       USE TABLE_MOD
       USE ELBUFDEF_MOD            
       USE MESSAGE_MOD
+      USE NLOCAL_REG_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -166,13 +167,14 @@ C
      .   AL_IMP(MVSIZ),SIGNOR(MVSIZ,6),VDX(*),VDY(*),VDZ(*),
      .   SVISC(NEL,6),AMU(MVSIZ),AMU2(MVSIZ),DPDM(MVSIZ),VOL_AVG(MVSIZ),EPSTH(NEL),EPSTH3(MVSIZ),
      .   ETOTSH(NEL,6),TSTAR(MVSIZ),MUOLD(NEL),CONDE(*), RHOREF(*), RHOSP(*)
-      TARGET :: BUFMAT
+      TARGET :: BUFMAT,DELTAX
       my_real, TARGET, DIMENSION(NUVAR*LLT):: UVAR
       my_real, TARGET, DIMENSION(LLT):: UVARF1,LTEMP,TEMPEL,SCALE1,INITVARF
       TYPE (BUF_FAIL_), TARGET  :: FBUF
       TYPE (BUF_VISC_)  :: VBUF
       TYPE (TTABLE), DIMENSION(NTABLE) ::  TABLE
       TYPE (ELBUF_STRUCT_), TARGET, DIMENSION(NGROUP) :: ELBUF_TAB
+      TYPE (NLOCAL_STR_) :: NLOC_DMG 
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -208,9 +210,10 @@ C-----------------------------------------------
       my_real 
      .   RHO0(MVSIZ),BIDON1,BIDON2,BIDON3,BIDON4,BIDON5,POLD
       my_real TT_LOCAL
+      my_real, DIMENSION(NEL), TARGET  :: LE_MAX
 C----
       my_real, DIMENSION(:), POINTER  :: UPARAM,UPARAMF,UVARF,DFMAX,TDEL,EL_TEMP, 
-     .                                   YLDFAC,DAM
+     .                                   YLDFAC,DAM,EL_LEN
       TYPE(ULAWINTBUF)                :: USERBUF
       TYPE(L_BUFEL_)  ,POINTER        :: LBUF, LBUF1, LBUF2    
       TYPE(G_BUFEL_)  ,POINTER        :: GBUF      
@@ -239,6 +242,12 @@ C=======================================================================
       ENDIF
       ISEQ   = ELBUF_TAB(NG)%BUFLY(ILAY)%L_SEQ
       INLOC  = IPARG(78,NG)
+      ! Make sure that the non-local variable increment is positive
+      IF (INLOC > 0) THEN 
+        DO I = LFT,LLT
+          VARNL(I) = MAX(VARNL(I),ZERO)
+        ENDDO
+      ENDIF
       ! needed in mqviscb
       FACQ0  = ONE                          
       MX     = MAT(1)                      
@@ -1141,6 +1150,17 @@ C                  FAILURE MODEL
 C=======================================================================
       IF ((ITASK==0).AND.(IMON_MAT==1))CALL STARTIME(121,1)
       IF (NFAIL > 0) THEN
+c
+        ! Failure criterion parameters scaling
+        IF (INLOC > 0) THEN
+          ! -> Length used for failure criterion parameters scaling is LE_MAX
+          LE_MAX(1:NEL) = NLOC_DMG%LE_MAX(IPM(1,MAT(1)))
+          EL_LEN => LE_MAX(1:NEL) 
+        ELSE
+          ! -> Length used for failure criterion parameters scaling is LE_MAX
+          EL_LEN => DELTAX(1:NEL) 
+        ENDIF
+c
         IF (ELBUF_TAB(NG)%BUFLY(ILAY)%L_PLA > 0) THEN
 C for non-local plastic law
           IF (INLOC > 0) THEN 
@@ -1371,7 +1391,7 @@ C---- energy failure
 C---- tabulated failure model
                CALL FAIL_TAB_S(
      1         LLT      ,NVARF    ,NPF      ,TF       ,TT       ,        
-     2         UPARAMF     ,NGL      ,IPM      ,MAT      ,DELTAX   ,        
+     2         UPARAMF  ,NGL      ,IPM      ,MAT      ,EL_LEN   ,        
      3         S1       ,S2       ,S3       ,S4       ,S5       ,S6,    
      4         DEFP     ,DPLA     ,EPSP1    ,TSTAR    ,UVARF ,             
      5         OFF      ,IP       ,TABLE    ,DFMAX    ,TDEL  ,
@@ -1411,7 +1431,7 @@ c  --- Biquadratic failure model
      3        NGL      ,IPM      ,MAT      ,                   
      4        S1       ,S2       ,S3       ,S4       ,S5       ,S6 ,
      5        DPLA     ,EPSP1    ,TSTAR    ,UVARF    ,OFF,IP   ,
-     6        DFMAX    ,TDEL     ,DELTAX)    
+     6        DFMAX    ,TDEL     ,EL_LEN   )    
           ELSEIF (IRUPT == 33) THEN                                
 c  --- Mullins Ogden-Roxburgh dammage model                                  
               CALL FAIL_MULLINS_OR_S(
@@ -1429,7 +1449,7 @@ C  --- Cockroft-Latham failure model
      4        ES1     ,ES2       ,ES3      ,ES4      ,ES5           ,ES6 ,
      5        S1      ,S2        ,S3       ,S4       ,S5            ,S6  ,
      6        DEFP    ,DPLA      ,EPSP     ,UVARF    ,OFF           ,
-     7        DELTAX  ,VOLN      ,DFMAX    ,TDEL) 
+     7        DFMAX   ,TDEL      ) 
           ELSEIF (IRUPT == 36) THEN                                           
 C  --- VISUAL failure model             
               CALL FAIL_VISUAL_S(
@@ -1442,7 +1462,7 @@ c
 c ---       tabulated failure model (old, obsolete version)
               CALL FAIL_TAB_OLD_S(
      1         LLT      ,NVARF    ,NPF      ,TF       ,TT       ,        
-     2         UPARAMF     ,NGL      ,IPM      ,MAT      ,DELTAX   ,        
+     2         UPARAMF  ,NGL      ,IPM      ,MAT      ,EL_LEN   ,        
      3         S1       ,S2       ,S3       ,S4       ,S5       ,S6,    
      4         DEFP     ,DPLA     ,EPSP1    ,TSTAR    ,UVARF ,             
      5         OFF      ,IP       ,DFMAX    ,TDEL     ,
@@ -1455,7 +1475,7 @@ c  --- Orthotropic biquadratic failure model
      2          NPF      ,TF       ,TT       ,DT1      ,UPARAMF  ,
      3          NGL      ,DPLA     ,EPSP1    ,UVARF    ,OFF      ,              
      4          S1       ,S2       ,S3       ,S4       ,S5       ,S6       ,
-     5          DFMAX    ,TDEL     ,DELTAX   )  
+     5          DFMAX    ,TDEL     ,EL_LEN   )  
 c
           ELSEIF (IRUPT == 39) THEN                                      
 c  --- GENE1 failure model                                  

--- a/starter/source/materials/fail/biquad/hm_read_fail_biquad.F
+++ b/starter/source/materials/fail/biquad/hm_read_fail_biquad.F
@@ -87,7 +87,7 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER   :: MFLAG,SFLAG,REG_FUNC
-      my_real   :: C1,C2,C3,C4,C5,E1,E2,E3,E4,PTHK,INST,REF_LEN
+      my_real   :: C1,C2,C3,C4,C5,E1,E2,E3,E4,PTHK,INST,REF_LEN,REF_SIZ_UNIT
       my_real   :: X_1(2)
       my_real   :: X_2(3)
       LOGICAL   :: IS_AVAILABLE,IS_CRYPTED
@@ -115,7 +115,11 @@ c
       CALL HM_GET_INTV   ('S_Flag'      ,SFLAG       ,IS_AVAILABLE,LSUBMODEL)
       CALL HM_GET_FLOATV ('Inst_start'  ,INST        ,IS_AVAILABLE,LSUBMODEL,UNITAB)  
       CALL HM_GET_INTV   ('fct_IDel'    ,REG_FUNC    ,IS_AVAILABLE,LSUBMODEL)
-      CALL HM_GET_FLOATV ('EI_ref'      ,REF_LEN     ,IS_AVAILABLE,LSUBMODEL,UNITAB)  
+      CALL HM_GET_FLOATV ('EI_ref'      ,REF_LEN     ,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      IF (REG_FUNC > 0 .AND. REF_LEN == ZERO) THEN 
+        CALL HM_GET_FLOATV_DIM('EI_ref' ,REF_SIZ_UNIT,IS_AVAILABLE, LSUBMODEL, UNITAB)
+        REF_LEN = ONE*REF_SIZ_UNIT
+      ENDIF  
 c---------------------------------------------------
 c     Optional input
 c---------------------------------------------------


### PR DESCRIPTION
Add failure criteria parameters scaling with LE_MAX non-local parameter

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Add the possibility to take into account the LE_MAX parameter of non-local method to scale some failure criteria parameters (BIQUAD, TAB ...). This will help some identification issues encountered by Stellantis. 

A small bug was found for BIQUAD in the starter. A default value was missing for the reference length which can lead to a Nan issue in the engine. 

Potential checkbound bug was found in COCKROFT failure model routine. Some input arguments were not correctly sized (but were not used).

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

The modification for shells and solids was done to take into account LE_MAX non-local constant value instead of element length for scaling the failure criteria parameters. 

The missing default value in /FAIL/BIQUAD reading routine was added/ 

The unused arguments of /FAIL/COCKROFT routine were removed following Romain's advises. 

