### PR TITLE
Fix an issue in the cylindrical joint

### DIFF
--- a/engine/source/constraints/general/cyl_joint/cjoint.F
+++ b/engine/source/constraints/general/cyl_joint/cjoint.F
@@ -62,7 +62,11 @@ C
         K=1
         DO N=1,NJOINT
             KIND(N) = K
-            K=K+LJOINT(K)+1
+            IF(IDTMINS==0.AND.IDTMINS_INT==0)THEN
+                K = K +1
+            ELSE
+                K=K+LJOINT(K)+1
+            ENDIF
         END DO
 
         IF(IDTMINS==0.AND.IDTMINS_INT==0)THEN


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug

A bug was recently found in the cylindrical joint. 


#### Description of the changes
The old array LJOINT was not allocated/initialized but was used if the condition (IDTMINS==0.AND.IDTMINS_INT==0) is true.
Now, LJOINTis used only if  (IDTMINS==0.AND.IDTMINS_INT==0) is false.


