### PR TITLE
Fix condition to compute damage variable in LAW 72 for solids only

### DIFF
--- a/engine/source/materials/mat/mat072/sigeps72.F
+++ b/engine/source/materials/mat/mat072/sigeps72.F
@@ -327,7 +327,7 @@ C
       INDX  = 0
       DO I=1,NEL
         ! Modified Mohr Criteria Failure Model
-        IF ((OFF(I) == ONE).AND.(DPLA(I) > ZERO)) THEN
+        IF (OFF(I) == ONE) THEN
           ! Pressure
           P    = THIRD*(SIGNXX(I) + SIGNYY(I) + SIGNZZ(I))
           ! Von Mises equivalent stress


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

A bad condition loop to compute damage was used in /MAT/LAW72 for solids only. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Fix the condition by removing DPLA > 0. 
