### PR TITLE
ALL CI - Use action download artifact v3 instead of v2 to fix warning…

### DIFF
--- a/.github/workflows/developer_ci.yml
+++ b/.github/workflows/developer_ci.yml
@@ -162,7 +162,7 @@ jobs:
           rm -rf exec
 
       # Download artifacts
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: bins-${{ matrix.os }}-${{ matrix.precision }}
           path: exec

--- a/.github/workflows/prmerge_ci_main.yml
+++ b/.github/workflows/prmerge_ci_main.yml
@@ -354,7 +354,7 @@ jobs:
           rm -rf exec
 
       # Download artifacts
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: bins-${{ matrix.os }}-${{ matrix.precision }}
           path: exec


### PR DESCRIPTION
Use action download artifact v3 instead of v2 to fix warning messages about deprecated functions