### PR TITLE
uninit:Starter must go up to Normal termination even with input inconsistency

### DIFF
--- a/starter/source/elements/solid/solide/sderi3.F
+++ b/starter/source/elements/solid/solide/sderi3.F
@@ -56,25 +56,27 @@ C-----------------------------------------------
 C   C o m m o n   B l o c k s
 C-----------------------------------------------
 #include      "param_c.inc"
+#include      "com04_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER :: IGEO(NPROPGI,*), NGL(*), NGEO(*)
+      INTEGER :: IGEO(NPROPGI,NUMGEO), NGL(NEL), NGEO(NEL)
       INTEGER :: NEL, JEUL, NXREF, IMULTI_FVM
 C
       my_real
-     .   VOL(*), VEUL(LVEUL,*) , GEO(NPROPG,*),
-     .   JAC1(*), JAC2(*), JAC3(*), JAC4(*), JAC5(*), JAC6(*),
-     .   PX1(*), PX2(*), PX3(*), PX4(*),  
-     .   PY1(*), PY2(*), PY3(*), PY4(*),  
-     .   PZ1(*), PZ2(*), PZ3(*), PZ4(*), DET(*)
+     .   VOL(NEL), VEUL(LVEUL,*) , GEO(NPROPG,NUMGEO),
+     .   JAC1(NEL), JAC2(NEL), JAC3(NEL), JAC4(NEL), JAC5(NEL), JAC6(NEL),
+     .   PX1(NEL), PX2(NEL), PX3(NEL), PX4(NEL),  
+     .   PY1(NEL), PY2(NEL), PY3(NEL), PY4(NEL),  
+     .   PZ1(NEL), PZ2(NEL), PZ3(NEL), PZ4(NEL), DET(NEL)
       DOUBLE PRECISION
      .   XD1(MVSIZ), XD2(MVSIZ), XD3(MVSIZ), XD4(MVSIZ),
      .   XD5(MVSIZ), XD6(MVSIZ), XD7(MVSIZ), XD8(MVSIZ),
      .   YD1(MVSIZ), YD2(MVSIZ), YD3(MVSIZ), YD4(MVSIZ),
      .   YD5(MVSIZ), YD6(MVSIZ), YD7(MVSIZ), YD8(MVSIZ),
      .   ZD1(MVSIZ), ZD2(MVSIZ), ZD3(MVSIZ), ZD4(MVSIZ),
-     .   ZD5(MVSIZ), ZD6(MVSIZ), ZD7(MVSIZ), ZD8(MVSIZ),VOLDP(*)
+     .   ZD5(MVSIZ), ZD6(MVSIZ), ZD7(MVSIZ), ZD8(MVSIZ),
+     .   VOLDP(NEL)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -95,7 +97,9 @@ C
      .   X17, X28, X35, X46,
      .   Y17, Y28, Y35, Y46,
      .   Z17, Z28, Z35, Z46
-C=======================================================================
+C-----------------------------------------------
+C   S o u r c e   L i n e s
+C-----------------------------------------------
 C
 C Jacobian matrix
       DO I=1,NEL
@@ -154,7 +158,7 @@ C
 C
       DO I=1,NEL
         IF (DET(I) > ZERO) CYCLE
-        IF (IGEO(11,NGEO(I)).NE.0 .AND. IGEO(11,NGEO(I)).NE.43) THEN
+        IF (IGEO(11,NGEO(I)) /= 0 .AND. IGEO(11,NGEO(I)) /= 43) THEN
           CALL ANCMSG(MSGID=245,
      .               MSGTYPE=MSGERROR,
      .               ANMODE=ANINFO,
@@ -248,8 +252,8 @@ C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE MESSAGE_MOD
-C------------------------------------------------------
-C------------------------------------------------------
+C-----------------------------------------------
+C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
 #include      "implicit_f.inc"

--- a/starter/source/elements/solid/solide/sinit3.F
+++ b/starter/source/elements/solid/solide/sinit3.F
@@ -108,23 +108,22 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER IXS(NIXS,*),IPARG(NPARG,NGROUP),
-     .   IPARG_GR(NPARG),IPARTS(*),IGEO(NPROPGI,*),
-     .   IPM(NPROPMI,*),IPART(LIPART1,*),PTSOL(*),
-     .   NG,NSIGI ,NVC,NEL,IUSER, NSIGS, NPF(*),
-     .   STRSGLOB(*),STRAGLOB(*),FAIL_INI(*), 
-     .   KXSP(NISP,*), IPARTSP(*), NOD2SP(*), SOL2SPH(2,*), IRST(3,*),
-     .   PERTURB(NPERTURB)
-      my_real
-     .   MAS(*), PM(NPROPM,*), X(3,*),GEO(NPROPG,*),
-     .   VEUL(LVEUL,*), DTELEM(*),SIGI(NSIGS,*),SKEW(LSKEW,*),STIFN(*),
-     .   PARTSAV(20,*), V(*), MSS(8,*), 
-     .   SIGSP(NSIGI,*),MSNF(*), MSSF(8,*), WMA(*),
-     .   VOLNOD(*), BVOLNOD(*), VNS(8,*), BNS(8,*),
-     .   IN(*),VR(*), INS(8,*),BUFMAT(*),
-     .   MCP(*), MCPS(8,*), TEMP(*),
-     .   XREFS(8,3,*), TF(*), MSSA(*),
-     .   SPBUF(NSPBUF,*),RNOISE(NPERTURB,*)
+      INTEGER IXS(NIXS,NUMELS),IPARG(NPARG,NGROUP),
+     .        IPARG_GR(NPARG),IPARTS(*),IGEO(NPROPGI,NUMGEO),
+     .        IPM(NPROPMI,NUMMAT),IPART(LIPART1,*),PTSOL(*),
+     .        NG,NSIGI ,NVC,NEL,IUSER, NSIGS, NPF(*),
+     .        STRSGLOB(*),STRAGLOB(*),FAIL_INI(*), 
+     .        KXSP(NISP,*), IPARTSP(*), NOD2SP(*), SOL2SPH(2,*), IRST(3,*),
+     .        PERTURB(NPERTURB)
+      my_real MAS(*), PM(NPROPM,NUMMAT), X(3,NUMNOD),GEO(NPROPG,NUMGEO),
+     .        VEUL(LVEUL,*), DTELEM(*),SIGI(NSIGS,*),SKEW(LSKEW,*),STIFN(*),
+     .        PARTSAV(20,*), V(*), MSS(8,*), 
+     .        SIGSP(NSIGI,*),MSNF(*), MSSF(8,*), WMA(*),
+     .        VOLNOD(*), BVOLNOD(*), VNS(8,*), BNS(8,*),
+     .        IN(*),VR(*), INS(8,*),BUFMAT(*),
+     .        MCP(*), MCPS(8,*), TEMP(*),
+     .        XREFS(8,3,*), TF(*), MSSA(*),
+     .        SPBUF(NSPBUF,*),RNOISE(NPERTURB,*)
       TYPE(ELBUF_STRUCT_), TARGET :: ELBUF_STR
       INTEGER,INTENT(IN) :: ILOADP(SIZLOADP,*)
       my_real,INTENT(IN) :: FACLOAD(LFACLOAD,*)
@@ -178,7 +177,7 @@ C-----------------------------------------------
       my_real, DIMENSION(:), POINTER  :: UVARF    
 C-----------------------------------------------
 C   S o u r c e  L i n e s
-C=======================================================================
+C-----------------------------------------------
       GBUF  => ELBUF_STR%GBUF
       LBUF  => ELBUF_STR%BUFLY(1)%LBUF(1,1,1)
       MBUF  => ELBUF_STR%BUFLY(1)%MAT(1,1,1)
@@ -202,6 +201,7 @@ c
       IBID = 0
       NDDIM = 0
       NF1=NFT+1
+      VOLU(1:NEL)=ZERO
 C
       IBOLTP = IPARG_GR(72)  !Bolt preloading
 C
@@ -271,7 +271,7 @@ C Orthotropy
 C
       CALL SVEOK3(NVC,8, IX1, IX2, IX3, IX4, IX5, IX6, IX7, IX8)
 C
-      IF(JEUL.NE.0.AND.INTEG8.NE.0) THEN
+      IF(JEUL /= 0.AND.INTEG8 /= 0) THEN
         CALL SDERI3B(GBUF%VOL,VEUL(1,NF1),LVEUL,GEO,IGEO ,NGL  ,PID  ,
      .              X1   ,X2   ,X3   ,X4   ,X5   ,X6   ,X7   ,X8   ,
      .              Y1   ,Y2   ,Y3   ,Y4   ,Y5   ,Y6   ,Y7   ,Y8   ,
@@ -286,7 +286,7 @@ C
       ELSE
 C LBUF%VOL0DP is not done for Isolid=12
         IF (JHBE == 24) THEN
-          CALL SZDERI3(
+          IF(ASSOCIATED(LBUF%VOL0DP)) CALL SZDERI3(
      .           GBUF%VOL ,VEUL(1,NF1),GEO  ,IGEO  ,
      .               XD1  ,XD2  ,XD3  ,XD4  ,XD5   ,XD6  ,XD7   ,XD8   ,
      .               YD1  ,YD2  ,YD3  ,YD4  ,YD5   ,YD6  ,YD7   ,YD8   ,
@@ -297,7 +297,7 @@ C LBUF%VOL0DP is not done for Isolid=12
      .               RX   ,RY   ,RZ   ,SX   ,SY   ,SZ   ,TZ   ,
      .               NGL  ,PID  ,VOLU ,LBUF%VOL0DP,NEL  ,JEUL ,NXREF)
         ELSE
-          CALL SDERI3(
+          IF(ASSOCIATED(LBUF%VOL0DP)) CALL SDERI3(
      .          GBUF%VOL ,VEUL(1,NF1),GEO  ,IGEO  ,
      .              XD1  ,XD2  ,XD3  ,XD4  ,XD5   ,XD6  ,XD7   ,XD8   ,
      .              YD1  ,YD2  ,YD3  ,YD4  ,YD5   ,YD6  ,YD7   ,YD8   ,
@@ -313,7 +313,7 @@ C LBUF%VOL0DP is not done for Isolid=12
      .            Z1   ,Z2   ,Z3   ,Z4   ,Z5   ,Z6   ,Z7   ,Z8,
      .            DELTAX, VOLU)
       ENDIF
-      IF(JEUL.NE.0)THEN
+      IF(JEUL /= 0)THEN
         CALL EDLEN3(VEUL(1,NF1), DELTAX)
         CALL ENORM3(VEUL(1,NF1),
      .              X1   ,X2   ,X3   ,X4   ,X5   ,X6   ,X7   ,X8   ,
@@ -361,8 +361,8 @@ C----------------------------------------
 C----------------------------------------
 C Masses initialization
 C----------------------------------------
-      IF(JLAG+JALE+JEUL.NE.0) THEN
-        IF(INTEG8.NE.0 .AND. JEUL.NE.0) THEN
+      IF(JLAG+JALE+JEUL /= 0) THEN
+        IF(INTEG8 /= 0 .AND. JEUL /= 0) THEN
           CALL SMASS3B(
      1          GBUF%RHO,MAS,VEUL(44,NF1),LVEUL      ,MSS(1,NF1),
      2          PARTSAV,X  ,V           ,IPARTS(NF1),MSNF      ,
@@ -387,17 +387,16 @@ C----------------------------------------
      5         IX1, IX2, IX3, IX4, IX5, IX6, IX7, IX8)
         ELSE
 C Case /INIBRIS/STRS_FGLO missed         
-         IF (ISIGI /= 0 .AND. (JCVT/=0.OR.ISORTH/=0)) 
-     .   CALL USTRSIN3(
-     .   SIGI    ,LBUF%SIG ,IXS     ,NIXS    ,NSIGS   ,
-     .   NEL     ,STRSGLOB ,JHBE    ,IGTYP   ,X       ,
-     .   GBUF%GAMA,PTSOL   ,LBUF%VOL0DP,RHO0,GBUF%RHO)
-C
+          IF (ISIGI /= 0 .AND. (JCVT /= 0 .OR. ISORTH /= 0) ) THEN
+            IF(ASSOCIATED(LBUF%VOL0DP)) CALL USTRSIN3( SIGI    ,LBUF%SIG ,IXS     ,NIXS    ,NSIGS   ,
+     .                                                 NEL     ,STRSGLOB ,JHBE    ,IGTYP   ,X       ,
+     .                                                 GBUF%GAMA,PTSOL   ,LBUF%VOL0DP,RHO0,GBUF%RHO )
+          ENDIF
           IF (((MTN>=28 .AND. MTN/=49) .OR. MTN==14 .OR. MTN==12) .OR.
      .         (ISTRAIN == 1 .AND. 
-     .         (MTN==1 .OR. MTN==2 .OR. MTN==3 .OR. MTN==4 .OR. 
-     .          MTN==6 .OR. MTN==10.OR. MTN == 21.OR.MTN == 22.OR.
-     .          MTN == 23))) THEN
+     .         (MTN==1  .OR. MTN==2  .OR. MTN==3    .OR. MTN==4  .OR. 
+     .          MTN==6  .OR. MTN==10 .OR. MTN==21   .OR. MTN==22 .OR.
+     .          MTN==23))) THEN
               IDEF = 1
           ENDIF
 c
@@ -444,7 +443,7 @@ C--------------------------------------------------------------------
 C----------------------------------------
 C Cell momentum for FVM
 C----------------------------------------      
-      IF(IALEFVM.NE.0) THEN      
+      IF(IALEFVM /= 0) THEN      
         CALL INIMOM_FVM(V   ,  GBUF%RHO,  GBUF%VOL,  GBUF%MOM,  IXS,
      .                  IPM ,  MAT     ,  IPARG_GR,  NPF     ,  TF ,
      .                  PM  ,  LBUF%SSP,  GBUF%SIG,  NEL
@@ -460,9 +459,8 @@ C------------------------------------------
      .     VOLU, DTX, IGEO )
 C
       DO I=1,NEL
-        IF(IXS(10,I+NFT).NE.0) THEN
-          IF(     IGTYP.NE.0 .AND.IGTYP.NE.6 .AND. IGTYP.NE.14
-     .       .AND.IGTYP.NE.15.AND. IGTYP.NE.29) THEN
+        IF(IXS(10,I+NFT) /= 0) THEN
+          IF(IGTYP /= 0 .AND.IGTYP /= 6 .AND. IGTYP /= 14 .AND.IGTYP /= 15.AND. IGTYP /= 29) THEN
              IPID1=IXS(NIXS-1,I+NFT)
              CALL FRETITL2(TITR1,IGEO(NPROPGI-LTITR+1,IPID1),LTITR)
              CALL ANCMSG(MSGID=226,

--- a/starter/source/output/message/message.F
+++ b/starter/source/output/message/message.F
@@ -1865,16 +1865,13 @@ C
             RETURN
           END IF
         IF (ANMODE.NE.ANINFO_BLIND_2) THEN
-            WRITE(ISTDO,'(/A,I6)')CMSGTYPE(1:LEN_TRIM(CMSGTYPE))
-     *                      //' ID : ',MSGID
+            WRITE(ISTDO,'(/A,I6)')CMSGTYPE(1:LEN_TRIM(CMSGTYPE))//' ID : ',MSGID
         END IF
         IF (ISTDO.NE.IOUT) THEN
           IF (IOUT.NE.0) THEN
-          WRITE(IOUT,'(/A,I6)')CMSGTYPE(1:LEN_TRIM(CMSGTYPE))
-     *                        //' ID : ',MSGID
+            WRITE(IOUT,'(/A,I6)')CMSGTYPE(1:LEN_TRIM(CMSGTYPE))//' ID : ',MSGID
           ELSE
-          WRITE(ISTDO,'(/A,I6)')CMSGTYPE(1:LEN_TRIM(CMSGTYPE))
-     *                       //' ID : ',MSGID
+            WRITE(ISTDO,'(/A,I6)')CMSGTYPE(1:LEN_TRIM(CMSGTYPE))//' ID : ',MSGID
           END IF
         END IF
         IBUF=0


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Starter now goes up to Normal Termination even with inconsistent input file (/PROP/SHELL + HEXA)
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
Even if these options are not compatible Starter must go up to a normal termination and must print the expected error message. Starter had failed with ERROR TRAPPED before displaying the Error message related to this specific input incompatibility.
_Updates :_
1. SINIT3( ) : Usage of LBUF%VOL0DP is conditionned to its allocation E
2. SINIT3( ) : VOLU is initialized to 0.0 (otherwise it also prevents Starter from going up to normal termination in case of input inconsistency)

#### Expected change in numerical solution : no

