### PR TITLE
Fix itet4=3 issue when tetra are deleted

### DIFF
--- a/engine/source/elements/solid/solide4_sfem/s4volnod3.F
+++ b/engine/source/elements/solid/solide4_sfem/s4volnod3.F
@@ -111,7 +111,7 @@ C----------------------------
 C     TETRAHEDRON VOLUME
 C----------------------------
       DO I=LFT,LLT
-       IF(OFFG(I) /= ONE) THEN
+       IF (OFFG(I) == ZERO .OR. ABS(OFFG(I)).GT.ONE) THEN
          DET(I)= ZERO
        ELSE
          X43 = X4(I) - X3(I)


### PR DESCRIPTION
Fix itet4=3 issue when tetra are deleted

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Simulations were crashing when tetra elements were deleted with Itet4=3 option activated. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Fix a wrong test on the element deletion status flag OFFG. The bug fix was double checked with Qiang. 
