### PR TITLE
No Cuthill-Mckee ordering after the first domain decomposition

### DIFF
--- a/starter/source/elements/shell/coque/cgrtails.F
+++ b/starter/source/elements/shell/coque/cgrtails.F
@@ -47,7 +47,7 @@ Chd|====================================================================
      6       IPART  ,SH4TREE ,NOD2ELC   ,ISHEOFF ,
      7       SH4TRIM ,TAGPRT_SMS,LGAUGE  ,IWORKSH ,
      8       STACK   ,DRAPE    ,RNOISE  ,MATPARAM_TAB,
-     9       SH4ANG)
+     9       SH4ANG, IDDLEVEL)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -120,7 +120,7 @@ C-----------------------------------------------
      .    IPM(NPROPMI,*), IPART(LIPART1,*), SH4TREE(KSH4TREE,*), 
      .    ISHEOFF(*),MINDEXC(NUMELC), TAGPRT_SMS(*),LGAUGE(3,*),
      .    NOD2ELC(*),IWORKSH(3,*)
-C     REAL OU REAL*8
+      INTEGER, INTENT(IN) :: IDDLEVEL
       MY_REAL
      .    PM(NPROPM,*), GEO(NPROPG,*), XNUM(*),THK(*),RNOISE(NPERTURB,*),
      .    SH4ANG(*)
@@ -258,7 +258,7 @@ C
       
 
 
-        IF(DOQA .NE. 0 .OR. NADMESH /=0) THEN
+        IF(DOQA .NE. 0 .OR. NADMESH /=0 .OR. IDDLEVEL == 0) THEN
           MODE=0
           CALL MY_ORDERS( MODE, WORK, CEP(NFT+1), INDEX, NEL , 1)
         ELSE

--- a/starter/source/elements/solid/solide/sgrtails.F
+++ b/starter/source/elements/solid/solide/sgrtails.F
@@ -44,7 +44,7 @@ Chd|====================================================================
      2       EADD   ,ND     ,NELS   ,IPARTS  ,DD_IAD  ,
      3       IDX    ,ISOLNOD,LB_MAX ,INUM    ,INDEX   ,
      4       CEP    ,ITR1   ,IXS10  ,IGRSURF ,IGRBRIC ,
-     5       IXS20  ,IXS16  ,IGEO    ,
+     5       IXS20  ,IXS16  ,IGEO    , IDDLEVEL,
      6       IPM    ,NOD2ELS,ISOLOFF,ISOLNOD1,
      7       TAGPRT_SMS,INIVOL,SPH2SOL ,SOL2SPH,SOL2SPH_TYP,
      8       IFLAG_BPRELOAD,CLUSTERS,MATPARAM_TAB,RNOISE)
@@ -115,6 +115,7 @@ C-----------------------------------------------
      .        NOD2ELS(*), ISOLOFF(*),ISOLNOD1(*),
      .        TAGPRT_SMS(*),SPH2SOL(*),
      .        SOL2SPH(2,*),SOL2SPH_TYP(*),IFLAG_BPRELOAD(*)
+      INTEGER, INTENT(IN) :: IDDLEVEL
       TYPE(MATPARAM_STRUCT_) , TARGET, DIMENSION(NUMMAT),INTENT(IN) :: MATPARAM_TAB
       MY_REAL  PM(NPROPM,NUMMAT), GEO(NPROPG,NUMGEO), RNOISE(NPERTURB,NUMELS)
 C-----------------------------------------------
@@ -211,7 +212,7 @@ C
           ENDDO
         END IF
       
-        IF(DOQA .NE. 0) THEN
+        IF(DOQA .NE. 0 .OR. IDDLEVEL == 0) THEN
           MODE=0
           CALL MY_ORDERS( MODE, WORK, CEP(NFT+1), INDEX, NEL , 1)
         ELSE

--- a/starter/source/starter/lectur.F
+++ b/starter/source/starter/lectur.F
@@ -5770,7 +5770,7 @@ C
      2       EADD     ,ND       ,BID13    ,IPARTS   ,DD_TMP(IDX),
      3       IDX      ,EANI     ,LB_MAX   ,INUM     ,INDEX1   ,
      4       CEP(OFF) ,ITRI1    ,IXS10    ,IGRSURF  ,IGRBRIC  ,
-     5       IXS20    ,IXS16    ,IGEO     ,
+     5       IXS20    ,IXS16    ,IGEO     ,IDDLEVEL,
      6       IPM      ,NOD2ELS  ,ISOLOFF  ,ISOLNOD  ,
      7       TAGPRT_SMS,USER_INIVOL  ,SPH2SOL  ,SOL2SPH  ,SOL2SPH_TYP,
      8       IFLAG_BPRELOAD, CLUSTERS ,MATPARAM_TAB ,RNOISE(1,MIN(SRNOISE2,NUMELC+NUMELTG+1)))
@@ -5905,7 +5905,7 @@ C
      6        IPART    ,SH4TREE  ,NOD2ELC  ,ISHEOFF ,
      7        SH4TRIM  ,TAGPRT_SMS, LGAUGE,IWORKSH    ,
      8        STACK    ,DRAPE   ,RNOISE  ,MATPARAM_TAB,
-     9        SH4ANG)
+     9        SH4ANG, IDDLEVEL)
          OFF = OFF + NUMELC
 
          DO I=1,NUMELC


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Element reordering was applied for both domain decomposition, but was useful only for the last one.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
Do not reorder elements if IDDLEVEL == 0

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
