### PR TITLE
/MAT/LAW24 : set istrain=1 for law24 and store strain in buffer

### DIFF
--- a/starter/source/elements/solid/solide/sgrtails.F
+++ b/starter/source/elements/solid/solide/sgrtails.F
@@ -1414,7 +1414,7 @@ C reperage groupe/processeur
           ELSE
             IPARG(41,NGROUP)=ITET4
           ENDIF
-          IF(MLN/=24.AND.MLN/=25.AND.MLN<28)THEN
+          IF(MLN/=25.AND.MLN<28)THEN
           IPARG(44,NGROUP)= ISTRAIN
           ELSEIF(MLN>=28)THEN
            ISTRAIN=2

--- a/starter/source/elements/solid/solide/sinit3.F
+++ b/starter/source/elements/solid/solide/sinit3.F
@@ -396,7 +396,7 @@ C Case /INIBRIS/STRS_FGLO missed
      .         (ISTRAIN == 1 .AND. 
      .         (MTN==1  .OR. MTN==2  .OR. MTN==3    .OR. MTN==4  .OR. 
      .          MTN==6  .OR. MTN==10 .OR. MTN==21   .OR. MTN==22 .OR.
-     .          MTN==23))) THEN
+     .          MTN==23 .OR. MTN==24))) THEN
               IDEF = 1
           ENDIF
 c


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
strain and stress not written and read correctly with sta output and INIBRI card
<!--- Describe the problem, ideally from the user viewpoint -->


set istrain=1 for law24 and store strain tensor in buffer in order to be retreived at the material level
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->


<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
