### PR TITLE
Law 112 performance improvement and bug fix on return mapping algorithm NICE

### DIFF
--- a/engine/source/materials/mat/mat112/mat112_xia_newton.F
+++ b/engine/source/materials/mat/mat112/mat112_xia_newton.F
@@ -580,7 +580,9 @@ c
             DSIGY5_DP(1:NEL)= DSIGY5_DP(1:NEL) * YSCALE5
             VARTMP(1:NEL,5) = IPOS(1:NEL,1)          
             ! Yield function value update
-            DO I = 1,NEL
+#include "vectorize.inc" 
+            DO II=1,NINDX 
+              I = INDEX(II)
               GAM1(I) = (N1(1)*SIGNXX(I)+N1(2)*SIGNYY(I))/SIGY1(I)
               GAM2(I) = (N2(1)*SIGNXX(I)+N2(2)*SIGNYY(I))/SIGY2(I)
               GAM3(I) = N3*SIGNXY(I)/SIGY3(I)
@@ -694,7 +696,9 @@ c
             DSIGYO_DP(1:NEL)= DSIGYO_DP(1:NEL) * YSCALEC
             VARTMP(1:NEL,6) = IPOS(1:NEL,1)
             ! Yield function value update
-            DO I = 1,NEL
+#include "vectorize.inc" 
+            DO II=1,NINDX2 
+              I = INDEX2(II)
               THETA(I) = - SIGNZZ(I) - SIGYO(I)
             ENDDO        
           ENDIF
@@ -801,7 +805,9 @@ c
             DSIGYS_DP(1:NEL)= DSIGYS_DP(1:NEL) * YSCALES
             VARTMP(1:NEL,7) = IPOS(1:NEL,1)
             ! Yield function value update
-            DO I = 1,NEL
+#include "vectorize.inc" 
+            DO II=1,NINDX3 
+              I = INDEX3(II)
               PSI(I) = (SQRT(SIGNYZ(I)**2 + SIGNZX(I)**2)/SIGYS(I)) - ONE
             ENDDO
           ENDIF

--- a/engine/source/materials/mat/mat112/mat112_xia_nice.F
+++ b/engine/source/materials/mat/mat112/mat112_xia_nice.F
@@ -790,7 +790,9 @@ c
           DSIGY5_DP(1:NEL)= DSIGY5_DP(1:NEL) * YSCALE5
           VARTMP(1:NEL,5) = IPOS(1:NEL,1)          
           ! Yield function value update
-          DO I = 1,NEL
+#include "vectorize.inc" 
+          DO II=1,NINDX 
+            I = INDEX(II)
             GAM1(I) = (N1(1)*SIGNXX(I)+N1(2)*SIGNYY(I))/SIGY1(I)
             GAM2(I) = (N2(1)*SIGNXX(I)+N2(2)*SIGNYY(I))/SIGY2(I)
             GAM3(I) = N3*SIGNXY(I)/SIGY3(I)
@@ -814,7 +816,9 @@ c
           DSIGYO_DP(1:NEL)= DSIGYO_DP(1:NEL) * YSCALEC
           VARTMP(1:NEL,6) = IPOS(1:NEL,1)
           ! Yield function value update
-          DO I = 1,NEL
+#include "vectorize.inc" 
+          DO II=1,NINDX2 
+            I = INDEX2(II)
             THETA(I) = - SIGNZZ(I) - SIGYO(I)
           ENDDO        
         ENDIF
@@ -830,7 +834,9 @@ c
           DSIGYS_DP(1:NEL)= DSIGYS_DP(1:NEL) * YSCALES
           VARTMP(1:NEL,7) = IPOS(1:NEL,1)
           ! Yield function value update
-          DO I = 1,NEL
+#include "vectorize.inc" 
+          DO II=1,NINDX3
+            I = INDEX3(II)
             PSI(I) = (SQRT(SIGNYZ(I)**2 + SIGNZX(I)**2)/SIGYS(I)) - ONE
           ENDDO
         ENDIF
@@ -839,9 +845,9 @@ c
       ! Storing new values
       DO I=1,NEL
         ! USR Outputs
-        UVAR(I,1)  = PHI(I)              ! In-plane yield function
-        UVAR(I,2)  = THETA(I)            ! Out-of-plane yield function
-        UVAR(I,3)  = PSI(I)              ! Transverse shear yield function
+        UVAR(I,1)  = ZERO ! Reset in-plane yield function value
+        UVAR(I,2)  = ZERO ! Reset out-of-plane yield function value
+        UVAR(I,3)  = ZERO ! Reset transverse shear yield function value
         ! Plastic strain
         PLA(I,1)   = SQRT(PLA(I,2)**2 + PLA(I,3)**2 + PLA(I,4)**2)        
         DPLA(I)    = (PLA(I,2)/(MAX(SQRT(PLA(I,2)**2 + PLA(I,3)**2 + PLA(I,4)**2),EM20)))*DPLA2(I) +
@@ -875,6 +881,27 @@ c
         SIGY(I)    = SQRT(KHI1(I)*SIGY1(I)**2 + KHI2(I)*SIGY2(I)**2 + KHI4(I)*SIGY4(I)**2 + 
      .                    KHI5(I)*SIGY5(I)**2 + TWO*KHI3(I)*SIGY3(I)**2 + SIGYO(I)**2
      .                    + TWO*SIGYS(I)**2)
+      ENDDO
+c
+      ! Save in-plane yield function remaining value
+#include "vectorize.inc" 
+      DO II=1,NINDX                                              
+        I = INDEX(II)
+        UVAR(I,1) = PHI(I) 
+      ENDDO
+c
+      ! Save out-of-plane yield function remaining value
+#include "vectorize.inc" 
+      DO II=1,NINDX2                                            
+        I = INDEX2(II)
+        UVAR(I,2) = THETA(I) 
+      ENDDO
+c
+      ! Save transverse shear yield function remaining value
+#include "vectorize.inc" 
+      DO II=1,NINDX3                                            
+        I = INDEX3(II)
+        UVAR(I,3) = PSI(I) 
       ENDDO
 c
       END

--- a/engine/source/materials/mat/mat112/mat112c_xia_newton.F
+++ b/engine/source/materials/mat/mat112/mat112c_xia_newton.F
@@ -537,7 +537,9 @@ c
             DSIGY5_DP(1:NEL)= DSIGY5_DP(1:NEL) * YSCALE5
             VARTMP(1:NEL,5) = IPOS(1:NEL,1)
             ! Yield function value update
-            DO I = 1,NEL
+#include "vectorize.inc" 
+            DO II=1,NINDX 
+              I = INDEX(II)
               GAM1(I) = (N1(1)*SIGNXX(I)+N1(2)*SIGNYY(I))/SIGY1(I)
               GAM2(I) = (N2(1)*SIGNXX(I)+N2(2)*SIGNYY(I))/SIGY2(I)
               GAM3(I) = N3*SIGNXY(I)/SIGY3(I)
@@ -649,7 +651,9 @@ c
             DSIGYS_DP(1:NEL)= DSIGYS_DP(1:NEL) * YSCALES
             VARTMP(1:NEL,7) = IPOS(1:NEL,1)
             ! Yield function value update
-            DO I = 1,NEL
+#include "vectorize.inc" 
+            DO II=1,NINDX2 
+              I = INDEX2(II)
               PSI(I) = (SQRT(SIGNYZ(I)**2 + SIGNZX(I)**2)/SIGYS(I)) - ONE
             ENDDO
           ENDIF

--- a/engine/source/materials/mat/mat112/mat112c_xia_nice.F
+++ b/engine/source/materials/mat/mat112/mat112c_xia_nice.F
@@ -652,7 +652,9 @@ c
           DSIGY5_DP(1:NEL)= DSIGY5_DP(1:NEL) * YSCALE5
           VARTMP(1:NEL,5) = IPOS(1:NEL,1)          
           ! Yield function value update
-          DO I = 1,NEL
+#include "vectorize.inc" 
+          DO II=1,NINDX 
+            I = INDEX(II)
             GAM1(I) = (N1(1)*SIGNXX(I)+N1(2)*SIGNYY(I))/SIGY1(I)
             GAM2(I) = (N2(1)*SIGNXX(I)+N2(2)*SIGNYY(I))/SIGY2(I)
             GAM3(I) = N3*SIGNXY(I)/SIGY3(I)
@@ -676,7 +678,9 @@ c
           DSIGYS_DP(1:NEL)= DSIGYS_DP(1:NEL) * YSCALES
           VARTMP(1:NEL,7) = IPOS(1:NEL,1)
           ! Yield function value update
-          DO I = 1,NEL
+#include "vectorize.inc" 
+          DO II=1,NINDX2 
+            I = INDEX2(II)
             PSI(I) = (SQRT(SIGNYZ(I)**2 + SIGNZX(I)**2)/SIGYS(I)) - ONE
           ENDDO
         ENDIF
@@ -685,8 +689,8 @@ c
       ! Storing new values
       DO I=1,NEL  
         ! USR Outputs
-        UVAR(I,1) = PHI(I) ! In-plane yield function value
-        UVAR(I,2) = PSI(I) ! Transverse shear yield function value
+        UVAR(I,1) = ZERO ! Reset in-plane yield function value
+        UVAR(I,2) = ZERO ! Reset transverse shear yield function value
         ! Plastic strain
         PLA(I,1)  = SQRT(PLA(I,2)**2 + PLA(I,4)**2)
         DPLA(I)   = (PLA(I,2)/(MAX(SQRT(PLA(I,2)**2 + PLA(I,4)**2),EM20)))*DPLA2(I) +
@@ -711,6 +715,20 @@ c
         ! Storing the yield stress
         SIGY(I) = SQRT(SIGY1(I)**2 + SIGY2(I)**2      + SIGY4(I)**2 + 
      .                 SIGY5(I)**2 + TWO*SIGY3(I)**2 + TWO*SIGYS(I)**2)
+      ENDDO
+c
+      ! Save in-plane yield function remaining value
+#include "vectorize.inc" 
+      DO II=1,NINDX                                              
+        I = INDEX(II)
+        UVAR(I,1) = PHI(I) 
+      ENDDO
+c
+      ! Save transverse shear yield function remaining value
+#include "vectorize.inc" 
+      DO II=1,NINDX2                                            
+        I = INDEX2(II)
+        UVAR(I,2) = PSI(I) 
       ENDDO
 c
       END


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Law 112 presented some issues in single precision when using NICE return mapping algorithm (QA test 8.1546). The return mapping was not fully correct with theory. Yield function value needed to be reset when the element behavior is not plastic. In addition, some loop performance could be increased by decreasing the number of treated element. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Fix NICE return mapping issue by resetting the yield function value when element behavior is not plastic + improve some loop. 

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
