### PR TITLE
Starter may fail if -i / -input is not set

### DIFF
--- a/engine/source/engine/execargcheck.F
+++ b/engine/source/engine/execargcheck.F
@@ -73,7 +73,7 @@ C-----------------------------------------------
        character(len=2096) ARGS2,ARGS_REDUCE
        CHARACTER(len=4096) ULIBC
        PARAMETER (LENLIST=18)
-       CHARACTER ARGLIST(LENLIST)*12
+       CHARACTER(LEN=12):: ARGLIST(LENLIST)
        EXTERNAL IARGC
        DATA ARGLIST/
      .    '-VERSION',  '-V',
@@ -385,6 +385,11 @@ C check if -i has got an argument or if the next string is an input command
              PATH(1:LENP)=INPUTR(1:LENP)
            ENDIF
          ENDIF
+       ELSE
+           ! -input/-i was not set. Exiting with error message.
+           MSG= ' ' 
+           CALL PHELPINFO(6,MSG,0)
+           CALL ARRET(7)
        ENDIF
 
 C------------------------------------------------
@@ -551,7 +556,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-       CHARACTER ARGLIST(LENLIST)*10
+       CHARACTER (LEN=12),INTENT(IN) :: ARGLIST(LENLIST)
        CHARACTER ARG*2096
        INTEGER LENLIST,ISIN
 C-----------------------------------------------
@@ -571,7 +576,7 @@ C-----------------------------------------------
 
        ISIN = 0
        DO I=1,LENLIST
-        IF (ARGLIST(I)==ARGC) ISIN=1
+        IF (TRIM(ARGLIST(I))==TRIM(ARGC)) ISIN=1
        ENDDO 
        END
 
@@ -598,13 +603,11 @@ C-----------------------------------------------
       INTEGER STATUS(MPI_STATUS_SIZE),IERROR,ICODE
       INTEGER MYRANK, NNODES
       INTEGER KEY, IERR
-      INTEGER ISV_KEY
-      PARAMETER (ISV_KEY=195118620) 
 #endif
       INTEGER IDUM
 C-----------------------------------------------
 #ifdef MPI
-        KEY = ISV_KEY
+        KEY = 0
         call MPI_INITIALIZED(KEY, IERR)
         CALL MPI_INIT(IERROR)
         CALL MPI_COMM_SIZE(MPI_COMM_WORLD, NNODES, IERROR)
@@ -690,12 +693,10 @@ C-----------------------------------------------
       INTEGER STATUS(MPI_STATUS_SIZE),IERROR,ICODE
       INTEGER MYRANK, NNODES
       INTEGER KEY, IERR
-      INTEGER ISV_KEY
-      PARAMETER (ISV_KEY=195118620) 
 #endif
 C-----------------------------------------------
 #ifdef MPI
-        KEY = ISV_KEY
+        KEY = 0
         call MPI_INITIALIZED(KEY, IERR)
         CALL MPI_INIT(IERROR)
         CALL MPI_COMM_SIZE(MPI_COMM_WORLD, NNODES, IERROR)
@@ -767,6 +768,11 @@ C-----------------------------------------------
          WRITE(6,'(A)') ' '
          WRITE(6,'(A,A,A,A,A)') 
      *     '*** ERROR : Wrong "',EMSG(1:SMSG),'" option'
+       ENDIF
+
+       IF (ERRN == 6)THEN
+         WRITE(6,'(A)') ' '
+         WRITE(6,'(A)') '*** ERROR : No input deck set. Use -input [Starter input file] '
        ENDIF
 
        WRITE(6,'(A)') ' '

--- a/engine/source/mpi/init/inipar.F
+++ b/engine/source/mpi/init/inipar.F
@@ -55,8 +55,6 @@ C-----------------------------------------------
 #include  "units_c.inc"
 #include  "commandline.inc"
       INTEGER KEY, IERR
-      INTEGER ISV_KEY
-      PARAMETER (ISV_KEY=195118620)
 C-----------------------------------------------
 C   L o c a l  V a r i a b l e s
 C-----------------------------------------------
@@ -86,7 +84,7 @@ C
           IFLSIZE = 4*IR4R8
         ENDIF
 C
-        KEY = ISV_KEY
+        KEY = 0
         CALL MPI_INITIALIZED(KEY, IERR)
 
         CALL MPI_INIT(IERROR)

--- a/starter/source/starter/execargcheck.F
+++ b/starter/source/starter/execargcheck.F
@@ -82,7 +82,7 @@ C-----------------------------------------------
        REAL(kind=8) :: RANDM_SEED_NBR,RANDM_ALEA_NBR
        INTEGER :: GOT_GRP_SIZE
        PARAMETER (LENLIST=28)
-       CHARACTER ARGLIST(LENLIST)*12
+       CHARACTER (LEN=12) ::  ARGLIST(LENLIST)
        EXTERNAL IARGC
        DATA ARGLIST/
      .    '-VERSION',  '-V',
@@ -495,6 +495,12 @@ C               CALL PRHELPINFO()
              PATH(1:LENP)=INPUTR(1:LENP)
            ENDIF
          ENDIF
+       ELSE
+           ! PINPUTI is 0, which means -input/-i was not set
+           WRITE(6,'(A)') ' '
+           WRITE(6,'(A)') '*** ERROR : No input deck set. Use -input [Starter input file] '
+           WRITE(6,'(A)') ' '
+           CALL PHELPINFO()
        ENDIF
  100    CONTINUE
 C------------------------------------------------
@@ -1010,7 +1016,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-       CHARACTER ARGLIST(LENLIST)*10
+       CHARACTER (LEN=12),INTENT(IN) :: ARGLIST(LENLIST)
        CHARACTER ARG*2096
        INTEGER LENLIST,ISIN
 C-----------------------------------------------
@@ -1020,7 +1026,7 @@ C-----------------------------------------------
 C-----------------------------------------------
        ISIN = 0
        DO I=1,LENLIST
-        IF (ARGLIST(I)==ARG) ISIN=1
+        IF (TRIM(ARGLIST(I))==TRIM(ARG)) ISIN=1
        ENDDO 
        END
 


### PR DESCRIPTION
Starter may hang if -i /-input is not set.
and 
Engine may hang if no input is given

Starter does not check if -i / -input is not set and does not exit with error message.
Starter exits now with a proper message when -input is not set...

Same for Engine which hangs.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->


