### PR TITLE
Fix SP issue for ITET4=3 with SPMD

### DIFF
--- a/engine/source/mpi/nodes/spmd_exch_vol.F
+++ b/engine/source/mpi/nodes/spmd_exch_vol.F
@@ -87,8 +87,9 @@ C-----------------------------------------------
         IF(SIZ/=0)THEN
           MSGTYP = MSGOFF
           CALL MPI_IRECV(
-     S      RBUF(1,L),SIZ,REAL,IT_SPMD(I),MSGTYP,
-     G      MPI_COMM_WORLD,REQ_R(I),IERROR)
+     S      RBUF(1,L),SIZ,MPI_DOUBLE_PRECISION,
+     G      IT_SPMD(I),MSGTYP,MPI_COMM_WORLD,
+     H      REQ_R(I),IERROR)
           L = L  + 2*LEN
         ENDIF
         IAD_RECV(I+1)  = L
@@ -137,8 +138,9 @@ C envoi a N+I mod P
           SIZ = LEN * 2 * SIZ6       
           L = IAD_SEND(I)
           CALL MPI_ISEND(
-     S      SBUF(1,L),SIZ,REAL,IT_SPMD(I),MSGTYP,
-     G      MPI_COMM_WORLD,REQ_S(I),IERROR)
+     S      SBUF(1,L),SIZ,MPI_DOUBLE_PRECISION,
+     G      IT_SPMD(I),MSGTYP,MPI_COMM_WORLD,
+     H      REQ_S(I),IERROR)
        ENDIF
 C--------------------------------------------------------------------
       ENDDO


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

SPMD simulations were crashing in Simple precision when using ITET4 = 3 flag. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

The exchange routine had a bug. The arrays exchanged at boundaries are double precision arrays, but they were sent and received as REAL that depends on the precision. REAL has been changed to MPI_DOUBLE_PRECISION. 
