### PR TITLE
Fix an issue in the collision detection algo

### DIFF
--- a/engine/share/modules/inter_sorting_mod.F
+++ b/engine/share/modules/inter_sorting_mod.F
@@ -155,6 +155,9 @@ Chd|====================================================================
             LOGICAL :: COARSE_GRID
             INTEGER, DIMENSION(:), ALLOCATABLE :: NB_LOCAL_CELL
             LOGICAL, DIMENSION(:,:,:), ALLOCATABLE :: CELL_BOOL
+
+            INTEGER :: REMOTE_S_NODE    ! number of real remote secondary nodes
+            INTEGER, DIMENSION(:), ALLOCATABLE :: LIST_REMOTE_S_NODE ! list of real remote secondary nodes
 !   -------------------------    
         END MODULE INTER_SORTING_MOD
 

--- a/engine/source/interfaces/generic/inter_count_node_curv.F
+++ b/engine/source/interfaces/generic/inter_count_node_curv.F
@@ -135,8 +135,8 @@ C-----------------------------------------------
                     MIN_LIMIT(J) = MIN(MIN_LIMIT(J),X(J,NOD))
                     SIGMA(J) = SIGMA(J) + X(J,NOD)
                     SIGMA2(J) = SIGMA2(J) + X(J,NOD)**2
-                    NMN_L = NMN_L + 1
                 ENDDO
+                NMN_L = NMN_L + 1
             ENDIF
             IF(INCONV==1) THEN
                 IF( NOD>0 ) THEN

--- a/engine/source/interfaces/int07/inter_sort_07.F
+++ b/engine/source/interfaces/int07/inter_sort_07.F
@@ -228,7 +228,14 @@ C
         ILD = 0
         NB_N_B = 1
 
- 50     CALL MY_BARRIER                              
+ 50     CALL MY_BARRIER    
+        IF(ITASK==0) THEN
+            IF(ALLOCATED( LIST_REMOTE_S_NODE ) ) DEALLOCATE( LIST_REMOTE_S_NODE )
+            ALLOCATE( LIST_REMOTE_S_NODE(NSNR) )
+            REMOTE_S_NODE = 0
+        ENDIF
+        CALL MY_BARRIER                          
+
         IF(IPARI(63,NIN) ==2 ) INTBUF_TAB%METRIC%ALGO = ALGO_VOXEL 
  
 #ifdef MPI
@@ -253,7 +260,7 @@ C
      B      GAPMIN ,GAPMAX      ,CURV_MAX_MAX   ,NUM_IMP   ,INTBUF_TAB%GAP_SL,
      C      INTBUF_TAB%GAP_ML(1+ESHIFT),INTTH ,ITASK  , INTBUF_TAB%VARIABLES(7),I_MEM     ,  
      D      INTBUF_TAB%KREMNODE(1+2*ESHIFT),INTBUF_TAB%REMNODE,ITAB , IPARI(63,NIN),DRAD         ,
-     E      ITIED ,INTBUF_TAB%CAND_F,DGAPLOADP)
+     E      ITIED ,INTBUF_TAB%CAND_F,DGAPLOADP,REMOTE_S_NODE,LIST_REMOTE_S_NODE)
 
         ELSE
             CALL I7BUCE(
@@ -367,6 +374,11 @@ C
             IF (IMONM > 0) CALL STOPTIME(26,1)
 !$OMP END SINGLE
         END IF
-C
-      RETURN
-      END
+
+      IF(ITASK==0) THEN
+        IF(ALLOCATED( LIST_REMOTE_S_NODE ) ) DEALLOCATE( LIST_REMOTE_S_NODE )
+      ENDIF
+      CALL MY_BARRIER
+
+        RETURN
+        END

--- a/engine/source/interfaces/intsort/i7buce.F
+++ b/engine/source/interfaces/intsort/i7buce.F
@@ -205,7 +205,7 @@ Chd|====================================================================
      B   GAPMIN   ,GAPMAX  ,CURV_MAX_MAX,NUM_IMP,GAP_S_L ,
      C   GAP_M_L  ,INTTH   ,ITASK   ,BGAPSMX  ,I_MEM   ,  
      D   KREMNOD  ,REMNOD  ,ITAB    ,FLAGREMNODE, DRAD ,
-     E   ITIED    ,CAND_F  ,DGAPLOAD)
+     E   ITIED    ,CAND_F  ,DGAPLOAD,REMOTE_S_NODE,LIST_REMOTE_S_NODE)
 C============================================================================
 C   M o d u l e s
 C-----------------------------------------------
@@ -236,6 +236,8 @@ C-----------------------------------------------
       INTEGER CAND_E(*),CAND_N(*),IFPEN(*),KREMNOD(*),REMNOD(*),ITAB(*)
       INTEGER NCONTACT,ESHIFT,ILD,NB_N_B, IGAP, NCONT,INTTH,I_MEM,
      *        II_STOK, FLAGREMNODE, ITIED
+      INTEGER, INTENT(inout) :: REMOTE_S_NODE
+      INTEGER, DIMENSION(NSNR), INTENT(inout) :: LIST_REMOTE_S_NODE
 C     REAL
       my_real
      .   GAP,TZINF,MAXBOX,MINBOX,CURV_MAX_MAX,
@@ -394,7 +396,7 @@ C (en // SMP il y a possibilite de redondance de traitement mais no pb)
      8   GAP_M   ,GAPMIN   ,GAPMAX   ,MARGE    ,CURV_MAX,
      9   NIN     ,ITASK    ,BGAPSMX  ,KREMNOD  ,REMNOD  ,
      A   ITAB    ,FLAGREMNODE,DRAD   ,ITIED    ,CAND_F  ,
-     B   DGAPLOAD)
+     B   DGAPLOAD,REMOTE_S_NODE,LIST_REMOTE_S_NODE)
  
  234  CONTINUE
 

--- a/engine/source/interfaces/intsort/i7main_tri.F
+++ b/engine/source/interfaces/intsort/i7main_tri.F
@@ -65,6 +65,7 @@ C-----------------------------------------------
       USE INTBUFDEF_MOD
       USE H3D_MOD
       USE MULTI_FVM_MOD
+      USE INTER_SORTING_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -427,6 +428,12 @@ C       INTBUF_TAB%METRIC%ALGO = ALGO_BUCKET
 C      ENDIF
 
  50   CALL MY_BARRIER
+      IF(ITASK==0) THEN
+        IF(ALLOCATED( LIST_REMOTE_S_NODE ) ) DEALLOCATE( LIST_REMOTE_S_NODE )
+        ALLOCATE( LIST_REMOTE_S_NODE(NSNR) )
+        REMOTE_S_NODE = 0
+      ENDIF
+      CALL MY_BARRIER
 !     IF REMNODE Then VOXEL                               
       IF(IPARI(63,NIN) ==2 ) INTBUF_TAB%METRIC%ALGO = ALGO_VOXEL 
  
@@ -453,7 +460,7 @@ C
      B GAPMIN ,GAPMAX      ,CURV_MAX_MAX   ,NUM_IMP   ,INTBUF_TAB%GAP_SL,
      C INTBUF_TAB%GAP_ML(1+ESHIFT),INTTH ,ITASK  , INTBUF_TAB%VARIABLES(7),I_MEM     ,  
      D INTBUF_TAB%KREMNODE(1+2*ESHIFT),INTBUF_TAB%REMNODE,ITAB , IPARI(63,NIN),DRAD         ,
-     E ITIED ,INTBUF_TAB%CAND_F,DGAPLOADP)
+     E ITIED ,INTBUF_TAB%CAND_F,DGAPLOADP,REMOTE_S_NODE,LIST_REMOTE_S_NODE)
       ELSE
         CALL I7BUCE(
      1 X      ,INTBUF_TAB%IRECTM(1+4*ESHIFT),INTBUF_TAB%NSV  ,INACTI    ,INTBUF_TAB%CAND_P,
@@ -569,6 +576,11 @@ C
         IF (IMONM > 0) CALL STOPTIME(26,1)
 !$OMP END SINGLE
       END IF
+
+      IF(ITASK==0) THEN
+        IF(ALLOCATED( LIST_REMOTE_S_NODE ) ) DEALLOCATE( LIST_REMOTE_S_NODE )
+      ENDIF
+      CALL MY_BARRIER
 C
       RETURN
       END

--- a/engine/source/interfaces/intsort/i7tri.F
+++ b/engine/source/interfaces/intsort/i7tri.F
@@ -211,6 +211,12 @@ C
 C Prise en compte candidats non locaux en SPMD
 C
       DO I = NSN+1, NSN+NSNR
+        IF( XREM(1,I-NSN)<XMIN) CYCLE
+        IF( XREM(1,I-NSN)>XMAX) CYCLE
+        IF( XREM(2,I-NSN)<YMIN) CYCLE
+        IF( XREM(2,I-NSN)>YMAX) CYCLE
+        IF( XREM(3,I-NSN)<ZMIN) CYCLE
+        IF( XREM(3,I-NSN)>ZMAX) CYCLE
         NB_NC = NB_NC + 1
         BPN(NB_NC) = I
       ENDDO

--- a/engine/source/interfaces/intsort/i7trivox.F
+++ b/engine/source/interfaces/intsort/i7trivox.F
@@ -44,7 +44,7 @@ Chd|====================================================================
      8      GAP_M  ,GAPMIN      ,GAPMAX  ,MARGE    ,CURV_MAX ,
      9      NIN    ,ITASK       ,BGAPSMX ,KREMNOD  ,REMNOD   ,
      A      ITAB   ,FLAGREMNODE ,DRAD    ,ITIED    ,CAND_F   ,
-     B      DGAPLOAD)
+     B      DGAPLOAD,REMOTE_S_NODE,LIST_REMOTE_S_NODE)
 C============================================================================
 C   M o d u l e s
 C-----------------------------------------------
@@ -122,6 +122,8 @@ C-----------------------------------------------
      .   TZINF,MARGE,GAP,GAPMIN,GAPMAX,BGAPSMX,
      .   CURV_MAX(*),GAP_S_L(*),GAP_M_L(*),CAND_F(*)
       my_real , INTENT(IN) :: DRAD,DGAPLOAD
+      INTEGER, INTENT(inout) :: REMOTE_S_NODE
+      INTEGER, DIMENSION(NSNR), INTENT(inout) :: LIST_REMOTE_S_NODE
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -261,7 +263,18 @@ C=======================================================================
 C=======================================================================
 C 2   REMOTE NODE CLUSTERING
 C=======================================================================
+       REMOTE_S_NODE = 0
        DO J = 1, NSNR
+
+        IF(XREM(1,J) < XMIN)  CYCLE                                             
+        IF(XREM(1,J) > XMAX)  CYCLE                                             
+        IF(XREM(2,J) < YMIN)  CYCLE                                             
+        IF(XREM(2,J) > YMAX)  CYCLE                                             
+        IF(XREM(3,J) < ZMIN)  CYCLE                                             
+        IF(XREM(3,J) > ZMAX)  CYCLE 
+
+        REMOTE_S_NODE = REMOTE_S_NODE + 1
+        LIST_REMOTE_S_NODE( REMOTE_S_NODE ) = J
         IIX(NSN+J)=INT(NBX*(XREM(1,J)-XMINB)/(XMAXB-XMINB))
         IIY(NSN+J)=INT(NBY*(XREM(2,J)-YMINB)/(YMAXB-YMINB))
         IIZ(NSN+J)=INT(NBZ*(XREM(3,J)-ZMINB)/(ZMAXB-ZMINB))
@@ -542,9 +555,11 @@ C=======================================================================
           VOXEL(IIX(I),IIY(I),IIZ(I))=0
         ENDIF
       ENDDO
-      NSNF = 1 + ITASK*NSNR / NTHREAD
-      NSNL = (ITASK+1)*NSNR / NTHREAD
-      DO J = NSNF, NSNL
+      NSNF = 1 + ITASK*REMOTE_S_NODE / NTHREAD
+      NSNL = (ITASK+1)*REMOTE_S_NODE / NTHREAD
+      IF(ITASK+1==NTHREAD) NSNL=REMOTE_S_NODE
+      DO JJ = NSNF, NSNL
+        J = LIST_REMOTE_S_NODE(JJ)
         VOXEL(IIX(NSN+J),IIY(NSN+J),IIZ(NSN+J))=0
       ENDDO
       CALL MY_BARRIER()


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
An issue was introduced in the PR related to the new collision detection algorithm
The number of main nodes was overestimated, so the standard deviation was wrong and the voxel of main surface was not centre on the main nodes
This lead to a really bad performance of the i7trivox routine


#### Description of the changes
The computation of the main node number is fixed


