### PR TITLE
/FVMBAG : dtold in restart files

### DIFF
--- a/engine/source/airbag/fvbag.F
+++ b/engine/source/airbag/fvbag.F
@@ -528,6 +528,11 @@ C---------------------------------------------------
 !$OMP END DO
 !$OMP DO SCHEDULE(GUIDED,1)
       DO IEL=1,NELT
+        FEL(IEL)=ZERO
+      ENDDO
+!$OMP END DO
+!$OMP DO SCHEDULE(GUIDED,1)
+      DO IEL=1,NELT
          N1=ELEM(1,IEL)
          N2=ELEM(2,IEL)
          N3=ELEM(3,IEL)
@@ -1595,9 +1600,11 @@ C
                   !loop over triangles
                   DO K=IFVTADR(JJ),IFVTADR(JJ+1)-1
                      KK  =IFVPOLY(K)
-                     WSURF(1)=WSURF(1)+VGRID(1,KK)
-                     WSURF(2)=WSURF(2)+VGRID(2,KK)
-                     WSURF(3)=WSURF(3)+VGRID(3,KK)
+                     IF(KK>0)THEN
+                       WSURF(1)=WSURF(1)+VGRID(1,KK)
+                       WSURF(2)=WSURF(2)+VGRID(2,KK)
+                       WSURF(3)=WSURF(3)+VGRID(3,KK)
+                     ENDIF
                   ENDDO! next K (triangle)
                   PW(1,I)=PW(1,I)+WSURF(1)
                   PW(2,I)=PW(2,I)+WSURF(2)

--- a/engine/source/output/restart/rdresb.F
+++ b/engine/source/output/restart/rdresb.F
@@ -2104,6 +2104,8 @@ C--------------------------------------
          ENDIF
 C
       ENDDO
+      
+      CALL READ_DB(FVMBAG_DTOLD,1)      
 C
       RETURN
       END

--- a/engine/source/output/restart/wrrest.F
+++ b/engine/source/output/restart/wrrest.F
@@ -670,6 +670,8 @@ C--------------------------------------
          ENDIF
 C
       ENDDO
+      
+      CALL WRITE_DB(FVMBAG_DTOLD,1)      
 C
       RETURN
       END

--- a/starter/share/modules1/fvbag_mod.F
+++ b/starter/share/modules1/fvbag_mod.F
@@ -126,6 +126,7 @@ C-----------------------------------------------
       TYPE(FVBAG_DATA), DIMENSION(:), ALLOCATABLE :: FVDATA
       TYPE(FVBAG_SPMD), DIMENSION(:), ALLOCATABLE :: FVSPMD
       INTEGER, DIMENSION(:), ALLOCATABLE :: FVID
+      my_real :: FVMBAG_DTOLD
 
 c after bug detected on fvmbags qa after starter paralellization
 !$OMP THREADPRIVATE(FVSPMD) 

--- a/starter/source/restart/ddsplit/fvwrestp.F
+++ b/starter/source/restart/ddsplit/fvwrestp.F
@@ -193,6 +193,10 @@ C
          ENDIF
 C
       ENDDO
+      
+      FVMBAG_DTOLD = EP20
+      CALL WRITE_DB(FVMBAG_DTOLD,1)
+      
       IF (ALLOCATED(FVSPMD)) DEALLOCATE(FVSPMD)
 C
       RETURN


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
/FVMBAG : dtold in restart files
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
Value FVMBAG_DTOLD was introduced. It must be transmitted through restart files to make possible to launch correctly an additional run after the end of the first simulation time.


