### PR TITLE
/sensor/time : initialize TSTART, used in airbag injectors

### DIFF
--- a/starter/source/tools/sensor/read_sensor_time.F
+++ b/starter/source/tools/sensor/read_sensor_time.F
@@ -89,7 +89,7 @@ c
       SENSOR_PTR%SENS_ID = SENS_ID
       SENSOR_PTR%STATUS  = 0            ! status = deactivated
       SENSOR_PTR%TSTART  = INFINITY
-      SENSOR_PTR%TCRIT   = INFINITY
+      SENSOR_PTR%TCRIT   = TDEL
       SENSOR_PTR%TMIN    = ZERO         ! TMIN global
       SENSOR_PTR%TDELAY  = TDEL         ! time delay before activation
       SENSOR_PTR%VALUE   = ZERO


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

correct problem with sensor TIME in airbags

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

initialize TSTART parameter of sensor TIME used in airbag injectors


