### PR TITLE
/EOS/COMPACTION:improve unload behavior

### DIFF
--- a/common_source/eos/compaction.F
+++ b/common_source/eos/compaction.F
@@ -26,15 +26,25 @@ Chd|-- called by -----------
 Chd|        EOSMAIN                       common_source/eos/eosmain.F   
 Chd|-- calls ---------------
 Chd|====================================================================
-      SUBROUTINE COMPACTION     (
-     1                            IFLAG,NEL  ,PM   ,OFF  ,EINT ,MU   ,MU2 , 
-     2                            ESPE ,DVOL ,DF   ,VNEW ,MAT  ,PSH  ,POLD,
-     3                            PNEW ,DPDM ,DPDE ,THETA,ECOLD,SIG  ,MU_OLD)
+      SUBROUTINE COMPACTION(
+     1                      IFLAG, NEL  , PM   , OFF  , EINT , MU   , MU2 , 
+     2                      ESPE , DVOL , DF   , VNEW , MAT  , PSH  , POLD,
+     3                      PNEW , DPDM , DPDE , THETA, ECOLD, SIG  , MU_OLD)
 C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
-C This subroutine contains numerical solving
-C of COMPACTION EOS
+C This subroutine contains numerical solving of COMPACTION EOS
+C
+C Iform : formulation flag for unload behavior
+C          1 : constant unload modulus (DEFAULT)
+C          2 : unload modulus increases with compaction from C1 to BUNL in [MU_MIN,MU_MAX]
+C         10 : legacy behvior (fixed with iform=1) (not documented)
+C
+C  MU_MIN : elastic behavior up to this limit
+C  MU_MAX : elastic behavior above this limit
+C  C0,C1,C2,C3 : EoS parameter
+C  BUNL : unload modulus
+C
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -45,17 +55,17 @@ C   G l o b a l   P a r a m e t e r s
 C-----------------------------------------------
 #include      "mvsiz_p.inc"
 #include      "param_c.inc"
+#include      "com04_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER MAT(*), IFLAG, NEL
-      my_real
-     .   PM(NPROPM,*), 
-     .   OFF(*)  ,EINT(*) ,MU(*)   , 
-     .   MU2(*)  ,ESPE(*) ,DVOL(*) ,DF(*)  , 
-     .   VNEW(*) ,PNEW(*) ,DPDM(*),
-     .   DPDE(*) ,THETA(*),ECOLD(*),
-     .   SIG(NEL,6),POLD(MVSIZ)
+      INTEGER,INTENT(IN) :: MAT(NEL), IFLAG, NEL
+      my_real,INTENT(INOUT) :: PM(NPROPM,NUMMAT), 
+     .        OFF(NEL)  ,EINT(NEL) ,MU(NEL), 
+     .        MU2(NEL)  ,ESPE(NEL) ,DVOL(NEL),
+     .        VNEW(NEL) ,PNEW(NEL) ,DPDM(NEL),
+     .        DPDE(NEL) ,THETA(NEL),ECOLD(NEL),
+     .        SIG(NEL,6),POLD(NEL) ,DF(NEL)   
 C-----------------------------------------------
 C   C o m m o n   B l o c k s
 C-----------------------------------------------
@@ -74,13 +84,13 @@ C-----------------------------------------------
 C   S o u r c e  L i n e s
 C-----------------------------------------------
 
-       MX           = MAT(LFT)
+       MX           = MAT(1)
        E0           = PM(23,MX)         
        C0           = PM(49,MX)
        C1           = PM(32,MX)
        C2           = PM(33,MX)
        C3           = PM(34,MX)
-       PSH(LFT:LLT) = PM(88,MX)
+       PSH(1:NEL)   = PM(88,MX)
        BUNL         = PM(45,MX)
        MU_MAX       = PM(46,MX)
        SPH          = PM(69,MX)
@@ -88,67 +98,70 @@ C-----------------------------------------------
        PFRAC        = PM(37,MX)
        MUMIN        = PM(47,MX)
        IFORM        = NINT(PM(48,MX))
+       
        TFEXTT       = ZERO
-
-       BULK(LFT:LLT)  = BUNL
-       BULK2(LFT:LLT) = BUNL
-
+       BULK(1:NEL)  = BUNL
+       BULK2(1:NEL) = BUNL
+       
       !----------------------------------------------------------------!
       !  COMPACTION EOS                                                !
       !----------------------------------------------------------------!  
-      IF(IFORM.EQ.1)THEN    
-        DO I=LFT,LLT
-          IF(MU_OLD(I).LT.ZERO)BULK(I)  = C1 
-          IF(MU(I).LT.ZERO)    BULK2(I) = C1
-          PNE1 = POLD(I)+PSH(I)+MU(I)*BULK2(I)-MU_OLD(I)*BULK(I)
-          P(I)    = C0+C1*MU(I)+C2*MU2(I)+C3*MU2(I)*MU(I)
-          IF(MU(I).LT.MU_MAX) P(I) = MIN(P(I),PNE1) 
-          P(I) = MAX(P(I),PFRAC)  *OFF(I) 
-          !B(I) = MAX(BULK(I),BULK2(I))
-          B(I) = BULK(I)
-        ENDDO !next I   
-      ELSEIF(IFORM.EQ.2)THEN
-        DO I=LFT,LLT
+      !--- constant unload slope ---!       
+      IF(IFORM == 1)THEN
+        DO I=1,NEL
           P(I) = C0+C1*MU(I)+(C2+C3*MU(I))*MU2(I)
           P_   = C0+C1*MU_OLD(I)+(C2+C3*MU_OLD(I))*MU_OLD(I)*MU_OLD(I)
-          B(I)=BUNL 
+          B(I) = BUNL 
           PNE1 = P_-(MU_OLD(I)-MU(I))*B(I)
-          IF(MU_OLD(I).GT.MUMIN) P(I) = MIN(PNE1, P(I))
-          P(I) = MAX(P(I),PFRAC)  *OFF(I)
+          IF(MU_OLD(I) > MUMIN) P(I) = MIN(PNE1, P(I))
+          P(I) = MAX(P(I),PFRAC)*OFF(I)
         ENDDO !next I   
-      ELSEIF(IFORM.EQ.3)THEN
-        DO I=LFT,LLT
+      !--- continuous unload slope (increases with compaction) ---!
+      ELSEIF(IFORM == 2)THEN
+        DO I=1,NEL
           P(I) = C0+C1*MU(I)+(C2+C3*MU(I))*MU2(I)
           P_   = C0+C1*MU_OLD(I)+(C2+C3*MU_OLD(I))*MU_OLD(I)*MU_OLD(I)
           !linear unload modulus
           ALPHA = ONE
-          IF(MU_MAX.GT.ZERO)THEN
+          IF(MU_MAX > ZERO)THEN
             ALPHA=MU_OLD(I)/MU_MAX
           ENDIF
           B(I) = ALPHA*BUNL+(ONE-ALPHA)*C1
           PNE1 = P_-(MU_OLD(I)-MU(I))*B(I)
-          IF(MU_OLD(I).GT.MUMIN) P(I) = MIN(PNE1, P(I))
+          IF(MU_OLD(I) > MUMIN) P(I) = MIN(PNE1, P(I))
           P(I) = MAX(P(I),PFRAC)  *OFF(I)
-        ENDDO !next I   
+        ENDDO !next I  
+      !--- legacy behavior ---! 
+      ELSEIF(IFORM == 10)THEN    
+        DO I=1,NEL
+          IF(MU_OLD(I) < ZERO)BULK(I)  = C1 
+          IF(MU(I) < ZERO)    BULK2(I) = C1
+          PNE1 = POLD(I)+PSH(I)+MU(I)*BULK2(I)-MU_OLD(I)*BULK(I)
+          P(I)    = C0+C1*MU(I)+C2*MU2(I)+C3*MU2(I)*MU(I)
+          IF(MU(I) < MU_MAX) P(I) = MIN(P(I),PNE1) 
+          P(I) = MAX(P(I),PFRAC)  *OFF(I) 
+          !B(I) = MAX(BULK(I),BULK2(I))
+          B(I) = BULK(I)
+        ENDDO !next I            
       ENDIF
       !----------------------------------------------------------------!
       !  SOUND SPEED                                                   !
       !----------------------------------------------------------------!      
-      DO I=LFT,LLT
-        DPDM(I) = C1 + TWO*C2*MU(I)+THREE*C3*MU2(I)   !can be discussed in expansion...
+      DO I=1,NEL
+        DPDM(I) = C1 + MAX(ZERO,MU(I)) *( TWO*C2+THREE*C3*MU(I) ) 
         DPDM(I) = MAX(B(I),DPDM(I))
         DPDE(I) = ZERO
       ENDDO !next I   
       !----------------------------------------------------------------!
       !  OUTPUT                                                        !
       !----------------------------------------------------------------!      
-      DO I=LFT,LLT
+      DO I=1,NEL
         P(I)=MAX(PFRAC,P(I))*OFF(I)
         PNEW(I) = P(I)-PSH(I)
       ENDDO !next I     
-      DO I=LFT,LLT
+      DO I=1,NEL
         ECOLD(I)=-THREE100*SPH
-        !IF(MU(I).GT.ZERO) ECOLD(I)=
+        !IF(MU(I) > ZERO) ECOLD(I)=
       ENDDO
 
       
@@ -157,61 +170,62 @@ C-----------------------------------------------
         !----------------------------------------------------------------!
         !  FRACTURE  - MU_OLD                                            !
         !----------------------------------------------------------------!      
-        DO I=LFT,LLT
+        DO I=1,NEL
           EINT(I) = EINT(I) - HALF*DVOL(I)*(PNEW(I)+PSH(I) )
         ENDDO !next I 
         !----------------------------------------------------------------!
         !  FRACTURE  - MU_OLD                                            !
         !----------------------------------------------------------------!      
-        IF(IFORM.EQ.1)THEN
-          DO I=LFT,LLT
-            IF(P(I).LE.PFRAC)THEN
+        IF(IFORM == 10)THEN
+          DO I=1,NEL
+            IF(P(I) <= PFRAC)THEN
               MU_OLD(I) =MU_OLD(I)+(PFRAC-POLD(I)-PSH(I))/BULK2(I)  
             ELSE
               MU_OLD(I)= MU(I)
             ENDIF
           ENDDO !next I
-        ELSEIF(IFORM.GE.2)THEN
-          DO I=LFT,LLT
-            IF(MU(I).GT.MU_OLD(I)) MU_OLD(I) = MIN(MU_MAX,MU(I))
+        ELSEIF(IFORM <= 2)THEN   !iform=1,2
+          DO I=1,NEL
+            IF(MU(I) > MU_OLD(I)) MU_OLD(I) = MIN(MU_MAX,MU(I))
           ENDDO !next I 
         ENDIF
         !----------------------------------------------------------------!
         !  OUTPUT                                                        !
         !----------------------------------------------------------------!      
-        DO I=LFT,LLT
+        DO I=1,NEL
           P(I)=MAX(PFRAC,P(I))*OFF(I)
           PNEW(I) = P(I)-PSH(I)
         ENDDO !next I     
-         DO I=LFT,LLT
+         DO I=1,NEL
            ECOLD(I)=-THREE100*SPH
-           !IF(MU(I).GT.ZERO) ECOLD(I)=
+           !IF(MU(I) > ZERO) ECOLD(I)=
          ENDDO
         !----------------------------------------------------------------!
         !  PRESSURE WORK                                                 !
         !----------------------------------------------------------------!      
-         DO I=LFT,LLT
+         DO I=1,NEL
            TFEXTT     = TFEXTT-DVOL(I)*PSH(I)
          ENDDO
 #include "atomic.inc"
          TFEXT = TFEXT + TFEXTT
 #include "atomend.inc"
 
+
       ELSEIF(IFLAG == 2) THEN
         !----------------------------------------------------------------!
         !  FRACTURE  - MU_OLD                                            !
         !----------------------------------------------------------------!      
-        IF(IFORM.EQ.1)THEN
+        IF(IFORM == 10)THEN
           DO I=1,NEL
-            IF(P(I).LE.PFRAC)THEN
+            IF(P(I) <= PFRAC)THEN
               MU_OLD(I) =MU_OLD(I)+(PFRAC-POLD(I)-PSH(I))/BULK2(I)  
             ELSE
               MU_OLD(I)= MU(I)
             ENDIF
           ENDDO !next I
-        ELSEIF(IFORM.GE.2)THEN
+        ELSEIF(IFORM <= 2)THEN  !iform=1,2
           DO I=1,NEL
-            IF(MU(I).GT.MU_OLD(I)) MU_OLD(I) = MIN(MU_MAX,MU(I))
+            IF(MU(I) > MU_OLD(I)) MU_OLD(I) = MIN(MU_MAX,MU(I))
           ENDDO !next I 
         ENDIF
         !----------------------------------------------------------------!
@@ -222,7 +236,6 @@ C-----------------------------------------------
           PNEW(I) = P(I)-PSH(I)
         ENDDO !next I     
       ENDIF
-
 
 C------------------------      
       RETURN

--- a/common_source/eos/eosmain.F
+++ b/common_source/eos/eosmain.F
@@ -110,7 +110,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER MAT(*),IFLAG, EOSTYP, NEL, MLW
+      INTEGER MAT(NEL),IFLAG, EOSTYP, NEL, MLW
       my_real
      .   PM(NPROPM,NUMMAT),BUFMAT(NEL)   ,OFF(NEL)  , 
      .   EINT(NEL) ,RHO(NEL)  ,RHO0(NEL) , 
@@ -126,19 +126,19 @@ C-----------------------------------------------
       INTEGER I, MX
 
       IF(IFLAG == 0) THEN
-       DO I=LFT,LLT
+       DO I=1,NEL
         MU2(I)=MAX(ZERO,MU(I))**2
         ESPE(I)=DF(I)*EINT(I)/ MAX(EM15,VNEW(I))         !ESPE=rho0.e   since EINT=rho.e.V  and DF=rho0/rho   =>  DF*EINT/V = E
        ENDDO
        IF(EOSTYP==13 .OR. EOSTYP==16)THEN
-         DO I = LFT, LLT
+         DO I = 1, NEL
            POLD(I)=-THIRD*(SIG(I,1)+SIG(I,2)+SIG(I,3))
          ENDDO
        ENDIF                
       ELSEIF (IFLAG == 2) THEN
       !LAW151 ONLY
          DO I = 1, NEL
-            IF (VNEW(I) .GT. ZERO) THEN
+            IF (VNEW(I) > ZERO) THEN
                MU2(I)=MAX(ZERO,MU(I))**2
             ENDIF
             ESPE(I) =  DF(I) * EINT(I)                   !law151 : EINT=rho.e
@@ -154,7 +154,7 @@ C-----------------------------------------------
       ! a quoi bon mettre a 0.0 quelque chose qui va etre ecrase dans le bloc SELECT CASE ce dessous.
       !IF (IFLAG==1)THEN
       !  IF (MLW .NE. 6 .AND. MLW .NE. 17) THEN
-      !      IF(EOSTYP/=13)PNEW(LFT:LLT) = ZERO
+      !      IF(EOSTYP/=13)PNEW(1:NEL) = ZERO
       !  ENDIF
       !ENDIF
            

--- a/engine/source/multifluid/multi_submatlaw.F
+++ b/engine/source/multifluid/multi_submatlaw.F
@@ -83,6 +83,7 @@ C-----------------------------------------------
       LLT = NEL
       RHO0(1:NEL) = PM(1, LOCAL_MATID)
       MAT(1:NEL) = LOCAL_MATID
+      DVOL(1:NEL) = ZERO
       DO II = 1, NEL
          IF (VOL(II) .GT. ZERO) THEN
             MU(II)    = RHO(II) / RHO0(II) - ONE

--- a/hm_cfg_files/config/CFG/radioss2022/MAT/mat_EOS.cfg
+++ b/hm_cfg_files/config/CFG/radioss2022/MAT/mat_EOS.cfg
@@ -94,6 +94,8 @@ ATTRIBUTES(COMMON)
     FSCALE_B            = VALUE(FLOAT,"Scale Factor Ordinates for function B");
     A_FUNC              = VALUE(FUNCT,"Function A");
     B_FUNC              = VALUE(FUNCT,"Function B");
+    IFORM               = VALUE(INT,"unload formulation flag");
+    
 }
 
 SKEYWORDS_IDENTIFIER(COMMON)
@@ -564,8 +566,8 @@ FORMAT(radioss2022) {
     }
     else if(EOS_Options == 14)
     {
-        COMMENT("#                 C0                  C1                  C2                  C3");
-        CARD("%20lg%20lg%20lg%20lg",EOS_COM_C0,EOS_COM_C1,EOS_COM_C2,EOS_COM_C3);
+        COMMENT("#                 C0                  C1                  C2                  C3               IFORM");
+        CARD("%20lg%20lg%20lg%20lg%10s%10d",EOS_COM_C0,EOS_COM_C1,EOS_COM_C2,EOS_COM_C3,_BLANK_,IFORM);
         
         COMMENT("#            Mue_min             Mue_max                   B");
         CARD("%20lg%20lg%20lg",EOS_COM_Mue_min,EOS_COM_Mue_max,EOS_COM_B);

--- a/starter/source/materials/eos/hm_read_eos_compaction.F
+++ b/starter/source/materials/eos/hm_read_eos_compaction.F
@@ -99,7 +99,7 @@ C-----------------------------------------------
       CALL HM_GET_FLOATV('EOS_COM_C1', C1, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('EOS_COM_C2', C2, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('EOS_COM_C3', C3, IS_AVAILABLE,LSUBMODEL,UNITAB)
-      !CALL HM_GET_INTV('IFORM', IFORM, IS_AVAILABLE,LSUBMODEL)
+      CALL HM_GET_INTV('IFORM', IFORM, IS_AVAILABLE,LSUBMODEL)
 
       CALL HM_GET_FLOATV('EOS_COM_Mue_min', MUMIN, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('EOS_COM_Mue_max', MUMAX, IS_AVAILABLE,LSUBMODEL,UNITAB)
@@ -118,7 +118,7 @@ C-----------------------------------------------
         RHO0=RHOR                   
       ENDIF
             
-      IF(C1.LE.ZERO)THEN
+      IF(C1 <= ZERO)THEN
          CALL ANCMSG(MSGID=67,
      .               MSGTYPE=MSGERROR,
      .               ANMODE=ANINFO,
@@ -127,14 +127,14 @@ C-----------------------------------------------
      .               C2='C1 MUST BE POSITIVE')
       ENDIF
 
-      !IFORM=1 : old formulation law10 (slope change when mu<0)
-      !IFORM=2 : new formulation slope is constant BUNL
-      !IFORM=3 : new formulation with linear unload modulus from CA to BUNL
-      IF(IFORM.LE.0 .OR. IFORM.GE.4)THEN 
+      !IFORM=1 : new formulation slope is constant BUNL (DEFAULT)
+      !IFORM=2 : new formulation with linear unload modulus from CA to BUNL
+      !IFORM=10 : old formulation law10 (slope change when mu<0) 
+      IF(IFORM /= 1 .AND. IFORM /= 2 .AND. IFORM /= 10)THEN 
         IFORM=1 !default     
         IOUTP=0
       ENDIF
-
+      
       MU = RHO0/RHOR-ONE
       P0 = C0+MIN(C1*MU,C1*MU+C2*MU*MU+C3*MU*MU*MU)
       E0 = ZERO
@@ -165,13 +165,13 @@ C-----------------------------------------------
       SSP0 = ZERO 
       G0 = PM(22)
       RHOI = PM(89) 
-        IF(IFORM.EQ.1)THEN    
+        IF(IFORM == 10)THEN    
             BB = BULK
-        ELSEIF(IFORM.EQ.2)THEN
+        ELSEIF(IFORM == 1)THEN
             BB=BUNL 
-        ELSEIF(IFORM.EQ.3)THEN
+        ELSEIF(IFORM == 2)THEN
           ALPHA = ONE
-          IF(MUMAX.GT.ZERO)THEN
+          IF(MUMAX > ZERO)THEN
             ALPHA=MUOLD/MUMAX
           ENDIF        
           BB = ALPHA*BUNL+(ONE-ALPHA)*C1
@@ -189,13 +189,13 @@ C-----------------------------------------------
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
         WRITE(IOUT,1500)C0,C1,C2,C3,PSH,BUNL,MUMIN,MUMAX
-        IF(IOUTP.EQ.1)THEN
-          IF(IFORM==1)THEN
+        IF(IOUTP == 1)THEN
+          IF(IFORM==10)THEN
+             WRITE(IOUT,1510)
+          ELSEIF(IFORM==1)THEN
              WRITE(IOUT,1501)
           ELSEIF(IFORM==2)THEN
              WRITE(IOUT,1502)
-          ELSEIF(IFORM==3)THEN
-             WRITE(IOUT,1503)
           ENDIF
         ENDIF
       ENDIF
@@ -213,12 +213,12 @@ C-----------------------------------------------
      & 5X,'BUNL : UNLOADING MODULUS. . . . . . . . . .=',1PG20.13/,
      & 5X,'MU_MIN : ELASTIC LIMIT. . . . . . . . . . .=',1PG20.13/,
      & 5X,'MU_MAX : MAXIMUM COMPACTION . . . . . . . .=',1PG20.13/)
+ 1510 FORMAT(
+     & 5X,'LEGACY FORMULATION'/)
  1501 FORMAT(
-     & 5X,'LEGACY FORMULATION PRIOR TO 2019.1 VERSION'/)
- 1502 FORMAT(
      & 5X,'CONSTANT UNLOAD MODULUS'/)
- 1503 FORMAT(
-     & 5X,'LINEAR UNLOAD MODULUS FROM C1 TO BUNL IN RANGE [MUMIN,MUMAX]'/)
+ 1502 FORMAT(
+     & 5X,'CONTINUOUS UNLOAD MODULUS FROM C1 TO BUNL IN RANGE [MUMIN,MUMAX]'/)
  999  CALL FREERR(3)
       RETURN
   


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### /EOS/COMPACTION:Unload behavior was fixed and a new additional formulation is proposed.
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
Legacy formulation is no longer the default one. It can however be used by setting IFORM=10
New default is IFORM=1 (unload slope is constant even if µ<0). Iform=2 is an additional formulation for which the unload slope increases with the compaction (from C1 to BUNL)
  **Iform=1** : **Constant** unload modulus (BUNL) (**new default**)
  **Iform=2** : **Linear** unload modulus form C1 to BUNL in [µ_min, µ_max]
  **Iform=10** : **legacy** formulation which had a slope change when µ<0 (it switches from BUNL when µ>=0 to C1)

#### Possible change in numerical solution : yes
It can change numerical solution since unload behavior is affected (bug fix)
This change occurs with {/EOS/COMPACTION + UNLOADING + µ<0}