### PR TITLE
fix compilation for windows with Intel compilers

### DIFF
--- a/engine/CMake_Compilers/cmake_linux64_intel.txt
+++ b/engine/CMake_Compilers/cmake_linux64_intel.txt
@@ -33,10 +33,25 @@ set ( wo_linalg "-DWITHOUT_LINALG" )
 endif()
 
 
+#
 # compiler Flags
 # --------------
+set (CMAKE_Fortran_FLAGS " " )
+set (CMAKE_C_FLAGS " " )
+set (CMAKE_CPP_FLAGS " " )
+set (CMAKE_CXX_FLAGS " " )
+
 set (CMAKE_Fortran_FLAGS_DEBUG " " )
 set (CMAKE_Fortran_FLAGS_RELEASE " " )
+
+set (CMAKE_C_FLAGS_DEBUG " " )
+set (CMAKE_C_FLAGS_RELEASE " " )
+
+set (CMAKE_CPP_FLAGS_DEBUG " " )
+set (CMAKE_CPP_FLAGS_RELEASE " " )
+
+set (CMAKE_CXX_FLAGS_DEBUG " " )
+set (CMAKE_CXX_FLAGS_RELEASE " " )
 
 # Single / Double Precision
 # -------------------------
@@ -115,10 +130,11 @@ set (F_O3_AXSSE3 " -O3 -axsse3 -no-fma -qopenmp -fp-model precise ${precision_fl
 set (C_BASIC "${cppmach} ${cpprel}" )
 set_source_files_properties( ${source_directory}/source/coupling/rad2rad/rad2rad_c.c PROPERTIES COMPILE_FLAGS ${C_BASIC})
 set_source_files_properties( ${source_directory}//source/output/tools/sortie_c.c PROPERTIES COMPILE_FLAGS ${C_BASIC})
+# ieee.cpp
+set_source_files_properties( ${source_directory}/source/output/tools/ieee.cpp PROPERTIES COMPILE_FLAGS ${C_BASIC})
+
 
 set (C_BASIC "${cppmach} ${cpprel} -std=c90" )
-# ieee.c
-set_source_files_properties( ${source_directory}/source/output/tools/ieee.c PROPERTIES COMPILE_FLAGS ${C_BASIC})
 set_source_files_properties( ${source_directory}/source/coupling/rad2rad/sys_pipes_c.c PROPERTIES COMPILE_FLAGS ${C_BASIC})
 
 

--- a/engine/CMake_Compilers/cmake_win64.txt
+++ b/engine/CMake_Compilers/cmake_win64.txt
@@ -144,8 +144,8 @@ set (F_O3_AXSSE3 "/Qaxsse3   /Qopenmp  /O3  /fp:precise /Qftz /Qimf-use-svml:tru
 
 set (C_BASIC "${cppmach} ${cpprel}")
 
-# ieee.c
-set_source_files_properties( ${source_directory}/source/output/tools/ieee.c PROPERTIES COMPILE_FLAGS ${C_BASIC})
+# ieee.cpp
+set_source_files_properties( ${source_directory}/source/output/tools/ieee.cpp PROPERTIES COMPILE_FLAGS ${C_BASIC})
 # rad2rad_c.c 
 set_source_files_properties( ${source_directory}/source/coupling/rad2rad/rad2rad_c.c PROPERTIES COMPILE_FLAGS ${C_BASIC})
 

--- a/starter/CMake_Compilers/cmake_linux64_intel.txt
+++ b/starter/CMake_Compilers/cmake_linux64_intel.txt
@@ -36,6 +36,10 @@ set (MKL_lib "-L${MKL_LDIR} -I${MKL_IDIR} -Wl,--start-group ${MKL_LDIR}/libmkl_i
 # --------------
 # compiler Flags
 # --------------
+set (CMAKE_Fortran_FLAGS " " )
+set (CMAKE_C_FLAGS " " )
+set (CMAKE_CPP_FLAGS " " )
+set (CMAKE_CXX_FLAGS " " )
 
 set (CMAKE_Fortran_FLAGS_DEBUG " " )
 set (CMAKE_Fortran_FLAGS_RELEASE " " )
@@ -45,6 +49,10 @@ set (CMAKE_C_FLAGS_RELEASE " " )
 
 set (CMAKE_CPP_FLAGS_DEBUG " " )
 set (CMAKE_CPP_FLAGS_RELEASE " " )
+
+set (CMAKE_CXX_FLAGS_DEBUG " " )
+set (CMAKE_CXX_FLAGS_RELEASE " " )
+
 
 # -------------------------
 # Single / Double Precision


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Not able to read rst files when `ieee.cpp` is compiled with O3 options

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
- compilation with default (O2) flag at the engine for windows
- flush some Cmake variables on linux64 with Intel OneAPI


<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
