### PR TITLE
Fix non-local compatibility with Ishell=12 and /DT/NODA

### DIFF
--- a/engine/source/elements/shell/coqueba/cbafint_reg.F
+++ b/engine/source/elements/shell/coqueba/cbafint_reg.F
@@ -382,21 +382,21 @@ c
             ENDIF
             NTN_VNL2 = SF2*SF1*VNL(POS1(I)+K-1) + SF2*SF2*VNL(POS2(I)+K-1) + SF2*SF3*VNL(POS3(I)+K-1) + SF2*SF4*VNL(POS4(I)+K-1)
             IF (NODADT > 0) THEN 
-              NTN_VNL1 = SF2*SF1*(SQRT(MASS(POS1(I)+K-1)/MASS0(POS1(I)+K-1)))*VNL(POS1(I)+K-1) + 
+              NTN_VNL2 = SF2*SF1*(SQRT(MASS(POS1(I)+K-1)/MASS0(POS1(I)+K-1)))*VNL(POS1(I)+K-1) + 
      .                   SF2*SF2*(SQRT(MASS(POS2(I)+K-1)/MASS0(POS2(I)+K-1)))*VNL(POS2(I)+K-1) + 
      .                   SF2*SF3*(SQRT(MASS(POS3(I)+K-1)/MASS0(POS3(I)+K-1)))*VNL(POS3(I)+K-1) + 
      .                   SF2*SF4*(SQRT(MASS(POS4(I)+K-1)/MASS0(POS4(I)+K-1)))*VNL(POS4(I)+K-1)
             ENDIF
             NTN_VNL3 = SF3*SF1*VNL(POS1(I)+K-1) + SF3*SF2*VNL(POS2(I)+K-1) + SF3*SF3*VNL(POS3(I)+K-1) + SF3*SF4*VNL(POS4(I)+K-1)
             IF (NODADT > 0) THEN 
-              NTN_VNL1 = SF3*SF1*(SQRT(MASS(POS1(I)+K-1)/MASS0(POS1(I)+K-1)))*VNL(POS1(I)+K-1) + 
+              NTN_VNL3 = SF3*SF1*(SQRT(MASS(POS1(I)+K-1)/MASS0(POS1(I)+K-1)))*VNL(POS1(I)+K-1) + 
      .                   SF3*SF2*(SQRT(MASS(POS2(I)+K-1)/MASS0(POS2(I)+K-1)))*VNL(POS2(I)+K-1) + 
      .                   SF3*SF3*(SQRT(MASS(POS3(I)+K-1)/MASS0(POS3(I)+K-1)))*VNL(POS3(I)+K-1) + 
      .                   SF3*SF4*(SQRT(MASS(POS4(I)+K-1)/MASS0(POS4(I)+K-1)))*VNL(POS4(I)+K-1)
             ENDIF
             NTN_VNL4 = SF4*SF1*VNL(POS1(I)+K-1) + SF4*SF2*VNL(POS2(I)+K-1) + SF4*SF3*VNL(POS3(I)+K-1) + SF4*SF4*VNL(POS4(I)+K-1)
             IF (NODADT > 0) THEN 
-              NTN_VNL1 = SF4*SF1*(SQRT(MASS(POS1(I)+K-1)/MASS0(POS1(I)+K-1)))*VNL(POS1(I)+K-1) + 
+              NTN_VNL4 = SF4*SF1*(SQRT(MASS(POS1(I)+K-1)/MASS0(POS1(I)+K-1)))*VNL(POS1(I)+K-1) + 
      .                   SF4*SF2*(SQRT(MASS(POS2(I)+K-1)/MASS0(POS2(I)+K-1)))*VNL(POS2(I)+K-1) + 
      .                   SF4*SF3*(SQRT(MASS(POS3(I)+K-1)/MASS0(POS3(I)+K-1)))*VNL(POS3(I)+K-1) + 
      .                   SF4*SF4*(SQRT(MASS(POS4(I)+K-1)/MASS0(POS4(I)+K-1)))*VNL(POS4(I)+K-1)

--- a/starter/source/materials/fail/nloc_dmg_init.F
+++ b/starter/source/materials/fail/nloc_dmg_init.F
@@ -114,7 +114,7 @@ C-----------------------------------------------
       ! Safety coefficient for non-local stability vs mechanical stability
       ! (here we have a good compromise to find, DENS must be as low as 
       !  possible but sufficiently high to avoid the decrease of the timestep)
-      my_real, PARAMETER                   :: CSTA = 20.0D0
+      my_real, PARAMETER                   :: CSTA = 40.0D0
       ! Position of integration points in the thickness
       DATA  Z01/
      1 0.       ,0.       ,0.       ,0.       ,0.       ,


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

NTN_VNL1 was overwritten several time for Ishell = 12 when using non-local and /DT/NODA. It was re-computed instead of computing NTN_VNL2,NTN_VNL3 and NTN_VNL4

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Change NTN_VNL1 to NTN_VNL2, NTN_VNL3 ... And increase the CSTA parameter in the starter to the same value we are using in the engine for non-local regularization. This improves the stability. 
