### PR TITLE
Issue in Sensor availibility cheks

### DIFF
--- a/starter/source/system/fsdcod.F
+++ b/starter/source/system/fsdcod.F
@@ -1958,10 +1958,11 @@ C
                 EXIT
               END IF
             ENDDO
-            IF (IOK == 0)  
-     .        CALL ANCMSG(MSGID=1240,ANMODE=ANINFO,MSGTYPE=MSGWARNING,
+            IF (IOK == 0) THEN  
+              CALL ANCMSG(MSGID=1240,ANMODE=ANINFO,MSGTYPE=MSGWARNING,
      .                    I1=ID,C1=TITR,I2=ISENS) 
               BUFMAT(IADD+13) = 0   ! If not found set SENSOR ID to 0 as if there is no sensor
+            ENDIF
           ENDIF
         ENDIF
       ENDDO


### PR DESCRIPTION
Issue was made during Sensor availability check in materials.
When a Sensor is not found, it should print the warning & set to 0.
Here the Check was not well made. IF did not had THEN, so set to Zero was done all the time.

#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->


<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
