### PR TITLE
/DT/NODA taking into account sound speed for law58

### DIFF
--- a/engine/source/airbag/mhvis3.F
+++ b/engine/source/airbag/mhvis3.F
@@ -42,7 +42,7 @@ Chd|====================================================================
      D                  VHX,VHY,H11,H12,H13,
      E                  H14,H21,H22,H23,H24,
      F                  H31,H32,H33,H34,H1 , 
-     G                  H2,IGEO,NEL)
+     G                  H2,IGEO,NEL,MTN,A1 )
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -70,7 +70,7 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER IXC(NIXC,*),IPARTC(*), JFT, JLT,PID(*),
-     .        IHBE  ,NFT ,ISMSTR,IGEO(NPROPGI, *),NEL
+     .        IHBE  ,NFT ,ISMSTR,IGEO(NPROPGI, *),NEL,MTN
       INTEGER MAT(MVSIZ) 
 C     REAL
       my_real
@@ -91,6 +91,7 @@ C     REAL
      .   VX4(MVSIZ), VY1(MVSIZ), VY2(MVSIZ), VY3(MVSIZ), VY4(MVSIZ),
      .   VZ1(MVSIZ), VZ2(MVSIZ), VZ3(MVSIZ), VZ4(MVSIZ), AREA(MVSIZ),
      .   A11R(MVSIZ)
+      my_real,DIMENSION(MVSIZ), INTENT(IN) :: A1
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -218,6 +219,7 @@ C
            A11(I) =PM(24,MX)
            G(I)  =PM(22,MX)
           ENDDO
+          IF (MTN==58) A11(JFT:JLT)=A1(JFT:JLT)
 !!        
           DO I=JFT,JLT
             IF (OFF(I)==ZERO) THEN

--- a/engine/source/elements/sh3n/coque3n/c3dt3.F
+++ b/engine/source/elements/sh3n/coque3n/c3dt3.F
@@ -33,7 +33,7 @@ Chd|====================================================================
      4                 ALPE  ,MSTG   ,DMELTG ,JSMS   ,PTG    ,
      5                 SHF   ,IGTYP  ,IGMAT  ,G      ,A1     ,
      6                 A11R  ,G_DT   ,DTEL   ,ALDT   ,THK0   ,
-     7                 AREA  ,NGL    ,IMAT   )
+     7                 AREA  ,NGL    ,IMAT   ,MTN    )
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -62,7 +62,7 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER JFT, JLT,NELTST,ITYPTST,ISMSTR,NFT,IOFC, JSMS,IGTYP,
-     .        IGMAT,IMAT
+     .        IGMAT,IMAT,MTN
       INTEGER NGL(MVSIZ)
       my_real
      .   PM(NPROPM,*), OFF(*),STI(*),STIR(*),OFFG(*),SSP(MVSIZ),
@@ -100,6 +100,7 @@ C
                 ENDIF
           ENDDO       
         ELSE
+           IF (MTN ==58 ) CALL CSSP2A11(PM   ,IMAT  ,SSP  ,A1   ,JLT   )
            DO  I=JFT,JLT
             A1(I) = PM(24,IMAT)
             G(I)  = PM(22,IMAT)

--- a/engine/source/elements/sh3n/coque3n/c3forc3.F
+++ b/engine/source/elements/sh3n/coque3n/c3forc3.F
@@ -504,7 +504,7 @@ C--------------------------
      4        ALPE   ,MSTG      ,DMELTG  ,JSMS   ,PTG     ,
      5        SHF    ,IGTYP     ,IGMAT   ,G      ,A11     ,
      6        A11R   ,GBUF%G_DT ,GBUF%DT ,ALDT   ,THK0    ,
-     7        AREA   ,NGL       ,IMAT    )
+     7        AREA   ,NGL       ,IMAT    ,MTN    )
 c
 C--------keep  GBUF%FOR,GBUF%MOM in new local sys as LBUF%SIG    
       CALL C3SROTO3(JFT    ,JLT    ,ECOS    ,ESIN      ,GBUF%FOR,

--- a/engine/source/elements/sh3n/coque3n/cssp2a11.F
+++ b/engine/source/elements/sh3n/coque3n/cssp2a11.F
@@ -1,0 +1,59 @@
+Copyright>        OpenRadioss
+Copyright>        Copyright (C) 1986-2022 Altair Engineering Inc.
+Copyright>    
+Copyright>        This program is free software: you can redistribute it and/or modify
+Copyright>        it under the terms of the GNU Affero General Public License as published by
+Copyright>        the Free Software Foundation, either version 3 of the License, or
+Copyright>        (at your option) any later version.
+Copyright>    
+Copyright>        This program is distributed in the hope that it will be useful,
+Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+Copyright>        GNU Affero General Public License for more details.
+Copyright>    
+Copyright>        You should have received a copy of the GNU Affero General Public License
+Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+Copyright>    
+Copyright>    
+Copyright>        Commercial Alternative: Altair Radioss Software 
+Copyright>    
+Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss 
+Copyright>        software under a commercial license.  Contact Altair to discuss further if the 
+Copyright>        commercial version may interest you: https://www.altair.com/radioss/.    
+Chd|====================================================================
+Chd|-- called by -----------
+Chd|-- calls ---------------
+Chd|====================================================================
+      SUBROUTINE CSSP2A11(PM    ,IMAT  ,SSP  ,A11   ,NEL   )
+C-----------------------------------------------
+C   I m p l i c i t   T y p e s
+C-----------------------------------------------
+#include      "implicit_f.inc"
+C-----------------------------------------------
+C   G l o b a l   P a r a m e t e r s
+C-----------------------------------------------
+#include      "mvsiz_p.inc"
+C-----------------------------------------------
+C   C o m m o n   B l o c k s
+C-----------------------------------------------
+#include      "com01_c.inc"
+#include      "com04_c.inc"
+#include      "param_c.inc"
+C-----------------------------------------------
+C   D u m m y   A r g u m e n t s
+C-----------------------------------------------
+      INTEGER IMAT   ,NEL
+      my_real,DIMENSION(NPROPM,NUMMAT), INTENT(IN) :: PM
+      my_real,DIMENSION(MVSIZ), INTENT(IN) :: SSP
+      my_real,DIMENSION(MVSIZ), INTENT(INOUT) :: A11
+C-----------------------------------------------
+C   L o c a l   V a r i a b l e s
+C-----------------------------------------------
+      INTEGER I, II
+      my_real RHO0
+C=======================================================================       
+      RHO0 = PM(1,IMAT)
+      A11(1:NEL) = RHO0*SSP(1:NEL)*SSP(1:NEL)
+C-----------
+      RETURN
+      END

--- a/engine/source/elements/sh3n/coquedk/cdkforc3.F
+++ b/engine/source/elements/sh3n/coquedk/cdkforc3.F
@@ -595,7 +595,8 @@ C--------------------------
      4        A11    ,ALDT   ,ALPE     ,NGL     , ISMSTR,
      5        IOFC   ,NNOD   ,AREA     ,G       ,SHF   ,
      6        MSTG   ,DMELTG ,JSMS     ,PTG     ,IGTYP ,
-     7        IGMAT  ,A11R   ,GBUF%G_DT, GBUF%DT )
+     7        IGMAT  ,A11R   ,GBUF%G_DT, GBUF%DT,MTN   ,
+     8        PM     ,MAT(JFT))
 C--------------------------
 C     THERMAL TIME STEP
 C--------------------------

--- a/engine/source/elements/sh3n/coquedk/cndt3.F
+++ b/engine/source/elements/sh3n/coquedk/cndt3.F
@@ -37,7 +37,8 @@ Chd|====================================================================
      3                 A1    ,ALDT    ,ALPE ,NGL  ,ISMSTR,
      4                 IOFC  ,NNE     ,AREA ,G    ,SHF   ,
      5                 MSC   ,DMELC   ,JSMS ,PTG  ,IGTYP ,
-     6                 IGMAT ,A11R    ,G_DT ,DTEL)
+     6                 IGMAT ,A11R    ,G_DT ,DTEL ,MTN   ,
+     7                 PM    ,IMAT    )
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -62,16 +63,18 @@ C-----------------------------------------------
 #include      "scr18_c.inc"
 #include      "sms_c.inc"
 #include      "units_c.inc"
+#include      "com04_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER JFT, JLT,NELTST,ITYPTST,ISMSTR,IOFC,NNE, JSMS,IGTYP
-      INTEGER NGL(*),IGMAT,G_DT
+      INTEGER NGL(*),IGMAT,G_DT,MTN,IMAT
 C     REAL
       my_real OFF(*),STI(*),STIR(*),OFFG(*),SSP(*),AMU(*),
      .   ALDT(*), ALPE(*), A1(*), THK0(*),THK02(*),
      .   VOL0(*), VISCMX(*), RHO(*),DT2T, AREA(*), G(*), SHF(*),
      .   MSC(*), DMELC(*), PTG(3,*),A11R(*),DTEL(MVSIZ)
+      my_real, DIMENSION(NPROPM,NUMMAT) ,INTENT(IN):: PM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -88,6 +91,14 @@ c---------------------------------------------------
 C
       ITYEL = 3
       IF (NNE==3) ITYEL = 7
+      IF (NODADT/=0) THEN
+        IF(IGTYP == 52 .OR. 
+     .   ((IGTYP == 11 .OR. IGTYP == 17 .OR. IGTYP == 51)
+     .                                   .AND. IGMAT > 0 )) THEN
+        ELSE
+          IF (MTN ==58 ) CALL CSSP2A11(PM   ,IMAT  ,SSP  ,A1   ,JLT   )
+        END IF
+      END IF
 C----- isub will add here-----
       IF(IDTMINS == 2)THEN
         DO I=JFT,JLT

--- a/engine/source/elements/sh3n/coquedk6/cdk6forc3.F
+++ b/engine/source/elements/sh3n/coquedk6/cdk6forc3.F
@@ -374,7 +374,8 @@ C--------------------------
      4        A11    ,ALDT   , ALPE    ,    NGL,ISMSTR,
      5        IOFC   ,NNOD   ,AREA     ,G      ,SHF   ,
      6        MSTG   ,DMELTG ,JSMS     ,PTG    ,IGTYP ,
-     7        IGMAT  ,A11R   ,GBUF%G_DT,GBUF%DT)
+     7        IGMAT  ,A11R   ,GBUF%G_DT, GBUF%DT,MTN   ,
+     8        PM     ,MAT(JFT))
 C--------------------------
 C     THERMAL TIME STEP
 C--------------------------

--- a/engine/source/elements/shell/coque/cforc3.F
+++ b/engine/source/elements/shell/coque/cforc3.F
@@ -496,6 +496,8 @@ C-----------------------------
       DO I=JFT,JLT
         VISCMX(I) = SQRT(ONE + VISCMX(I)*VISCMX(I)) - VISCMX(I)
       ENDDO
+      IF (NODADT /= 0 .AND. MTN ==58 ) 
+     .            CALL CSSP2A11(PM,MAT(JFT),SSP ,A11  ,JLT   )
 c---------------------------------------------------
       IF (IABS(NPTTOT) == 1) THEN
         CALL MHVIS3(JFT    ,JLT    ,PM     ,GBUF%THK,GBUF%HOURG,
@@ -513,7 +515,7 @@ c---------------------------------------------------
      D              VHX    ,VHY    ,H11    ,H12     ,H13       ,
      E              H14    ,H21    ,H22    ,H23     ,H24       ,
      F              H31    ,H32    ,H33    ,H34     ,H1        ,
-     G              H2     ,IGEO   ,NEL    )
+     G              H2     ,IGEO   ,NEL    ,MTN     ,A11      )
       ELSEIF(IHBE == 2)THEN
         CALL CHSTI3(JFT    ,JLT    ,GBUF%THK,GBUF%HOURG,OFF    ,PX1 ,
      2              PX2    ,PY1    ,PY2     ,SIGY      ,IXC    ,DT1C,

--- a/engine/source/elements/shell/coqueba/cbaforc3.F
+++ b/engine/source/elements/shell/coqueba/cbaforc3.F
@@ -1089,7 +1089,8 @@ C
      4        A11    ,LC   ,ALPE       , NGL    ,ISMSTR,     
      5        IOFC   ,NNOD   ,AREA     , G      ,SHF   ,     
      6        MSC    ,DMELC  ,JSMS     , BID    ,IGTYP ,     
-     7        IGMAT  ,A11R   ,GBUF%G_DT, GBUF%DT)
+     7        IGMAT  ,A11R   ,GBUF%G_DT, GBUF%DT,MTN   ,
+     8        PM     ,MAT(JFT))
 C
       ENDIF
 C--------------------------

--- a/engine/source/elements/shell/coquez/czforc3.F
+++ b/engine/source/elements/shell/coquez/czforc3.F
@@ -547,7 +547,8 @@ C
      4        A11   ,LL   ,ALPE,NGL,ISMSTR,
      5        IOFC  ,NNOD ,AREA,G  ,SHF   ,
      6        MSC   ,DMELC,JSMS,BID , IGTYP ,
-     7        IGMAT ,A11R ,GBUF%G_DT, GBUF%DT)
+     7        IGMAT  ,A11R   ,GBUF%G_DT, GBUF%DT,MTN   ,
+     8        PM     ,MAT(JFT))
 c-------------------------------
          CALL CZFINTCE(JFT  ,JLT  ,THK0 ,THK02,A_I     ,X13     ,
      2                 X24  ,Y13  ,Y24  ,Z1   ,MX23    ,MX13    ,

--- a/engine/source/elements/xfem/c3forc3_crk.F
+++ b/engine/source/elements/xfem/c3forc3_crk.F
@@ -453,7 +453,7 @@ C--------------------------
      4          ALPE     ,MSTG      ,DMELTG  ,JSMS   ,PTG     ,
      5          SHF      ,IGTYP     ,IGMAT   ,G     ,A11      ,
      6          A11R     ,GBUF%G_DT ,GBUF%DT ,ALDT  ,THK0     ,
-     7          AREA     ,NGL       ,IMAT    )
+     7          AREA     ,NGL       ,IMAT    ,MTN   )
 
 C--------------------------
 C     BILANS PAR MATERIAU

--- a/engine/source/elements/xfem/cforc3_crk.F
+++ b/engine/source/elements/xfem/cforc3_crk.F
@@ -455,6 +455,8 @@ C-----------------------------
       DO I=JFT,JLT
         VISCMX(I) = SQRT(ONE + VISCMX(I)*VISCMX(I)) - VISCMX(I)
       ENDDO
+      IF (NODADT /= 0 .AND. MTN ==58 ) 
+     .            CALL CSSP2A11(PM,MAT(JFT),SSP ,A11  ,JLT   )
 c---------------------------------------------------
         IF (NPTT == 1) THEN
           CALL MHVIS3(JFT    ,JLT    ,PM     ,THKG    ,HOURGG    ,
@@ -472,7 +474,7 @@ c---------------------------------------------------
      D                VHX    ,VHY    ,H11    ,H12     ,H13       ,
      E                H14    ,H21    ,H22    ,H23     ,H24       ,
      F                H31    ,H32    ,H33    ,H34     ,H1        ,
-     G                H2     ,IGEO   ,NEL    )
+     G                H2     ,IGEO   ,NEL    ,MTN     ,A11      )
         ELSEIF (IHBE == 2) THEN
           CALL CHSTI3(
      1            JFT    ,JLT    ,THKG   ,HOURGG ,OFF   ,PX1    ,

--- a/engine/source/elements/xfem/czforc3_crk.F
+++ b/engine/source/elements/xfem/czforc3_crk.F
@@ -493,7 +493,8 @@ C
      4             A11    ,LL     ,ALPE   , NGL    ,ISMSTR,
      5             IOFC   ,NNOD   ,AREA   , G      ,SHF   ,
      6             MSC    ,DMELC  ,JSMS   , BID    ,IGTYP ,
-     7             IGMAT  ,A11R   ,GBUF%DT, GBUF%DT)
+     7             IGMAT  ,A11R   ,GBUF%G_DT, GBUF%DT,MTN   ,
+     8             PM     ,MAT(JFT))
         CALL CZFINTCE(JFT  ,JLT  ,THK0 ,THK02,A_I    ,X13    ,
      2                X24  ,Y13  ,Y24  ,Z1   ,MX23   ,MX13   ,
      3                MX34 ,MY13 ,MY23 ,MY34 ,FORG   ,MOMG   ,


### PR DESCRIPTION
fixing random sound speed value of law58

remove debug law58 (submit by Maciek before)

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
nodal time step isn't consisting w/ sound speed of law58
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
sound speed of law58 has been changed (Maciek), now nodal time step will take into account this change, generally higher
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->


