### PR TITLE
fix for title lengths

### DIFF
--- a/engine/source/output/restart/w_gr_entity.F
+++ b/engine/source/output/restart/w_gr_entity.F
@@ -42,6 +42,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   C o m m o n   B l o c k s
 C-----------------------------------------------
+#include      "nchar_c.inc"
 #include      "com04_c.inc"
 #include      "scr17_c.inc"
 C-----------------------------------------------
@@ -55,7 +56,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,J,ID,IGU,NENTITY,GRTYPE,SORTED,GRPGRP,LEVEL,
      .        ERR,R2R_ALL,R2R_SHARE,ENTITY,ITITLE(LTITR),L_GROUP
-      CHARACTER(LEN=LTITR) :: TITR
+      CHARACTER(LEN=nchartitle) :: TITR
       INTEGER, ALLOCATABLE, DIMENSION (:)  ::  IGROUP
 C-----------------------------------------------
 !       LTITR = 40

--- a/engine/source/output/restart/w_line_str.F
+++ b/engine/source/output/restart/w_line_str.F
@@ -41,6 +41,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   C o m m o n   B l o c k s
 C-----------------------------------------------
+#include      "nchar_c.inc"
 #include      "com04_c.inc"
 #include      "scr17_c.inc"
 #include      "tabsiz_c.inc"
@@ -54,7 +55,7 @@ C-----------------------------------------------
       INTEGER ISU,I,J,K,ERR,L_SLIN,ID,NSEG,TYPE,PROC,
      .        LEVEL,NSEG_R2R_ALL,NSEG_R2R_SHARE,
      .        NODE,ELTYP,ELEM,ITITLE(LTITR)
-      CHARACTER(LEN=LTITR) :: TITR
+      CHARACTER(LEN=nchartitle) :: TITR
       INTEGER, ALLOCATABLE, DIMENSION (:)  ::  ISLINI
 C-----------------------------------------------
       DO ISU=1,NSLIN

--- a/engine/source/output/restart/w_surf_str.F
+++ b/engine/source/output/restart/w_surf_str.F
@@ -41,6 +41,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   C o m m o n   B l o c k s
 C-----------------------------------------------
+#include      "nchar_c.inc"
 #include      "com04_c.inc"
 #include      "scr17_c.inc"
 #include      "tabsiz_c.inc"
@@ -54,7 +55,7 @@ C-----------------------------------------------
       INTEGER ISU,I,J,K,ERR,L_SURF,ID,NSEG,TYPE,ID_MADYMO,IAD_BUFR,
      .        NB_MADYMO,TYPE_MADYMO,LEVEL,TH_SURF,ISH4N3N,NSEG_R2R_ALL,
      .        NSEG_R2R_SHARE,NODE,ELTYP,ELEM,ITITLE(LTITR)
-      CHARACTER(LEN=LTITR) :: TITR
+      CHARACTER(LEN=nchartitle) :: TITR
       INTEGER, ALLOCATABLE, DIMENSION (:)  ::  ISURFI
 C-----------------------------------------------
       DO ISU=1,NSURF


### PR DESCRIPTION
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
The length is set to `ncharline` instead of `LTITR`
