### PR TITLE
Fix a mpi hang and a segfault introduced in the shoot algo commit

### DIFF
--- a/engine/source/interfaces/interf/check_nodal_state.F
+++ b/engine/source/interfaces/interf/check_nodal_state.F
@@ -73,7 +73,7 @@ C-----------------------------------------------
         FIRST = 1 + ITASK * (NUMNOD / NTHREAD)
         LAST = (ITASK + 1) * (NUMNOD / NTHREAD)
         IF(ITASK+1==NTHREAD) LAST = NUMNOD
-        ALLOCATE( LOCAL_INDEX_SECONDARY_NODE( NUMNOD/NTHREAD ) )
+        ALLOCATE( LOCAL_INDEX_SECONDARY_NODE( LAST-FIRST+1 ) )
         ! --------------------------
         ! find the deactivated nodes 
         DO I=FIRST,LAST

--- a/engine/source/mpi/kinematic_conditions/spmd_exchseg_idel.F
+++ b/engine/source/mpi/kinematic_conditions/spmd_exchseg_idel.F
@@ -88,7 +88,7 @@ C-----------------------------------------------
 C   E x t e r n a l   F u n c t i o n s
 C-----------------------------------------------
       INTEGER SYSFUS2
-C-----------------------------------------------
+C-----------------------------------------------    
       ALLOCATE(BUFR(IRSIZE))
       LOC_PROC = ISPMD+1
 
@@ -98,7 +98,7 @@ C-----------------------------------------------
       REQ_R1(1:NSPMD) = MPI_REQUEST_NULL
       DO I = 1, NSPMD
         SIZ = (IAD_ELEM(1,I+1)-IAD_ELEM(1,I))
-        IF(I.NE.LOC_PROC.AND.LBUFS.GT.0.AND.SIZ>0) THEN
+        IF(I/=LOC_PROC.AND.IRECV(I)>0.AND.SIZ>0) THEN
           MSGTYP = MSGOFF2 
           CALL MPI_IRECV(
      .      BUFR(IDEB),IRECV(I),MPI_INTEGER,IT_SPMD(I),MSGTYP,
@@ -112,7 +112,7 @@ C-----------------------------------------------
 C Proc sends the same BUFS to everybody
       DO I = 1, NSPMD
         SIZ = (IAD_ELEM(1,I+1)-IAD_ELEM(1,I))
-        IF(I.NE.LOC_PROC.AND.LBUFS.GT.0.AND.SIZ>0) THEN
+        IF(I/=LOC_PROC.AND.LBUFS>0.AND.SIZ>0) THEN
            MSGTYP = MSGOFF2
            CALL MPI_ISEND(
      C      BUFS,LBUFS,MPI_INTEGER,IT_SPMD(I),MSGTYP,
@@ -120,14 +120,14 @@ C Proc sends the same BUFS to everybody
         ENDIF
       ENDDO
 
-
       IDEB = 0
       IOFF = 0
       LEN = 0
 C Proc recieve only if IRECV(I) > 0
 C
       DO I = 1, NSPMD
-        IF(IRECV(I)>0) THEN
+        SIZ = (IAD_ELEM(1,I+1)-IAD_ELEM(1,I))
+        IF(I/=LOC_PROC.AND.IRECV(I)>0.AND.SIZ>0) THEN
           MSGTYP = MSGOFF2 
           CALL MPI_WAIT(REQ_R1(I),STATUS,IERROR)
           LEN = LEN+IRECV(I)
@@ -208,7 +208,7 @@ C
       IDEB = 1
       DO I = 1, NSPMD
         SIZ = (IAD_ELEM(1,I+1)-IAD_ELEM(1,I))
-        IF(I.NE.LOC_PROC.AND.LINDEX.GT.0.AND.SIZ>0) THEN
+        IF(I/=LOC_PROC.AND.IRECV(I)>0.AND.SIZ>0) THEN
           LEN = IRECV(I)
           MSGTYP = MSGOFF3
           CALL MPI_ISEND(
@@ -221,7 +221,8 @@ C
 C Test reception envoi BUFS
 C
       DO I = 1, NSPMD
-        IF(I/=LOC_PROC.AND.LBUFS>0) THEN
+        SIZ = (IAD_ELEM(1,I+1)-IAD_ELEM(1,I))
+        IF(I/=LOC_PROC.AND.LBUFS>0.AND.SIZ>0) THEN
           CALL MPI_WAIT(REQ_S2(I),STATUS,IERROR)
         ENDIF
       ENDDO
@@ -234,7 +235,8 @@ C
           BUFS(I) = 0
         ENDDO
         DO I = 1, NSPMD
-          IF(I/=LOC_PROC.AND.LINDEX>0) THEN
+          SIZ = (IAD_ELEM(1,I+1)-IAD_ELEM(1,I))
+          IF(I/=LOC_PROC.AND.LINDEX>0.AND.SIZ>0) THEN
             MSGTYP = MSGOFF3
             CALL MPI_RECV(
      .        BUFS2,LINDEX,MPI_INTEGER,IT_SPMD(I),MSGTYP,
@@ -251,7 +253,8 @@ C
 C Test reception envoi BUFR
 C
       DO I = 1, NSPMD
-        IF(IRECV(I)>0) THEN
+        SIZ = (IAD_ELEM(1,I+1)-IAD_ELEM(1,I))
+        IF(I/=LOC_PROC.AND.SIZ>0.AND.IRECV(I)>0) THEN
           CALL MPI_WAIT(REQ_S3(I),STATUS,IERROR)
         ENDIF
       ENDDO


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
Two bugs were introduced in the shooting node algorithm : a mpi hang in the spmd_exchseg_idel.F routine and a segfault in the check_nodal_state.F routine
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
Mpi hang : tha mpi_wait conditions and the mpi_isend/irecv were not consistent
Segfault : the segfault occured only with several OMP_NUM_THREADS, a local array dimension was not correct for the last thread

