### PR TITLE
 Missing include in timediff

### DIFF
--- a/starter/source/system/timediff.c
+++ b/starter/source/system/timediff.c
@@ -25,6 +25,12 @@
 #include <time.h>
 #define _FCALL
 
+#ifdef _WIN64
+    #include <memory.h>
+#else
+    #include <string.h>
+#endif
+
 void strptime_impl(char* date, struct tm *tm);
 /* ------------------------------------------------------------
    time_difference : get the difference between 2 dates in UTC


### PR DESCRIPTION
memset call int timediff.c needs an include : memset.h under Windows & string.h under Linux.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->


