### PR TITLE
Use of unallocated array IN_B in i2_dtn_27.F at starter

### DIFF
--- a/starter/source/interfaces/inter3d1/i2_dtn_27.F
+++ b/starter/source/interfaces/inter3d1/i2_dtn_27.F
@@ -413,13 +413,13 @@ C
           IX3 = IRECT(3,L)                                       
           IX4 = IRECT(4,L)
 C
-          IF ((MSEGTYP2(L)==1).AND.(IN(I)>EM20)) THEN
+          IROT = ZERO
+          IF(IRODDL > 0) THEN
+            IF ((MSEGTYP2(L)==1).AND.(IN(I)>EM20)) THEN
 C-- shell main segment --
-            IROT = ONE
-          ELSE
-C-- solid main segment --
-            IROT = ZERO
-          ENDIF 
+              IROT = ONE
+            ENDIF
+          ENDIF
 C
           IF (IX3 == IX4) THEN
 C--         Shape functions of triangles

--- a/starter/source/starter/lectur.F
+++ b/starter/source/starter/lectur.F
@@ -9840,6 +9840,8 @@ C     Mass and inertia are not modified - a specific array is used
       IF (IRODDL==1) THEN
         ALLOCATE(IN_B(NUMNOD),STAT=stat)
         IN_B(1:NUMNOD)=IN(1:NUMNOD)
+      ELSE
+        ALLOCATE(IN_B(1))
       ENDIF
 C
       IF (NS10E>0.AND.N2D==0) CALL STIFN0_ND(ICNDS10,STIFFN)
@@ -9888,7 +9890,7 @@ C--------------------------------------------
       DEALLOCATE (STIFINT)
       DEALLOCATE (STIFINTR)
       DEALLOCATE (MS_B)
-      IF (IRODDL==1) DEALLOCATE (IN_B)
+      DEALLOCATE (IN_B)
       DEALLOCATE (DTELEM)
       CALL TRACE_OUT1()
 C--------------------------------------------


### PR DESCRIPTION

#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Invalid read of unallocated array in i2_dtn_27.F for cases with only solid (IRODDL=1)

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
IN_B not used anymore if IRODDL=1. 
IN_B is always allocated, even if not used, because it is passed as a dummy argument

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
