### PR TITLE
Fix intent attribute issue for mtag and matparam_tab data structure

### DIFF
--- a/starter/source/materials/mat/mat002/hm_read_mat02.F
+++ b/starter/source/materials/mat/mat002/hm_read_mat02.F
@@ -94,7 +94,7 @@ C-----------------------------------------------
       my_real, DIMENSION(MAXUPARAM), INTENT(INOUT) :: UPARAM
       my_real, INTENT(INOUT) :: PARMAT(*)
       TYPE(MLAW_TAG_),INTENT(INOUT)         :: MTAG
-      TYPE(MATPARAM_STRUCT_)  :: MATPARAM
+      TYPE(MATPARAM_STRUCT_),INTENT(INOUT)  :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat010/hm_read_mat10.F
+++ b/starter/source/materials/mat/mat010/hm_read_mat10.F
@@ -78,7 +78,7 @@ C-----------------------------------------------
       CHARACTER*nchartitle ,INTENT(IN)             :: TITR
       my_real, DIMENSION(NPROPM)  ,INTENT(INOUT)   :: PM
       TYPE(SUBMODEL_DATA), DIMENSION(NSUBMOD),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(OUT)                 :: MTAG
+      TYPE(MLAW_TAG_), INTENT(INOUT)               :: MTAG
       TYPE(EOS_TAG_) , TARGET, DIMENSION(0:MAXEOS) ,INTENT(OUT) :: EOS_TAG      
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/starter/source/materials/mat/mat012/hm_read_mat12.F
+++ b/starter/source/materials/mat/mat012/hm_read_mat12.F
@@ -83,9 +83,9 @@ C-----------------------------------------------
       CHARACTER*nchartitle ,INTENT(IN)             :: TITR
       my_real, DIMENSION(NPROPM)  ,INTENT(INOUT)   :: PM
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(OUT)                 :: MTAG
+      TYPE(MLAW_TAG_), INTENT(INOUT)               :: MTAG
       TYPE(EOS_TAG_) , TARGET, DIMENSION(0:MAXEOS) ,INTENT(OUT) :: EOS_TAG      
-      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
+      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT)        :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat013/hm_read_mat13.F
+++ b/starter/source/materials/mat/mat013/hm_read_mat13.F
@@ -66,7 +66,7 @@ C-----------------------------------------------
       TYPE(MLAW_TAG_), INTENT(INOUT)               :: MTAG
       INTEGER, DIMENSION(NPROPMI) ,INTENT(INOUT)   :: IPM
       my_real, DIMENSION(NPROPM)  ,INTENT(INOUT)   :: PM
-      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
+      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT)        :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat016/hm_read_mat16.F
+++ b/starter/source/materials/mat/mat016/hm_read_mat16.F
@@ -70,8 +70,8 @@ C-----------------------------------------------
       my_real, DIMENSION(NPROPM)  ,INTENT(INOUT)   :: PM
       my_real, DIMENSION(LUNIT,NUNITS) ,INTENT(IN) :: UNITAB
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(OUT)                 :: MTAG
-      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
+      TYPE(MLAW_TAG_), INTENT(INOUT)               :: MTAG
+      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT)        :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat018/hm_read_mat18.F
+++ b/starter/source/materials/mat/mat018/hm_read_mat18.F
@@ -71,7 +71,7 @@ c
       INTEGER, INTENT(OUT)   :: IPM(NPROPMI)
       my_real, INTENT(OUT)   :: PM(NPROPM)     
       INTEGER, INTENT(OUT)   :: NUPARAM,NUVAR,NFUNC,JTHE
-      TYPE(MLAW_TAG_) ,INTENT(OUT)         :: MTAG
+      TYPE(MLAW_TAG_) ,INTENT(INOUT)         :: MTAG
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat021/hm_read_mat21.F
+++ b/starter/source/materials/mat/mat021/hm_read_mat21.F
@@ -78,7 +78,7 @@ C-----------------------------------------------
       CHARACTER*nchartitle ,INTENT(IN)             :: TITR
       my_real, DIMENSION(NPROPM)  ,INTENT(INOUT)   :: PM
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(OUT)                 :: MTAG
+      TYPE(MLAW_TAG_), INTENT(INOUT)               :: MTAG
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat024/hm_read_mat24.F
+++ b/starter/source/materials/mat/mat024/hm_read_mat24.F
@@ -79,7 +79,7 @@ C-----------------------------------------------
       my_real, DIMENSION(NPROPM)  ,INTENT(OUT)     :: PM     
       CHARACTER(nchartitle) ,INTENT(IN)            :: TITR
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_) :: MTAG
+      TYPE(MLAW_TAG_), INTENT(INOUT) :: MTAG
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat025/hm_read_mat25.F
+++ b/starter/source/materials/mat/mat025/hm_read_mat25.F
@@ -82,7 +82,7 @@ c
       INTEGER, INTENT(OUT)                         :: ISRATE
       my_real, DIMENSION(100)       ,INTENT(OUT)   :: PARMAT     
       my_real, DIMENSION(NPROPM)    ,INTENT(OUT)   :: PM     
-      TYPE(MLAW_TAG_)               ,INTENT(OUT)   :: MTAG
+      TYPE(MLAW_TAG_)               ,INTENT(INOUT) :: MTAG
       TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
 c
       INTEGER :: MAXUPARAM,NUPARAM

--- a/starter/source/materials/mat/mat026/hm_read_mat26.F
+++ b/starter/source/materials/mat/mat026/hm_read_mat26.F
@@ -70,7 +70,7 @@ C-----------------------------------------------
       my_real, DIMENSION(NPROPM)  ,INTENT(INOUT)   :: PM
       my_real, DIMENSION(LUNIT,NUNITS) ,INTENT(IN) :: UNITAB
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(OUT)                 :: MTAG
+      TYPE(MLAW_TAG_), INTENT(INOUT)               :: MTAG
       my_real ,DIMENSION(*), INTENT(INOUT)         :: BUFMAT
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/starter/source/materials/mat/mat027/hm_read_mat27.F
+++ b/starter/source/materials/mat/mat027/hm_read_mat27.F
@@ -81,7 +81,7 @@ C-----------------------------------------------
       INTEGER, INTENT(INOUT)                       :: ISRATE
       my_real, DIMENSION(100),INTENT(OUT) :: PARMAT
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(OUT) :: MTAG
+      TYPE(MLAW_TAG_), INTENT(INOUT) :: MTAG
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat044/hm_read_mat44.F
+++ b/starter/source/materials/mat/mat044/hm_read_mat44.F
@@ -81,7 +81,7 @@ C-----------------------------------------------
       my_real, DIMENSION(MAXUPARAM) ,INTENT(OUT)   :: UPARAM
       my_real, DIMENSION(100),INTENT(OUT) :: PARMAT
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(OUT) :: MTAG
+      TYPE(MLAW_TAG_), INTENT(INOUT) :: MTAG
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat050/hm_read_mat50.F
+++ b/starter/source/materials/mat/mat050/hm_read_mat50.F
@@ -84,7 +84,7 @@ C-----------------------------------------------
       my_real, DIMENSION(MAXUPARAM) ,INTENT(OUT)   :: UPARAM
       my_real, DIMENSION(100),INTENT(OUT) :: PARMAT
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(OUT) :: MTAG
+      TYPE(MLAW_TAG_), INTENT(INOUT) :: MTAG
       TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/starter/source/materials/mat/mat058/hm_read_mat58.F
+++ b/starter/source/materials/mat/mat058/hm_read_mat58.F
@@ -80,7 +80,7 @@ C-----------------------------------------------
       my_real, DIMENSION(MAXUPARAM) ,INTENT(OUT)   :: UPARAM
       my_real, DIMENSION(100),INTENT(OUT) :: PARMAT
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(OUT) :: MTAG
+      TYPE(MLAW_TAG_), INTENT(INOUT) :: MTAG
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat063/hm_read_mat63.F
+++ b/starter/source/materials/mat/mat063/hm_read_mat63.F
@@ -81,7 +81,7 @@ C-----------------------------------------------
       my_real, DIMENSION(MAXUPARAM) ,INTENT(OUT)   :: UPARAM
       my_real, DIMENSION(100),INTENT(OUT) :: PARMAT
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL      
-      TYPE(MLAW_TAG_), INTENT(OUT) :: MTAG
+      TYPE(MLAW_TAG_), INTENT(INOUT) :: MTAG
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat065/hm_read_mat65.F
+++ b/starter/source/materials/mat/mat065/hm_read_mat65.F
@@ -83,7 +83,7 @@ C-----------------------------------------------
       my_real, DIMENSION(MAXUPARAM) ,INTENT(OUT)   :: UPARAM
       my_real, DIMENSION(100),INTENT(OUT) :: PARMAT
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(OUT) :: MTAG
+      TYPE(MLAW_TAG_), INTENT(INOUT) :: MTAG
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat072/hm_read_mat72.F
+++ b/starter/source/materials/mat/mat072/hm_read_mat72.F
@@ -88,7 +88,7 @@ C-----------------------------------------------
       INTEGER,INTENT(IN)                    :: MAT_ID
       CHARACTER*nchartitle,INTENT(IN)       :: TITR
       TYPE(SUBMODEL_DATA),INTENT(IN)        :: LSUBMODEL(*)
-      TYPE(MATPARAM_STRUCT_) ,INTENT(OUT)   :: MATPARAM
+      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat076/hm_read_mat76.F
+++ b/starter/source/materials/mat/mat076/hm_read_mat76.F
@@ -95,7 +95,7 @@ C-----------------------------------------------
       TYPE (UNIT_TYPE_),INTENT(IN) ::UNITAB 
       TYPE (SUBMODEL_DATA),INTENT(IN)      :: LSUBMODEL(*)
       TYPE (MLAW_TAG_)    ,INTENT(INOUT)   :: MTAG
-      TYPE (MATPARAM_STRUCT_) ,INTENT(OUT) :: MATPARAM
+      TYPE (MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
       TYPE (TTABLE) TABLE(NTABLE)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/starter/source/materials/mat/mat077/hm_read_mat77.F
+++ b/starter/source/materials/mat/mat077/hm_read_mat77.F
@@ -86,7 +86,7 @@ C-----------------------------------------------
       INTEGER, DIMENSION(MAXFUNC)   ,INTENT(OUT)   :: IFUNC
       my_real, DIMENSION(MAXUPARAM) ,INTENT(OUT)   :: UPARAM
       my_real, DIMENSION(100),INTENT(OUT) :: PARMAT
-      TYPE(MATPARAM_STRUCT_) ,INTENT(OUT) :: MATPARAM
+      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/starter/source/materials/mat/mat078/hm_read_mat78.F
+++ b/starter/source/materials/mat/mat078/hm_read_mat78.F
@@ -75,7 +75,7 @@ C-----------------------------------------------
       my_real  ,DIMENSION(100)          ,INTENT(OUT) :: PARMAT   
       my_real  ,DIMENSION(MAXUPARAM)    ,INTENT(OUT) :: UPARAM
       INTEGER         ,INTENT(OUT)     :: NFUNC,NUVAR,NVARTMP,NUPARAM,ISRATE,IMATVIS
-      TYPE(MLAW_TAG_) ,INTENT(OUT)     :: MTAG
+      TYPE(MLAW_TAG_) ,INTENT(INOUT)   :: MTAG
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat083/hm_read_law83.F
+++ b/starter/source/materials/mat/mat083/hm_read_law83.F
@@ -82,7 +82,7 @@ C-----------------------------------------------
       my_real, INTENT(INOUT)          :: PM(NPROPM),PARMAT(100),UPARAM(MAXUPARAM)
       CHARACTER*nchartitle,INTENT(IN) :: TITR
       TYPE(SUBMODEL_DATA),INTENT(IN)  :: LSUBMODEL(NSUBMOD)
-      TYPE(MLAW_TAG_), INTENT(OUT)    :: MTAG
+      TYPE(MLAW_TAG_), INTENT(INOUT)  :: MTAG
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat102/hm_read_mat102.F
+++ b/starter/source/materials/mat/mat102/hm_read_mat102.F
@@ -93,7 +93,7 @@ C-----------------------------------------------
       INTEGER,INTENT(IN)              :: MAT_ID
       CHARACTER*nchartitle,INTENT(IN) :: TITR
       TYPE(SUBMODEL_DATA),INTENT(IN)  :: LSUBMODEL(*)
-      TYPE(MATPARAM_STRUCT_) ,INTENT(OUT) :: MATPARAM
+      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat104/hm_read_mat104.F
+++ b/starter/source/materials/mat/mat104/hm_read_mat104.F
@@ -68,8 +68,8 @@ C-----------------------------------------------
       CHARACTER*nchartitle ,INTENT(IN)             :: TITR
       my_real, DIMENSION(100),INTENT(INOUT)        :: PARMAT      
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(OUT)                 :: MTAG
-      TYPE(MATPARAM_STRUCT_) ,INTENT(OUT)          :: MATPARAM
+      TYPE(MLAW_TAG_), INTENT(INOUT)               :: MTAG
+      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT)        :: MATPARAM
       my_real, DIMENSION(NPROPM) ,INTENT(INOUT)    :: PM 
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/starter/source/materials/mat/mat104/law104_upd.F
+++ b/starter/source/materials/mat/mat104/law104_upd.F
@@ -60,7 +60,7 @@ C-----------------------------------------------
       my_real, DIMENSION(NUPARF) , INTENT(IN)  :: UPARF
       my_real, DIMENSION(NUPARAM), INTENT(OUT) :: UPARAM
       TYPE (NLOCAL_STR_) :: NLOC_DMG 
-      TYPE(MLAW_TAG_)    :: MLAW_TAG
+      TYPE(MLAW_TAG_),INTENT(INOUT)    :: MLAW_TAG
       TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT)    :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/starter/source/materials/mat/mat107/hm_read_mat107.F
+++ b/starter/source/materials/mat/mat107/hm_read_mat107.F
@@ -74,8 +74,8 @@ C-----------------------------------------------
       my_real, DIMENSION(MAXUPARAM) ,INTENT(OUT)   :: UPARAM
       my_real, DIMENSION(100),INTENT(INOUT) :: PARMAT
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(OUT) :: MTAG
-      TYPE(MATPARAM_STRUCT_) ,INTENT(OUT) :: MATPARAM
+      TYPE(MLAW_TAG_), INTENT(INOUT) :: MTAG
+      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
 C     
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/starter/source/materials/mat/mat108/hm_read_mat108.F
+++ b/starter/source/materials/mat/mat108/hm_read_mat108.F
@@ -69,7 +69,7 @@ C-----------------------------------------------
       my_real, DIMENSION(MAXUPARAM) ,INTENT(OUT) :: UPARAM
       my_real, DIMENSION(100),INTENT(INOUT) :: PARMAT
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(OUT) :: MTAG
+      TYPE(MLAW_TAG_), INTENT(INOUT) :: MTAG
 C     
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/starter/source/materials/mat/mat109/hm_read_mat109.F
+++ b/starter/source/materials/mat/mat109/hm_read_mat109.F
@@ -76,7 +76,7 @@ C-----------------------------------------------
       TYPE(MLAW_TAG_),INTENT(INOUT)   :: MTAG
       TYPE(SUBMODEL_DATA),INTENT(IN)  :: LSUBMODEL(*)
       TYPE (UNIT_TYPE_)  ,INTENT(IN)  :: UNITAB 
-      TYPE(MATPARAM_STRUCT_) ,INTENT(OUT) :: MATPARAM
+      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat110/hm_read_mat110.F
+++ b/starter/source/materials/mat/mat110/hm_read_mat110.F
@@ -75,7 +75,7 @@ C-----------------------------------------------
       my_real, DIMENSION(MAXUPARAM) ,INTENT(OUT)   :: UPARAM
       my_real, DIMENSION(100),INTENT(OUT) :: PARMAT
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(OUT) :: MTAG
+      TYPE(MLAW_TAG_), INTENT(INOUT) :: MTAG
       TYPE(MATPARAM_STRUCT_),INTENT(INOUT) :: MATPARAM
 C     
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat111/hm_read_mat111.F
+++ b/starter/source/materials/mat/mat111/hm_read_mat111.F
@@ -90,7 +90,7 @@ C-----------------------------------------------
       INTEGER,INTENT(IN)                    :: MAT_ID
       CHARACTER*nchartitle,INTENT(IN)       :: TITR
       TYPE(SUBMODEL_DATA),INTENT(IN)        :: LSUBMODEL(*)
-      TYPE(MATPARAM_STRUCT_) ,INTENT(OUT)   :: MATPARAM
+      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat112/hm_read_mat112.F
+++ b/starter/source/materials/mat/mat112/hm_read_mat112.F
@@ -74,8 +74,8 @@ C-----------------------------------------------
       my_real, DIMENSION(MAXUPARAM) ,INTENT(OUT)   :: UPARAM
       my_real, DIMENSION(100),INTENT(INOUT)        :: PARMAT
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(OUT)                 :: MTAG
-      TYPE(MATPARAM_STRUCT_) ,INTENT(OUT)          :: MATPARAM
+      TYPE(MLAW_TAG_), INTENT(INOUT)               :: MTAG
+      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT)        :: MATPARAM
 C     
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/starter/source/materials/mat/mat113/hm_read_mat113.F
+++ b/starter/source/materials/mat/mat113/hm_read_mat113.F
@@ -69,7 +69,7 @@ C-----------------------------------------------
       my_real, DIMENSION(MAXUPARAM) ,INTENT(OUT) :: UPARAM
       my_real, DIMENSION(100),INTENT(INOUT) :: PARMAT
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(OUT) :: MTAG
+      TYPE(MLAW_TAG_), INTENT(INOUT) :: MTAG
 C     
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/starter/source/materials/mat/mat114/hm_read_mat114.F
+++ b/starter/source/materials/mat/mat114/hm_read_mat114.F
@@ -68,7 +68,7 @@ C-----------------------------------------------
       my_real, DIMENSION(MAXUPARAM) ,INTENT(OUT) :: UPARAM
       my_real, DIMENSION(100),INTENT(INOUT) :: PARMAT
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(OUT) :: MTAG
+      TYPE(MLAW_TAG_), INTENT(INOUT) :: MTAG
 C     
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/starter/source/materials/mat/mat115/hm_read_mat115.F
+++ b/starter/source/materials/mat/mat115/hm_read_mat115.F
@@ -73,8 +73,8 @@ C-----------------------------------------------
       my_real, DIMENSION(MAXUPARAM) ,INTENT(OUT)   :: UPARAM
       my_real, DIMENSION(100),INTENT(OUT)          :: PARMAT
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(OUT)                 :: MTAG
-      TYPE(MATPARAM_STRUCT_) ,INTENT(OUT)          :: MATPARAM  
+      TYPE(MLAW_TAG_), INTENT(INOUT)               :: MTAG
+      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT)        :: MATPARAM  
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat116/hm_read_mat116.F
+++ b/starter/source/materials/mat/mat116/hm_read_mat116.F
@@ -82,7 +82,7 @@ C-----------------------------------------------
       my_real, INTENT(INOUT)          :: PM(NPROPM),PARMAT(100),UPARAM(MAXUPARAM)
       CHARACTER*nchartitle,INTENT(IN) :: TITR
       TYPE(SUBMODEL_DATA),INTENT(IN)  :: LSUBMODEL(*)
-      TYPE(MLAW_TAG_), INTENT(OUT)    :: MTAG
+      TYPE(MLAW_TAG_), INTENT(INOUT)  :: MTAG
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat117/hm_read_mat117.F
+++ b/starter/source/materials/mat/mat117/hm_read_mat117.F
@@ -82,7 +82,7 @@ C-----------------------------------------------
       my_real, INTENT(INOUT)          :: PM(NPROPM),PARMAT(100),UPARAM(MAXUPARAM)
       CHARACTER*nchartitle,INTENT(IN) :: TITR
       TYPE(SUBMODEL_DATA),INTENT(IN)  :: LSUBMODEL(*)
-      TYPE(MLAW_TAG_), INTENT(OUT)    :: MTAG
+      TYPE(MLAW_TAG_), INTENT(INOUT)  :: MTAG
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat119/hm_read_mat119.F
+++ b/starter/source/materials/mat/mat119/hm_read_mat119.F
@@ -86,7 +86,7 @@ C-----------------------------------------------
       my_real ,INTENT(INOUT):: PM(NPROPM),PARMAT(100),UPARAM(MAXUPARAM)
       TYPE (UNIT_TYPE_)      ,INTENT(IN)    :: UNITAB 
       TYPE(SUBMODEL_DATA)    ,INTENT(IN)    :: LSUBMODEL(*)
-      TYPE(MLAW_TAG_)        ,INTENT(OUT)   :: MTAG
+      TYPE(MLAW_TAG_)        ,INTENT(INOUT) :: MTAG
       TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/starter/source/materials/mat/mat120/hm_read_mat120.F
+++ b/starter/source/materials/mat/mat120/hm_read_mat120.F
@@ -86,8 +86,8 @@ C-----------------------------------------------
       my_real ,INTENT(INOUT)          :: PM(NPROPM),PARMAT(100),UPARAM(MAXUPARAM)
       CHARACTER*nchartitle,INTENT(IN) :: TITR
       TYPE(SUBMODEL_DATA),INTENT(IN)  :: LSUBMODEL(*)
-      TYPE(MLAW_TAG_), INTENT(OUT)    :: MTAG
-      TYPE(MATPARAM_STRUCT_) ,INTENT(OUT) :: MATPARAM
+      TYPE(MLAW_TAG_), INTENT(INOUT)  :: MTAG
+      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat121/hm_read_mat121.F
+++ b/starter/source/materials/mat/mat121/hm_read_mat121.F
@@ -74,8 +74,8 @@ C-----------------------------------------------
       my_real, DIMENSION(MAXUPARAM) ,INTENT(INOUT) :: UPARAM
       my_real, DIMENSION(100),INTENT(OUT)          :: PARMAT
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(OUT)                 :: MTAG
-      TYPE(MATPARAM_STRUCT_) ,INTENT(OUT)          :: MATPARAM  
+      TYPE(MLAW_TAG_), INTENT(INOUT)               :: MTAG
+      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT)        :: MATPARAM  
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Some data structure already initialized (MTAG and MATPARAM_TAB) were passed in argument of some material laws reading routine with INTENT(OUT) attribute, leading to overwritting of those structure. This could lead to strong issue with R2R. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Replace INTENT(OUT) by INTENT(INOUT) where needed. 

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
