### PR TITLE
/EOS/TABULATED:init. derivative for colocated scheme

### DIFF
--- a/common_source/eos/tabulated.F
+++ b/common_source/eos/tabulated.F
@@ -197,11 +197,13 @@ C-----------------------------------------------
            DO I=LFT,LLT
              RES_A(I) = ZERO
              RES_B(I) = FSCALE_B*FINTER(B_fun_id,MU(I),NPF,TF,DERI_B(I))
+             DERI_A(I) = ZERO             
            ENDDO
          ELSEIF(B_fun_id == 0)THEN
            DO I=LFT,LLT
              RES_A(I) = FSCALE_A*FINTER(A_fun_id,MU(I),NPF,TF,DERI_A(I))
              RES_B(I) = ZERO
+             DERI_B(I) = ZERO             
            ENDDO         
          ELSE
            DO I=LFT,LLT         
@@ -215,8 +217,8 @@ C-----------------------------------------------
                PP      = RES_A(I) + RES_B(I)*ESPE(I) - PSH(I)                  
                DPDM(I) = DERI_A(I)+DERI_B(I)*ESPE(I) + RES_B(I)*(PP+PSH(I))/( (ONE+MU(I))*(ONE+MU(I)) ) ! A'(MU0) + B'(MU0)*E0+B(MU0)/(ONE+MU0)/(ONE+MU0)*P0     !total derivative
                DPDE(I) = RES_B(I) ! B(MU(I))                                               !partial derivative
-               PNEW(I) = PP                                                        
-            ENDIF                                                                  
+               PNEW(I) = PP                                                       
+            ENDIF 
          ENDDO                                                                     
       ENDIF
 C-----------------------------------------------


### PR DESCRIPTION
#### Description of the feature or the bug
Initialization of sound speed derivative in case of colocated scheme (law151) with new tabulated EoS.
This fix ensures the expected behavior when A_func or B_func is not provided.


#### Description of the changes
Changes are obvious : 
DERIA_A is set to 0.0 when A_FUNC is not provided
DERIA_B is set to 0.0 when B_FUNC is not provided



<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
