### PR TITLE
Fix internal user ID and shell /FAIL/TAB for parameter scaling with LE_MAX

### DIFF
--- a/engine/source/materials/fail/tabulated/fail_tab_c.F
+++ b/engine/source/materials/fail/tabulated/fail_tab_c.F
@@ -41,7 +41,7 @@ Chd|====================================================================
      4           SIGNXX   ,SIGNYY   ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,
      5           DPLA     ,EPSP     ,THK      ,ALDT     ,TEMP     ,
      6           PTHKF    ,DMG_FLAG ,DMG_SCALE,OFF      ,FOFF     ,
-     7           DFMAX    ,TDEL     ,IGTYP    )
+     7           DFMAX    ,TDEL     ,IGTYP    ,INLOC    )
 C-----------------------------------------------
 C    tabulated failure model
 C-----------------------------------------------
@@ -91,7 +91,7 @@ C IPT                         CURRENT INTEGRATION POINT IN THE LAYER
 C-----------------------------------------------
 C   I N P U T   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER ,INTENT(IN) :: NEL,NUPARAM,NUVAR,IPG,ILAY,IPT,IGTYP
+      INTEGER ,INTENT(IN) :: NEL,NUPARAM,NUVAR,IPG,ILAY,IPT,IGTYP,INLOC
       INTEGER ,DIMENSION(NEL) ,INTENT(IN) :: NGL
       my_real ,INTENT(IN) :: TIME
       my_real ,DIMENSION(NEL) ,INTENT(IN)    :: OFF,THK,ALDT,DPLA,EPSP,
@@ -196,6 +196,7 @@ C---------
       NINDX   = 0  
       NINSTAB = 0
       DO I=1,NEL
+        IF (INLOC > 0) UVAR(I,5) = ALDT(I)
         IF (OFF(I) == ONE .and. FOFF(I) == 1) THEN
           NINDX = NINDX+1                                                 
           INDX(NINDX) = I

--- a/engine/source/materials/mat_share/mmain.F
+++ b/engine/source/materials/mat_share/mmain.F
@@ -1538,7 +1538,7 @@ C------------------------------------------------------------
         INLOC = IPARG(78,NG)
         IF (INLOC > 0) THEN
           ! -> Length used for failure criterion parameters scaling is LE_MAX
-          LE_MAX(1:NEL) = NLOC_DMG%LE_MAX(IPM(1,MAT(1)))
+          LE_MAX(1:NEL) = NLOC_DMG%LE_MAX(MAT(1))
           EL_LEN => LE_MAX(1:NEL) 
           ! -> Copying the non-local plastic strain increment
           IF (ELBUF_TAB(NG)%BUFLY(ILAY)%L_PLA > 0) THEN 

--- a/engine/source/materials/mat_share/mulaw.F
+++ b/engine/source/materials/mat_share/mulaw.F
@@ -1662,7 +1662,7 @@ c
         ! Failure criterion parameters scaling
         IF (INLOC > 0) THEN
           ! -> Length used for failure criterion parameters scaling is LE_MAX
-          LE_MAX(1:NEL) = NLOC_DMG%LE_MAX(IPM(1,MAT(1)))
+          LE_MAX(1:NEL) = NLOC_DMG%LE_MAX(MAT(1))
           EL_LEN => LE_MAX(1:NEL) 
         ELSE
           ! -> Length used for failure criterion parameters scaling is LE_MAX

--- a/engine/source/materials/mat_share/mulawc.F
+++ b/engine/source/materials/mat_share/mulawc.F
@@ -1692,7 +1692,7 @@ c
             ! Length used for regularization (failure criterion parameters scaling)
             !  -> If non-local, criterion parameters are scaled with LE_MAX parameter
             IF (INLOC > 0) THEN 
-              LE_MAX(1:NEL) = NLOC_DMG%LE_MAX(IPM(1,MAT(1)))
+              LE_MAX(1:NEL) = NLOC_DMG%LE_MAX(MAT(1))
               EL_LEN => LE_MAX(1:NEL)
             !  -> If not, criterion parameters are scaled with the element characteristic length
             ELSE
@@ -2001,7 +2001,7 @@ c
      4                SIGNXX    ,SIGNYY    ,SIGNXY    ,SIGNYZ    ,SIGNZX    ,      
      5                DPLA      ,EPSPL     ,THKN      ,EL_LEN    ,TSTAR     ,
      6                PTHKF(ILAYER,IFL),DMG_FLAG,DMG_LOC_SCALE ,OFF  ,FOFF      ,
-     7                DFMAX     ,TDEL      ,IGTYP     )
+     7                DFMAX     ,TDEL      ,IGTYP     ,INLOC   )
                 ELSE
                   CALL FAIL_TAB_XFEM(
      1                NEL      ,NUPAR    ,NVARF    ,NPF      ,TF       ,

--- a/engine/source/materials/mat_share/usermat_shell.F
+++ b/engine/source/materials/mat_share/usermat_shell.F
@@ -1208,7 +1208,7 @@ c
             ! Length used for regularization (failure criterion parameters scaling)
             !  -> If non-local, criterion parameters are scaled with LE_MAX parameter
             IF (INLOC > 0) THEN 
-              LE_MAX(1:NEL) = NLOC_DMG%LE_MAX(IPM(1,MAT(1)))
+              LE_MAX(1:NEL) = NLOC_DMG%LE_MAX(MAT(1))
               EL_LEN => LE_MAX(1:NEL)
             !  -> If not, criterion parameters are scaled with the element characteristic length
             ELSE
@@ -1517,7 +1517,7 @@ c
      4                SIGNXX    ,SIGNYY    ,SIGNXY    ,SIGNYZ    ,SIGNZX    ,      
      5                DPLA      ,EPSPL     ,THKN      ,EL_LEN    ,TSTAR     ,
      6                PTHKF(ILAYER,IFL),DMG_FLAG,DMG_LOC_SCALE ,OFF  ,FOFF      ,
-     7                DFMAX     ,TDEL      ,IGTYP     )
+     7                DFMAX     ,TDEL      ,IGTYP     ,INLOC     )
                 ELSE
                   CALL FAIL_TAB_XFEM(
      1                NEL      ,NUPAR    ,NVARF    ,NPF      ,TF       ,

--- a/engine/source/materials/mat_share/usermat_solid.F
+++ b/engine/source/materials/mat_share/usermat_solid.F
@@ -1155,7 +1155,7 @@ c
         ! Failure criterion parameters scaling
         IF (INLOC > 0) THEN
           ! -> Length used for failure criterion parameters scaling is LE_MAX
-          LE_MAX(1:NEL) = NLOC_DMG%LE_MAX(IPM(1,MAT(1)))
+          LE_MAX(1:NEL) = NLOC_DMG%LE_MAX(MAT(1))
           EL_LEN => LE_MAX(1:NEL) 
         ELSE
           ! -> Length used for failure criterion parameters scaling is LE_MAX


### PR DESCRIPTION
Fix internal user ID and shell /FAIL/TAB for parameter scaling with LE_MAX

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

The feature of parameter scaling with non-local length LE_MAX was not working properly for /FAIL/TAB for shells. More over, the user ID of materials was used to recover the value of LE_MAX instead of the internal ID. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

/FAIL/TAB for shells needed an additional operation and user ID were switched by internal IDs to recover LE_MAX value.
