### PR TITLE
Fix a check bounds issue

### DIFF
--- a/starter/source/spmd/domain_decomposition/check_skew.F
+++ b/starter/source/spmd/domain_decomposition/check_skew.F
@@ -30,7 +30,7 @@ Chd|        IFRONTPLUS                    source/spmd/node/frontplus.F
 Chd|        SKEW_MOD                      share/modules1/skew_mod.F     
 Chd|====================================================================
         SUBROUTINE CHECK_SKEW(IXR,IGEO,ISKN,CEP,ISKWP,NSKWP,TAG_SKN,MULTIPLE_SKEW,
-     .                        R_SKEW,IPM)
+     .                        R_SKEW,IPM,OFFSET)
 C----------------------------------------------------------
 C----------------------------------------------------------
         USE SKEW_MOD
@@ -66,6 +66,7 @@ C-----------------------------------------------
         INTEGER, DIMENSION(LISKN,SISKWN/LISKN), INTENT(IN) :: ISKN
         INTEGER, DIMENSION(NPROPMI,NUMMAT), INTENT(IN) :: IPM
         TYPE(SKEW_TYPE), DIMENSION(NUMSKW+1), INTENT(INOUT) :: MULTIPLE_SKEW
+        INTEGER, INTENT(IN) :: OFFSET
 !       -*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-**-*-*-*-*-*-*-*-*-*-*-*-*
 !       NSKWP : integer ; dimension = NSPMD
 !               number of skew per processor
@@ -92,6 +93,7 @@ C-----------------------------------------------
 !       MULTIPLE_SKEW : SKEW_TYPE ; dimension=NUMSKW+1
 !                       MULTIPLE_SKEW(I)%PLIST(:) is a list of processor
 !                       where the SKEW is stuck
+!       OFFSET :: integer, offset to point to the good place in CEP array
 !       -*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-**-*-*-*-*-*-*-*-*-*-*-*-*
 
 C-----------------------------------------------
@@ -177,7 +179,7 @@ C
                         IF(SPRING_TYPE==8 .OR. (SPRING_TYPE== 23 .AND. MAT_TYPE == 108)) THEN
                                 NUMBER_SKEW_SP = NUMBER_SKEW_SP + 1
                                 SKEW_PER_SP( NUMBER_SKEW_SP ) = R_SKEW(I)   
-                                LOCAL_P(NUMBER_SKEW_SP) = CEP(I)+1
+                                LOCAL_P(NUMBER_SKEW_SP) = CEP(OFFSET+I)+1
                                 TAG_SKN( R_SKEW(I) ) = TAG_SKN( R_SKEW(I) ) + 1
                         ENDIF
                      ENDIF
@@ -188,7 +190,7 @@ C
                         IF(SPRING_TYPE==8 .OR. SPRING_TYPE==13 .OR. SPRING_TYPE== 23) THEN
                                 NUMBER_SKEW_SP = NUMBER_SKEW_SP + 1
                                 SKEW_PER_SP( NUMBER_SKEW_SP ) = IGEO( 2,IXR(1,I) )    
-                                LOCAL_P(NUMBER_SKEW_SP) = CEP(I)+1
+                                LOCAL_P(NUMBER_SKEW_SP) = CEP(OFFSET+I)+1
                                 TAG_SKN( IGEO(2,IXR(1,I)) ) = TAG_SKN( IGEO(2,IXR(1,I)) ) + 1
                         ENDIF     
                     ENDIF

--- a/starter/source/spmd/domdec2.F
+++ b/starter/source/spmd/domdec2.F
@@ -220,8 +220,8 @@ C skew global fixe
        IF(N2D==0 .AND. LEN_CEP > 0)THEN
         OFFSET = NUMELS + NUMELQ + NUMELC + NUMELT + NUMELP
 !       check if a SPRING is linked with a SKEW
-        CALL CHECK_SKEW(IXR,IGEO,ISKN,CEP(OFFSET+1),ISKWP,NSKWP,TAG_SKN,MULTIPLE_SKEW,
-     .                  R_SKEW,IPM)
+        CALL CHECK_SKEW(IXR,IGEO,ISKN,CEP,ISKWP,NSKWP,TAG_SKN,MULTIPLE_SKEW,
+     .                  R_SKEW,IPM,OFFSET)
 
 
         DO I=1,NUMSKW


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
A bug was recently introduced in PR#975 : CEP array is now always allocated with a size greater than 0. -fcheck=bounds (or intel compiler option -check bounds) complains about this new size in a starter routine
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
OFFSET variable is now an argument of CHECK_SKEW array : OFFSET allows to point to the good place in CEP array

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
