### PR TITLE
Intel OneAPI: lower optimization level for FVM airbags routines

### DIFF
--- a/engine/CMake_Compilers/cmake_linux64_intel.txt
+++ b/engine/CMake_Compilers/cmake_linux64_intel.txt
@@ -113,6 +113,7 @@ set (C_BASIC "${cppmach} ${cpprel}")
 
 if ( debug STREQUAL "0" )
 
+
 # outp_c_s.F
 set_source_files_properties( ${source_directory}/source/sty/outp_c_s.F PROPERTIES COMPILE_FLAGS ${F_O3_AXSSE3})
 
@@ -220,6 +221,13 @@ set_source_files_properties( ${source_directory}/source/coupling/rad2rad/rad2rad
 
 # ieee.c
 set_source_files_properties( ${source_directory}/source/output/tools/ieee.c PROPERTIES COMPILE_FLAGS ${C_BASIC})
+
+# fvm airbags           
+set_source_files_properties( ${source_directory}/source/airbag/fv_up_switch.F PROPERTIES COMPILE_FLAGS ${F_O1_AXSSE3})
+set_source_files_properties( ${source_directory}/source/airbag/fvbag.F PROPERTIES COMPILE_FLAGS ${F_O1_AXSSE3})
+set_source_files_properties( ${source_directory}/source/airbag/fvbag0.F PROPERTIES COMPILE_FLAGS ${F_O1_AXSSE3})
+set_source_files_properties( ${source_directory}/source/airbag/fvbag1.F PROPERTIES COMPILE_FLAGS ${F_O1_AXSSE3})
+set_source_files_properties( ${source_directory}/source/airbag/fvbag2.F PROPERTIES COMPILE_FLAGS ${F_O1_AXSSE3})
 
 endif()
 

--- a/engine/CMake_Compilers/cmake_win64.txt
+++ b/engine/CMake_Compilers/cmake_win64.txt
@@ -213,11 +213,12 @@ set_source_files_properties( ${source_directory}/source/mpi/interfaces/spmd_i7to
 # ieee.c
 set_source_files_properties( ${source_directory}/source/output/tools/ieee.c PROPERTIES COMPILE_FLAGS ${C_BASIC})
 
-# fv_up_switch.F
+# fvm airbags           
 set_source_files_properties( ${source_directory}/source/airbag/fv_up_switch.F PROPERTIES COMPILE_FLAGS ${F_O1_AXSSE3})
-
-# fvbag.F
 set_source_files_properties( ${source_directory}/source/airbag/fvbag.F PROPERTIES COMPILE_FLAGS ${F_O1_AXSSE3})
+set_source_files_properties( ${source_directory}/source/airbag/fvbag0.F PROPERTIES COMPILE_FLAGS ${F_O1_AXSSE3})
+set_source_files_properties( ${source_directory}/source/airbag/fvbag1.F PROPERTIES COMPILE_FLAGS ${F_O1_AXSSE3})
+set_source_files_properties( ${source_directory}/source/airbag/fvbag2.F PROPERTIES COMPILE_FLAGS ${F_O1_AXSSE3})
 
 endif()
 


### PR DESCRIPTION
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
As seen in #811 , OneAPI compiler (ifx) may fail to compile FVMBAG routines

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
Optimization level set to 01. May be increased again after Intel's feedback

