### PR TITLE
H3D:unplug schlieren calculation with unexpected situation

### DIFF
--- a/engine/source/output/anim/generate/schlieren.F
+++ b/engine/source/output/anim/generate/schlieren.F
@@ -77,7 +77,7 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER, INTENT(IN) :: IX(NIX,*),IPARG(NPARG,NGROUP),NIX,NG
-      my_real :: WA_L(*),X(3,NUMNOD),V(3,NUMNOD),W(3,NUMNOD),EVAR(*),VOL(MVSIZ),PM(NPROPM,NUMMAT)
+      my_real :: WA_L(*),X(3,NUMNOD),V(3,NUMNOD),W(3,NUMNOD),EVAR(MVSIZ),VOL(MVSIZ),PM(NPROPM,NUMMAT)
       TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP), TARGET :: ELBUF_TAB            
       TYPE(t_ale_connectivity), INTENT(IN) :: ALE_CONNECTIVITY
 C-----------------------------------------------
@@ -101,7 +101,7 @@ C-----------------------------------------------
       !-------------------------------------!                                                                                   
       !     COMPUTE NORMAL ON FACES                                                                                             
       !-------------------------------------!   
-      IF(N2D == 0)THEN !3d solids
+      IF(N2D == 0 .AND. ITYP == 1)THEN !3d solids
         DO I=LFT,LLT
           IE=I+NFT      
          !---8 local node numbers NC1 TO NC8 for 3D solid element IE ---!         
@@ -177,7 +177,7 @@ C-----------------------------------------------
           N(1:3,5,I) = HALF * N(1:3,5,I)
           N(1:3,6,I) = HALF * N(1:3,6,I)
         ENDDO 
-      ELSEIF(ITYP==2)THEN !quads
+      ELSEIF(N2D>0 .AND. ITYP==2)THEN !quads
         DO I=LFT,LLT                                                                                                                
           IE=I+NFT    
           !---4 local node numbers NC1 TO NC4 for 2D solid element IE ---!                                                          
@@ -231,7 +231,7 @@ C-----------------------------------------------
            AREA(I)=GBUF%AREA(I)
           ENDIF
         ENDDO                                                                                                                       
-      ELSEIF(ITYP==7)THEN !triangles
+      ELSEIF(N2D>0 .AND. ITYP==7)THEN !triangles
         DO I=LFT,LLT                                                                                                                
           IE=I+NFT                                                             
           !---3 local node numbers NC1 TO NC3 for 2D solid element IE ---!                                                          
@@ -282,7 +282,7 @@ C-----------------------------------------------
       !-------------------------------------!
       !     FACE RECONSTRUCTION
       !-------------------------------------! 
-      IF(N2D == 0)THEN  
+      IF(N2D == 0 .AND. ITYP==1)THEN  
         DO I=LFT,LLT
           IE=I+NFT 
           IAD2 = ALE_CONNECTIVITY%ee_connect%iad_connect(IE)
@@ -319,7 +319,7 @@ C-----------------------------------------------
           SCH = EXP(-SCH)          
           EVAR(I) = SCH        
         ENDDO!next I
-      ELSEIF(ITYP==2)THEN
+      ELSEIF(N2D>0 .AND. ITYP==2)THEN
         GBUF => ELBUF_TAB(NG)%GBUF
         DO I=LFT,LLT
           IE=I+NFT 
@@ -353,7 +353,7 @@ C-----------------------------------------------
           SCH = EXP(-SCH)
           EVAR(I) = SCH
         ENDDO!next I
-      ELSEIF(ITYP==7)THEN
+      ELSEIF(N2D>0 .AND. ITYP==7)THEN
         GBUF => ELBUF_TAB(NG)%GBUF      
         DO I=LFT,LLT
           IE=I+NFT 
@@ -384,7 +384,9 @@ C-----------------------------------------------
           SCH = SQRT(SUM(GRAD(2:3)*GRAD(2:3)))
           SCH = EXP(-SCH)
           EVAR(I) = SCH
-        ENDDO!next I        
+        ENDDO!next I  
+      ELSE
+        EVAR(LFT:LLT)=ONE  !  exp(0.) = 1.
       ENDIF
 
       END SUBROUTINE SCHLIEREN

--- a/engine/source/output/h3d/h3d_results/h3d_quad_scalar.F
+++ b/engine/source/output/h3d/h3d_results/h3d_quad_scalar.F
@@ -640,7 +640,7 @@ C--------------------------------------------------
             ELSEIF(KEYWORD == 'SCHLIEREN') THEN     
 C--------------------------------------------------                                                   
                IALEL=IPARG(7,NG)+IPARG(11,NG)
-               IF(IPARG(7,NG)+IPARG(11,NG) /= 0)THEN                                         
+               IF(IALEL /= 0)THEN                                         
                  CALL SCHLIEREN(
      1                 EVAR  , IXQ  , X         , V           , W       ,
      2                 IPARG , WA_L , ELBUF_TAB , ALE_CONNECT , GBUF%VOL,

--- a/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
@@ -2939,19 +2939,21 @@ C--------------------------------------------------
             ELSEIF(KEYWORD == 'SCHLIEREN') THEN     
 C--------------------------------------------------                                                   
                IALEL=IPARG(7,NG)+IPARG(11,NG)
-               IF(IALEL /= 0)THEN 
-                 EVAR(1:NEL)=ZERO  
-                 LFT=1
-                 LLT=NEL                                      
-                 CALL SCHLIEREN(
-     1                 EVAR  , IXTG , X         , V           , W       ,
-     2                 IPARG , WA_L , ELBUF_TAB , ALE_CONNECT , GBUF%VOL,
-     3                 PM    , NG   , NIXTG     , ITY) 
-                 DO  I=1,NEL 
-                   VALUE(I) = EVAR(I) 
-		   IS_WRITTEN_VALUE(I) = 1
-                 ENDDO
-               ENDIF                       
+               IF(IALEL /= 0)THEN
+                 IF(ITY ==7 .AND. N2D /= 0)THEN 
+                   EVAR(1:NEL)=ZERO  
+                   LFT=1
+                   LLT=NEL                                      
+                   CALL SCHLIEREN(
+     1                   EVAR  , IXTG , X         , V           , W       ,
+     2                   IPARG , WA_L , ELBUF_TAB , ALE_CONNECT , GBUF%VOL,
+     3                   PM    , NG   , NIXTG     , ITY) 
+                   DO  I=1,NEL 
+                     VALUE(I) = EVAR(I) 
+	  	   IS_WRITTEN_VALUE(I) = 1
+                   ENDDO
+                 ENDIF  
+               ENDIF                     
 C--------------------------------------------------
             ELSE IF ( KEYWORD == 'ERROR/THICK') THEN
 C--------------------------------------------------


### PR DESCRIPTION
#### Ensure correct elem type before starting calculation

#### Description of the changes
Improves Engine behavior when /H3D/ELEM/SCHLIEREN is requested. Unplug calculation when it is not expected.
Schlieren calculation  requires :
- ALE frawework (adjacent elem buffer must be allocated to evaluate density gradient)
- 3d solids (hexas,tetras) , 2D solids (quads and trias)
It fixes a specific situation for case  {N2D=0 + /ALE/MAT +  /SHELL + /H3D/ELEM/SCHLIEREN} which may lead to segmentation fault

#### expected change of numerical solution : no

