### PR TITLE
Fix default value of EUTS in Law2 when Iflag=1

### DIFF
--- a/starter/source/materials/mat/mat002/hm_read_mat02.F
+++ b/starter/source/materials/mat/mat002/hm_read_mat02.F
@@ -234,42 +234,44 @@ C-----------------------------------------------
       ENDIF
 
       IF(MFLAG == 0) THEN
-          IF(IFLAG == 0) THEN
-            IF(CN == ZERO)   CN    = ONE
-           ELSE
-            CB0= CB
-            RM = CB *(ONE+CN)
-            AG = LOG(ONE+CN)
-            CN0= CN
-            CN = RM*AG / (RM-CA)
-            CB = RM/(CN*AG**(CN-ONE))
-            IF (CN .GT. ONE) THEN
-              CN = ONE
-              CB = (CB0*(ONE+CN0)-CA)/(LOG(1+CN0)-CB0*(1+CN0)/YOUNG-CA/YOUNG)
-              CALL ANCMSG(MSGID=277,
-     .                    MSGTYPE=MSGWARNING,
-     .                    ANMODE=ANINFO_BLIND_1,
-     .                    I1=ID, 
-     .                    C1=TITR)
-            ENDIF
-            IF (CN .LT. ZERO .AND. CB .LT. ZERO) THEN
-              CN = ZERO
-              CB = ZERO          
-              CALL ANCMSG(MSGID=278,
-     .                    MSGTYPE=MSGWARNING,
-     .                    ANMODE=ANINFO_BLIND_1,
-     .                    I1=ID, 
-     .                    C1=TITR)
-            ENDIF
+        ! Exponent must be set to one if equals to zero in the input
+        ! in any case (Iflag=0 or Iflag=1)
+        IF (CN == ZERO) CN = ONE
+        ! If Iflag == 1, parameters B and n must be recomputed
+        IF (IFLAG == 1) THEN
+          CB0 = CB
+          RM  = CB *(ONE+CN)
+          AG  = LOG(ONE+CN)
+          CN0 = CN
+          CN  = RM*AG / (RM-CA)
+          CB  = RM/(CN*AG**(CN-ONE))
+          IF (CN .GT. ONE) THEN
+            CN = ONE
+            CB = (CB0*(ONE+CN0)-CA)/(LOG(1+CN0)-CB0*(1+CN0)/YOUNG-CA/YOUNG)
+            CALL ANCMSG(MSGID=277,
+     .                  MSGTYPE=MSGWARNING,
+     .                  ANMODE=ANINFO_BLIND_1,
+     .                  I1=ID, 
+     .                  C1=TITR)
           ENDIF
-        ELSE      ! small material database, materials as in /FAIL/BiQUAD
-          IF     (MFLAG >= 1) THEN ! Mild Seel unit = Ton, sec, mm
-            FAC_M = FAC_M_WORK                        
-            FAC_L = FAC_L_WORK
-            FAC_T = FAC_T_WORK
-            FAC_PRES = FAC_M/ (FAC_L*FAC_T*FAC_T)                      
-            FAC_DENS = FAC_M/ (FAC_L*FAC_L*FAC_L)
-            SELECT CASE (MFLAG)
+          IF (CN .LT. ZERO .AND. CB .LT. ZERO) THEN
+            CN = ZERO
+            CB = ZERO          
+            CALL ANCMSG(MSGID=278,
+     .                  MSGTYPE=MSGWARNING,
+     .                  ANMODE=ANINFO_BLIND_1,
+     .                  I1=ID, 
+     .                  C1=TITR)
+          ENDIF
+        ENDIF
+      ELSE      ! small material database, materials as in /FAIL/BiQUAD
+        IF (MFLAG >= 1) THEN ! Mild Seel unit = Ton, sec, mm
+          FAC_M = FAC_M_WORK                        
+          FAC_L = FAC_L_WORK
+          FAC_T = FAC_T_WORK
+          FAC_PRES = FAC_M/ (FAC_L*FAC_T*FAC_T)                      
+          FAC_DENS = FAC_M/ (FAC_L*FAC_L*FAC_L)
+          SELECT CASE (MFLAG)
             CASE(1)                                ! Mild steel
 c!            RHO0  = 7.85d-9          * FAC_DENS
               RHO0  = 7850d0           / FAC_DENS
@@ -344,8 +346,8 @@ c!            YOUNG = 210000.0d0       * FAC_PRES
               CA    = 160000000.0d0    / FAC_PRES
               CB    = 513330169.33870d0/ FAC_PRES      
               CN    = 0.3257084899598d0
-            END SELECT
-          ENDIF
+          END SELECT
+        ENDIF
       ENDIF       
 C-----
       IF(CC > ZERO .AND. EPS0 > ZERO  .AND. FCUT == ZERO) THEN


### PR DESCRIPTION
Fix default value of EUTS in Law2 when Iflag=1

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

When using Iflag = 1, the default value of EUTS was not set to one (as specified in the doc) but zero. The problem is that it is used in the starter to compute some parameters, and it is used as a denominator leading to NaN parameters value.  

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Set EUTS default value to one when using Iflag=1 (same as Iflag=0). (The indentation of the corresponding conditional loop was also revised for a better reading and some comments were added to help the reviewer). 
