### PR TITLE
Add possibility to restrict SIGP1MAX criterion to positive stress triaxialities

### DIFF
--- a/engine/source/materials/fail/gene1/fail_gene1_c.F
+++ b/engine/source/materials/fail/gene1/fail_gene1_c.F
@@ -110,7 +110,7 @@ C!-----------------------------------------------
      .        XVEC(NEL,2),Q,R,R_INTER,E11(NEL),E22(NEL),VOL_STRAIN(NEL),DAV,
      .        E1D,E2D,E3D,E4D,S11(NEL),S22(NEL),EFF_STRAIN(NEL),S1,S2,
      .        EPSMAX(NEL),SIGMAX(NEL),FACL(NEL),VFAIL(NEL),E1FLD(NEL),
-     .        DFLD(NEL),HARDR(NEL),VTOT,VDAM,DENOM
+     .        DFLD(NEL),HARDR(NEL),VTOT,VDAM,DENOM,TRIAX(NEL)
       TYPE(BUF_FAIL_) ,POINTER :: FBUF
 C!--------------------------------------------------------------
       !=======================================================================
@@ -292,6 +292,7 @@ c
         SZZ    = P(I)
         SVM(I) = SQRT(SIGNXX(I)*SIGNXX(I) + SIGNYY(I)*SIGNYY(I)
      .           - SIGNXX(I)*SIGNYY(I) + THREE*SIGNXY(I)*SIGNXY(I))
+        TRIAX(I) = -P(I)/MAX(SVM(I),EM20)
         !  -> computing the principal stresses
         S1     = HALF*(SIGNXX(I) + SIGNYY(I))
         S2     = HALF*(SIGNXX(I) - SIGNYY(I))
@@ -365,9 +366,18 @@ c
             IPMIN(I) = 1
           ENDIF
           !  -> maximal principal stress
-          IF (S11(I) >= SIGP1*FACL(I)) THEN 
-            NCRIT(I)  = NCRIT(I) + 1
-            IS1MAX(I) = 1
+          !     (unrestricted)
+          IF (SIGP1 > ZERO) THEN 
+            IF (S11(I) >= SIGP1*FACL(I)) THEN 
+              NCRIT(I)  = NCRIT(I) + 1
+              IS1MAX(I) = 1
+            ENDIF
+          !     (restricted to positive stress triaxialities)
+          ELSE
+            IF ((S11(I) >= ABS(SIGP1)*FACL(I)).AND.(TRIAX(I)>EM10)) THEN 
+              NCRIT(I)  = NCRIT(I) + 1
+              IS1MAX(I) = 1            
+            ENDIF
           ENDIF
           !  -> maximum time
           IF (TIME >= TMAX) THEN
@@ -585,8 +595,8 @@ c------------------------
             WRITE(ISTDO,1003) P(I),MINPRES*FACL(I)
           ENDIF
           IF (IS1MAX(I) == 1) THEN
-            WRITE(IOUT, 1004) S11(I),SIGP1*FACL(I)
-            WRITE(ISTDO,1004) S11(I),SIGP1*FACL(I)
+            WRITE(IOUT, 1004) S11(I),ABS(SIGP1)*FACL(I)
+            WRITE(ISTDO,1004) S11(I),ABS(SIGP1)*FACL(I)
           ENDIF
           IF (ITMAX(I) == 1) THEN 
             WRITE(IOUT, 1005) TIME,TMAX

--- a/engine/source/materials/fail/gene1/fail_gene1_s.F
+++ b/engine/source/materials/fail/gene1/fail_gene1_s.F
@@ -108,7 +108,8 @@ C!-----------------------------------------------
      .        Q,R,R_INTER,PHI,E11(NEL),E22(NEL),E33(NEL),VOL_STRAIN(NEL),DAV,E1D,
      .        E2D,E3D,E4D,E5D,E6D,S11(NEL),S22(NEL),S33(NEL),EFF_STRAIN(NEL),PSI,
      .        EPSMAX(NEL),SIGMAX(NEL),FACL(NEL),SH12(NEL),SH13(NEL),E1C(NEL),
-     .        XVEC(NEL,2),E1FLD(NEL),DFLD(NEL),HARDR(NEL),VTOT,VDAM,DENOM,VFAIL(NEL)
+     .        XVEC(NEL,2),E1FLD(NEL),DFLD(NEL),HARDR(NEL),VTOT,VDAM,DENOM,VFAIL(NEL),
+     .        TRIAX(NEL)
       TYPE(BUF_FAIL_) ,POINTER :: FBUF
 C!--------------------------------------------------------------
       !=======================================================================
@@ -321,6 +322,7 @@ c
         SVM(I) = HALF*(SXX**2 + SYY**2 + SZZ**2)
      .        + SIGNXY(I)**2 + SIGNZX(I)**2 + SIGNYZ(I)**2
         SVM(I) = SQRT(THREE*SVM(I))
+        TRIAX(I) = -P(I)/MAX(SVM(I),EM20)
         !  -> computing the principal stresses
         I1 = SIGNXX(I)+SIGNYY(I)+SIGNZZ(I)
         I2 = SIGNXX(I)*SIGNYY(I)+SIGNYY(I)*SIGNZZ(I)+SIGNZZ(I)*SIGNXX(I)-
@@ -411,9 +413,18 @@ c
             IPMIN(I) = 1
           ENDIF
           !  -> maximal principal stress
-          IF (S11(I) >= SIGP1*FACL(I)) THEN 
-            NCRIT(I)  = NCRIT(I) + 1
-            IS1MAX(I) = 1
+          !     (unrestricted)
+          IF (SIGP1 > ZERO) THEN 
+            IF (S11(I) >= SIGP1*FACL(I)) THEN 
+              NCRIT(I)  = NCRIT(I) + 1
+              IS1MAX(I) = 1
+            ENDIF
+          !     (restricted to positive stress triaxialities)
+          ELSE 
+            IF ((S11(I) >= ABS(SIGP1)*FACL(I)).AND.(TRIAX(I)>EM10)) THEN 
+              NCRIT(I)  = NCRIT(I) + 1
+              IS1MAX(I) = 1
+            ENDIF
           ENDIF
           !  -> maximum time
           IF (TIME >= TMAX) THEN
@@ -635,8 +646,8 @@ c------------------------
             WRITE(ISTDO,1003) P(I),MINPRES*FACL(I)
           ENDIF
           IF (IS1MAX(I) == 1) THEN
-            WRITE(IOUT, 1004) S11(I),SIGP1*FACL(I)
-            WRITE(ISTDO,1004) S11(I),SIGP1*FACL(I)
+            WRITE(IOUT, 1004) S11(I),ABS(SIGP1)*FACL(I)
+            WRITE(ISTDO,1004) S11(I),ABS(SIGP1)*FACL(I)
           ENDIF
           IF (ITMAX(I) == 1) THEN 
             WRITE(IOUT, 1005) TIME,TMAX

--- a/starter/source/materials/fail/gene1/hm_read_fail_gene1.F
+++ b/starter/source/materials/fail/gene1/hm_read_fail_gene1.F
@@ -483,7 +483,9 @@ c-----------------------------------------------------
  1101 FORMAT(
      & 5X,'MAXIMUM PRESSURE (POSITIVE IN COMPRESSION) . . . . .=',1PG20.13,/) 
  1102 FORMAT(        
-     & 5X,'MAXIMUM PRINCIPAL STRESS . . . . . . . . . . . . . .=',1PG20.13,/)
+     & 5X,'MAXIMUM PRINCIPAL STRESS . . . . . . . . . . . . . .=',1PG20.13,/
+     & 5X,'   < 0.0 : RESTRICTED TO POSITIVE STRESS TRIAXIALITIES',/, 
+     & 5X,'   > 0.0 : UNRESTRICTED                               ',/)
  1103 FORMAT(
      & 5X,'FAILURE TIME . . . . . . . . . . . . . . . . . . . .=',1PG20.13,/)
  1104 FORMAT(


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Add the possibility to restrict the use of SIGP1 criterion to positive stress triaxialities. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

This is done with the input : 
- if SIGP1 < 0: it is restricted to positive stress triaxialities,
- if SIGP1 > 0: it is unrestricted. 

