### PR TITLE
Fix a simple precion issue in the law 25

### DIFF
--- a/starter/source/materials/mat/mat025/hm_read_mat25.F
+++ b/starter/source/materials/mat/mat025/hm_read_mat25.F
@@ -104,6 +104,11 @@ C-----------------------------------------------
      .   WPLAMXT2,EPS1C1,EPS2C1,SIGRSC1,WPLAMXC1,EPS1C2,EPS2C2,
      .   SIGRSC2,WPLAMXC2,EPS1T12,EPS2T12,SIGRST12,WPLAMXT12,WPLAREF,
      .   EPSF1,EPSF2,RATIO,D11,D22,D12,DMIN,FAC,FSCAL_UNIT
+      ! -------------------------
+      ! Simple precision issue 
+      REAL(kind=8) :: SIGYT1_DB,SIGYC1_DB,SIGYT2_DB,SIGYC2_DB,SIGYT12_DB,SIGYC12_DB
+      REAL(kind=8) :: F1_DB,F2_DB,F11_DB,F22_DB,F33_DB,F12_DB,FT1_DB
+      ! -------------------------
 C=======================================================================
       IS_ENCRYPTED   = .FALSE.
       IS_AVAILABLE = .FALSE.
@@ -617,14 +622,35 @@ C----------------------------------------
      .               C1=TITR,
      .               C2='SIGYC12')
       ENDIF      
-C
-      F1  = ONE / SIGYT1 - ONE / SIGYC1
-      F2  = ONE / SIGYT2 - ONE / SIGYC2
-      F11 = ONE / MIN(EP20,(SIGYT1*SIGYC1))
-      F22 = ONE / MIN(EP20,(SIGYT2*SIGYC2))
-      F33 = ONE / MIN(EP20,(SIGYT12*SIGYC12))
-      F12 = -ALPHA/(TWO*SQRT(MIN(EP20,SIGYT1*SIGYC1*SIGYT2*SIGYC2)))    
-      FT1 = F11*F22 - FOUR*F12**2
+
+      ! -------------------------
+      ! Simple precision issue : if SIGYT1/... are not defined 
+      ! in the material card, the default value is 1.D+20
+      ! some computation can lead to NaN in simple precision
+      SIGYT1_DB = SIGYT1
+      SIGYC1_DB = SIGYC1
+      SIGYT2_DB = SIGYT2
+      SIGYC2_DB = SIGYC2
+      SIGYT12_DB = SIGYT12
+      SIGYC12_DB = SIGYC12
+
+      F1_DB  = ONE / SIGYT1_DB - ONE / SIGYC1_DB
+      F2_DB  = ONE / SIGYT2_DB - ONE / SIGYC2_DB
+      F11_DB = ONE / MAX(EM20,MIN(EP20,(SIGYT1_DB*SIGYC1_DB)))
+      F22_DB = ONE / MAX(EM20,MIN(EP20,(SIGYT2_DB*SIGYC2_DB)))
+      F33_DB = ONE / MAX(EM20,MIN(EP20,(SIGYT12_DB*SIGYC12_DB)))
+      F12_DB = -ALPHA/(TWO*SQRT(MAX(EM20,MIN(EP20,SIGYT1_DB*SIGYC1_DB*SIGYT2_DB*SIGYC2_DB))))    
+      FT1_DB = F11_DB*F22_DB - FOUR*F12_DB**2
+
+      F1 = F1_DB
+      F2 = F2_DB
+      F11 = F11_DB
+      F22 = F22_DB  
+      F33 = F33_DB 
+      F12 = F12_DB  
+      FT1 = FT1_DB 
+      ! -------------------------
+
       WRITE(IOUT,1650) F1,F2,F11,F22,F33,F12
 c------------------------------------------------------------
       PM(54)=F1


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
In simple precision, some default values defined in the law 25 can lead to NaN in the starter.


#### Description of the changes
The computation now is done with double precision, then the double precision results are loaded in simple precision variable. 


