### PR TITLE
/LOAD/PBLAST:verification  {ITA_SHIT=2 + usage of TDET parameter}

### DIFF
--- a/engine/source/loads/pblast/pblast_1.F
+++ b/engine/source/loads/pblast/pblast_1.F
@@ -473,6 +473,8 @@ C-----------------------------------------------
           DT_0    =  DT_0    / FAC_T_bb                                                                                                                                                               
           DT_0_   =  DT_0_   / FAC_T_bb                                                                                                                                                               
           T_A     =  T_A     / FAC_T_bb                                                                                                                                                               
+
+          T_A    = T_A + TDET                                                                                                                                                                         
                                                                                                                                                                                                       
           !update wave parameters                                                                                                                                                                     
           PBLAST_TAB(IL)%cos_theta(I) = cos_theta                                                                                                                                                     
@@ -485,7 +487,7 @@ C-----------------------------------------------
                                                                                                                                                                                                       
         ELSE                                                                                                                                                                                          
                                                                                                                                                                                                       
-          !Use Starter Parameters                                                                                                                                                                     
+          !update wave parameters (Starter)
           Z=ZERO                                                                                                                                                                                      
           cos_theta = PBLAST_TAB(IL)%cos_theta(I)                                                                                                                                                     
           P_inci = PBLAST_TAB(IL)%P_inci(I)                                                                                                                                                           
@@ -497,7 +499,6 @@ C-----------------------------------------------
 
         ENDIF !IF(IZ_UPDATE==1)                                                                                                                                                                       
                                                                                                                                                                                                       
-        T_A    = T_A + TDET                                                                                                                                                                         
 
         T0INF_LOC = MIN(T0INF_LOC,DT_0)                                                                                                                                                             
                                                                                                                                                                                                       
@@ -518,10 +519,7 @@ C-----------------------------------------------
         IF(TT_STAR>=T_A)THEN                                                                                                                                                                          
           WAVE_INCI =  P_inci*(ONE-(TT_STAR-T_A)/DT_0)*exp(-DECAY_inci*(TT_STAR-T_A)/DT_0)                                                                                                            
           WAVE_REFL =  P_refl*(ONE-(TT_STAR-T_A)/DT_0)*exp(-DECAY_refl*(TT_STAR-T_A)/DT_0)                                                                                                            
-!          write(*,FMT='(A,5e30.16)') "TT_STAR,TA,P_refl,I_refl,WAVE_refl=", TT_STAR,T_A,P_refl,I_refl,WAVE_refl                                                                                      
-!          write(*,FMT='(A,5e30.16)') "(ONE-(TT_STAR-T_A)/I_refl), exp    =", (ONE-(TT_STAR-T_A)/I_refl),  exp(-(TT_STAR-T_A)/I_refl)                                                                 
         ELSE                                                                                                                                                                                          
-         !to do  ? stop loading when TT_STAR>=T0                                                                                                                        
           WAVE_INCI = ZERO                                                                                                                                                                            
           WAVE_REFL = ZERO                                                                                                                                                                            
         ENDIF                                                                                                                                                                                         
@@ -529,9 +527,7 @@ C-----------------------------------------------
         P = MAX(P,PMIN)                                                                                                                                                                               
         IF (NUMSKINP > 0) PBLAST_TAB(IL)%PRES(I) = P                                                                                                                                                  
 
-        !Send Pressure load to nodes                                                                                                                                                                  
-        !compiler should optimize P/norm with -O3                                                                                                                                                     
-        !directly used in A(:,inod) so it is divided by /Npt                                                                                                                                          
+        !!Expand Pressure load to nodes                                                                                                                                            
         PBLAST_TAB(IL)%FX(I)= -P * HALF*NX / PBLAST_TAB(IL)%NPT(I)                                                                                                                                                                  
         PBLAST_TAB(IL)%FY(I)= -P * HALF*NY / PBLAST_TAB(IL)%NPT(I)                                                                                                                                                                  
         PBLAST_TAB(IL)%FZ(I)= -P * HALF*NZ / PBLAST_TAB(IL)%NPT(I)                                                                                                                                                                  

--- a/engine/source/loads/pblast/pblast_2.F
+++ b/engine/source/loads/pblast/pblast_2.F
@@ -473,15 +473,17 @@ C-----------------------------------------------
           DT_0    =  DT_0    / FAC_T_bb                                                                                                                                                               
           DT_0_   =  DT_0_   / FAC_T_bb                                                                                                                                                               
           T_A     =  T_A     / FAC_T_bb                                                                                                                                                               
+
+          T_A    = T_A + TDET                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                       
-          !update wave parameters                                                                                                                                                                     
+          !update wave parameters (Starter)
           PBLAST_TAB(IL)%cos_theta(I) = cos_theta                                                                                                                                                     
           PBLAST_TAB(IL)%P_inci(I) = P_inci                                                                                                                                                           
           PBLAST_TAB(IL)%P_refl(I) = P_refl                                                                                                                                                           
           PBLAST_TAB(IL)%ta(I) = T_A                                                                                                                                                                  
           PBLAST_TAB(IL)%t0(I) = DT_0                                                                                                                                                                 
           PBLAST_TAB(IL)%decay_inci(I) = decay_inci                                                                                                                                                   
-          PBLAST_TAB(IL)%decay_refl(I) = decay_refl                                                                                                                                                   
+          PBLAST_TAB(IL)%decay_refl(I) = decay_refl  
                                                                                                                                                                                                       
         ELSE                                                                                                                                                                                          
                                                                                                                                                                                                       
@@ -496,9 +498,7 @@ C-----------------------------------------------
 
         ENDIF !IF(IZ_UPDATE==1)                                                                                                                                                                       
 
-          T_A    = T_A + TDET                                                                                                                                                                         
-
-          T0INF_LOC = MIN(T0INF_LOC,DT_0)                                                                                                                                                             
+        T0INF_LOC = MIN(T0INF_LOC,DT_0)                                                                                                                                                             
 
 !-------------------------------                                                                                                                                                                   ---
                                                                                                                                                                                                       

--- a/engine/source/loads/pblast/pblast_3.F
+++ b/engine/source/loads/pblast/pblast_3.F
@@ -650,8 +650,10 @@ C-----------------------------------------------
            P_refl  =  P_refl / FAC_P_bb                                                                                                                                                              
            I_refl  =  I_refl / FAC_I_bb                                                                                                                                                              
            DT_0    =  DT_0    / FAC_T_bb                                                                                                                                                             
-           T_A     =  T_A     / FAC_T_bb                                                                                                                                                             
-                                                                                                                                                                                                     
+           T_A     =  T_A     / FAC_T_bb 
+
+           T_A    = T_A + TDET 
+
            !update wave parameters                                                                                                                                                                   
            PBLAST_TAB(IL)%cos_theta(I) = cos_theta                                                                                                                                                   
            PBLAST_TAB(IL)%P_inci(I) = P_inci                                                                                                                                                         
@@ -674,9 +676,7 @@ C-----------------------------------------------
                                                                                                                                                                                                      
         ENDIF                                                                                                                                                                                        
 
-          T_A    = T_A + TDET                                                                                                                                                                        
-
-          T0INF_LOC = MIN(T0INF_LOC,DT_0)                                                                                                                                                            
+        T0INF_LOC = MIN(T0INF_LOC,DT_0)                                                                                                                                                            
                                                                                                                                                                                                      
 !-------------------------------                                                                                                                                                                  ---
                                                                                                                                                                                                      

--- a/starter/source/loads/pblast/hm_read_pblast.F
+++ b/starter/source/loads/pblast/hm_read_pblast.F
@@ -273,7 +273,6 @@ C-----------------------------------------------
                         
             IF(ITA_SHIFT==0) ITA_SHIFT = 1
             IF(ITA_SHIFT < 0 .OR. ITA_SHIFT >= 3)ITA_SHIFT = 1
-            IF(ITA_SHIFT==2)TDET=ZERO
             
             ! IMODEL : flag for blast model
             !---1:Friedlander


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Validating usage of both parameters ITA_SHIFT=2 and TDET>0
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
Verification Test is successful. Tdet is correctly taken into account when ITA_SHIFT=2 is defined.
This option starts computation when first face of the structure is hit ; consequently structure is immediately loaded and there is no useless computation.

#### expected change of numerical solution : yes
 if {ITA_SHIFT=2 & TDET >0 }


