### PR TITLE
Fix typos in hm_cfg_files/config/CFG/Keyword* subdir

### DIFF
--- a/hm_cfg_files/config/CFG/Keyword971/AIRBAG/airbag_reference_geometry.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/AIRBAG/airbag_reference_geometry.cfg
@@ -32,7 +32,7 @@ ATTRIBUTES {
     nodes_table_y       = ARRAY[table_count](FLOAT, "Y-Coordinate");
     nodes_table_z       = ARRAY[table_count](FLOAT, "Z-Coordinate");
 
-    //Atrributes for HM usage
+    //Attributes for HM usage
     IO_FLAG             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG     = VALUE(INT, "Write HM Comments");
     _HWCOLOR            = VALUE(INT, "Entity Color"); 

--- a/hm_cfg_files/config/CFG/Keyword971/AIRBAG/airbag_shell_reference_geometry.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/AIRBAG/airbag_shell_reference_geometry.cfg
@@ -33,7 +33,7 @@ ATTRIBUTES(COMMON) {
     elems_table_n3      = ARRAY[table_count](NODE, "Nodal point 3");
     elems_table_n4      = ARRAY[table_count](NODE, "Nodal point 4");
     
-    //Atrributes for HM usage
+    //Attributes for HM usage
     IO_FLAG             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG     = VALUE(INT, "Write HM Comments");
     _HWCOLOR            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971/CONTACT/2dContact.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTACT/2dContact.cfg
@@ -179,8 +179,8 @@ GUI(COMMON)
         RADIO(LSD_BC_FLAG)
         {
             //ADD(0, "<OFF>");
-            ADD(0, "0 Thermal boundry conditions are on when parts are in contact");
-            ADD(1, "1 Thermal boundry conditions are off when parts are in contact");
+            ADD(0, "0 Thermal boundary conditions are on when parts are in contact");
+            ADD(1, "1 Thermal boundary conditions are off when parts are in contact");
         }
         RADIO(LSD_ALGO)
         {

--- a/hm_cfg_files/config/CFG/Keyword971/CONTACT/AutomaticGeneral.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTACT/AutomaticGeneral.cfg
@@ -506,10 +506,10 @@ GUI(COMMON)
         RADIO(LSDYNA_PENTOL)
         {
             ADD(0, "<OFF>");
-            ADD(1, "0: Defaul to 2");
+            ADD(1, "0: Default to 2");
             ADD(2, "1: Pinball edge-edge contact(not recommended");
             ADD(3, "2: Assume planer segments");
-            ADD(4, "3: Wraped segment checking");
+            ADD(4, "3: Wrapped segment checking");
             ADD(5, "4: Sliding option");
             ADD(6, "5: Do option 3 and 4");
         }

--- a/hm_cfg_files/config/CFG/Keyword971/CONTACT/BeamsToSurface.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTACT/BeamsToSurface.cfg
@@ -538,10 +538,10 @@ GUI(COMMON)
         RADIO(LSDYNA_PENTOL)
         {
             ADD(0, "<OFF>");
-            ADD(1, "0: Defaul to 2");
+            ADD(1, "0: Default to 2");
             ADD(2, "1: Pinball edge-edge contact(not recommended");
             ADD(3, "2: Assume planer segments");
-            ADD(4, "3: Wraped segment checking");
+            ADD(4, "3: Wrapped segment checking");
             ADD(5, "4: Sliding option");
             ADD(6, "5: Do option 3 and 4");
         }

--- a/hm_cfg_files/config/CFG/Keyword971/CONTACT/ContactSingEdge.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTACT/ContactSingEdge.cfg
@@ -539,10 +539,10 @@ GUI(COMMON)
         RADIO(LSDYNA_PENTOL)
         {
             ADD(0, "<OFF>");
-            ADD(1, "0: Defaul to 2");
+            ADD(1, "0: Default to 2");
             ADD(2, "1: Pinball edge-edge contact(not recommended");
             ADD(3, "2: Assume planer segments");
-            ADD(4, "3: Wraped segment checking");
+            ADD(4, "3: Wrapped segment checking");
             ADD(5, "4: Sliding option");
             ADD(6, "5: Do option 3 and 4");
         }

--- a/hm_cfg_files/config/CFG/Keyword971/CONTACT/DrawBead.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTACT/DrawBead.cfg
@@ -501,10 +501,10 @@ GUI(COMMON)
         RADIO(LSDYNA_PENTOL)
         {
             ADD(0, "<OFF>");
-            ADD(1, "0: Defaul to 2");
+            ADD(1, "0: Default to 2");
             ADD(2, "1: Pinball edge-edge contact(not recommended");
             ADD(3, "2: Assume planer segments");
-            ADD(4, "3: Wraped segment checking");
+            ADD(4, "3: Wrapped segment checking");
             ADD(5, "4: Sliding option");
             ADD(6, "5: Do option 3 and 4");
         }

--- a/hm_cfg_files/config/CFG/Keyword971/CONTACT/ForceTransducer.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTACT/ForceTransducer.cfg
@@ -540,10 +540,10 @@ GUI(COMMON)
         RADIO(LSDYNA_PENTOL)
         {
             ADD(0, "<OFF>");
-            ADD(1, "0: Defaul to 2");
+            ADD(1, "0: Default to 2");
             ADD(2, "1: Pinball edge-edge contact(not recommended");
             ADD(3, "2: Assume planer segments");
-            ADD(4, "3: Wraped segment checking");
+            ADD(4, "3: Wrapped segment checking");
             ADD(5, "4: Sliding option");
             ADD(6, "5: Do option 3 and 4");
         }

--- a/hm_cfg_files/config/CFG/Keyword971/CONTACT/ForceTransducerPenalty.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTACT/ForceTransducerPenalty.cfg
@@ -474,10 +474,10 @@ GUI(COMMON)
         RADIO(LSDYNA_PENTOL)
         {
             ADD(0, "<OFF>");
-            ADD(1, "0: Defaul to 2");
+            ADD(1, "0: Default to 2");
             ADD(2, "1: Pinball edge-edge contact(not recommended");
             ADD(3, "2: Assume planer segments");
-            ADD(4, "3: Wraped segment checking");
+            ADD(4, "3: Wrapped segment checking");
             ADD(5, "4: Sliding option");
             ADD(6, "5: Do option 3 and 4");
         }

--- a/hm_cfg_files/config/CFG/Keyword971/CONTACT/NodesToSurface.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTACT/NodesToSurface.cfg
@@ -642,10 +642,10 @@ GUI(COMMON)
         RADIO(LSDYNA_PENTOL)
         {
             ADD(0, "<OFF>");
-            ADD(1, "0: Defaul to 2");
+            ADD(1, "0: Default to 2");
             ADD(2, "1: Pinball edge-edge contact(not recommended");
             ADD(3, "2: Assume planer segments");
-            ADD(4, "3: Wraped segment checking");
+            ADD(4, "3: Wrapped segment checking");
             ADD(5, "4: Sliding option");
             ADD(6, "5: Do option 3 and 4");
         }

--- a/hm_cfg_files/config/CFG/Keyword971/CONTACT/OneWaySurfToSurf.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTACT/OneWaySurfToSurf.cfg
@@ -774,10 +774,10 @@ GUI(COMMON)
         RADIO(LSDYNA_PENTOL)
         {
             ADD(0, "<OFF>");
-            ADD(1, "0: Defaul to 2");
+            ADD(1, "0: Default to 2");
             ADD(2, "1: Pinball edge-edge contact(not recommended");
             ADD(3, "2: Assume planer segments");
-            ADD(4, "3: Wraped segment checking");
+            ADD(4, "3: Wrapped segment checking");
             ADD(5, "4: Sliding option");
             ADD(6, "5: Do option 3 and 4");
         }

--- a/hm_cfg_files/config/CFG/Keyword971/CONTACT/RgdBodyToRgdBody.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTACT/RgdBodyToRgdBody.cfg
@@ -518,10 +518,10 @@ GUI(COMMON)
         RADIO(LSDYNA_PENTOL)
         {
             ADD(0, "<OFF>");
-            ADD(1, "0: Defaul to 2");
+            ADD(1, "0: Default to 2");
             ADD(2, "1: Pinball edge-edge contact(not recommended");
             ADD(3, "2: Assume planer segments");
-            ADD(4, "3: Wraped segment checking");
+            ADD(4, "3: Wrapped segment checking");
             ADD(5, "4: Sliding option");
             ADD(6, "5: Do option 3 and 4");
         }

--- a/hm_cfg_files/config/CFG/Keyword971/CONTACT/RgdNodeToRgdBody.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTACT/RgdNodeToRgdBody.cfg
@@ -505,10 +505,10 @@ GUI(COMMON)
         RADIO(LSDYNA_PENTOL)
         {
             ADD(0, "<OFF>");
-            ADD(1, "0: Defaul to 2");
+            ADD(1, "0: Default to 2");
             ADD(2, "1: Pinball edge-edge contact(not recommended");
             ADD(3, "2: Assume planer segments");
-            ADD(4, "3: Wraped segment checking");
+            ADD(4, "3: Wrapped segment checking");
             ADD(5, "4: Sliding option");
             ADD(6, "5: Do option 3 and 4");
         }

--- a/hm_cfg_files/config/CFG/Keyword971/CONTACT/SingleSurface.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTACT/SingleSurface.cfg
@@ -558,10 +558,10 @@ GUI(COMMON)
         RADIO(LSDYNA_PENTOL)
         {
             ADD(0, "<OFF>");
-            ADD(1, "0: Defaul to 2");
+            ADD(1, "0: Default to 2");
             ADD(2, "1: Pinball edge-edge contact(not recommended");
             ADD(3, "2: Assume planer segments");
-            ADD(4, "3: Wraped segment checking");
+            ADD(4, "3: Wrapped segment checking");
             ADD(5, "4: Sliding option");
             ADD(6, "5: Do option 3 and 4");
         }

--- a/hm_cfg_files/config/CFG/Keyword971/CONTACT/contact_SlidingOnly.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTACT/contact_SlidingOnly.cfg
@@ -395,10 +395,10 @@ GUI(COMMON)
         RADIO(LSDYNA_PENTOL)
         {
             //ADD(0, "<OFF>");
-            ADD(0, "0: Defaul to 2");
+            ADD(0, "0: Default to 2");
             ADD(1, "1: Pinball edge-edge contact(not recommended");
             ADD(2, "2: Assume planer segments");
-            ADD(3, "3: Wraped segment checking");
+            ADD(3, "3: Wrapped segment checking");
             ADD(4, "4: Sliding option");
             ADD(5, "5: Do option 3 and 4");
         }

--- a/hm_cfg_files/config/CFG/Keyword971/CONTACT/contact_surface_to_surface.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTACT/contact_surface_to_surface.cfg
@@ -864,10 +864,10 @@ GUI(COMMON)
         RADIO(LSDYNA_PENTOL)
         {
             ADD(0, "<OFF>");
-            ADD(1, "0: Defaul to 2");
+            ADD(1, "0: Default to 2");
             ADD(2, "1: Pinball edge-edge contact(not recommended");
             ADD(3, "2: Assume planer segments");
-            ADD(4, "3: Wraped segment checking");
+            ADD(4, "3: Wrapped segment checking");
             ADD(5, "4: Sliding option");
             ADD(6, "5: Do option 3 and 4");
         }

--- a/hm_cfg_files/config/CFG/Keyword971/CONTROL_CARDS/control_contact.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTROL_CARDS/control_contact.cfg
@@ -394,7 +394,7 @@ GUI(COMMON)
     {
       ADD(-1,"-1: Conduction evevenly distributed (pre R4)");
       ADD(0,"0: Default set to 1");
-      ADD(0,"1: Conduction weighted by shape functions, reduced intergration");
+      ADD(0,"1: Conduction weighted by shape functions, reduced integration");
       ADD(1,"2: Conduction weighted by shape functions, full integration");
     } 
     RADIO(CONT_TDCNOF)

--- a/hm_cfg_files/config/CFG/Keyword971/CONTROL_CARDS/control_efg.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTROL_CARDS/control_efg.cfg
@@ -20,7 +20,7 @@
 ATTRIBUTES(COMMON)
 {
 // INPUT ATTRIBUTES
-  Controlefg_ISPLANE                      = VALUE(INT,"Optional choice for the mesh-free kernal functions:");
+  Controlefg_ISPLANE                      = VALUE(INT,"Optional choice for the mesh-free kernel functions:");
   Controlefg_IDILA                        = VALUE(INT,"Optional choice for the normalized dilation parameter:");
   Controlefg_ININT                        = VALUE(INT,"This is the factor needed for the estimation of maximum workspace (MWSPAC) that can be used during the initialization phase");
   LSD_IMLM                                = VALUE(INT,"Optional choice for the matrix operation, linear solving and memory usage:");

--- a/hm_cfg_files/config/CFG/Keyword971/CONTROL_CARDS/control_implicit_forming.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTROL_CARDS/control_implicit_forming.cfg
@@ -21,7 +21,7 @@ ATTRIBUTES(COMMON)
 {
 // INPUT ATTRIBUTES
   LSD_IOPTION                             = VALUE(INT,"Solution type");
-  LSD_NSMIN                               = VALUE(INT,"Minimun number of implicit steps for IOPTION=2");
+  LSD_NSMIN                               = VALUE(INT,"Minimum number of implicit steps for IOPTION=2");
   LSD_NSMAX                               = VALUE(INT,"Maximum number of implicit steps for IOPTION=2");
   LSD_TBIRTH                              = VALUE(FLOAT,"Birth time to activate this feature");
   LSD_TDEATH                              = VALUE(FLOAT,"Death time");

--- a/hm_cfg_files/config/CFG/Keyword971/CONTROL_CARDS/control_shell.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTROL_CARDS/control_shell.cfg
@@ -188,7 +188,7 @@ GUI(COMMON)
       }
       RADIO(LSD_TSHELL) 
       {
-         ADD(0,"0: No temperature gradient is considered through the shell tickness (default)") ;
+         ADD(0,"0: No temperature gradient is considered through the shell thickness (default)") ;
          ADD(1,"1: A temperature gradient is calculated through the shell thickness") ;
       } 
       SCALAR(LSD_NFAIL1) {DIMENSION="DIMENSIONLESS";}

--- a/hm_cfg_files/config/CFG/Keyword971/CONTROL_CARDS/control_timestep.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTROL_CARDS/control_timestep.cfg
@@ -21,7 +21,7 @@ ATTRIBUTES(COMMON)
 {
 
     KEYWORD_STR                             = VALUE(STRING, "Solver Keyword");
-    LSD_DTINIT                              = VALUE(FLOAT,  "Intial time step size");
+    LSD_DTINIT                              = VALUE(FLOAT,  "Initial time step size");
     LSD_TSSFAC                              = VALUE(FLOAT,  "Scale factor for computed time step");
     LSD_ISDO                                = VALUE(INT,  "Basis of time size calculation for 4-node shell elements");
     LSD_TSLIMT                              = VALUE(FLOAT,  "Shell element minimum time step assignment");

--- a/hm_cfg_files/config/CFG/Keyword971/CONTROL_CARDS/interface_comp_new.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTROL_CARDS/interface_comp_new.cfg
@@ -69,7 +69,7 @@ GUI(COMMON)
     {
        ADD(1, "1: deprecated");
        ADD(2, "2: deprecated");
-       ADD(3, "3: Similar to Method 6, howewer, it is a linear method and no iteration is necessary");
+       ADD(3, "3: Similar to Method 6, however, it is a linear method and no iteration is necessary");
        ADD(4, "4: deprecated");
        ADD(5, "5: deprecated");
        ADD(6, "6: The smoothness and the transition region of the modified surface will depend on the spring back magnitude and the smoothing factor");

--- a/hm_cfg_files/config/CFG/Keyword971/LOAD/initial_velocity.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/LOAD/initial_velocity.cfg
@@ -22,7 +22,7 @@ ATTRIBUTES(COMMON) {
   //
   entityid                                          = VALUE(SETS, "Node ID") { SUBTYPES = ( /SETS ) ; }
   exempt_nodes                                      = VALUE(SETS, "Exempted nodal set"){ SUBTYPES = (/SETS/SET_NODE_IDPOOL) ; }
-  box_region_def                                    = VALUE(BLOCK, "Nodes in box are initialzed");
+  box_region_def                                    = VALUE(BLOCK, "Nodes in box are initialized");
   rgd_bdy_vel_opt_overwrite                         = VALUE(INT, "Overwrite vel of all *PART_INERTIA and *CNRB");
   inputsystem                                       = VALUE(SYSTEM,"Local Coordinate System") ;
   part_set_overwrite_vel                            = VALUE(SETS, "Part Set ID, ID of Parts to overwrite"){ SUBTYPES = (/SETS/SET_PART_IDPOOL) ; }

--- a/hm_cfg_files/config/CFG/Keyword971/MAT/MATL_USER_DEF.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/MAT/MATL_USER_DEF.cfg
@@ -95,7 +95,7 @@ ATTRIBUTES(COMMON)
     LSD_DM_PL_COMPR                         = VALUE(INT, "Deactivate Module for PL-COMPR");
     LSD_MAT_USER_PL_ORTHO                   = VALUE(CURVE,  "Plastic orthotropy module");
     LSD_MAT_USER_PL_ISKIN                   = VALUE(CURVE,  "Isotropic-kinematic hardening module");
-    LSD_MAT_USER_PL_ASYMM                   = VALUE(CURVE,  "Tension-compression assymetry moodule for anisotropic hardening");
+    LSD_MAT_USER_PL_ASYMM                   = VALUE(CURVE,  "Tension-compression asymmetry module for anisotropic hardening");
     LSD_MAT_USER_PL_WAIST                   = VALUE(CURVE,  "Waisted shear module for anisotropic hardening");
     LSD_MAT_USER_PL_BIAXF                   = VALUE(CURVE,  "Biaxial correction module for anisotropic hardening");
     LSD_MAT_USER_PL_COMPR                   = VALUE(CURVE,  "Compressibility module");

--- a/hm_cfg_files/config/CFG/Keyword971/MAT/mat_020.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/MAT/mat_020.cfg
@@ -180,7 +180,7 @@ optional:
     {
         ADD(-1.0, "-1.0: Constraints applied in local directions (SPC constraint)");
         ADD( 0.0, " 0.0: No constraints");
-        ADD( 1.0, " 1.0: Constrainsts applied in global directions");
+        ADD( 1.0, " 1.0: Constraints applied in global directions");
     }
     if(LSDYNA_CMO == 1.0)
     {
@@ -277,7 +277,7 @@ FORMAT(Keyword971)
     COMMENT("$      MID       RHO         E        PR         N    COUPLE         M     ALIAS");
     CARD("%10d%10lg%10lg%10lg%10lg%10lg%10lg%10s",_ID_,Rho,E,Nu,LSDYNA_N,LSDYNA_COUPLE,LSDYNA_M,LSDYNA_ALIAS);
 
-    //Folowing code is to handle export
+    //Following code is to handle export
     if(IO_FLAG == 2 && LSDYNA_CMO == -1.0)
     {
         if(ConstrainedXTranslation == 1)

--- a/hm_cfg_files/config/CFG/Keyword971/MAT/mat_086.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/MAT/mat_086.cfg
@@ -186,7 +186,7 @@ GUI(COMMON)
      RADIO(axisOptFlag)
      {
         ADD(1, "By element nodes");
-        ADD(2, "Define global vetor");
+        ADD(2, "Define global vector");
         ADD(3, "Define local vector");
         ADD(4, "Pick system");
      }

--- a/hm_cfg_files/config/CFG/Keyword971/MAT/mat_186.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/MAT/mat_186.cfg
@@ -123,9 +123,9 @@ GUI(COMMON)
      }
      RADIO(MAT186_TES)
      {
-        ADD(0.0, "0.0: A dimentional separation measure is used, and power law for interaxction between mode I and II");
-        ADD(1.0, "1.0: A dimentional separation measure is used, and Benzeggah-Kenane law for interaxction between mode I and II");
-        ADD(2.0, "2.0: A dimentional separation measure is used");
+        ADD(0.0, "0.0: A dimensional separation measure is used, and power law for interaction between mode I and II");
+        ADD(1.0, "1.0: A dimensional separation measure is used, and Benzeggah-Kenane law for interaction between mode I and II");
+        ADD(2.0, "2.0: A dimensional separation measure is used");
      }
      DATA(MAT186_TSLC);
      SCALAR(LSDYNA_GIC);

--- a/hm_cfg_files/config/CFG/Keyword971/MAT/mat_187.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/MAT/mat_187.cfg
@@ -207,7 +207,7 @@ GUI(COMMON)
      SCALAR(LSD_MIPS)                           {DIMENSION="DIMENSIONLESS";}
      RADIO(LSD_IQUAD)
      {
-        ADD(-1, "-1: The failure model is deactived");
+        ADD(-1, "-1: The failure model is deactivated");
         ADD( 0, " 0: Failure evolution is independent of the triaxiality");
         ADD( 1, " 1: Incremental formulation is used to compute the failure value");
      }

--- a/hm_cfg_files/config/CFG/Keyword971/MAT/mat_221.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/MAT/mat_221.cfg
@@ -334,15 +334,15 @@ GUI(COMMON)
      RADIO(MAT221_NERODE)
      {
         ADD(0, "0: No Failure");
-        ADD(1, "1: Failure if one failure criterion is reached in all intergration points");
-        ADD(2, "2: Failure if one failure criterion is reached in one intergration points");
-        ADD(3, "3: Failure if tension or compression failure in the a-direction for one intergration point ");
-        ADD(4, "4: Failure if tension or compression failure in the b-direction for one intergration point ");
-        ADD(5, "5: Failure if tension or compression failure in the c-direction for one intergration point ");
-        ADD(6, "6: Failure if tension or compression failure in the a- and b-direction for 1 or 2 intergration point ");
-        ADD(7, "7: Failure if tension or compression failure in the b- and c-direction for 1 or 2 intergration point ");
-        ADD(8, "8: Failure if tension or compression failure in the a- and c-direction for 1 or 2 intergration point ");
-        ADD(9, "9: Failure if tension or compression failure in the 3 directions for one or diffrent intergration points ");
+        ADD(1, "1: Failure if one failure criterion is reached in all integration points");
+        ADD(2, "2: Failure if one failure criterion is reached in one integration points");
+        ADD(3, "3: Failure if tension or compression failure in the a-direction for one integration point ");
+        ADD(4, "4: Failure if tension or compression failure in the b-direction for one integration point ");
+        ADD(5, "5: Failure if tension or compression failure in the c-direction for one integration point ");
+        ADD(6, "6: Failure if tension or compression failure in the a- and b-direction for 1 or 2 integration point ");
+        ADD(7, "7: Failure if tension or compression failure in the b- and c-direction for 1 or 2 integration point ");
+        ADD(8, "8: Failure if tension or compression failure in the a- and c-direction for 1 or 2 integration point ");
+        ADD(9, "9: Failure if tension or compression failure in the 3 directions for one or different integration points ");
      }
      RADIO(MAT221_NDAM)
      {

--- a/hm_cfg_files/config/CFG/Keyword971/PROP/section_1005.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/PROP/section_1005.cfg
@@ -34,7 +34,7 @@ ATTRIBUTES(COMMON){
   DZ    = VALUE(FLOAT,"Normalized dilation (in  Z direction)");
   ISPLINE  = VALUE(INT,"ISPLINE");
   IDILA  = VALUE(INT,"IDILA");
-  IEBT  = VALUE(INT,"[IEBT] Essential boundary conditon treatment");
+  IEBT  = VALUE(INT,"[IEBT] Essential boundary condition treatment");
   IDIM  = VALUE(INT,"[IDIM] Domain Integration method");
   TOLDEF  = VALUE(FLOAT,"Deformation tolerance");
 

--- a/hm_cfg_files/config/CFG/Keyword971/PROPERTY/mat_add_erosion.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/PROPERTY/mat_add_erosion.cfg
@@ -77,7 +77,7 @@ ATTRIBUTES(COMMON)
     LSD_DCTYP                               = ARRAY[_size_IDAM](FLOAT, "Damage composition option for multiple criteria");
     LSD_Q1_ARRAY                            = ARRAY[_size_IDAM](FLOAT, "Damage evolution parameter");
     LSD_Q1_CURVE                            = ARRAY[_size_IDAM](CURVE, "Damage evolution parameter");
-    LSD_Q2_ARRAY                            = ARRAY[_size_IDAM](FLOAT, "Set to 1.0 to output information to log files (messag and d3hsp) when an integration point fails");
+    LSD_Q2_ARRAY                            = ARRAY[_size_IDAM](FLOAT, "Set to 1.0 to output information to log files (message and d3hsp) when an integration point fails");
 
     //Optional Cards with additional failure criteria
 

--- a/hm_cfg_files/config/CFG/Keyword971_R10.1/CONTROL_CARDS/control_output.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R10.1/CONTROL_CARDS/control_output.cfg
@@ -37,7 +37,7 @@ ATTRIBUTES(COMMON)
     COU_IERODE                              = VALUE(INT,  "Output eroded internal and kinetic energy into the 'matsum' file");
     COU_TET10                               = VALUE(INT,  "Output ten connectivity nodes into 'd3plot' database");
     COU_MSGMAX                              = VALUE(INT,  "Maximum number of each error/warning message");
-    COU_IPCURV                              = VALUE(INT,  "Flag to output digitized curve data to messag and d3hsp files");
+    COU_IPCURV                              = VALUE(INT,  "Flag to output digitized curve data to message and d3hsp files");
     LSD_GMDT                                = VALUE(FLOAT,  "Output interval for recorded motions from *INTERFACE_SSI_AUX");
     LSD_IP1DBLT                             = VALUE(INT,  "Output information of 1D (bar-type) seatbelt created for 2D (shell-type) seatbelt to sbtout");
     LSD_EOCS                                = VALUE(INT, "Elout Coordinate System: controls the coordinate system to be used when writing out shell data to the elout file");
@@ -54,7 +54,7 @@ ATTRIBUTES(COMMON)
     LSD_CDETOL                              = VALUE(FLOAT, "Tolerance for output of *DEFINE_CURVE discretization warnings");
     LSD_CTRL_OUT_OPTCARD4                   = VALUE(INT, "");
     //Optional card 4
-    LSD_PHSCHNG                             = VALUE(INT, "Message to messag file when materials 216, 217, and 218 change phase");
+    LSD_PHSCHNG                             = VALUE(INT, "Message to message file when materials 216, 217, and 218 change phase");
     LSD_DEMDEN                              = VALUE(INT, "Output DEM density data to d3plot database");
     // HM INTERNAL
     KEYWORD_STR                             = VALUE(STRING, "Solver Keyword");

--- a/hm_cfg_files/config/CFG/Keyword971_R10.1/FREQUENCY/frequency_domain_frf.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R10.1/FREQUENCY/frequency_domain_frf.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R10.1/FREQUENCY/frequency_domain_mode.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R10.1/FREQUENCY/frequency_domain_mode.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R10.1/FREQUENCY/frequency_domain_random_vibration.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R10.1/FREQUENCY/frequency_domain_random_vibration.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");
@@ -445,8 +445,8 @@ GUI(COMMON)
                 RADIO(snlimt)
                 {
                     ADD(0, "0: If LCID > 0 , use the life at the last point on S - N curve. If LCID < 0 , use the life at STHRES");
-                    ADD(1, "1: If LCID > 0 , extrapolation from the last two points on S - N curve. If LCID < 0 , Ingnored");
-                    ADD(2, "2: If LCID > 0 or LCID < 0 , Ingnored");
+                    ADD(1, "1: If LCID > 0 , extrapolation from the last two points on S - N curve. If LCID < 0 , Ignored");
+                    ADD(2, "2: If LCID > 0 or LCID < 0 , Ignored");
                 }
             }
         }

--- a/hm_cfg_files/config/CFG/Keyword971_R10.1/FREQUENCY/frequency_domain_ssd.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R10.1/FREQUENCY/frequency_domain_ssd.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R10.1/MAT/mat_157.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R10.1/MAT/mat_157.cfg
@@ -106,7 +106,7 @@ ATTRIBUTES(COMMON)
     LSD_MAT_157_SXY                         = VALUE(FLOAT,  "SXY Shear strength ab-plane");
     LSD_LCSXY                               = VALUE(FUNCT,  "Curve ID for SXY");
     LSD_MAT_157_FF12                        = VALUE(FLOAT,  "Scale factor");
-    LSD_MAT_157_NCFAIL                      = VALUE(FLOAT,  "Number of timesteps to reduce stresses untill element deletion");
+    LSD_MAT_157_NCFAIL                      = VALUE(FLOAT,  "Number of timesteps to reduce stresses until element deletion");
     optionZT                                = VALUE(INT,    "Option for ZT");
     LSD_MAT_157_ZT                          = VALUE(FLOAT,  "Transverse tensile strength c-axis");
     LSD_LCZT                                = VALUE(FUNCT,  "Curve ID for ZT");

--- a/hm_cfg_files/config/CFG/Keyword971_R10.1/MAT/mat_169.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R10.1/MAT/mat_169.cfg
@@ -31,7 +31,7 @@ ATTRIBUTES(COMMON)
     LSD_MAT169_GCSHR                        = VALUE(FLOAT,  "Energy per unit area to fail the bond in shear");
     LSD_MAT169_GCTE                         = VALUE(FLOAT,  "Energy per unit length to fail the edge of the bond in tension");
     LSD_MAT169_GCTEN                        = VALUE(FLOAT,  "Energy per unit area to fail the bond in tension");
-    LSD_MAT169_OUTFAIL                      = VALUE(FLOAT,  "Flag for additional output to messag file");
+    LSD_MAT169_OUTFAIL                      = VALUE(FLOAT,  "Flag for additional output to message file");
     LSD_MAT169_PWRS                         = VALUE(FLOAT,  "Power law term for shear");
     LSD_MAT169_PWRSE                        = VALUE(FLOAT,  "Power law term for shear");
     LSD_MAT169_PWRT                         = VALUE(FLOAT,  "Power law term for tension");
@@ -61,7 +61,7 @@ ATTRIBUTES(COMMON)
     LSD_MAT169_GCSHR_FUN                    = VALUE(FUNCT,  "GCSHR Function ID"); 
     LSD_MAT169_SHRP_FUN                     = VALUE(FUNCT,  "SHRP Function ID"); 
      
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     LSD_OPT_MAT169_SDFAC                    = VALUE(INT,  "SDFAC FUNCUTION OPTION");
     LSD_OPT_MAT169_SGFAC                    = VALUE(INT,  "SGFAC FUNCUTION OPTION");
     LSD_OPT_MAT169_TENMAX                   = VALUE(INT,  "TENMAX FUNCUTION OPTION");

--- a/hm_cfg_files/config/CFG/Keyword971_R11.1/CONTACT/contact_automatic_single_surface.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R11.1/CONTACT/contact_automatic_single_surface.cfg
@@ -59,7 +59,7 @@ ATTRIBUTES(COMMON)
     LSDYNA_SFMT                     = VALUE(FLOAT,"Scale factor applied to contact thickness of master surface");
     LSDYNA_FSF                      = VALUE(FLOAT,"Coulomb Friction scale factor");
     LSDYNA_VSF                      = VALUE(FLOAT,"Viscous friction scale factor");
-    LSD_CLOSE                       = VALUE(FLOAT, "A tolerence for tying surfaces using a penalty formulation");
+    LSD_CLOSE                       = VALUE(FLOAT,"A tolerance for tying surfaces using a penalty formulation");
     // Additional Cards
     LSDYNA_SOFT                     = VALUE(INT,"Soft constraint option");
     LSDYNA_SOFSCL                   = VALUE(FLOAT,"Scale factor for constraint forces of soft constraint option");

--- a/hm_cfg_files/config/CFG/Keyword971_R11.1/CONTROL_CARDS/control_implicit_auto.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R11.1/CONTROL_CARDS/control_implicit_auto.cfg
@@ -31,8 +31,8 @@ ATTRIBUTES(COMMON)
     LSD_LCID8        = VALUE(CURVE,"Curve ID gives the time interval as a function of time");
     LSD_KFAIL        = VALUE(INT,"Number of failed attempts to converge implicitly for the current time step before automatically switching to explicit time integration");
     LSD_KCYCLE       = VALUE(INT,"Number of explicit cycles to run in explicit mode before returning to the implicit mode");
-    LSD_HCMIN        = VALUE(FLOAT,"Mid-point relative Euclidian residual norm min tolerance");
-    LSD_HCMAX        = VALUE(FLOAT,"Mid-point relative Euclidian residual norm min tolerance");
+    LSD_HCMIN        = VALUE(FLOAT,"Mid-point relative Euclidean residual norm min tolerance");
+    LSD_HCMAX        = VALUE(FLOAT,"Mid-point relative Euclidean residual norm min tolerance");
     LSD_HMMIN        = VALUE(FLOAT,"Mid-point relative maximum residual norm min tolerance");
     LSD_HMMAX        = VALUE(FLOAT,"Mid-point relative maximum residual norm min tolerance");
     LSD_HNTMAX       = VALUE(FLOAT,"Mid-point absolute Nodal Translational norm tolerance");

--- a/hm_cfg_files/config/CFG/Keyword971_R11.1/CONTROL_CARDS/control_implicit_forming.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R11.1/CONTROL_CARDS/control_implicit_forming.cfg
@@ -22,7 +22,7 @@ ATTRIBUTES(COMMON)
   // INPUT ATTRIBUTES
   LSD_CifOpt                              = VALUE(INT,"Options");
   LSD_IOPTION                             = VALUE(INT,"Solution type");
-  LSD_NSMIN                               = VALUE(INT,"Minimun number of implicit steps for IOPTION=2");
+  LSD_NSMIN                               = VALUE(INT,"Minimum number of implicit steps for IOPTION=2");
   LSD_NSMAX                               = VALUE(INT,"Maximum number of implicit steps for IOPTION=2");
   LSD_TBIRTH                              = VALUE(FLOAT,"Birth time to activate this feature");
   LSD_TDEATH                              = VALUE(FLOAT,"Death time");

--- a/hm_cfg_files/config/CFG/Keyword971_R11.1/CONTROL_CARDS/control_output.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R11.1/CONTROL_CARDS/control_output.cfg
@@ -37,7 +37,7 @@ ATTRIBUTES(COMMON)
     COU_IERODE                              = VALUE(INT,  "Output eroded internal and kinetic energy into the 'matsum' file");
     COU_TET10                               = VALUE(INT,  "Output ten connectivity nodes into 'd3plot' database");
     COU_MSGMAX                              = VALUE(INT,  "Maximum number of each error/warning message");
-    COU_IPCURV                              = VALUE(INT,  "Flag to output digitized curve data to messag and d3hsp files");
+    COU_IPCURV                              = VALUE(INT,  "Flag to output digitized curve data to message and d3hsp files");
     LSD_GMDT                                = VALUE(FLOAT,  "Output interval for recorded motions from *INTERFACE_SSI_AUX");
     LSD_IP1DBLT                             = VALUE(INT,  "Output information of 1D (bar-type) seatbelt created for 2D (shell-type) seatbelt to sbtout");
     LSD_EOCS                                = VALUE(INT, "Elout Coordinate System: controls the coordinate system to be used when writing out shell data to the elout file");
@@ -54,7 +54,7 @@ ATTRIBUTES(COMMON)
     LSD_CDETOL                              = VALUE(FLOAT, "Tolerance for output of *DEFINE_CURVE discretization warnings");
     LSD_CTRL_OUT_OPTCARD4                   = VALUE(INT, "");
     //Optional card 4
-    LSD_PHSCHNG                             = VALUE(INT, "Message to messag file when materials 216, 217, and 218 change phase");
+    LSD_PHSCHNG                             = VALUE(INT, "Message to message file when materials 216, 217, and 218 change phase");
     LSD_DEMDEN                              = VALUE(INT, "Output DEM density data to d3plot database");
     LSD_ICRFILE                             = VALUE(INT, "Flag to output node sets and element sets used in computing secforc data");
     //Optional card 5

--- a/hm_cfg_files/config/CFG/Keyword971_R11.1/MAT/mat_153.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R11.1/MAT/mat_153.cfg
@@ -52,7 +52,7 @@ ATTRIBUTES(COMMON)
     LSD_HARDK4                              = VALUE(FLOAT,  "Kinematic hardening modulus C4");
     LSD_GAMMA4                              = VALUE(FLOAT,  "Kinematic hardening parameter 4");
     LSD_LCKH                                = VALUE(FUNCT,  "Load curve ID");
-    LSD_NKH                                 = VALUE(INT,  "Number of kitematic hardening parameteres");
+    LSD_NKH                                 = VALUE(INT,  "Number of kitematic hardening parameters");
 
 }
 

--- a/hm_cfg_files/config/CFG/Keyword971_R11.1/MAT/mat_169.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R11.1/MAT/mat_169.cfg
@@ -31,7 +31,7 @@ ATTRIBUTES(COMMON)
     LSD_MAT169_GCSHR                        = VALUE(FLOAT,  "Energy per unit area to fail the bond in shear");
     LSD_MAT169_GCTE                         = VALUE(FLOAT,  "Energy per unit length to fail the edge of the bond in tension");
     LSD_MAT169_GCTEN                        = VALUE(FLOAT,  "Energy per unit area to fail the bond in tension");
-    LSD_MAT169_OUTFAIL                      = VALUE(FLOAT,  "Flag for additional output to messag file");
+    LSD_MAT169_OUTFAIL                      = VALUE(FLOAT,  "Flag for additional output to message file");
     LSD_MAT169_PWRS                         = VALUE(FLOAT,  "Power law term for shear");
     LSD_MAT169_PWRSE                        = VALUE(FLOAT,  "Power law term for shear");
     LSD_MAT169_PWRT                         = VALUE(FLOAT,  "Power law term for tension");
@@ -62,7 +62,7 @@ ATTRIBUTES(COMMON)
     LSD_MAT169_GCSHR_FUN                    = VALUE(FUNCT,  "GCSHR Function ID"); 
     LSD_MAT169_SHRP_FUN                     = VALUE(FUNCT,  "SHRP Function ID"); 
      
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     LSD_OPT_MAT169_SDFAC                    = VALUE(INT,  "SDFAC FUNCUTION OPTION");
     LSD_OPT_MAT169_SGFAC                    = VALUE(INT,  "SGFAC FUNCUTION OPTION");
     LSD_OPT_MAT169_TENMAX                   = VALUE(INT,  "TENMAX FUNCUTION OPTION");

--- a/hm_cfg_files/config/CFG/Keyword971_R11.2/FREQUENCY/frequency_domain_acoustic_bem.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R11.2/FREQUENCY/frequency_domain_acoustic_bem.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R11.2/FREQUENCY/frequency_domain_mode.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R11.2/FREQUENCY/frequency_domain_mode.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R11.2/FREQUENCY/frequency_domain_path.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R11.2/FREQUENCY/frequency_domain_path.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R11.2/FREQUENCY/frequency_domain_random_vibration.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R11.2/FREQUENCY/frequency_domain_random_vibration.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");
@@ -449,8 +449,8 @@ GUI(COMMON)
                 RADIO(snlimt)
                 {
                     ADD(0, "0: If LCID > 0 , use the life at the last point on S - N curve. If LCID < 0 , use the life at STHRES");
-                    ADD(1, "1: If LCID > 0 , extrapolation from the last two points on S - N curve. If LCID < 0 , Ingnored");
-                    ADD(2, "2: If LCID > 0 or LCID < 0 , Ingnored");
+                    ADD(1, "1: If LCID > 0 , extrapolation from the last two points on S - N curve. If LCID < 0 , Ignored");
+                    ADD(2, "2: If LCID > 0 or LCID < 0 , Ignored");
                 }
             }
         }

--- a/hm_cfg_files/config/CFG/Keyword971_R11.2/FREQUENCY/frequency_domain_response_spectrum.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R11.2/FREQUENCY/frequency_domain_response_spectrum.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R11.2/FREQUENCY/frequency_domain_ssd.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R11.2/FREQUENCY/frequency_domain_ssd.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R12.0/FREQUENCY/frequency_domain_acceleration_unit.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R12.0/FREQUENCY/frequency_domain_acceleration_unit.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");
@@ -43,7 +43,7 @@ GUI(COMMON)
     {
         ADD(0, "0: Use [length unit]/[time unit]2 as unit of acceleration");
         ADD(1, "1: Use g as unit for acceleration, and SI units (Newton, kg, meter, second, etc.) elsewhere");
-        ADD(2, "2: Use g as unit for acceleration, and Engineering units (lbf, lbf × second2/inch, inch, second, etc.) elsewhere");
+        ADD(2, "2: Use g as unit for acceleration, and Engineering units (lbf, lbf ï¿½ second2/inch, inch, second, etc.) elsewhere");
         ADD(3, "3: Use g as unit for acceleration, and units (kN, kg, mm, ms, GPa, etc.) elsewhere");
         ADD(4, "4: use g as unit for acceleration, and units (Newton, ton, mm, second, MPa, etc.) elsewhere");
         ADD(-1, "-1: Use g as unit for acceleration and provide the multiplier for converting g to [length unit]/[time unit]2");

--- a/hm_cfg_files/config/CFG/Keyword971_R12.0/FREQUENCY/frequency_domain_acoustic_fem.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R12.0/FREQUENCY/frequency_domain_acoustic_fem.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R12.0/FREQUENCY/frequency_domain_local.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R12.0/FREQUENCY/frequency_domain_local.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R12.0/FREQUENCY/frequency_domain_random_vibration.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R12.0/FREQUENCY/frequency_domain_random_vibration.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");
@@ -460,8 +460,8 @@ GUI(COMMON)
                 RADIO(snlimt)
                 {
                     ADD(0, "0: If LCID > 0 , use the life at the last point on S - N curve. If LCID < 0 , use the life at STHRES");
-                    ADD(1, "1: If LCID > 0 , extrapolation from the last two points on S - N curve. If LCID < 0 , Ingnored");
-                    ADD(2, "2: If LCID > 0 or LCID < 0 , Ingnored");
+                    ADD(1, "1: If LCID > 0 , extrapolation from the last two points on S - N curve. If LCID < 0 , Ignored");
+                    ADD(2, "2: If LCID > 0 or LCID < 0 , Ignored");
                 }
             }
         }

--- a/hm_cfg_files/config/CFG/Keyword971_R12.0/FREQUENCY/frequency_domain_sea_connection.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R12.0/FREQUENCY/frequency_domain_sea_connection.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R12.0/FREQUENCY/frequency_domain_sea_input.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R12.0/FREQUENCY/frequency_domain_sea_input.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R12.0/FREQUENCY/frequency_domain_sea_subsystem.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R12.0/FREQUENCY/frequency_domain_sea_subsystem.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R12.0/FREQUENCY/frequency_domain_ssd.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R12.0/FREQUENCY/frequency_domain_ssd.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/CONTROL_CARDS/control_contact.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/CONTROL_CARDS/control_contact.cfg
@@ -403,7 +403,7 @@ GUI(COMMON)
     {
       ADD(-1,"-1: Conduction evevenly distributed (pre R4)");
       ADD(0,"0: Default set to 1");
-      ADD(0,"1: Conduction weighted by shape functions, reduced intergration");
+      ADD(0,"1: Conduction weighted by shape functions, reduced integration");
       ADD(1,"2: Conduction weighted by shape functions, full integration");
     } 
     RADIO(CONT_TDCNOF)

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/CONTROL_CARDS/control_efg.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/CONTROL_CARDS/control_efg.cfg
@@ -20,7 +20,7 @@
 ATTRIBUTES(COMMON)
 {
 // INPUT ATTRIBUTES
-  Controlefg_ISPLANE                      = VALUE(INT,"Optional choice for the mesh-free kernal functions:");
+  Controlefg_ISPLANE                      = VALUE(INT,"Optional choice for the mesh-free kernel functions:");
   Controlefg_IDILA                        = VALUE(INT,"Optional choice for the normalized dilation parameter:");
   Controlefg_ININT                        = VALUE(INT,"This is the factor needed for the estimation of maximum workspace (MWSPAC) that can be used during the initialization phase");
   LSD_IMLM                                = VALUE(INT,"Optional choice for the matrix operation, linear solving and memory usage:");

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/CONTROL_CARDS/control_output.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/CONTROL_CARDS/control_output.cfg
@@ -37,7 +37,7 @@ ATTRIBUTES(COMMON)
     COU_IERODE                              = VALUE(INT,  "Output eroded internal and kinetic energy into the 'matsum' file");
     COU_TET10                               = VALUE(INT,  "Output ten connectivity nodes into 'd3plot' database");
     COU_MSGMAX                              = VALUE(INT,  "Maximum number of each error/warning message");
-    COU_IPCURV                              = VALUE(INT,  "Flag to output digitized curve data to messag and d3hsp files");
+    COU_IPCURV                              = VALUE(INT,  "Flag to output digitized curve data to message and d3hsp files");
     LSD_GMDT                                = VALUE(FLOAT,  "Output interval for recorded motions from *INTERFACE_SSI_AUX");
     LSD_IP1DBLT                             = VALUE(INT,  "Output information of 1D (bar-type) seatbelt created for 2D (shell-type) seatbelt to sbtout");
 
@@ -90,7 +90,7 @@ DEFAULTS(COMMON)
     LSD_IPNINT_NUM  = 0;
     LSD_IKEDIT  = 100;
     LSD_IFLUSH  = 5000;
-    //DEFAULT ATTIBUTES Optional Card 2
+    //DEFAULT ATTRIBUTES Optional Card 2
     LSD_IPRTF   = 0;
     COU_IERODE    = 0;
     COU_TET10    = 2;

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/CONTROL_CARDS/control_shell.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/CONTROL_CARDS/control_shell.cfg
@@ -215,7 +215,7 @@ GUI(COMMON)
       }
       RADIO(LSD_TSHELL) 
       {
-         ADD(0,"0: No temperature gradient is considered through the shell tickness (default)") ;
+         ADD(0,"0: No temperature gradient is considered through the shell thickness (default)") ;
          ADD(1,"1: A temperature gradient is calculated through the shell thickness") ;
       } 
     }

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/CONTROL_CARDS/interface_comp_new.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/CONTROL_CARDS/interface_comp_new.cfg
@@ -75,7 +75,7 @@ GUI(COMMON)
     {
        ADD(1, "1: deprecated");
        ADD(2, "2: deprecated");
-       ADD(3, "3: Similar to Method 6, howewer, it is a linear method and no iteration is necessary");
+       ADD(3, "3: Similar to Method 6, however, it is a linear method and no iteration is necessary");
        ADD(4, "4: deprecated");
        ADD(5, "5: deprecated");
        ADD(6, "6: The smoothness and the transition region of the modified surface will depend on the spring back magnitude and the smoothing factor");

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/CONTROL_CARDS/interface_comp_new_multi_steps.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/CONTROL_CARDS/interface_comp_new_multi_steps.cfg
@@ -75,7 +75,7 @@ GUI(COMMON)
     {
        ADD(1, "1: deprecated");
        ADD(2, "2: deprecated");
-       ADD(3, "3: Similar to Method 6, howewer, it is a linear method and no iteration is necessary");
+       ADD(3, "3: Similar to Method 6, however, it is a linear method and no iteration is necessary");
        ADD(4, "4: deprecated");
        ADD(5, "5: deprecated");
        ADD(6, "6: The smoothness and the transition region of the modified surface will depend on the spring back magnitude and the smoothing factor");

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/FREQUENCY/frequency_domain_acoustic_bem.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/FREQUENCY/frequency_domain_acoustic_bem.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/FREQUENCY/frequency_domain_acoustic_fem.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/FREQUENCY/frequency_domain_acoustic_fem.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/FREQUENCY/frequency_domain_frf.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/FREQUENCY/frequency_domain_frf.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/FREQUENCY/frequency_domain_response_spectrum.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/FREQUENCY/frequency_domain_response_spectrum.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/FREQUENCY/frequency_domain_ssd.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/FREQUENCY/frequency_domain_ssd.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/INITIAL/initial_airbag_particle_position.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/INITIAL/initial_airbag_particle_position.cfg
@@ -26,7 +26,7 @@ ATTRIBUTES {
     nodes_table_y       = ARRAY[table_count](FLOAT, "Y-Coordinate");
     nodes_table_z       = ARRAY[table_count](FLOAT, "Z-Coordinate");
   
-    //Atrributes for HM usage
+    //Attributes for HM usage
     _HMCOMMENTSFLAG     = VALUE(INT, "Write HM Comments");
     _HWCOLOR            = VALUE(INT, "Entity Color");  
 }

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/LOADS/initial_velocity_node.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/LOADS/initial_velocity_node.cfg
@@ -18,11 +18,11 @@
 
 ATTRIBUTES(COMMON)
 {
-    // IMPUT ATTRIBUTES
+    // INPUT ATTRIBUTES
     entityid                                = VALUE(NODE,   "Node ID");
     LSD_VX                                  = VALUE(FLOAT,  "Initial translational velocity in x-direction");
     LSD_VY                                  = VALUE(FLOAT,  "Initial translational velocity in y-direction");
-    LSD_VZ                                  = VALUE(FLOAT,  "Initial translational velocity in z-direction");      
+    LSD_VZ                                  = VALUE(FLOAT,  "Initial translational velocity in z-direction");
     LSD_VXR                                 = VALUE(FLOAT,  "Initial rotational velocity in x-direction");
     LSD_VYR                                 = VALUE(FLOAT,  "Initial rotational velocity in y-direction");
     LSD_VZR                                 = VALUE(FLOAT,  "Initial rotational velocity in z-direction");
@@ -37,7 +37,7 @@ ATTRIBUTES(COMMON)
 
 SKEYWORDS_IDENTIFIER(COMMON)
 {
-    // IMPUT ATTRIBUTES
+    // INPUT ATTRIBUTES
     LSD_VX                                  = 747;
     LSD_VY                                  = 748;
     LSD_VZ                                  = 749;

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/LOADS/sub_obj_initial_velocity_none.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/LOADS/sub_obj_initial_velocity_none.cfg
@@ -19,7 +19,7 @@
 
 ATTRIBUTES(COMMON)
 {
-  // IMPUT ATTRIBUTES
+  // INPUT ATTRIBUTES
 
   //Card 1
   LSD_NSID                                = VALUE(SETS,   "Nodal set ID, see *SET_NODES, containing nodes for initial velocity") { SUBTYPES = (/SETS/SET_NODE_IDPOOL) ; }
@@ -47,7 +47,7 @@ ATTRIBUTES(COMMON)
 
 SKEYWORDS_IDENTIFIER(COMMON)
 {
-  // IMPUT ATTRIBUTES
+  // INPUT ATTRIBUTES
 
   //Card 1
   LSD_NSID                                = 745;

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/MAT/MATL_USER_DEF.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/MAT/MATL_USER_DEF.cfg
@@ -140,7 +140,7 @@ ATTRIBUTES(COMMON)
     LSD_DM_PL_COMPR                         = VALUE(INT, "Deactivate Module for PL-COMPR");
     LSD_MAT_USER_PL_ORTHO                   = VALUE(CURVE,  "Plastic orthotropy module");
     LSD_MAT_USER_PL_ISKIN                   = VALUE(CURVE,  "Isotropic-kinematic hardening module");
-    LSD_MAT_USER_PL_ASYMM                   = VALUE(CURVE,  "Tension-compression assymetry moodule for anisotropic hardening");
+    LSD_MAT_USER_PL_ASYMM                   = VALUE(CURVE,  "Tension-compression asymmetry module for anisotropic hardening");
     LSD_MAT_USER_PL_WAIST                   = VALUE(CURVE,  "Waisted shear module for anisotropic hardening");
     LSD_MAT_USER_PL_BIAXF                   = VALUE(CURVE,  "Biaxial correction module for anisotropic hardening");
     LSD_MAT_USER_PL_COMPR                   = VALUE(CURVE,  "Compressibility module");

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/MAT/mat_086.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/MAT/mat_086.cfg
@@ -186,7 +186,7 @@ GUI(COMMON)
      RADIO(axisOptFlag)
      {
         ADD(1, "By element nodes");
-        ADD(2, "Define global vetor");
+        ADD(2, "Define global vector");
         ADD(3, "Define local vector");
         ADD(4, "Pick system");
      }

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/MAT/mat_133.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/MAT/mat_133.cfg
@@ -335,7 +335,7 @@ GUI(COMMON)
      }
      RADIO(MATL133_ISCALE)
      {
-         ADD(0.0, "0.0: Scaling on - refrence direction = rolling direction");
+         ADD(0.0, "0.0: Scaling on - reference direction = rolling direction");
          ADD(1.0, "1.0: Scaling  off - reference direction arbitrary ");
      }
      SCALAR(LSDYNA_C)                               {DIMENSION="DIMENSIONLESS";}

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/MAT/mat_156.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/MAT/mat_156.cfg
@@ -52,7 +52,7 @@ ATTRIBUTES(COMMON)
     CURVE_SVR                               = VALUE(FUNCT, "Absolute value gives load curve ID");
     LSD_SVR                                 = VALUE(FLOAT, "Constant value of 1.0 is used");
 
-    FLAG_SSP                                = VALUE(INT, "Isometric dimensionless stress varies with strech ratio, l/lorig for the parallel elastic elements");
+    FLAG_SSP                                = VALUE(INT, "Isometric dimensionless stress varies with stretch ratio, l/lorig for the parallel elastic elements");
     CURVE_SSP                               = VALUE(FUNCT, "Absolute value gives load curve ID or table ID");
     LSD_SSP                                 = VALUE(FLOAT, "Isometric dimensionless stress (if 0. exponential function is used, >0 constant value of 0.0 is used");
 

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/OUTPUTBLOCK/database_history_beam.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/OUTPUTBLOCK/database_history_beam.cfg
@@ -31,7 +31,7 @@ ATTRIBUTES(COMMON)
     LSD_TitleOpt                            = VALUE(INT, "TitleOpt");  //it doesn't work. keyword_name is used
     keyword_name                            = VALUE(INT, "Title");
     IO_FLAG                                 = VALUE(INT, "IO_FLAG");
-    _opt                                    = VALUE(STRING, "Temporay variable");
+    _opt                                    = VALUE(STRING, "Temporary variable");
 }
 
 SKEYWORDS_IDENTIFIER(COMMON)

--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/RIGIDBODY/constrained_nodal_rigid_body.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/RIGIDBODY/constrained_nodal_rigid_body.cfg
@@ -131,7 +131,7 @@ SKEYWORDS_IDENTIFIER(COMMON)
     _HAS_HEADER                             = -1;
     TITLE                                   = -1;
 
-    // Added this new atrribute to resolve the issue cause because LSD_CID2 attribute
+    // Added this new attribute to resolve the issue cause because LSD_CID2 attribute
     // is used twice in the same keyword i.e. card2 and card 6 which is not correct and to resolve added this temporary variable. 
     LSD_CON1_SID                            = -1;
 }

--- a/hm_cfg_files/config/CFG/Keyword971_R7.1/CONTROL_CARDS/control_contact.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R7.1/CONTROL_CARDS/control_contact.cfg
@@ -407,7 +407,7 @@ GUI(COMMON)
     {
       ADD(-1,"-1: Conduction evevenly distributed (pre R4)");
       ADD(0,"0: Default set to 1");
-      ADD(0,"1: Conduction weighted by shape functions, reduced intergration");
+      ADD(0,"1: Conduction weighted by shape functions, reduced integration");
       ADD(1,"2: Conduction weighted by shape functions, full integration");
     } 
     RADIO(CONT_TDCNOF)

--- a/hm_cfg_files/config/CFG/Keyword971_R7.1/CONTROL_CARDS/control_implicit_forming.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R7.1/CONTROL_CARDS/control_implicit_forming.cfg
@@ -22,7 +22,7 @@ ATTRIBUTES(COMMON)
 // INPUT ATTRIBUTES  
   LSD_CifOpt                              = VALUE(INT,"Options"); 
   LSD_IOPTION                             = VALUE(INT,"Solution type");
-  LSD_NSMIN                               = VALUE(INT,"Minimun number of implicit steps for IOPTION=2");
+  LSD_NSMIN                               = VALUE(INT,"Minimum number of implicit steps for IOPTION=2");
   LSD_NSMAX                               = VALUE(INT,"Maximum number of implicit steps for IOPTION=2");
   LSD_TBIRTH                              = VALUE(FLOAT,"Birth time to activate this feature");
   LSD_TDEATH                              = VALUE(FLOAT,"Death time");

--- a/hm_cfg_files/config/CFG/Keyword971_R7.1/CONTROL_CARDS/control_output.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R7.1/CONTROL_CARDS/control_output.cfg
@@ -37,7 +37,7 @@ ATTRIBUTES(COMMON)
     COU_IERODE                              = VALUE(INT,  "Output eroded internal and kinetic energy into the 'matsum' file");
     COU_TET10                               = VALUE(INT,  "Output ten connectivity nodes into 'd3plot' database");
     COU_MSGMAX                              = VALUE(INT,  "Maximum number of each error/warning message");
-    COU_IPCURV                              = VALUE(INT,  "Flag to output digitized curve data to messag and d3hsp files");
+    COU_IPCURV                              = VALUE(INT,  "Flag to output digitized curve data to message and d3hsp files");
     LSD_GMDT                                = VALUE(FLOAT,  "Output interval for recorded motions from *INTERFACE_SSI_AUX");
     LSD_IP1DBLT                             = VALUE(INT,  "Output information of 1D (bar-type) seatbelt created for 2D (shell-type) seatbelt to sbtout");
     LSD_EOCS                                = VALUE(INT, "Elout Coordinate System: controls the coordinate system to be used when writing out shell data to the elout file");
@@ -102,7 +102,7 @@ DEFAULTS(COMMON)
     LSD_IPNINT_NUM  = 0;
     LSD_IKEDIT  = 100;
     LSD_IFLUSH  = 5000;
-    //DEFAULT ATTIBUTES Optional Card 2
+    //DEFAULT ATTRIBUTES Optional Card 2
     LSD_IPRTF   = 0;
     COU_IERODE    = 0;
     COU_TET10    = 2;

--- a/hm_cfg_files/config/CFG/Keyword971_R7.1/CONTROL_CARDS/control_shell.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R7.1/CONTROL_CARDS/control_shell.cfg
@@ -215,7 +215,7 @@ GUI(COMMON)
       }
       RADIO(LSD_TSHELL) 
       {
-         ADD(0,"0: No temperature gradient is considered through the shell tickness (default)") ;
+         ADD(0,"0: No temperature gradient is considered through the shell thickness (default)") ;
          ADD(1,"1: A temperature gradient is calculated through the shell thickness") ;
       } 
     }

--- a/hm_cfg_files/config/CFG/Keyword971_R7.1/CONTROL_CARDS/dynrelax.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R7.1/CONTROL_CARDS/dynrelax.cfg
@@ -87,7 +87,7 @@ GUI(COMMON)
         ADD(2,"2: initialization to a prescribed geometry");
         ADD(3,"3: dynamic relaxation is activated as with IDRFLG=1, but with a part set ID for convergence checking");
         ADD(5,"5: initialize implicitly and run explicitly");
-        ADD(6,"5: initialize implicity but only for the part set specified by DRPSET");
+        ADD(6,"5: initialize implicitly but only for the part set specified by DRPSET");
     }
 
     if( LSD_IDRFLG == 3 || LSD_IDRFLG == 6)

--- a/hm_cfg_files/config/CFG/Keyword971_R7.1/CONTROL_CARDS/interface_comp_new_local_smooth.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R7.1/CONTROL_CARDS/interface_comp_new_local_smooth.cfg
@@ -75,7 +75,7 @@ GUI(COMMON)
     {
        ADD(1, "1: deprecated");
        ADD(2, "2: deprecated");
-       ADD(3, "3: Similar to Method 6, howewer, it is a linear method and no iteration is necessary");
+       ADD(3, "3: Similar to Method 6, however, it is a linear method and no iteration is necessary");
        ADD(4, "4: deprecated");
        ADD(5, "5: deprecated");
        ADD(6, "6: The smoothness and the transition region of the modified surface will depend on the spring back magnitude and the smoothing factor");

--- a/hm_cfg_files/config/CFG/Keyword971_R7.1/FREQUENCY/frequency_domain_acoustic_bem.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R7.1/FREQUENCY/frequency_domain_acoustic_bem.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R7.1/FREQUENCY/frequency_domain_acoustic_fem.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R7.1/FREQUENCY/frequency_domain_acoustic_fem.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R7.1/FREQUENCY/frequency_domain_frf.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R7.1/FREQUENCY/frequency_domain_frf.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R7.1/FREQUENCY/frequency_domain_mode.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R7.1/FREQUENCY/frequency_domain_mode.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R7.1/FREQUENCY/frequency_domain_path.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R7.1/FREQUENCY/frequency_domain_path.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R7.1/FREQUENCY/frequency_domain_response_spectrum.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R7.1/FREQUENCY/frequency_domain_response_spectrum.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R7.1/FREQUENCY/frequency_domain_ssd.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R7.1/FREQUENCY/frequency_domain_ssd.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R7.1/MAT/MATL_USER_DEF.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R7.1/MAT/MATL_USER_DEF.cfg
@@ -141,7 +141,7 @@ ATTRIBUTES(COMMON)
     LSD_DM_PL_COMPR                         = VALUE(INT, "Deactivate Module for PL-COMPR");
     LSD_MAT_USER_PL_ORTHO                   = VALUE(CURVE,  "Plastic orthotropy module");
     LSD_MAT_USER_PL_ISKIN                   = VALUE(CURVE,  "Isotropic-kinematic hardening module");
-    LSD_MAT_USER_PL_ASYMM                   = VALUE(CURVE,  "Tension-compression assymetry moodule for anisotropic hardening");
+    LSD_MAT_USER_PL_ASYMM                   = VALUE(CURVE,  "Tension-compression asymmetry module for anisotropic hardening");
     LSD_MAT_USER_PL_WAIST                   = VALUE(CURVE,  "Waisted shear module for anisotropic hardening");
     LSD_MAT_USER_PL_BIAXF                   = VALUE(CURVE,  "Biaxial correction module for anisotropic hardening");
     LSD_MAT_USER_PL_COMPR                   = VALUE(CURVE,  "Compressibility module");

--- a/hm_cfg_files/config/CFG/Keyword971_R7.1/MAT/mat_133.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R7.1/MAT/mat_133.cfg
@@ -337,7 +337,7 @@ GUI(COMMON)
      }
      RADIO(MATL133_ISCALE)
      {
-         ADD(0.0, "0.0: Scaling on - refrence direction = rolling direction");
+         ADD(0.0, "0.0: Scaling on - reference direction = rolling direction");
          ADD(1.0, "1.0: Scaling  off - reference direction arbitrary ");
      }
      SCALAR(LSDYNA_C)                               {DIMENSION="DIMENSIONLESS";}

--- a/hm_cfg_files/config/CFG/Keyword971_R7.1/MAT/mat_169.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R7.1/MAT/mat_169.cfg
@@ -37,7 +37,7 @@ ATTRIBUTES(COMMON)
     LSD_MAT169_GCSHR                        = VALUE(FLOAT,  "Energy per unit area to fail the bond in shear");
     LSD_MAT169_GCTE                         = VALUE(FLOAT,  "Energy per unit length to fail the edge of the bond in tension");
     LSD_MAT169_GCTEN                        = VALUE(FLOAT,  "Energy per unit area to fail the bond in tension");
-    LSD_MAT169_OUTFAIL                      = VALUE(FLOAT,  "Flag for additional output to messag file");
+    LSD_MAT169_OUTFAIL                      = VALUE(FLOAT,  "Flag for additional output to message file");
     LSD_MAT169_PWRS                         = VALUE(FLOAT,  "Power law term for shear");
     LSD_MAT169_PWRSE                        = VALUE(FLOAT,  "Power law term for shear");
     LSD_MAT169_PWRT                         = VALUE(FLOAT,  "Power law term for tension");

--- a/hm_cfg_files/config/CFG/Keyword971_R8.0/CONTROL_CARDS/control_contact.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R8.0/CONTROL_CARDS/control_contact.cfg
@@ -410,7 +410,7 @@ GUI(COMMON)
     {
       ADD(-1,"-1: Conduction evevenly distributed (pre R4)");
       ADD(0,"0: Default set to 1");
-      ADD(0,"1: Conduction weighted by shape functions, reduced intergration");
+      ADD(0,"1: Conduction weighted by shape functions, reduced integration");
       ADD(1,"2: Conduction weighted by shape functions, full integration");
     } 
     RADIO(CONT_TDCNOF)

--- a/hm_cfg_files/config/CFG/Keyword971_R8.0/CONTROL_CARDS/control_output.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R8.0/CONTROL_CARDS/control_output.cfg
@@ -37,7 +37,7 @@ ATTRIBUTES(COMMON)
     COU_IERODE                              = VALUE(INT,  "Output eroded internal and kinetic energy into the 'matsum' file");
     COU_TET10                               = VALUE(INT,  "Output ten connectivity nodes into 'd3plot' database");
     COU_MSGMAX                              = VALUE(INT,  "Maximum number of each error/warning message");
-    COU_IPCURV                              = VALUE(INT,  "Flag to output digitized curve data to messag and d3hsp files");
+    COU_IPCURV                              = VALUE(INT,  "Flag to output digitized curve data to message and d3hsp files");
     LSD_GMDT                                = VALUE(FLOAT,  "Output interval for recorded motions from *INTERFACE_SSI_AUX");
     LSD_IP1DBLT                             = VALUE(INT,  "Output information of 1D (bar-type) seatbelt created for 2D (shell-type) seatbelt to sbtout");
     LSD_EOCS                                = VALUE(INT, "Elout Coordinate System: controls the coordinate system to be used when writing out shell data to the elout file");
@@ -106,7 +106,7 @@ DEFAULTS(COMMON)
     LSD_IPNINT_NUM  = 0;
     LSD_IKEDIT  = 100;
     LSD_IFLUSH  = 5000;
-    //DEFAULT ATTIBUTES Optional Card 2
+    //DEFAULT ATTRIBUTES Optional Card 2
     LSD_IPRTF   = 0;
     COU_IERODE    = 0;
     COU_TET10    = 2;

--- a/hm_cfg_files/config/CFG/Keyword971_R8.0/FREQUENCY/frequency_domain_acceleration_unit.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R8.0/FREQUENCY/frequency_domain_acceleration_unit.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");
@@ -43,7 +43,7 @@ GUI(COMMON)
     {
         ADD(0, "0: Use [length unit]/[time unit]2 as unit of acceleration");
         ADD(1, "1: Use g as unit for acceleration, and SI units (Newton, kg, meter, second, etc.) elsewhere");
-        ADD(2, "2: Use g as unit for acceleration, and Engineering units (lbf, lbf × second2/inch, inch, second, etc.) elsewhere");
+        ADD(2, "2: Use g as unit for acceleration, and Engineering units (lbf, lbf ï¿½ second2/inch, inch, second, etc.) elsewhere");
         ADD(3, "3: Use g as unit for acceleration, and units (kN, kg, mm, ms, GPa, etc.) elsewhere");
         ADD(-1, "-1: Use g as unit for acceleration and provide the multiplier for converting g to [length unit]/[time unit]2");
     }

--- a/hm_cfg_files/config/CFG/Keyword971_R8.0/FREQUENCY/frequency_domain_acoustic_bem.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R8.0/FREQUENCY/frequency_domain_acoustic_bem.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R8.0/FREQUENCY/frequency_domain_acoustic_fem.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R8.0/FREQUENCY/frequency_domain_acoustic_fem.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R8.0/FREQUENCY/frequency_domain_acoustic_incident_wave.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R8.0/FREQUENCY/frequency_domain_acoustic_incident_wave.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R8.0/FREQUENCY/frequency_domain_acoustic_sound_speed.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R8.0/FREQUENCY/frequency_domain_acoustic_sound_speed.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R8.0/FREQUENCY/frequency_domain_path.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R8.0/FREQUENCY/frequency_domain_path.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R8.0/FREQUENCY/frequency_domain_ssd.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R8.0/FREQUENCY/frequency_domain_ssd.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R8.0/LOADS/sub_obj_initial_velocity_generation.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R8.0/LOADS/sub_obj_initial_velocity_generation.cfg
@@ -19,7 +19,7 @@
 
 ATTRIBUTES(COMMON)
 {
-    // IMPUT ATTRIBUTES
+    // INPUT ATTRIBUTES
 
     // Card 1
     STYP                                    = VALUE(INT,       "Set type");
@@ -51,7 +51,7 @@ ATTRIBUTES(COMMON)
 
 SKEYWORDS_IDENTIFIER(COMMON)
 {
-    // IMPUT ATTRIBUTES
+    // INPUT ATTRIBUTES
 
     // Card 1
     STYP                                    = 2788;

--- a/hm_cfg_files/config/CFG/Keyword971_R8.0/MAT/mat_248.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R8.0/MAT/mat_248.cfg
@@ -158,7 +158,7 @@ ATTRIBUTES(COMMON)
     MAT248_PS_CURVE                         = VALUE(INT,  "curvePS");
     MAT248_TABRHO                           = VALUE(FUNCT,  "phase and temp. dependent densities");
     MAT248_TRIP                             = VALUE(INT,  "trip effect calculation");
-    Nu                                      = VALUE(FLOAT,  "Poisson’s ratio");
+    Nu                                      = VALUE(FLOAT,  "Poissonï¿½s ratio");
     Rho                                     = VALUE(FLOAT,  "Material density");
     optionE                                 = VALUE(INT,  "optionE");
     optionHEAT                              = VALUE(INT,  "Heat flag");
@@ -578,7 +578,7 @@ optional:
     RADIO(LSD_ISLC)
     {
        ADD(0, "0.0: All 16 parameters on Cards 10 and 11 are constant values");
-       ADD(1, "1.0: PHI_F, CR_F, PHI_P, CR_P, PHI_B, and CR_B are load curves defining values as functions of cooling rate. The remaining 10 paramters on Cards 10 and 11 are constant values.");
+       ADD(1, "1.0: PHI_F, CR_F, PHI_P, CR_P, PHI_B, and CR_B are load curves defining values as functions of cooling rate. The remaining 10 parameters on Cards 10 and 11 are constant values.");
        ADD(2, "2.0: All 16 parameters on Cards 10 and 11 are load curves defining values as functions of cooling rate");
     }
     RADIO(LSD_IEXTRA)

--- a/hm_cfg_files/config/CFG/Keyword971_R9.0/MAT/mat_169.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R9.0/MAT/mat_169.cfg
@@ -31,7 +31,7 @@ ATTRIBUTES(COMMON)
     LSD_MAT169_GCSHR                        = VALUE(FLOAT,  "Energy per unit area to fail the bond in shear");
     LSD_MAT169_GCTE                         = VALUE(FLOAT,  "Energy per unit length to fail the edge of the bond in tension");
     LSD_MAT169_GCTEN                        = VALUE(FLOAT,  "Energy per unit area to fail the bond in tension");
-    LSD_MAT169_OUTFAIL                      = VALUE(FLOAT,  "Flag for additional output to messag file");
+    LSD_MAT169_OUTFAIL                      = VALUE(FLOAT,  "Flag for additional output to message file");
     LSD_MAT169_PWRS                         = VALUE(FLOAT,  "Power law term for shear");
     LSD_MAT169_PWRSE                        = VALUE(FLOAT,  "Power law term for shear");
     LSD_MAT169_PWRT                         = VALUE(FLOAT,  "Power law term for tension");
@@ -60,7 +60,7 @@ ATTRIBUTES(COMMON)
     LSD_MAT169_GCSHR_FUN                    = VALUE(FUNCT,  "GCSHR Function ID"); 
     LSD_MAT169_SHRP_FUN                     = VALUE(FUNCT,  "SHRP Function ID"); 
      
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     LSD_OPT_MAT169_SDFAC                    = VALUE(INT,  "SDFAC FUNCUTION OPTION");
     LSD_OPT_MAT169_SGFAC                    = VALUE(INT,  "SGFAC FUNCUTION OPTION");
     LSD_OPT_MAT169_TENMAX                   = VALUE(INT,  "TENMAX FUNCUTION OPTION");

--- a/hm_cfg_files/config/CFG/Keyword971_R9.0/MAT/mat_186.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R9.0/MAT/mat_186.cfg
@@ -124,9 +124,9 @@ GUI(COMMON)
      }
      RADIO(MAT186_TES)
      {
-        ADD(0.0, "0.0: A dimentional separation measure is used, and power law for interaxction between mode I and II");
-        ADD(1.0, "1.0: A dimentional separation measure is used, and Benzeggah-Kenane law for interaxction between mode I and II");
-        ADD(2.0, "2.0: A dimentional separation measure is used");
+        ADD(0.0, "0.0: A dimensional separation measure is used, and power law for interaction between mode I and II");
+        ADD(1.0, "1.0: A dimensional separation measure is used, and Benzeggah-Kenane law for interaction between mode I and II");
+        ADD(2.0, "2.0: A dimensional separation measure is used");
      }
      DATA(MAT186_TSLC);
      SCALAR(LSDYNA_GIC);

--- a/hm_cfg_files/config/CFG/Keyword971_R9.3/CONTROL_CARDS/control_output.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R9.3/CONTROL_CARDS/control_output.cfg
@@ -37,7 +37,7 @@ ATTRIBUTES(COMMON)
     COU_IERODE                              = VALUE(INT,  "Output eroded internal and kinetic energy into the 'matsum' file");
     COU_TET10                               = VALUE(INT,  "Output ten connectivity nodes into 'd3plot' database");
     COU_MSGMAX                              = VALUE(INT,  "Maximum number of each error/warning message");
-    COU_IPCURV                              = VALUE(INT,  "Flag to output digitized curve data to messag and d3hsp files");
+    COU_IPCURV                              = VALUE(INT,  "Flag to output digitized curve data to message and d3hsp files");
     LSD_GMDT                                = VALUE(FLOAT,  "Output interval for recorded motions from *INTERFACE_SSI_AUX");
     LSD_IP1DBLT                             = VALUE(INT,  "Output information of 1D (bar-type) seatbelt created for 2D (shell-type) seatbelt to sbtout");
     LSD_EOCS                                = VALUE(INT, "Elout Coordinate System: controls the coordinate system to be used when writing out shell data to the elout file");
@@ -54,7 +54,7 @@ ATTRIBUTES(COMMON)
     LSD_CDETOL                              = VALUE(FLOAT, "Tolerance for output of *DEFINE_CURVE discretization warnings");
     LSD_CTRL_OUT_OPTCARD4                   = VALUE(INT, "");
     //Optional card 4
-    LSD_PHSCHNG                             = VALUE(INT, "Message to messag file when materials 216, 217, and 218 change phase");
+    LSD_PHSCHNG                             = VALUE(INT, "Message to message file when materials 216, 217, and 218 change phase");
     // HM INTERNAL
     KEYWORD_STR                             = VALUE(STRING, "Solver Keyword");
     IO_FLAG                                 = VALUE(INT, "");
@@ -113,7 +113,7 @@ DEFAULTS(COMMON)
     LSD_IPNINT_NUM  = 0;
     LSD_IKEDIT  = 100;
     LSD_IFLUSH  = 5000;
-    //DEFAULT ATTIBUTES Optional Card 2
+    //DEFAULT ATTRIBUTES Optional Card 2
     LSD_IPRTF   = 0;
     COU_IERODE    = 0;
     COU_TET10    = 2;

--- a/hm_cfg_files/config/CFG/Keyword971_R9.3/CONTROL_CARDS/control_shell.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R9.3/CONTROL_CARDS/control_shell.cfg
@@ -217,7 +217,7 @@ GUI(COMMON)
       }
       RADIO(LSD_TSHELL) 
       {
-         ADD(0,"0: No temperature gradient is considered through the shell tickness (default)") ;
+         ADD(0,"0: No temperature gradient is considered through the shell thickness (default)") ;
          ADD(1,"1: A temperature gradient is calculated through the shell thickness") ;
       } 
     }

--- a/hm_cfg_files/config/CFG/Keyword971_R9.3/FREQUENCY/frequency_domain_acoustic_bem.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R9.3/FREQUENCY/frequency_domain_acoustic_bem.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R9.3/FREQUENCY/frequency_domain_acoustic_fem.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R9.3/FREQUENCY/frequency_domain_acoustic_fem.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R9.3/FREQUENCY/frequency_domain_acoustic_fringe_plot.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R9.3/FREQUENCY/frequency_domain_acoustic_fringe_plot.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R9.3/FREQUENCY/frequency_domain_acoustic_incident_wave.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R9.3/FREQUENCY/frequency_domain_acoustic_incident_wave.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");

--- a/hm_cfg_files/config/CFG/Keyword971_R9.3/FREQUENCY/frequency_domain_ssd.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R9.3/FREQUENCY/frequency_domain_ssd.cfg
@@ -15,7 +15,7 @@
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 ATTRIBUTES(COMMON) {
 
-    //Atrributes for HM usage 
+    //Attributes for HM usage 
     IO_FLAG                             = VALUE(INT, "Import/Export flag");
     _HMCOMMENTSFLAG                     = VALUE(INT, "Write HM Comments");
     _HWCOLOR                            = VALUE(INT, "Entity Color");


### PR DESCRIPTION
#### Description of the feature or the bug
Fix typos in hm_cfg_files/config/CFG/Keyword* subdir  
Found via `codespell`

#### Description of the changes
self-explanatory