### PR TITLE
initia>eporin3( ) : unplug condition in case of incompatible input options

### DIFF
--- a/starter/source/elements/initia/initia.F
+++ b/starter/source/elements/initia/initia.F
@@ -1603,7 +1603,7 @@ C-----------------------------------------------------
         JLAG  =IPARG(14,NG)
         JMULT =IPARG(20,NG)
         JPOR  =IPARG(27,NG)
-        IF(ITY == 1.AND.JEUL * (1 - IMULTI_FVM)/=0)THEN
+        IF(ITY==1 .AND. JEUL*(1-IMULTI_FVM)/=0 .AND. N2D==0)THEN
             LFT=1
             LLT=NEL
             NFT = IPARG(3,NG)


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Introducing unplug condition
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
In case of wrong value in /ANALY option (2D instead of 3D) the call of EPORIN3 subroutine is now unplug. Otherwise it is called with unallocated arguments and Starter crash. Starter is now running up to the end in this specific case (and error id 603 is displayed)

#### expected change of numerical solution : no


