### PR TITLE
cfg file correction for *DEFINE_TABLE_2D option

### DIFF
--- a/hm_cfg_files/config/CFG/Keyword971_R6.1/CURVE/define_table.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R6.1/CURVE/define_table.cfg
@@ -91,7 +91,7 @@ FORMAT(Keyword971_R6.1) {
 
     FREE_CARD_LIST(ArrayCount)
     {
-        COMMENT("$              VALUE      LCID");
-        CARD("%20lg%10d",LSD_VALUE,CurveIds);
+        COMMENT("$              VALUE                LCID");
+        CARD("%20lg%20d",LSD_VALUE,CurveIds);
     }
 }


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
issue in the *DEFINE_TABLE_2D cfg option
format was incorrect , curve Ids are read on a field that have 20 digits ( not 10 as it is specified in cfg)


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
correction of number of digits of the Curves Ids


