### PR TITLE
sysfus.F:msgid=79, prevent from unexpected output

### DIFF
--- a/starter/source/system/sysfus.F
+++ b/starter/source/system/sysfus.F
@@ -708,7 +708,7 @@ C
       DO I=2,NLIST
           IDM=ID
           ID=INDEX(INDEX(I,1),3)
-          IF(ID==IDM)THEN
+          IF(ID==IDM .AND. ID/=0)THEN
              CALL ANCMSG(MSGID=79,
      .                   MSGTYPE=MSGERROR,
      .                   ANMODE=ANINFO,
@@ -971,7 +971,7 @@ C
       DO I=2,NLIST
           IDM=ID
           ID=INDEX(INDEX(I,1),3)
-          IF(ID==IDM)THEN
+          IF(ID==IDM .AND. ID/=0)THEN
              CALL ANCMSG(MSGID=79,
      .                   MSGTYPE=MSGERROR,
      .                   ANMODE=ANINFO,
@@ -1414,7 +1414,7 @@ C
       DO I=2,NLIST
           IDM=ID
           ID=INDEX(INDEX(I,1),3)
-          IF(ID==IDM)THEN
+          IF(ID==IDM .AND. ID/=0)THEN
              CALL ANCMSG(MSGID=79,
      .                   MSGTYPE=MSGERROR,
      .                   ANMODE=ANINFO,


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### sysfus.F:msgid=79, prevent from unexpected output
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
sysfus.F : msgid 79 is displayed only id ID is not 0

It prevents Starter from outputing unexpected messages

> ERROR ID :     79
> ** ERROR: DUPLICATE ID
> DESCRIPTION :  
>    IN TH GROUP
>    ID=0 is DUPLICATED

   
   whenever a suitable message is already displayed :
   

>   ERROR ID :     69
> ** ERROR IN TH SELECTION (ELEMENT)
> DESCRIPTION :  
>    -- THGROUP ID:	2
>    -- THGROUP TITLE: New TH 2
>    TH ELEMENT SELECTION ID=64 DOES NOT EXIST




