### PR TITLE
Add relevant license files in hm_reader directory

### DIFF
--- a/extlib/hm_reader/apr_license.txt
+++ b/extlib/hm_reader/apr_license.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f854aeef66ecd55a126226e82b3f26793fc3b1c584647f6a0edc5639974c38ad
+size 17979

--- a/extlib/hm_reader/boost_license.txt
+++ b/extlib/hm_reader/boost_license.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d8291caf1cee26d23acf3eb67c9f9a2d58f1c681b16a4fbe8cbfb9e3c0b5a9b
+size 1337

--- a/extlib/hm_reader/cpp-btree_license.txt
+++ b/extlib/hm_reader/cpp-btree_license.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30
+size 11358

--- a/extlib/hm_reader/dtoa_license.txt
+++ b/extlib/hm_reader/dtoa_license.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d04360743ae3338bb08ab2106b51e24309e3ca4b1c6b1186139531ade351b7e3
+size 862

--- a/extlib/hm_reader/fdlibm_license.txt
+++ b/extlib/hm_reader/fdlibm_license.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40ace3dd8f51a6f9ad3191cf4f40d664b4cd940bfa656e7347d9acbda6047f44
+size 453

--- a/extlib/hm_reader/openthreads_license.txt
+++ b/extlib/hm_reader/openthreads_license.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7a120f655178b436e3550f64577a7291d723ec966f2430af7c5f13643423004
+size 30022

--- a/extlib/hm_reader/phmap_license.txt
+++ b/extlib/hm_reader/phmap_license.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9cee3ed052eacdf216bc840447377a4640bbd4f90395adc1df89c4c9f20e200
+size 11534

--- a/extlib/hm_reader/zlib_license.txt
+++ b/extlib/hm_reader/zlib_license.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:079d574fcfd37d8134d6b42a02c790467c5ebebc53d3715c0509284c3b9ae813
+size 1106


### PR DESCRIPTION
Third Party code license files are now in 2 places :
* The directory where the third party belongs, 
* The license directory in extlib.

