### PR TITLE
Fix damage evolution function for fail tab1 with solids

### DIFF
--- a/engine/source/materials/fail/tabulated/fail_tab_s.F
+++ b/engine/source/materials/fail/tabulated/fail_tab_s.F
@@ -214,7 +214,7 @@ C
         NINDX  = 0  
         DO I=1,NEL
           IF (SFLAG==1 .AND. OFF(I)==ONE) THEN
-            ID_DD = IFUNC(NFUNC)
+            ID_DD = IFUNC(4)
             IF(ID_DD /= 0 )THEN
              DP = FINTER(ID_DD,UVAR(I,1),NPF,TF,DF)
             ELSE
@@ -246,7 +246,7 @@ C----
 c---           
           IF (OFF(I) == ONE .AND. (SFLAG==2 .OR. SFLAG==3)) THEN
             IF (UVAR(I,1) < DCRIT)THEN
-             ID_DD = IFUNC(NFUNC)
+             ID_DD = IFUNC(4)
              IF(ID_DD /= 0 )THEN
                DP = FINTER(ID_DD,UVAR(I,1),NPF,TF,DF)
               ELSE

--- a/starter/source/materials/fail/tabulated/hm_read_fail_tab1.F
+++ b/starter/source/materials/fail/tabulated/hm_read_fail_tab1.F
@@ -248,7 +248,11 @@ c-----------------------------------------------------------------------
         ENDIF
         IF (IXFEM > 0) WRITE(IOUT, 1003) IXFEM,DADV
         WRITE(IOUT, 1004) P_THICKFAIL,P_THINNFAIL
-        WRITE(IOUT, 1005) DCRIT,DD,DN,ECRIT
+        IF (IFUN_DMG > 0) THEN 
+          WRITE(IOUT, 1009) DCRIT,IFUN_DMG,ECRIT
+        ELSE 
+          WRITE(IOUT, 1005) DCRIT,DD,DN,ECRIT
+        ENDIF
         IF (FADE_EXPO >= ZERO) THEN
           WRITE(IOUT, 1006) FADE_EXPO
         ELSE
@@ -299,6 +303,10 @@ c-----------------------------------------------------------------------
      & 5X,'CRITICAL DAMAGE VALUE . . . . . . . . . . . . . . . .=',E12.4/
      & 5X,'DAMAGE PARAMETER D. . . . . . . . . . . . . . . . . .=',E12.4/
      & 5X,'DAMAGE PARAMETER N. . . . . . . . . . . . . . . . . .=',E12.4/
+     & 5X,'INSTABILITY STRAIN. . . . . . . . . . . . . . . . . .=',E12.4)
+ 1009 FORMAT(
+     & 5X,'CRITICAL DAMAGE VALUE . . . . . . . . . . . . . . . .=',E12.4/
+     & 5X,'DAMAGE EVOLUTION FUNCTION . . . . . . . . . . . . . .=',I10/
      & 5X,'INSTABILITY STRAIN. . . . . . . . . . . . . . . . . .=',E12.4)
  1006 FORMAT(
      & 5X,'FADE PARAMETER. . . . . . . . . . . . . . . . . . . .=',E12.4)


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Damage evolution function for /FAIL/TAB1 was not displayed in the starter .out file and was not properly used for solids.  


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Add the output after starter and change the number of the function used in the engine. 
