### PR TITLE
include radioss deck in dyna deck using *INCLUDE_RADIOSS option

### DIFF
--- a/hm_cfg_files/config/CFG/Keyword971_R12.0/INCLUDE/include_radioss.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R12.0/INCLUDE/include_radioss.cfg
@@ -1,0 +1,34 @@
+//Copyright>    CFG Files and Library ("CFG")
+//Copyright>    Copyright (C) 1986-2022 Altair Engineering Inc.
+//Copyright>
+//Copyright>    Altair Engineering Inc. grants to third parties limited permission to 
+//Copyright>    use and modify CFG solely in connection with OpenRadioss software, provided 
+//Copyright>    that any modification to CFG by a third party must be provided back to 
+//Copyright>    Altair Engineering Inc. and shall be deemed a Contribution under and therefore
+//Copyright>    subject to the CONTRIBUTOR LICENSE AGREEMENT for OpenRadioss software. 
+//Copyright>  
+//Copyright>    CFG IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
+//Copyright>    INCLUDING, BUT NOT LIMITED TO, THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR 
+//Copyright>    A PARTICULAR PURPOSE, AND NONINFRINGEMENT.  IN NO EVENT SHALL ALTAIR ENGINEERING
+//Copyright>    INC. OR ITS AFFILIATES BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, 
+//Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
+//Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
+//
+//INCLUDE_RADIOSS
+//
+
+ATTRIBUTES(COMMON)
+{
+// INPUT ATTRIBUTES
+    FileName          = VALUE(STRING, "modelName");
+}
+
+
+//File format
+FORMAT(Keyword971)
+{
+  HEADER("*INCLUDE_RADIOSS");
+ 
+  COMMENT("$  FileName");
+  CARD("%-100s", FileName);
+}

--- a/hm_cfg_files/config/CFG/Keyword971_R12.0/data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R12.0/data_hierarchy.cfg
@@ -7808,3 +7808,17 @@ HIERARCHY {
         USER_NAMES = (INITIAL_STRAIN_SHELL,INITIAL_STRAIN_SOLID,INITIAL_STRAIN_TSHELL);
     }
 }
+
+HIERARCHY { 
+    KEYWORD = INCLUDE;
+    TITLE   = "INCLUDE"; 
+    TYPE    = INCLUDE;
+    //
+    HIERARCHY {
+      KEYWORD    = INCLUDE_RADIOSS;
+      TITLE      = "INCLUDE_RADIOSS";
+      FILE       = "INCLUDE/include_radioss.cfg";
+      SUBTYPE    = USER;
+      USER_NAMES = (INCLUDE_RADIOSS);
+    } 
+}


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Target of this dev is to be able to include radioss deck in dyna deck 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
It's now possible to mix Radioss & Dyna input using *INCLUDE_RADIOSS card 
Limitations : part and related material & property ( section is dyna) should be in same format
nodes & elements not supported for the moment in the *INCLUDE_RADIOSS option

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
