### PR TITLE
Correction of an uninitialized variable in reading /FRICTION card

### DIFF
--- a/starter/source/interfaces/friction/reader/hm_read_friction.F
+++ b/starter/source/interfaces/friction/reader/hm_read_friction.F
@@ -659,7 +659,7 @@ C
                      IPP = GRPN1
                   ENDIF
 
-                      
+                  NSET = NSET + 1
                   NCOUPLE = NCOUPLE + 1          
                   TABCOUPLEPARTS_FRIC_TMP(NIF,NCOUPLE) = IPP  
                   NCOUPLE = NCOUPLE + 1          
@@ -873,7 +873,7 @@ C
                     IPP = GRPN1
                  ENDIF
 
-
+                 NSET = NSET + 1
                  NCOUPLE = NCOUPLE + 1          
                  TABCOUPLEPARTS_FRIC_TMP(NIF,NCOUPLE) = IPP  
                  NCOUPLE = NCOUPLE + 1          


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Uninitialized variable in reading /FRICTION card. Starter crashes in debug mode.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Correction of un uninitialized variable, reading /FRICTION card.

