### PR TITLE
ALL CI - Use action checkout v3 instead of v2 to fix warning messages…

### DIFF
--- a/.github/workflows/developer_ci.yml
+++ b/.github/workflows/developer_ci.yml
@@ -80,7 +80,7 @@ jobs:
           md5sum exec/* || echo "Nothing in exec/" 
 
       # Get last git modifications, WS is not persistent here
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           lfs: 'true'
           ref: refs/pull/${{ github.event.number }}/merge
@@ -152,7 +152,7 @@ jobs:
     steps:
 
       # Get git related to the commit
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           lfs: 'true'
           ref: refs/pull/${{ github.event.number }}/merge

--- a/.github/workflows/prmerge_ci_main.yml
+++ b/.github/workflows/prmerge_ci_main.yml
@@ -58,7 +58,7 @@ jobs:
           md5sum exec/* || echo "Nothing in exec/" 
 
       # Get last git modifications, don't clean before (way to keep persistent obj files)
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: ${{ steps.set_workdir.outputs.value }}
           clean: 'false'
@@ -200,7 +200,7 @@ jobs:
           md5sum exec/* || echo "Nothing in exec/" 
 
       # Get last git modifications, don't clean before (way to keep persistent obj files)
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: ${{ steps.set_workdir.outputs.value }}
           clean: 'false'
@@ -345,7 +345,7 @@ jobs:
     steps:
 
       # Get git related to the commit
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           lfs: 'true'
 
@@ -520,7 +520,7 @@ jobs:
         rm -rf exec todeliver
 
     # Get last git modifications, don't clean before (way to go faster)
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         clean: 'false'
         lfs: 'true'

--- a/.github/workflows/prmerge_ci_sync.yml
+++ b/.github/workflows/prmerge_ci_sync.yml
@@ -181,7 +181,7 @@ jobs:
             --current_commit ${{github.sha}} 
 
       # Create/Upgrade local git repo
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: ${{ steps.set_workdir.outputs.value }}
           clean: 'false'

--- a/.github/workflows/upd_headers_ci.yml
+++ b/.github/workflows/upd_headers_ci.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
 
       # Get last git modifications, WS is not persistent here
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           lfs: 'true'
           # Use a PAT else the push won't trigger the next workflow


### PR DESCRIPTION
Use action checkout v3 instead of v2 to fix warning messages…