### PR TITLE
replace internal scratch files with real files

### DIFF
--- a/engine/share/modules/scratchfiles_mod.F
+++ b/engine/share/modules/scratchfiles_mod.F
@@ -1,0 +1,39 @@
+Copyright>        OpenRadioss
+Copyright>        Copyright (C) 1986-2022 Altair Engineering Inc.
+Copyright>    
+Copyright>        This program is free software: you can redistribute it and/or modify
+Copyright>        it under the terms of the GNU Affero General Public License as published by
+Copyright>        the Free Software Foundation, either version 3 of the License, or
+Copyright>        (at your option) any later version.
+Copyright>    
+Copyright>        This program is distributed in the hope that it will be useful,
+Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+Copyright>        GNU Affero General Public License for more details.
+Copyright>    
+Copyright>        You should have received a copy of the GNU Affero General Public License
+Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+Copyright>    
+Copyright>    
+Copyright>        Commercial Alternative: Altair Radioss Software 
+Copyright>    
+Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss 
+Copyright>        software under a commercial license.  Contact Altair to discuss further if the 
+Copyright>        commercial version may interest you: https://www.altair.com/radioss/.    
+Chd|====================================================================
+Chd|  SEATBELT_MOD                  modules/seatbelt_mod.F        
+Chd|-- called by -----------
+Chd|-- calls ---------------
+Chd|====================================================================
+Chd| Module to share Scratchfile names among the Solver.
+Chr|           scratchfile names are opened in 
+Chd|           Radioss2.F & closed in arret
+Chd|====================================================================
+      MODULE SCRATCHFILE_MOD
+
+      CHARACTER(LEN=256) :: IINFNA,IUSC4_FNAM,IUSC2_FNAM,
+     *                      IFXS_FN,IFXM_FN,IEIGM_FN
+      INTEGER LEN_IINFNA,LEN_IUSC4_FNAM,LEN_IFXS_FN,LEN_IFXM_FN,
+     *        LEN_IEIGM_FN
+
+      END MODULE SCRATCHFILE_MOD 

--- a/engine/source/engine/radioss2.F
+++ b/engine/source/engine/radioss2.F
@@ -183,6 +183,7 @@ C-----------------------------------------------
       USE LINEAR_SOLVER_MOD
       USE MDS_RESTART_MOD
       USE SEGVAR_MOD
+      USE SCRATCHFILE_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -289,6 +290,11 @@ C-----------------------------------------------
      .          CHR_OLD*2,FNAME*2048,IOFF1*3,IOFF2*3,IOFF3*3
       CHARACTER*2048 INAME
       CHARACTER*4 PROCNAM,CHRU_M1
+
+      CHARACTER*10 CPID
+      CHARACTER*6 CISPMD
+      INTEGER MY_PID
+
       CHARACTER ABC(26)*1, FILNAMTH*100, FILTH*3, LINE*256,
      .          FILNAMABF*100,FILNAMABF_TMP*100
       DATA ABC/'a','b','c','d','e','f','g','h','i','j','k','l','m','n',
@@ -504,6 +510,9 @@ C------------------------------------------------------------------
       IUTITLHI(8)=117
       IUTITLHI(9)=118
 C--------------------------------------------------
+C Initialize ProcessID variable for scratch filesqq
+      CALL MY_GETPID(MY_PID)
+C--------------------------------------------------
 C Radioss userlibraries initialization
 C--------------------------------------------------
         IF(GOT_USERL_ALTNAME==1)THEN
@@ -620,18 +629,21 @@ C--------------------------------------------------
       HVISC=HALF
       HVLIN=ZERO
 C--------------------------------------------------
-      OPEN(UNIT=IIN,FORM='FORMATTED',STATUS='SCRATCH')
+      WRITE(CPID,'(I10.10)') MY_PID
+      WRITE(CISPMD,'(I6.6)') ISPMD
+      IINFNA='8_'//ROOTN(1:LENROOTN)//'_'//CPID//'_'//CISPMD//'.tmp'
+      OPEN(UNIT=IIN,FORM='FORMATTED',FILE=TRIM(IINFNA))   ! Create tempo file
 
       IF ( GOT_INPUT == 0)THEN
        IF (ISPMD/=0) THEN
 C redirect IOUT to tmp file  fichier temporaire when SPMD on pi <> 0
          IOUT = IUSC4
-         OPEN(UNIT=IOUT,ACCESS='SEQUENTIAL',
-     .       FORM='FORMATTED',STATUS='SCRATCH')
+         IUSC4_FNAM='70_'//ROOTN(1:LENROOTN)//'_'//CPID//'_'//CISPMD//'.tmp'
+         LEN_IUSC4_FNAM=LEN_TRIM(IUSC4_FNAM)
+         OPEN(UNIT=IOUT,ACCESS='SEQUENTIAL',FORM='FORMATTED',FILE=TRIM(IUSC4_FNAM) )
 
          WRITE(UNIT=IOUT,IOSTAT=IOS,FMT='(A)')
-         OPEN(UNIT=ISTDI,FORM='FORMATTED',FILE=INPUTNAM,
-     .       STATUS='OLD',IOSTAT=IO_ERR)
+         OPEN(UNIT=ISTDI,FORM='FORMATTED',FILE=INPUTNAM,STATUS='OLD',IOSTAT=IO_ERR)
          IF (IO_ERR/=0) THEN
            CALL ANCMSG(MSGID=145,ANMODE=ANINFO,
      .            C1=INPUTNAM)
@@ -641,8 +653,10 @@ C redirect IOUT to tmp file  fichier temporaire when SPMD on pi <> 0
       ELSE
        IF (ISPMD/=0) THEN
          IOUT = IUSC4
-         OPEN(UNIT=IOUT,ACCESS='SEQUENTIAL',
-     .       FORM='FORMATTED',STATUS='SCRATCH')
+         IUSC4_FNAM='70_'//ROOTN(1:LENROOTN)//'_'//CPID//'_'//CISPMD//'.tmp'
+         LEN_IUSC4_FNAM=LEN_TRIM(IUSC4_FNAM)
+         OPEN(UNIT=IOUT,ACCESS='SEQUENTIAL',FORM='FORMATTED',FILE=TRIM(IUSC4_FNAM))
+
          WRITE(UNIT=IOUT,IOSTAT=IOS,FMT='(A)')
        ENDIF
       ENDIF
@@ -760,9 +774,7 @@ C       Create info, hist, monitor, progress and tpl files for writing implicit 
             LEN_TMP_NAME = OUTFILE_NAME_LEN+ROOTLEN+9
             TMP_NAME=OUTFILE_NAME(1:OUTFILE_NAME_LEN)//FILNAM(1:ROOTLEN+9)
             INPUTNAM='CHECK_DATA'
-            OPEN(UNIT=IOUT,FILE=TMP_NAME(1:LEN_TMP_NAME),
-     .       ACCESS='SEQUENTIAL',
-     .       FORM='FORMATTED',STATUS='UNKNOWN')
+            OPEN(UNIT=IOUT,FILE=TMP_NAME(1:LEN_TMP_NAME),ACCESS='SEQUENTIAL',FORM='FORMATTED',STATUS='UNKNOWN')
 
              IO_ERRL=0
             DO WHILE (IO_ERRL>=0)
@@ -771,13 +783,11 @@ C       Create info, hist, monitor, progress and tpl files for writing implicit 
  1000      BACKSPACE(IOUT)
            WRITE(IOUT,'(1X,A)')FILNAM(1:ROOTLEN+9)
            WRITE(PROCNAM,'(I4.4)')ISPMD
-           FILNAM =ROOTNAM(1:ROOTLEN)
-     .                  //'_'//CHRUN//'_'//PROCNAM//'.rst'
+           FILNAM =ROOTNAM(1:ROOTLEN)//'_'//CHRUN//'_'//PROCNAM//'.rst'
            LEN = ROOTLEN + 14
          ENDIF
          WRITE(PROCNAM,'(I4.4)')ISPMD+1
-         FILNAM =ROOTNAM(1:ROOTLEN)
-     .               //'_'//CHRUN//'_'//PROCNAM//'.rst'
+         FILNAM =ROOTNAM(1:ROOTLEN)//'_'//CHRUN//'_'//PROCNAM//'.rst'
          LEN = ROOTLEN + 14
         ELSE
          IF (ISPMD==0) THEN
@@ -885,6 +895,7 @@ C end init rdresa after call xtime0
 
       CALL INIPAR(ITID,3,NNODES,INPUTNAM,GOT_INPUT,NBTASK)
       IF(ISPMD==0) THEN
+
        WRITE(IOUT, '(1X,A,I5)')'NUMBER OF SPMD DOMAINS       ',
      .                           NSPMD
        IF(NBTASK(NSPMD+1) == NSPMD*NTHREAD)THEN
@@ -1541,7 +1552,13 @@ C------------------------------------------------
      F              IGRPART,TAG_SKINS6,ICFIELD,LCFIELD,TAGSLV_RBY,
      G              IPART_DYNAIN,MDS_LABEL,MDS_OUTPUT_TABLE,MDS_NMAT,
      H              MAX_DEPVAR,MDS_NDEPSVAR,STACK,IBCL,ILOADP,LLOADP)
-       CLOSE (UNIT=IIN)
+
+C------------------------------------------------
+C Close & Delete scratch file
+      CLOSE (UNIT=IIN)
+      LEN_IINFNA=LEN_TRIM(IINFNA)
+      CALL DELETE_USER_FILE(IINFNA,LEN_IINFNA)
+C------------------------------------------------
       CALL TRACE_OUT(16)
 C------------------------------------------------
       CALL TRACE_IN(19,0,ZERO)

--- a/engine/source/input/freform.F
+++ b/engine/source/input/freform.F
@@ -181,6 +181,13 @@ C-----------------------------------------------
       INTEGER :: NUM_ALE_KEY2, INUM
       LOGICAL :: lFOUND
 C-----------------------------------------------
+      INTEGER MY_PID,LEN_IUSC1_FN,LEN_IUSC2_FN,LEN_IUSCTMP_FN
+      CHARACTER(LEN=10) :: CPID
+      CHARACTER(LEN=6) :: CISPMD
+      CHARACTER(LEN=256) :: IUSC1_FN,IUSC2_FN,IUSCTMP_FN
+      
+
+C-----------------------------------------------
 C   E x t e r n a l   F u n c t i o n s
 C-----------------------------------------------
       INTEGER NVAR,INTDT
@@ -239,12 +246,23 @@ C------------------------------------------------------------------
       KEY2=" "
       KEY3=" "
       KEY4=" "
+      
+      CALL MY_GETPID(MY_PID)
+      WRITE(CPID,'(I10.10)') MY_PID
+      WRITE(CISPMD,'(I6.6)') ISPMD
 
-      OPEN(UNIT=IUSC1,FORM='FORMATTED',ACCESS='DIRECT',RECL=120,STATUS='SCRATCH')
-      OPEN(UNIT=IUSC2,FORM='FORMATTED',STATUS='SCRATCH')
+      IUSC1_FN='9_'//ROOTN(1:LENROOTN)//'_'//CPID//'_'//CISPMD//'.tmp'
+      IUSC2_FN='30_'//ROOTN(1:LENROOTN)//'_'//CPID//'_'//CISPMD//'.tmp'
+      IUSCTMP_FN='60_'//ROOTN(1:LENROOTN)//'_'//CPID//'_'//CISPMD//'.tmp'
+      LEN_IUSC1_FN=LEN_TRIM(IUSC1_FN)
+      LEN_IUSC2_FN=LEN_TRIM(IUSC2_FN)
+      LEN_IUSCTMP_FN=LEN_TRIM(IUSCTMP_FN)
+      OPEN(UNIT=IUSC1,FORM='FORMATTED',ACCESS='DIRECT',RECL=120,FILE=TRIM(IUSC1_FN))
+      OPEN(UNIT=IUSC2,FORM='FORMATTED',FILE=TRIM(IUSC2_FN))
+
 C attention IBM/MPI ne supporte pas de REWIND sur STDIN !
       IUSC_TMP=60
-      OPEN(UNIT=IUSC_TMP,FORM='FORMATTED',STATUS='SCRATCH')
+      OPEN(UNIT=IUSC_TMP,FORM='FORMATTED',FILE=TRIM(IUSCTMP_FN))
 C
       ROOTNAM=' '
       ROOTLEN = 0
@@ -452,6 +470,7 @@ C
       ENDDO
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7--
         CLOSE(UNIT=IUSC_TMP)
+        CALL DELETE_USER_FILE(IUSCTMP_FN,LEN_IUSCTMP_FN)
         ISTDI = 5
        IF (GOT_INPUT==1) THEN
         ISTDI=80
@@ -2619,8 +2638,11 @@ c autoselect of files format
       ENDDO
 C========================================================================
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7--
-      CLOSE (UNIT=IUSC1)
-      CLOSE (UNIT=IUSC2)
+      CLOSE(UNIT=IUSC1)
+      CLOSE(UNIT=IUSC2)
+      CALL DELETE_USER_FILE(IUSC1_FN,LEN_IUSC1_FN)
+      CALL DELETE_USER_FILE(IUSC2_FN,LEN_IUSC2_FN)
+
       IF(IERR==0) RETURN
       CALL ARRET(0)
 C

--- a/engine/source/output/restart/rdresb.F
+++ b/engine/source/output/restart/rdresb.F
@@ -1371,6 +1371,7 @@ Chd|====================================================================
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
+      USE SCRATCHFILE_MOD
       USE FXB_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
@@ -1383,6 +1384,8 @@ C-----------------------------------------------
 #include      "scr05_c.inc"
 #include      "units_c.inc"
 #include      "fxbcom.inc"
+#include      "chara_c.inc"
+#include      "task_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
@@ -1393,6 +1396,9 @@ C-----------------------------------------------
      .        IRCS, IRCS0, IRCS1, LREC, I, J, RCLEN
       my_real
      .        VV(6)
+      INTEGER MY_PID
+      CHARACTER(LEN=10) :: CPID
+      CHARACTER(LEN=6) :: CISPMD
 C--------------------------------------
 C     READING INTEGERS
 C--------------------------------------
@@ -1443,10 +1449,17 @@ C--------------------------------------
       ENDIF
 C Lecture des fichiers de modes et de contraintes
       INQUIRE(IOLENGTH=RCLEN) VV
-      OPEN(UNIT=IFXM,STATUS='SCRATCH',
-     .     ACCESS='DIRECT',RECL=RCLEN)
-      OPEN(UNIT=IFXS,STATUS='SCRATCH',
-     .     ACCESS='DIRECT',RECL=RCLEN)
+
+      CALL MY_GETPID(MY_PID)
+      WRITE(CPID,'(I10.10)') MY_PID
+      WRITE(CISPMD,'(I6.6)') ISPMD
+      IFXM_FN='25_'//ROOTN(1:LENROOTN)//'_'//CPID//'_'//CISPMD//'.tmp'
+      IFXS_FN='26_'//ROOTN(1:LENROOTN)//'_'//CPID//'_'//CISPMD//'.tmp'
+      LEN_IFXM_FN=LEN_TRIM(IFXM_FN)
+      LEN_IFXS_FN=LEN_TRIM(IFXS_FN)
+
+      OPEN(UNIT=IFXM,FILE=TRIM(IFXM_FN),ACCESS='DIRECT',RECL=RCLEN)
+      OPEN(UNIT=IFXS,FILE=TRIM(IFXS_FN),ACCESS='DIRECT',RECL=RCLEN)
       NRECM=0
       NRECS=0
       DO I=1,NFXBODY
@@ -1489,6 +1502,7 @@ C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE EIG_MOD
+      USE SCRATCHFILE_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -1500,6 +1514,8 @@ C-----------------------------------------------
 #include      "com04_c.inc"
 #include      "scr05_c.inc"
 #include      "eigcom.inc"
+#include      "chara_c.inc"
+#include      "task_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
@@ -1509,6 +1525,9 @@ C-----------------------------------------------
       INTEGER NRECM, IRCM, NBN, NBM, IAD, LREC, I, J, RCLEN
       my_real
      .        VV(6)
+      CHARACTER(LEN=10) :: CPID
+      CHARACTER(LEN=6) :: CISPMD
+      INTEGER MY_PID
 C--------------------------------------
 C     READING INTEGERS
 C--------------------------------------
@@ -1529,8 +1548,14 @@ C--------------------------------------
       ENDIF
 C Lecture du fichier de modes additionnels
       INQUIRE(IOLENGTH=RCLEN) VV
-      OPEN(UNIT=IEIGM,STATUS='SCRATCH',
-     .     ACCESS='DIRECT',RECL=RCLEN)
+
+      CALL MY_GETPID(MY_PID)
+      WRITE(CPID,'(I10.10)') MY_PID
+      WRITE(CISPMD,'(I6.6)') ISPMD
+      IEIGM_FN='27_'//ROOTN(1:LENROOTN)//'_'//CPID//'_'//CISPMD//'.tmp'
+      LEN_IEIGM_FN=LEN_TRIM(IEIGM_FN)
+      OPEN(UNIT=IEIGM,FILE=TRIM(IEIGM_FN),ACCESS='DIRECT',RECL=RCLEN)
+
       NRECM=0
       DO I=1,NEIG
          NBN=EIGIPM(10,I)

--- a/engine/source/output/restart/wrrest.F
+++ b/engine/source/output/restart/wrrest.F
@@ -37,6 +37,7 @@ C-----------------------------------------------
 C   M o d u l e s
 C----------------------------------------------- 
       USE FXB_MOD
+      USE SCRATCHFILE_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -62,51 +63,30 @@ C--------------------------------------
 C     ECRITURE DES ENTIERS
 C--------------------------------------
       LEN_IPM=NBIPM*NFXBODY
-      IF (IRFORM/5<=1) THEN
-        CALL WRTSQI (FXBIPM,LEN_IPM,IRFORM)
-        IF (LENNOD>0) CALL WRTSQI (FXBNOD,LENNOD,IRFORM)
-        IF (LENELM>0) CALL WRTSQI (FXBELM,LENELM,IRFORM)
-        IF (LENGRVI>0) CALL WRTSQI (FXBGRVI,LENGRVI,IRFORM)
-      ELSE
-        CALL WRITE_I_C(FXBIPM,LEN_IPM)
-        IF (LENNOD>0) CALL WRITE_I_C(FXBNOD,LENNOD)
-        IF (LENELM>0) CALL WRITE_I_C(FXBELM,LENELM)
-        IF (LENGRVI>0) CALL WRITE_I_C(FXBGRVI,LENGRVI)
-      ENDIF
+      CALL WRITE_I_C(FXBIPM,LEN_IPM)
+      IF (LENNOD>0) CALL WRITE_I_C(FXBNOD,LENNOD)
+      IF (LENELM>0) CALL WRITE_I_C(FXBELM,LENELM)
+      IF (LENGRVI>0) CALL WRITE_I_C(FXBGRVI,LENGRVI)
 C--------------------------------------
 C     ECRITURE DES REELS
 C--------------------------------------
       LEN_MOD=LENMOD*6
-      IF (IRFORM/5<=1) THEN
-        IF (LEN_MOD>0) CALL WRTSQR (FXBMOD,LEN_MOD,IRFORM)
-        IF (LENGLM>0) CALL WRTSQR (FXBGLM,LENGLM,IRFORM)
-        IF (LENCP>0) CALL WRTSQR (FXBCPM,LENCP ,IRFORM)
-        IF (LENCP>0) CALL WRTSQR (FXBCPS,LENCP ,IRFORM)
-        IF (LENLM>0) CALL WRTSQR (FXBLM, LENLM ,IRFORM)
-        IF (LENFLS>0) CALL WRTSQR (FXBFLS,LENFLS,IRFORM)
-        IF (LENDLS>0) CALL WRTSQR (FXBDLS,LENDLS,IRFORM)
-        CALL WRTSQR (FXBDEP,LENVAR,IRFORM)
-        CALL WRTSQR (FXBVIT,LENVAR,IRFORM)
-        CALL WRTSQR (FXBACC,LENVAR,IRFORM)
-        CALL WRTSQR (FXBRPM,LENRPM,IRFORM)
-        IF (LENSIG>0) CALL WRTSQR (FXBSIG,LENSIG,IRFORM)
-        IF (LENGRVR>0) CALL WRTSQR (FXBGRVR,LENGRVR,IRFORM)
-      ELSE
-        IF (LEN_MOD>0) CALL WRITE_DB(FXBMOD,LEN_MOD)
-        IF (LENGLM>0) CALL WRITE_DB(FXBGLM,LENGLM)
-        IF (LENCP>0) CALL WRITE_DB(FXBCPM,LENCP )
-        IF (LENCP>0) CALL WRITE_DB(FXBCPS,LENCP )
-        IF (LENLM>0) CALL WRITE_DB(FXBLM, LENLM )
-        IF (LENFLS>0) CALL WRITE_DB(FXBFLS,LENFLS)
-        IF (LENDLS>0) CALL WRITE_DB(FXBDLS,LENDLS)
-        CALL WRITE_DB(FXBDEP,LENVAR)
-        CALL WRITE_DB(FXBVIT,LENVAR)
-        CALL WRITE_DB(FXBACC,LENVAR)
-        CALL WRITE_DB(FXBRPM,LENRPM)
-        IF (LENSIG>0) CALL WRITE_DB(FXBSIG,LENSIG)
-        IF (LENGRVR>0) CALL WRITE_DB(FXBGRVR,LENGRVR)
-      ENDIF
-C Ecriture des fichiers de modes et de contraintes
+      IF (LEN_MOD>0) CALL WRITE_DB(FXBMOD,LEN_MOD)
+      IF (LENGLM>0) CALL WRITE_DB(FXBGLM,LENGLM)
+      IF (LENCP>0) CALL WRITE_DB(FXBCPM,LENCP )
+      IF (LENCP>0) CALL WRITE_DB(FXBCPS,LENCP )
+      IF (LENLM>0) CALL WRITE_DB(FXBLM, LENLM )
+      IF (LENFLS>0) CALL WRITE_DB(FXBFLS,LENFLS)
+      IF (LENDLS>0) CALL WRITE_DB(FXBDLS,LENDLS)
+      CALL WRITE_DB(FXBDEP,LENVAR)
+      CALL WRITE_DB(FXBVIT,LENVAR)
+      CALL WRITE_DB(FXBACC,LENVAR)
+      CALL WRITE_DB(FXBRPM,LENRPM)
+      IF (LENSIG>0) CALL WRITE_DB(FXBSIG,LENSIG)
+      IF (LENGRVR>0) CALL WRITE_DB(FXBGRVR,LENGRVR)
+      
+C Write modes & constraint files in Restart
+C -----------------------------------------
       NRECM=0
       NRECS=0
       DO I=1,NFXBODY
@@ -131,6 +111,11 @@ C Ecriture des fichiers de modes et de contraintes
          CALL WRITE_DB(VV,LREC)
       ENDDO
 C
+      ClOSE(UNIT=IFXM)
+      CLOSE(UNIT=IFXS)
+      CALL DELETE_USER_FILE(IFXS_FN,LEN_IFXS_FN)
+      CALL DELETE_USER_FILE(IFXM_FN,LEN_IFXM_FN)
+
       RETURN
       END
 Chd|====================================================================
@@ -143,6 +128,10 @@ Chd|        WRTSQI                        source/output/tools/wrtsqi.F
 Chd|        WRTSQR                        source/output/tools/wrtsqr.F  
 Chd|====================================================================
       SUBROUTINE EIGWREST(EIGIPM, EIGIBUF, EIGRPM)      
+C-----------------------------------------------
+C   M o d u l e s
+C-----------------------------------------------
+      USE SCRATCHFILE_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -202,6 +191,7 @@ C
          CALL WRITE_DB(VV,LREC)
       ENDDO
       CLOSE(IEIGM)
+      CALL DELETE_USER_FILE(IEIGM_FN,LEN_IEIGM_FN)
 C
       RETURN
       END

--- a/engine/source/system/arret.F
+++ b/engine/source/system/arret.F
@@ -430,6 +430,7 @@ Chd|====================================================================
       USE INOUTFILE_MOD
       USE QA_OUT_MOD
       USE DYNLIB_MOD
+      USE SCRATCHFILE_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -615,6 +616,10 @@ C
               ENDIF
 
               CLOSE(UNIT=IOUT)
+              IF(ISPMD /=0) THEN
+                 CALL DELETE_USER_FILE(IUSC4_FNAM,LEN_IUSC4_FNAM)
+              ENDIF
+
               CLOSE(UNIT=IUHIS)
               CALL MY_EXIT(0)
  
@@ -648,6 +653,10 @@ C
               ENDIF
 
               CLOSE(UNIT=IOUT)
+              IF(ISPMD /=0) THEN
+                 CALL DELETE_USER_FILE(IUSC4_FNAM,LEN_IUSC4_FNAM)
+              ENDIF
+
               CLOSE(UNIT=IUHIS)
 
               CALL MY_EXIT(0)


### PR DESCRIPTION
Engine use internal Scratch files to parse input Deck & some options use some as well.
It is cleaner to use Real files and delete them after usage. 
Files are named now with deck Rootname + ProcessID + MPI Rank 
to avoid 2 MPI ranks have same file name.

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->


