### PR TITLE
FVMBAG:DTBAG th output

### DIFF
--- a/engine/source/airbag/fv_up_switch.F
+++ b/engine/source/airbag/fv_up_switch.F
@@ -1601,7 +1601,7 @@ C
            DHOUT  =DHOUT+RBAGHOL(22,IVENT)
         ENDDO
         FSAV(7) =FSAV(7) /MAX(AOUTOT,EM20)
-        FSAV(13)=DTPOLH(PHDT)
+        FSAV(13)=DTX ! not DTPOLH(PHDT) since DTX may be updated with smoothing factor
 
         IF(ITYP == 8) THEN
            CALL FVINJT8_1(NJET, IBAGJET , RBAGJET , IGEO, GEO, PM,

--- a/engine/source/airbag/fvbag.F
+++ b/engine/source/airbag/fvbag.F
@@ -1472,7 +1472,7 @@ C---------------------------------------------------
 !$OMP DO SCHEDULE(GUIDED,1)        
           DO I=1,NPOLH
              IF (IBPOLH(I) == 0 .AND.IDTMIN(52) < 2) THEN
-                DLS(I)=DLH ! constant length calculated during starter
+               DLS(I)=DLH ! constant length calculated during starter
              ELSE
                DLS(I)=PVOLU(I)**THIRD
              ENDIF
@@ -1965,7 +1965,7 @@ C
            DHOUT  =DHOUT+RBAGHOL(22,IVENT)
         ENDDO
         FSAV(7) =FSAV(7) /MAX(AOUTOT,EM20)
-        FSAV(13)=DTPOLH(PHDT)
+        FSAV(13)=DTX ! not DTPOLH(PHDT) since DTX may be updated with smoothing factor
 
         IF(ITYP == 8) THEN
            CALL FVINJT8_1(NJET, IBAGJET , RBAGJET , IGEO, GEO, PM,


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### /TH/MONV : DTBAG updated in case of smoothing parameter defined
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
When using new time step option /DT/FVMBAG/2 a smoothing parameter can be input (lambda). It affects the airbag time step and this has to be taken into account in Time Histories output.

#### expected change to numerical solution : no
but it fixes output from /TH/MONV(DTBAG)

