### PR TITLE
/LOAD/PBLAST - default Iform value set to 2

### DIFF
--- a/starter/source/loads/pblast/hm_read_pblast.F
+++ b/starter/source/loads/pblast/hm_read_pblast.F
@@ -317,7 +317,7 @@ C-----------------------------------------------
             ! IMODEL : flag for blast model
             !---1:Friedlander
             !---2:modified Friedlander
-            IF(IMODEL <= 0 .OR. IMODEL > 2)IMODEL=1
+            IF(IMODEL <= 0 .OR. IMODEL > 2)IMODEL=2
 
             IF(IZ_UPDATE /= 1)IZ_UPDATE=0 !0:update scaled distance  
             !     0:do not update scaled distance  


### PR DESCRIPTION
#### Description of the feature or the bug
/LOAD/PBLAST - default Iform value set to 2


#### Description of the changes
Default mathematical model to describe blast wave is "modified Friedlander wave" Iform=2
Defaut iform is updated from 1 to 2

#### Expected numerical changes : yes
if Iform was set to 0 (/LOAD/PBLAST), then this will affect numerical result

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
