### PR TITLE
activates implicit option when linked with mumps

### DIFF
--- a/engine/CMake_Compilers/cmake_linux64_gf.txt
+++ b/engine/CMake_Compilers/cmake_linux64_gf.txt
@@ -62,17 +62,21 @@ set ( RELNAME ${arch}${mpi_suf}  )
 set (h3d_inc "-I${source_directory}/../extlib/h3d/includes")
 
 
-
-
-#mumps
-# Download and install MUMPS prerequisites (blas/lapack, scalapack) 
-# download mumps and compile mumps in the extlib directory
-#  - wget http://mumps.enseeiht.fr/MUMPS_5.4.1.tar.gz
+#MUMPS linear solver, used for Implicit, FSI. 
+#  - Create and enter the directory OpenRadioss/extlib/mumps
+#  - Download, extract and build Lapack, Scalalapack and mumps. 
+#    - wget https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v3.10.1.tar.gz
+#    - [Optional] wget http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-5.1.0.tar.gz
+#    - wget https://github.com/Reference-ScaLAPACK/scalapack/archive/refs/tags/v2.2.0.tar.gz ; (set the compiler variable to /opt/openmpi/mpif90)
+#    - wget http://mumps.enseeiht.fr/MUMPS_5.4.1.tar.gz (or wget http://ftp.mcs.anl.gov/pub/petsc/externalpackages/MUMPS_5.5.1.tar.gz)  
 # uncomment the following lines
-#set(MUMPSLIB "${source_directory}/../extlib/mumps/MUMPS_5.4.1/lib")
-#set(mumps_inc "-I${source_directory}/../extlib/mumps/MUMPS_5.4.1/include")
-#set(mumps_libs "${MUMPSLIB}/libdmumps.a ${MUMPSLIB}/libmumps_common.a ${MUMPSLIB}/libpord.a ${metis_lib}")
+#set(MUMPSLIB "${source_directory}/../extlib/mumps/MUMPS_5.5.1/lib")
+#set(mumps_inc "-I${source_directory}/../extlib/mumps/MUMPS_5.5.1/include")
 #set(mumps_flag "-Dpord -Dmetis -Dthr_all -DMUMPS5 -DAdd_")
+#set(mumps_dep_path "${source_directory}/../extlib/mumps")
+#set(mumps_dep_libs "${mumps_dep_path}/scalapack-2.2.0/libscalapack.a ${mumps_dep_path}/lapack-3.10.1/liblapack.a   ${mumps_dep_path}/lapack-3.10.1/libtmglib.a ${mumps_dep_path}/lapack-3.10.1/librefblas.a")
+#set(mumps_libs "${MUMPSLIB}/libdmumps.a ${MUMPSLIB}/libmumps_common.a ${MUMPSLIB}/libpord.a ${mumps_dep_libs}")
+#
 
 
 
@@ -144,23 +148,17 @@ set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS " -O2 $
 
 endif()
 
+
 # Linking flags
 set (CMAKE_EXE_LINKER_FLAGS "-rdynamic -fopenmp  -ldl -lrt -lstdc++ ${FSANITIZE}  " )
 
 #Libraries
 if ( static_link STREQUAL "1" )
-  set (LINK "rt  -ldl -static-libgfortran -static-libstdc++ -static-libgcc ${mpi_lib} -Wunused-function")
+  set (LINK "rt  ${mumps_libs} -ldl -static-libgfortran -static-libstdc++ -static-libgcc ${mpi_lib} -Wunused-function")
 else()
-  set (LINK "rt ${mpi_lib} -ldl -Wunused-function"  )
+  set (LINK "rt  ${mumps_libs} ${mpi_lib} -ldl -Wunused-function"  )
 endif()
 
-#Assuming that all libraries are in LIBRARY_PATH
-#Uncomment the following line and update the libraries name if necessary (especially for scalapack) 
-#set(LINK "${LINK} -DMUMPS5 ${mumps_libs} -lmetis -lscalapack-openmpi -lblas -llapack") 
-#otheriwse, if libs are not in LIBRARY_PATH, you uncomment the 3 following lines  
-#set(lapack_lib "${source_directory}/../extlib/lapack-3.10.0/lib_linux64_gf/liblapack.a ${source_directory}/../extlib/lapack-3.10.0/lib_linux64_gf/librefblas.a  ${source_directory}/../extlib/lapack-3.10.0/lib_linux64_gf/libtmglib.a [....]")
-#set(metis_lib "${source_directory}/../extlib/metis/linux64/libmetis_linux64_gcc.a")
-#set(LINK "${LINK} -DMUMPS5 ${metis_lib} ${lapack_lib} ${mumps_libs}") 
 
 # -------------------------------------------------------------------------------------------------------------------------------------------
 # Specific set of compilation flag

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -1005,7 +1005,7 @@ C----
      .        NNZK0P(NSPMD), NDDLP(NSPMD), NNZKP(NSPMD),
      .        NNMAXP(NSPMD), NDDLPMAX
       INTEGER, DIMENSION(:), ALLOCATABLE :: CDDLP
-#if defined(MUMPS5) && defined(DNC)
+#if defined(MUMPS5)
       TYPE(DMUMPS_STRUC) MUMPS_PAR
 #endif
       INTEGER IFVMESH
@@ -2614,7 +2614,7 @@ C
                    R_IMP=>IMPBUF_TAB%R_IMP
            ALLOCATE(FAC_K(0), IPIV_K(0))
          IF (IMUMPSV >0.OR.(ISOLV==7.AND.NSPMD>1)) THEN
-#if defined(MUMPS5) && defined(DNC)
+#if defined(MUMPS5) 
           CALL SPMD_MUMPS_INI(MUMPS_PAR, 1)
 #else
           WRITE(6,*) __LINE__,"Fatal error: MUMPS required"
@@ -8455,7 +8455,7 @@ C                                     PARALLEL SECTION (SMP)
 C========================================================================================
 
       IF (IMP_CHK > 0) THEN
-#if defined(MUMPS5) && defined(DNC)
+#if defined(MUMPS5) 
          CALL IMP_CHKM(
      1  ICODE  ,ISKEW  ,ISKWN  ,IPART  ,IXUR   ,IXTG   ,IXS    ,IXQ    ,
      2  IXC    ,IXT    ,IXP    ,IXR    ,IXTG1          ,ITAB   ,ITABM1 ,
@@ -8486,7 +8486,7 @@ C===============================================================================
 C-----integer : 1:IKC,2:IKUD,3:W_DDL,4:IADM,5:JDIM,6:NDOFI,7:IDDLI
 C-----reel : 1,2,3,4:DIAG_K,LT_K,DIAG_M,LT_M,5,6:LB,DB,7:BKUD,8,9:D_IMP,DR_IMP
 C----       10,11,12:ELBUF_C,BUFMAT_C,X_C,13,14:DD,DDR,15,16:X_ac,V_zero,23,24:AC,ACR
-#if defined(MUMPS5) && defined(DNC)
+#if defined(MUMPS5) 
         CALL IMP_SOLV(
      1  ICODE  ,ISKEW  ,ISKWN  ,IPART  ,IXUR   ,IXTG   ,IXS    ,IXQ    ,
      2  IXC    ,IXT    ,IXP    ,IXR    ,IXTG1          ,ITAB   ,ITABM1 ,
@@ -9743,7 +9743,7 @@ C
         END IF
         IF(IMPL_S>0.OR.NEIG>0)THEN
                    CALL DEALLOC_IMPBUF(IMPBUF_TAB)
-#if defined(MUMPS5) && defined(DNC)
+#if defined(MUMPS5) 
           CALL DEALLOCM_IMP(MUMPS_PAR)
 #endif
         END IF

--- a/engine/source/implicit/imp_solv.F
+++ b/engine/source/implicit/imp_solv.F
@@ -20,7 +20,7 @@ Copyright>
 Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss 
 Copyright>        software under a commercial license.  Contact Altair to discuss further if the 
 Copyright>        commercial version may interest you: https://www.altair.com/radioss/.    
-#if defined(MUMPS5) && defined(DNC)
+#if defined(MUMPS5) 
 Chd|====================================================================
 Chd|  IMP_SOLV                      source/implicit/imp_solv.F    
 Chd|-- called by -----------
@@ -894,12 +894,14 @@ c          ENDIF
 !         END IF
 C
          IF (ISOLV==4.OR.ISOLV==6) THEN
+#ifdef DNC
 C  Renumerotation des ddls du graphe pour suivre celle de la matrice
 C  de rigidite
             CALL DSRENUM0(GRAPHE, NDDL_INI0)
             CALL DSRENUM(GRAPHE, IDDL, NDOF, NDDL0, NDDL_INI0)
 C  Report des blocages au niveau du graphe pour DSOLVE
             CALL DSACTI1(GRAPHE, IKC, NDDL, NDDL0)
+#endif
          ENDIF
 C-----------------------------
 citask0         END IF !(ITASK == 0) THEN
@@ -1077,12 +1079,14 @@ C
            DEALLOCATE(LT_I0)
 C
            IF (ISOLV==4.OR.ISOLV==6) THEN
+#ifdef DNC
 C Remise a zero des modifications au graphe dues aux interfaces
               IF (ISETK==0) CALL DSACTI1(GRAPHE, IKC, NDDL, NDDL0)
 C
               CALL DSMAJI7(
      .            GRAPHE, NUM_IMP, NS_IMP, NE_IMP, INTBUF_TAB,
      .            NDDL,   IPARI  )
+#endif
            ENDIF
 C
           ELSE
@@ -1294,7 +1298,7 @@ C
      .                     IKC    ,DIAG_K  ,MS     ,IN     ,WEIGHT)
 C
 C        WRITE(6,*) IMUMPSV,IDSC,IMCONV
-#if defined(MUMPS5) && defined(DNC)
+#if defined(MUMPS5) 
          IF (IMUMPSV >0 .AND.IDSC==1.AND.IMCONV>=0)
      .     CALL IMP_MUMPS1(NDDL0,   NNZK0,     NDDL,   NNZK,  NNMAX,
      .                     NODGLOB, IDDL,      NDOF,   INLOC, IKC,
@@ -3114,7 +3118,7 @@ C------------------------------------------
  1002 FORMAT(' NODE NUM. =',I10,5X,'ROT_DIR = ',1A,5X,'VAL.= ',G14.7)
  1003 FORMAT(/,' LOOK AT CONNECTIVITY FOR NODE NUM. =',I10)
       END
-#if defined(MUMPS5) && defined(DNC)
+#if defined(MUMPS5) 
 Chd|====================================================================
 Chd|  IMP_CHKM                      source/implicit/imp_solv.F    
 Chd|-- called by -----------
@@ -4997,7 +5001,7 @@ C------------------------------------------
       RETURN
       END
 
-#if defined(MUMPS5) && defined(DNC)
+#if defined(MUMPS5) 
 Chd|====================================================================
 Chd|  DEALLOCM_IMP                  source/implicit/imp_solv.F    
 Chd|-- called by -----------


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
By default, the implicit option was not enabled even if OpenRadioss was built and link with MUMPS. 
Now, when MUMPS is available, the compilation flag `-DMUMPS5` activates the implicit option.  


