### PR TITLE
consisting FLD output (H3D)

### DIFF
--- a/engine/source/materials/mat_share/mulaw.F
+++ b/engine/source/materials/mat_share/mulaw.F
@@ -1873,13 +1873,8 @@ C   user3
                 CALL ARRET(2)
               ! ----------------
             ENDIF
-          ELSEIF (IRUPT == 7) THEN                                        
-                  CALL FAIL_FLD_TSH(
-     1            NEL       ,NPAR      ,NVARF     ,NFUNC    ,IFUNC      ,
-     2            NPF       ,TF        ,TT        ,DT1      ,UPARAMF,   
-     3            UVARF     ,NGL       ,IPG       ,ILAY     ,IPTT         ,
-     5            ES1       ,ES2       ,ES4       ,ES5      ,ES6          ,
-     6            OFF       ,FOFF      ,FLD_IDX   ,DAM      ,DFMAX     )
+          ELSEIF (IRUPT == 7) THEN  
+C----- removed to ouput (H3D)          
           ELSEIF (IRUPT == 8) THEN                                         
 C---- Johnson cook + spalling          
               CALL FAIL_SPALLING_S(NEL ,NPAR,NVARF,NFUNC,IFUNC,

--- a/engine/source/output/h3d/h3d_results/h3d_fld_strain.F
+++ b/engine/source/output/h3d/h3d_results/h3d_fld_strain.F
@@ -1,0 +1,129 @@
+Copyright>        OpenRadioss
+Copyright>        Copyright (C) 1986-2022 Altair Engineering Inc.
+Copyright>    
+Copyright>        This program is free software: you can redistribute it and/or modify
+Copyright>        it under the terms of the GNU Affero General Public License as published by
+Copyright>        the Free Software Foundation, either version 3 of the License, or
+Copyright>        (at your option) any later version.
+Copyright>    
+Copyright>        This program is distributed in the hope that it will be useful,
+Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+Copyright>        GNU Affero General Public License for more details.
+Copyright>    
+Copyright>        You should have received a copy of the GNU Affero General Public License
+Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+Copyright>    
+Copyright>    
+Copyright>        Commercial Alternative: Altair Radioss Software 
+Copyright>    
+Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss 
+Copyright>        software under a commercial license.  Contact Altair to discuss further if the 
+Copyright>        commercial version may interest you: https://www.altair.com/radioss/.    
+C
+Chd|====================================================================
+      SUBROUTINE H3D_FLD_STRAIN(ELBUF_TAB,X  ,IXS   ,
+     .                          JHBE,MLWI,ILAY,KCVT,IOR_TSH,
+     .                          ICSTR,NPTR,NPTS,NEL,F_EXP,EVAR )
+C-----------------------------------------------
+C   M o d u l e s
+C-----------------------------------------------
+      USE ELBUFDEF_MOD    
+C-----------------------------------------------
+C   I m p l i c i t   T y p e s
+C-----------------------------------------------
+#include      "implicit_f.inc"
+C-----------------------------------------------
+C   C o m m o n   B l o c k s
+C-----------------------------------------------
+#include      "mvsiz_p.inc"
+#include      "param_c.inc"
+#include      "com04_c.inc"
+C-----------------------------------------------
+C   D u m m y   A r g u m e n t s
+C-----------------------------------------------
+      INTEGER , INTENT(IN) :: JHBE,ILAY,MLWI,KCVT,IOR_TSH,
+     .                        NPTR,NPTS,ICSTR,NEL 
+      INTEGER ,DIMENSION(NIXS,NUMELS), INTENT(IN) ::  IXS
+      my_real , INTENT(IN) ::  F_EXP
+      my_real ,DIMENSION(3,MVSIZ), INTENT(OUT) ::  EVAR
+      my_real ,DIMENSION(3,NUMNOD), INTENT(IN) ::  X
+      TYPE (ELBUF_STRUCT_), TARGET :: ELBUF_TAB
+C-----------------------------------------------
+C   L o c a l   V a r i a b l e s
+C----------------------------------------------- 
+      my_real
+     .   DIR(MVSIZ,2),DIRB(MVSIZ,2)
+      INTEGER I,I1,II,J,IR,IS,IT,IL,JJ(4)
+
+      TYPE(G_BUFEL_)  ,POINTER :: GBUF     
+      TYPE(L_BUFEL_)  ,POINTER :: LBUF     
+C----------------------------------------------- 
+       EVAR(1:3,1:NEL) = ZERO
+       IT = 1
+       DO I=1,4
+         JJ(I) = NEL*(I-1)
+       ENDDO
+        GBUF => ELBUF_TAB%GBUF
+        IF (JHBE==15) THEN
+           IR = 1
+           IS = 1
+           LBUF => ELBUF_TAB%BUFLY(ILAY)%LBUF(IR,IS,IT)
+            IF (MLWI == 12 .OR. MLWI == 14) THEN
+              DO I=1,NEL						   
+               EVAR(1:2,I) = LBUF%EPE(JJ(1:2) + I)       
+               EVAR(3,I)   = HALF*LBUF%EPE(JJ(4) + I)
+              ENDDO						       
+            ELSEIF (MLWI /= 49 ) THEN                 
+              DO I=1,NEL						   
+               EVAR(1:2,I) = LBUF%STRA(JJ(1:2) + I)       
+               EVAR(3,I)   = HALF*LBUF%STRA(JJ(4) + I)
+              ENDDO						       
+            END IF               
+C------      
+        ELSE ! 14,16
+          IF (MLWI == 12 .OR. MLWI == 14) THEN
+            DO IR=1,NPTR
+              DO IS=1,NPTS
+                 LBUF => ELBUF_TAB%BUFLY(ILAY)%LBUF(IR,IS,IT)         
+                 DO I=1,NEL						   
+                  EVAR(1:2,I) = EVAR(1:2,I)+LBUF%EPE(JJ(1:2) + I)       
+                  EVAR(3,I)   = EVAR(3,I)+HALF*LBUF%EPE(JJ(4) + I)
+                 ENDDO						       
+              END DO 
+            END DO 
+          ELSEIF (MLWI /= 49 ) THEN                 
+            DO IR=1,NPTR
+              DO IS=1,NPTS
+                 LBUF => ELBUF_TAB%BUFLY(ILAY)%LBUF(IR,IS,IT)         
+                 DO I=1,NEL						   
+                  EVAR(1:2,I) = EVAR(1:2,I)+LBUF%STRA(JJ(1:2) + I)       
+                  EVAR(3,I)   = EVAR(3,I)+ HALF*LBUF%STRA(JJ(4) + I)
+                 ENDDO						       
+              ENDDO 
+            END DO 
+          END IF               
+        END IF               
+        EVAR(1:3,1:NEL) = F_EXP*EVAR(1:3,1:NEL)
+C------         
+        IF (KCVT==2) THEN
+           IF(IOR_TSH==1)THEN
+             DO I=1,NEL
+              DIR(I,1:2)= GBUF%GAMA(JJ(1:2) + I)
+             ENDDO
+           ELSEIF(IOR_TSH==2)THEN
+             IF(JHBE==14)THEN
+              IR = 1
+              IS = 1
+             END IF
+             LBUF => ELBUF_TAB%BUFLY(ILAY)%LBUF(IR,IS,IT)         
+             DO I=1,NEL
+              DIR(I,1:2)= LBUF%GAMA(JJ(1:2) + I)
+             ENDDO
+           END IF
+           CALL TSH_DIR2(X,IXS,DIR,DIRB,ICSTR,NEL)
+           CALL ROTO_SIG2D(1,NEL,EVAR,DIRB)
+        END IF !(KCVT==2) THEN
+C
+      RETURN
+      END SUBROUTINE H3D_FLD_STRAIN

--- a/engine/source/output/h3d/h3d_results/h3d_fld_tsh.F
+++ b/engine/source/output/h3d/h3d_results/h3d_fld_tsh.F
@@ -1,0 +1,100 @@
+Copyright>        OpenRadioss
+Copyright>        Copyright (C) 1986-2022 Altair Engineering Inc.
+Copyright>    
+Copyright>        This program is free software: you can redistribute it and/or modify
+Copyright>        it under the terms of the GNU Affero General Public License as published by
+Copyright>        the Free Software Foundation, either version 3 of the License, or
+Copyright>        (at your option) any later version.
+Copyright>    
+Copyright>        This program is distributed in the hope that it will be useful,
+Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+Copyright>        GNU Affero General Public License for more details.
+Copyright>    
+Copyright>        You should have received a copy of the GNU Affero General Public License
+Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+Copyright>    
+Copyright>    
+Copyright>        Commercial Alternative: Altair Radioss Software 
+Copyright>    
+Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss 
+Copyright>        software under a commercial license.  Contact Altair to discuss further if the 
+Copyright>        commercial version may interest you: https://www.altair.com/radioss/.    
+Chd|====================================================================
+      SUBROUTINE H3D_FLD_TSH(ELBUF_TAB,
+     .                       IR,IS,IT,ILAY,IFAIL,IP,MX,
+     .                       IPM,NPF,TF,BUFMAT,
+     .                       NGL,EVAR,NEL )
+C-----------------------------------------------
+C   M o d u l e s
+C-----------------------------------------------
+      USE ELBUFDEF_MOD    
+C-----------------------------------------------
+C   I m p l i c i t   T y p e s
+C-----------------------------------------------
+#include      "implicit_f.inc"
+C-----------------------------------------------
+C   C o m m o n   B l o c k s
+C-----------------------------------------------
+#include      "mvsiz_p.inc"
+#include      "com01_c.inc"
+#include      "com04_c.inc"
+#include      "com06_c.inc"
+#include      "com08_c.inc"
+#include      "param_c.inc"
+#include      "tabsiz_c.inc"
+C-----------------------------------------------
+C   D u m m y   A r g u m e n t s
+C-----------------------------------------------
+C-----------------------------------------------
+C   D u m m y   A r g u m e n t s
+C-----------------------------------------------
+      INTEGER , INTENT(IN) :: IR,IS,IT,ILAY,IFAIL,IP,MX,NEL 
+      INTEGER , DIMENSION(NEL), INTENT(IN) ::  NGL
+      my_real , DIMENSION(3,MVSIZ), INTENT(IN) ::  EVAR
+      my_real , DIMENSION(SBUFMAT), TARGET ::  BUFMAT
+      my_real , DIMENSION(STF), INTENT(IN) ::  TF
+      INTEGER , DIMENSION(SNPC), INTENT(IN) ::  NPF
+      INTEGER , DIMENSION(NPROPMI,NUMMAT), TARGET ::  IPM
+      TYPE (ELBUF_STRUCT_), TARGET :: ELBUF_TAB
+C-----------------------------------------------
+C   L o c a l   V a r i a b l e s
+C----------------------------------------------- 
+      INTEGER I,I1,II,J,IL
+      INTEGER NPAR,IADBUF,NFUNC,IPG,NVARF
+      INTEGER, DIMENSION(:) ,POINTER   :: FLD_IDX,FOFF,IFUNC
+      my_real, DIMENSION(:), POINTER   :: UPARAMF,UVARF,DFMAX,
+     .                                    TDEL,DAM
+      my_real, DIMENSION(NEL) :: ES1,ES2,ES4,ES5,ES6
+
+      TYPE(G_BUFEL_)  ,POINTER :: GBUF     
+      TYPE(L_BUFEL_)  ,POINTER :: LBUF     
+      TYPE(BUF_FAIL_) ,POINTER :: FBUF 
+C-----------------------------------------------
+        GBUF => ELBUF_TAB%GBUF
+        LBUF => ELBUF_TAB%BUFLY(ILAY)%LBUF(IR,IS,IT)                            
+        FBUF => ELBUF_TAB%BUFLY(ILAY)%FAIL(IR,IS,IT)                            
+        NPAR   = IPM(112+IP, MX)   
+        IADBUF = IPM(114+IP ,MX)
+        UPARAMF => BUFMAT(IADBUF:IADBUF+NPAR) 
+        NFUNC  = IPM(115+IP, MX)             
+        IFUNC  => IPM(115+IP+1:115+IP+NFUNC, MX)         
+        UVARF => FBUF%FLOC(IFAIL)%VAR  
+        NVARF  = FBUF%FLOC(IFAIL)%NVAR 
+        DFMAX => FBUF%FLOC(IFAIL)%DAMMX 
+        TDEL  => FBUF%FLOC(IFAIL)%TDEL   
+        FLD_IDX=> FBUF%FLOC(IFAIL)%INDX
+        FOFF   => FBUF%FLOC(IFAIL)%OFF
+        DAM    => FBUF%FLOC(IFAIL)%DAM
+        ES1(1:NEL) = EVAR(1,1:NEL)
+        ES2(1:NEL) = EVAR(2,1:NEL)
+        ES4(1:NEL) = EVAR(3,1:NEL)
+         CALL FAIL_FLD_TSH(
+     1            NEL       ,NPAR      ,NVARF     ,NFUNC    ,IFUNC      ,
+     2            NPF       ,TF        ,TT        ,DT1      ,UPARAMF,   
+     3            UVARF     ,NGL       ,IT        ,ILAY     ,IT         ,
+     5            ES1       ,ES2       ,ES4       ,ES5      ,ES6        ,
+     6            LBUF%OFF  ,FOFF      ,FLD_IDX   ,DAM      ,DFMAX     )
+C
+      RETURN
+      END SUBROUTINE H3D_FLD_TSH

--- a/engine/source/output/h3d/h3d_results/h3d_skin_scalar.F
+++ b/engine/source/output/h3d/h3d_results/h3d_skin_scalar.F
@@ -101,21 +101,27 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       my_real
-     .   VALUE(MVSIZ),RINDX
+     .   VALUE(MVSIZ),RINDX,STRAIN(3,MVSIZ),F_EXP,F_GAUSS(9)
       INTEGER I,I1,II,J,NG,NEL,NPTR,NPTS,NPTT,NLAY,L,IFAIL,ILAY,
      .        IR,IS,IT,IL,MLW, NUVAR,IUS,LENF,PTF,PTM,PTS,NFAIL,
      .        N,NN,K,K1,K2,JTURB,MT,IMID,IALEL,IPID,ISH3N,NNI,
      .        NN1,NN2,NN3,NN4,NN5,NN6,NN9,NF,BUF,NVARF,
      .        OFFSET,IHBE,NPTM,NPG, MPT,IPT,IADD,IADR,IPMAT,IFAILT,
      .        IIGEO,IADI,ISUBSTACK,ITHK,NB_PLYOFF,IUVAR,IDX,IPOS,ITRIMAT,
-     .        IALEFVM_FLG, IMAT,IADBUF,NUPARAM,IOK_PART(MVSIZ)
+     .        IALEFVM_FLG, IMAT,IADBUF,NUPARAM,IOK_PART(MVSIZ),
+     .        MLWI,PID,MID,IP,MX,KCVT,IOR_TSH,ICSTR
       INTEGER 
      .        IS_WRITTEN_VALUE(MVSIZ),NFRAC,IU(4),IV,NB_FACE,KFACE,NSKIN
+      INTEGER NGL(MVSIZ) 
       TYPE(G_BUFEL_)  ,POINTER :: GBUF     
       TYPE(L_BUFEL_)  ,POINTER :: LBUF  
       TYPE(BUF_MAT_)  ,POINTER :: MBUF      
       TYPE(BUF_LAY_)  ,POINTER :: BUFLY     
       TYPE(BUF_FAIL_) ,POINTER :: FBUF 
+      DATA F_GAUSS / 
+     9 1.000000000000000,1.732050807568877,1.290994448735806,
+     9 1.161256338324528,1.103533701926633,1.072421119155361,
+     9 1.053620970803647,1.041352247171806,1.032886870574820/
 C-----------------------------------------------
       NSKIN = 0
       IS_WRITTEN_SKIN(1:NUMSKIN) = 0
@@ -126,7 +132,7 @@ C
      2          MLW     ,NEL     ,NFT     ,IAD     ,ITY     ,  
      3          NPT     ,JALE    ,ISMSTR  ,JEUL    ,JTUR    ,  
      4          JTHE    ,JLAG    ,JMULT   ,JHBE    ,JIVF    ,  
-     5          NVAUX   ,JPOR    ,JCVT    ,JCLOSE  ,JPLASOL ,  
+     5          NVAUX   ,JPOR    ,KCVT    ,JCLOSE  ,JPLASOL ,  
      6          IREP    ,IINT    ,IGTYP   ,ISRAT   ,ISROT   ,  
      7          ICSEN   ,ISORTH  ,ISORTHG ,IFAILURE,JSMS    )
 C     
@@ -143,11 +149,19 @@ C-----------------------------------------------
 !              1--------------2
         IF (ITY == 1.AND.(IGTYP==20 .OR. IGTYP==21 .OR. IGTYP==22)) THEN
           NFT = IPARG(3,NG)
+          ICSTR = IPARG(17,NG)
           LLT=NEL
           NLAY = ELBUF_TAB(NG)%NLAY                
           NPTR = ELBUF_TAB(NG)%NPTR                 
           NPTS = ELBUF_TAB(NG)%NPTS                 
           NPTT = ELBUF_TAB(NG)%NPTT
+          IOR_TSH = 0
+          IF (IGTYP == 21) THEN
+           IOR_TSH = 1
+          ELSEIF (IGTYP == 22) THEN
+           IOR_TSH = 2
+          END IF
+          IF (KCVT==1.AND.IOR_TSH/=0) KCVT=2
 c
           DO I=1,NEL
             VALUE(I) = ZERO
@@ -155,176 +169,168 @@ c
             IOK_PART(I) = 0 
             IF( H3D_PART(IPARTS(NFT+I)) == 1) IOK_PART(I) = 1
           ENDDO	     
+          MLWI = MLW
+          IF (IGTYP == 22 .AND. NLAY>9) THEN
+           F_EXP = ONE
+          ELSE
+           F_EXP = F_GAUSS(NLAY)
+          END IF
+          IF (JHBE==14.OR.JHBE==16)   F_EXP = F_EXP/(NPTR*NPTS)
 C-----------------------------------------------
           IF (KEYWORD == 'FLDZ/OUTER') THEN
             IS_WRITTEN_VALUE(1:NEL) = 1
+            MX = IXS(1,1 + NFT)
+            NGL(1:NEL) =IXS(NIXS,1 + NFT:NEL + NFT) 
+            IT = 1
 C-----------------------------------------------
               ILAY=1
-              IT = 1
 C-------- grp skin_inf first
-           IF (JHBE==15) THEN
+            IF (IGTYP == 22) THEN
+             PID = IXS(NIXS-1,1 + NFT)
+             MID = IGEO(100+ILAY,PID)
+             MLWI=NINT(PM(19,MID))
+            END IF
+            CALL H3D_FLD_STRAIN(ELBUF_TAB(NG),X  ,IXS   ,
+     .                       JHBE,MLWI,ILAY,KCVT,IOR_TSH,
+     .                       ICSTR,NPTR,NPTS,NEL,F_EXP,STRAIN )
+C----------    F.I. uses also average strain to be consisting
               IR = 1
               IS = 1
               FBUF => ELBUF_TAB(NG)%BUFLY(ILAY)%FAIL(IR,IS,IT)                            
               NFAIL = ELBUF_TAB(NG)%BUFLY(ILAY)%NFAIL                                                                   
              DO IFAIL=1,NFAIL                                                          
                IF (FBUF%FLOC(IFAIL)%ILAWF == 7) THEN ! check /FLD model                
-                  DO I=1,NEL 
+                  IP=(IFAIL -1)*15         
+                  CALL H3D_FLD_TSH(ELBUF_TAB(NG),
+     .                       IR,IS,IT,ILAY,IFAIL,IP,MX,
+     .                       IPM,NPF,TF,BUFMAT,
+     .                       NGL,STRAIN,NEL )
+                   DO I=1,NEL 
                     RINDX = FBUF%FLOC(IFAIL)%INDX(I)                  
                     VALUE(I) = MAX(VALUE(I),RINDX) 
                     IS_WRITTEN_VALUE(I) = 1	                         
                   ENDDO                                                                 
                ENDIF
              END DO               
-           ELSE ! 14,16
-             DO IR=1,NPTR
-               DO IS=1,NPTS
-                  FBUF => ELBUF_TAB(NG)%BUFLY(ILAY)%FAIL(IR,IS,IT)                            
-                  NFAIL = ELBUF_TAB(NG)%BUFLY(ILAY)%NFAIL                                                                   
-                 DO IFAIL=1,NFAIL                                                          
-                   IF (FBUF%FLOC(IFAIL)%ILAWF == 7) THEN ! check /FLD model                
-                      DO I=1,NEL                                                      
-                        RINDX = FBUF%FLOC(IFAIL)%INDX(I)                  
-                        VALUE(I) = MAX(VALUE(I),RINDX) 
-                      ENDDO                                                                 
-                   ENDIF
-                 END DO               
-               ENDDO 
-             ENDDO
-C----------            
-           END IF !IF (JHBE==15)             
 C------           
-           DO I=1,NEL
-             SKIN_SCALAR(NSKIN+I) = VALUE(I)
-             IF(IOK_PART(I) == 1 ) IS_WRITTEN_SKIN(NSKIN+I) = IS_WRITTEN_VALUE(I)
-           END DO
-           NSKIN = NSKIN + NEL
+             DO I=1,NEL
+               SKIN_SCALAR(NSKIN+I) = VALUE(I)
+               IF(IOK_PART(I) == 1 ) IS_WRITTEN_SKIN(NSKIN+I) = IS_WRITTEN_VALUE(I)
+             END DO
+             NSKIN = NSKIN + NEL
 C-------- grp skin_up
               ILAY=NLAY
-              IT = 1
               VALUE(1:NEL) = ZERO
-           IF (JHBE==15) THEN
+             IF (IGTYP == 22) THEN
+              PID = IXS(NIXS-1,1 + NFT)
+              MID = IGEO(100+ILAY,PID)
+              MLWI=NINT(PM(19,MID))
+             END IF
+             CALL H3D_FLD_STRAIN(ELBUF_TAB(NG),X  ,IXS   ,
+     .                         JHBE,MLWI,ILAY,KCVT,IOR_TSH,
+     .                         ICSTR,NPTR,NPTS,NEL,F_EXP,STRAIN )
               IR = 1
               IS = 1
               FBUF => ELBUF_TAB(NG)%BUFLY(ILAY)%FAIL(IR,IS,IT)                            
               NFAIL = ELBUF_TAB(NG)%BUFLY(ILAY)%NFAIL                                                                   
              DO IFAIL=1,NFAIL                                                          
                IF (FBUF%FLOC(IFAIL)%ILAWF == 7) THEN ! check /FLD model                
+                  IP=(IFAIL -1)*15         
                   DO I=1,NEL                                                      
+                     CALL H3D_FLD_TSH(ELBUF_TAB(NG),
+     .                       IR,IS,IT,ILAY,IFAIL,IP,MX,
+     .                       IPM,NPF,TF,BUFMAT,
+     .                       NGL,STRAIN,NEL )
                     RINDX = FBUF%FLOC(IFAIL)%INDX(I)                  
                     VALUE(I) = MAX(VALUE(I),RINDX) 
                     IS_WRITTEN_VALUE(I) = 1	                         
                   ENDDO                                                                 
                ENDIF
              END DO               
-           ELSE ! 14,16
-             DO IR=1,NPTR
-               DO IS=1,NPTS
-                  FBUF => ELBUF_TAB(NG)%BUFLY(ILAY)%FAIL(IR,IS,IT)                            
-                  NFAIL = ELBUF_TAB(NG)%BUFLY(ILAY)%NFAIL                                                                   
-                 DO IFAIL=1,NFAIL                                                          
-                   IF (FBUF%FLOC(IFAIL)%ILAWF == 7) THEN ! check /FLD model                
-                      DO I=1,NEL                                                      
-                        RINDX = FBUF%FLOC(IFAIL)%INDX(I)                  
-                        VALUE(I) = MAX(VALUE(I),RINDX) 
-                        IS_WRITTEN_VALUE(I) = 1	                         
-                      ENDDO                                                                 
-                   ENDIF
-                 END DO               
-               ENDDO 
-             ENDDO
-           END IF   !IF (JHBE==15)            
-           DO I=1,NEL
-             SKIN_SCALAR(NSKIN+I) = VALUE(I)
-             IF(IOK_PART(I) == 1 ) IS_WRITTEN_SKIN(NSKIN+I) = IS_WRITTEN_VALUE(I)
-           END DO
-           NSKIN = NSKIN + NEL
+             DO I=1,NEL
+               SKIN_SCALAR(NSKIN+I) = VALUE(I)
+               IF(IOK_PART(I) == 1 ) IS_WRITTEN_SKIN(NSKIN+I) = IS_WRITTEN_VALUE(I)
+             END DO
+             NSKIN = NSKIN + NEL
 C-----------------------------------------------
           ELSEIF (KEYWORD == 'FLDF/OUTER') THEN
             IS_WRITTEN_VALUE(1:NEL) = 1
+            MX = IXS(1,1 + NFT)
+            NGL(1:NEL) =IXS(NIXS,1 + NFT:NEL + NFT) 
 C-----------------------------------------------
               ILAY=1
               IT = 1
+            IF (IGTYP == 22) THEN
+             PID = IXS(NIXS-1,1 + NFT)
+             MID = IGEO(100+ILAY,PID)
+             MLWI=NINT(PM(19,MID))
+            END IF
+            CALL H3D_FLD_STRAIN(ELBUF_TAB(NG),X  ,IXS   ,
+     .                        JHBE,MLWI,ILAY,KCVT,IOR_TSH,
+     .                        ICSTR,NPTR,NPTS,NEL,F_EXP,STRAIN )
 C-------- grp skin_inf first
-           IF (JHBE==15) THEN
               IR = 1
               IS = 1
               FBUF => ELBUF_TAB(NG)%BUFLY(ILAY)%FAIL(IR,IS,IT)                            
               NFAIL = ELBUF_TAB(NG)%BUFLY(ILAY)%NFAIL                                                                   
              DO IFAIL=1,NFAIL                                                          
                IF (FBUF%FLOC(IFAIL)%ILAWF == 7) THEN ! check /FLD model                
+                  IP=(IFAIL -1)*15         
+                  CALL H3D_FLD_TSH(ELBUF_TAB(NG),
+     .                       IR,IS,IT,ILAY,IFAIL,IP,MX,
+     .                       IPM,NPF,TF,BUFMAT,
+     .                       NGL,STRAIN,NEL )
                   DO I=1,NEL                                                      
                     VALUE(I) = MAX(VALUE(I),FBUF%FLOC(IFAIL)%DAM(I)) 
                     IS_WRITTEN_VALUE(I) = 1	                         
                   ENDDO                                                                 
                ENDIF
              END DO               
-           ELSE ! 14,16
-             DO IR=1,NPTR
-               DO IS=1,NPTS
-                  FBUF => ELBUF_TAB(NG)%BUFLY(ILAY)%FAIL(IR,IS,IT)                            
-                  NFAIL = ELBUF_TAB(NG)%BUFLY(ILAY)%NFAIL                                                                   
-                 DO IFAIL=1,NFAIL                                                          
-                   IF (FBUF%FLOC(IFAIL)%ILAWF == 7) THEN ! check /FLD model                
-                      DO I=1,NEL                                                      
-                        VALUE(I) = MAX(VALUE(I),FBUF%FLOC(IFAIL)%DAM(I)) 
-                        IS_WRITTEN_VALUE(I) = 1	                         
-                      ENDDO                                                                 
-                   ENDIF
-                 END DO               
-               ENDDO 
-             ENDDO
-C----------            
-           END IF !IF (JHBE==15)             
 C------           
-           DO I=1,NEL
-             N = I + NFT
-             SKIN_SCALAR(NSKIN+I) = VALUE(I)
-             IF(IOK_PART(I) == 1 ) IS_WRITTEN_SKIN(NSKIN+I) = IS_WRITTEN_VALUE(I)
-           END DO
-           NSKIN = NSKIN + NEL
+             DO I=1,NEL
+               N = I + NFT
+               SKIN_SCALAR(NSKIN+I) = VALUE(I)
+               IF(IOK_PART(I) == 1 ) IS_WRITTEN_SKIN(NSKIN+I) = IS_WRITTEN_VALUE(I)
+             END DO
+             NSKIN = NSKIN + NEL
 C-------- grp skin_up
               ILAY=NLAY
               IT = 1
-           VALUE(1:NEL) = ZERO
-           IF (JHBE==15) THEN
+             VALUE(1:NEL) = ZERO
+             IF (IGTYP == 22) THEN
+              PID = IXS(NIXS-1,1 + NFT)
+              MID = IGEO(100+ILAY,PID)
+              MLWI=NINT(PM(19,MID))
+             END IF
+             CALL H3D_FLD_STRAIN(ELBUF_TAB(NG),X  ,IXS   ,
+     .                        JHBE,MLWI,ILAY,KCVT,IOR_TSH,
+     .                        ICSTR,NPTR,NPTS,NEL,F_EXP,STRAIN )
               IR = 1
               IS = 1
               FBUF => ELBUF_TAB(NG)%BUFLY(ILAY)%FAIL(IR,IS,IT)                            
               NFAIL = ELBUF_TAB(NG)%BUFLY(ILAY)%NFAIL                                                                   
              DO IFAIL=1,NFAIL                                                          
                IF (FBUF%FLOC(IFAIL)%ILAWF == 7) THEN ! check /FLD model                
+                  IP=(IFAIL -1)*15         
+                  CALL H3D_FLD_TSH(ELBUF_TAB(NG),
+     .                       IR,IS,IT,ILAY,IFAIL,IP,MX,
+     .                       IPM,NPF,TF,BUFMAT,
+     .                       NGL,STRAIN,NEL )
                   DO I=1,NEL                                                      
                     VALUE(I) = MAX(VALUE(I),FBUF%FLOC(IFAIL)%DAM(I)) 
                     IS_WRITTEN_VALUE(I) = 1	                         
                   ENDDO                                                                 
                ENDIF
              END DO               
-           ELSE ! 14,16
-             DO IR=1,NPTR
-               DO IS=1,NPTS
-                  FBUF => ELBUF_TAB(NG)%BUFLY(ILAY)%FAIL(IR,IS,IT)                            
-                  NFAIL = ELBUF_TAB(NG)%BUFLY(ILAY)%NFAIL                                                                   
-                 DO IFAIL=1,NFAIL                                                          
-                   IF (FBUF%FLOC(IFAIL)%ILAWF == 7) THEN ! check /FLD model                
-                      DO I=1,NEL                                                      
-                        VALUE(I) = MAX(VALUE(I),FBUF%FLOC(IFAIL)%DAM(I)) 
-                        IS_WRITTEN_VALUE(I) = 1	                         
-                      ENDDO                                                                 
-                   ENDIF
-                 END DO               
-               ENDDO 
-             ENDDO
-           END IF   !IF (JHBE==15)            
-           DO I=1,NEL
-             N = I + NFT
-             SKIN_SCALAR(NSKIN+I) = VALUE(I)
-             IF(IOK_PART(I) == 1 ) IS_WRITTEN_SKIN(NSKIN+I) = IS_WRITTEN_VALUE(I)
-           END DO
-           NSKIN = NSKIN + NEL
+             DO I=1,NEL
+               N = I + NFT
+               SKIN_SCALAR(NSKIN+I) = VALUE(I)
+               IF(IOK_PART(I) == 1 ) IS_WRITTEN_SKIN(NSKIN+I) = IS_WRITTEN_VALUE(I)
+             END DO
+             NSKIN = NSKIN + NEL
 C------------to get right NSKIN for next case          
           ELSE
-           NSKIN = NSKIN + 2*NEL
+            NSKIN = NSKIN + 2*NEL
           END IF !(KEYWORD
         END IF !(ITY == 1.AND.(IGTYP==20 .OR. IGTYP==21 .OR. IGTYP==22)) THEN
       END DO !NG=1,NGROUP


### PR DESCRIPTION
file missed

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
actual /H3D/SOLID/FLDZ/OUTER has inconsistent result w/ output strain when fully integration thick-shell is used   
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
change actual  FLD output implementation to be consistent to the strain (elementary average) output, because FLD output curve for forming simulation need both of them that the consistence is important.
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->


