### PR TITLE
Implementation of /FAIL/SYAZWAN 

### DIFF
--- a/engine/source/materials/fail/syazwan/fail_syazwan_c.F
+++ b/engine/source/materials/fail/syazwan/fail_syazwan_c.F
@@ -1,0 +1,287 @@
+Copyright>        OpenRadioss
+Copyright>        Copyright (C) 1986-2022 Altair Engineering Inc.
+Copyright>    
+Copyright>        This program is free software: you can redistribute it and/or modify
+Copyright>        it under the terms of the GNU Affero General Public License as published by
+Copyright>        the Free Software Foundation, either version 3 of the License, or
+Copyright>        (at your option) any later version.
+Copyright>    
+Copyright>        This program is distributed in the hope that it will be useful,
+Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+Copyright>        GNU Affero General Public License for more details.
+Copyright>    
+Copyright>        You should have received a copy of the GNU Affero General Public License
+Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+Copyright>    
+Copyright>    
+Copyright>        Commercial Alternative: Altair Radioss Software 
+Copyright>    
+Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss 
+Copyright>        software under a commercial license.  Contact Altair to discuss further if the 
+Copyright>        commercial version may interest you: https://www.altair.com/radioss/.    
+Chd|====================================================================
+Chd|  FAIL_SYAZWAN_C                      source/materials/fail/syazwan/fail_syazwan_c.F
+Chd|-- called by -----------
+Chd|        MULAWC                        source/materials/mat_share/mulawc.F
+Chd|        USERMAT_SHELL                 source/materials/mat_share/usermat_shell.F
+Chd|====================================================================
+      SUBROUTINE FAIL_SYAZWAN_C(
+     1           NEL      ,NUVAR    ,
+     2           TIME     ,UPARAM   ,NGL      ,IPT      ,NPTOT    ,
+     3           SIGNXX   ,SIGNYY   ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,
+     4           EPSXX    ,EPSYY    ,EPSXY    ,EPSYZ    ,EPSZX    ,
+     5           DPLA     ,EPSP     ,UVAR     ,PTHKF    ,UEL1     ,
+     6           OFF      ,OFFL     ,DFMAX    ,TDEL     ,NFUNC    ,
+     7           IFUNC    ,ALDT     ,FOFF     ,IPG      ,PLA      ,
+     8           DMG_FLAG ,DMG_SCALE,NPF      ,TF )
+C-----------------------------------------------
+C    Simplified Fracture Surface
+C-----------------------------------------------
+C-----------------------------------------------
+C   I m p l i c i t   T y p e s
+C-----------------------------------------------
+#include      "implicit_f.inc"
+C-----------------------------------------------
+C   G l o b a l   P a r a m e t e r s
+C-----------------------------------------------
+#include "units_c.inc"
+#include "param_c.inc"
+#include "scr17_c.inc"
+#include "scr19_c.inc"
+#include "comlock.inc"
+#include "mvsiz_p.inc"
+C---------+---------+---+---+--------------------------------------------
+C VAR     | SIZE    |TYP| RW| DEFINITION
+C---------+---------+---+---+--------------------------------------------
+C NEL     |  1      | I | R | SIZE OF THE ELEMENT GROUP NEL 
+C NUVAR   |  1      | I | R | NUMBER OF USER ELEMENT VARIABLES
+C---------+---------+---+---+--------------------------------------------
+C NPT     |  1      | I | R | NUMBER OF LAYERS OR INTEGRATION POINTS   
+C IPT     |  1      | I | R | LAYER OR INTEGRATION POINT NUMBER   
+C ISHELL  |  *      | I | R | GEOMETRICAL FLAGS   
+C NGL     | NEL     | I | R | ELEMEMT NUMBER
+C SHF     | NEL     | F | R | SHEAR FACTOR
+C---------+---------+---+---+--------------------------------------------
+C TIME    |  1      | F | R | CURRENT TIME
+C---------+---------+---+---+--------------------------------------------
+C SIGNXX  | NEL     | F | W | NEW ELASTO PLASTIC STRESS XX
+C SIGNYY  | NEL     | F | W | NEW ELASTO PLASTIC STRESS YY
+C ...     |         |   |   |
+C SOUNDSP | NEL     | F | W | SOUND SPEED (NEEDED FOR TIME STEP)
+C VISCMAX | NEL     | F | W | MAXIMUN DAMPING MODULUS(NEEDED FOR TIME STEP)
+C---------+---------+---+---+--------------------------------------------
+C PLA     | NEL     | F |R/W| PLASTIC STRAIN
+C UVAR    |NEL*NUVAR| F |R/W| USER ELEMENT VARIABLE ARRAY
+C OFF     | NEL     | F |R/W| DELETED ELEMENT FLAG (=1. ON, =0. OFF)
+C FOFF    | NEL     | I |R/W| DELETED INTEGRATION POINT FLAG (=1 ON, =0 OFF)
+C---------+---------+---+---+--------------------------------------------
+C IPTT                        CURRENT INTEGRATION POINT IN THE LAYER (FOR OUTPUT ONLY)
+C NPTOT                       NUMBER OF INTEGRATION POINTS IN ALL LAYERS (TOTAL)
+C NOFF                        NUMBER OF FAILED INTEGRATION POINTS (TOTAL)
+C IGTYP                       PROPERTY TYPE
+C-----------------------------------------------
+C   I N P U T   A r g u m e n t s
+C-----------------------------------------------
+      INTEGER NEL,NUVAR,IPT,NPTOT,NFUNC,IPG
+      INTEGER NGL(NEL),IFUNC(NFUNC)
+      my_real TIME,UPARAM(*),DPLA(NEL),EPSP(NEL),
+     .   UEL1(NEL),ALDT(NEL),PTHKF
+C-----------------------------------------------
+C   I N P U T   O U T P U T   A r g u m e n t s 
+C-----------------------------------------------
+       INTEGER DMG_FLAG,FOFF(NEL)
+      my_real 
+     .  UVAR(NEL,NUVAR),OFF(NEL),OFFL(NEL),
+     .  SIGNXX(NEL),SIGNYY(NEL),SIGNXY(NEL),SIGNYZ(NEL),SIGNZX(NEL),
+     .  EPSXX(NEL),EPSYY(NEL),EPSXY(NEL),EPSYZ(NEL),EPSZX(NEL),
+     .  DFMAX(NEL),TDEL(NEL),PLA(NEL),DMG_SCALE(NEL)
+C-----------------------------------------------
+C   L o c a l   V a r i a b l e s
+C-----------------------------------------------
+       INTEGER I,J,NINDX1,NINDX2,MAP,INST
+       INTEGER, DIMENSION(MVSIZ) :: INDX1,INDX2
+
+       my_real  E12, S1, S2, Q, SS, BETA, EPS
+       my_real  DAM_SF, DAM_LIM, N_VAL
+       my_real ,DIMENSION(NEL) :: EMAJ,EMIN
+       my_real  C1, C2, C3, C4, C5, C6, EPSMIN
+       my_real  P, SVM, ST, SXX, SYY, R
+       my_real  LODE, LODEP, DAMAGE, EPSFAIL, EPS_C
+       my_real  EQUA1, EQUA2, E1, E2, DCRIT, ALPHA
+       my_real  SOFTEXP, REF_LEN, LAMBDA, FAC
+       my_real  DYDX
+C-----------------------------------------------
+C   VARIABLES FOR FUNCTION INTERPOLATION 
+C-----------------------------------------------
+      INTEGER NPF(*)
+      my_real FINTER ,TF(*)
+      EXTERNAL FINTER
+C        Y = FINTER(IFUNC(J),X,NPF,TF,DYDX)
+C        Y       : y = f(x)
+C        X       : x
+C        DYDX    : f'(x) = dy/dx
+C        IFUNC(J): FUNCTION INDEX
+C              J : FIRST(J=1), SECOND(J=2) .. FUNCTION USED FOR THIS LAW
+C        NPF,TF  : FUNCTION PARAMETER
+C-----------------------------------------------
+C      Explicit definition for trial
+C-----------------------------------------------
+       C1           = UPARAM(1)
+       C2           = UPARAM(2)
+       C3           = UPARAM(3)
+       C4           = UPARAM(4)
+       C5           = UPARAM(5)
+       C6           = UPARAM(6)
+       EPSMIN       = UPARAM(7)
+       PTHKF        = UPARAM(8)
+       MAP          = UPARAM(9)
+       DAM_SF       = UPARAM(10)
+       DAM_LIM      = UPARAM(11)
+       INST         = UPARAM(12)
+       N_VAL        = UPARAM(13)
+       SOFTEXP      = UPARAM(14)
+       REF_LEN      = UPARAM(15)
+       NINDX1       = 0
+       NINDX2       = 0
+       EPSFAIL      = ZERO
+       IF(INST == 1) DMG_FLAG = 1
+
+
+       IF (TIME == ZERO .AND. NFUNC > 0) THEN
+        DO I=1,NEL
+          IF (NUVAR == 5) THEN
+            UVAR(I,5) = ALDT(I)
+            LAMBDA = UVAR(I,5) / REF_LEN
+            FAC = FINTER(IFUNC(1),LAMBDA,NPF,TF,DYDX)
+            UVAR(I,5) = FAC
+          ENDIF
+        ENDDO
+       ENDIF
+
+       
+C---------INITIALIZE DAMAGE DUE TO MANUF. HISTORY-------------
+C---------ASSUME LINEAR STRAIN PATH---------------------------
+       IF (TIME == ZERO .AND. MAP == 1) THEN
+        DO I = 1,NEL
+         IF (PLA(I) /= ZERO) THEN
+C----------IMPLEMENTATION-------------------------------------
+           E12= HALF*EPSXY(I)
+           S1 = HALF*(EPSXX(I) + EPSYY(I))
+           S2 = HALF*(EPSXX(I) - EPSYY(I))
+           Q  = SQRT(S2**2 + E12**2)
+           EMAJ(I) = S1 + Q
+           EMIN(I) = S1 - Q
+           IF (EMIN(I) >= EMAJ(I)) THEN
+             SS      = EMIN(I)
+             EMIN(I) = EMAJ(I)
+             EMAJ(I) = SS
+           ENDIF
+           BETA = EMIN(I)/EMAJ(I)
+           ST = (1+BETA)/SQRT(THREE)/SQRT(1+BETA+BETA**2)
+C           LODEP = ONE-(TWO/PI*ACOS(-TWENTY7*HALF*ST*(ST**2-THIRD)))
+           LODEP = ASIN((-TWENTY7*HALF*ST)*(ST**2-THIRD))*2/PI
+           EPSFAIL = C1+C2*ST+C3*LODEP+C4*ST**2+C5*LODEP**2+C6*ST*LODEP
+           EPSFAIL = MAX(EPSFAIL,EPSMIN)
+           IF(NUVAR==5) EPSFAIL = EPSFAIL*UVAR(I,5)
+           EPS = TWO*EMAJ(I)/SQRT(THREE)*SQRT(ONE+BETA+BETA**2) 
+           UVAR(I,1) = EPS/MAX(EPSFAIL,EM6)*DAM_SF
+           UVAR(I,1) = MIN(DAM_LIM,UVAR(I,1))
+           DFMAX(I) = UVAR(I,1)
+         ENDIF
+        ENDDO
+       ENDIF
+
+       DO I=1,NEL
+         IF(OFF(I) == ONE .AND. DPLA(I) /= ZERO .AND. FOFF(I) == 1) THEN
+           DAMAGE = UVAR(I,1)
+           P   = THIRD*(SIGNXX(I) + SIGNYY(I))
+           SVM = SQRT (SIGNXX(I)**2 + SIGNYY(I)**2
+     .           - SIGNXX(I)*SIGNYY(I) + THREE*SIGNXY(I)**2)
+           ST  = P/MAX(EM20,SVM)
+           SXX = SIGNXX(I) - P
+           SYY = SIGNYY(I) - P
+           R   = (TWENTY7*HALF*SXX*SYY*(-P))**THIRD
+           LODE = (R/SVM)**3
+           IF(LODE > ONE) LODE = ONE
+           IF(LODE < -ONE) LODE = -ONE
+           LODEP = ONE-TWO/PI*ACOS(LODE)
+           EPSFAIL =C1+C2*ST+C3*LODEP+C4*ST**2+C5*LODEP**2+C6*ST*LODEP
+           EPSFAIL = MAX(EPSFAIL, EPSMIN)
+           IF(NUVAR==5) EPSFAIL = EPSFAIL*UVAR(I,5)
+           IF (EPSFAIL>ZERO) THEN     
+                IF (INST == 1) THEN
+                  E12= HALF*EPSXY(I)
+                  S1 = HALF*(EPSXX(I) + EPSYY(I))
+                  S2 = HALF*(EPSXX(I) - EPSYY(I))
+                  Q  = SQRT(S2**2 + E12**2)
+                  EMAJ(I) = S1 + Q
+                  EMIN(I) = S1 - Q
+                  IF (EMIN(I) >= EMAJ(I)) THEN
+                    SS      = EMIN(I)
+                    EMIN(I) = EMAJ(I)
+                    EMAJ(I) = SS
+                  ENDIF
+                  BETA = EMIN(I)/MAX(EMAJ(I),EM06)
+                  BETA = MAX(-0.999,BETA)
+                  BETA = MIN(ONE,BETA)
+                  ALPHA = (TWO*BETA+ONE)/(TWO+BETA)
+                  EQUA1 = ONE-ALPHA+ALPHA**2
+                  EQUA2 = FOUR-THREE*ALPHA-THREE*ALPHA**2+FOUR*ALPHA
+                  E1 = TWO*(TWO-ALPHA)*EQUA1/EQUA2*N_VAL
+                  EPS_C = TWO*E1/SQRT(THREE)*SQRT(ONE+BETA+BETA**2)
+                  IF (PLA(I)>EPS_C .AND. UVAR(I,3)/=ONE) THEN
+                    UVAR(I,3)=ONE
+                    UVAR(I,4)=EPS_C/EPSFAIL
+                  ENDIF
+                  IF(UVAR(I,3)==ONE) THEN
+                    DCRIT=UVAR(I,4)
+                    DMG_SCALE(I)=ONE-((DFMAX(I)-DCRIT)
+     .                  /MAX(ONE-DCRIT,EM20))**SOFTEXP
+                  ENDIF
+                ENDIF
+             DAMAGE = DAMAGE + DPLA(I)/EPSFAIL
+             UVAR(I,1) = DAMAGE
+           ENDIF
+         ENDIF 
+         
+         DFMAX(I)= MIN(ONE,MAX(DFMAX(I),UVAR(I,1)))
+         
+         IF(OFFL(I) == 1. .AND. DFMAX(I) >= 1.0) THEN
+           FOFF(I)       = 0
+           NINDX1        = NINDX1 + 1
+           INDX1(NINDX1) = I
+         ENDIF
+
+         IF(DAMAGE > ONE .AND. UVAR(I,2) == ZERO .AND. OFFL(I) == ONE) THEN
+             UVAR(I,2) = ONE
+         ENDIF
+       ENDDO
+c-----------------------
+      IF (NINDX1 > 0) THEN
+        DO J=1,NINDX1
+          I = INDX1(J)
+#include "lockon.inc"
+          WRITE(IOUT, 2000) NGL(I),IPG,IPT,TIME
+          WRITE(ISTDO,2000) NGL(I),IPG,IPT,TIME
+#include "lockoff.inc"
+        ENDDO
+      ENDIF
+      IF (NINDX2 > 0) THEN
+        DO J=1,NINDX2
+          I = INDX2(J)
+#include "lockon.inc"
+          WRITE(IOUT, 2200) NGL(I), TIME
+          WRITE(ISTDO,2200) NGL(I), TIME
+#include "lockoff.inc"
+        END DO
+      END IF   ! NINDX             
+C---------Damage for output  0 < DFMAX < 1 --------------------
+ 2000 FORMAT(1X,'FOR SHELL ELEMENT (SYAZWAN)',I10,1X,'GAUSS POINT',I3,
+     .       1X,'LAYER',I3,':',/,
+     .       1X,'STRESS TENSOR SET TO ZERO',1X,'AT TIME :',1PE12.4)
+ 2200 FORMAT(1X,' *** RUPTURE OF SHELL ELEMENT (SYAZWAN)',I10,1X,
+     . ' AT TIME :',1PE12.4)
+c------------------------
+       RETURN
+       END

--- a/engine/source/materials/mat_share/mulawc.F
+++ b/engine/source/materials/mat_share/mulawc.F
@@ -49,6 +49,7 @@ Chd|        FAIL_RTCL_C                   source/materials/fail/rtcl/fail_rtcl_c
 Chd|        FAIL_SETOFF_C                 source/materials/fail/fail_setoff_c.F
 Chd|        FAIL_SETOFF_NPG_C             source/materials/fail/fail_setoff_npg_c.F
 Chd|        FAIL_SETOFF_WIND_FRWAVE       source/materials/fail/fail_setoff_wind_frwave.F
+Chd|        FAIL_SYAZWAN                  source/materials/fail/syazwan/fail_syazwan_c.F
 Chd|        FAIL_TAB2_C                   source/materials/fail/tabulated/fail_tab2_c.F
 Chd|        FAIL_TAB_C                    source/materials/fail/tabulated/fail_tab_c.F
 Chd|        FAIL_TAB_OLD_C                source/materials/fail/tabulated/fail_tab_old_c.F
@@ -2209,7 +2210,22 @@ c
      4            SIGNXX   ,SIGNYY   ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,              
      5            EL_PLA   ,EL_TEMP  ,SIGY     ,FOFF     ,DFMAX    ,
      6            TDEL     ,IPT      ,IPG      ,DMG_FLAG ,DMG_LOC_SCALE,
-     7            PTHKF(ILAYER,IFL)) 
+     7            PTHKF(ILAYER,IFL))
+c
+              CASE (99)     !    Syazwan failure model
+                DO I=JFT,JLT
+                  COPY_PLA(I) = LBUF%PLA(I)
+                ENDDO
+                CALL FAIL_SYAZWAN_C(
+     1          JLT      ,NVARF   ,
+     2          TT       ,UPARAMF ,NGL      ,IPT      ,MPT      ,
+     3          SIGNXX   ,SIGNYY  ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,
+     4          EPSXX    ,EPSYY   ,EPSXY    ,EPSYZ    ,EPSZX    ,
+     5          DPLA     ,EPSPL   ,UVARF    ,PTHKF(ILAYER,IFL)  ,UELR1    ,
+     6          OFF      ,OFFL    ,DFMAX    ,TDEL     ,NFUNC1   ,
+     7          IFUNC1   ,EL_LEN  ,FOFF     ,IPG      ,COPY_PLA ,
+     8          DMG_FLAG ,DMG_LOC_SCALE,NPF ,TF)
+c  
 c-------------
               END SELECT
 c-------------

--- a/engine/source/materials/mat_share/usermat_shell.F
+++ b/engine/source/materials/mat_share/usermat_shell.F
@@ -55,6 +55,7 @@ Chd|        FAIL_RTCL_C                   source/materials/fail/rtcl/fail_rtcl_c
 Chd|        FAIL_SETOFF_C                 source/materials/fail/fail_setoff_c.F
 Chd|        FAIL_SETOFF_NPG_C             source/materials/fail/fail_setoff_npg_c.F
 Chd|        FAIL_SETOFF_WIND_FRWAVE       source/materials/fail/fail_setoff_wind_frwave.F
+Chd|        FAIL_SYAZWAN                  source/materials/fail/syazwan/fail_syazwan_c.F
 Chd|        FAIL_TAB2_C                   source/materials/fail/tabulated/fail_tab2_c.F
 Chd|        FAIL_TAB_C                    source/materials/fail/tabulated/fail_tab_c.F
 Chd|        FAIL_TAB_OLD_C                source/materials/fail/tabulated/fail_tab_old_c.F
@@ -1720,7 +1721,22 @@ c
      4            SIGNXX   ,SIGNYY   ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,              
      5            EL_PLA   ,EL_TEMP  ,SIGY     ,FOFF     ,DFMAX    ,
      6            TDEL     ,IPT      ,IPG      ,DMG_FLAG ,DMG_LOC_SCALE,
-     7            PTHKF(ILAYER,IFL)) 
+     7            PTHKF(ILAYER,IFL))
+c
+              CASE (99)     !    Syazwan failure model
+                DO I=JFT,JLT
+                  COPY_PLA(I) = LBUF%PLA(I)
+                ENDDO
+                CALL FAIL_SYAZWAN_C(
+     1          JLT      ,NVARF   ,
+     2          TT       ,UPARAMF ,NGL      ,IPT      ,MPT      ,
+     3          SIGNXX   ,SIGNYY  ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,
+     4          EPSXX    ,EPSYY   ,EPSXY    ,EPSYZ    ,EPSZX    ,
+     5          DPLA     ,EPSPL   ,UVARF    ,GBUF%NOFF,UELR1    ,
+     6          OFF      ,OFFL    ,DFMAX    ,TDEL     ,NFUNC1   ,
+     7          IFUNC1   ,EL_LEN  ,FOFF    , IGTYP    ,COPY_PLA ,
+     8          DMG_FLAG ,DMG_LOC_SCALE,NPF,TF)
+c 
 c-------------
               END SELECT
 c-------------

--- a/hm_cfg_files/config/CFG/radioss2022/FAIL/fail_syazwan.cfg
+++ b/hm_cfg_files/config/CFG/radioss2022/FAIL/fail_syazwan.cfg
@@ -1,0 +1,152 @@
+//Copyright>    CFG Files and Library ("CFG")
+//Copyright>    Copyright (C) 1986-2022 Altair Engineering Inc.
+//Copyright>
+//Copyright>    Altair Engineering Inc. grants to third parties limited permission to 
+//Copyright>    use and modify CFG solely in connection with OpenRadioss software, provided 
+//Copyright>    that any modification to CFG by a third party must be provided back to 
+//Copyright>    Altair Engineering Inc. and shall be deemed a Contribution under and therefore
+//Copyright>    subject to the CONTRIBUTOR LICENSE AGREEMENT for OpenRadioss software. 
+//Copyright>  
+//Copyright>    CFG IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
+//Copyright>    INCLUDING, BUT NOT LIMITED TO, THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR 
+//Copyright>    A PARTICULAR PURPOSE, AND NONINFRINGEMENT.  IN NO EVENT SHALL ALTAIR ENGINEERING
+//Copyright>    INC. OR ITS AFFILIATES BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, 
+//Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
+//Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
+//
+// Failure model, SYAZWAN Setup File
+// 
+
+ATTRIBUTES(COMMON){ 
+
+	_HMCOMMENTSFLAG  					= VALUE(INT, "Write HM Comments");
+	mat_id           					= VALUE(MAT,  "Material");
+
+	C1       						= VALUE(FLOAT,"C1 constant");
+	C2      						= VALUE(FLOAT,"C2 constant");
+	C3      						= VALUE(FLOAT,"C3 constant");
+	C4       						= VALUE(FLOAT,"C4 constant");
+	C5      						= VALUE(FLOAT,"C5 constant");
+	C6      						= VALUE(FLOAT,"C6 constant");
+	EPSMIN      						= VALUE(FLOAT,"EPSMIN constant");
+	PTHCKF        					        = VALUE(FLOAT,"Percentage of through thickness integration points failure limit");
+
+	STRAIN2DAM                                              = VALUE(INT,"Estimate Damage from strain tensor");
+        DAM_SF                                                  = VALUE(FLOAT,"Damage scale factor");
+	MAX_DAM                                                 = VALUE(FLOAT,"Max damage limit");
+        
+	INST							= VALUE(INT,"Incorporate instability");
+	N_VAL                                                   = VALUE(FLOAT,"N value, from Holomon Law");
+	SOFTEXP                                                 = VALUE(FLOAT,"Stress softening exponent");
+
+	REG_FUNC						= VALUE(INT,"Regularization curve ID");
+	REF_LEN                                                 = VALUE(FLOAT,"Reference Element Length");
+
+	ID_CARD_EXIST						= VALUE(BOOL, "Give an Id");
+}
+
+SKEYWORDS_IDENTIFIER(COMMON)
+{
+	_HMCOMMENTSFLAG=-1;
+}
+
+GUI(COMMON) 
+{
+
+ 
+  SCALAR(C1)    { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(C2)    { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(C3)    { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(C4)    { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(C5)    { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(C6)    { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(EPSMIN)    { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(PTHCKF)        { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(STRAIN2DAM)        { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(DAM_SF)        { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(MAX_DAM)        { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(INST)        { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(N_VAL)        { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(SOFTEXP)        { DIMENSION = "DIMENSIONLESS"; }
+
+  SCALAR(REF_LEN)        { DIMENSION="l"; }
+  SCALAR(REG_FUNC)        { DIMENSION = "DIMENSIONLESS"; }
+
+
+}
+
+
+/*
+DEFINITIONS(COMMON) {
+  SUPPORTING=(MAT);
+}
+DEFAULTS(COMMON) {
+  S_Flag=1;
+}
+
+GUI(COMMON) {
+  DATA(MAT) {SUBTYPES=(/MAT/COWPER,
+                       /MAT/DAMA,
+                       /MAT/HILL,
+                       /MAT/HILL_TAB,
+                       /MAT/HYD_JCOOK,
+                       /MAT/HYDPLA,
+                       /MAT/LAW23,
+                       /MAT/PLAS_BRIT,
+                       /MAT/PLAS_JOHNS,
+                       /MAT/PLAS_TAB,
+                       /MAT/PLAS_T3,
+                       /MAT/PLAS_ZERIL,
+                       /MAT/STEINB,
+                       /MAT/ZHAO,
+                       /MAT/LAW80,
+                       /MAT/LAW83,
+                       /MAT/LAW84,
+                       /MAT/BARLAT2000); }
+
+  SCALAR(C1) { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(C2) { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(C3) { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(C4) { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(C5) { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(C6) { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(EPSMIN) { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(PTHCKF)  { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(STRAIN2DAM)        { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(DAM_SF)        { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(MAX_DAM)        { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(INST)        { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(N_VAL)        { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(SOFTEXP)        { DIMENSION = "DIMENSIONLESS"; }
+
+  SCALAR(REF_LEN)        { DIMENSION="l"; }
+  SCALAR(REG_FUNC)        { DIMENSION = "DIMENSIONLESS"; }
+
+  //
+  //
+  FLAG(ID_CARD_EXIST);
+}
+
+*/
+FORMAT(radioss2018) { 
+	HEADER("/FAIL/SYAZWAN/%d",mat_id);
+	COMMENT("#                 C1                  C2                  C3                  C4                  C5");
+	CARD("%20lg%20lg%20lg%20lg%20lg",C1,C2,C3,C4,C5);
+
+	COMMENT("#                 C6              EPSMIN              PTHCKF             REF_LEN            REG_FUNC");
+	CARD("%20lg%20lg%20lg%20lg%20lg",C6,EPSMIN,PTHCKF,REF_LEN,REG_FUNC);
+
+        COMMENT("#         STRAIN2DAM              DAM_SF             MAX_DAM");
+        CARD("%20lg%20lg%20lg",STRAIN2DAM,DAM_SF,MAX_DAM);
+
+        COMMENT("#               INST               N_VAL             SOFTEXP");
+        CARD("%20lg%20lg%20lg",INST,N_VAL,SOFTEXP);
+	
+	if (ID_CARD_EXIST==TRUE)
+	{
+		COMMENT("#  FAIL_ID") ;
+	}
+	FREE_CARD(ID_CARD_EXIST,"%10d", _ID_);
+}
+
+

--- a/hm_cfg_files/config/CFG/radioss2022/data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/radioss2022/data_hierarchy.cfg
@@ -2423,6 +2423,15 @@ HIERARCHY {
         USER_NAMES = (RTCL);
     }
 
+        HIERARCHY {
+        KEYWORD = FAIL_SYAZWAN;
+        TITLE   = "FAIL_SYAZWAN";
+        SUBTYPE = USER;
+        USER_ID = 99;
+        FILE    = "FAIL/fail_syazwan.cfg";
+        USER_NAMES = (SYAZWAN);
+    }
+
     HIERARCHY {
         KEYWORD = FAIL_USER1;
         TITLE   = "FAIL_USER1";

--- a/hm_cfg_files/config/CFG/radioss2022/hm_data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/radioss2022/hm_data_hierarchy.cfg
@@ -2528,6 +2528,15 @@ HIERARCHY {
         USER_NAMES = (RTCL);
     }
 
+        HIERARCHY {
+        KEYWORD = FAIL_SYAZWAN;
+        TITLE   = "FAIL_SYAZWAN";
+        SUBTYPE = USER;
+        USER_ID = 99;
+        FILE    = "FAIL/fail_syazwan.cfg";
+        USER_NAMES = (SYAZWAN);
+    }
+
     HIERARCHY {
         KEYWORD = FAIL_USER1;
         TITLE   = "FAIL_USER1";

--- a/starter/source/materials/fail/hm_read_fail.F
+++ b/starter/source/materials/fail/hm_read_fail.F
@@ -353,6 +353,9 @@ c--------------------------------------------
 c--------------------------------------------      
         ELSEIF(KEY(1:6) == 'INIEVO')THEN
              IRUP= 42
+c--------------------------------------------
+        ELSEIF(KEY(1:7) == 'SYAZWAN')THEN
+             IRUP= 99
 c--------------------------------------------      
         ELSE  
              IRUP= 0
@@ -583,6 +586,12 @@ c---
      .             UPARAM   ,MAXPARAM ,NUPARAM        ,NUVAR     ,IFUNC    ,
      .             MAXFUNC  ,NFUNC    ,UNITAB         ,FAIL_ID   ,MAT_ID   ,
      .             TABLE    ,TITR     ,LSUBMODEL)
+c---
+            CASE(99)
+              CALL HM_READ_FAIL_SYAZWAN(
+     .             UPARAM   ,MAXPARAM ,NUPARAM        ,NUVAR     ,IFUNC    ,
+     .             MAXFUNC  ,NFUNC    ,UNITAB         ,MAT_ID    ,FAIL_ID  ,
+     .             LSUBMODEL)
 c
 c--------------------------------------------      
             END SELECT

--- a/starter/source/materials/fail/syazwan/hm_read_fail_syazwan.F
+++ b/starter/source/materials/fail/syazwan/hm_read_fail_syazwan.F
@@ -1,0 +1,207 @@
+Copyright>        OpenRadioss
+Copyright>        Copyright (C) 1986-2022 Altair Engineering Inc.
+Copyright>    
+Copyright>        This program is free software: you can redistribute it and/or modify
+Copyright>        it under the terms of the GNU Affero General Public License as published by
+Copyright>        the Free Software Foundation, either version 3 of the License, or
+Copyright>        (at your option) any later version.
+Copyright>    
+Copyright>        This program is distributed in the hope that it will be useful,
+Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+Copyright>        GNU Affero General Public License for more details.
+Copyright>    
+Copyright>        You should have received a copy of the GNU Affero General Public License
+Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+Copyright>    
+Copyright>    
+Copyright>        Commercial Alternative: Altair Radioss Software 
+Copyright>    
+Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss 
+Copyright>        software under a commercial license.  Contact Altair to discuss further if the 
+Copyright>        commercial version may interest you: https://www.altair.com/radioss/.    
+Chd|====================================================================
+Chd|  HM_READ_FAIL_SYAZWAN                source/materials/fail/syazwan/hm_read_fail_syazwan.F
+Chd|-- called by -----------
+Chd|        HM_READ_FAIL                  source/materials/fail/hm_read_fail.F
+Chd|-- calls ---------------
+Chd|        ANCMSG                        source/output/message/message.F
+Chd|        HM_GET_FLOATV                 source/devtools/hm_reader/hm_get_floatv.F
+Chd|        HM_GET_INTV                   source/devtools/hm_reader/hm_get_intv.F
+Chd|        HM_OPTION_IS_ENCRYPTED        source/devtools/hm_reader/hm_option_is_encrypted.F
+Chd|        HM_OPTION_READ_MOD            share/modules1/hm_option_read_mod.F
+Chd|        MESSAGE_MOD                   share/message_module/message_mod.F
+Chd|        SUBMODEL_MOD                  share/modules1/submodel_mod.F 
+Chd|====================================================================
+      SUBROUTINE HM_READ_FAIL_SYAZWAN(
+     .           UPARAM    ,MAXUPARAM ,NUPARAM ,NUVAR  ,IFUNC  ,
+     .           MAXFUNC   ,NFUNC     ,UNITAB  ,IMID_F ,FAIL_ID,
+     .           LSUBMODEL )
+C-----------------------------------------------
+C   ROUTINE DESCRIPTION :
+C   ===================
+C   READ FAILURE SYAZWAN
+C-----------------------------------------------
+C   DUMMY ARGUMENTS DESCRIPTION:
+C   ===================
+C
+C     NAME            DESCRIPTION                         
+C
+C     UNITAB          UNITS ARRAY
+C     FAIL_ID         FAILURE ID(INTEGER)
+C     TITR            MATERIAL TITLE
+C     LSUBMODEL       SUBMODEL STRUCTURE   
+C-----------------------------------------------
+C   M o d u l e s
+C-----------------------------------------------
+      USE UNITAB_MOD
+      USE MESSAGE_MOD
+      USE SUBMODEL_MOD
+      USE HM_OPTION_READ_MOD
+C-----------------------------------------------
+C   I m p l i c i t   T y p e s
+C-----------------------------------------------
+#include      "implicit_f.inc"
+C----------+---------+---+---+--------------------------------------------
+C VAR      | SIZE    |TYP| RW| DEFINITION
+C----------+---------+---+---+--------------------------------------------
+C UPARAM   | NUPARAM | F | W | USER FAILURE MODEL PARAMETER ARRAY
+C MAXUPARAM|  1      | I | R | MAXIMUM SIZE OF UPARAM 
+C NUPARAM  |  1      | I | W | SIZE OF UPARAM =< MAXUPARAM
+C NUVAR    |  1      | I | W | NUMBER OF USER  VARIABLES
+C----------+---------+---+---+--------------------------------------------
+C IFUNC    | NFUNC   | I | W | FUNCTION NUMBER ARRAY
+C MAXFUNC  |  1      | I | R | MAXIMUM SIZE OF IFUNC
+C NFUNC    |  1      | I | W | SIZE OF IFUNC =< MAXFUNC
+C FAIL_ID  |  1      | I | W | ID OF FAILURE CRITERIA
+C----------+---------+---+---+--------------------------------------------
+#include      "scr17_c.inc"
+#include      "units_c.inc"
+#include      "submod_c.inc"
+#include      "sysunit.inc"
+C-----------------------------------------------
+C   D u m m y   A r g u m e n t s
+C-----------------------------------------------
+C INPUT ARGUMENTS
+      TYPE (UNIT_TYPE_),INTENT(IN) ::UNITAB 
+      INTEGER,INTENT(IN)             ::MAXUPARAM,MAXFUNC,FAIL_ID,IMID_F
+      TYPE(SUBMODEL_DATA),INTENT(IN) ::LSUBMODEL(*)
+C MODIFIED ARGUMENT
+      INTEGER,INTENT(INOUT)          ::IFUNC(MAXFUNC),NFUNC
+      my_real,INTENT(INOUT)          ::UPARAM(MAXUPARAM)
+      INTEGER,INTENT(OUT)            ::NUPARAM,NUVAR
+C-----------------------------------------------
+C   L o c a l   V a r i a b l e s
+C-----------------------------------------------
+      my_real C1,C2,C3,C4,C5,C6,EPSMIN,PTHCKF
+      my_real DAM_SF, MAX_DAM, N_VAL, SOFTEXP
+      my_real REF_LEN,REF_SIZ_UNIT
+      INTEGER STRAIN2DAM, INST, REG_FUNC
+      LOGICAL :: IS_AVAILABLE,IS_ENCRYPTED
+C-----------------------------------------------    
+!!      FAC_T = UNITAB(4) 
+      IS_ENCRYPTED   = .FALSE.
+      IS_AVAILABLE = .FALSE.
+C--------------------------------------------------
+C EXTRACT DATA (IS OPTION CRYPTED)
+C--------------------------------------------------
+      CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
+C--------------------------------------------------
+C EXTRACT DATAS (REAL VALUES)
+C--------------------------------------------------
+      CALL HM_GET_FLOATV         ('C1'           ,C1      ,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV         ('C2'           ,C2      ,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV         ('C3'           ,C3      ,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV         ('C4'           ,C4      ,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV         ('C5'           ,C5      ,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV         ('C6'           ,C6      ,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV         ('EPSMIN'       ,EPSMIN  ,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV         ('PTHCKF'       ,PTHCKF  ,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_INTV           ('STRAIN2DAM'   ,STRAIN2DAM  ,IS_AVAILABLE,LSUBMODEL)
+      CALL HM_GET_FLOATV         ('DAM_SF'       ,DAM_SF  ,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV         ('MAX_DAM'      ,MAX_DAM ,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_INTV           ('INST'         ,INST    ,IS_AVAILABLE,LSUBMODEL)
+      CALL HM_GET_FLOATV         ('N_VAL'        ,N_VAL   ,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV         ('SOFTEXP'      ,SOFTEXP ,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_INTV           ('REG_FUNC'     ,REG_FUNC,IS_AVAILABLE,LSUBMODEL)
+      CALL HM_GET_FLOATV         ('REF_LEN'      ,REF_LEN ,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      IF (REG_FUNC > 0 .AND. REF_LEN == ZERO) THEN
+        CALL HM_GET_FLOATV_DIM('REF_LEN' ,REF_SIZ_UNIT,IS_AVAILABLE, LSUBMODEL, UNITAB)
+        REF_LEN = ONE*REF_SIZ_UNIT
+      ENDIF
+
+!
+      IF(PTHCKF==0) PTHCKF=1.0
+      PTHCKF = MIN(PTHCKF,ONE)
+      PTHCKF = MAX(PTHCKF,ZERO)
+      IF(DAM_SF==0) DAM_SF=1.0
+      IF(MAX_DAM==0) MAX_DAM=1.0
+      MAX_DAM = MIN(MAX_DAM,ONE)
+      MAX_DAM = MAX(MAX_DAM,ZERO)
+      IF(INST==1 .AND. N_VAL==ZERO) THEN
+        N_VAL = 0.25
+      ENDIF
+      IF(SOFTEXP==0) SOFTEXP=1
+      SOFTEXP = MAX(EM06,SOFTEXP)
+!
+      UPARAM(1) = C1
+      UPARAM(2) = C2
+      UPARAM(3) = C3
+      UPARAM(4) = C4
+      UPARAM(5) = C5
+      UPARAM(6) = C6
+      UPARAM(7) = EPSMIN
+      UPARAM(8) = PTHCKF
+      UPARAM(9) = STRAIN2DAM
+      UPARAM(10) = DAM_SF
+      UPARAM(11) = MAX_DAM
+      UPARAM(12) = INST
+      UPARAM(13) = N_VAL
+      UPARAM(14) = SOFTEXP
+      UPARAM(15) = REF_LEN
+      IFUNC(1) = REG_FUNC
+      NUPARAM = 15
+      NFUNC = 1
+      IF (REG_FUNC == 0) THEN
+        NUVAR = 4
+      ELSE
+        NUVAR = 5
+      ENDIF
+
+C----
+      IF (IS_ENCRYPTED) THEN
+        WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
+      ELSE
+        WRITE(IOUT,1000)C1,C2,C3,C4,C5,C6,EPSMIN,PTHCKF,REF_LEN,REG_FUNC
+        WRITE(IOUT,1100)STRAIN2DAM,DAM_SF,MAX_DAM
+        WRITE(IOUT,1200)INST,N_VAL,SOFTEXP
+      ENDIF
+C---
+C
+ 1000 FORMAT(
+     & 5X,40H  SYAZWAN DAMAGE PARAMETER              ,/,
+     & 5X,40H  -----------------------------         ,/,
+     & 5X,'FIRST FAILURE PARAMETER (C1).. . . . . =',E12.4/
+     & 5X,'SECOND FAILURE PARAMETER(C2). . . . . .=',E12.4/
+     & 5X,'THIRD FAILURE PARAMETER (C3). . . . . .=',E12.4/
+     & 5X,'FORTH FAILURE PARAMETER (C4). . . . . .=',E12.4/
+     & 5X,'FIFTH FAILURE PARAMETER (C5). . . . . .=',E12.4/
+     & 5X,'SIXTH FAILURE PARAMETER (C6). . . . . .=',E12.4/
+     & 5X,'MIN PLASTIC STRAIN (EPSMIN).  . . . . .=',E12.4/
+     & 5X,'PERCENTAGE OF LAYER FAILURE (PTHCKF). .=',E12.4/
+     & 5X,'REFERENCE ELEMENT LENGTH. . . . . . . .=',E12.4/
+     & 5X,'REGULARIZATION FUNCTION ID. . . . . . .=',I10/)
+C-----------
+ 1100 FORMAT(
+     & 5X,'STRAIN TO DAMAGE CALCULATION FLAG . . .=',I10/
+     & 5X,'DAMAGE SCALE FACTOR . . . . . . . . . .=',E12.4/
+     & 5X,'MAXIMUM ALLOWABLE DAMAGE. . . . . . . .=',E12.4/)
+C-----------
+ 1200 FORMAT(
+     & 5X,'INSTABILITY FLAG. . . . . . . . . . . .=',I10/
+     & 5X,'N VALUE . . . . . . . . . . . . . . . .=',E12.4/
+     & 5X,'STRESS SOFTENING EXPONENT . . . . . . .=',E12.4/)
+
+      RETURN
+      END
+


### PR DESCRIPTION
Added /FAIL/SYAZWAN, using ID 99. Currently available for shell element only.
1. Added features to initialize damage value from strain histories
2. Implementation of failure model based on failure surface equation
3. Mesh regularization function
4. Added option for instability based on Swift Instability theory (using n-value)

Comparison of damage value from complete simulation against the initialized value
![image](https://user-images.githubusercontent.com/113438036/198703776-84a812ff-9f5a-4aef-b4bf-5a8065ed5f71.png)

