### PR TITLE
/DT/FVMBAG/2:fix issue at time to fire

### DIFF
--- a/engine/source/airbag/fv_up_switch.F
+++ b/engine/source/airbag/fv_up_switch.F
@@ -1283,8 +1283,10 @@ C
       IF(NCYCLE > 0)THEN
         LAMBDA = FVDATA(IFV)%LAMBDA
         IF(LAMBDA > ZERO)THEN
-          DTOLD = FVDATA(IFV)%DTOLD        
-          DTX = MIN(  DTX,(DTOLD)*(ONE+LAMBDA))
+          DTOLD = FVDATA(IFV)%DTOLD   
+          IF(DTOLD > ZERO)THEN     
+            DTX = MIN( DTX, DTOLD*(ONE+LAMBDA))
+          ENDIF
         ENDIF
       ENDIF
       FVDATA(IFV)%DTOLD = DTX      

--- a/engine/source/airbag/fvbag.F
+++ b/engine/source/airbag/fvbag.F
@@ -1655,8 +1655,10 @@ C---------------------------------------------------
       IF(NCYCLE > 0)THEN
         PARAM_LAMBDA =  FVDATA(IFV)%LAMBDA
         IF(PARAM_LAMBDA > ZERO)THEN
-          DTOLD = FVDATA(IFV)%DTOLD        
-          DTX = MIN(  DTX,DTOLD*(ONE+PARAM_LAMBDA))
+          DTOLD = FVDATA(IFV)%DTOLD
+          IF(DTOLD > ZERO)THEN        
+            DTX = MIN( DTX, DTOLD*(ONE+PARAM_LAMBDA))
+          ENDIF
         ENDIF
       ENDIF
       FVDATA(IFV)%DTOLD = DTX


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### fvmbag:Engine is no longer crashing with Iequi=1 at Time to Fire
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
With Iequi=1 option (/MONVOL/FVMBAG1) Engine does not call fvbag.F and fv_up_switch.F subroutines. (polyhedra calculation skipped). Consequently at time to fire there was an initialization issue. Engine now works properly at time to fire when using /DT/FVMBAG/2

