### PR TITLE
Fix element size regularization with Ishell 1 2 3 4

### DIFF
--- a/engine/source/elements/shell/coque/cforc3.F
+++ b/engine/source/elements/shell/coque/cforc3.F
@@ -388,7 +388,7 @@ C
      8            SRH1   ,SRH2   ,SRH3     ,IGEO    ,
      9            A11R    ,ISUBSTACK      ,STACK%PM )
 C
-      IF ((NODADT == 0 .AND. ISMSTR /= 3 .AND. IDT1SH == 0) .OR.
+      IF ((ISMSTR /= 3 .AND. IDT1SH == 0) .OR.
      .     IDTMIN(3) /= 0 .OR. IGTYP == 16.OR.IDT_THERM == 1) THEN
 C      CDTLEN must be always called for tissue property/law for time step correction
        CALL CDLEN3(JFT     ,JLT     ,PM      ,OFF     ,AREA,


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

ALDT table is not computed with using Ishell = 1,2,3,4 and /DT/NODA. However, it is needed for some material laws and failure criteria. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

After debugging with Qiang, a condition "NODADT == 0"  was removed to fix the problem. 

