### PR TITLE
Fix missing output keyword for TSAIWU criterion in ANIM files

### DIFF
--- a/engine/source/output/anim/reader/anim_dcod_key_0.F
+++ b/engine/source/output/anim/reader/anim_dcod_key_0.F
@@ -2618,7 +2618,11 @@ C--------------------------
         ELSEIF(KEY3(1:5)=='COLOR')THEN
          IDX           = 13547 + 4*MX_PLY_ANIM + 1000 + 3
          ANIM_CE(IDX)  = 1  
-         ANIM_SE(4967) = 1      
+         ANIM_SE(4967) = 1  
+        ELSEIF(KEY3(1:4) == 'DAMG') THEN 
+         IDX           = 14551 + 4*MX_PLY_ANIM
+         ANIM_CE(IDX)  = 1  
+         ANIM_SE(4968) = 1    
         ELSE IF(KEY3(1:7)=='NL_EPSP')THEN
          IDX           = 14567 + 4*MX_PLY_ANIM
          ANIM_CE(IDX)  = 1
@@ -2627,6 +2631,10 @@ C--------------------------
          IDX           = 14581 + 4*MX_PLY_ANIM
          ANIM_CE(IDX)  = 1
          ANIM_SE(4970) = 1
+        ELSE IF(KEY3(1:6)=='TSAIWU')THEN 
+         IDX           = 14595 + 4*MX_PLY_ANIM 
+         ANIM_CE(IDX)  = 1 
+         ANIM_SE(4971) = 1 
        ELSE
          IXITKEY=IXITKEY+1
        ENDIF


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

/ANIM/ELEM/TSAIWU was not functionnal (similar problem was noticed for DAMG).

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Allow the engine keywords /ANIM/ELEM/TSAIWU and /ANIM/ELEM/DAMG

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
