### PR TITLE
Fix unit of fmax in /MAT/LAW25 .cfg file

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2019/MAT/matl25_compsh.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/MAT/matl25_compsh.cfg
@@ -386,9 +386,9 @@ GUI(COMMON) {
         SCALAR(MAT_R00)     { DIMENSION="DIMENSIONLESS"; }
         if(MAT_Iflag==0) {
             // Tsai-Wu formulation
-            SCALAR(MAT_BETA)            { DIMENSION="DIMENSIONLESS"; }
+            SCALAR(MAT_BETA)            { DIMENSION="DIMENSIONLESS";}
             SCALAR(MAT_HARD)            { DIMENSION="DIMENSIONLESS";}
-            SCALAR(MAT_SIG)             { DIMENSION="pressure";         }
+            SCALAR(MAT_SIG)             { DIMENSION="DIMENSIONLESS";}
             SCALAR(MAT_SIGYT1,"Yield stress in tension in dir. 1")      { DIMENSION="pressure"; }
             SCALAR(MAT_SIGYT2,"Yield stress\nin tension in dir. 2")     { DIMENSION="pressure"; }
             //sig_1yc=1126


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Bad unit of MAT_SIG parameter when MAT_Iflag = 0, MAT_SIG was supposed to be dimensionless

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Set MAT_SIG as dimensionless. 
