### PR TITLE
Issue in compiler flags (linuxa64)

### DIFF
--- a/engine/CMake_Compilers/cmake_linuxa64.txt
+++ b/engine/CMake_Compilers/cmake_linuxa64.txt
@@ -133,10 +133,10 @@ set (LINK "dl ${mpi_lib} -lrt -lm -lstdc++"  )
 # -------------------------------------------------------------------------------------------------------------------------------------------
 # Specific set of compilation flag
 
-set (F_O0 " -O0 ${Vect_op} ${Vect_precise} ${precision_flag} ${Fortran} ${mpi_flag} ${wo_linalg} ${cppmach} ${cpprel} ${h3d_inc}")
-set (F_O1 " -O1 ${Vect_op} ${Vect_precise} ${precision_flag} ${Fortran} ${mpi_flag} ${wo_linalg} ${cppmach} ${cpprel} ${h3d_inc}")
-set (F_O2 " -O2 ${Vect_op} ${Vect_precise} ${precision_flag} ${Fortran} ${mpi_flag} ${wo_linalg} ${cppmach} ${cpprel} ${h3d_inc}")
-set (F_O2 " -O3 ${Vect_op} ${Vect_precise} ${precision_flag} ${Fortran} ${mpi_flag} ${wo_linalg} ${cppmach} ${cpprel} ${h3d_inc}")
+set (F_O0 " -O0 ${Vect_opt} ${Vect_precise} ${precision_flag} ${Fortran} ${mpi_flag} ${wo_linalg} ${cppmach} ${cpprel} ${h3d_inc}")
+set (F_O1 " -O1 ${Vect_opt} ${Vect_precise} ${precision_flag} ${Fortran} ${mpi_flag} ${wo_linalg} ${cppmach} ${cpprel} ${h3d_inc}")
+set (F_O2 " -O2 ${Vect_opt} ${Vect_precise} ${precision_flag} ${Fortran} ${mpi_flag} ${wo_linalg} ${cppmach} ${cpprel} ${h3d_inc}")
+set (F_O2 " -O3 ${Vect_opt} ${Vect_precise} ${precision_flag} ${Fortran} ${mpi_flag} ${wo_linalg} ${cppmach} ${cpprel} ${h3d_inc}")
 
 set (C_BASIC "-fopenmp ${cppmach} ${cpprel}")
 


### PR DESCRIPTION
ARM version : 

Vect_opt Flag for specific compilation was wrong, therefore some flags like -fopenmp is 
missing
Modidy the cmake to take this into account
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->


