### PR TITLE
 typo issue in cmake scripts

### DIFF
--- a/engine/CMake_Compilers/cmake_linux64_AOCC.txt
+++ b/engine/CMake_Compilers/cmake_linux64_AOCC.txt
@@ -40,7 +40,7 @@ if ( DEFINED MPI )
             set (mpi_inc "-I${mpi_incdir}")
         endif()
         if ( DEFINED mpi_libdir )
-            set (mpi_lib "-I${mpi_libdir} -lmpi -lmpi_mpifh")
+            set (mpi_lib "-L${mpi_libdir} -lmpi -lmpi_mpifh")
         endif()
 
       endif()

--- a/engine/CMake_Compilers/cmake_linux64_gf.txt
+++ b/engine/CMake_Compilers/cmake_linux64_gf.txt
@@ -39,7 +39,7 @@ if ( DEFINED MPI )
             set (mpi_inc "-I${mpi_incdir}")
         endif()
         if ( DEFINED mpi_libdir )
-            set (mpi_lib "-I${mpi_libdir} -lmpi -lmpi_mpifh")
+            set (mpi_lib "-L${mpi_libdir} -lmpi -lmpi_mpifh")
         endif()
 
       endif()

--- a/engine/CMake_Compilers/cmake_linuxa64.txt
+++ b/engine/CMake_Compilers/cmake_linuxa64.txt
@@ -40,7 +40,7 @@ if ( DEFINED MPI )
             set (mpi_inc "-I${mpi_incdir}")
         endif()
         if ( DEFINED mpi_libdir )
-            set (mpi_lib "-I${mpi_libdir} -lmpi -lmpi_mpifh")
+            set (mpi_lib "-L${mpi_libdir} -lmpi -lmpi_mpifh")
         endif()
 
       endif()


### PR DESCRIPTION
Typo issue in cmake scripts  for loading the libraries with -mpi-root option.
