### PR TITLE
/MAT/LAW58 - correct bug of sound speed calculation dpending on eleme…

### DIFF
--- a/engine/source/materials/mat/mat058/sigeps58c.F
+++ b/engine/source/materials/mat/mat058/sigeps58c.F
@@ -150,7 +150,7 @@ C-----------------------------------------------
       my_real ,DIMENSION(NEL) :: EC,ET,LC,LT,FN,SIGG0,DTANG,TFOLD,YC,YT,
      .        EMINRLC,EMAXRLC,EPSMAXC,EMINRLT,EMAXRLT,EPSMAXT,EPSNC,EPSNT,EPSNS,
      .        KMAX,STIFFC,STIFFT,EPSNRLC,EPSNRLT,SMAXRLC,SMAXRLT,SMINRLC,SIGMAXC,
-     .        SMINRLT,SIGMAXT,PHIMIN,PHIMAX,PHIRLMAX,SXYMAX,
+     .        SMINRLT,SIGMAXT,PHIMIN,PHIMAX,PHIRLMAX,SXYMAX,ALDTM,
      .        SXYMIN,SXYMAXRL,CVISC,CVIST
 C-----------------------------------------------
 C   S t a t e    V a r i a b l e s  (U V A R)
@@ -514,7 +514,8 @@ C---      contraintes frottement cisaillement
 C---
           SINN = TAN_PHI(I) / SQRT(ONE + TAN2)
           KMAX(I) = MAX(STIFFC(I)*RFAC,STIFFT(I)*RFAT)*(ONE+SINN) + KG
-          LMIN = MIN(DC/DC0,DT/DT0)*UVAR(I,14)
+          LMIN    = MIN(DC/DC0,DT/DT0)*UVAR(I,14)
+          ALDTM(I)= ALDT(I) / LMIN
           VISCMAX(I) = MAX(V1,V2)
           ETSE(I)    = ONE
         ENDDO
@@ -522,7 +523,7 @@ C---
 #include "vectorize.inc"
         DO  J=1,NINDX
           I=INDEX(J)
-          SOUNDSP(I)= SQRT(KMAX(I)/(RHO0(I)))*ALDT(I)/LMIN
+          SOUNDSP(I)= SQRT(KMAX(I)/(RHO0(I)))*ALDTM(I)
           UVAR(I,1) = SIGNXX(I) + SIGVXX(I)
           UVAR(I,2) = SIGNYY(I) + SIGVYY(I)
           UVAR(I,3) = SIGNXY(I) + SIGVXY(I)
@@ -1571,7 +1572,8 @@ C---      contraintes frottement cisaillement
 C---
           SINN = TAN_PHI(I) / SQRT(ONE + TAN2)
           KMAX(I) = MAX(STIFFC(I)*RFAC,STIFFT(I)*RFAT)*(ONE+SINN) + KG
-          LMIN = MIN(DC/DC0,DT/DT0)*UVAR(I,14)
+          LMIN    = MIN(DC/DC0,DT/DT0)*UVAR(I,14)
+          ALDTM(I)= ALDT(I) / LMIN
           VISCMAX(I) = MAX(V1,V2)
           ETSE(I)    = ONE
         ENDDO
@@ -1579,7 +1581,7 @@ C---
 #include "vectorize.inc"
         DO  J=1,NINDX
           I=INDEX(J)
-          SOUNDSP(I)= SQRT(KMAX(I)/(RHO0(I)))*ALDT(I)/LMIN
+          SOUNDSP(I)= SQRT(KMAX(I)/(RHO0(I)))*ALDTM(I)
           UVAR(I,1) = SIGNXX(I) + SIGVXX(I)
           UVAR(I,2) = SIGNYY(I) + SIGVYY(I)
           UVAR(I,3) = SIGNXY(I) + SIGVXY(I)


### PR DESCRIPTION
…nt size

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

correction of time step calculation in law58

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

sound speed depending on element size was calculated with last scalar value in element group instead of each element size
