### PR TITLE
Add lf Attributes for script files 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 extlib/**/* filter=lfs diff=lfs merge=lfs -text
+*.sh text eol=lf
+*.pl text eol=lf
+

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -129,12 +129,14 @@ The Git Bash tool is not need, but can be installed.
    * Next will install the packages.
 
 * Post installation task must de done :
-  In cygwin, /bin/link.exe program conflicts with Visual Studio. 
-  Rename it to avoid issues :
+
+   * In cygwin, /bin/link.exe program conflicts with Visual Studio. 
+   * Rename it to avoid issues :
 
          Launch cygwin
          in the shell : move /bin/link.exe in /bin/link_cygwin.exe :
          mv /bin/link.exe in /bin/link_cygwin.exe 
+
 
 **Notes**
 Cygwin is a Unix environment for Windows, all unix tools are accessible.
@@ -162,9 +164,15 @@ Launch cygwin build environment and apply the git configuration :
 
             git lfs install
 
+* Add in Git global environment the autocrlf flag
+
+            git config --global core.autocrlf true
+	    
 * Create the ssh key & set it in GitHub
 
             ssh-keygen -t rsa
+  
+  **Note: Accept all defaults, Standard directory, no passphrase**
 
 * Copy the new generated ssh key in cygwin home directory
   As a workaround to used git in cygwin, copy the ssh key in cygwin home directory 


### PR DESCRIPTION
When files are cloned on windows,
scripts must be in Unix format to be used in cygwin.

Adding stuff in .gitattributes

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->



