### PR TITLE
law51:array_dimension

### DIFF
--- a/starter/source/materials/mat/mat051/m51init.F
+++ b/starter/source/materials/mat/mat051/m51init.F
@@ -59,7 +59,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER IPM(NPROPMI,NUMMAT),NGL(NEL),MAT(NEL), IPARG(NPARG),IFORM,NIX,IX(NIX,NEL)
+      INTEGER IPM(NPROPMI,NUMMAT),NGL(NEL),MAT(NEL), IPARG(NPARG),IFORM,NIX,IX(NIX,*)
       my_real PM(NPROPM,NUMMAT),UVAR(NEL,NUVAR),UPARAM(*), X(3,NUMNOD), BUFMAT(*), RHO0
       INTEGER,INTENT(IN)                   :: NEL
       my_real,INTENT(INOUT) :: SIG(NEL,6)
@@ -72,7 +72,7 @@ C-----------------------------------------------
       INTEGER I,J,NUVAR, GG1, GG2, GG3, ISFLUID
       INTEGER NPH,IFLG,NV46,ISUBW,ISUBA,NL
       INTEGER M_IID,M_UID,IE,IMAT
-      INTEGER N(3,8),ITER,NITER,KK
+      INTEGER N(3,8),ITER,NITER,KK,NUMEL
       my_real C0,C1,C2,C3,C4,C5,E0,EF,PF,RHOF,EINTF,RHOE
       my_real A1,RHO0_LIQ,RHO0_GAS,GAM,PMIN,PSH,
      .        XBAS,YBAS,ZBAS,
@@ -198,11 +198,15 @@ C-----------------------------------------------
       !---------------------------------!      
       IF(IFORM == 6) THEN
         NV46 = 4
-        IF(N2D==0)NV46 = 6
+        NUMEL=NUMELQ+NUMELTG
+        IF(N2D==0)THEN
+          NV46 = 6
+          NUMEL=NUMELS
+        ENDIF
         CALL NRF51INI (
      .                  IPM              , PM    , X     , NIX     ,  IX,
      .                  ALE_CONNECTIVITY , BUFMAT, UPARAM, NV46    ,  RHO0,
-     .                  UVAR             , NUVAR , NEL   , GBUF%RHO
+     .                  UVAR             , NUVAR , NEL   , GBUF%RHO, NUMEL
      .                )
       ENDIF      
 C---

--- a/starter/source/materials/mat/mat051/nrf51ini.F
+++ b/starter/source/materials/mat/mat051/nrf51ini.F
@@ -29,9 +29,9 @@ Chd|        ANCMSG                        source/output/message/message.F
 Chd|        ALE_CONNECTIVITY_MOD          ../common_source/modules/ale_connectivity_mod.F
 Chd|        MESSAGE_MOD                   share/message_module/message_mod.F
 Chd|====================================================================
-      SUBROUTINE NRF51INI(IPM             ,     PM,      X, NIX,    IX,
-     .                    ALE_CONNECTIVITY, BUFMAT, UPARAM, NV46, RHO0,
-     .                    UVAR            , NUVAR , NEL   , RHO
+      SUBROUTINE NRF51INI(IPM             ,     PM,      X, NIX,     IX,
+     .                    ALE_CONNECTIVITY, BUFMAT, UPARAM, NV46,  RHO0,
+     .                    UVAR            , NUVAR , NEL   , RHO , NUMEL
      .                   )
 C-----------------------------------------------
 C   D e s c r i p t i o n
@@ -45,6 +45,13 @@ C NRF READS
 C AV, RHO, E, PMIN, P0, SSP
 C 0.0 means automatic initialisation
 C otherwise use read
+C
+C NUMEL : total number of solid elements (2d or 3d)
+C NEL   : Number of element in current group (<=MVSIZ)
+C IX    : element connectivity + mat_id
+C IPM   : material properties (integer)
+C PM    : material properties (real)
+C
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -72,7 +79,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER,INTENT(IN)    :: NIX,IX(NIX,NEL),IPM(NPROPMI,NUMMAT),NV46,NUVAR,NEL
+      INTEGER,INTENT(IN)    :: NUMEL,NIX,IX(NIX,NUMEL),IPM(NPROPMI,NUMMAT),NV46,NUVAR,NEL
       my_real               :: PM(NPROPM,NUMMAT), X(3,NUMNOD),  UPARAM(*),  RHO0
       my_real,TARGET        :: BUFMAT(*)
       my_real,INTENT(INOUT) :: UVAR(NEL,NUVAR), RHO(NEL)


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### IX array dimension was reset to '*' instead of 'NEL'
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
This change is fixing issue reported by runtime tool "check bounds" when Starter is compiled with debug version. (NEL << NUMELS or NUMELQ,   since NEL is group size, not total element numbers)

#### expected change to numerical solution : no

