### PR TITLE
Fix non-local erosion for solid elements

### DIFF
--- a/engine/source/elements/solid/solide/sfint_reg.F
+++ b/engine/source/elements/solid/solide/sfint_reg.F
@@ -35,7 +35,7 @@ Chd|====================================================================
      .                     PX2     ,PX3      ,PX4      ,PY1     ,
      .                     PY2     ,PY3      ,PY4      ,PZ1     ,
      .                     PZ2     ,PZ3      ,PZ4      ,IMAT    ,
-     .                     ITASK   ,DT2T     )
+     .                     ITASK   ,DT2T     ,VOL0     )
 C-----------------------------------------------
 C   M o d u l e s
 C----------------------------------------------- 
@@ -60,7 +60,7 @@ C-----------------------------------------------
       my_real, INTENT(INOUT)                     ::
      .  DT2T
       my_real, DIMENSION(NEL), INTENT(IN) :: 
-     .   VOL,OFF,VAR_REG,
+     .   VOL,OFF,VAR_REG,VOL0,
      .   PX1,PX2,PX3,PX4,PY1,PY2,PY3,PY4,PZ1,PZ2,PZ3,PZ4
       TYPE(NLOCAL_STR_), TARGET :: NLOC_DMG 
 C-----------------------------------------------
@@ -72,7 +72,7 @@ C-----------------------------------------------
      . B1,B2,B3,B4,B5,B6,B7,B8,ZETA,SSPNL,DTNL,LE_MAX,
      . MAXSTIF
       my_real, DIMENSION(NEL) :: 
-     . F1,F2,F3,F4,F5,F6,F7,F8
+     . F1,F2,F3,F4,F5,F6,F7,F8,LC
       my_real, DIMENSION(:) ,ALLOCATABLE   :: 
      . BTB11,BTB12,BTB13,BTB14,BTB22,BTB23,BTB24,
      . BTB33,BTB34,BTB44,STI1,STI2,STI3,STI4,STI5,
@@ -95,6 +95,7 @@ C=======================================================================
       SSPNL  = NLOC_DMG%SSPNL(IMAT)
       LE_MAX = NLOC_DMG%LE_MAX(IMAT) ! Maximal length of convergence
       NTN  = EIGHT*EIGHT
+      LC(1:NEL) = ZERO
       ALLOCATE(BTB11(NEL),BTB12(NEL),BTB13(NEL),BTB14(NEL),BTB22(NEL),
      . BTB23(NEL),BTB24(NEL),BTB33(NEL),BTB34(NEL),BTB44(NEL),POS1(NEL),
      . POS2(NEL),POS3(NEL),POS4(NEL),POS5(NEL),POS6(NEL),POS7(NEL),POS8(NEL))
@@ -262,25 +263,29 @@ c
 c            
         ! If the element is broken, the non-local wave is absorbed  
         ELSE
+c
+          ! Initial element characteristic length
+          LC(I) = VOL0(I)**THIRD  
+c
           IF (NODADT > 0) THEN
      
             ! Non-local absorbing forces
             F1(I) = SQRT(MASS(POS1(I))/MASS0(POS1(I)))*ZETA*SSPNL*HALF*
-     .                                (VNL(POS1(I))+VNL0(POS1(I)))*(THREE/FOUR)*(LE_MAX**2)
+     .                                (VNL(POS1(I))+VNL0(POS1(I)))*(THREE/FOUR)*(LC(I)**2)
             F2(I) = SQRT(MASS(POS2(I))/MASS0(POS2(I)))*ZETA*SSPNL*HALF*
-     .                                (VNL(POS2(I))+VNL0(POS2(I)))*(THREE/FOUR)*(LE_MAX**2)
+     .                                (VNL(POS2(I))+VNL0(POS2(I)))*(THREE/FOUR)*(LC(I)**2)
             F3(I) = SQRT(MASS(POS3(I))/MASS0(POS3(I)))*ZETA*SSPNL*HALF*
-     .                                (VNL(POS3(I))+VNL0(POS3(I)))*(THREE/FOUR)*(LE_MAX**2)
+     .                                (VNL(POS3(I))+VNL0(POS3(I)))*(THREE/FOUR)*(LC(I)**2)
             F4(I) = SQRT(MASS(POS4(I))/MASS0(POS4(I)))*ZETA*SSPNL*HALF*
-     .                                (VNL(POS4(I))+VNL0(POS4(I)))*(THREE/FOUR)*(LE_MAX**2)
+     .                                (VNL(POS4(I))+VNL0(POS4(I)))*(THREE/FOUR)*(LC(I)**2)
             F5(I) = SQRT(MASS(POS5(I))/MASS0(POS5(I)))*ZETA*SSPNL*HALF*
-     .                                (VNL(POS5(I))+VNL0(POS5(I)))*(THREE/FOUR)*(LE_MAX**2)
+     .                                (VNL(POS5(I))+VNL0(POS5(I)))*(THREE/FOUR)*(LC(I)**2)
             F6(I) = SQRT(MASS(POS6(I))/MASS0(POS6(I)))*ZETA*SSPNL*HALF*
-     .                                (VNL(POS6(I))+VNL0(POS6(I)))*(THREE/FOUR)*(LE_MAX**2)
+     .                                (VNL(POS6(I))+VNL0(POS6(I)))*(THREE/FOUR)*(LC(I)**2)
             F7(I) = SQRT(MASS(POS7(I))/MASS0(POS7(I)))*ZETA*SSPNL*HALF*
-     .                                (VNL(POS7(I))+VNL0(POS7(I)))*(THREE/FOUR)*(LE_MAX**2)
+     .                                (VNL(POS7(I))+VNL0(POS7(I)))*(THREE/FOUR)*(LC(I)**2)
             F8(I) = SQRT(MASS(POS8(I))/MASS0(POS8(I)))*ZETA*SSPNL*HALF*
-     .                                (VNL(POS8(I))+VNL0(POS8(I)))*(THREE/FOUR)*(LE_MAX**2)
+     .                                (VNL(POS8(I))+VNL0(POS8(I)))*(THREE/FOUR)*(LC(I)**2)
             ! Computing nodal equivalent stiffness
             STI1(I) = EM20
             STI2(I) = EM20
@@ -292,14 +297,14 @@ c
             STI8(I) = EM20
           ELSE
             ! Non-local absorbing forces
-            F1(I) = ZETA*SSPNL*HALF*(VNL(POS1(I))+VNL0(POS1(I)))*(THREE/FOUR)*(LE_MAX**2)
-            F2(I) = ZETA*SSPNL*HALF*(VNL(POS2(I))+VNL0(POS2(I)))*(THREE/FOUR)*(LE_MAX**2)
-            F3(I) = ZETA*SSPNL*HALF*(VNL(POS3(I))+VNL0(POS3(I)))*(THREE/FOUR)*(LE_MAX**2)
-            F4(I) = ZETA*SSPNL*HALF*(VNL(POS4(I))+VNL0(POS4(I)))*(THREE/FOUR)*(LE_MAX**2)
-            F5(I) = ZETA*SSPNL*HALF*(VNL(POS5(I))+VNL0(POS5(I)))*(THREE/FOUR)*(LE_MAX**2)
-            F6(I) = ZETA*SSPNL*HALF*(VNL(POS6(I))+VNL0(POS6(I)))*(THREE/FOUR)*(LE_MAX**2)
-            F7(I) = ZETA*SSPNL*HALF*(VNL(POS7(I))+VNL0(POS7(I)))*(THREE/FOUR)*(LE_MAX**2)
-            F8(I) = ZETA*SSPNL*HALF*(VNL(POS8(I))+VNL0(POS8(I)))*(THREE/FOUR)*(LE_MAX**2)          
+            F1(I) = ZETA*SSPNL*HALF*(VNL(POS1(I))+VNL0(POS1(I)))*(THREE/FOUR)*(LC(I)**2)
+            F2(I) = ZETA*SSPNL*HALF*(VNL(POS2(I))+VNL0(POS2(I)))*(THREE/FOUR)*(LC(I)**2)
+            F3(I) = ZETA*SSPNL*HALF*(VNL(POS3(I))+VNL0(POS3(I)))*(THREE/FOUR)*(LC(I)**2)
+            F4(I) = ZETA*SSPNL*HALF*(VNL(POS4(I))+VNL0(POS4(I)))*(THREE/FOUR)*(LC(I)**2)
+            F5(I) = ZETA*SSPNL*HALF*(VNL(POS5(I))+VNL0(POS5(I)))*(THREE/FOUR)*(LC(I)**2)
+            F6(I) = ZETA*SSPNL*HALF*(VNL(POS6(I))+VNL0(POS6(I)))*(THREE/FOUR)*(LC(I)**2)
+            F7(I) = ZETA*SSPNL*HALF*(VNL(POS7(I))+VNL0(POS7(I)))*(THREE/FOUR)*(LC(I)**2)
+            F8(I) = ZETA*SSPNL*HALF*(VNL(POS8(I))+VNL0(POS8(I)))*(THREE/FOUR)*(LC(I)**2)          
           ENDIF
         ENDIF
       ENDDO

--- a/engine/source/elements/solid/solide/sforc3.F
+++ b/engine/source/elements/solid/solide/sforc3.F
@@ -1191,7 +1191,7 @@ C Virtual internal forces of regularized non local dof
      .       PX2      ,PX3      ,PX4      ,PY1      ,
      .       PY2      ,PY3      ,PY4      ,PZ1      ,
      .       PZ2      ,PZ3      ,PZ4      ,MXT(LFT) ,
-     .       ITASK    ,DT2T     )
+     .       ITASK    ,DT2T     ,GBUF%VOL )
       ENDIF 
 C
       IF (JTHE < 0) THEN

--- a/engine/source/elements/solid/solide4/s4fint_reg.F
+++ b/engine/source/elements/solid/solide4/s4fint_reg.F
@@ -33,7 +33,7 @@ Chd|====================================================================
      .                      PX2     ,PX3      ,PX4      ,PY1     ,
      .                      PY2     ,PY3      ,PY4      ,PZ1     ,
      .                      PZ2     ,PZ3      ,PZ4      ,IMAT    ,
-     .                      ITASK   ,DT2T     )
+     .                      ITASK   ,DT2T     ,VOL0     )
 C-----------------------------------------------
 C   M o d u l e s
 C----------------------------------------------- 
@@ -58,7 +58,7 @@ C-----------------------------------------------
       my_real, INTENT(INOUT)                     ::
      .  DT2T
       my_real, DIMENSION(NEL), INTENT(IN) :: 
-     .   VOL,OFF,VAR_REG,
+     .   VOL,OFF,VAR_REG,VOL0,
      .   PX1,PX2,PX3,PX4,PY1,PY2,PY3,PY4,PZ1,PZ2,PZ3,PZ4
       TYPE(NLOCAL_STR_), TARGET :: NLOC_DMG 
 C-----------------------------------------------
@@ -69,7 +69,7 @@ C-----------------------------------------------
      . DX, DY, DZ, L2,NTN,NTN_UNL,NTN_VNL,XI,NTVAR,A,
      . B1,B2,B3,B4,ZETA,SSPNL,DTNL,LE_MAX,MAXSTIF
       my_real, DIMENSION(NEL) :: 
-     . F1,F2,F3,F4
+     . F1,F2,F3,F4,LC
       my_real, DIMENSION(:) ,ALLOCATABLE   :: 
      . BTB11,BTB12,BTB13,BTB14,BTB22,BTB23,BTB24,
      . BTB33,BTB34,BTB44,STI1,STI2,STI3,STI4
@@ -91,6 +91,7 @@ C=======================================================================
       SSPNL  = NLOC_DMG%SSPNL(IMAT)
       LE_MAX = NLOC_DMG%LE_MAX(IMAT) ! Maximal length of convergence
       NTN    = FOUR*FOUR
+      LC(1:NEL) = ZERO
       ALLOCATE(BTB11(NEL),BTB12(NEL),BTB13(NEL),BTB14(NEL),BTB22(NEL),
      . BTB23(NEL),BTB24(NEL),BTB33(NEL),BTB34(NEL),BTB44(NEL),POS1(NEL),
      . POS2(NEL),POS3(NEL),POS4(NEL))
@@ -203,16 +204,20 @@ c
 c
         ! If the element is broken, computation of absorbing forces
         ELSE
+c
+          ! Initial element characteristic length
+          LC(I) = VOL0(I)**THIRD  
+c
           IF (NODADT > 0) THEN     
             ! Non-local absorbing forces
             F1(I) = SQRT(MASS(POS1(I))/MASS0(POS1(I)))*ZETA*SSPNL*HALF*
-     .                          (VNL(POS1(I))+VNL0(POS1(I)))*(SQRT(THREE)/FOUR)*(LE_MAX**2)
+     .                          (VNL(POS1(I))+VNL0(POS1(I)))*(SQRT(THREE)/FOUR)*(LC(I)**2)
             F2(I) = SQRT(MASS(POS2(I))/MASS0(POS2(I)))*ZETA*SSPNL*HALF*
-     .                          (VNL(POS2(I))+VNL0(POS2(I)))*(SQRT(THREE)/FOUR)*(LE_MAX**2)
+     .                          (VNL(POS2(I))+VNL0(POS2(I)))*(SQRT(THREE)/FOUR)*(LC(I)**2)
             F3(I) = SQRT(MASS(POS3(I))/MASS0(POS3(I)))*ZETA*SSPNL*HALF*
-     .                          (VNL(POS3(I))+VNL0(POS3(I)))*(SQRT(THREE)/FOUR)*(LE_MAX**2)
+     .                          (VNL(POS3(I))+VNL0(POS3(I)))*(SQRT(THREE)/FOUR)*(LC(I)**2)
             F4(I) = SQRT(MASS(POS4(I))/MASS0(POS4(I)))*ZETA*SSPNL*HALF*
-     .                          (VNL(POS4(I))+VNL0(POS4(I)))*(SQRT(THREE)/FOUR)*(LE_MAX**2) 
+     .                          (VNL(POS4(I))+VNL0(POS4(I)))*(SQRT(THREE)/FOUR)*(LC(I)**2)
             ! Computing nodal equivalent stiffness
             STI1(I) = EM20
             STI2(I) = EM20
@@ -220,10 +225,10 @@ c
             STI4(I) = EM20        
           ELSE
             ! Non-local absorbing forces
-            F1(I) = ZETA*SSPNL*HALF*(VNL(POS1(I))+VNL0(POS1(I)))*(SQRT(THREE)/FOUR)*(LE_MAX**2)
-            F2(I) = ZETA*SSPNL*HALF*(VNL(POS2(I))+VNL0(POS2(I)))*(SQRT(THREE)/FOUR)*(LE_MAX**2)
-            F3(I) = ZETA*SSPNL*HALF*(VNL(POS3(I))+VNL0(POS3(I)))*(SQRT(THREE)/FOUR)*(LE_MAX**2)
-            F4(I) = ZETA*SSPNL*HALF*(VNL(POS4(I))+VNL0(POS4(I)))*(SQRT(THREE)/FOUR)*(LE_MAX**2)          
+            F1(I) = ZETA*SSPNL*HALF*(VNL(POS1(I))+VNL0(POS1(I)))*(SQRT(THREE)/FOUR)*(LC(I)**2)
+            F2(I) = ZETA*SSPNL*HALF*(VNL(POS2(I))+VNL0(POS2(I)))*(SQRT(THREE)/FOUR)*(LC(I)**2)
+            F3(I) = ZETA*SSPNL*HALF*(VNL(POS3(I))+VNL0(POS3(I)))*(SQRT(THREE)/FOUR)*(LC(I)**2)
+            F4(I) = ZETA*SSPNL*HALF*(VNL(POS4(I))+VNL0(POS4(I)))*(SQRT(THREE)/FOUR)*(LC(I)**2)          
           ENDIF
         ENDIF
       ENDDO

--- a/engine/source/elements/solid/solide4/s4forc3.F
+++ b/engine/source/elements/solid/solide4/s4forc3.F
@@ -641,7 +641,7 @@ c--------------------------
      .        PX2      ,PX3      ,PX4      ,PY1       ,
      .        PY2      ,PY3      ,PY4      ,PZ1       ,
      .        PZ2      ,PZ3      ,PZ4      ,MXT(LFT)  ,
-     .        ITASK    ,DT2T     )
+     .        ITASK    ,DT2T     ,GBUF%VOL )
       ENDIF 
 C --------------------------
       IF(NFILSOL/=0) CALL S4FILLOPT(GBUF%FILL,STI,

--- a/engine/source/elements/solid/solide8e/s8eforc3.F
+++ b/engine/source/elements/solid/solide8e/s8eforc3.F
@@ -1386,7 +1386,7 @@ c--------------------------
      .       PY8(1,IP),PZ1(1,IP),PZ2(1,IP),PZ3(1,IP),
      .       PZ4(1,IP),PZ5(1,IP),PZ6(1,IP),PZ7(1,IP),
      .       PZ8(1,IP),IMAT     ,H        ,WI       ,
-     .       IP       ,ITASK    ,DT2T     )
+     .       IP       ,ITASK    ,DT2T     ,GBUF%VOL )
       ENDIF
 c
        DO I=LFT,LLT

--- a/engine/source/elements/solid/solide8s/s8sforc3.F
+++ b/engine/source/elements/solid/solide8s/s8sforc3.F
@@ -1142,7 +1142,7 @@ c--------------------------
      .       PZ1      ,PZ2      ,PZ3      ,PZ4      ,
      .       PZ5      ,PZ6      ,PZ7      ,PZ8      ,
      .       IMAT     ,H        ,WI       ,IP       ,
-     .       ITASK    ,DT2T     )
+     .       ITASK    ,DT2T     ,GBUF%VOL )
        ENDIF
        DO I=LFT,LLT
         OFFG(I)=MIN(OFFG(I),OFF(I))

--- a/engine/source/elements/solid/solide8z/s8zfint_reg.F
+++ b/engine/source/elements/solid/solide8z/s8zfint_reg.F
@@ -40,7 +40,7 @@ Chd|====================================================================
      .                     PZ1     ,PZ2      ,PZ3      ,PZ4      ,
      .                     PZ5     ,PZ6      ,PZ7      ,PZ8      ,
      .                     IMAT    ,H        ,WI       ,IP       ,
-     .                     ITASK   ,DT2T     )
+     .                     ITASK   ,DT2T     ,VOL0     )
 C-----------------------------------------------
 C   M o d u l e s
 C----------------------------------------------- 
@@ -69,7 +69,7 @@ C-----------------------------------------------
       my_real, DIMENSION(NEL), INTENT(IN) :: 
      .   VAR_REG,PX1,PX2,PX3,PX4,PX5,PX6,PX7,PX8,
      .   PY1,PY2,PY3,PY4,PY5,PY6,PY7,PY8,PZ1,PZ2,
-     .   PZ3,PZ4,PZ5,PZ6,PZ7,PZ8,VOL,H(8)
+     .   PZ3,PZ4,PZ5,PZ6,PZ7,PZ8,VOL,H(8),VOL0
       TYPE(NLOCAL_STR_), TARGET :: NLOC_DMG 
       my_real
      .   WI
@@ -83,7 +83,7 @@ C-----------------------------------------------
      . A1,A2,A3,A4,A5,A6,A7,A8,C1,C2,C3,C4,C5,C6,C7,C8,
      . ZETA,SSPNL,DTNL,LE_MAX,MAXSTIF
       my_real, DIMENSION(NEL) :: 
-     . F1,F2,F3,F4,F5,F6,F7,F8
+     . F1,F2,F3,F4,F5,F6,F7,F8,LC
       my_real, DIMENSION(:) ,ALLOCATABLE   :: 
      . BTB11,BTB12,BTB13,BTB14,BTB15,BTB16,BTB17,BTB18,
      . BTB22,BTB23,BTB24,BTB25,BTB26,BTB27,BTB28,BTB33,
@@ -108,6 +108,7 @@ C=======================================================================
       ZETA   = NLOC_DMG%DENS(IMAT)
       SSPNL  = NLOC_DMG%SSPNL(IMAT)
       LE_MAX = NLOC_DMG%LE_MAX(IMAT) ! Maximal length of convergence
+      LC(1:NEL) = ZERO
       VNL  => NLOC_DMG%VNL(1:L_NLOC)
       VNL0 => NLOC_DMG%VNL_OLD(1:L_NLOC)
       UNL  => NLOC_DMG%UNL(1:L_NLOC)
@@ -450,24 +451,28 @@ c
 c
         ! If the element is broken
         ELSE
+c
+          ! Initial element characteristic length
+          LC(I) = VOL0(I)**THIRD 
+c
           IF (NODADT > 0) THEN           
             ! Non-local absorbing forces
             F1(I) = SQRT(MASS(POS1(I))/MASS0(POS1(I)))*H(1)*ZETA*SSPNL*HALF*
-     .                                (VNL(POS1(I))+VNL0(POS1(I)))*(THREE/FOUR)*(LE_MAX**2)
+     .                                (VNL(POS1(I))+VNL0(POS1(I)))*(THREE/FOUR)*(LC(I)**2)
             F2(I) = SQRT(MASS(POS2(I))/MASS0(POS2(I)))*H(2)*ZETA*SSPNL*HALF*
-     .                                (VNL(POS2(I))+VNL0(POS2(I)))*(THREE/FOUR)*(LE_MAX**2)
+     .                                (VNL(POS2(I))+VNL0(POS2(I)))*(THREE/FOUR)*(LC(I)**2)
             F3(I) = SQRT(MASS(POS3(I))/MASS0(POS3(I)))*H(3)*ZETA*SSPNL*HALF*
-     .                                (VNL(POS3(I))+VNL0(POS3(I)))*(THREE/FOUR)*(LE_MAX**2)
+     .                                (VNL(POS3(I))+VNL0(POS3(I)))*(THREE/FOUR)*(LC(I)**2)
             F4(I) = SQRT(MASS(POS4(I))/MASS0(POS4(I)))*H(4)*ZETA*SSPNL*HALF*
-     .                                (VNL(POS4(I))+VNL0(POS4(I)))*(THREE/FOUR)*(LE_MAX**2)
+     .                                (VNL(POS4(I))+VNL0(POS4(I)))*(THREE/FOUR)*(LC(I)**2)
             F5(I) = SQRT(MASS(POS5(I))/MASS0(POS5(I)))*H(5)*ZETA*SSPNL*HALF*
-     .                                (VNL(POS5(I))+VNL0(POS5(I)))*(THREE/FOUR)*(LE_MAX**2)
+     .                                (VNL(POS5(I))+VNL0(POS5(I)))*(THREE/FOUR)*(LC(I)**2)
             F6(I) = SQRT(MASS(POS6(I))/MASS0(POS6(I)))*H(6)*ZETA*SSPNL*HALF*
-     .                                (VNL(POS6(I))+VNL0(POS6(I)))*(THREE/FOUR)*(LE_MAX**2)
+     .                                (VNL(POS6(I))+VNL0(POS6(I)))*(THREE/FOUR)*(LC(I)**2)
             F7(I) = SQRT(MASS(POS7(I))/MASS0(POS7(I)))*H(7)*ZETA*SSPNL*HALF*
-     .                                (VNL(POS7(I))+VNL0(POS7(I)))*(THREE/FOUR)*(LE_MAX**2)
+     .                                (VNL(POS7(I))+VNL0(POS7(I)))*(THREE/FOUR)*(LC(I)**2)
             F8(I) = SQRT(MASS(POS8(I))/MASS0(POS8(I)))*H(8)*ZETA*SSPNL*HALF*
-     .                                (VNL(POS7(I))+VNL0(POS7(I)))*(THREE/FOUR)*(LE_MAX**2)
+     .                                (VNL(POS7(I))+VNL0(POS7(I)))*(THREE/FOUR)*(LC(I)**2)
             ! Computing nodal equivalent stiffness
             STI1(I) = EM20
             STI2(I) = EM20
@@ -479,14 +484,14 @@ c
             STI8(I) = EM20
           ELSE
             ! Non-local absorbing forces
-            F1(I) = H(1)*ZETA*SSPNL*HALF*(VNL(POS1(I))+VNL0(POS1(I)))*(THREE/FOUR)*(LE_MAX**2)
-            F2(I) = H(2)*ZETA*SSPNL*HALF*(VNL(POS2(I))+VNL0(POS2(I)))*(THREE/FOUR)*(LE_MAX**2)
-            F3(I) = H(3)*ZETA*SSPNL*HALF*(VNL(POS3(I))+VNL0(POS3(I)))*(THREE/FOUR)*(LE_MAX**2)
-            F4(I) = H(4)*ZETA*SSPNL*HALF*(VNL(POS4(I))+VNL0(POS4(I)))*(THREE/FOUR)*(LE_MAX**2)
-            F5(I) = H(5)*ZETA*SSPNL*HALF*(VNL(POS5(I))+VNL0(POS5(I)))*(THREE/FOUR)*(LE_MAX**2)
-            F6(I) = H(6)*ZETA*SSPNL*HALF*(VNL(POS6(I))+VNL0(POS6(I)))*(THREE/FOUR)*(LE_MAX**2)
-            F7(I) = H(7)*ZETA*SSPNL*HALF*(VNL(POS7(I))+VNL0(POS7(I)))*(THREE/FOUR)*(LE_MAX**2)
-            F8(I) = H(8)*ZETA*SSPNL*HALF*(VNL(POS8(I))+VNL0(POS8(I)))*(THREE/FOUR)*(LE_MAX**2)
+            F1(I) = H(1)*ZETA*SSPNL*HALF*(VNL(POS1(I))+VNL0(POS1(I)))*(THREE/FOUR)*(LC(I)**2)
+            F2(I) = H(2)*ZETA*SSPNL*HALF*(VNL(POS2(I))+VNL0(POS2(I)))*(THREE/FOUR)*(LC(I)**2)
+            F3(I) = H(3)*ZETA*SSPNL*HALF*(VNL(POS3(I))+VNL0(POS3(I)))*(THREE/FOUR)*(LC(I)**2)
+            F4(I) = H(4)*ZETA*SSPNL*HALF*(VNL(POS4(I))+VNL0(POS4(I)))*(THREE/FOUR)*(LC(I)**2)
+            F5(I) = H(5)*ZETA*SSPNL*HALF*(VNL(POS5(I))+VNL0(POS5(I)))*(THREE/FOUR)*(LC(I)**2)
+            F6(I) = H(6)*ZETA*SSPNL*HALF*(VNL(POS6(I))+VNL0(POS6(I)))*(THREE/FOUR)*(LC(I)**2)
+            F7(I) = H(7)*ZETA*SSPNL*HALF*(VNL(POS7(I))+VNL0(POS7(I)))*(THREE/FOUR)*(LC(I)**2)
+            F8(I) = H(8)*ZETA*SSPNL*HALF*(VNL(POS8(I))+VNL0(POS8(I)))*(THREE/FOUR)*(LC(I)**2)
           ENDIF
         ENDIF
       ENDDO

--- a/engine/source/elements/solid/solide8z/s8zforc3.F
+++ b/engine/source/elements/solid/solide8z/s8zforc3.F
@@ -1113,7 +1113,7 @@ c--------------------------
      .       PY8      ,PZ1      ,PZ2      ,PZ3      ,
      .       PZ4      ,PZ5      ,PZ6      ,PZ7      ,
      .       PZ8      ,IMAT     ,H        ,WI       ,
-     .       IP       ,ITASK    ,DT2T     )
+     .       IP       ,ITASK    ,DT2T     ,GBUF%VOL )
       ENDIF       
 c
        DO I=LFT,LLT

--- a/engine/source/elements/solid/solidez/szforc3.F
+++ b/engine/source/elements/solid/solidez/szforc3.F
@@ -815,7 +815,7 @@ C Virtual internal forces of regularized non local dof
      .       PX2      ,PX3      ,PX4      ,PY1      ,
      .       PY2      ,PY3      ,PY4      ,PZ1      ,
      .       PZ2      ,PZ3      ,PZ4      ,IMAT     ,
-     .       ITASK    ,DT2T     )
+     .       ITASK    ,DT2T     ,GBUF%VOL )
       ENDIF      
 C
 C Finite element heat transfert


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Some issue appeared during erosion with non-local method. LE_MAX value seems to be too high in some cases to compute absorbing forces. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Replace LE_MAX by the initial characteristic length of the element. 
