### PR TITLE
missing initialization of BUFLY%NPTT

### DIFF
--- a/starter/source/elements/elbuf_init/zerovars_auto.F
+++ b/starter/source/elements/elbuf_init/zerovars_auto.F
@@ -442,6 +442,8 @@ c---
 c---
 C  nb of layer variable
         BUFLY%NVAR_LAY = IAD
+
+        BUFLY%NPTT = 0
 c---
       ENDDO 
 c-----------------------------------------------


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Valgrind pointed out an uninitialized value written in restart files.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
`BUFLY%NPTT` is set to 0
