### PR TITLE
Revert some changes in volume computation that caused numerical diffs

### DIFF
--- a/engine/source/elements/solid/solide/sforc3.F
+++ b/engine/source/elements/solid/solide/sforc3.F
@@ -1450,7 +1450,15 @@ C
      .   X17(MVSIZ), X28(MVSIZ), X35(MVSIZ), X46(MVSIZ),
      .   Y17(MVSIZ), Y28(MVSIZ), Y35(MVSIZ), Y46(MVSIZ),
      .   Z17(MVSIZ), Z28(MVSIZ), Z35(MVSIZ), Z46(MVSIZ),
-     .   JAC_59_68(MVSIZ), JAC_67_49(MVSIZ), JAC_48_57(MVSIZ)
+     .   JAC_59_68(MVSIZ), JAC_67_49(MVSIZ), JAC_48_57(MVSIZ),
+     .   A17_46(MVSIZ),
+     .   A28_35(MVSIZ),
+     .   B17_46(MVSIZ),
+     .   B28_35(MVSIZ),
+     .   C17_46(MVSIZ),
+     .   C28_35(MVSIZ)
+ 
+
 C=======================================================================
       DO I=1,NEL
         X17(I)=X7(I)-X1(I)
@@ -1468,22 +1476,28 @@ C
         Z35(I)=Z5(I)-Z3(I)
         Z46(I)=Z6(I)-Z4(I)
       ENDDO
-C
-C Jacobian Matrix
+
       DO I=1,NEL
         JAC1(I)=X17(I)+X28(I)-X35(I)-X46(I)
         JAC2(I)=Y17(I)+Y28(I)-Y35(I)-Y46(I)
         JAC3(I)=Z17(I)+Z28(I)-Z35(I)-Z46(I)
-C
-        JAC4(I)=X17(I)+X46(I)+X28(I)+X35(I)
-        JAC5(I)=Y17(I)+Y46(I)+Y28(I)+Y35(I)
-        JAC6(I)=Z17(I)+Z46(I)+Z28(I)+Z35(I)
-C
-        JAC7(I)=X17(I)+X46(I)-X28(I)-X35(I)
-        JAC8(I)=Y17(I)+Y46(I)-Y28(I)-Y35(I)
-        JAC9(I)=Z17(I)+Z46(I)-Z28(I)-Z35(I)     
+        A17_46(I)=X17(I)+X46(I)
+        A28_35(I)=X28(I)+X35(I)
+        B17_46(I)=Y17(I)+Y46(I)
+        B28_35(I)=Y28(I)+Y35(I)
+        C17_46(I)=Z17(I)+Z46(I)
+        C28_35(I)=Z28(I)+Z35(I)
       ENDDO
-C
+         
+      DO I=1,NEL
+        JAC4(I)=A17_46(I)+A28_35(I)
+        JAC5(I)=B17_46(I)+B28_35(I)
+        JAC6(I)=C17_46(I)+C28_35(I)
+        JAC7(I)=A17_46(I)-A28_35(I)
+        JAC8(I)=B17_46(I)-B28_35(I)
+        JAC9(I)=C17_46(I)-C28_35(I)
+      ENDDO
+
       DO I=1,NEL
         JAC_59_68(I)=JAC5(I)*JAC9(I)-JAC6(I)*JAC8(I)
         JAC_67_49(I)=JAC6(I)*JAC7(I)-JAC4(I)*JAC9(I)

--- a/starter/source/elements/elbuf_init/suderi3.F
+++ b/starter/source/elements/elbuf_init/suderi3.F
@@ -39,9 +39,6 @@ C   G l o b a l   P a r a m e t e r s
 C-----------------------------------------------
 #include      "mvsiz_p.inc"
 C-----------------------------------------------
-C   C o m m o n   B l o c k s
-C-----------------------------------------------
-C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER NEL
@@ -53,8 +50,8 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I
-C
+      INTEGER I,J
+      
       DOUBLE PRECISION
      .   XD1(MVSIZ), XD2(MVSIZ), XD3(MVSIZ), XD4(MVSIZ),
      .   XD5(MVSIZ), XD6(MVSIZ), XD7(MVSIZ), XD8(MVSIZ),
@@ -62,45 +59,47 @@ C
      .   YD5(MVSIZ), YD6(MVSIZ), YD7(MVSIZ), YD8(MVSIZ),
      .   ZD1(MVSIZ), ZD2(MVSIZ), ZD3(MVSIZ), ZD4(MVSIZ),
      .   ZD5(MVSIZ), ZD6(MVSIZ), ZD7(MVSIZ), ZD8(MVSIZ)
-C
+C     REAL
       my_real
      .   JAC1(MVSIZ), JAC2(MVSIZ), JAC3(MVSIZ), JAC4(MVSIZ), JAC5(MVSIZ), JAC6(MVSIZ),
-     .   JAC7(MVSIZ), JAC8(MVSIZ), JAC9(MVSIZ),
-     .   JAC_59_68(MVSIZ), JAC_67_49(MVSIZ), JAC_48_57(MVSIZ)
+     .   JAC7(MVSIZ), JAC8(MVSIZ) , JAC9(MVSIZ),
+     .   A17(MVSIZ) , A28(MVSIZ) ,
+     .   B17(MVSIZ) , B28(MVSIZ) ,
+     .   C17(MVSIZ) , C28(MVSIZ) 
       my_real
      .   X17(MVSIZ), X28(MVSIZ), X35(MVSIZ), X46(MVSIZ),
      .   Y17(MVSIZ), Y28(MVSIZ), Y35(MVSIZ), Y46(MVSIZ),
-     .   Z17(MVSIZ), Z28(MVSIZ), Z35(MVSIZ), Z46(MVSIZ)
+     .   Z17(MVSIZ), Z28(MVSIZ), Z35(MVSIZ), Z46(MVSIZ),
+     .   JAC_59_68(MVSIZ), JAC_67_49(MVSIZ), JAC_48_57(MVSIZ),
+     .   JAC12(MVSIZ),   JAC45(MVSIZ),   JAC78(MVSIZ)
 C=======================================================================
       DO I=1,NEL
-         XD1(I)=X1(I)
-         XD2(I)=X2(I)
-         XD3(I)=X3(I)
-         XD4(I)=X4(I)
-         XD5(I)=X5(I)
-         XD6(I)=X6(I)
-         XD7(I)=X7(I)
-         XD8(I)=X8(I)
-C
-         YD1(I)=Y1(I)
-         YD2(I)=Y2(I)
-         YD3(I)=Y3(I)
-         YD4(I)=Y4(I)
-         YD5(I)=Y5(I)
-         YD6(I)=Y6(I)
-         YD7(I)=Y7(I)
-         YD8(I)=Y8(I)
-C
-         ZD1(I)=Z1(I)
-         ZD2(I)=Z2(I)
-         ZD3(I)=Z3(I)
-         ZD4(I)=Z4(I)
-         ZD5(I)=Z5(I)
-         ZD6(I)=Z6(I)
-         ZD7(I)=Z7(I)
-         ZD8(I)=Z8(I)
-      ENDDO	
-C
+        XD1(I)=X1(I)
+        XD2(I)=X2(I)
+        XD3(I)=X3(I)
+        XD4(I)=X4(I)
+        XD5(I)=X5(I)
+        XD6(I)=X6(I)
+        XD7(I)=X7(I)
+        XD8(I)=X8(I)
+        YD1(I)=Y1(I)
+        YD2(I)=Y2(I)
+        YD3(I)=Y3(I)
+        YD4(I)=Y4(I)
+        YD5(I)=Y5(I)
+        YD6(I)=Y6(I)
+        YD7(I)=Y7(I)
+        YD8(I)=Y8(I)
+        ZD1(I)=Z1(I)
+        ZD2(I)=Z2(I)
+        ZD3(I)=Z3(I)
+        ZD4(I)=Z4(I)
+        ZD5(I)=Z5(I)
+        ZD6(I)=Z6(I)
+        ZD7(I)=Z7(I)
+        ZD8(I)=Z8(I)
+      ENDDO 
+
       DO I=1,NEL
         X17(I)=XD7(I)-XD1(I)
         X28(I)=XD8(I)-XD2(I)
@@ -114,22 +113,28 @@ C
         Z28(I)=ZD8(I)-ZD2(I)
         Z35(I)=ZD5(I)-ZD3(I)
         Z46(I)=ZD6(I)-ZD4(I)
-      ENDDO	
+      ENDDO 
 C
-C Jacobian Matrix
       DO I=1,NEL               
         JAC1(I)=X17(I)+X28(I)-X35(I)-X46(I)
         JAC2(I)=Y17(I)+Y28(I)-Y35(I)-Y46(I)
         JAC3(I)=Z17(I)+Z28(I)-Z35(I)-Z46(I)
-C
-        JAC4(I)=X17(I)+X46(I)+X28(I)+X35(I)
-        JAC5(I)=Y17(I)+Y46(I)+Y28(I)+Y35(I)
-        JAC6(I)=Z17(I)+Z46(I)+Z28(I)+Z35(I)
-C
-        JAC7(I)=X17(I)+X46(I)-X28(I)-X35(I)
-        JAC8(I)=Y17(I)+Y46(I)-Y28(I)-Y35(I)
-        JAC9(I)=Z17(I)+Z46(I)-Z28(I)-Z35(I)
-      ENDDO	
+        A17(I)=X17(I)+X46(I)
+        A28(I)=X28(I)+X35(I)
+        B17(I)=Y17(I)+Y46(I)
+        B28(I)=Y28(I)+Y35(I)
+        C17(I)=Z17(I)+Z46(I)
+        C28(I)=Z28(I)+Z35(I)
+      ENDDO 
+         
+      DO I=1,NEL
+        JAC4(I)=A17(I)+A28(I)
+        JAC5(I)=B17(I)+B28(I)
+        JAC6(I)=C17(I)+C28(I)
+        JAC7(I)=A17(I)-A28(I)
+        JAC8(I)=B17(I)-B28(I)
+        JAC9(I)=C17(I)-C28(I)
+      ENDDO 
 C
       DO I=1,NEL
         JAC_59_68(I)=JAC5(I)*JAC9(I)-JAC6(I)*JAC8(I)

--- a/starter/source/elements/solid/solide/checksvolume.F
+++ b/starter/source/elements/solid/solide/checksvolume.F
@@ -20,6 +20,9 @@ Copyright>
 Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss 
 Copyright>        software under a commercial license.  Contact Altair to discuss further if the 
 Copyright>        commercial version may interest you: https://www.altair.com/radioss/.    
+
+
+
       FUNCTION CHECKVOLUME_8N(X,IXS)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
@@ -44,6 +47,7 @@ C-----------------------------------------------
      .   Z1, Z2, Z3, Z4, Z5, Z6, Z7, Z8,
      .   X17, X28, X35, X46, Y17, Y28, Y35, Y46, Z17, Z28, Z35, Z46,
      .   JAC1,JAC2,JAC3,JAC4,JAC5,JAC6,JAC7,JAC8,JAC9, 
+     .   A17,A28,B17,B28,C17,C28, 
      .   JAC_59_68, JAC_67_49, JAC_48_57
 C=======================================================================
       CHECKVOLUME_8N = ZERO
@@ -77,36 +81,35 @@ C
       X28=X8-X2
       X35=X5-X3
       X46=X6-X4
-C
       Y17=Y7-Y1
       Y28=Y8-Y2
       Y35=Y5-Y3
       Y46=Y6-Y4
-C
       Z17=Z7-Z1
       Z28=Z8-Z2
       Z35=Z5-Z3
       Z46=Z6-Z4
 C
-C Jacobian matrix
       JAC1=X17+X28-X35-X46
       JAC2=Y17+Y28-Y35-Y46
       JAC3=Z17+Z28-Z35-Z46
-C
-      JAC4=X17+X46+X28+X35 
-      JAC5=Y17+Y46+Y28+Y35 
-      JAC6=Z17+Z46+Z28+Z35 
-C
-      JAC7=X17+X46-X28-X35 
-      JAC8=Y17+Y46-Y28-Y35 
-      JAC9=Z17+Z46-Z28-Z35 
-C
+      A17=X17+X46
+      A28=X28+X35
+      B17=Y17+Y46
+      B28=Y28+Y35
+      C17=Z17+Z46
+      C28=Z28+Z35
+      JAC4=A17+A28
+      JAC5=B17+B28
+      JAC6=C17+C28
+      JAC7=A17-A28
+      JAC8=B17-B28
+      JAC9=C17-C28
       JAC_59_68=JAC5*JAC9-JAC6*JAC8
       JAC_67_49=JAC6*JAC7-JAC4*JAC9
       JAC_48_57=JAC4*JAC8-JAC5*JAC7
-C
       CHECKVOLUME_8N=ONE_OVER_64*(JAC1*JAC_59_68+JAC2*JAC_67_49+JAC3*JAC_48_57)
-C
+
       RETURN
       END
       FUNCTION CHECKVOLUME_6N(X,IXS)
@@ -129,7 +132,8 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       my_real
      .   X1,X2,X3,X4,X5,X6,Y1,Y2,Y3,Y4,Y5,Y6,Z1,Z2,Z3,Z4,Z5,Z6,
-     .   JAC1,JAC2,JAC3,JAC4,JAC5,JAC6,JAC7,JAC8,JAC9,JAC_59_68,JAC_67_49,JAC_48_57
+     .   X21,X31,X41,X54,X64,Y21,Y31,Y41,Y54,Y64,Z21,Z31,Z41,Z54,Z64,
+     .   JAC1,JAC2,JAC3,JAC4,JAC5,JAC6,JAC7,JAC8,JAC9, JAC_59_68,JAC_67_49,JAC_48_57
 C=======================================================================
       CHECKVOLUME_6N = ZERO
 C
@@ -152,25 +156,37 @@ C
       Y6=X(2,IXS(8))
       Z6=X(3,IXS(8))
 C
-C Jacobian matrix
-      JAC1=X2-X1+X5-X4
-      JAC2=Y2-Y1+Y5-Y4
-      JAC3=Z2-Z1+Z5-Z4 
+      X21=X2-X1
+      X31=X3-X1
+      X41=X4-X1
+      X54=X5-X4
+      X64=X6-X4
+      Y21=Y2-Y1
+      Y31=Y3-Y1
+      Y41=Y4-Y1
+      Y54=Y5-Y4
+      Y64=Y6-Y4
+      Z21=Z2-Z1
+      Z31=Z3-Z1
+      Z41=Z4-Z1
+      Z54=Z5-Z4
+      Z64=Z6-Z4
 C
-      JAC4=X3-X1+X6-X4 
-      JAC5=Y3-Y1+Y6-Y4 
-      JAC6=Z3-Z1+Z6-Z4
-C
-      JAC7=THIRD*(X4-X1+X5-X2+X6-X3)
-      JAC8=THIRD*(Y4-Y1+Y5-Y2+Y6-Y3)
-      JAC9=THIRD*(Z4-Z1+Z5-Z2+Z6-Z3)
+      JAC1=X21+X54
+      JAC2=Y21+Y54
+      JAC3=Z21+Z54
+      JAC4=X31+X64
+      JAC5=Y31+Y64
+      JAC6=Z31+Z64
+      JAC7=THIRD*(X41+X5-X2+X6-X3)
+      JAC8=THIRD*(Y41+Y5-Y2+Y6-Y3)
+      JAC9=THIRD*(Z41+Z5-Z2+Z6-Z3)
 C
       JAC_59_68=JAC5*JAC9-JAC6*JAC8
       JAC_67_49=JAC6*JAC7-JAC4*JAC9
       JAC_48_57=JAC4*JAC8-JAC5*JAC7
 C
       CHECKVOLUME_6N=ONE_OVER_8*(JAC1*JAC_59_68+JAC2*JAC_67_49+JAC3*JAC_48_57)
-C
       RETURN
       END
       FUNCTION CHECKVOLUME_4N(X,IXS)
@@ -213,7 +229,6 @@ C
       Y4=X(2,IXS(6))
       Z4=X(3,IXS(6))
 C
-C Jacobian matrix
       JAC1=X1-X4
       JAC2=Y1-Y4
       JAC3=Z1-Z4

--- a/starter/source/elements/solid/solide/sderi3.F
+++ b/starter/source/elements/solid/solide/sderi3.F
@@ -66,6 +66,7 @@ C
       my_real
      .   VOL(NEL), VEUL(LVEUL,*) , GEO(NPROPG,NUMGEO),
      .   JAC1(NEL), JAC2(NEL), JAC3(NEL), JAC4(NEL), JAC5(NEL), JAC6(NEL),
+     .   JAC12(NEL), JAC45(NEL), JAC78(NEL),
      .   PX1(NEL), PX2(NEL), PX3(NEL), PX4(NEL),  
      .   PY1(NEL), PY2(NEL), PY3(NEL), PY4(NEL),  
      .   PZ1(NEL), PZ2(NEL), PZ3(NEL), PZ4(NEL), DET(NEL)
@@ -192,23 +193,35 @@ C Jacobian matrix inverse
 C
 C Shape functions partial derivatives
       DO I=1,NEL
-        PX1(I)=-JACI1(I)-JACI2(I)-JACI3(I)
-        PY1(I)=-JACI4(I)-JACI5(I)-JACI6(I)
-        PZ1(I)=-JACI7(I)-JACI8(I)-JACI9(I)
-C
-        PX2(I)=-JACI1(I)-JACI2(I)+JACI3(I)
-        PY2(I)=-JACI4(I)-JACI5(I)+JACI6(I)
-        PZ2(I)=-JACI7(I)-JACI8(I)+JACI9(I)
-C
-        PX3(I)= JACI1(I)-JACI2(I)+JACI3(I)
-        PY3(I)= JACI4(I)-JACI5(I)+JACI6(I)
-        PZ3(I)= JACI7(I)-JACI8(I)+JACI9(I)
-C
-        PX4(I)= JACI1(I)-JACI2(I)-JACI3(I)
-        PY4(I)= JACI4(I)-JACI5(I)-JACI6(I)
-        PZ4(I)= JACI7(I)-JACI8(I)-JACI9(I)
+        JAC12(I)=JACI1(I)-JACI2(I)
+        JAC45(I)=JACI4(I)-JACI5(I)
+        JAC78(I)=JACI7(I)-JACI8(I)
       ENDDO
 C
+      DO I=1,NEL
+        PX3(I)= JAC12(I)+JACI3(I)
+        PY3(I)= JAC45(I)+JACI6(I)
+        PZ3(I)= JAC78(I)+JACI9(I)
+        PX4(I)= JAC12(I)-JACI3(I)
+        PY4(I)= JAC45(I)-JACI6(I)
+        PZ4(I)= JAC78(I)-JACI9(I)
+      ENDDO
+C
+      DO I=1,NEL
+        JAC12(I)=JACI1(I)+JACI2(I)
+        JAC45(I)=JACI4(I)+JACI5(I)
+        JAC78(I)=JACI7(I)+JACI8(I)
+      ENDDO
+C
+      DO I=1,NEL
+        PX1(I)=-JAC12(I)-JACI3(I)
+        PY1(I)=-JAC45(I)-JACI6(I)
+        PZ1(I)=-JAC78(I)-JACI9(I)
+        PX2(I)=-JAC12(I)+JACI3(I)
+        PY2(I)=-JAC45(I)+JACI6(I)
+        PZ2(I)=-JAC78(I)+JACI9(I)
+      ENDDO
+
       IF(JEUL * (1 - IMULTI_FVM) /= 0)THEN
         DO I=1,NEL
           VEUL(1,I) = PX1(I)

--- a/starter/source/elements/solid/solidez/szderi3.F
+++ b/starter/source/elements/solid/solidez/szderi3.F
@@ -83,45 +83,50 @@ C-----------------------------------------------
      .   JACI1(MVSIZ), JACI2(MVSIZ), JACI3(MVSIZ), JACI4(MVSIZ), 
      .   JACI5(MVSIZ), JACI6(MVSIZ), JACI7(MVSIZ), JACI8(MVSIZ), JACI9(MVSIZ), 
      .   JAC_59_68(MVSIZ), JAC_67_49(MVSIZ), JAC_48_57(MVSIZ),
-     .   X_17_46 , X_28_35 ,
-     .   Y_17_46 , Y_28_35 ,
-     .   Z_17_46 , Z_28_35
+     .   A17_46(MVSIZ),
+     .   A28_35(MVSIZ),
+     .   B17_46(MVSIZ),
+     .   B28_35(MVSIZ),
+     .   C17_46(MVSIZ),
+     .   C28_35(MVSIZ)
       DOUBLE PRECISION
-     .   X17, X28, X35, X46,
-     .   Y17, Y28, Y35, Y46,
-     .   Z17, Z28, Z35, Z46
+     .   X17(MVSIZ), X28(MVSIZ), X35(MVSIZ), X46(MVSIZ),
+     .   Y17(MVSIZ), Y28(MVSIZ), Y35(MVSIZ), Y46(MVSIZ),
+     .   Z17(MVSIZ), Z28(MVSIZ), Z35(MVSIZ), Z46(MVSIZ)
+
 C=======================================================================
-C
-C Jacobian matrix
       DO I=1,NEL
-        X17=XD7(I)-XD1(I)
-        X28=XD8(I)-XD2(I)
-        X35=XD5(I)-XD3(I)
-        X46=XD6(I)-XD4(I)
-        Y17=YD7(I)-YD1(I)
-        Y28=YD8(I)-YD2(I)
-        Y35=YD5(I)-YD3(I)
-        Y46=YD6(I)-YD4(I)
-        Z17=ZD7(I)-ZD1(I)
-        Z28=ZD8(I)-ZD2(I)
-        Z35=ZD5(I)-ZD3(I)
-        Z46=ZD6(I)-ZD4(I)
-C
-        JAC4(I)=X17+X28-X35-X46
-        JAC5(I)=Y17+Y28-Y35-Y46
-        JAC6(I)=Z17+Z28-Z35-Z46
-        X_17_46=X17+X46
-        X_28_35=X28+X35
-        Y_17_46=Y17+Y46
-        Y_28_35=Y28+Y35
-        Z_17_46=Z17+Z46
-        Z_28_35=Z28+Z35
-        JAC7(I)=X_17_46+X_28_35
-        JAC8(I)=Y_17_46+Y_28_35
-        JAC9(I)=Z_17_46+Z_28_35
-        JAC1(I)=X_17_46-X_28_35
-        JAC2(I)=Y_17_46-Y_28_35
-        JAC3(I)=Z_17_46-Z_28_35
+        X17(I)=XD7(I)-XD1(I)
+        X28(I)=XD8(I)-XD2(I)
+        X35(I)=XD5(I)-XD3(I)
+        X46(I)=XD6(I)-XD4(I)
+        Y17(I)=YD7(I)-YD1(I)
+        Y28(I)=YD8(I)-YD2(I)
+        Y35(I)=YD5(I)-YD3(I)
+        Y46(I)=YD6(I)-YD4(I)
+        Z17(I)=ZD7(I)-ZD1(I)
+        Z28(I)=ZD8(I)-ZD2(I)
+        Z35(I)=ZD5(I)-ZD3(I)
+        Z46(I)=ZD6(I)-ZD4(I)
+      ENDDO
+      DO I=1,NEL
+        JAC4(I)=X17(I)+X28(I)-X35(I)-X46(I)
+        JAC5(I)=Y17(I)+Y28(I)-Y35(I)-Y46(I)
+        JAC6(I)=Z17(I)+Z28(I)-Z35(I)-Z46(I)
+        A17_46(I)=X17(I)+X46(I)
+        A28_35(I)=X28(I)+X35(I)
+        B17_46(I)=Y17(I)+Y46(I)
+        B28_35(I)=Y28(I)+Y35(I)
+        C17_46(I)=Z17(I)+Z46(I)
+        C28_35(I)=Z28(I)+Z35(I)
+      ENDDO
+      DO I=1,NEL
+        JAC7(I)=A17_46(I)+A28_35(I)
+        JAC8(I)=B17_46(I)+B28_35(I)
+        JAC9(I)=C17_46(I)+C28_35(I)
+        JAC1(I)=A17_46(I)-A28_35(I)
+        JAC2(I)=B17_46(I)-B28_35(I)
+        JAC3(I)=C17_46(I)-C28_35(I)
       ENDDO
 C
       DO I=1,NEL
@@ -129,6 +134,7 @@ C
         JAC_67_49(I)=JAC6(I)*JAC7(I)-JAC4(I)*JAC9(I)
         JAC_48_57(I)=JAC4(I)*JAC8(I)-JAC5(I)*JAC7(I)
       ENDDO
+
 C
       DO I=1,NEL
        VOLDP(I)=ONE_OVER_64*(JAC1(I)*JAC_59_68(I)+JAC2(I)*JAC_67_49(I)+JAC3(I)*JAC_48_57(I))


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Going back to original formulation for computation of volume because of unexpected numerical changes on benches. 
