### PR TITLE
Fix SP issue for QA tests setup

### DIFF
--- a/engine/source/materials/mat/mat104/mat104c_nodam_newton.F
+++ b/engine/source/materials/mat/mat104/mat104c_nodam_newton.F
@@ -142,7 +142,7 @@ c
       ! Recovering internal variables
       DO I=1,NEL
         IF (OFF(I) < EM01) OFF(I) = ZERO
-        IF (OFF(I) < ONE)   OFF(I) = OFF(I)*FOUR_OVER_5
+        IF (OFF(I) < ONE)  OFF(I) = OFF(I)*FOUR_OVER_5
         ! Standard inputs
         DPLA(I)  = ZERO      ! Initialization of the plastic strain increment
         ET(I)    = ONE        ! Initialization of hourglass coefficient
@@ -477,7 +477,7 @@ c
      .            + TWO*SIGNXY(I)*SIGNXY(I)
      .            + TWO*SIGNYZ(I)*SIGNYZ(I)
      .            + TWO*SIGNZX(I)*SIGNZX(I))
-          IF (NORMSIG>ZERO) THEN  
+          IF (NORMSIG>EM10) THEN  
             FDR(I)     =  (J2(I)/(NORMSIG**2))**3 - CDR*((J3(I)/(NORMSIG**3))**2)       
             DPHI_DFDR  =  DPHI_DSIG*KDR*(ONE/SIX)*EXP(-(FIVE/SIX)*LOG(FDR(I)))             
             DSDRDJ2    =  DPHI_DFDR*THREE*(J2(I)/(NORMSIG**2))**2                             

--- a/engine/source/materials/mat/mat104/mat104c_nodam_nice.F
+++ b/engine/source/materials/mat/mat104/mat104c_nodam_nice.F
@@ -145,7 +145,7 @@ c
       ! Recovering internal variables
       DO I=1,NEL
         IF (OFF(I) < EM01) OFF(I) = ZERO
-        IF (OFF(I) < ONE)   OFF(I) = OFF(I)*FOUR_OVER_5
+        IF (OFF(I) < ONE)  OFF(I) = OFF(I)*FOUR_OVER_5
         ! User inputs
         PHI0(I)  = UVAR(I,1) ! Previous yield function value
         ! Standard inputs
@@ -496,8 +496,8 @@ c
      .            + TWO*SIGNXY(I)*SIGNXY(I)
      .            + TWO*SIGNYZ(I)*SIGNYZ(I)
      .            + TWO*SIGNZX(I)*SIGNZX(I))
-          IF (NORMSIG>ZERO) THEN  
-            FDR(I)     =  (J2(I)/(NORMSIG**2))**3 - CDR*((J3(I)/(NORMSIG**3))**2)       
+          IF (NORMSIG>EM10) THEN  
+            FDR(I)     =  (J2(I)/(NORMSIG**2))**3 - CDR*((J3(I)/(NORMSIG**3))**2)   
             DPHI_DFDR  =  DPHI_DSIG*KDR*(ONE/SIX)*EXP(-(FIVE/SIX)*LOG(FDR(I)))             
             DSDRDJ2    =  DPHI_DFDR*THREE*(J2(I)/(NORMSIG**2))**2                             
             DSDRDJ3    = -DPHI_DFDR*TWO*CDR*(J3(I)/(NORMSIG**3))                                                   


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

In simple precision, the test NORMSIG > ZERO could be fulfilled at a very low value even if the stress tensor is null. This could lead to FDR value close to zero generating NaN issue. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Set up a strictly positive tolerance at EM10 to avoid NaN computation. 
