### PR TITLE
forcheck feedback

### DIFF
--- a/starter/source/airbag/fvmesh.F
+++ b/starter/source/airbag/fvmesh.F
@@ -2848,8 +2848,8 @@ C
          NNP=IPOLY_F(2,I)
          NHOL=0
          IF (IPOLY_F(1,I) == 2) NHOL=IPOLY_F(6+NNP+1,I)
-         ALLOCATE(PNODES(2,NNP), PSEG(2,NNP), PHOLES(2,NHOL),
-     .            PTRI(3,NNP), REDIR(NNP))   
+         ALLOCATE(PNODES(2,NNP), PSEG(2,NNP), PHOLES(2,NHOL),PTRI(3,NNP), REDIR(NNP)) 
+         PTRI(1:3,1:NNP) = 0       
 C
          DO J=1,NNP
             IF (IPOLY_F(6+J,I) > 0) THEN
@@ -2974,8 +2974,8 @@ C
             DEALLOCATE(ADR)
          ENDIF
 C
-         CALL C_TRICALL(PNODES, PSEG, PHOLES, PTRI, NNP,
-     .                  NSEG,   NHOL, NELP  )
+         NELP = 0
+         CALL C_TRICALL(PNODES, PSEG, PHOLES, PTRI, NNP, NSEG, NHOL, NELP)
 C
          FVDATA(IFV)%IFVTADR(NPOLY)=NNTR+1
 C avoid bug with PGI => comp O1

--- a/starter/source/airbag/polyhedr1.F
+++ b/starter/source/airbag/polyhedr1.F
@@ -86,6 +86,7 @@ C--------------------------------
          NNP=IPOLY(2,I)
          NHOL=0
          ALLOCATE(PNODES(2,NNP), PSEG(2,NNP),PTRI(3,2*NNP),PHOLES(2,1))
+         PTRI(1:3,1:2*NNP) = 0
 C
 C Coordonnees des sommets dans le plan du polygone
          NX=RPOLY(2,I)
@@ -124,6 +125,7 @@ C
          PSEG(2,NNP)=1
          NSEG=NNP
 C
+         NELP = 0
          CALL C_TRICALL(PNODES, PSEG, PHOLES, PTRI, NNP,
      .                  NSEG,   NHOL, NELP  )
 CFA         IF(NELP > NNP) THEN


### PR DESCRIPTION
#### FVMBAG : Forcheck Feedback

#### Description of the changes
initialization of NELP and PTRI to 0 in order to disable Forcheck warnings (subroutines fvmesh.F and polyhedr1.F)
