### PR TITLE
Fix cfg file, strain-rate filtering and element size scaling for /FAIL/ORTHSTRAIN

### DIFF
--- a/engine/source/materials/fail/orthstrain/fail_orthstrain_c.F
+++ b/engine/source/materials/fail/orthstrain/fail_orthstrain_c.F
@@ -133,14 +133,14 @@ C-----------------------------------------------
 C=======================================================================
 C     USER VARIABLES INITIALIZATION
 C-----------------------------------------------
-      DMG_FLAG = INT(UPARAM(1))
-      PTHKF  = UPARAM(2)
-      ALPHA  = UPARAM(16)
-      EPSPREF= UPARAM(17)
+      DMG_FLAG   = INT(UPARAM(1))
+      PTHKF      = UPARAM(2)
+      ALPHA      = MIN(TWO*PI*UPARAM(16)*TIMESTEP,ONE)
+      EPSPREF    = UPARAM(17)
       FSCALE_SIZ = UPARAM(26)
       REF_SIZ    = UPARAM(27)
       STRDEF     = NINT(UPARAM(28))
-      IFUNC_SIZ = IFUNC(13)
+      IFUNC_SIZ  = IFUNC(13)
 c
 c     et1  = mode1 , et2  = mode 2, ec1 = mode 3, ec2 = mode 4, 
 c     et12 = mode 5, ec12 = mode 6
@@ -161,14 +161,14 @@ c-------------------
         IF (ISMSTR == 1 .OR. ISMSTR == 3 .OR. ISMSTR == 11) THEN
           STRFLAG = 3
         END IF
-      END IF           
+      END IF     
 c--------------------------
       SELECT CASE (STRFLAG)
 c
         CASE (2)  !  transform true strain to engineering
           DO I=1,NEL
             IF (OFF(I) == ONE ) THEN
-              THETA  = HALF*ATAN(EPSXY(I) / (EPSXX(I)-EPSYY(I)))
+              THETA  = HALF*ATAN(EPSXY(I) / MAX((EPSXX(I)-EPSYY(I)),EM20))
               C = COS(THETA)
               S = SIN(THETA)
 c             strain principal + transformation              
@@ -190,14 +190,14 @@ c             strain rate
               EPSD2  = (ONE+EPST2)*EPSD2
               EPSP11(I) = C*C*EPSD1 + S*S*EPSD2
               EPSP22(I) = S*S*EPSD1 + C*C*EPSD2
-              EPSP12(I) = S*C*(EPSD2 - EPSD1)  
+              EPSP12(I) = S*C*(EPSD2 - EPSD1) 
             END IF
           ENDDO
 c
         CASE (3)  !  transform engineering to true strain
           DO I=1,NEL
             IF (OFF(I) == ONE ) THEN
-              THETA  = HALF*ATAN(EPSXY(I) / (EPSXX(I)-EPSYY(I)))
+              THETA  = HALF*ATAN(EPSXY(I) / MAX((EPSXX(I)-EPSYY(I)),EM20))
               C = COS(THETA)
               S = SIN(THETA)
 c             strain principal + transformation              
@@ -231,21 +231,21 @@ c
            EPSP11(1:NEL) = EPSPXX(1:NEL)
            EPSP22(1:NEL) = EPSPYY(1:NEL)
            EPSP12(1:NEL) = HALF*EPSPXY(1:NEL)
-      END SELECT
+      END SELECT 
 c----------------------------------------------
 c     Element size scale factor
       FSIZE => UVAR(1:NEL,32)
 c
       IF (TIME == ZERO) THEN
         IF (IFUNC_SIZ > 0) THEN
-	         ESCAL(1:NEL) = FSCALE_SIZ * ALDT(1:NEL) / REF_SIZ
+	        ESCAL(1:NEL) = ALDT(1:NEL) / REF_SIZ
           IPOSP(1:NEL) = 0
           IADP (1:NEL) = NPF(IFUNC_SIZ) / 2 + 1
           ILENP(1:NEL) = NPF(IFUNC_SIZ  + 1) / 2 - IADP(1:NEL)
-c
           CALL VINTER2(TF,IADP,IPOSP,ILENP,NEL,ESCAL,DYDXE,FSIZE)
+          FSIZE(1:NEL) = FSCALE_SIZ * FSIZE(1:NEL)
         ELSE
-	         FSIZE(1:NEL) = ONE
+	        FSIZE(1:NEL) = ONE
         ENDIF
       ENDIF
 c
@@ -313,7 +313,7 @@ c
           ELSE
             FRATE = ONE
           ENDIF
-		        FRATE = FRATE*FSIZE(I)
+		      FRATE = FRATE*FSIZE(I)
           ET1M = FRATE * ET1M
           ET1  = FRATE * ET1
           DEPS = EPS11(I) - ET1

--- a/engine/source/materials/fail/orthstrain/fail_orthstrain_s.F
+++ b/engine/source/materials/fail/orthstrain/fail_orthstrain_s.F
@@ -127,8 +127,8 @@ C-----------------------------------------------
      .         EPSPTENS(3,3),EPSPTENS2(3,3),EPSP_PR(3)
       INTEGER  NROT,K,L,M
 C=======================================================================
-      ALPHA  = UPARAM(16)
-      EPSPREF= UPARAM(17)
+      ALPHA      = MIN(TWO*PI*UPARAM(16)*TIMESTEP,ONE)
+      EPSPREF    = UPARAM(17)
       FSCALE_SIZ = UPARAM(26)
       REF_SIZ    = UPARAM(27)
       STRDEF     = NINT(UPARAM(28))
@@ -145,7 +145,7 @@ c-------------------
         IF (ISMSTR == 1 .OR. ISMSTR == 3 .OR. ISMSTR == 11) THEN
           STRFLAG = 3
         END IF
-      END IF           
+      END IF         
 c--------------------------
       SELECT CASE (STRFLAG)
 c
@@ -359,14 +359,14 @@ c
 c------------------------------
 c     Element size scale factor
       IF (IFUNC_SIZ > 0) THEN
-	       ESCAL(1:NEL) = FSCALE_SIZ * DELTAX(1:NEL) / REF_SIZ
+	      ESCAL(1:NEL) = DELTAX(1:NEL) / REF_SIZ
         IPOSP(1:NEL) = NINT(UVAR(1:NEL,32))
         IADP (1:NEL) = NPF(IFUNC_SIZ) / 2 + 1
         ILENP(1:NEL) = NPF(IFUNC_SIZ  + 1) / 2 - IADP(1:NEL) - IPOSP(1:NEL)
-c
         CALL VINTER2(TF,IADP,IPOSP,ILENP,NEL,ESCAL,DYDX,FSIZE)
+        FSIZE(1:NEL) = FSCALE_SIZ * FSIZE(1:NEL)
       ELSE
-	       FSIZE(1:NEL) = ONE
+	      FSIZE(1:NEL) = ONE
       ENDIF
 c------------------------------
 c

--- a/hm_cfg_files/config/CFG/radioss2021/FAIL/fail_orthstrain.cfg
+++ b/hm_cfg_files/config/CFG/radioss2021/FAIL/fail_orthstrain.cfg
@@ -131,45 +131,6 @@ FORMAT(radioss2021) {
 		
 }       		
 
-FORMAT(radioss2021) {
-	HEADER("/FAIL/ORTHSTRAIN/%d",mat_id);
-
-	COMMENT("#                                   PTHK");
-	CARD("                    %20lg",Pthk);
-	
-	COMMENT("#    EPSILON_DOT_REF                FCUT");
-	CARD("%20lg%20lg",Epsilon_Dot_ref,Fcut);
-	
-	COMMENT("#           FCT_IDEL           FSCALE_EL              EI_REF");
-	CARD("%20lg%20lg%20lg",fct_IDel,Fscale_el,EI_ref);
-	
-	COMMENT("#       EPSILON_11TF        EPSILON_11TM FCT_ID11T        EPSILON_11CF        EPSILON_11CM FCT_ID_11C");
-	CARD("%20lg%20lg%10d%20lg%20lg%10d",Epsilon_11tf,Epsilon_11tm,Fct_ID_11t,Epsilon_11cf,Epsilon_11cm,Fct_ID_11c);
-	
-	COMMENT("#       EPSILON_22TF        EPSILON_22TM FCT_ID22T        EPSILON_22CF        EPSILON_22CM FCT_ID_22C");
-	CARD("%20lg%20lg%10d%20lg%20lg%10d",Epsilon_22tf,Epsilon_22tm,Fct_ID_22t,Epsilon_22cf,Epsilon_22cm,Fct_ID_22c);
-	
-	COMMENT("#       EPSILON_33TF        EPSILON_33TM FCT_ID33T        EPSILON_33CF        EPSILON_33CM FCT_ID_33C");
-	CARD("%20lg%20lg%10d%20lg%20lg%10d",Epsilon_33tf,Epsilon_33tm,Fct_ID_33t,Epsilon_33cf,Epsilon_33cm,Fct_ID_33c);
-	
-	COMMENT("#       EPSILON_12TF        EPSILON_12TM FCT_ID12T        EPSILON_12CF        EPSILON_12CM FCT_ID_12C");
-	CARD("%20lg%20lg%10d%20lg%20lg%10d",Epsilon_12tf,Epsilon_12tm,Fct_ID_12t,Epsilon_12cf,Epsilon_12cm,Fct_ID_12c);
-	
-	COMMENT("#       EPSILON_23TF        EPSILON_23TM FCT_ID23T        EPSILON_23CF        EPSILON_23CM FCT_ID_23C");
-	CARD("%20lg%20lg%10d%20lg%20lg%10d",Epsilon_23tf,Epsilon_23tm,Fct_ID_23t,Epsilon_23cf,Epsilon_23cm,Fct_ID_23c);
-	
-	COMMENT("#       EPSILON_31TF        EPSILON_31TM FCT_ID31T        EPSILON_31CF        EPSILON_31CM FCT_ID_31C");
-	CARD("%20lg%20lg%10d%20lg%20lg%10d",Epsilon_31tf,Epsilon_31tm,Fct_ID_31t,Epsilon_31cf,Epsilon_31cm,Fct_ID_31c);
-	
-	if (ID_CARD_EXIST==TRUE)
-	{
-	 COMMENT("#  FAIL_ID") ;
-	}
-	FREE_CARD(ID_CARD_EXIST,"%10d", _ID_);
-		
-}       		
-
-
 FORMAT(radioss2018) {
 	HEADER("/FAIL/ORTHSTRAIN/%d",mat_id);
 

--- a/starter/source/materials/fail/orthstrain/hm_read_fail_orthstrain.F
+++ b/starter/source/materials/fail/orthstrain/hm_read_fail_orthstrain.F
@@ -95,12 +95,12 @@ C MODIFIED ARGUMENT
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER IDAM,ISOLID,NCYCLE,FT1,FT2,FT12,FC1,FC2,FC12,STRDEF
+      INTEGER IDAM,ISOLID,FT1,FT2,FT12,FC1,FC2,FC12,STRDEF
       my_real 
      .    EPSPREF,ET1,ET2,ET12,EC1,EC2,EC12,ET3,EC3,EC23,ET23,EC31,ET31,
      .    ET1M,ET2M,ET12M,EC1M,EC2M,EC12M,ET3M,EC3M,EC23M,ET23M,EC31M,ET31M,
      .    FAC_M,FAC_L,FAC_T,FAC_E,PTHK,ALPHA,FSCALE_SIZ,REF_SIZ,
-     .    EPSPREF_UNIT,FSCAL_UNIT,REF_SIZ_UNIT
+     .    EPSPREF_UNIT,FSCAL_UNIT,REF_SIZ_UNIT,FCUT
       LOGICAL :: IS_AVAILABLE,IS_CRYPTED
 C=======================================================================
       IS_CRYPTED   = .FALSE.
@@ -116,7 +116,7 @@ C--------------------------------------------------
       CALL HM_GET_INTV           ('Strdef'           ,STRDEF        ,IS_AVAILABLE,LSUBMODEL)
 c
       CALL HM_GET_FLOATV         ('Epsilon_Dot_ref'  ,EPSPREF       ,IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_INTV           ('Fcut'             ,NCYCLE        ,IS_AVAILABLE,LSUBMODEL)
+      CALL HM_GET_FLOATV         ('Fcut'             ,FCUT          ,IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_INTV           ('fct_IDel'         ,IFUNC(13)     ,IS_AVAILABLE,LSUBMODEL)
       CALL HM_GET_FLOATV         ('Fscale_el'        ,FSCALE_SIZ    ,IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV         ('EI_ref'           ,REF_SIZ       ,IS_AVAILABLE,LSUBMODEL,UNITAB)
@@ -194,8 +194,7 @@ c-----------------------------------------------------
       IF (EC3   == ZERO) EC3 = ET3
       IF (EC3M  == ZERO) EC3M = 1.2*EC3
       IF (PTHK  == ZERO) PTHK = ONE
-      IF (NCYCLE == 0)   NCYCLE = 12
-      ALPHA = ONE / (NCYCLE + 1)
+      IF (FCUT  == ZERO) FCUT = 10000.0D0*FAC_T_WORK
 !
       IDAM = 0
       ISOLID = 0
@@ -219,7 +218,7 @@ C
       UPARAM(13)  = ET12M
       UPARAM(14)  = EC12
       UPARAM(15)  = EC12M
-      UPARAM(16)  = ALPHA   ! strain rate filtering coefficient
+      UPARAM(16)  = FCUT
       UPARAM(17)  = EPSPREF
       UPARAM(18)  = ET3
       UPARAM(19)  = ET3M
@@ -244,7 +243,7 @@ c-----------------------------------------------------
       IF (IS_CRYPTED) THEN
         WRITE(IOUT, 1000)
        ELSE
-        WRITE(IOUT, 1000) FAIL_ID,PTHK,STRDEF,EPSPREF,NCYCLE,
+        WRITE(IOUT, 1000) FAIL_ID,PTHK,STRDEF,EPSPREF,FCUT,
      .     IFUNC(13),FSCALE_SIZ,REF_SIZ,
      .     ET1,ET1M,IFUNC(1)   ,EC1,EC1M,IFUNC(4),
      .     ET2,ET2M,IFUNC(2)   ,EC2,EC2M,IFUNC(5),
@@ -264,7 +263,7 @@ c-----------------------------------------------------
      & 5X,' =2 (ENGINEERING STRAIN) . . . . . . . . ',/                
      & 5X,' =3 (TRUE STRAIN). . . . . . . . . . . . ',/                 
      & 5X,'REFERENCE STRAIN RATE . . . . . . . . . =',E12.4/,
-     & 5X,'STRAIN RATE FILTERING PERIOD IN CYCLES. =',I10/,
+     & 5X,'STRAIN RATE FILTERING FREQUENCY . . . . =',E12.4/,
      & 5X,'ELEMENT SIZE FACTOR FUNCTION. . . . . . =',I10/, 
      & 5X,'SCALE FACTOR OF ELEMENT SIZE FUNCTION . =',E12.4/,
      & 5X,'REFERENCE ELEMENT SIZE. . . . . . . . . =',E12.4/,


### PR DESCRIPTION
Fix cfg file, strain-rate filtering and element size scaling for /FAIL/ORTHSTRAIN

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

CFG file, strain-rate filtering and element size scaling were not working properly for /FAIL/ORTHSTRAIN.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Fix .cfg file (2x radioss2021 format), fix strain-rate filtering reading + engine part, fix element size scaling treatment. 
