### PR TITLE
Fix typos in `engine/source/interfaces`

### DIFF
--- a/engine/source/interfaces/generic/check_coarse_grid.F
+++ b/engine/source/interfaces/generic/check_coarse_grid.F
@@ -30,7 +30,7 @@ Chd|====================================================================
         SUBROUTINE CHECK_COARSE_GRID(NIN,MAIN_COARSE_GRID,SORT_COMM,ITIED)
 !$COMMENT
 !       CHECK_COARSE_GRID description :
-!       for a given interface, check if the currect processor needs to communicate with a remote processor
+!       for a given interface, check if the correct processor needs to communicate with a remote processor
 !
 !       CHECK_COARSE_GRID organization :
 !           loop over the processor P and :

--- a/engine/source/interfaces/generic/inter_check_sort.F
+++ b/engine/source/interfaces/generic/inter_check_sort.F
@@ -79,7 +79,7 @@ C-----------------------------------------------
         INTEGER, DIMENSION(NBINTC), INTENT(inout) :: LIST_INTER_SORTED   !   list of interfaces that need to be sorted
         INTEGER, DIMENSION(NPARI,NINTER), INTENT(in) :: IPARI    !   interface data
         TYPE(INTBUF_STRUCT_),DIMENSION(NINTER) :: INTBUF_TAB    ! interface data
-        TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   struture for interface
+        TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   structure for interface
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) :: SENSOR_TAB
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/engine/source/interfaces/generic/inter_color_voxel.F
+++ b/engine/source/interfaces/generic/inter_color_voxel.F
@@ -82,7 +82,7 @@ C-----------------------------------------------
         INTEGER, DIMENSION(NPARI,NINTER), INTENT(in) :: IPARI    !   interface data
         TYPE(INTBUF_STRUCT_),DIMENSION(NINTER), INTENT(in) :: INTBUF_TAB    ! interface data
         my_real, DIMENSION(3*NUMNOD), INTENT(in) :: X            !   position
-        TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   struture for interface
+        TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   structure for interface
         TYPE(sorting_comm_type), DIMENSION(NINTER), INTENT(inout) :: SORT_COMM   ! structure for interface sorting comm
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/engine/source/interfaces/generic/inter_count_node_curv.F
+++ b/engine/source/interfaces/generic/inter_count_node_curv.F
@@ -84,7 +84,7 @@ C-----------------------------------------------
         TYPE(INTBUF_STRUCT_),DIMENSION(NINTER) :: INTBUF_TAB    ! interface data
         my_real, DIMENSION(3,NUMNOD), INTENT(in) :: X            !   position
         INTEGER, DIMENSION(NUMNOD), INTENT(in) :: WEIGHT !   flag for secondary nodes (1= current proc is the master proc)
-        TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   struture for interface
+        TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   structure for interface
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/engine/source/interfaces/generic/inter_deallocate_wait.F
+++ b/engine/source/interfaces/generic/inter_deallocate_wait.F
@@ -85,7 +85,7 @@ C-----------------------------------------------
       INTEGER, DIMENSION(NPARI,NINTER), INTENT(in) :: IPARI    !   interface data
       INTEGER, DIMENSION(NINTER+1,NSPMD+1), INTENT(in) :: ISENDTO,IRECVFROM 
       TYPE(INTBUF_STRUCT_),DIMENSION(NINTER), INTENT(inout) :: INTBUF_TAB    ! interface data
-      TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   struture for interface
+      TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   structure for interface
       TYPE(sorting_comm_type), DIMENSION(NINTER), INTENT(inout) :: SORT_COMM   ! structure for interface sorting comm
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) :: SENSOR_TAB
 C-----------------------------------------------

--- a/engine/source/interfaces/generic/inter_prepare_sort.F
+++ b/engine/source/interfaces/generic/inter_prepare_sort.F
@@ -114,7 +114,7 @@ C-----------------------------------------------
 
 
         TYPE(INTBUF_STRUCT_), DIMENSION(NINTER), INTENT(inout) :: INTBUF_TAB   ! interface data
-        TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   struture for interface
+        TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   structure for interface
         TYPE(sorting_comm_type), DIMENSION(NINTER), INTENT(inout) :: SORT_COMM   ! structure for interface sorting comm
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/engine/source/interfaces/generic/inter_sort.F
+++ b/engine/source/interfaces/generic/inter_sort.F
@@ -95,7 +95,7 @@ C-----------------------------------------------
       INTEGER, DIMENSION(NSPMD), INTENT(inout) :: NSNFIOLD
       TYPE(MULTI_FVM_STRUCT), INTENT(INOUT), TARGET     :: MULTI_FVM
       TYPE(H3D_DATABASE) :: H3D_DATA
-      TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   struture for interface
+      TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   structure for interface
       TYPE(sorting_comm_type), DIMENSION(NINTER), INTENT(inout) :: SORT_COMM   ! structure for interface sorting comm
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) :: SENSOR_TAB
 C-----------------------------------------------

--- a/engine/source/interfaces/generic/inter_struct_init.F
+++ b/engine/source/interfaces/generic/inter_struct_init.F
@@ -67,7 +67,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-        TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   struture for interface
+        TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   structure for interface
         TYPE(sorting_comm_type), DIMENSION(NINTER), INTENT(inout) :: SORT_COMM   ! structure for interface sorting comm
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/engine/source/interfaces/int07/i7cdcor3.F
+++ b/engine/source/interfaces/int07/i7cdcor3.F
@@ -63,7 +63,7 @@ C-----------------------------------------------
       INTEGER I 
 C-----------------------------------------------
 C
-      !intialization of local buffer (1:MVSIZ)
+      !initialization of local buffer (1:MVSIZ)
       DO I=1,JLT
         CAND_E_N(I) = CAND_E(INDEX(I))
         CAND_N_N(I) = CAND_N(INDEX(I))

--- a/engine/source/interfaces/int07/i7ke3.F
+++ b/engine/source/interfaces/int07/i7ke3.F
@@ -807,7 +807,7 @@ C-----------------------------------------------
       INTEGER I,NS,NI,NN
 C-----------------------------------------------
 C--------------------------------------------------------
-C  Due to multi-contacts, zero initialization should be done globaly
+C  Due to multi-contacts, zero initialization should be done globally
 C--------------------------------------------------------
        IF (NSPMD>1) THEN
         DO I=1,JLT

--- a/engine/source/interfaces/int07/inter_sort_07.F
+++ b/engine/source/interfaces/int07/inter_sort_07.F
@@ -110,7 +110,7 @@ C-----------------------------------------------
         TYPE(INTBUF_STRUCT_) INTBUF_TAB
         TYPE(H3D_DATABASE) :: H3D_DATA
         TYPE(MULTI_FVM_STRUCT), INTENT(INOUT) :: MULTI_FVM
-        TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   struture for interface
+        TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   structure for interface
         TYPE(sorting_comm_type), DIMENSION(NINTER), INTENT(inout) :: SORT_COMM   ! structure for interface sorting comm
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/engine/source/interfaces/int07/inter_trc_7.F
+++ b/engine/source/interfaces/int07/inter_trc_7.F
@@ -75,7 +75,7 @@ C-----------------------------------------------
         TYPE(INTBUF_STRUCT_),DIMENSION(NINTER) :: INTBUF_TAB    ! interface data
         INTEGER, INTENT(in) :: NB_INTER_SORTED        !   number of interfaces that need to be sorted
         INTEGER, DIMENSION(NB_INTER_SORTED), INTENT(in) :: LIST_INTER_SORTED   !   list of interfaces that need to be sorted
-        TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   struture for interface
+        TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   structure for interface
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/engine/source/interfaces/int17/i17main.F
+++ b/engine/source/interfaces/int17/i17main.F
@@ -208,7 +208,7 @@ C -------------------------------------------------------------
      5   MX_CAND    ,EMINX(1,NME+1),ESH_T ,INTBUF_TAB%FROTS,INTBUF_TAB%KS,
      6   IDUM1      ,IDUM2	 ,IDUM3   ,NIN  	,NMESR        ,
      7   V	    )
-C IDUM1 & IDUM2 replace ISENDTO, IRCVFROM usefull for SPMD i17 pena
+C IDUM1 & IDUM2 replace ISENDTO, IRCVFROM useful for SPMD i17 pena
 C -------------------------------------------------------------
          CALL MY_BARRIER
 C -------------------------------------------------------------

--- a/engine/source/interfaces/int18/i18dst3.F
+++ b/engine/source/interfaces/int18/i18dst3.F
@@ -147,7 +147,7 @@ C-----------------------------------------------
          Y0(I) = FOURTH*(Y1(I)+Y2(I)+Y3(I)+Y4(I))
          Z0(I) = FOURTH*(Z1(I)+Z2(I)+Z3(I)+Z4(I)) 
         ELSE
-         !alrady a triangle
+         !already a triangle
          X0(I) = X3(I)
          Y0(I) = Y3(I)
          Z0(I) = Z3(I)

--- a/engine/source/interfaces/int18/i18for3.F
+++ b/engine/source/interfaces/int18/i18for3.F
@@ -63,7 +63,7 @@ C   D e s c r i p t i o n
 C-----------------------------------------------
 C This subroutine is computing reaction forces
 C for fluid structure interaction /INTER/TYPE18
-C It also ouputs contour and time histories.
+C It also outputs contour and time histories.
 C
 C   I=1:JLT : local loop (JLT<=128)
 C   INDEX(I) is Node id (internal)

--- a/engine/source/interfaces/int18/i18main_kine.F
+++ b/engine/source/interfaces/int18/i18main_kine.F
@@ -49,7 +49,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n 
 C-----------------------------------------------
 C This subroutine is a 'kinematic version' of coupling interface type 18
-C It is an old and experimental version which has never been released (abandonned)
+C It is an old and experimental version which has never been released (abandoned)
 C  Principle : Structural velocity is imposing fluid velocity
 C  Starter Keyword : /INTER/TYPE18/KINE
 C-----------------------------------------------
@@ -641,7 +641,7 @@ C
       KMIN  =INTBUF_TAB%VARIABLES(17)
       KMAX  =INTBUF_TAB%VARIABLES(18)
 
-C     parrallel part after elem forces
+C     parallel part after elem forces
 C     static cutting
       NB_LOC = I_STOK / NTHREAD
       IF (JTASK == NTHREAD) THEN
@@ -1761,7 +1761,7 @@ C
 C
       ENDDO
 C---------------------------------
-C    transfering fluid force to structure nodes
+C    transferring fluid force to structure nodes
 C---------------------------------
       DO I=1,JLT
         IF(PENE(I) > ZERO)THEN
@@ -1781,7 +1781,7 @@ C
           FY4(I)=FYI(I)*H4(I)
           FZ4(I)=FZI(I)*H4(I)
 C---------------------------------
-c       transfering fluid tensorial mass to structural nodes
+c       transferring fluid tensorial mass to structural nodes
 C---------------------------------
 c
 c            | nx*nx nx*ny nx*nz |

--- a/engine/source/interfaces/int18/int18_law151_omp_accumulation.F
+++ b/engine/source/interfaces/int18/int18_law151_omp_accumulation.F
@@ -34,7 +34,7 @@ Chd|====================================================================
 !       INT18_LAW151_OMP_ACCUMULATION description
 !       accumulation of force for remote nodes on the 
 !       main OpenMP thread
-!       only usefull when OMP_NUM_THREADS > 1
+!       only useful when OMP_NUM_THREADS > 1
 !       
 !       INT18_LAW151_OMP_ACCUMULATION organization :
 !           loop over the NTHREADS OpenMP task + NODFI phantom nodes 

--- a/engine/source/interfaces/int18/multi_i18_force_pon.F
+++ b/engine/source/interfaces/int18/multi_i18_force_pon.F
@@ -48,8 +48,8 @@ Chd|====================================================================
 !                             accumulation in FORC_INT array
 !            * if NSV < 0 --> remote node
 !                             accumulation in AFI array
-!       for each secondary node, a float_to_6_float operation is perfomed
-!       in order to garantee the parith/on
+!       for each secondary node, a float_to_6_float operation is performed
+!       in order to guarantee the parith/on
 !$ENDCOMMENT
 C-----------------------------------------------
 C   M o d u l e s

--- a/engine/source/interfaces/int22/deltax22.F
+++ b/engine/source/interfaces/int22/deltax22.F
@@ -35,7 +35,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 C this subroutines update VOLN for cut cells.
 C Main cells have extended values of volume due
@@ -123,10 +123,10 @@ C-----------------------------------------------
            !---meth2:supercell dx estimated with main cell dx (minorant)
            !DELTAX(I)   = VOLM/AREAM  
             
-           !---meth3:isomorph supercell to equivlent brick(cube) 
+           !---meth3:isomorph supercell to equivalent brick(cube)
            !DELTAX(I)   = (VOLN(I))**THIRD
            
-           !---meth4:isomorph main cell only to equivlent brick(cube) 
+           !---meth4:isomorph main cell only to equivalent brick(cube)
            !DELTAX(I)   = VOLM**THIRD  
                     
            !---meth5: no specific treatment (FAST but only valid if time step scale factor <= 0.5 in engine file)

--- a/engine/source/interfaces/int22/destroy_cell.F
+++ b/engine/source/interfaces/int22/destroy_cell.F
@@ -33,7 +33,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C----------------------------------------------- 
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 C Destroy a cell ICELL_target for a given cut 
 C cell IB in the cut cell buffer.

--- a/engine/source/interfaces/int22/get_group_id.F
+++ b/engine/source/interfaces/int22/get_group_id.F
@@ -52,7 +52,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 C   Defines following surjective application  
 C            [1:SPHI]    -->   [1:NGROUP] x [1:MVSIZ] 

--- a/engine/source/interfaces/int22/get_unique_master_cell.F
+++ b/engine/source/interfaces/int22/get_unique_master_cell.F
@@ -26,7 +26,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C----------------------------------------------- 
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 ! With interface 22 Hexahedral cell is cut and
 ! main one is the biggest one which is greater

--- a/engine/source/interfaces/int22/i22assembly.F
+++ b/engine/source/interfaces/int22/i22assembly.F
@@ -38,7 +38,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------

--- a/engine/source/interfaces/int22/i22cor3.F
+++ b/engine/source/interfaces/int22/i22cor3.F
@@ -49,7 +49,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 C-----------------------------------------------
 C   M o d u l e s

--- a/engine/source/interfaces/int22/i22datainit.F
+++ b/engine/source/interfaces/int22/i22datainit.F
@@ -35,7 +35,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 C=======================================================================   
 C   I m p l i c i t   T y p e s
@@ -305,7 +305,7 @@ C=======================================================================
        Gtria(:, 2, 3) = (/1,2,4/)                      
        Gtria(:, 3, 3) = (/1,4,5/)                             
 
-       Gtria(:, 1, 4) = (/1,2,3/)  !HEXAE (2 traingles)
+       Gtria(:, 1, 4) = (/1,2,3/)  !HEXAE (2 triangles)
        Gtria(:, 2, 4) = (/1,3,4/) 
        
        Gtria(:, 1, 5) = (/1,6,5/)  !POLY4 (4 triangles)

--- a/engine/source/interfaces/int22/i22datainit_db.F
+++ b/engine/source/interfaces/int22/i22datainit_db.F
@@ -35,7 +35,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------

--- a/engine/source/interfaces/int22/i22for3.F
+++ b/engine/source/interfaces/int22/i22for3.F
@@ -62,7 +62,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 C-----------------------------------------------
 C   M o d u l e s
@@ -319,7 +319,7 @@ c        IF(NBCUT==0) print *, "     C Y C L E"
           ! +  IX      /II+   I   | IX +
           ! +---------/---+-------|----+
           !                       |
-          !                       | <------ face of this edge must not be projected on vitual cut surface from cell 20
+          !                       | <------ face of this edge must not be projected on virtual cut surface from cell 20
           !                                 this case is not treated (lagrangian face too complex or multiple surface, self-impact, etc...)
           !                                 Use a simple surface : smooth and without holes
 
@@ -400,7 +400,7 @@ c        IF(NBCUT==0) print *, "     C Y C L E"
           FF(:) = FFO * N_SURF(:,iabs(CAND_E(I)))
           !rint *, "F_cog=", FF(:)
           
-          !distributed forces using weigthing coefficients
+          !distributed forces using weighting coefficients
           FX1(I)= FX1(I) + delta(1,ICUT,I) * FF(1)
           FY1(I)= FY1(I) + delta(1,ICUT,I) * FF(2) 
           FZ1(I)= FZ1(I) + delta(1,ICUT,I) * FF(3) 
@@ -551,11 +551,11 @@ C              endif
           !force au CoG
           FF(:)        = FFO * N_SURF(:,iabs(CAND_E(I)))
           !rint *, "F_cog=", FF(:)
-          
-          !distributed forces using weigthing coefficients
+
+          !distributed forces using weighting coefficients
           FX1(I)       = FX1(I) + delta(1,8+J,I) * FF(1)
-          FY1(I)       = FY1(I) + delta(1,8+J,I) * FF(2) 
-          FZ1(I)       = FZ1(I) + delta(1,8+J,I) * FF(3) 
+          FY1(I)       = FY1(I) + delta(1,8+J,I) * FF(2)
+          FZ1(I)       = FZ1(I) + delta(1,8+J,I) * FF(3)
 
           FX2(I)       = FX2(I) + delta(2,8+J,I) * FF(1)
           FY2(I)       = FY2(I) + delta(2,8+J,I) * FF(2)
@@ -674,8 +674,8 @@ C
 
       !---------------------------------!
       !       ASSEMBLY PARITH ON/OFF    !
-      !---------------------------------!     
-      !these array could be removed from inter22 later during source cleaing
+      !---------------------------------!
+      !these array could be removed from inter22 later during source cleaning
       H1 = ZERO
       H2 = ZERO
       H3 = ZERO

--- a/engine/source/interfaces/int22/i22get_prev_data.F
+++ b/engine/source/interfaces/int22/i22get_prev_data.F
@@ -38,7 +38,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 C  This subroutine get data from cut cell buffer
 C  in previous cycle and update new buffer with

--- a/engine/source/interfaces/int22/i22ident.F
+++ b/engine/source/interfaces/int22/i22ident.F
@@ -37,7 +37,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 C Determine intersection type
 C---------local numbering of edges------------------
@@ -168,7 +168,7 @@ C=======================================================================
       NBL = (ITASK+1)*NB/NTHREAD
  
       DO I=NBF,NBL
-       !KEEP TRIPLE POINTS, INTERPRETATION OF PARTIITONING IS MADE TAKING MOST COMPLEX POLY EVEN IF THERE ARE EXPECTED REMAING INTERSECTION POINTS
+       !KEEP TRIPLE POINTS, INTERPRETATION OF PARTITIONING IS MADE TAKING MOST COMPLEX POLY EVEN IF THERE ARE EXPECTED REMAINING INTERSECTION POINTS
     !        CALL REMOVE_DOUBLE_INTP(
     ! 1                              IXS, X, ITASK, NIN, BUFBRIC,
     ! 2                              I )      

--- a/engine/source/interfaces/int22/i22intersect.F
+++ b/engine/source/interfaces/int22/i22intersect.F
@@ -41,7 +41,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 C  X(3,*) is used for local nodes (cells) for surface nodes use IRECTL  
 C-----------------------------------------------
@@ -338,7 +338,7 @@ C================================================================
       NBF = 1+ITASK*NCANDB/NTHREAD
       NBL = (ITASK+1)*NCANDB/NTHREAD
 
-      !NCANDB bricks are present in candidates. Theses NCANDB bricks are multi-threaded. Each thread will handle ( (/CAND_B(IADF(I):IADL(I)) , CAND_B(IADF(I):IADL(I))/), I=NBF,NBL)
+      !NCANDB bricks are present in candidates. These NCANDB bricks are multi-threaded. Each thread will handle ( (/CAND_B(IADF(I):IADL(I)) , CAND_B(IADF(I):IADL(I))/), I=NBF,NBL)
 
       DO I=NBF,NBL !each thread handle its bricks (no duplicate work)
         BRICK_LIST(NIN,I)%Seg_add_LFT = IADF(I)    ! corresponding window in CAND_B(i)  : CAND_B(IADFL(I):IADL(I)) = I
@@ -449,7 +449,7 @@ C          END IF
                 !IF(J==1 .OR. J==5 .OR. J==8 .OR. J==12)THEN
                 !  ON1(1:3) = X(1:3,iN(1))
                 !  N1N2(1:3)= EDGE_LIST(NIN,K)%VECTOR(1:3)
-                !  CUTCOOR     = ONE-EM06                                      !interection on edge nodes1,5,8 ou 12 (necessary case to get a corresponding topology without risking to loose the lagrangian surface while it moves)
+                !  CUTCOOR     = ONE-EM06                                      !intserection on edge nodes1,5,8 ou 12 (necessary case to get a corresponding topology without risking to loose the lagrangian surface while it moves)
                 !  CUTCOOR2    = EM06
                 
                 
@@ -466,7 +466,7 @@ C          END IF
                 !IF(J==1 .OR. J==5 .OR. J==8 .OR. J==12)THEN
                   ON1(1:3) = X(1:3,iN(1))
                   N1N2(1:3)= EDGE_LIST(NIN,K)%VECTOR(1:3)
-                  CUTCOOR     = EM06                                     !interection on edge nodes 1,5,8 ou 12 (necessary case to get a corresponding topology without risking to loose the lagrangian surface while it moves)
+                  CUTCOOR     = EM06                                     !intserection on edge nodes 1,5,8 ou 12 (necessary case to get a corresponding topology without risking to loose the lagrangian surface while it moves)
                   POINT(1:3)  = ON1(1:3) + ZERO * N1N2(1:3)              
                   NBCUT2 = 0             
                 !ELSE
@@ -486,7 +486,7 @@ C          END IF
                 !IF(J==1 .OR. J==5 .OR. J==8 .OR. J==12)THEN
                   ON1(1:3) = X(1:3,iN(1))
                   N1N2(1:3)= EDGE_LIST(NIN,K)%VECTOR(1:3)
-                  CUTCOOR     = ONE-EM06                                     !interection with edge nodes 1,5,8 ou 12 (necessary case to get a corresponding topology without risking to loose the lagrangian surface while it moves)
+                  CUTCOOR     = ONE-EM06                                     !intserection with edge nodes 1,5,8 ou 12 (necessary case to get a corresponding topology without risking to loose the lagrangian surface while it moves)
                   POINT(1:3)  = ON1(1:3) + ONE * N1N2(1:3)              
                   NBCUT2 = 0             
                 !ELSE
@@ -521,13 +521,13 @@ C          END IF
               endif                      
 
               !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-              !If intersection with inifinite plane, we calculate coordinates on the edge : COOR = N1+ t N1N2
+              !If intersection with infinite plane, we calculate coordinates on the edge : COOR = N1+ t N1N2
               ! if t is not within [0,1] we are not on the segment but on the open entity (N1N2)\[N1N2]
               IF(NBCUT>0) THEN !if we detect intersection on current shell          
                 IF(DEJA==0)THEN !edge is not yet cut : first intersection detected
                   !print *, "nouveau point", CUTCOOR                
                   NBCUT=1
-                  EDGE_LIST(NIN,K)%CUTCOOR(1)  = CUTCOOR          ! sotrage
+                  EDGE_LIST(NIN,K)%CUTCOOR(1)  = CUTCOOR          ! storage
                   EDGE_LIST(NIN,K)%CUTSHELL(1) = IE
                 ELSEIF (DEJA==1)THEN                              ! already cut => 2nd intersection
                   OLD_CUTCOOR  = EDGE_LIST(NIN,K)%CUTCOOR(1)      ! first store, the ordering the 2 intersections
@@ -669,7 +669,7 @@ C================================================================
         N1N2(1:3)    = EDGE_LIST(NIN,IAD)%VECTOR(1:3)
         ON1(1:3)     = X(1:3,iN(1)) 
           DO K=1,NBCUT
-            !intersection coordonates
+            !intersection coordinates
             POINT(1:3)= ON1(1:3) + CUT(K) * N1N2(1:3)
             ! EDGE_LIST(NIN,IAD)%CUTPOINT(1:3) = POINT(1:3)              
            !===script HM=====!
@@ -783,7 +783,7 @@ Chd|====================================================================
 C-----------------------------------------------
 C   P r e c o n d i t i o n s
 C-----------------------------------------------
-! Precondition : Point P is on the inifinite plane generated by 3-node-shell (Z,A,B)
+! Precondition : Point P is on the infinite plane generated by 3-node-shell (Z,A,B)
 C-----------------------------------------------
 C   D e s c r i p t  i o n
 C-----------------------------------------------

--- a/engine/source/interfaces/int22/i22mainf.F
+++ b/engine/source/interfaces/int22/i22mainf.F
@@ -62,7 +62,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 C-----------------------------------------------
 C   M o d u l e s

--- a/engine/source/interfaces/int22/i22subvol.F
+++ b/engine/source/interfaces/int22/i22subvol.F
@@ -39,7 +39,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 C CThis subroutine computes coordinates of intersection points and faces area
 C-----------------------------------------------
@@ -211,9 +211,9 @@ C----------------------------------------------------------------
         BRICK_LIST(NIN,IB)%PCUT(1:9)%Vel(3)   = ZERO
         
         !--------------------------------------------------------------------------------!
-        !  1. CHECK FIRST IF AMBIGOUS COMBINATION                                        !
+        !  1. CHECK FIRST IF AMBIGUOUS COMBINATION                                       !
         !--------------------------------------------------------------------------------!
-        !bAMBIGOUS == .TRUE. => ambigous combination detected
+        !bAMBIGOUS == .TRUE. => ambiguous combination detected
         ! (code1_bis, code2_bis) is then the alternative combination
         IF(BRICK_LIST(NIN,IB)%NBCUT == 2)THEN
           SECTYPE = BRICK_LIST(NIN,IB)%SECTYPE(1)
@@ -252,9 +252,9 @@ C----------------------------------------------------------------
           ENDIF
           !CHECK SURFACE NORMAL AND SOLVE THE AMBIGUITY
           IF(.NOT.bAMBIGOUS)THEN
-            !print *, "not ambigous"
+            !print *, "not ambiguous"
           ELSE
-            !print *, "ambigous=", Cod1,Cod2
+            !print *, "ambiguous=", Cod1,Cod2
             !----------------------------------------------------------------
             !RETRIEVING LAGRANGIAN FACES & CUT PLANE NORMAL
             !----------------------------------------------------------------            
@@ -473,7 +473,7 @@ CC              print *, "inter22 : ambigus intersection not solved" ;
           !---------------------------------------------------------------- 
           !CALCUL DES COORDONNEES DES POINTS D'INTERSECTION
           !---------------------------------------------------------------- 
-          !if twice the same intersections, the 2nd one  is the biggest one choose farest intersection points 
+          !if twice the same intersections, the 2nd one is the biggest one choose farthest intersection points
           DO K=1,NTRUS  
              tagEDG   =  Gcorner(K,SECID)
             IF(tagEDG<0)THEN
@@ -1134,7 +1134,7 @@ C             if (IBUG22_subvol==1)WRITE (*,FMT='(A1)') " "
             vF(:,3) =I22AERA(4,(/n2,a2,a3,n3/)          ,   C(1:3,Fa(3)))
             vF(:,4) =I22AERA(4,(/n1,n4,a4,a1/)          ,   C(1:3,Fa(4)))
             vF(:,5) =I22AERA(7,(/n4,n3,a3,a6,a5,a4,n4/) ,   C(1:3,Fa(5)))
-            vF(:,0) =I22AERA(6,(/a1,a4,a5,a6,a3,a2/)    ,   C(1:3,   0 ))  !TO BE UPDATED LATER IF NEEED : this is an approximation
+            vF(:,0) =I22AERA(6,(/a1,a4,a5,a6,a3,a2/)    ,   C(1:3,   0 ))  !TO BE UPDATED LATER IF NEEDED : this is an approximation
             BRICK_LIST(NIN,IB)%POLY(9)%FACE(Fa(1))%Center(1:3) = BRICK_LIST(NIN,IB)%POLY(9)%FACE(Fa(1))%Center(1:3) + ZERO    !put sum intersection point in icell 9 (will be used in sinit22_fvm.F to compute faceCenter for poly9
             BRICK_LIST(NIN,IB)%POLY(9)%FACE(Fa(2))%Center(1:3) = BRICK_LIST(NIN,IB)%POLY(9)%FACE(Fa(2))%Center(1:3) +a1+a2
             BRICK_LIST(NIN,IB)%POLY(9)%FACE(Fa(3))%Center(1:3) = BRICK_LIST(NIN,IB)%POLY(9)%FACE(Fa(3))%Center(1:3) +a2+a3             
@@ -2115,7 +2115,7 @@ C             if (IBUG22_subvol==1)WRITE (*,FMT='(A1)') " "
               
               ValTMP(1:3)                                = BRICK_LIST(NIN,IB)%POLY(1)%CellCenter(1:3)
                                                                                                                                   
-              !bakup poly1                                                                                                         
+              !backup poly1                                                                                                         
               BRICK_LIST(NIN,IB)%POLY(3)%FACE(1:6)%Surf  = BRICK_LIST(NIN,IB)%POLY(1)%FACE(1:6)%Surf                                     
               BRICK_LIST(NIN,IB)%PCUT(3)%SCUT            = BRICK_LIST(NIN,IB)%PCUT(1)%SCUT                                         
               BRICK_LIST(NIN,IB)%PCUT(3)%B(1:3)          = BRICK_LIST(NIN,IB)%PCUT(1)%B(1:3)                                       

--- a/engine/source/interfaces/int22/i22wetsurf.F
+++ b/engine/source/interfaces/int22/i22wetsurf.F
@@ -48,7 +48,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 C-----------------------------------------------
 C   M o d u l e s
@@ -765,7 +765,7 @@ C--------------------------------------------------------
        !POLYGONAL CLIPPING (SCUT with projected segment)
 C-------------------------------------------------------- 
 ! Projected Segment might be non convex. In this case it is decomposed into 2 triangles (hourglass shape)
-! If projected segment is convex then it is splitted into 4 triangles (recquired for parith on)
+! If projected segment is convex then it is splitted into 4 triangles (required for parith on)
 !
         DO ICUT = 1, NBCUT                                                                                        
           SEFF(ICUT,I)              = ZERO 

--- a/engine/source/interfaces/int22/int22ListCombi.F
+++ b/engine/source/interfaces/int22/int22ListCombi.F
@@ -28,7 +28,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 C  Recursive combinatory algorithm.
 C
@@ -46,7 +46,7 @@ C           potential combination. Is Updated
 C           to remove incompatibility with
 C           combination in ListFIX. Is expanded
 C           into new sublist to test new recursively
-C           new list os combiantion
+C           new list os combination
 C NBITS   : number of bits which represent the
 C           number of intersection points (on brick edges)
 C           remains UNCHANGED in the recursion process
@@ -123,13 +123,13 @@ ccc        print *, arg_ListVAR(1:arg_SizeVAR)
         COUNT      = 0
         CountFIX   = 0
         CountVAR   = 0
-        !accumulation of intersection points recquired by each combination present in the Fixed List.          
+        !accumulation of intersection points required by each combination present in the Fixed List.          
         DO I=1,SizeFIX
           pCODE    = IABS(ListFIX(I))
           ITYP     = GetPolyhedraType(pCODE)
           CountFIX = CountFIX + C_POLYH(ITYP)
         ENDDO !next I
-        !accumulation of intersection points recquired by each combination present in the Variable List.    
+        !accumulation of intersection points required by each combination present in the Variable List.    
         DO I=1,SizeVAR
           pCODE    = ListVAR(I)
           ITYP     = GetPolyhedraType(pCODE)
@@ -199,7 +199,7 @@ c          print *, "   *** EXPAND"
           !------------------------------------------------!
           ! UPDATE FIXED LIST AND VARIABLE LIST (NEW LOCAL)!
           !------------------------------------------------!         
-          !Expanding the varaible sublist & taking each combination in varaible list to add it in a new fix list.
+          !Expanding the variable sublist & taking each combination in variable list to add it in a new fix list.
           SizeLLFIX = SizeFIX + 1
           !SizeLLVAR = SizeVAR - 1 
           !SizeLLVAR_bak =  SizeLLVAR        
@@ -247,7 +247,7 @@ ccc            print *, "=====LLVAR(II,1:SizeLLVAR) = ",LLVAR(II,1:SizeLLVAR)
                 DO J=1,8
                   IF( TAG_nod_tmp(J)==0)CYCLE
                   TAG_nod_fix(J) = TAG_nod_fix(J)+1
-                  IF(TAG_nod_fix(J) >= 2)GOTO 50 !already a complementary polyhjedron, the original one is incomaptible with the previous in the list, so exit                
+                  IF(TAG_nod_fix(J) >= 2)GOTO 50 !already a complementary polyhedron, the original one is incompatible with the previous in the list, so exit                
                 ENDDO
               ELSE
                 DO J=1,NNOD
@@ -258,7 +258,7 @@ ccc            print *, "=====LLVAR(II,1:SizeLLVAR) = ",LLVAR(II,1:SizeLLVAR)
               ENDIF
               !this polyhedron also isolate same nodes. Check complementary polyhedron
               IF(BOOL)THEN
-                !restor TAG_nod_fix
+                !restore TAG_nod_fix
                 TAG_nod_fix(1:8) = TAG_nod_bak(1:8)       
                 !check complementary nodes
                 TAG_nod_tmp(1:8) = 1

--- a/engine/source/interfaces/int22/link_with_unique_master_cell.F
+++ b/engine/source/interfaces/int22/link_with_unique_master_cell.F
@@ -26,7 +26,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 ! With interface 22 Hexahedral cell is cut and
 ! main one is the biggest one which is greater

--- a/engine/source/interfaces/int22/r_bufbric_22.F
+++ b/engine/source/interfaces/int22/r_bufbric_22.F
@@ -36,7 +36,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 C This subroutine is reading buffer from RESTART file
 C-----------------------------------------------

--- a/engine/source/interfaces/int22/sigeps37_single_cell.F
+++ b/engine/source/interfaces/int22/sigeps37_single_cell.F
@@ -37,10 +37,10 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 C This subroutine is treating material law 37.
-C    !UVAR(I,1) : massic percentage of liquid * global density  (rho1*V1/V : it needs to give liquid mass multipling by element volume in aleconve.F)
+C    !UVAR(I,1) : massic percentage of liquid * global density  (rho1*V1/V : it needs to give liquid mass multiplying by element volume in aleconve.F)
 C    !UVAR(I,2) : density of gas
 C    !UVAR(I,3) : density of liquid
 C    !UVAR(I,4) : volumetric fraction of liquid

--- a/engine/source/interfaces/int22/sinit22_fvm.F
+++ b/engine/source/interfaces/int22/sinit22_fvm.F
@@ -48,7 +48,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 
 ! This subroutine is called for FSI interface 22
@@ -62,7 +62,7 @@ C
       ! @03. INIT/MULTITHREADING                                   !
       ! @04. INIT/ALLOCATION                                       !
       ! @05. RESET TAG22                                           !
-      ! @06. COMPUTE UNEXTENDED main CELL VOLUMES                !
+      ! @06. COMPUTE UNEXTENDED main CELL VOLUMES                  !
       ! @07. BUILDING BIJECTION APPLICATION for cut cells          !
       ! @08. ADJACENT BRICKS DATA IN CUT CELL BUFFER               !
       ! @09. AREA and VOLUME RATIO UPDATE for cut cells            !
@@ -73,15 +73,15 @@ C
       ! @14. FILL MATERIAL BUFFER : %bakMAT%...                    !
       ! @15. FINDING & STORING ADJACENT CELLS                      !
       ! @16. BUILD POLYGONAL TRACE FOR POLY9                       !
-      ! @17. PRE-TREATMENT FOR DBLE SECONDARY WITH BOTH V=0            !
-      ! @18. TAGGING SECONDARY CUT CELL                                !
-      ! @19. LINKING SECONDARY CELL TO A main ONE                    !
-      ! @20. LIST ALL SECONDARY CELLS LINKED TO A GIVEN main CELL    !
+      ! @17. PRE-TREATMENT FOR DBLE SECONDARY WITH BOTH V=0        !
+      ! @18. TAGGING SECONDARY CUT CELL                            !
+      ! @19. LINKING SECONDARY CELL TO A main ONE                  !
+      ! @20. LIST ALL SECONDARY CELLS LINKED TO A GIVEN main CELL  !
       ! @21. INDIRECT LINKING                                      !
       ! @22. INDIRECT LINKING                                      !
       ! @23. TAG SECONDARY CELLS WHICH ARE BASED ON FORMER main NODE !
-      ! @24. VOLUME MERGING BETWEEN SECONDARY CELL & ITS main ONE    !
-      ! @25. MATERIAL MERGING (IF main HAS TO BE DEPORTED)       !
+      ! @24. VOLUME MERGING BETWEEN SECONDARY CELL & ITS main ONE  !
+      ! @25. MATERIAL MERGING (IF main HAS TO BE DEPORTED)         !
       ! @26. DEMERGING CRITERIA                                    !
       ! @27. MATERIAL DEMERGING                                    !
       ! @28. COMPUTE VOLD_Vnew_Cell for newly cell in buffer       !
@@ -89,11 +89,11 @@ C
       ! @30. LINK SWITCHING                                        !
       ! @31. LEVEL2 NEIGHBORHOOD (FOR FLUXES & CONVECTION)         !
       ! @32. COUNT POINTS ON A GIVEN POLYHEDRON FACE               !
-      ! @33. LOCATE WHERE WAS main FOR NEXT CYCLE                !
+      ! @33. LOCATE WHERE WAS main FOR NEXT CYCLE                  !
       ! @34. SET IIAD22(1:NUMELS) = %ELBUG_TAB(NG)%TAG22(I)        !
       ! @35. SET MLW                                               !
-      ! @36. RESET OLD SECONDARY LIST CONNECTIVIY                      !
-      ! @37. SET main STRONG NODE                                !
+      ! @36. RESET OLD SECONDARY LIST CONNECTIVITY                 !
+      ! @37. SET main STRONG NODE                                  !
       ! @38. DRAW SUPERCELL CONNEXION WITH 1D TRUSSES              !
       ! @39. COMPUTE DVOL PREDICTION FOR EACH CELL                 !
       ! @40. BUILD SUPERCELL DVOL (PREDICTION)                     !
@@ -102,13 +102,13 @@ C
       ! @43. DEBUG OUTPUT                                          !
       ! @44. DEBUG - WRITE CUT CELL BUFFER                         !
       ! @45. SUPERCELL CENTERS                                     !
-      ! @46. MARK SUPER-CELL CENTERS WITH ORPHAN NODES             ! 
+      ! @46. MARK SUPER-CELL CENTERS WITH ORPHAN NODES             !
       ! @47. UNCUT CELLS + POLY 9 : CENTERS                        !
       ! @48. MARK CELL CENTERS WITH ORPHAN NODES                   !
-      ! @49. MARK FACE CENTERS WITH ORPHAN NODES                   !            
+      ! @49. MARK FACE CENTERS WITH ORPHAN NODES                   !
       ! @50. DEALLOCATE                                            !
       !------------------------------------------------------------!
-        
+
 !
 ! BUFFERS :
 !         BRICK_LIST     : BUT CELL BUFFER(NIN,IB) : NIN interface id, IB:cut cell id
@@ -721,7 +721,7 @@ c      ALLOCATE (Ntarget(NBF:NBL))
             BRICK_LIST(NIN,IB)%POLY(ICELL)%Vnew = GBUF%VOL(IDLOCB(IB)) + VOL                             
           ENDIF                               
           VOLratio = BRICK_LIST(NIN,IB)%POLY(ICELL)%Vnew / ELBUF_TAB(NGB(IB))%GBUF%VOL(IDLOCB(IB))       
-          !  THRESOLD VOLUME : Smax = O(V**(2/3)), dh= EM03 * O(V**(1/3)) => Veps = EM04*O(V) => VOLratio = Veps/V = EM04     (EM04 => dh = 0.01 % * average_edge)  
+          !  THRESHOLD VOLUME : Smax = O(V**(2/3)), dh= EM03 * O(V**(1/3)) => Veps = EM04*O(V) => VOLratio = Veps/V = EM04     (EM04 => dh = 0.01 % * average_edge) 
           IF(ABS(VOLratio) <= EM04)THEN     
              I22_DEGENERATED = 1              
           ENDIF                               
@@ -778,7 +778,7 @@ c      ALLOCATE (Ntarget(NBF:NBL))
            pPOINT(1:3)    = ZERO           
            !saving brick nodes used by remaining polyhedron (complementary one)                                                          
            DO J=1,8                        
-             IF(pWhichCellNod(J)%WhichCell/=0) CYCLE   !a tagged brick node is alredy used by a polyhedron    
+             IF(pWhichCellNod(J)%WhichCell/=0) CYCLE   !a tagged brick node is already used by a polyhedron
              pWhichCellNod(J)%WhichCell      = 9       
              MNOD                  = MNOD + 1
              pListNodID(9)%p(MNOD) = J !IXS(J+1,ID)                                                     
@@ -994,11 +994,11 @@ c      ALLOCATE (Ntarget(NBF:NBL))
               IF(IAD22 == 0)THEN
               !adjacent brick is in cut cell buffer : it also uncut
                 BRICK_LIST(NIN,IB)%POLY(ICELL)%FACE(J)%NAdjCell         = 1
-                BRICK_LIST(NIN,IB)%POLY(ICELL)%FACE(J)%Adjacent_Cell(1) = 1 !necessairly ICELLv=1                
+                BRICK_LIST(NIN,IB)%POLY(ICELL)%FACE(J)%Adjacent_Cell(1) = 1 !necessarily ICELLv=1                
               ELSEIF(BRICK_LIST(NIN,IAD22)%NBCUT==0)THEN
               !adjacent brick is in cut cell buffer but is uncut
                 BRICK_LIST(NIN,IB)%POLY(ICELL)%FACE(J)%NAdjCell         = 1
-                BRICK_LIST(NIN,IB)%POLY(ICELL)%FACE(J)%Adjacent_Cell(1) = 1 !necessairly ICELLv=1    
+                BRICK_LIST(NIN,IB)%POLY(ICELL)%FACE(J)%Adjacent_Cell(1) = 1 !necessarily ICELLv=1    
               ELSE
              
                 pWhichCellNodv(1:8) => BRICK_LIST(NIN,IAD22)%NODE(1:8)
@@ -1067,7 +1067,7 @@ c      ALLOCATE (Ntarget(NBF:NBL))
                   BRICK_LIST(NIN,IB)%Poly9woNodes(J,2)             = 0 
 C                  !DESTRUCTION POLYEDRE VOISIN DETECTE AU DEBUT DU PARAGRAPHE @14.
 C                  pNAdjCell(ICELL,J)  = 0
-C                  pAdjCELL(J,ICELL,1) = 0 !necessairly ICELLv=1                                                         
+C                  pAdjCELL(J,ICELL,1) = 0 !necessarily ICELLv=1                                                         
 C  non sinon cell trapped error et aussi on ne peut pas trouver de pression voisin poru le contact
                 ELSE
                   !le polyedre voisin utilise le point d'intersection le plus proche du noeud sommet => le polyedre voisin deveint systematiquement le polyedre 9. (faire dessins)
@@ -1260,7 +1260,7 @@ C              print *, "sinit22_fvm marked closure hypothesis."
             VOL      = BRICK_LIST(NIN,IB)%POLY(ICELL)%Vnew
             UNCUTVOL = BRICK_LIST(NIN,IB)%UncutVol
             RATIO    = VOL / UNCUTVOL
-            IF(ABS(RATIO)>EM04)CYCLE    !Vol=1.01e-05, UNCUTVOL=10 => ratio > EM06. So EM04 is retained.   THRESOLD VOLUME : Smax = O(V**(2/3)), dh= EM03 * O(V**(1/3)) => Veps = EM04*O(V) => ratio=Veps/V = EM04 
+            IF(ABS(RATIO)>EM04)CYCLE    !Vol=1.01e-05, UNCUTVOL=10 => ratio > EM06. So EM04 is retained.   THRESHOLD VOLUME : Smax = O(V**(2/3)), dh= EM03 * O(V**(1/3)) => Veps = EM04*O(V) => ratio=Veps/V = EM04 
             IDLOC    = MAXLOC(BRICK_LIST(NIN,IB)%POLY(ICELL)%FACE(1:6)%SURF,1)
             RatioF   = BRICK_LIST(NIN,IB)%POLY(ICELL)%FACE(IDLOC)%SURF / BRICK_LIST(NIN,IB)%Face_Brick(IDLOC) 
             !volume degenere
@@ -1275,7 +1275,7 @@ C              print *, "sinit22_fvm marked closure hypothesis."
                 VOLv      = BRICK_LIST(NIN,IBv)%POLY(ICELLv)%Vnew
                 UNCUTVOLv = BRICK_LIST(NIN,IBv)%UncutVOL
                 RATIOv    = VOLv/UncutVOLv
-                !Vol=1.01e-05, UNCUTVOL=10 => ratio > EM06. So EM04 is retained.   THRESOLD VOLUME : Smax = O(V**(2/3)), dh= EM03 * O(V**(1/3)) => Veps = EM04*O(V) => ratio=Veps/V = EM04 
+                !Vol=1.01e-05, UNCUTVOL=10 => ratio > EM06. So EM04 is retained.   THRESHOLD VOLUME : Smax = O(V**(2/3)), dh= EM03 * O(V**(1/3)) => Veps = EM04*O(V) => ratio=Veps/V = EM04 
                 IF(ABS(RATIOv)>EM04  .OR. IBv>IB )CYCLE 
                   !IF( (ITASKv==ITASK.AND.IB>IBv) .OR. (ITASKv<ITASK) )THEN
                     IPOS                 = IPOS + 1
@@ -1455,7 +1455,7 @@ C              print *, "sinit22_fvm marked closure hypothesis."
             ENDDO
             sumFACE = SUM(adjMAIN_face(1:6))
             IF(sumFACE==ZERO)THEN
-c              print *, "**Waring inter22 : no main cell to link with cell from BRICK ID:",IXS(11,BRICK_LIST(NIN,IB)%ID)
+c              print *, "**Warning inter22 : no main cell to link with cell from BRICK ID:",IXS(11,BRICK_LIST(NIN,IB)%ID)
               N_UNLINKED_L(ITASK)                 = N_UNLINKED_L(ITASK) + 1
               UNLINKED_CELLS_L(ITASK,1,N_UNLINKED_L(ITASK)) = IB
               UNLINKED_CELLS_L(ITASK,2,N_UNLINKED_L(ITASK)) = ICELL 
@@ -1485,8 +1485,8 @@ c              print *, "**Waring inter22 : no main cell to link with cell from 
       
  
       !------------------------------------------------------------!
-      ! @20. LIST ALL SECONDARY CELLS LINKED TO A GIVEN main CELL    !
-      !-------------------------------------------------------- ---!
+      ! @20. LIST ALL SECONDARY CELLS LINKED TO A GIVEN main CELL  !
+      !------------------------------------------------------------!
       DO IB=NBF,NBL
         NBCUT         =  BRICK_LIST(NIN,IB)%NBCUT
         MCELL         =  BRICK_LIST(NIN,IB)%MainID
@@ -1501,7 +1501,7 @@ c              print *, "**Waring inter22 : no main cell to link with cell from 
           Iv     = BRICK_LIST(NIN,IB)%Adjacent_Brick(J,1) 
           NGv    = BRICK_LIST(NIN,IB)%Adjacent_Brick(J,2) 
           IDLOCv = BRICK_LIST(NIN,IB)%Adjacent_Brick(J,3)             
-          IBv    = BRICK_LIST(NIN,IB)%Adjacent_Brick(J,4) !necessairly different from zero because a cut cell (NBCUT>0) has all its neighbor in cut cell buffer (TZINF increased)
+          IBv    = BRICK_LIST(NIN,IB)%Adjacent_Brick(J,4) !necessarily different from zero because a cut cell (NBCUT>0) has all its neighbor in cut cell buffer (TZINF increased)
           IFv    = BRICK_LIST(NIN,IB)%Adjacent_Brick(J,5)        
           NADJ   = BRICK_LIST(NIN,IB)%POLY(MCELL)%FACE(J)%NAdjCell
           IF(IBv==0)CYCLE
@@ -1586,9 +1586,9 @@ c              print *, "**Waring inter22 : no main cell to link with cell from 
 
       !------------------------------------------------------------!
       ! @22. INDIRECT LINKING                                      !
-      !      UPDATE main CELL BUFFER                             !
+      !      UPDATE main CELL BUFFER                               !
       !------------------------------------------------------------!
-      !need to wait all thread finishing to link before updating their supercll volume and their buffer
+      !need to wait all thread finishing to link before updating their supercell volume and their buffer
       !-------------------!
         CALL MY_BARRIER()
       !-------------------!
@@ -1640,25 +1640,25 @@ c              print *, "**Waring inter22 : no main cell to link with cell from 
 
 
       !------------------------------------------------------------!
-      ! @23. TAG SECND CELLS WHICH ARE BASED ON FORMER main NODE !
-      !------------------------------------------------------------!       
-!      TARGET_DATA(:,:,:) = 0 !tag main cells linked to theses secnd ones.      
-!      Ntarget(NBF:NBL)   = 0 
+      ! @23. TAG SECND CELLS WHICH ARE BASED ON FORMER main NODE   !
+      !------------------------------------------------------------!
+!      TARGET_DATA(:,:,:) = 0 !tag main cells linked to these secnd ones.
+!      Ntarget(NBF:NBL)   = 0
       DO IB=NBF,NBL
         BRICK_LIST(NIN,IB)%Ntarget = 0
-        NBCUT                      =  BRICK_LIST(NIN,IB)%NBCUT        
+        NBCUT                      =  BRICK_LIST(NIN,IB)%NBCUT
         NCELL                      =  NBCUT
         ICELL                      =  0
-        pNodWasMain(1:8)         => BRICK_LIST(NIN,IB)%NODE(1:8)!%NodWasMain 
+        pNodWasMain(1:8)         => BRICK_LIST(NIN,IB)%NODE(1:8)!%NodWasMain
          pListNodID(1)%p(1:8)      => BRICK_LIST(NIN,IB)%POLY(1)%ListNodID(1:8)
-         pListNodID(2)%p(1:8)      => BRICK_LIST(NIN,IB)%POLY(2)%ListNodID(1:8) 
+         pListNodID(2)%p(1:8)      => BRICK_LIST(NIN,IB)%POLY(2)%ListNodID(1:8)
          pListNodID(3)%p(1:8)      => BRICK_LIST(NIN,IB)%POLY(3)%ListNodID(1:8)
          pListNodID(4)%p(1:8)      => BRICK_LIST(NIN,IB)%POLY(4)%ListNodID(1:8)
          pListNodID(5)%p(1:8)      => BRICK_LIST(NIN,IB)%POLY(5)%ListNodID(1:8)
-         pListNodID(6)%p(1:8)      => BRICK_LIST(NIN,IB)%POLY(6)%ListNodID(1:8) 
-         pListNodID(7)%p(1:8)      => BRICK_LIST(NIN,IB)%POLY(7)%ListNodID(1:8) 
-         pListNodID(8)%p(1:8)      => BRICK_LIST(NIN,IB)%POLY(8)%ListNodID(1:8)  
-         pListNodID(9)%p(1:8)      => BRICK_LIST(NIN,IB)%POLY(9)%ListNodID(1:8)   
+         pListNodID(6)%p(1:8)      => BRICK_LIST(NIN,IB)%POLY(6)%ListNodID(1:8)
+         pListNodID(7)%p(1:8)      => BRICK_LIST(NIN,IB)%POLY(7)%ListNodID(1:8)
+         pListNodID(8)%p(1:8)      => BRICK_LIST(NIN,IB)%POLY(8)%ListNodID(1:8)
+         pListNodID(9)%p(1:8)      => BRICK_LIST(NIN,IB)%POLY(9)%ListNodID(1:8)
         MCELL                      =  BRICK_LIST(NIN,IB)%MainID
         NTAG                       =  0   
         MAIN_TAG(:,:)            =  0
@@ -1708,12 +1708,12 @@ c        Ntarget(IB)                = NTAG ! number of secnd cell whose nodes we
         ! enumeration of the target
         !ACHTUNG : what happen if 2 secnd cells have the same main cell. Doubloon are not possible by tagging main target
       ENDDO!next IB
-      
+
       !------------------------------------------------------------!
-      ! @24. VOLUME MERGING BETWEEN SECND CELL & ITS main ONE    !
-      !      UNCONDITIONNAL                                        !
-      !      for law51 old volume need also to be merged           !      
-      !------------------------------------------------------------! 
+      ! @24. VOLUME MERGING BETWEEN SECND CELL & ITS main ONE      !
+      !      UNCONDITIONAL                                         !
+      !      for law51 old volume need also to be merged           !
+      !------------------------------------------------------------!
       !loop on intersected bricks.
       DO IB=NBF,NBL
         NCELL          =  BRICK_LIST(NIN,IB)%NBCUT  
@@ -1753,11 +1753,11 @@ c        Ntarget(IB)                = NTAG ! number of secnd cell whose nodes we
           !Volume change correspond to DDVOL=DV/DT = f(fluxes). Gird deformation influences relative material velocity ans also fluxes  
           DO ITRIMAT=1,TRIMAT                                                                                                           
             IPOS                   = 1                                                                                                  
-            K1                     = N0PHAS + (ITRIMAT-1)*NVPHAS +IPOS-1   ! exemple : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)}         
+            K1                     = N0PHAS + (ITRIMAT-1)*NVPHAS +IPOS-1   ! example : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)}         
             K                      = K1 * LLT_                                                                                          
             VFRAC(ITRIMAT)         = MBUF%VAR(K+IDLOCB(IB))        !backup for material merging                                         
             IPOS                   = 11                                                                                                 
-            K1                     = N0PHAS + (ITRIMAT-1)*NVPHAS +IPOS-1   ! exemple : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)}         
+            K1                     = N0PHAS + (ITRIMAT-1)*NVPHAS +IPOS-1   ! example : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)}         
             K                      = K1 * LLT_                                                                                          
             VAR                    = BRICK_LIST(NIN,IB)%Vnew_SCell*VFRAC(itrimat)                                                       
             MBUF%VAR(K+IDLOCB(IB)) = VAR                                                                                                
@@ -1810,7 +1810,7 @@ c        Ntarget(IB)                = NTAG ! number of secnd cell whose nodes we
             IBv    = BRICK_LIST(NIN,IB )%Adjacent_Brick(J,4)        !TARGET CELL DATA IS STORED IN EINT_L(...,IBv), RHOL, UVARL...     
           ENDIF          
           GBUFv           => ELBUF_TAB(NGv)%GBUF  
-          RATIO           =  ONE/Ntar !in the loop but avoid conditionnal tests "IF(Ntar>0)" for NBF:NBL if not applicable 
+          RATIO           =  ONE/Ntar !in the loop but avoid conditional tests "IF(Ntar>0)" for NBF:NBL if not applicable 
           ITASKv          =  BRICK_LIST(NIN,IBv)%ITASK
           IMERGEL(ITASKv) = 1
           BRICK_LIST(NIN,IBv)%IsMergeTarget = 1
@@ -1865,7 +1865,7 @@ c        Ntarget(IB)                = NTAG ! number of secnd cell whose nodes we
           !-----------------------MULTI-MATERIAL-----------------------! 
           MTN_ = IPARG(1,NGB(IB))  
           IF(MTN_==37)THEN
-            !UVAR(I,1) : massic percentage of liquid * global density  (rho1*V1/V : it needs to give liquid mass multipling by element volume in aleconve.F)
+            !UVAR(I,1) : massic percentage of liquid * global density  (rho1*V1/V : it needs to give liquid mass multiplying by element volume in aleconve.F)
             !UVAR(I,2) : density of gas
             !UVAR(I,3) : density of liquid
             !UVAR(I,4) : volumetric fraction of liquid  
@@ -1892,7 +1892,7 @@ c            print *, "merge-adding ratio uvar1="  , BRICK_LIST(NIN,IB)%bakMAT%U
             !Volume change correspond to DDVOL=DV/DT = f(fluxes). Gird deformation influences relative material velocity ans also fluxes
             DO ITRIMAT=1,TRIMAT
               IPOS               = 11
-              K                  = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS)     ! exemple : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)}                                             
+              K                  = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS)     ! example : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)}                                             
               VOL51(IB,ITRIMAT)  = BRICK_LIST(NIN,IB)%bakMAT%UVAR(K)         !backup for material merging                                                    
               VAR                = RATIO * VOL51(IB,ITRIMAT)
               IF(VAR/=ZERO) SuperCellVOL_L(ITASK,ITRIMAT,IBv) = SuperCellVOL_L(ITASK,ITRIMAT,IBv) + VAR
@@ -1908,7 +1908,7 @@ c            print *, "adding 3 "   , BRICK_LIST(NIN,IB)%bakMAT%UVAR(3), UVARL(I
               IF(VAR==ZERO)CYCLE
               DO IPOS = 1,NVPHAS   
                 IF(IPOS==11)CYCLE                                                !volume already treated merged during geomeetrical merging.    
-                K                     =  ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS)   ! exemple : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)} 
+                K                     =  ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS)   ! example : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)} 
                 pVAR                  => BRICK_LIST(NIN,IB)%bakMAT%UVAR(K)                                                  
                 UVARL(ITASK,IBv,K)    =  UVARL(ITASK,IBv,K) + pVAR *  VAR  
 c                 print *, "adding j "   , BRICK_LIST(NIN,IB)%bakMAT%UVAR(K) ,VAR, UVARL(ITASK,IBv,K)             
@@ -2048,7 +2048,7 @@ c                 print *, "adding j "   , BRICK_LIST(NIN,IB)%bakMAT%UVAR(K) ,VA
         
         MTN_ = IPARG(1,NGB(IB))  
         IF(MTN_==37)THEN
-          !UVAR(I,1) : massic percentage of liquid * global density  (rho1*V1/V : it needs to give liquid mass multipling by element volume in aleconve.F)
+          !UVAR(I,1) : massic percentage of liquid * global density  (rho1*V1/V : it needs to give liquid mass multiplying by element volume in aleconve.F)
           !UVAR(I,2) : density of gas
           !UVAR(I,3) : density of liquid
           !UVAR(I,4) : volumetric fraction of liquid  
@@ -2188,7 +2188,7 @@ c          print *, ""
       ! to the N=Ntar target main cells.
       NBL1 = NBL
       IF(DT1==ZERO)NBL1       = 0
-      ORIGIN_DATA(:,:,:)        = 0 !tag main cells linked to theses secnd ones.      
+      ORIGIN_DATA(:,:,:)        = 0 !tag main cells linked to these secnd ones.      
       Norigin(NBF:NBL)          = 0 
       DO IB=NBF,NBL1
         NBCUT            =  BRICK_LIST(NIN,IB)%NBCUT        
@@ -2341,7 +2341,7 @@ ccc        print *, "    IDEMERGE= : ", IDEMERGE
         IF(Brick_list(nin,ib)%IsMergeTarget==1)THEN
        !   pause
           !!!print *, "ismergeTarget , Norigin", ixs(11,brickID), Norigin(IB), BRICK_LIST(NIN,IB)%Ntarget
-          ! This cell recieved material from a merge.it also has to be taken into account
+          ! This cell received material from a merge.it also has to be taken into account
           VolCell   = BRICK_LIST(NIN,IB)%Vold_Scell
           RHO       = VolCell* GBUF%RHO(IDLOC)
           EINT      = VolCell* GBUF%EINT(IDLOC)
@@ -2371,7 +2371,7 @@ ccc        print *, "    IDEMERGE= : ", IDEMERGE
             DO ITRIMAT=1,TRIMAT                                         
               DO IPOS = 1 , NVPHAS                                      
                 IF(IPOS==11) CYCLE                                       
-                K               = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! exemple : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)}   
+                K               = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! example : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)}   
                 K1              = K * LLT_                             
                 UVAR(K+1)       = volSECND51(ITRIMAT) * MBUF%VAR(K1+IDLOC)                                           
               ENDDO!next IPOS                                           
@@ -2526,7 +2526,7 @@ ccc        print *, "    IDEMERGE= : ", IDEMERGE
             !  MULTI-MATERIAL CUMULULATION  !
             !-------------------------------!           
             IF(MTN_==37)THEN
-              !UVAR(I,1) : massic percentage of liquid * global density  (rho1*V1/V : it needs to give liquid mass multipling by element volume in aleconve.F)
+              !UVAR(I,1) : massic percentage of liquid * global density  (rho1*V1/V : it needs to give liquid mass multiplying by element volume in aleconve.F)
               !UVAR(I,2) : density of gas
               !UVAR(I,3) : density of liquid
               !UVAR(I,4) : volumetric fraction of liquid  
@@ -2550,7 +2550,7 @@ ccc        print *, "    IDEMERGE= : ", IDEMERGE
               DO ITRIMAT=1,TRIMAT
                 !get,store Volumetric Fraction
                 IPOS                 = 1
-                K1                   = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! exemple : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)} 
+                K1                   = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! example : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)} 
                 Kv                   = K1 * LLT_v
                 Vfrac(ITRIMAT)       = MBUFv%VAR(Kv+IDLOCv)
                 VolSECND51(ITRIMAT)  = Vfrac(ITRIMAT) * VOLsecnd     !submaterial volume in secnd cell 
@@ -2566,7 +2566,7 @@ ccc        print *, "    IDEMERGE= : ", IDEMERGE
               DO ITRIMAT=1,TRIMAT
                 DO IPOS = 1 , NVPHAS
                   Ko              = ((N0PHAS + (ITRIMAT-1)*NVPHAS ))
-                  K1              = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! exemple : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)} 
+                  K1              = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! example : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)} 
                   Kv              = K1 * LLT_v
                   IF(IPOS==11)THEN
                     UVAR(K1+1) = UVAR(K1+1) + volSECND51(ITRIMAT)                 
@@ -2589,7 +2589,7 @@ ccc        print *, "    IDEMERGE= : ", IDEMERGE
               DO ITRIMAT=1,TRIMAT
                 !remove submaterial volume in detached secnd cell
                 IPOS                 = 11
-                K1                   = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! exemple : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)}                                                  
+                K1                   = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! example : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)}                                                  
                 Kv                   = K1 * LLT_v
                 MBUFv%VAR(Kv+IDLOCv) = MBUFv%VAR(Kv+IDLOCv) - VolSECND51(ITRIMAT)
               ENDDO!next ITRIMAT  
@@ -2619,7 +2619,7 @@ ccc        print *, "    IDEMERGE= : ", IDEMERGE
           UVAR(5) =  UVAR(5) / VOLcell     
           !call sigeps37_single_cell before storing in MBUF%VAR              
         ELSEIF(MTN_==51)THEN
-          UVAR(1) = (UVAR(1) + IADV*UVAR_ADV(1)) / VOLcell  !sum of full volume because UVAR(1:3) are homogeneized data, not submaterial one.
+          UVAR(1) = (UVAR(1) + IADV*UVAR_ADV(1)) / VOLcell  !sum of full volume because UVAR(1:3) are homogenized data, not submaterial one.
           UVAR(2) = (UVAR(2) + IADV*UVAR_ADV(2)) / VOLcell
           UVAR(3) = (UVAR(3) + IADV*UVAR_ADV(3)) / VOLcell      
           DO ITRIMAT=1,TRIMAT
@@ -2692,26 +2692,26 @@ c          print *, "demerge-1",  MBUF%VAR((1-1)*LLT_+IDLOC) , UVAR(1)
             IF(VOLcell51(ITRIMAT)/=ZERO)THEN         
               !get,store Volumetric Fraction
               DO IPOS=1,NVPHAS
-                K0                 = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! exemple : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)} 
+                K0                 = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! example : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)} 
                 K1                 = K0 * LLT_
                 MBUF%VAR(K1+IDLOC) = UVAR(N0PHAS+(ITRIMAT-1)*NVPHAS+IPOS)  
               ENDDO
 
               IPOS=1
-                K0                 = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! exemple : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)} 
+                K0                 = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! example : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)} 
                 K1                 = K0 * LLT_
                 MBUF%VAR(K1+IDLOC) = VolCELL51(ITRIMAT)/VolCELL            
               IPOS=11
-                K0                 = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! exemple : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)} 
+                K0                 = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! example : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)} 
                 K1                 = K0 * LLT_
                 MBUF%VAR(K1+IDLOC) = VolCELL51(ITRIMAT)           
             ELSE
               IPOS=1
-                K0                 = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! exemple : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)} 
+                K0                 = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! example : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)} 
                 K1                 = K0 * LLT_
                 MBUF%VAR(K1+IDLOC) = ZERO           
               IPOS=11
-                K0                 = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! exemple : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)} 
+                K0                 = ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! example : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)} 
                 K1                 = K0 * LLT_
                 MBUF%VAR(K1+IDLOC) = ZERO               
             ENDIF
@@ -2772,7 +2772,7 @@ c          print *, "demerge-1",  MBUF%VAR((1-1)*LLT_+IDLOC) , UVAR(1)
             RHO20                      =  BUFMAT(IADBUF-1+12) 
             IF(UVAR(3) == ZERO)   UVAR(3) = RHO10 
             IF(UVAR(2) == ZERO)   UVAR(2) = RHO20                                       
-              !UVAR(I,1) : massic percentage of liquid * global density  (rho1*V1/V : it needs to give liquid mass multipling by element volume in aleconve.F)
+              !UVAR(I,1) : massic percentage of liquid * global density  (rho1*V1/V : it needs to give liquid mass multiplying by element volume in aleconve.F)
               !UVAR(I,2) : density of gas
               !UVAR(I,3) : density of liquid
               !UVAR(I,4) : volumetric fraction of liquid  
@@ -3093,7 +3093,7 @@ c        print *, "check switch in brickID=", ixs(11,brick_list(nin,ib)%id)
           DO K1=1,NNODES !Nodes attached to IB
             INOD   = BRICK_LIST(NIN,IBv)%POLY(ICELLv)%ListNodID(K1)
             FV_old = BRICK_LIST(NIN,IBv)%NODE(INOD)%WhereWasMain !FACE
-            IF (FV_old == 0)CYCLE !the node was wet by main cell : MERGE PROCESS APLLIES (see related chapter)
+            IF (FV_old == 0)CYCLE !the node was wet by main cell : MERGE PROCESS APPLIES (see related chapter)
             !OLD_M
             IF (FV_old == FV)CYCLE ! NO LINK CHANGE : this is still linked to the same direction
             !else FV_old /= FV : THERE WAS A SWITCH
@@ -3149,7 +3149,7 @@ c        print *, "check switch in brickID=", ixs(11,brick_list(nin,ib)%id)
                 INOD2  = OLD_SecndList(NIN,IBmo)%ListNodID(IC2,K2)
                 ICELL2 = BRICK_LIST(NIN,IBv2)%NODE(INOD2)%WhichCell
                 IBmCur = BRICK_LIST(NIN,IBv2)%POLY(ICELL2)%WhereIsMain(4)
-                IF(IBmCur == IB) VolSECND = VolSECND + ONE/NNODES*BRICK_LIST(NIN,IBv2)%POLY(ICELL2)%Vnew   !exemple brick 20 devient main dans cas 15.14 : le penta dans 41 a deux noeuds, si on boucle 2 fois on prend 2 fois son volume pour l'injecter dans bric 30.
+                IF(IBmCur == IB) VolSECND = VolSECND + ONE/NNODES*BRICK_LIST(NIN,IBv2)%POLY(ICELL2)%Vnew   !example brick 20 devient main dans cas 15.14 : le penta dans 41 a deux noeuds, si on boucle 2 fois on prend 2 fois son volume pour l'injecter dans bric 30.
                 VolCELL = VolCELL + ONE/NNODES*BRICK_LIST(NIN,IBv2)%POLY(ICELL2)%Vnew
               ENDDO
               if (VolSECND == ZERO)CYCLE
@@ -3218,7 +3218,7 @@ c        print *, "check switch in brickID=", ixs(11,brick_list(nin,ib)%id)
                 IADBUF                     =  IPM(7,MT) 
                 RHO10                      =  BUFMAT(IADBUF-1+11)
                 RHO20                      =  BUFMAT(IADBUF-1+12)              
-                !UVAR(I,1) : massic percentage of liquid * global density  (rho1*V1/V : it needs to give liquid mass multipling by element volume in aleconve.F)
+                !UVAR(I,1) : massic percentage of liquid * global density  (rho1*V1/V : it needs to give liquid mass multiplying by element volume in aleconve.F)
                 !UVAR(I,2) : density of gas
                 !UVAR(I,3) : density of liquid
                 !UVAR(I,4) : volumetric fraction of liquid  
@@ -3297,14 +3297,14 @@ C                print *, "link switch 1", pVAR, (pVAR * VOLD + VOLcell * pVARo)
                 DO ITRIMAT=1,TRIMAT
                   !IBm_old - volume fraction!                
                   IPOS                     = 1                                 
-                  K0                       = N0PHAS + (ITRIMAT-1)*NVPHAS +IPOS-1   ! exemple : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)}   
+                  K0                       = N0PHAS + (ITRIMAT-1)*NVPHAS +IPOS-1   ! example : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)}   
                   K                        = K0 * LLT_o                         
                   VFrac(ITRIMAT)           = MBUFo%VAR(K+IDLOCB(IBmo))            
                 ENDDO!next ITRIMAT 
                 
                 DO ITRIMAT=1,TRIMAT
                   IPOS                     = 11                                
-                  K0                       = N0PHAS + (ITRIMAT-1)*NVPHAS +IPOS-1   ! exemple : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)}   
+                  K0                       = N0PHAS + (ITRIMAT-1)*NVPHAS +IPOS-1   ! example : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)}   
                   K                        = K0 * LLT_
                   VOLcell51(ITRIMAT)       = VOLcell * VFrac(ITRIMAT)         
                   MBUF%VAR(K+IDLOCB(IBm))   = MBUF%VAR(K+IDLOCB(IBm)) + VOLcell51(ITRIMAT)        
@@ -3313,13 +3313,13 @@ C                print *, "link switch 1", pVAR, (pVAR * VOLD + VOLcell * pVARo)
                 DO ITRIMAT=1,TRIMAT
                   !IBm - volume fraction!
                   IPOS                     = 1                                 
-                  K0                       = N0PHAS + (ITRIMAT-1)*NVPHAS +IPOS-1   ! exemple : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)}   
+                  K0                       = N0PHAS + (ITRIMAT-1)*NVPHAS +IPOS-1   ! example : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)}   
                   K                        = K0 * LLT_                         
                   VFrac(ITRIMAT)           = MBUF%VAR(K+IDLOCB(IBm))                   
                   IF(VOLcell51(ITRIMAT)<=ZERO)CYCLE  !unplug if nothiong to add (otherwise div by zero)
                   DO IPOS = 1,NVPHAS   
                     IF(IPOS==11)CYCLE                                                  !volume already treated   
-                    K2                    =  ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! exemple : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)} 
+                    K2                    =  ((N0PHAS + (ITRIMAT-1)*NVPHAS )+IPOS-1)   ! example : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)} 
                     K                     =  LLT_ * K2                                              
                     Ko                    =  LLT_o * K2                     
                     pVAR                  => MBUF%VAR(K+IDLOCB(IBm))  
@@ -3396,7 +3396,7 @@ C              print *, " --- set VOLD_L += VOLcell, IB, ID ", VOLcell , IBMo, i
             LLT_  = IPARG(2,NGB(IB))  
             DO ITRIMAT=1,TRIMAT                                                         
               IPOS                     = 11                                             
-              K0                       = N0PHAS + (ITRIMAT-1)*NVPHAS +IPOS-1   ! exemple : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)}                
+              K0                       = N0PHAS + (ITRIMAT-1)*NVPHAS +IPOS-1   ! example : IPOS=1 => VFRAC  {UVAR(I,ADD)=UVAR(K+I)}                
               K                        = K0 * LLT_       
               MBUF%VAR(K+IDLOCB(IB))   = MBUF%VAR(K+IDLOCB(IB)) - VOLD_L(IT,ITRIMAT,IB)
             ENDDO!next ITRIMAT      
@@ -3608,7 +3608,7 @@ ccc          endif
       ENDDO    
       
       !------------------------------------------------------------!
-      ! @36. RESET OLD SECND LIST CONNECTIVIY                      !
+      ! @36. RESET OLD SECND LIST CONNECTIVITY                     !
       !      WILL BE DEFINED IN I22_GET_PRV_DATA()                 !
       !------------------------------------------------------------!
       !RESET ONLY NON ZERO VALUES
@@ -3649,7 +3649,7 @@ ccc          endif
       IGR         = IPARI(52) !reserved GRTRUS  ---> truss group identifier
       NTRUS       = IPARI(53 )!reserved GRTRUS  ---> truss group NEL
       IF( ITASK==0 .AND. NTRUS/=0 )THEN
-        II        = 1  ! firts node of group node
+        II        = 1  ! first node of group node
         DO IB=NBF,NBL 
           MCELL = BRICK_LIST(NIN,IB)%mainID
           IF (MCELL==0              ) CYCLE
@@ -4048,7 +4048,7 @@ C     .          "  vold=",brick_list(nin,ib)%vold_scell,"  vnew=",brick_list(ni
         NNODES      = IGRNOD(IPARI(70))%NENTITY
         !!!WRITE(*,*)(ITAB(IBUFSSG(J)),J=IAD0,IAD0+NNODES-1)
         IF( ITASK==0 .AND. NNODES/=0 )THEN
-          II        = 1  ! firts node of group node
+          II        = 1  ! first node of group node
           DO IB=NBF,NBL 
             MCELL = BRICK_LIST(NIN,IB)%mainID
             IF (MCELL==0              ) CYCLE
@@ -4168,7 +4168,7 @@ C     .          "  vold=",brick_list(nin,ib)%vold_scell,"  vnew=",brick_list(ni
         NNODES      = IGRNOD(IPARI(81))%NENTITY
         !!!WRITE(*,*)(ITAB(IBUFSSG(J)),J=IAD0,IAD0+NNODES-1)
         IF( ITASK==0 .AND. NNODES/=0 )THEN
-          II        = 1  ! firts node of group node
+          II        = 1  ! first node of group node
           DO IB=NBF,NBL           
             ICELL   =  0  
             NCELL   = BRICK_LIST(NIN,IB)%NBCUT                     
@@ -4206,7 +4206,7 @@ C     .          "  vold=",brick_list(nin,ib)%vold_scell,"  vnew=",brick_list(ni
        IF(IPARI(82)/=0)THEN
          NNODES      = IGRNOD(IPARI(82))%NENTITY
          IF(NNODES==0)RETURN
-         II        = 1  ! firts node of group node
+         II        = 1  ! first node of group node
          DO IB=NBF,NBL    
            IE                    = BRICK_LIST(NIN,IB)%ID
            ICELL                 =  0     

--- a/engine/source/interfaces/int22/voln22.F
+++ b/engine/source/interfaces/int22/voln22.F
@@ -34,7 +34,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 C this subroutines update VOLN for cut cells.
 C Main cells have extended values of volume due

--- a/engine/source/interfaces/int22/w_bufbric_22.F
+++ b/engine/source/interfaces/int22/w_bufbric_22.F
@@ -35,7 +35,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 C This subroutine is writing buffer in RESTART file.
 C-----------------------------------------------

--- a/engine/source/interfaces/int22/weighting_cell_nodes.F
+++ b/engine/source/interfaces/int22/weighting_cell_nodes.F
@@ -33,7 +33,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 ! Get Nodes which is the farthest from intersection points
 ! equivalent to calculating mean adjacent surface ratio.

--- a/engine/source/interfaces/int22/write_cut_cell_buffer.F
+++ b/engine/source/interfaces/int22/write_cut_cell_buffer.F
@@ -35,7 +35,7 @@ C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
 C Interface Type22 (/INTER/TYPE22) is an FSI coupling method based on cut cell method. 
-C   This experimental cut cell method is not completed, abandonned, and is not an official option.
+C   This experimental cut cell method is not completed, abandoned, and is not an official option.
 C
 C This subroutine was introduce for debug purpose
 C only. The aim is to print full Cut Cell Buffer

--- a/engine/source/interfaces/int24/i24cork3.F
+++ b/engine/source/interfaces/int24/i24cork3.F
@@ -557,7 +557,7 @@ C
            MSI(JLT_NEW)= MSFI(NIN)%P(NN)
            ITQ = IRTLM_FI(NIN)%P(2,NN)
            IF (ITQ>4.OR.ITQ==0) THEN
-            print *,'Intenal Error, ITQ=',ITQ
+            print *,'Internal Error, ITQ=',ITQ
             CALL ARRET(2)
            END IF
            IX1(JLT_NEW)  = IRECT(IC(1,ITQ),L)

--- a/engine/source/interfaces/int24/i24dst3.F
+++ b/engine/source/interfaces/int24/i24dst3.F
@@ -327,7 +327,7 @@ c      endif
       EPS = (TWO+HALF)/HUNDRED
       UNPT   = ONE + EPS
       ZEROMT = ZERO - EPS
-C------used for high penetration case (extention criterion)      
+C------used for high penetration case (extension criterion)
       EPS2=EPS*EPS
 C------0.1%----      
       EPS = EM3
@@ -353,7 +353,7 @@ c      if (ncycle<100) write(iout,*)'JLT,ncycle=',JLT,ncycle
         N=CAND_N(I)
 c       IRTLM(1,N)>0 node previously impacted on global MAIN IRTLM(1,N)
 c          treat one contact but no new intersection
-c       IRTLM(1,N)<0 node curently impacted on global MAIN -IRTLM(1,N)
+c       IRTLM(1,N)<0 node currently impacted on global MAIN -IRTLM(1,N)
 c          treat multiple contact during one cycle
 c       IRTLM(1,N)==0 node not impacted 
         IPEN0(I)=0 

--- a/engine/source/interfaces/int24/i24dst3e.F
+++ b/engine/source/interfaces/int24/i24dst3e.F
@@ -249,7 +249,7 @@ c check if convex
             SZS = SZS1 + SZS2
 
             AAA = SXS*SXM+SYS*SYM+SZS*SZM
-            IF(AAA > ZERO) CYCLE ! MAIN and SECONDARY dihedral are not loocking each other
+            IF(AAA > ZERO) CYCLE ! MAIN and SECONDARY dihedral are not locking each other
 
 c           vecteur SECONDARY MAIN 
             SXSM = Y12*ZIJ - Z12*YIJ

--- a/engine/source/interfaces/int24/i24gap_pxfem.F
+++ b/engine/source/interfaces/int24/i24gap_pxfem.F
@@ -98,7 +98,7 @@ C-----------------------------------------------
      .     NXX(NRTM,17),NYY(NRTM,17),NZZ(NRTM,17),BBB,
      .     XX0(NRTM,17),YY0(NRTM,17),ZZ0(NRTM,17),DN
 C --------------------------------------------------------------------- 
-C  all cordinate of segment
+C  all coordinates of segment
 C
 C initiailisation
       NINDX =0
@@ -291,7 +291,7 @@ C
 C       
 C--------------------------------------------------------
 C
-C  for update of gap when main segement is ply-xfem formulation
+C  for update of gap when main segment is ply-xfem formulation
 C           <
          DO II=1,NINDX
           I = INDX(II) 

--- a/engine/source/interfaces/int24/i24iply_pxfem.F
+++ b/engine/source/interfaces/int24/i24iply_pxfem.F
@@ -104,7 +104,7 @@ C
 C for computing contact ply forces.
 C
            DO I=1,JLT
-C or by node segement if it needed            
+C or by node segment if it needed            
              IPLY(1,I) = 0
              IPLY(2,I) = 0
              IPLY(3,I) = 0

--- a/engine/source/interfaces/int25/i25main_slid.F
+++ b/engine/source/interfaces/int25/i25main_slid.F
@@ -385,7 +385,7 @@ C
 
           IPARI(29,NIN) = 0
 C
-C         Recieve buffer ( + wait for sizes)
+C         Receive buffer ( + wait for sizes)
           IF(NSPMD > 1) THEN
             CALL SPMD_I25_SLIDE_EXCH(IBUFR    ,RBUFR      ,ISIZ(NI25)     ,RSIZ(NI25) 
      .                    ,SIZBUFR_GLOB       ,COMM_INT,COMM_REAL,COMM_SIZ

--- a/engine/source/interfaces/int25/i25norm.F
+++ b/engine/source/interfaces/int25/i25norm.F
@@ -1038,7 +1038,7 @@ C
 C
 C       IF(ACTNOR(IRM)==0 .OR. STIFM(IRM)==ZERO) CYCLE
 
-! Nod Normal should be recieved even if IRM 
+! Nod Normal should be received even if IRM 
 C is deleted
 C ISPMD may still send the edge during for contact detection
 C (i.e. ISPMD is PMAIN)
@@ -1057,7 +1057,7 @@ C         DEBUG_E2E(INT_CHECKSUM(IDS,4,1) == D_EM,JRM)
             NOD_NORMAL(2,J,IRM) = WNOD_NORMAL(2,J,IRM)
             NOD_NORMAL(3,J,IRM) = WNOD_NORMAL(3,J,IRM)
 C If the local segment is broken
-C The (secoundary) edge can still be sended by ISPMD to the processor that have
+C The (secondary) edge can still be sended by ISPMD to the processor that have
 C the main segment. 
 C In that case, the ordering of (JEDG) should be the one on the side that is not
 C broken

--- a/engine/source/interfaces/int25/i25slid.F
+++ b/engine/source/interfaces/int25/i25slid.F
@@ -753,7 +753,7 @@ C             attention si ici <=> pb parith/on
           END IF  
         END IF  
 C
-C       swith to negative value if no more kept 
+C       switch to negative value if no more kept 
         IF(IKEEP == 0) CAND_N(J)=-CAND_N(J)
       END DO
 C----------------------------------------------------------------------

--- a/engine/source/interfaces/interf/find_edge_inter.F
+++ b/engine/source/interfaces/interf/find_edge_inter.F
@@ -83,7 +83,7 @@ C-----------------------------------------------
         INTEGER, DIMENSION(2,24), TARGET :: EDGES_TETRA10 ! definition of edge for tetra10
         INTEGER, DIMENSION(2,4), TARGET :: EDGES_SHELL ! definition of edge for shell/quad
         INTEGER, DIMENSION(2,3), TARGET :: EDGES_TRI ! definition of edge for triangle & spring type12
-        INTEGER, DIMENSION(2,1), TARGET :: EDGES_2DELM ! definition of edge for 2d elment : truss/beam/spring
+        INTEGER, DIMENSION(2,1), TARGET :: EDGES_2DELM ! definition of edge for 2d element : truss/beam/spring
         INTEGER, DIMENSION(2,2), TARGET :: EDGES_SPRING_TYP12 ! definition of edge spring type 12
         INTEGER,DIMENSION(:,:), POINTER :: POINTER_EDGE,IX
 
@@ -456,7 +456,7 @@ C-----------------------------------------------
                         DO J=1,NB_RESULT_INTERSECT_2
                             IF(RESULT_INTERSECT_2(J)/=ISPMD+1) THEN
                                 SHOOT_STRUCT%SAVE_PROC_NB_EDGE = SHOOT_STRUCT%SAVE_PROC_NB_EDGE + 1
-                                SHOOT_STRUCT%SAVE_PROC_EDGE( SHOOT_STRUCT%SAVE_PROC_NB_EDGE ) =  RESULT_INTERSECT_2(J)    ! save the remore proc id
+                                SHOOT_STRUCT%SAVE_PROC_EDGE( SHOOT_STRUCT%SAVE_PROC_NB_EDGE ) =  RESULT_INTERSECT_2(J)    ! save the remote proc id
 
                                 DO IJK=1,2
                                     SHOOT_STRUCT%SAVE_PROC_NB_EDGE = 

--- a/engine/source/interfaces/interf/find_surface_inter.F
+++ b/engine/source/interfaces/interf/find_surface_inter.F
@@ -354,7 +354,7 @@ C-----------------------------------------------
                         DO J=1,NB_RESULT_INTERSECT_2
                             IF(RESULT_INTERSECT_2(J)/=ISPMD+1) THEN
                                 SHOOT_STRUCT%SAVE_PROC_NB = SHOOT_STRUCT%SAVE_PROC_NB + 1
-                                SHOOT_STRUCT%SAVE_PROC( SHOOT_STRUCT%SAVE_PROC_NB ) =  RESULT_INTERSECT_2(J)    ! save the remore proc id
+                                SHOOT_STRUCT%SAVE_PROC( SHOOT_STRUCT%SAVE_PROC_NB ) =  RESULT_INTERSECT_2(J)    ! save the remote proc id
 
                                 IF(NODE_SURF_NB==3) LOCAL_NODE(4) = LOCAL_NODE(3)
                                 DO IJK=1,4

--- a/engine/source/interfaces/interf/i2for28_cin.F
+++ b/engine/source/interfaces/interf/i2for28_cin.F
@@ -80,7 +80,7 @@ C     REAL
 C=======================================================================
 C
 C------------------------------
-C     DUPPLICATED FROM I2FOMO3 - SPOTFLAG1 FORMULATION
+C     DUPLICATED FROM I2FOMO3 - SPOTFLAG1 FORMULATION
 C------------------------------
 C
       NIR=4

--- a/engine/source/interfaces/interf/i2for28_pen.F
+++ b/engine/source/interfaces/interf/i2for28_pen.F
@@ -496,7 +496,7 @@ C
           ENDIF
 
 C------------------------------------------------                  
-C         Compuation of stiffness for nodal time step
+C         Computation of stiffness for nodal time step
 C------------------------------------------------
 C
           STF     = STFN(II)*(VISC + SQRT(VISC**2 + (ONE+STBRK)))**2

--- a/engine/source/interfaces/interf/i2for28p_cin.F
+++ b/engine/source/interfaces/interf/i2for28p_cin.F
@@ -82,7 +82,7 @@ C     REAL
 C=======================================================================
 C
 C------------------------------
-C     DUPPLICATED FROM I2FOMO3P - SPOTFLAG1 FORMULATION
+C     DUPLICATED FROM I2FOMO3P - SPOTFLAG1 FORMULATION
 C------------------------------
 C
       I0BASE = I0

--- a/engine/source/interfaces/interf/i2for28p_pen.F
+++ b/engine/source/interfaces/interf/i2for28p_pen.F
@@ -497,7 +497,7 @@ C
           ENDIF
 C
 C------------------------------------------------                  
-C         Compuation of stiffness for nodal time step
+C         Computation of stiffness for nodal time step
 C------------------------------------------------
 C
           STF     = STFN(II)*(VISC + SQRT(VISC**2 + (ONE+STBRK)))**2

--- a/engine/source/interfaces/interf/init_nodal_state.F
+++ b/engine/source/interfaces/interf/init_nodal_state.F
@@ -157,7 +157,7 @@ C-----------------------------------------------
                 DO I=1,NSN
                     NODE_ID = INTBUF_TAB(NIN)%NSV(I)
                     ! need to check the node_id value : for typ24 + edge to edge,
-                    ! a fameous developper introduced NODE_ID greater than the number of node NUMNOD :(
+                    ! a famous developer introduced NODE_ID greater than the number of node NUMNOD :(
                     IF(NODE_ID<=NUMNOD) SHOOT_STRUCT%SHIFT_S_NODE(NODE_ID+1) = SHOOT_STRUCT%SHIFT_S_NODE(NODE_ID+1) + 1
                 ENDDO
             ENDIF
@@ -667,7 +667,7 @@ C-----------------------------------------------
         ! --------------------------------
         ! WORKING ARRAY
         ! --------------------------------
-        ALLOCATE( SHOOT_STRUCT%GLOBAL_NB_ELEM_OFF(NTHREAD) )    ! numner of deactivated element for  each thread
+        ALLOCATE( SHOOT_STRUCT%GLOBAL_NB_ELEM_OFF(NTHREAD) )    ! number of deactivated element for each thread
 
         RETURN
         END SUBROUTINE INIT_NODAL_STATE

--- a/engine/source/interfaces/interf/intti1.F
+++ b/engine/source/interfaces/interf/intti1.F
@@ -250,7 +250,7 @@ C---
             IF (ILEV == 0.OR.ILEV == 1.OR.ILEV == 3.OR.ILEV == 27.OR.ILEV == 28) I2MSCH = 1
             IF (ILEV==25.OR.ILEV==26.OR.ILEV==27.OR.ILEV==28) I7KGLO=1 
         !       Optimization :
-        !       If NSN=0, somes variables are loaded in INTTI2F (NRTS,...)
+        !       If NSN=0, some variables are loaded in INTTI2F (NRTS,...)
         !       if the number of TYPE2 interface is important (>3000) and if the number of
         !       spmd domain is quite important (NSPMD>50), the initialisation time is important :
         !       for_array_copy_in and other initialisations represent up to 5% of total CPUTIME

--- a/engine/source/interfaces/interf/intti2.F
+++ b/engine/source/interfaces/interf/intti2.F
@@ -83,7 +83,7 @@ C=======================================================================
         IF (NTY == 2) THEN                                            
           IF(IPARI(5,N)>0) THEN !       check if NSN=IPARI(5,N)>0
         !       Optimization :
-        !       If IPARI(5,N)=NSN=0, somes variables are loaded in INTTI2V
+        !       If IPARI(5,N)=NSN=0, some variables are loaded in INTTI2V
         !       if the number of TYPE2 interface is important (>3000) and if the number of
         !       spmd domain is quite important (NSPMD>50), the initialisation time is important :
         !       for_array_copy_in and other initialisations represent up to 5% of total CPUTIME

--- a/engine/source/interfaces/intsort/i22main_tri.F
+++ b/engine/source/interfaces/intsort/i22main_tri.F
@@ -410,7 +410,7 @@ C -------------------------------------------------------------
       BMINMA_FLU(6) = MIN(BMINMA_FLU(6),MINVAL(ZMINS))
 #include "lockoff.inc"
 
-      CALL MY_BARRIER ! wating for fluid local domain bounds definition (multi-threading)
+      CALL MY_BARRIER ! waiting for fluid local domain bounds definition (multi-threading)
 
       IF(ITASK==0) THEN
        BMINMA_FLU(1) = BMINMA_FLU(1)+TZINF

--- a/engine/source/interfaces/intsort/i22trivox.F
+++ b/engine/source/interfaces/intsort/i22trivox.F
@@ -358,7 +358,7 @@ c     .        "  Remplissage Voxel avec shell suivantes :"
         EIZ2(NE)=MAX(1,2+MIN(NBZ,IZ2))
       END DO    
       !-------------------------------------------!
-      !  VOXEL INDEX RANGE FOR VOXEL RESETING     !
+      !  VOXEL INDEX RANGE FOR VOXEL RESETTING     !
       !-------------------------------------------!
       !pour reset des voxel   
       MIN_IX_LOC = MIN(MIN_IX,MINVAL(EIX1(NBF:NBL)))
@@ -642,7 +642,7 @@ C 3   VOXEL RESET
 C=======================================================================
  1000 CONTINUE
 
-      CALL MY_BARRIER ! All threads need to finish its work with common Voxel before reseting it.
+      CALL MY_BARRIER ! All threads need to finish its work with common Voxel before resetting it.
 
       if(itask==0.AND.ibug22_trivox==1) print *, 
      .    "  i22trivox.F:nb de candidats:" , II_STOK, ITASK

--- a/engine/source/interfaces/intsort/i24optcd.F
+++ b/engine/source/interfaces/intsort/i24optcd.F
@@ -285,7 +285,7 @@ C
                COUNT_CAND = COUNT_CAND+1
                IF(IG(IS) > NUMNOD) COUNT_CAND = COUNT_CAND + 3
              ELSE
-CC--         Count of contact connections for AMS (+ addtional connections related to contact on type2 - T2MAIN_SMS(1) > 1)
+CC--         Count of contact connections for AMS (+ additional connections related to contact on type2 - T2MAIN_SMS(1) > 1)
                IF(IG(IS) > NUMNOD) THEN
                  COUNT_CAND = COUNT_CAND+4
                  NS = IG(IS) - NUMNOD
@@ -423,7 +423,7 @@ c secnd in contact on this main keep candidate
                 COUNT_CAND = COUNT_CAND+1
                 IF(IG(IS) > NUMNOD) COUNT_CAND = COUNT_CAND + 3
               ELSE
-CC--         Count of contact connections for AMS (+ addtional connections related to contact on type2 - T2MAIN_SMS(1) > 1)
+CC--         Count of contact connections for AMS (+ additional connections related to contact on type2 - T2MAIN_SMS(1) > 1)
                 IG(IS) = NSV(CAND_N(I))
                 CAND_N(I) = -CAND_N(I)
                 L  = CAND_E(I)
@@ -474,7 +474,7 @@ c PMAX_GAP is not used here (node not in contact)
                 COUNT_CAND = COUNT_CAND+1
                 IF(IG(IS) > NUMNOD) COUNT_CAND = COUNT_CAND + 3
               ELSE
-CC--         Count of contact connections for AMS (+ addtional connections related to contact on type2 - T2MAIN_SMS(1) > 1)
+CC--         Count of contact connections for AMS (+ additional connections related to contact on type2 - T2MAIN_SMS(1) > 1)
                 IF(IG(IS) > NUMNOD) THEN
                   COUNT_CAND = COUNT_CAND+4
                   NS = IG(IS) - NUMNOD
@@ -590,7 +590,7 @@ c PMAX_GAP is not used here (node not in contact)
                    CT = CT + 1
                    IF(ISEDGE_FI(NIN)%P(II)==1) CT = CT+3
                  ELSE
-CC--             Count of contact connections for AMS (+ addtional connections related to contact on type2 - T2MAIN_SMS(1) > 1)
+CC--             Count of contact connections for AMS (+ additional connections related to contact on type2 - T2MAIN_SMS(1) > 1)
                    IF(ISEDGE_FI(NIN)%P(II)==1) THEN
                      CT = CT + 4
                      IF (IS2SE_FI(NIN)%P(1,II) > 0) THEN
@@ -731,7 +731,7 @@ c secnd in contact on this main keep candidate
                CT = CT + 1
                IF(ISEDGE_FI(NIN)%P(II)==1) CT = CT+3
              ELSE
-CC--           Count of contact connections for AMS (+ addtional connections related to contact on type2 - T2MAIN_SMS(1) > 1)
+CC--           Count of contact connections for AMS (+ additional connections related to contact on type2 - T2MAIN_SMS(1) > 1)
                L = CAND_E(I)
                IX1(IS)=IRECT(1,L)
                IX2(IS)=IRECT(2,L)
@@ -779,7 +779,7 @@ c PMAX_GAP is not used here (node not in contact)
                    CT = CT + 1
                    IF(ISEDGE_FI(NIN)%P(II)==1) CT = CT+3
                ELSE
-CC--             Count of contact connections for AMS (+ addtional connections related to contact on type2 - T2MAIN_SMS(1) > 1)
+CC--             Count of contact connections for AMS (+ additional connections related to contact on type2 - T2MAIN_SMS(1) > 1)
                    IF(ISEDGE_FI(NIN)%P(II)==1) THEN
                      CT = CT + 4
                      IF (IS2SE_FI(NIN)%P(1,II) > 0) THEN
@@ -818,7 +818,7 @@ c      write(iout,*)'i24optcd 5'
 C
 C ---------------------------------------------------------------------------
 C T24E2E TREATMENT for SMP coherency in force computation / Initialize ISPT2
-C This treatment was initialy made in I24COR3 which is too late
+C This treatment was initially made in I24COR3 which is too late
 C ---------------------------------------------------------------------------
 C Care - SPMD Treatments are made in SPMD_EXCH_I24 due to communication
 C ---------------------------------------------------------------------------

--- a/engine/source/interfaces/intsort/i24trivox.F
+++ b/engine/source/interfaces/intsort/i24trivox.F
@@ -186,7 +186,7 @@ c INUTIL POUR INT 24 !!!!!!!!!!!!!!!!!
 C=======================================================================
 C 1   mise des noeuds dans les boites
 C=======================================================================
-C Note for Edge2Edge : X is no more the Radioss X Array but an extention
+C Note for Edge2Edge : X is no more the Radioss X Array but an extension
 C                      NUMNOD+SNE
 C                      It is updated at any cycle
       IF(ITASK == 0)THEN

--- a/engine/source/interfaces/intsort/i25main_tri.F
+++ b/engine/source/interfaces/intsort/i25main_tri.F
@@ -433,7 +433,7 @@ C
 C
       IF (IMONM > 0) CALL STARTIME(30,1)
 C
-C     NCONT additional candidates (if all secondary nodes are alreay impacted, cf i25optcd)
+C     NCONT additional candidates (if all secondary nodes are already impacted, cf i25optcd)
       MULTIMP = IPARI(23,NIN)
       MULNSN  = INTBUF_TAB%S_CAND_N - NCONT
       CALL I25BUCE(

--- a/engine/source/interfaces/intsort/i25pen3.F
+++ b/engine/source/interfaces/intsort/i25pen3.F
@@ -455,7 +455,7 @@ C
        ENDDO
       ENDIF
 C--------------------------------------------------------
-C     Case of solids, cf symetry conditions
+C     Case of solids, cf symmetry conditions
 C--------------------------------------------------------
       DO I=1,JLT
 

--- a/engine/source/interfaces/intsort/i7buce_crit.F
+++ b/engine/source/interfaces/intsort/i7buce_crit.F
@@ -91,7 +91,7 @@ C=======================================================================
 
       IF(NSN+NMN < NUMNOD+NUMFAKENODIGEO)THEN
 C
-!#include "simd.inc" --> this loop can't be vectorized because there are somes dependencies 
+!#include "simd.inc" --> this loop can't be vectorized because there are some dependencies 
         DO I=NSNF,NSNL
           J=NSV(I)
           IF(STFN(I)/=ZERO) THEN
@@ -112,7 +112,7 @@ C
 
           ENDIF
         END DO
-!#include "simd.inc" --> this loop can't be vectorized because there are somes dependencies 
+!#include "simd.inc" --> this loop can't be vectorized because there are some dependencies 
         DO I=NMNF,NMNL
           II = I+NSN
           J=MSR(I)
@@ -134,7 +134,7 @@ C
         END DO
       ELSE
 C
-!#include "simd.inc" --> this loop can't be vectorized because there are somes dependencies 
+!#include "simd.inc" --> this loop can't be vectorized because there are some dependencies 
         DO I=NSNF,NSNL
           J=NSV(I)
           IF(STFN(I)/=ZERO) THEN
@@ -155,7 +155,7 @@ C
 
           ENDIF
         END DO
-!#include "simd.inc" --> this loop can't be vectorized because there are somes dependencies 
+!#include "simd.inc" --> this loop can't be vectorized because there are some dependencies 
         DO I=NMNF,NMNL
           J=MSR(I)
           IF(J>0) THEN

--- a/engine/source/interfaces/intsort/i7trc.F
+++ b/engine/source/interfaces/intsort/i7trc.F
@@ -718,7 +718,7 @@ C
         NN = CAND_N(I)
         E  = CAND_E(I)
 
-C The symetric surface on shell elements must be kept
+C The symmetric surface on shell elements must be kept
 C On solids, the symmetric is the same
 
         ISH = MSEGTYP(E)

--- a/engine/source/interfaces/intsort/i7trivox.F
+++ b/engine/source/interfaces/intsort/i7trivox.F
@@ -187,7 +187,7 @@ C-----------------------------------------------
         ZMAXB = XYZM(12)
       ELSE
 ! we use the global bounding box
-! the box reduction seemed ineficient
+! the box reduction seemed inefficient
 ! at the first sorting
 ! because too many SECONDARY nodes were outside
 ! the reduced box
@@ -571,17 +571,17 @@ C=======================================================================
       DBG_type18_fvm=.false.
       if(inacti==7 .AND. DBG_type18_fvm)then
          write(*,FMT='(A)')"------------------------------------------"
-         write(*,*)"RESULT : Search Algorithm with VOXEL partitionning"
+         write(*,*)"RESULT : Search Algorithm with VOXEL partitioning"
          write(*,*)"  Number of couples =", II_STOK
          if(II_STOK>0)then
            write(*,FMT='(A,(I10))')"  --> SECONDARY Node ids: ", CAND_N(1:II_STOK)
            write(*,FMT='(A,(I10))')"  --> Local Face ids: ", CAND_E(1:II_STOK)
          endif
-         write(*,*)" S    tructure domain :"
+         write(*,*)" Structure domain :"
          write(*,FMT='(A,F30.16,A,F30.16)')" Xmin=",XMIN,"  Xmax=",XMAX
          write(*,FMT='(A,F30.16,A,F30.16)')" Ymin=",YMIN,"  Ymax=",YMAX
          write(*,FMT='(A,F30.16,A,F30.16)')" Zmin=",ZMIN,"  Zmax=",ZMAX
-         write(*,*)" Partitionning domain :"
+         write(*,*)" Partitioning domain :"
          write(*,*)"   TZINF,AAA=",TZINF,AAA
          write(*,FMT='(A,F30.16,A,F30.16)')" Xmin=",XMIN-AAA,"  Xmax=",XMAX+AAA
          write(*,FMT='(A,F30.16,A,F30.16)')" Ymin=",YMIN-AAA,"  Ymax=",YMAX+AAA

--- a/engine/source/interfaces/intsort/inttri.F
+++ b/engine/source/interfaces/intsort/inttri.F
@@ -218,7 +218,7 @@ C-----------------------------------------------
       TYPE(H3D_DATABASE) :: H3D_DATA
       TYPE(t_ale_connectivity), INTENT(IN) :: ALE_CONNECTIVITY
       INTEGER, INTENT(in) :: RENUM_SIZ
-      TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   struture for interface
+      TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   structure for interface
       TYPE(sorting_comm_type), DIMENSION(NINTER), INTENT(inout) :: SORT_COMM   ! structure for interface sorting comm
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) :: SENSOR_TAB
 C-----------------------------------------------
@@ -649,7 +649,7 @@ C Fin Partie non parallele smt
 
       RETRI = 0
       ! ------------------------
-      ! new sorting algorythm     
+      ! new sorting algorithm     
       IF(ITASK==0) NEED_TO_SORT = 0
       ! find the list of interface (for the moment : type7) that needs to be sorted
       CALL INTER_CHECK_SORT( ITASK,NEED_TO_SORT,NBINTC,INTLIST,IPARI,
@@ -696,12 +696,12 @@ C Fin Partie non parallele smt
      2                       RENUM,NSNFIOLD,MULTI_FVM,H3D_DATA,SENSOR_TAB,
      3                       INTER_STRUCT,SORT_COMM ,RENUM_SIZ)
       ENDIF
-      ! end : new sorting algorythm
+      ! end : new sorting algorithm
       ! ------------------------  
 
 
       ! ------------------------
-      ! old sorting algorythm   
+      ! old sorting algorithm   
 C=======================================================================
 C     non implicit options-------
 C=======================================================================
@@ -1284,11 +1284,11 @@ C
         END IF
 C
       END IF
-      ! end : old sorting algorythm 
+      ! end : old sorting algorithm 
       ! ------------------------
 
       ! ------------------------------
-      ! new sorting algorythm 
+      ! new sorting algorithm 
       ! deallocation & wait
       CALL MY_BARRIER()
       ! ------------------------
@@ -1297,7 +1297,7 @@ C
         CALL INTER_DEALLOCATE_WAIT( ITASK,NB_INTER_SORTED,LIST_INTER_SORTED,IPARI,ISENDTO,
      1                                IRECVFROM,INTBUF_TAB,SENSOR_TAB,INTER_STRUCT,SORT_COMM )
       ENDIF
-      ! end : new sorting algorythm 
+      ! end : new sorting algorithm 
       ! ------------------------------
 C=======================================================================
 C


### PR DESCRIPTION
Found via `codespell -q 3 -S ./.git,./extlib -L activ,addresse,adress,adresse,adresses,alph,als,ans,bloc,bord,bu,candidat,candidats,childs,clos,connectes,contrl,crypted,defaut,datas,detecte,dum,filles,fils,fixe,flagg,fonction,fonctions,globaly,groupe,groupes,idel,incluse,initiales,inout,invers,iself,ist,itens,ivalid,iverse,lamda,lamdas,lengt,limite,marge,mater,mot,mouvement,nam,nd,nin,ninty,nodel,normale,parametres,parm,pinter,pointeur,polygone,pres,probleme,prset,rotat,runn,sav,sirect,siz,som,somme,tage,thck,transfert,trian,ue,varn,verifie,versio`

#### Description of the feature or the bug

Fix typos in source comments and documentation of the `engine/source/interfaces` subdirectory. Some whitespace fixes have been added as well.

#### Description of the changes

Self-explanatory