### PR TITLE
./engine/ale : grid velocity subroutines. X has size SX=3*(NUMNOD+NRCVVOIS)

### DIFF
--- a/engine/source/ale/aleflux.F
+++ b/engine/source/ale/aleflux.F
@@ -59,19 +59,19 @@ C-----------------------------------------------
 #include      "task_c.inc"
 #include      "parit_c.inc"
 #include      "scr06_c.inc"
+#include      "tabsiz_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER  IXS(NIXS,*),NC1(*), NC2(*), NC3(*), 
-     .   NC4(*), NC5(*), NC6(*),NC7(*),NC8(*),NGL(*)
+      INTEGER  IXS(NIXS,NUMELS),NC1(*), NC2(*), NC3(*), NC4(*), NC5(*), NC6(*),NC7(*),NC8(*),NGL(*)
       my_real PM(NPROPM,NUMMAT), V(3,NUMNOD), W(3,NUMNOD), FLUX(MVSIZ,6), FLU1(*),
-     .    X1(*), X2(*), X3(*), X4(*), X5(*), X6(*), X7(*), X8(*),
-     .    Y1(*), Y2(*), Y3(*), Y4(*), Y5(*), Y6(*), Y7(*), Y8(*),
-     .    Z1(*), Z2(*), Z3(*), Z4(*), Z5(*), Z6(*), Z7(*), Z8(*),
-     .    ALPHA(MVSIZ,6),
-     . VDX1(*),VDX2(*),VDX3(*),VDX4(*),VDX5(*),VDX6(*),VDX7(*),VDX8(*),
-     . VDY1(*),VDY2(*),VDY3(*),VDY4(*),VDY5(*),VDY6(*),VDY7(*),VDY8(*),
-     . VDZ1(*),VDZ2(*),VDZ3(*),VDZ4(*),VDZ5(*),VDZ6(*),VDZ7(*),VDZ8(*)
+     .        X1(*), X2(*), X3(*), X4(*), X5(*), X6(*), X7(*), X8(*),
+     .        Y1(*), Y2(*), Y3(*), Y4(*), Y5(*), Y6(*), Y7(*), Y8(*),
+     .        Z1(*), Z2(*), Z3(*), Z4(*), Z5(*), Z6(*), Z7(*), Z8(*),
+     .        ALPHA(MVSIZ,6),
+     .        VDX1(*),VDX2(*),VDX3(*),VDX4(*),VDX5(*),VDX6(*),VDX7(*),VDX8(*),
+     .        VDY1(*),VDY2(*),VDY3(*),VDY4(*),VDY5(*),VDY6(*),VDY7(*),VDY8(*),
+     .        VDZ1(*),VDZ2(*),VDZ3(*),VDZ4(*),VDZ5(*),VDZ6(*),VDZ7(*),VDZ8(*)
       TYPE(t_ale_connectivity), INTENT(IN) :: ALE_CONNECT
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/engine/source/ale/alew.F
+++ b/engine/source/ale/alew.F
@@ -38,18 +38,15 @@ C-----------------------------------------------
 C     D e s c r i p t i o n
 C-----------------------------------------------
 C     Compute Grid for /ALE/GRID/DONEA
+C
+C     X,D,V are allocated to SX,SD,DV=3*(NUMNOD_L+NUMVVOIS_L)
+C      in grid subroutine it may needed to access nodes which
+C      are connected to a remote elem. They are sored in X(1:3,NUMNOD+1:)
+C      Consequently X is defined here X(3,SX/3) instead of X(3,NUMNOD) as usually
 C-----------------------------------------------
 C     I m p l i c i t   T y p e s
 C-----------------------------------------------
 #include      "implicit_f.inc"
-C-----------------------------------------------
-C     D u m m y   A r g u m e n t s
-C-----------------------------------------------
-      INTEGER NALE(*), NODFT, NODLT, ITASK,
-     .     NBRCVOIS(*),NBSDVOIS(*),
-     .     LNRCVOIS(*),LNSDVOIS(*) ,ITAB(NUMNOD) 
-      my_real X(3,NUMNOD), D(3,NUMNOD), V(3,NUMNOD), W(3,NUMNOD), WA(3,*)
-      TYPE(t_connectivity), INTENT(IN) :: ALE_NN_CONNECT
 C-----------------------------------------------
 C     C o m m o n   B l o c k s
 C-----------------------------------------------
@@ -59,6 +56,16 @@ C-----------------------------------------------
 #include      "com07_c.inc"
 #include      "com08_c.inc"
 #include      "param_c.inc"
+#include      "tabsiz_c.inc"
+C-----------------------------------------------
+C     D u m m y   A r g u m e n t s
+C-----------------------------------------------
+      INTEGER NALE(*), NODFT, NODLT, ITASK,
+     .     NBRCVOIS(*),NBSDVOIS(*),
+     .     LNRCVOIS(*),LNSDVOIS(*) ,ITAB(NUMNOD) 
+      my_real X(3,SX/3), D(3,SD/3), V(3,SV/3), W(3,SW/3), WA(3,*)
+      TYPE(t_connectivity), INTENT(IN) :: ALE_NN_CONNECT
+
 C-----------------------------------------------
 C     L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/engine/source/ale/alew1.F
+++ b/engine/source/ale/alew1.F
@@ -37,18 +37,15 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Compute Grid for /ALE/GRID/DISP
+C
+C     X,D,V are allocated to SX,SD,DV=3*(NUMNOD_L+NUMVVOIS_L)
+C      in grid subroutine it may needed to access nodes which
+C      are connected to a remote elem. They are sored in X(1:3,NUMNOD+1:)
+C      Consequently X is defined here X(3,SX/3) instead of X(3,NUMNOD) as usually
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
 #include      "implicit_f.inc"
-C-----------------------------------------------
-C   D u m m y   A r g u m e n t s
-C-----------------------------------------------
-      INTEGER NALE(NUMNOD), NODFT, NODLT, ITASK,
-     .        NBRCVOIS(*),NBSDVOIS(*),
-     .        LNRCVOIS(*),LNSDVOIS(*),ITAB(NUMNOD)
-      my_real X(3,NUMNOD), D(3,NUMNOD), V(3,NUMNOD), W(3,NUMNOD)     
-      TYPE(t_connectivity), INTENT(IN) :: ALE_NN_CONNECT
 C-----------------------------------------------
 C   C o m m o n   B l o c k s
 C-----------------------------------------------
@@ -58,12 +55,19 @@ C-----------------------------------------------
 #include      "com07_c.inc"
 #include      "com08_c.inc"
 #include      "param_c.inc"
+#include      "tabsiz_c.inc"
+C-----------------------------------------------
+C   D u m m y   A r g u m e n t s
+C-----------------------------------------------
+      INTEGER NALE(NUMNOD), NODFT, NODLT, ITASK,NBRCVOIS(*),NBSDVOIS(*),LNRCVOIS(*),LNSDVOIS(*),ITAB(NUMNOD)
+      my_real X(3,SX/3), D(3,SD/3), V(3,SV/3), W(3,SW/3)     
+      TYPE(t_connectivity), INTENT(IN) :: ALE_NN_CONNECT
+
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I, N, IA1, IA2, IA3, IA4, IA5, IA6, L, LENCOM
-      my_real
-     .     DX, DY, DZ,FAC
+      INTEGER I, LENCOM
+      my_real DX, DY, DZ,FAC
       INTEGER :: IAD, IAD1, IAD2, NODE_ID
       my_real :: DX_MAX, DX_MIN
       my_real :: DY_MAX, DY_MIN

--- a/engine/source/ale/alew2.F
+++ b/engine/source/ale/alew2.F
@@ -37,6 +37,11 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Compute Grid for /ALE/GRID/SPRING
+C
+C     X,D,V are allocated to SX,SD,DV=3*(NUMNOD_L+NUMVVOIS_L)
+C      in grid subroutine it may needed to access nodes which
+C      are connected to a remote elem. They are sored in X(1:3,NUMNOD+1:)
+C      Consequently X is defined here X(3,SX/3) instead of X(3,NUMNOD) as usually
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -56,27 +61,28 @@ C-----------------------------------------------
 #include      "scr05_c.inc"
 #include      "task_c.inc"
 #include      "parit_c.inc"
+#include      "tabsiz_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER NALE(NUMNOD), IPARG(NPARG,NGROUP), NC(11,*), ADDCNE(*), PROCNE(*),
      .        IAD_ELEM(2,*), FR_ELEM(*), FR_NBCC(2,*), IADS(8,*),ITAB(NUMNOD),
      .        SIZEN
-      my_real X(3,NUMNOD), D(3,NUMNOD), V(3,NUMNOD), W(3,NUMNOD), WA(3,*), WB(3,*),
+      my_real X(3,SX/3), D(3,SD/3), V(3,SV/3), W(3,SW/3), WA(3,*), WB(3,*),
      .        FSKY(8,LSKY), FSKYV(LSKY,8)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER ICT(2,28), J1(MVSIZ), J2(MVSIZ), I, NG, NEL, NFT, ITY, MQE, ITR,
-     .   NTR, N, NNC, NCT, K, II, J, SIZE, LENR, LENS
+     .   NTR, N, NNC, NCT, K, II, SIZE, LENR, LENS
       my_real
      .   FAC(28), 
      .   DX(MVSIZ)   ,DY(MVSIZ) , DZ(MVSIZ), 
      .   XX(MVSIZ)   ,XY(MVSIZ) , XZ(MVSIZ),
-     .   DL1(MVSIZ)  ,DL2(MVSIZ), DDX(MVSIZ), DDY(MVSIZ), DDZ(MVSIZ), 
+     .   DL1(MVSIZ)  ,DDX(MVSIZ), DDY(MVSIZ), DDZ(MVSIZ), 
      .   DL(MVSIZ)   ,XL(MVSIZ) , DDL(MVSIZ), 
      .   BETA, DLM, DLMIN, GAM1, XLAG,
-     .   XALE, WBTMP(3,SIZEN)
+     .   WBTMP(3,SIZEN)
      
 C-----------------------------------------------
       DATA FAC/1.,1.,1.,1.,

--- a/engine/source/ale/alew4.F
+++ b/engine/source/ale/alew4.F
@@ -38,6 +38,11 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Compute Grid for /ALE/GRID/STANDARD
+C
+C     X,D,V are allocated to SX,SD,DV=3*(NUMNOD_L+NUMVVOIS_L)
+C      in grid subroutine it may needed to access nodes which
+C      are connected to a remote elem. They are sored in X(1:3,NUMNOD+1:)
+C      Consequently X is defined here X(3,SX/3) instead of X(3,NUMNOD) as usually
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -57,14 +62,15 @@ C-----------------------------------------------
 #include      "scr05_c.inc"
 #include      "task_c.inc"
 #include      "parit_c.inc"
+#include      "tabsiz_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER NALE(NUMNOD), IPARG(NPARG,NGROUP), NC(NIX,*), ADDCNE(*), PROCNE(*),ITAB(*),
+      INTEGER NALE(NUMNOD), IPARG(NPARG,NGROUP), NC(NIX,*), ADDCNE(*), PROCNE(*),ITAB(NUMNOD),
      .        IAD_ELEM(2,*), FR_ELEM(*), FR_NBCC(2,*), IADX(NIADX,*) ,
      .        SIZEN, NIX, NIADX
       my_real
-     .   X(3,NUMNOD), D(3,NUMNOD), V(3,NUMNOD), W(3,NUMNOD), WA(3,*), WB(3,*),
+     .   X(3,SX/3), D(3,SD/3), V(3,SV/3), W(3,SW/3), WA(3,*), WB(3,*),
      .   FSKY(8,LSKY), FSKYV(LSKY,8), WMA(*)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/engine/source/ale/alew5.F
+++ b/engine/source/ale/alew5.F
@@ -51,19 +51,15 @@ C     WEIGHT : 1/n = umbrella
 C     l_ij/sum(l_ik,k) = fujiwara operator   (we must update CFL with DT2< edge_min**2/LAMBDA)
 C     
 C     please note that W will be used as a displacement in this subroutine and translated into grid velocity again before returning 
+C
+C     X,D,V are allocated to SX,SD,DV=3*(NUMNOD_L+NUMVVOIS_L)
+C      in grid subroutine it may needed to access nodes which
+C      are connected to a remote elem. They are sored in X(1:3,NUMNOD+1:)
+C      Consequently X is defined here X(3,SX/3) instead of X(3,NUMNOD) as usually
 C-----------------------------------------------
 C     I m p l i c i t   T y p e s
 C-----------------------------------------------
 #include      "implicit_f.inc"
-C-----------------------------------------------
-C     D u m m y   A r g u m e n t s
-C-----------------------------------------------
-      INTEGER NALE(NUMNOD), NODFT, NODLT, ITASK,
-     .     NBRCVOIS(*),NBSDVOIS(*),
-     .     LNRCVOIS(*),LNSDVOIS(*),ITAB(*),ISKEW(*),ICODT(*)
-      my_real
-     .     X(3,NUMNOD), D(3,NUMNOD), V(3,NUMNOD), W(3,NUMNOD), WA(3,*), SKEW(LSKEW,*)   
-      TYPE(t_connectivity), INTENT(IN) :: ALE_NN_CONNECT
 C-----------------------------------------------
 C     C o m m o n   B l o c k s
 C-----------------------------------------------
@@ -73,7 +69,17 @@ C-----------------------------------------------
 #include      "com07_c.inc"
 #include      "com08_c.inc"
 #include      "param_c.inc"
-#include      "timeri_c.inc"      
+#include      "timeri_c.inc"    
+#include      "tabsiz_c.inc"  
+C-----------------------------------------------
+C     D u m m y   A r g u m e n t s
+C-----------------------------------------------
+      INTEGER NALE(NUMNOD), NODFT, NODLT, ITASK,
+     .     NBRCVOIS(*),NBSDVOIS(*),
+     .     LNRCVOIS(*),LNSDVOIS(*),ITAB(*),ISKEW(*),ICODT(*)
+      my_real
+     .     X(3,SX/3), D(3,SD/3), V(3,SV/3), W(3,SW/3), WA(3,*), SKEW(LSKEW,*)   
+      TYPE(t_connectivity), INTENT(IN) :: ALE_NN_CONNECT
 C-----------------------------------------------
 C     L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/engine/source/ale/alew6.F
+++ b/engine/source/ale/alew6.F
@@ -45,6 +45,11 @@ C     D e s c r i p t i o n
 C-----------------------------------------------
 C     VOLUME GRID SMOOTHING
 C     Compute Grid for /ALE/GRID/VOLUME
+C
+C     X,D,V are allocated to SX,SD,DV=3*(NUMNOD_L+NUMVVOIS_L)
+C      in grid subroutine it may needed to access nodes which
+C      are connected to a remote elem. They are sored in X(1:3,NUMNOD+1:)
+C      Consequently X is defined here X(3,SX/3) instead of X(3,NUMNOD) as usually
 C-----------------------------------------------
 C     M o d u l e s
 C-----------------------------------------------
@@ -56,16 +61,6 @@ C-----------------------------------------------
 #include      "implicit_f.inc"
 #include      "spmd_c.inc"
 C-----------------------------------------------
-C     D u m m y   A r g u m e n t s
-C-----------------------------------------------
-      INTEGER NALE(NUMNOD), NODFT, NODLT, ITASK,
-     .     NBRCVOIS(*),NBSDVOIS(*),
-     .     LNRCVOIS(*),LNSDVOIS(*),ITAB(NUMNOD),IPARG(NPARG,NGROUP),IXS(NIXS,NUMELS),IXQ(NIXQ,NUMELQ)
-      my_real X(3,NUMNOD), D(3,NUMNOD), V(3,NUMNOD), W(3,NUMNOD), WA(3,*), XCELL(3, *), XFACE(3,6,*)  
-      TYPE(t_connectivity), INTENT(IN) :: ALE_NN_CONNECT, ALE_NE_CONNECT
-      INTEGER, INTENT(IN) :: NERCVOIS(*), NESDVOIS(*), LERCVOIS(*), LESDVOIS(*)
-      TYPE(ELBUF_STRUCT_), DIMENSION(NGROUP) :: ELBUF_TAB
-C-----------------------------------------------
 C     C o m m o n   B l o c k s
 C-----------------------------------------------
 #include      "scr05_c.inc"
@@ -75,6 +70,17 @@ C-----------------------------------------------
 #include      "com08_c.inc"
 #include      "param_c.inc"
 #include      "task_c.inc"
+#include      "tabsiz_c.inc"
+C-----------------------------------------------
+C     D u m m y   A r g u m e n t s
+C-----------------------------------------------
+      INTEGER NALE(NUMNOD), NODFT, NODLT, ITASK,
+     .     NBRCVOIS(*),NBSDVOIS(*),
+     .     LNRCVOIS(*),LNSDVOIS(*),ITAB(NUMNOD),IPARG(NPARG,NGROUP),IXS(NIXS,NUMELS),IXQ(NIXQ,NUMELQ)
+      my_real X(3,SX/3), D(3,SD/3), V(3,SV/3), W(3,SW/3), WA(3,*), XCELL(3, *), XFACE(3,6,*)  
+      TYPE(t_connectivity), INTENT(IN) :: ALE_NN_CONNECT, ALE_NE_CONNECT
+      INTEGER, INTENT(IN) :: NERCVOIS(*), NESDVOIS(*), LERCVOIS(*), LESDVOIS(*)
+      TYPE(ELBUF_STRUCT_), DIMENSION(NGROUP) :: ELBUF_TAB
 C-----------------------------------------------
 C     L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/engine/source/ale/alewdx.F
+++ b/engine/source/ale/alewdx.F
@@ -80,6 +80,11 @@ C-----------------------------------------------
 !   6       VOLUME
 ! 
 ! This subroutine is switching to grid formulation depending on NWALE value.
+C
+C     X,D,V are allocated to SX,SD,DV=3*(NUMNOD_L+NUMVVOIS_L)
+C      in grid subroutine it may needed to access nodes which
+C      are connected to a remote elem. They are sored in X(1:3,NUMNOD+1:)
+C      Consequently X is defined here X(3,SX/3) instead of X(3,NUMNOD) as usually
 C-----------------------------------------------
 C     M o d u l e s
 C-----------------------------------------------
@@ -111,11 +116,12 @@ C-----------------------------------------------
 #include      "vale_c.inc"
 #include      "parit_c.inc"
 #include      "ale_param.inc"
+#include      "tabsiz_c.inc"
 C-----------------------------------------------------------------
 C     D u m m y   A r g u m e n t s
 C-----------------------------------------------
       TYPE(MULTI_FVM_STRUCT) :: MULTI_FVM
-      INTEGER ISKEW(*), IXS(NIXS,*),IXQ(NIXQ,*),
+      INTEGER ISKEW(*), IXS(NIXS,NUMELS),IXQ(NIXQ,NUMELQ),
      .     NPF(*),LAS(*), IPARG(NPARG,NGROUP), IPARI(NPARI,NINTER),
      .     NPRW(*), ICODT(*), LINALE(*),
      .     NODPOR(*), NBRCVOIS(*),NBSDVOIS(*), PROCNE(*),FR_NBCC(*),
@@ -126,10 +132,10 @@ C-----------------------------------------------
       INTEGER, INTENT(IN) :: ITAB(NUMNOD)
       DOUBLE PRECISION    :: XDP(3,*),DDP(3,*)
       my_real
-     .     X(3,NUMNOD) ,D(3,NUMNOD), V(3,NUMNOD) ,VR(3,NUMNOD) ,A(3,NUMNOD) ,AR(3,NUMNOD), FSKY(*),
+     .     X(3,SX/3) ,D(3,SD/3), V(3,SV/3) ,VR(3,SVR/3) ,A(3,SA/3) ,AR(3,SAR/3), FSKY(*),
      .     MS(*)   ,IN(*)   ,PM(NPROPM,NUMMAT),SKEW(LSKEW,*),GEO(NPROPG,NUMGEO),
-     .     W(3,NUMNOD), WB(*), TF(*), FSAV(NTHVKI,*) ,XLAS(*),
-     .     RWBUF(NRWLP,*),RBY(NRBY,*),WA(3,*),DR(3,*),XCELL(3,*), XFACE(3,6,*)
+     .     W(3,SW/3), WB(*), TF(*), FSAV(NTHVKI,*) ,XLAS(*),
+     .     RWBUF(NRWLP,*),RBY(NRBY,*),WA(3,*),DR(3,SDR/3),XCELL(3,SXCELL), XFACE(3,6,*)
       my_real DT2SAVE
       TYPE(ELBUF_STRUCT_), DIMENSION(NGROUP) :: ELBUF_TAB
       TYPE(INTBUF_STRUCT_) INTBUF_TAB(*)

--- a/engine/source/ale/arezon.F
+++ b/engine/source/ale/arezon.F
@@ -69,9 +69,9 @@ C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       my_real FLUX(*), PHI(*)
       INTEGER NDIM, NVAR, ITASK, LENCOM,ITRIMAT,NV,
-     .        IPARG(NPARG,*), 
+     .        IPARG(NPARG,NGROUP), 
      .        NERCVOIS(*),NESDVOIS(*),LERCVOIS(*),LESDVOIS(*),
-     .        BHOLE(*),IXS(NIXS,*)
+     .        BHOLE(*),IXS(NIXS,NUMELS)
       TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP), TARGET :: ELBUF_STR
       TYPE(t_ale_connectivity), INTENT(IN) :: ALE_CONNECT
 C-----------------------------------------------

--- a/engine/source/ale/atherm.F
+++ b/engine/source/ale/atherm.F
@@ -62,18 +62,18 @@ C-----------------------------------------------
 #include      "scr01_c.inc"
 #include      "scr05_c.inc"
 #include      "com01_c.inc"
+#include      "com04_c.inc"
 #include      "vect01_c.inc"
 #include      "param_c.inc"
 #include      "mmale51_c.inc"
+#include      "tabsiz_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER  IPARG(NPARG,*), IXS(NIXS,*), IXQ(7,*), NPF(*),
+      INTEGER  IPARG(NPARG,NGROUP), IXS(NIXS,NUMELS), IXQ(7,NUMELQ), NPF(*),
      .         NERCVOIS(*),NESDVOIS(*),LERCVOIS(*),LESDVOIS(*),
-     .         IPM(NPROPMI,*), LENCOM
-      my_real
-     .   PM(NPROPM,*), FLUX(*), VAL2(*), T(*), FV(*), X(*),
-     .   TF(*),BUFMAT(*)
+     .         IPM(NPROPMI,NUMMAT), LENCOM
+      my_real PM(NPROPM,NUMMAT), FLUX(*), VAL2(*), T(*), FV(*), X(3,NUMNOD),TF(*),BUFMAT(*)
       TYPE (ELBUF_STRUCT_), DIMENSION (NGROUP), TARGET :: ELBUF_TAB
       TYPE(t_ale_connectivity), INTENT(IN) :: ALE_CONNECT
 C-----------------------------------------------
@@ -81,10 +81,8 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER NG, I, J, K, NPH1, NPH2, NPH3, IADBUF
       INTEGER MAT(MVSIZ)
-      my_real
-     .   RK, RE, R, YP0, XMU, AX, E, A, CMU, RPR, YPLUS, P, XMT
-      my_real,
-     .   DIMENSION(:) ,POINTER :: PH1,PH2,PH3
+      my_real RK, RE, R, YP0, XMU, AX, E, A, CMU, RPR, YPLUS, P, XMT
+      my_real, DIMENSION(:) ,POINTER :: PH1,PH2,PH3
       TYPE(G_BUFEL_)  ,POINTER :: GBUF     
 C-----------------------------------------------
 C   S o u r c e   L i n e s 

--- a/engine/source/ale/aturbn.F
+++ b/engine/source/ale/aturbn.F
@@ -41,24 +41,20 @@ C-----------------------------------------------
 C   C o m m o n   B l o c k s
 C-----------------------------------------------
 #include      "vect01_c.inc"
+#include      "com04_c.inc"
 #include      "com08_c.inc"
 #include      "param_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER MAT(*),NGEO(*)
-      my_real
-     .   PM(NPROPM,*), OFF(*), RHO(*), RK(*), RE(*),GEO(NPROPG,*)
-      my_real
-     .   EINC(*), DVOL(*), VNEW(*), PNEW(*), TMU(*), VIS(*),
-     .   VD2(*)
+      my_real PM(NPROPM,NUMMAT), OFF(*), RHO(*), RK(*), RE(*),GEO(NPROPG,NUMGEO)
+      my_real EINC(*), DVOL(*), VNEW(*), PNEW(*), TMU(*), VIS(*), VD2(*)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I
-      my_real
-     .   EI, 
-     .   XFAC, ARK, C1, C2, C3, SGSL, CMU, SE, FAC, RESGS     
+      my_real EI, XFAC, ARK, C1, C2, C3, SGSL, CMU, SE, FAC, RESGS     
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/engine/source/ale/int12w.F
+++ b/engine/source/ale/int12w.F
@@ -40,17 +40,19 @@ C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
 #include      "implicit_f.inc"
-C-----------------------------------------------
-C   D u m m y   A r g u m e n t s
-C-----------------------------------------------
-      INTEGER IPARI(*), ICODE,IBCS
-      my_real VG(*),X,V,A,BCS
-      TYPE(INTBUF_STRUCT_) INTBUF_TAB
 C----------------------------------------------
 C   C o m m o n   B l o c k s
 C-----------------------------------------------
 #include      "scr04_c.inc"
 #include      "param_c.inc"
+#include      "tabsiz_c.inc"
+C-----------------------------------------------
+C   D u m m y   A r g u m e n t s
+C-----------------------------------------------
+      INTEGER IPARI(SIPARI), ICODE,IBCS
+      my_real VG(*),X,V,A,BCS
+      TYPE(INTBUF_STRUCT_) INTBUF_TAB
+
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/engine/source/ale/intal2.F
+++ b/engine/source/ale/intal2.F
@@ -46,21 +46,23 @@ C   I m p l i c i t   T y p e s
 C-----------------------------------------------
 #include      "implicit_f.inc"
 C-----------------------------------------------
+C   C o m m o n   B l o c k s
+C-----------------------------------------------
+#include      "com01_c.inc"
+#include      "com04_c.inc"
+#include      "scr04_c.inc"
+#include      "param_c.inc"
+#include      "tabsiz_c.inc"
+C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER,INTENT(INOUT) :: IPARI(*), ISKEW(*), LCOD(*), ITAB(*)
-      my_real,INTENT(INOUT) :: X(*), V(*), A(*), SKEW(*), E(*), MSM(*), MS(*),FSAV(*)
+      INTEGER,INTENT(INOUT) :: IPARI(SIPARI), ISKEW(*), LCOD(*), ITAB(NUMNOD)
+      my_real,INTENT(INOUT) :: X(3,NUMNOD), V(3,NUMNOD), A(3,NUMNOD), SKEW(*), E(*), MSM(*), MS(*),FSAV(*)
 
       TYPE(INTBUF_STRUCT_) INTBUF_TAB
       
        my_real,INTENT(INOUT) :: FCONT(3,*),FNCONT(3,*),FTCONT(3,*)
       TYPE(H3D_DATABASE) :: H3D_DATA
-C-----------------------------------------------
-C   C o m m o n   B l o c k s
-C-----------------------------------------------
-#include      "com01_c.inc"
-#include      "scr04_c.inc"
-#include      "param_c.inc"
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/engine/source/ale/intal3.F
+++ b/engine/source/ale/intal3.F
@@ -54,15 +54,14 @@ C-----------------------------------------------
 #include      "task_c.inc"
 #include      "units_c.inc"
 #include      "scr05_c.inc"
+#include      "tabsiz_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER IPARI(NPARI,*), ICODE(*) ,
-     .        IXS(NIXS,*),IXQ(NIXQ,*), IPARG(NPARG,*),
+      INTEGER IPARI(NPARI,NINTER), ICODE(*) ,
+     .        IXS(NIXS,NUMELS),IXQ(NIXQ,NUMELQ), IPARG(NPARG,NGROUP),
      .        ISKEW(*), NALE(*)
-      my_real
-     .   X(*), V(*), A(*), VG(*), SKEW(*),
-     .   PM(NPROPM,*)
+      my_real X(3,NUMNOD), V(3,NUMNOD), A(3,NUMNOD), VG(*), SKEW(*), PM(NPROPM,NUMMAT)
       TYPE(ELBUF_STRUCT_), DIMENSION(NGROUP) :: ELBUF_TAB
       TYPE(INTBUF_STRUCT_) INTBUF_TAB(*)
 C-----------------------------------------------

--- a/engine/source/ale/intal4.F
+++ b/engine/source/ale/intal4.F
@@ -39,17 +39,20 @@ C   I m p l i c i t   T y p e s
 C-----------------------------------------------
 #include      "implicit_f.inc"
 C-----------------------------------------------
-C   D u m m y   A r g u m e n t s
-C-----------------------------------------------
-      my_real A
-      INTEGER IPARI(*), ICODE(*), IBCS(*)
-      my_real X(*), V(*), VG(*), BCS(*)
-      TYPE(INTBUF_STRUCT_) INTBUF_TAB
-C-----------------------------------------------
 C   C o m m o n   B l o c k s
 C-----------------------------------------------
 #include      "scr04_c.inc"
+#include      "com04_c.inc"
 #include      "param_c.inc"
+#include      "tabsiz_c.inc"
+C-----------------------------------------------
+C   D u m m y   A r g u m e n t s
+C-----------------------------------------------
+      my_real A
+      INTEGER IPARI(SIPARI), ICODE(*), IBCS(*)
+      my_real X(3,NUMNOD), V(3,NUMNOD), VG(*), BCS(*)
+      TYPE(INTBUF_STRUCT_) INTBUF_TAB
+
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/engine/source/ale/iqela1.F
+++ b/engine/source/ale/iqela1.F
@@ -48,6 +48,7 @@ C-----------------------------------------------
 C   C o m m o n   B l o c k s
 C-----------------------------------------------
 #include      "com01_c.inc"
+#include      "com04_c.inc"
 #include      "com06_c.inc"
 #include      "com08_c.inc"
 #include      "scr04_c.inc"
@@ -58,11 +59,12 @@ C-----------------------------------------------
 #include      "scr16_c.inc"
 #include      "param_c.inc"
 #include      "comlock.inc"
+#include      "tabsiz_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER,INTENT(INOUT) :: IRECT(4,*), LMSR(4,*), MSR(*), NSV(*), ILOC(*), IRTL(*),LCODE(*), ISKEW(*),ITAB(*)
-      my_real,INTENT(INOUT) :: X(3,*), SKEW(LSKEW,*), A(*), E(*), MSM(*), CRST(2,*), MS(*),NOR(3,*),FSAV(*)
+      INTEGER,INTENT(INOUT) :: IRECT(4,*), LMSR(4,*), MSR(*), NSV(*), ILOC(*), IRTL(*),LCODE(*), ISKEW(*),ITAB(NUMNOD)
+      my_real,INTENT(INOUT) :: X(SX), SKEW(LSKEW,*), A(SA), E(*), MSM(*), CRST(2,*), MS(*),NOR(3,*),FSAV(*)
       my_real,INTENT(INOUT) :: FCONT(3,*),FNCONT(3,*),FTCONT(3,*)
       TYPE(H3D_DATABASE) :: H3D_DATA
 C-----------------------------------------------
@@ -85,9 +87,9 @@ C-----------------------------------------------
       IPCONT = .FALSE.
       IANIM  = .FALSE.
       ICONT  = (ANIM_V(4)+OUTP_V(4) > 0+H3D_DATA%N_VECT_CONT)
-      IF(ANIM_V(12)+OUTP_V(12)+H3D_DATA%N_VECT_PCONT  > 0)THEN      
+      IF(ANIM_V(12)+OUTP_V(12)+H3D_DATA%N_VECT_PCONT > 0)THEN      
        IF(TT >= TANIM.OR.TT >= TOUTP.OR.TT >= H3D_DATA%TH3D.OR.
-     .      (MANIM >= 4.AND.MANIM <= 15).OR. H3D_DATA%MH3D  /=  0)THEN
+     .      (MANIM >= 4.AND.MANIM <= 15).OR. H3D_DATA%MH3D /= 0)THEN
          IPCONT = .TRUE.
        ENDIF
       ENDIF

--- a/engine/source/ale/iqela2.F
+++ b/engine/source/ale/iqela2.F
@@ -41,23 +41,22 @@ C   I m p l i c i t   T y p e s
 C-----------------------------------------------
 #include      "implicit_f.inc"
 C-----------------------------------------------
-C   D u m m y   A r g u m e n t s
-C-----------------------------------------------
-      INTEGER IRECT(4,*), LMSR(4,*), MSR(*), NSV(*), ILOC(*), IRTL(*),
-     .   LCODE(*), ISKEW(*), ITAB(*)
-      my_real
-     .   X(3,*), SKEW(LSKEW,*), A(*), E(*), MSM(*), CRST(2,*), V(*),
-     .   NOR(3,*)
-C-----------------------------------------------
 C   C o m m o n   B l o c k s
 C-----------------------------------------------
 #include      "com01_c.inc"
+#include      "com04_c.inc"
 #include      "scr04_c.inc"
 #include      "scr08_s_c.inc"
 #include      "scr08_a_c.inc"
 #include      "units_c.inc"
 #include      "param_c.inc"
 #include      "warn_c.inc"
+#include      "tabsiz_c.inc"
+C-----------------------------------------------
+C   D u m m y   A r g u m e n t s
+C-----------------------------------------------
+      INTEGER IRECT(4,*), LMSR(4,*), MSR(*), NSV(*), ILOC(*), IRTL(*),LCODE(*), ISKEW(*), ITAB(NUMNOD)
+      my_real X(3,NUMNOD), SKEW(LSKEW,*), A(SA), E(*), MSM(*), CRST(2,*), V(SV),NOR(3,*)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/engine/source/ale/iqela3.F
+++ b/engine/source/ale/iqela3.F
@@ -41,15 +41,17 @@ C-----------------------------------------------
 C   C o m m o n   B l o c k s
 C-----------------------------------------------
 #include      "com01_c.inc"
+#include      "com04_c.inc"
 #include      "scr04_c.inc"
 #include      "scr08_s_c.inc"
 #include      "scr08_a_c.inc"
+#include      "tabsiz_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER,INTENT(IN)    :: IRECT(4,*), NSV(*), ILOC(*), IRTL(*), ICODE(*), IBCS(*), MSR(*)
-      my_real,INTENT(IN)    :: V(3,*), CRST(2,*), BCS(9,*)
-      my_real,INTENT(INOUT) :: W(3,*)
+      my_real,INTENT(IN)    :: V(3,NUMNOD), CRST(2,*), BCS(9,*)
+      my_real,INTENT(INOUT) :: W(3,NUMNOD)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/engine/source/ale/rgwal1.F
+++ b/engine/source/ale/rgwal1.F
@@ -55,18 +55,18 @@ C-----------------------------------------------
 #include      "scr05_c.inc"
 #include      "parit_c.inc"
 #include      "com08_c.inc"
+#include      "tabsiz_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER LPRW(*), NPRW(*), IXS(NIXS,*),
-     .        IXQ(NIXQ,*),IPARG(NPARG,*),
+      INTEGER LPRW(*), NPRW(*), IXS(NIXS,NUMELS),
+     .        IXQ(NIXQ,NUMELQ),IPARG(NPARG,NGROUP),
      .        ICODT(*), ISKEW(*), NALE(*),NPF(*),
      .        WEIGHT(*),IAD_ELEM(*), FR_ELEM(*),
      .        FR_WALL(NSPMD+2,*)
-      my_real
-     .   X(3,NUMNOD), A(3,NUMNOD), V(3,NUMNOD), W(3,NUMNOD), RWBUF(NRWLP,*), MS(*),
-     .   FSAV(NTHVKI,*), SKEW(LSKEW,*),
-     .   PM(NPROPM,*), TF(*)
+      my_real X(3,NUMNOD), A(3,NUMNOD), V(3,NUMNOD), W(3,NUMNOD), RWBUF(NRWLP,*), MS(*),
+     .        FSAV(NTHVKI,*), SKEW(LSKEW,*),
+     .        PM(NPROPM,NUMMAT), TF(*)
       TYPE(ELBUF_STRUCT_), DIMENSION(NGROUP) :: ELBUF_TAB
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Update dimension from X(3,NUMNOD) to X(3,SX/3)
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
X,V,D sizes are SX,SV,SD = 3*(NUMNOD+NRCVVOIS)
In specific subroutines such as grid formulation subroutines, we need to access nodes from remote elems which are store in X(1:3,NUMNOD+1:). Size must be declared consequently to avoid runtime check tools to display an error.

