### PR TITLE
addressing AMD's AOCC build issues

### DIFF
--- a/engine/CMake_Compilers/cmake_linux64_AOCC.txt
+++ b/engine/CMake_Compilers/cmake_linux64_AOCC.txt
@@ -10,7 +10,7 @@
 
 # General machine flag setting
 set ( cppmach "-DCPP_mach=CPP_p4linux964" ) 
-set ( cpprel  "-DCPP_rel=80" )
+set ( cpprel  "-DCPP_rel=96" )
 
 
 # MPI
@@ -62,7 +62,7 @@ set ( RELNAME ${arch}${mpi_suf}  )
 set (h3d_inc "-I${source_directory}/../extlib/h3d/includes")
 
 #Lapack
-set (lapack_lib "${source_directory}/../extlib/lapack-3.10.0/lib_linux64_gf/liblapack.a ${source_directory}/../extlib/lapack-3.10.0/lib_linux64_gf/librefblas.a  ${source_directory}/../extlib/lapack-3.10.0/lib_linux64_gf/libtmglib.a")
+set (lapack_lib "${source_directory}/../extlib/lapack-3.10.0/lib_linux64_AOCC/liblapack.a ${source_directory}/../extlib/lapack-3.10.0/lib_linux64_AOCC/libblas.a  ${source_directory}/../extlib/lapack-3.10.0/lib_linux64_gf/libtmglib.a")
 
 #
 # compiler Flags
@@ -91,11 +91,7 @@ if ( NOT DEFINED WITH_LINEAR_ALGEBRA)
 set ( wo_linalg "-DWITHOUT_LINALG" )
 endif()
 
-if ( CMAKE_C_COMPILER_VERSION VERSION_GREATER 10) 
-set( portability " -fallow-argument-mismatch -g  -fallow-invalid-boz -std=legacy")
-endif()
-
-set ( opt_flag "  ${wo_linalg} -DCOMP_GFORTRAN=1 -ffp-contract=off -frounding-math -fopenmp -fno-unsafe-math-optimizations -fno-fast-math ${portability}" )
+set ( opt_flag "  ${wo_linalg} -DCOMP_AOCC -ffp-contract=off -frounding-math -fopenmp -fno-unsafe-math-optimizations -fno-fast-math -Wno-null-conversion" )
 
 if ( sanitize STREQUAL "1" )
 set( FSANITIZE "-fsanitize=address -DSANITIZE") 
@@ -117,14 +113,13 @@ else ()
 
 # Fortran
 
-
-set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS " -O3 ${opt_flag} ${precision_flag} ${cppmach} ${cpprel} -DCPP_comp=f90 -Mextend ${mpi_flag} ${ADF} " )
+set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS " -O3  ${opt_flag} ${precision_flag} ${cppmach} ${cpprel} -DCPP_comp=f90 -Mextend ${mpi_flag} ${ADF} " )
 
 # C source files
-set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS " -O2 ${h3d_inc} ${opt_flag} ${precision_flag} ${cppmach} ${cpprel} " )
+set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS " -O3 ${h3d_inc} ${opt_flag} ${precision_flag} ${cppmach} ${cpprel} " )
 
 # CXX source files
-set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS " -O2 ${h3d_inc} ${opt_flag} ${precision_flag} ${cppmach} ${cpprel} -std=c++11  " )
+set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS " -O3  ${h3d_inc} ${opt_flag} ${precision_flag} ${cppmach} ${cpprel} -std=c++11  " )
 
 endif()
 

--- a/engine/CMake_Compilers/platforms.txt
+++ b/engine/CMake_Compilers/platforms.txt
@@ -1,6 +1,7 @@
 
          -arch=linux64_gf                (SMP executable / Gfortran compiler / Linux X86-64)
          -arch=linux64_gf  -mpi=ompi     (OpenMPI executable / Gfortran compiler / Linux X86-64)
+         -arch=linux64_AOCC  -mpi=ompi     (OpenMPI executable / AOCC compiler / Linux X86-64)
          -arch=linux64_intel                (SMP executable / Intel compiler / Linux X86-64)
          -arch=linux64_intel  -mpi=impi     (MPI executable / Intel compiler / Linux X86-64)
          -arch=linuxa64_gf               (SMP executable / Armflang compiler / Linux ARM64)

--- a/engine/share/spe_inc/machine.inc
+++ b/engine/share/spe_inc/machine.inc
@@ -77,6 +77,9 @@ C
 #elif CPP_rel == 40
       CPUNAM='linux64 bmpi'
       ARCHTITLE='Linux 64 bits, Intel compiler, OpenMPI'
+#elif CPP_rel == 96
+      CPUNAM='linux64 AMD'
+      ARCHTITLE='Linux 64 bits, AMD AOCC compiler'
 #elif CPP_rel == 70
 #if defined(MPI)
         CPUNAM='linuxa64 ompi'

--- a/engine/share/spe_inc/my_allocate.inc
+++ b/engine/share/spe_inc/my_allocate.inc
@@ -20,6 +20,25 @@ Copyright>
 Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss 
 Copyright>        software under a commercial license.  Contact Altair to discuss further if the 
 Copyright>        commercial version may interest you: https://www.altair.com/radioss/.    
+
+#ifdef COMP_AOCC
+
+#define MY_ERROR(ARRAY,MY_IERR) CALL ERROR_ALLOC(#ARRAY, MY_IERR)
+
+#ifndef MY_ALLOCATE
+#define MY_ALLOCATE(ARRAY,LENGTH) ALLOCATE(ARRAY(LENGTH),STAT=MY_IERR); MY_ERROR(ARRAY,MY_IERR)
+#endif
+
+#ifndef MY_ALLOCATE2D
+#define MY_ALLOCATE2D(ARRAY,LENGTH1,LENGTH2) ALLOCATE(ARRAY(LENGTH1,LENGTH2),STAT=MY_IERR); MY_ERROR(ARRAY,MY_IERR)
+#endif
+
+#ifndef MY_ALLOCATE3D
+#define MY_ALLOCATE3D(ARRAY,LENGTH1,LENGTH2,LENGTH3) ALLOCATE(ARRAY(LENGTH1,LENGTH2,LENGTH3),STAT=MY_IERR); MY_ERROR(ARRAY,MY_IERR)
+#endif
+
+#else
+
 #ifdef COMP_ARMFLANG
 
 #ifndef MY_ALLOCATE
@@ -88,5 +107,6 @@ ENDIF
 
 #endif
 
+#endif
 #endif
 

--- a/engine/share/spe_inc/vectorize.inc
+++ b/engine/share/spe_inc/vectorize.inc
@@ -42,12 +42,17 @@ CDIR$ IVDEP
 !$OMP SIMD
 #else
 
+#ifdef COMP_AOCC
+!$OMP SIMD
+#else
+
 #ifdef COMP_ARMFLANG
 !DIR$ IVDEP
 #else
 !DIR$ IVDEP
 #endif
 
+#endif
 #endif
 
 #elif 1

--- a/extlib/lapack-3.10.0/lib_linux64_AOCC/libblas.a
+++ b/extlib/lapack-3.10.0/lib_linux64_AOCC/libblas.a
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a71faca69fca5f32e6fe68f7eef6b50f9331f497b07e5d71c3ff8efc491dcdcd
+size 1090846

--- a/extlib/lapack-3.10.0/lib_linux64_AOCC/liblapack.a
+++ b/extlib/lapack-3.10.0/lib_linux64_AOCC/liblapack.a
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4c75b4c5f5ab9260768c80b97a8328e7408121fce6c71090b74469d8e6526f8
+size 18081484

--- a/starter/CMake_Compilers/cmake_linux64_AOCC.txt
+++ b/starter/CMake_Compilers/cmake_linux64_AOCC.txt
@@ -10,19 +10,19 @@ set ( RELNAME ${arch}  )
 
 
 # General machine flag setting
-set ( cppmach "-DCPP_mach=CPP_p4linux964 -DCOMP_LLVM" )
-set ( cpprel  "-DCPP_rel=80" )
+set ( cppmach "-DCPP_mach=CPP_p4linux964 -DCOMP_AOCC" )
+set ( cpprel  "-DCPP_rel=96" )
 
 
 # Third party libraries
 # ---------------------
 
 #hm_reader
-set ( reader_lib "-L${source_directory}/../extlib/hm_reader/linux64/ -lhm_reader_linux64 ${source_directory}/../extlib/hm_reader/linux64/libapr-1.so.0 /opt/rh/devtoolset-8/root/usr/lib/gcc/x86_64-redhat-linux/8/libgfortran.a"  )
+set ( reader_lib "-L${source_directory}/../extlib/hm_reader/linux64/ -lhm_reader_linux64 ${source_directory}/../extlib/hm_reader/linux64/libapr-1.so.0 "  )
 
 
 #Lapack
-set (lapack_lib "${source_directory}/../extlib/lapack-3.10.0/lib_linux64_gf/liblapack.a ${source_directory}/../extlib/lapack-3.10.0/lib_linux64_gf/librefblas.a  ${source_directory}/../extlib/lapack-3.10.0/lib_linux64_gf/libtmglib.a")
+set (lapack_lib "${source_directory}/../extlib/lapack-3.10.0/lib_linux64_AOCC/liblapack.a ${source_directory}/../extlib/lapack-3.10.0/lib_linux64_AOCC/libblas.a  ${source_directory}/../extlib/lapack-3.10.0/lib_linux64_gf/libtmglib.a")
 
 #metis
 set (metis_lib "${source_directory}/../extlib/metis/linux64/libmetis_linux64_gcc.a")
@@ -58,14 +58,11 @@ message (STATUS "modules: ${CMAKE_Fortran_MODULE_DIRECTORY}")
 if ( sanitize STREQUAL "1" )
 set( FSANITIZE "-fsanitize=address -DSANITIZE") 
 endif()
-if ( CMAKE_C_COMPILER_VERSION VERSION_GREATER 10) 
-set( portability " -fallow-argument-mismatch -g  -fallow-invalid-boz -std=legacy")
-endif()
 
 if ( debug STREQUAL "1" )
 
 # Fortran
-set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} -DCPP_comp=f90 -DCOMP_GFORTRAN=1  -g -O0 -ffp-contract=off -frounding-math -fopenmp -Mextend -Mbackslash ${ADF} ${portability}" )
+set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} -DCPP_comp=f90 -DCOMP_AOCC=1  -g -O0 -ffp-contract=off -frounding-math -fopenmp -Mextend -Mbackslash ${ADF} " )
 
 # C source files
 set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} -O0 -g -fopenmp " )
@@ -76,13 +73,13 @@ set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "${FSAN
 else ()
 
 # Fortran
-set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS " ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} -DCPP_comp=f90 -DCOMP_GFORTRAN=1  -O2 -ffp-contract=off -frounding-math -fopenmp -Mextend  -Mbackslash ${ADF} ${portability} " )
+set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS " -O3  ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} -DCPP_comp=f90 -DCOMP_AOCC=1  -O3 -ffp-contract=off -frounding-math -fopenmp -Mextend  -Mbackslash ${ADF} " )
 
 # C source files
-set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS "${precision_flag} -DMETIS5 ${cppmach} ${cpprel} -O2 -fopenmp " )
+set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS "${precision_flag} -DMETIS5 ${cppmach} ${cpprel} -O3 -fopenmp " )
 
 # CXX source files
-set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "${precision_flag} -DMETIS5 ${cppmach} ${cpprel} -O2 -fopenmp -std=c++11  " )
+set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "${precision_flag} -DMETIS5 ${cppmach} ${cpprel} -O3 -fopenmp -std=c++11  " )
 
 endif()
 

--- a/starter/CMake_Compilers/platforms.txt
+++ b/starter/CMake_Compilers/platforms.txt
@@ -1,4 +1,5 @@
          -arch=linux64_gf  (SMP executable / Gfortran compiler)
+         -arch=linux64_AOCC (SMP executable / AOCC compiler)
          -arch=linuxa64    (SMP executable / ARM Linux - Armflang compiler)
          -arch=win64       (SMP executable / Windows X86-64 - Intel OneAPI)
 

--- a/starter/share/spe_inc/machine.inc
+++ b/starter/share/spe_inc/machine.inc
@@ -55,6 +55,8 @@ C
       ARCHTITLE='Linux 64 bits, ARM compiler'
 #elif CPP_rel == 80
       ARCHTITLE='Linux 64 bits, GNU compiler'
+#elif CPP_rel == 96
+      ARCHTITLE='Linux 64 bits, AMD AOCC compiler'
 #elif 1
       ARCHTITLE='Linux 64 bits, Intel compiler'
 #endif

--- a/starter/share/spe_inc/my_allocate.inc
+++ b/starter/share/spe_inc/my_allocate.inc
@@ -21,6 +21,21 @@ Copyright>        As an alternative to this open-source version, Altair also off
 Copyright>        software under a commercial license.  Contact Altair to discuss further if the 
 Copyright>        commercial version may interest you: https://www.altair.com/radioss/.    
 
+#if defined(COMP_AOCC)
+#ifndef MY_ALLOCATE 
+#define MY_ALLOCATE(A,L) ALLOCATE(A(L))
+#endif
+
+#ifndef MY_ALLOCATE2D
+#define MY_ALLOCATE2D(A,L1,L2) ALLOCATE(A(L1,L2));
+#endif
+
+#ifndef MY_ALLOCATE3D
+#define MY_ALLOCATE3D(A,L1,L2,L3) ALLOCATE(A(L1,L2,L3))
+#endif
+
+#else
+
 #if defined(COMP_LLVM)
 #ifndef MY_ALLOCATE
 #define MY_ALLOCATE(A,L)\
@@ -106,6 +121,7 @@ ALLOCATE(ARRAY(LENGTH1,LENGTH2,LENGTH3),STAT=MY_IERR);\
 IF(MY_IERR/=0) THEN;\
 CALL ANCMSG(MSGID=268,MSGTYPE=MSGERROR,ANMODE=ANSTOP,C1=#ARRAY);\
 ENDIF
+#endif
 #endif
 #endif
 #endif

--- a/starter/share/spe_inc/vectorize.inc
+++ b/starter/share/spe_inc/vectorize.inc
@@ -38,7 +38,11 @@ C$pragma SUN pipeloop=0
 CDIR$ IVDEP
 #elif CPP_mach == CPP_p4linux964 || CPP_mach == p4win64
 
-#ifdef COMP_GFORTRAN
+#ifdef COMP_GFORTRAN 
+!$OMP SIMD
+#else
+
+#ifdef COMP_AOCC 
 !$OMP SIMD
 #else
 
@@ -48,6 +52,7 @@ CDIR$ IVDEP
 !DIR$ IVDEP
 #endif
 
+#endif
 #endif
 
 #elif 1

--- a/starter/source/coupling/rad2rad/r2r_fork.F
+++ b/starter/source/coupling/rad2rad/r2r_fork.F
@@ -75,7 +75,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER ISTAT,KDOM,IPID_RET,IERROR,WAIT,IPID_L,STAT,DOM_SWITCH
       LOGICAL(4) WAITA       
-#if defined(COMP_ARMFLANG) || defined(COMP_LLVM)
+#if defined(COMP_ARMFLANG) || defined(COMP_LLVM) || defined(COMP_AOCC)
       INTEGER  GETPID
 #endif
       INTEGER :: LEN_TMP_NAME
@@ -108,7 +108,7 @@ C----------------------------------------------------------------------
 C-------------------INTEL -> LINUX/LINUXIA64/MACOSX--------------------
 C----------------------------------------------------------------------         
 #else
-#if defined (COMP_GFORTRAN) ||  defined(COMP_ARMFLANG) || defined(COMP_LLVM)
+#if defined(COMP_GFORTRAN) || defined(COMP_ARMFLANG)|| defined(COMP_LLVM) || defined(COMP_AOCC)
         CALL MY_FORK(IPID)
         IPID_RET = GETPID()
 #else
@@ -139,7 +139,7 @@ C----------------------------------------------------------------------
 C-------------------INTEL -> LINUX/LINUXIA64/MACOSX--------------------
 C----------------------------------------------------------------------                     
 #else
-#if defined(COMP_GFORTRAN) ||  defined(COMP_ARMFLANG) || defined(COMP_LLVM)
+#if defined(COMP_GFORTRAN) ||  defined(COMP_ARMFLANG) || defined(COMP_LLVM) ||  defined(COMP_AOCC)
             CALL MY_WAITPID(IPID,ISTAT,0,IPID_RET)
 #else
             CALL PXFWAITPID(IPID,ISTAT,0,IPID_RET,IERROR)


### PR DESCRIPTION
#### Description of the feature or the bug
The changes enables build with the latest release of AMD's AOCC-4.0 compiler. The changes, in theory, should only introduce perturbations to the results. 

#### Description of the changes
1. removed some flags that are meaningless for AOCC-4.0 compiler and replaced them as needed in _cmake_linux64_AOCC.txt_
2. The '\\' in the C -preprocessor macros leads to the "unmatched quotes" error even with -fbacklash (or -fnobacklash) flag; mitigated this issue by minor modifcations in the  _engine/share/spe_inc/my_allocate.inc_ as well as _starter/share/spe_inc/my_allocate.inc_
which is AOCC specific and should not affect other compilers.  (Introduced COMP_AOCC for this purpose)
3. Built Lapack by AOCC-4.0 and integrated to the extlib/ using git-lfs; An alternative way would be to integrate lapack  by ExternalProject_Add utility in cmake, which would build the library on the fly; This can be a subject matter of another ticket (Just a recommendation) 
4. Added AOCC compiler stamp to the logfile  _engine/share/spe_inc/machine.inc_
AOCC-4.0 is released with Genoa launch and has up to 96 cores; That is why I assigned 96 to  CPP_rel, if you prefer to use another number it is ok, I was just looking for something unique and in a way relevant
Note: I could not find any instructions on how to use the qa scripts as I was looking to upload a clean report.   
5. Added AOCCand Openmpi to the list of platforms 