### PR TITLE
Remove the buggy sorting routine trirap

### DIFF
--- a/engine/source/time_step/find_dt_for_targeted_added_mass.F
+++ b/engine/source/time_step/find_dt_for_targeted_added_mass.F
@@ -40,6 +40,7 @@ C-----------------------------------------------
 C   A n a l y s e   M o d u l e
 C-----------------------------------------------
       USE GROUPDEF_MOD
+      USE MESSAGE_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -60,6 +61,7 @@ C-----------------------------------------------
 #include      "com06_c.inc"
 #include      "units_c.inc"
 #include      "task_c.inc"
+#include      "my_allocate.inc"
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -72,6 +74,8 @@ C-----------------------------------------------
       my_real, DIMENSION(:),POINTER ::
      .   TMP
       my_real SUMK,SUMM,TARGET_PERCENT
+      INTEGER :: IERROR
+      INTEGER, DIMENSION(:), ALLOCATABLE :: PERM
 C=======================================================================
 C
 C--------------------------------------------------------------------------------------
@@ -143,6 +147,7 @@ C
       IF (ISPMD == 0) THEN     
 C
         TMP => DT2_L(SIZG+1:SIZG*2)
+        MY_ALLOCATE( PERM,SIZG )
 C
 C  --- Sorting
 C
@@ -150,11 +155,15 @@ C
         SUMK = ZERO
         DO I=1,SIZG
           TMP(I)=I
+          PERM(I) = I
           SUMM = SUMM + MS_L(I)
           SUMK = SUMK + STF_L(I)
         ENDDO
 
-        CALL TRIRAP(SIZG,DT2_L,SIZG)
+        CALL MYQSORT(SIZG,DT2_L,PERM,IERROR)
+        TMP(1:NUMNOD) = PERM(1:NUMNOD)
+
+        DEALLOCATE( PERM )
 C
 C----- determination of target time step
 C

--- a/starter/source/coupling/rad2rad/r2r_speedup.F
+++ b/starter/source/coupling/rad2rad/r2r_speedup.F
@@ -169,6 +169,7 @@ C   M o d u l e s
 C-----------------------------------------------
       USE R2R_MOD
       USE INOUTFILE_MOD
+      USE MESSAGE_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -183,6 +184,7 @@ C-----------------------------------------------
 #include      "sphcom.inc"
 #include      "rnur_c.inc"
 #include      "r2r_c.inc"
+#include      "my_allocate.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
@@ -199,6 +201,8 @@ C-----------------------------------------------
      .   DTSCA,DTMINI,DTINI,DTMAX,DT_MIN_ELEM(11),DTFAC1(11)
       INTEGER :: LEN_TMP_NAME
       CHARACTER(len=4096) :: TMP_NAME
+      INTEGER :: IERROR
+      INTEGER, DIMENSION(:), ALLOCATABLE :: PERM
 C-----------------------------------------------
 C
       FLG_CHK = 0
@@ -210,6 +214,7 @@ C
       DTFAC1(:) = DTFAC
       NUMEL= NUMELC+NUMELS+NUMELT+NUMELQ+NUMELP+NUMELR+NUMELUR+NUMELTG
      .      +NUMELX+NUMSPH+NUMELIG3D
+      MY_ALLOCATE( PERM,NUMEL )
   
 C-----------------------------------------------
 C     Computation of index in dtelem for each type of elements
@@ -283,7 +288,10 @@ C
       END DO
 C
       DO I=1,11
-        IF (FLAG_TRI(I)==1) CALL TRIRAP(NUME(I),DTELEM(1+DT_INDEX(I)),NUMEL)
+        IF (FLAG_TRI(I)==1) THEN
+            CALL MYQSORT(NUME(I),DTELEM(1+DT_INDEX(I)),PERM(1+DT_INDEX(I)),IERROR)
+            DTELEM(NUMEL+1+DT_INDEX(I):NUMEL+NUME(I)+1+DT_INDEX(I)) = PERM(1+DT_INDEX(I):NUME(I)+1+DT_INDEX(I))
+        ENDIF
       END DO
 
 C-----------------------------------------------
@@ -457,6 +465,8 @@ C
       IF (DTNODA>ZERO) DT = DTNODA
 C
       DT = MIN(DT,DTMAX)
+
+      DEALLOCATE( PERM )
                    
 C------------------------------------------- 
       RETURN

--- a/starter/source/materials/time_step/outri.F
+++ b/starter/source/materials/time_step/outri.F
@@ -34,6 +34,10 @@ C
 C     TRI DES DTEL (POUR CHAQUE TYPE D'ELEMENT) ET IMPRESSIONS
 C
 C-----------------------------------------------
+C   M o d u l e s
+C-----------------------------------------------
+      USE MESSAGE_MOD
+C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
 #include      "implicit_f.inc"
@@ -50,6 +54,7 @@ C-----------------------------------------------
 #include      "param_c.inc"
 #include      "rnur_c.inc"
 #include      "units_c.inc"
+#include      "my_allocate.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
@@ -65,81 +70,125 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER NUM2, I, NUMIMP, NUMELO, NUM1, IS_PROP45     
       REAL*4 VINGTR4, TEMPO
+      INTEGER :: IERROR
+      INTEGER, DIMENSION(:), ALLOCATABLE :: PERM
       DATA VINGTR4 /20./
 C=======================================================================
 C     INITIALISATION DES NOS INTERNES DES ELEMENTS AVANT TRI
 C
-      DO 1 I=1,NUMELS+NUMELQ
- 1    DTELEM(NUMEL+I)=I
-C
-      NUM2=NUMEL+NUMELS+NUMELQ
-      DO 2 I=1,NUMELC
- 2    DTELEM(NUM2+I)=I
-C
+      MY_ALLOCATE(PERM,NUMEL)
+      ! --------------------
+      ! solid and quad
+      NUM2 = 0
+      DO I=1,NUMELS+NUMELQ
+        PERM(NUM2+I)=I
+      ENDDO
+      ! --------------------
+      ! shell
+      NUM2=NUMELS+NUMELQ
+      DO I=1,NUMELC
+        PERM(NUM2+I)=I
+      ENDDO
+      ! --------------------
+      ! truss
       NUM2=NUM2+NUMELC
-      DO 3 I=1,NUMELT
- 3    DTELEM(NUM2+I)=I
-C
+      DO I=1,NUMELT
+        PERM(NUM2+I)=I
+      ENDDO
+      ! --------------------
+      ! beam
       NUM2=NUM2+NUMELT
-      DO 4 I=1,NUMELP
- 4    DTELEM(NUM2+I)=I
-C
+      DO I=1,NUMELP
+        PERM(NUM2+I)=I
+      ENDDO
+      ! --------------------
+      ! spring
       NUM2=NUM2+NUMELP
-      DO 5 I=1,NUMELR
- 5    DTELEM(NUM2+I)=I
-C
+      DO I=1,NUMELR
+        PERM(NUM2+I)=I
+      ENDDO
+      ! --------------------
+      ! triangle
       NUM2=NUM2+NUMELR
-      DO 6 I=1,NUMELTG
- 6    DTELEM(NUM2+I)=I
-C
+      DO I=1,NUMELTG
+        PERM(NUM2+I)=I
+      ENDDO
+      ! --------------------
+      ! user solid
       NUM2=NUM2+NUMELTG
-      DO 7 I=1,NUMELUR
- 7    DTELEM(NUM2+I)=I
-C
+      DO  I=1,NUMELUR
+        PERM(NUM2+I)=I
+      ENDDO
+      ! --------------------
+      ! the X element :)
       NUM2=NUM2+NUMELUR
-      DO 8 I=1,NUMELX
- 8    DTELEM(NUM2+I)=I
-C
+      DO  I=1,NUMELX
+        PERM(NUM2+I)=I
+      ENDDO
+      ! --------------------
+      ! sph
       NUM2=NUM2+NUMELX
-      DO 9 I=1,NUMSPH
- 9    DTELEM(NUM2+I)=I
-C
+      DO I=1,NUMSPH
+        PERM(NUM2+I)=I
+      ENDDO
+      ! --------------------
+      ! igeo element
       NUM2=NUM2+NUMSPH
-      DO 10 I=1,NUMELIG3D
-10    DTELEM(NUM2+I)=I
+      DO  I=1,NUMELIG3D
+        PERM(NUM2+I)=I
+      ENDDO
+      ! --------------------
 C
 C     TRIS DES ELEMENTS EN FONCTION DU PAS DE TEMPS
 C
-      IF (NUMELS>1) CALL TRIRAP(NUMELS,DTELEM(1),NUMEL)
-      IF (NUMELQ>1) CALL TRIRAP(NUMELQ,DTELEM(1),NUMEL)
-      IF (NUMELC>1) CALL TRIRAP(NUMELC,DTELEM(NUMELS+1),NUMEL)
-      IF (NUMELT>1) CALL TRIRAP(NUMELT,
-     .                 DTELEM(NUMELS+NUMELC+1),NUMEL)
-      IF (NUMELP>1) CALL TRIRAP(NUMELP,
-     .                 DTELEM(NUMELS+NUMELC+NUMELT+1),NUMEL)
-      IF (NUMELR>1) CALL TRIRAP(NUMELR,
-     .                 DTELEM(NUMELS+NUMELC+NUMELT+NUMELP+1),NUMEL)
+      IF (NUMELS>1) THEN
+        NUM2 = 1
+        CALL MYQSORT(NUMELS,DTELEM(NUM2),PERM(NUM2),IERROR)
+      ENDIF
+      IF (NUMELQ>1) THEN
+        NUM2 = 1
+        CALL MYQSORT(NUMELQ,DTELEM(NUM2),PERM(NUM2),IERROR)
+      ENDIF
+      IF (NUMELC>1) THEN
+        NUM2 = NUMELS+1
+        CALL MYQSORT(NUMELC,DTELEM(NUM2),PERM(NUM2),IERROR)
+      ENDIF
+      IF (NUMELT>1) THEN
+        NUM2 = NUMELS+NUMELC+1
+        CALL MYQSORT(NUMELT,DTELEM(NUM2),PERM(NUM2),IERROR)
+      ENDIF
+      IF (NUMELP>1) THEN
+        NUM2 = NUMELS+NUMELC+NUMELT+1
+        CALL MYQSORT(NUMELP,DTELEM(NUM2),PERM(NUM2),IERROR)
+      ENDIF
+      IF (NUMELR>1) THEN
+        NUM2 = NUMELS+NUMELC+NUMELT+NUMELP+1
+        CALL MYQSORT(NUMELR,DTELEM(NUM2),PERM(NUM2),IERROR)
+      ENDIF
       IF (NUMELTG>1) THEN
           NUM2=NUMELS+NUMELC+NUMELT+NUMELP+NUMELR+1
-          CALL TRIRAP(NUMELTG,DTELEM(NUM2),NUMEL)
+          CALL MYQSORT(NUMELTG,DTELEM(NUM2),PERM(NUM2),IERROR)
       ENDIF
       IF (NUMELUR>1) THEN
           NUM2=NUMELS+NUMELC+NUMELT+NUMELP+NUMELR+NUMELTG+1
-          CALL TRIRAP(NUMELUR,DTELEM(NUM2),NUMEL)
+          CALL MYQSORT(NUMELUR,DTELEM(NUM2),PERM(NUM2),IERROR)
       ENDIF
       IF (NUMELX>1) THEN
           NUM2=NUMELS+NUMELC+NUMELT+NUMELP+NUMELR+NUMELTG+NUMELUR+1
-          CALL TRIRAP(NUMELX,DTELEM(NUM2),NUMEL)
+          CALL MYQSORT(NUMELX,DTELEM(NUM2),PERM(NUM2),IERROR)
       ENDIF
       IF (NUMSPH>1) THEN
         NUM2=NUMELS+NUMELC+NUMELT+NUMELP+NUMELR+NUMELTG+NUMELUR+NUMELX+1
-        CALL TRIRAP(NUMSPH,DTELEM(NUM2),NUMEL)
+        CALL MYQSORT(NUMSPH,DTELEM(NUM2),PERM(NUM2),IERROR)
       ENDIF
       IF (NUMELIG3D>1) THEN
         NUM2=NUMELS+NUMELC+NUMELT+NUMELP+NUMELR+NUMELTG+NUMELUR+NUMELX+
      .       NUMSPH+1
-        CALL TRIRAP(NUMELIG3D,DTELEM(NUM2),NUMEL)
+        CALL MYQSORT(NUMELIG3D,DTELEM(NUM2),PERM(NUM2),IERROR)
       ENDIF
+      
+      DTELEM(NUMEL+1:2*NUMEL) = PERM(1:NUMEL)
+
 C
 C     IMPRESSIONS PAR GROUPES DES ELEMENTS TRIES
 C
@@ -309,7 +358,7 @@ c        CALL ANCHECK(93)
            WRITE(IOUT,1002)DTELEM(NUM1+I),KXIG3D(5,NUMELO)
         END DO
       ENDIF
-      
+      DEALLOCATE( PERM )
 C--------------------------------------------------------
  1000 FORMAT(//,'         SOLID ELEMENTS TIME STEP')
  1001 FORMAT(  '         ------------------------',//,
@@ -347,6 +396,7 @@ C   M o d u l e s
 C-----------------------------------------------
       USE R2R_MOD
       USE PLOT_CURVE_MOD
+      USE MESSAGE_MOD
 C-----------------------------------------------
 C     TRI DES DT NODAUX ET IMPRESSIONS
 C-----------------------------------------------
@@ -356,6 +406,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   A n a l y s e   M o d u l e
 C-----------------------------------------------
+#include      "my_allocate.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
@@ -373,14 +424,14 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,N,IMAX, OLD_NUMB, P80, NB_OF_COLUM, STORAGE, OLD_COMPT, COMPT
-      my_real, DIMENSION(NUMNOD*2),TARGET ::
-     .   DT
-      my_real, DIMENSION(:),POINTER ::
-     .   TMP
+      my_real, DIMENSION(:), ALLOCATABLE :: DT
       my_real
      .   DTNODA_STAT(20),NB_NOD_STAT(20),CHUNK, DT_MAX, DT_MIN, SEUIL
+      INTEGER :: IERROR
+      INTEGER, DIMENSION(:), ALLOCATABLE :: PERM
 C=======================================================================
-      TMP => DT(NUMNOD+1:NUMNOD*2)
+      MY_ALLOCATE(PERM,NUMNOD)
+      MY_ALLOCATE(DT,NUMNOD)
       DTNODA = EP30
 C 
       DO I=1,NUMNOD
@@ -411,19 +462,20 @@ C---- Multidomains : Nodal time step is deactivated for splited RBODY
       END IF
 C
       DO I=1,NUMNOD
-        TMP(I)=I
+        PERM(I)=I
       ENDDO
-      CALL TRIRAP(NUMNOD,DT,NUMNOD)
+
+      CALL MYQSORT(NUMNOD,DT,PERM,IERROR)
 C
       DTNODA = MIN(DTNODA,DT(1))
 C
       IF ( N2D/=1) THEN        
         WRITE(IOUT,1000)
         WRITE(IOUT,1001)
-        N=NINT(TMP(1))
+        N=PERM(1)
 c        CALL ANCHECK(96)      
         DO I=1,MIN(NUMNOD0,MAX(100,NUMNOD0/50))
-          N=NINT(TMP(I))  
+          N=PERM(I) 
           WRITE(IOUT,1002)DT(I),ITAB(N)
         ENDDO
 C
@@ -489,6 +541,9 @@ C
      .                  INPUT_TXT_X="NODAL TIME STEP",INPUT_TXT_Y="% OF NODES")
       ENDIF
 C
+
+      DEALLOCATE( PERM )
+      DEALLOCATE( DT )
 
 C-----------
  1000 FORMAT(//,'         NODAL TIME STEP (estimation)')

--- a/starter/source/tools/admas/add_mass_stat.F
+++ b/starter/source/tools/admas/add_mass_stat.F
@@ -35,6 +35,7 @@ C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE PLOT_CURVE_MOD
+      USE MESSAGE_MOD
 C-----------------------------------------------
 C     TRI DES DT NODAUX ET IMPRESSIONS
 C-----------------------------------------------
@@ -58,10 +59,13 @@ C-----------------------------------------------
 #include      "com06_c.inc"
 #include      "units_c.inc"
 #include      "scr18_c.inc"
+#include      "my_allocate.inc"
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,N,COMPT,K,NVAL
+      INTEGER :: IERROR
+      INTEGER, DIMENSION(:), ALLOCATABLE :: PERM
       my_real, DIMENSION(NUMNOD*2),TARGET ::
      .   DT
       my_real, DIMENSION(:),POINTER ::
@@ -73,6 +77,7 @@ C-------------------------------------------------------------------------------
 C     DUPLICATED FROM OUTRIN - STATS ON ADDED MASS + TARGET NODAL TIME STEP ESTIMATION
 C--------------------------------------------------------------------------------------
 C
+      MY_ALLOCATE(PERM,NUMNOD)
       MASS0_START = TOTMAS
       DTSCA = ZEP9
 C
@@ -94,13 +99,17 @@ C
 
       DO I=1,NUMNOD
         TMP(I)=I
+        PERM(I) = I
         IF (DT(I) < EP30) THEN
           SUMM = SUMM + MS(I)
           SUMK = SUMK + STIFN(I)
         ENDIF
       ENDDO
 C
-      CALL TRIRAP(NUMNOD,DT,NUMNOD)
+      CALL MYQSORT(NUMNOD,DT,PERM,IERROR)
+      TMP(1:NUMNOD) = PERM(1:NUMNOD)
+
+      DEALLOCATE( PERM )
 C
       NVAL = 20
       DO I=1,20


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
The TRIRAP routine is a very old buggy sorting routine. The aim of this PR is to replace TRIRAP by a non-buggy routine MYQSORT 


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
TRIRAP is now replaced by MYQSORT routine. MYQSORT routine needs 4 arguments :
MYQSORT( N    ,    A     ,     PERM    ,      IERROR   )
N : size of array A and PERM
A : double or float array, this array is sorted 
PERM : integer array, permutation array
IERROR : integer, flag to detect an error 


