### PR TITLE
Fix a hang in the collision detetion algo with itied/=0

### DIFF
--- a/engine/source/mpi/interfaces/spmd_cell_list_exchange.F
+++ b/engine/source/mpi/interfaces/spmd_cell_list_exchange.F
@@ -342,7 +342,7 @@ C-----------------------------------------------
 
                 IF(SORT_COMM(NIN)%PROC_LIST(REMOTE_PROC)==ISPMD+1) IS_EXCHANGE_NEEDED = .FALSE.
                 IF(IS_EXCHANGE_NEEDED.AND.SORT_COMM(NIN)%NB_CELL_PROC(REMOTE_PROC)==0) IS_EXCHANGE_NEEDED = .FALSE. !   proc without any main node cell
-                IF(ITIED/=0)  IS_EXCHANGE_NEEDED = .TRUE.   ! itied option : force the exchange    
+                IF(ITIED/=0.AND.IRCVFROM(NIN,REMOTE_PROC)/=0)  IS_EXCHANGE_NEEDED = .TRUE.   ! itied option : force the exchange    
                 !   -------------------------
                 IF(IS_EXCHANGE_NEEDED) THEN
                     !   send/rcv the number of secondary nodes


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
There is a hang in the collision detection algorithm with the option itied/=0 : processors don't receive some message from remote processors (because mpi_ircv comm are not posted) but remote processors send the message (because mpi_isend are posted)

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
To insure consistence between mpi_isend / mpi_ircv, the mpi comm is now done only if the number of main node on the remote processor is greater than 0


