### PR TITLE
Fix issue when using old material laws with fail tab 2 on solid elements

### DIFF
--- a/engine/source/materials/mat_share/mmain.F
+++ b/engine/source/materials/mat_share/mmain.F
@@ -1938,18 +1938,12 @@ c         DAMAGED STRESSES
 c---------------------------------------------------------
           IF (DMG_FLAG > 0) THEN 
             DO I = 1,NEL
-              LBUF%SIG(NEL*(1-1) + I) = 
-     .            LBUF%SIG(NEL*(1-1) + I)*DMG_SCALE(I)
-              LBUF%SIG(NEL*(2-1) + I) = 
-     .            LBUF%SIG(NEL*(2-1) + I)*DMG_SCALE(I)
-              LBUF%SIG(NEL*(3-1) + I) = 
-     .            LBUF%SIG(NEL*(3-1) + I)*DMG_SCALE(I)
-              LBUF%SIG(NEL*(4-1) + I) = 
-     .            LBUF%SIG(NEL*(4-1) + I)*DMG_SCALE(I)
-              LBUF%SIG(NEL*(5-1) + I) = 
-     .            LBUF%SIG(NEL*(5-1) + I)*DMG_SCALE(I)
-              LBUF%SIG(NEL*(6-1) + I) = 
-     .            LBUF%SIG(NEL*(6-1) + I)*DMG_SCALE(I)
+              SS1(I) = SS1(I)*DMG_SCALE(I)
+              SS2(I) = SS2(I)*DMG_SCALE(I)
+              SS3(I) = SS3(I)*DMG_SCALE(I)
+              SS4(I) = SS4(I)*DMG_SCALE(I)
+              SS5(I) = SS5(I)*DMG_SCALE(I)
+              SS6(I) = SS6(I)*DMG_SCALE(I)
             ENDDO
           ENDIF
 C                                       


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Recently implemented /FAIL/TAB2 presented and issue when using old solid material laws (< /MAT/LAW28) 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Fix the bug by changing the stress softening variable. 
