### PR TITLE
correct TH output of strains in user variables in law58

### DIFF
--- a/engine/source/output/th/thcoq.F
+++ b/engine/source/output/th/thcoq.F
@@ -649,8 +649,8 @@ C---
                               UVAR=>ELBUF_TAB(NG)%BUFLY(IL)%MAT(IR,IS,IT)%VAR              
                               DO J = 1, NUVAR
                                 I1 = (J-1)*NEL                             
-                                IF (J==4 .OR. J==5) THEN                                         
-                                  VAR(J,IL) = VAR(J,IL) + LOG(UVAR(I1+I)+ONE)/NPG
+                                IF (J==4 .OR. J==5) THEN    ! convert to eng strain                                     
+                                  VAR(J,IL) = VAR(J,IL) + (EXP(UVAR(I1+I))-ONE)/NPG
                                 ELSE
                                   VAR(J,IL) = VAR(J,IL) + UVAR(I1+I)/NPG
                                 ENDIF               
@@ -671,8 +671,8 @@ C---
                             K = NPTR*(IS-1) + IR                                        
                             DO J = 1, NUVAR
                               I1 = (J-1)*NEL 
-                              IF (J==4 .OR. J==5) THEN
-                               VAR(J,IPT) = VAR(J, IPT) + LOG(UVAR(I1+I)+ONE)/NPG               
+                              IF (J==4 .OR. J==5) THEN        ! convert to eng strain 
+                               VAR(J,IPT) = VAR(J, IPT) + (EXP(UVAR(I1+I))-ONE)/NPG               
                               ELSE                                          
                                VAR(J,IPT) = VAR(J, IPT) + UVAR(I1 + I)/NPG               
                               ENDIF                                          


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Correct problem of user variables in law58 TH output. It should be converted to engineering strains.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

correct conversion of strains in UVAR(4) and UVAR(5) to engineering strains before output

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
