### PR TITLE
updating array bounds

### DIFF
--- a/starter/source/elements/solid_2d/quad/qgrtails.F
+++ b/starter/source/elements/solid_2d/quad/qgrtails.F
@@ -94,13 +94,12 @@ C-----------------------------------------------
 C   D U M M Y   A R G U M E N T S
 C-----------------------------------------------
       INTEGER ND, IDX, LB_MAX
-      INTEGER IGEO(NPROPGI,NUMGEO),IPM(NPROPMI,NUMMAT), IXQ(7,*),IPARG(NPARG,NGROUP),
+      INTEGER IGEO(NPROPGI,NUMGEO),IPM(NPROPMI,NUMMAT), IXQ(NIXQ,NUMELQ),IPARG(NPARG,*),
      .        EADD(*),DD_IAD(NSPMD+1,*),INUM(9,*),INDEX(*),
      .        CEP(*),IPARTQ(*),NELQ(*),ITR1(*),
      .        IQUAOFF(*)
       TYPE (INIVOL_) , DIMENSION(NINIVOL) :: INIVOL
-      MY_REAL
-     .    PM(NPROPM,NUMMAT), GEO(NPROPG,NUMGEO)
+      MY_REAL PM(NPROPM,NUMMAT), GEO(NPROPG,NUMGEO)
 C-----------------------------------------------
       TYPE (GROUP_)  , DIMENSION(NGRQUAD)  :: IGRQUAD
       TYPE (SURF_)   , DIMENSION(NSURF)    :: IGRSURF

--- a/starter/source/elements/solid_2d/tria/t3grtails.F
+++ b/starter/source/elements/solid_2d/tria/t3grtails.F
@@ -113,7 +113,7 @@ C-----------------------------------------------
 C   D U M M Y   A R G U M E N T S
 C-----------------------------------------------
       INTEGER ND, IDX, LB_MAX,
-     .        IXTG(NIXTG,*), IPARG(NPARG,NGROUP), EADD(*), IXTG1(4,*),
+     .        IXTG(NIXTG,*), IPARG(NPARG,*), EADD(*), IXTG1(4,*),
      .        DD_IAD(NSPMD+1,*),IPARTTG(*), NELTG(*),
      .        INUM(10,*),ITR1(*),INDEX(*),CEP(*),ICNOD(*),IPM(NPROPMI,NUMMAT),
      .        ITRIOFF(*), SH3TRIM(*),IGEO(NPROPGI,NUMGEO),

--- a/starter/source/elements/sph/spgrhead.F
+++ b/starter/source/elements/sph/spgrhead.F
@@ -68,13 +68,11 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER KXSP(NISP,*),IPARG(NPARG,NGROUP),IXSP(KVOISPH,*),
+      INTEGER KXSP(NISP,*),IPARG(NPARG,*),IXSP(KVOISPH,*),
      .        IPART(LIPART1,*),IPARTSP(*), EADD(*), CEPSP(*),
      .        IPM(NPROPMI,NUMMAT), IGEO(NPROPGI,NUMGEO),
      .        ND, SPH2SOL(*), SOL2SPH(2,*), IRST(3,NSPHSOL)
-C     REAL
-      my_real
-     .        PM(NPROPM,NUMMAT), SPBUF(NSPBUF,NUMSPH)
+      my_real PM(NPROPM,NUMMAT), SPBUF(NSPBUF,NUMSPH)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/output/th/hm_read_thgrne.F
+++ b/starter/source/output/th/hm_read_thgrne.F
@@ -252,9 +252,12 @@ C
        CALL UDOUBLE(ITHBUF(IAD+2*nne),1,NNE,MESS,0,BID)              
       ELSE   ! Not used in the program. Now is used for saving skew number when it's defined                                                        
        DO I=1,NNE                                                    
-         K = ITHBUF(IAD)                                             
-         ITHBUF(IAD+2*NNE)=IX(NIX,K)                                 
-         IAD=IAD+1                                                   
+         K = ITHBUF(IAD) 
+         IF(K>0)THEN                                            
+           ITHBUF(IAD+2*NNE)=IX(NIX,K)                                 
+           IAD=IAD+1 
+           !if K==0, error msg id=69 is already displayed (see above)
+         ENDIF                                                   
        ENDDO                                                         
        IAD=ITHGRP(5)                                                 
        CALL UDOUBLE(ITHBUF(IAD+2*nne),1,NNE,MESS,0,BID)              


### PR DESCRIPTION
#### Array bounds update

#### Description of the changes
- qgrtail, t3grtail, spgrhead : IPARG(NPARG,NGROUP) restored with IPARG(NPARG,*) since IPARG is here IPARGTMP and dimension is oversized to NUMEL instead NGROUP. 
- hm_read_thgrne : ensure correct program behavior  (error message and normal termination) with check bounds runtime tool 

#### expected change of numerical solution : no