### PR TITLE
missing initialization of DTX in sinit3.F for material 26

### DIFF
--- a/starter/source/elements/solid/solide/sinit3.F
+++ b/starter/source/elements/solid/solide/sinit3.F
@@ -454,6 +454,7 @@ C------------------------------------------
 C Compute element time step
 C------------------------------------------
       AIRE(:) = ZERO
+      DTX(:) = ZERO
       CALL DTMAIN(GEO      , PM       , IPM        , PID    , MAT    , FV    ,
      .     GBUF%EINT, GBUF%TEMP, GBUF%DELTAX, GBUF%RK, GBUF%RE, BUFMAT, DELTAX, AIRE, 
      .     VOLU, DTX, IGEO )


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Missing initialization for `DTX` for some materials

