### PR TITLE
add optional logarithmic interpolation for strain rate

### DIFF
--- a/engine/source/materials/mat/mat036/sigeps36.F
+++ b/engine/source/materials/mat/mat036/sigeps36.F
@@ -97,12 +97,14 @@ C---------+---------+---+---+--------------------------------------------
 #include      "scr17_c.inc"
 #include      "scr05_c.inc"
 #include      "com01_c.inc"
+#include      "com04_c.inc"
 #include      "com08_c.inc"
 #include      "units_c.inc"
 #include      "impl1_c.inc"
 C=======================================================================
-      INTEGER NEL, NUPARAM, NUVAR,IPT,IPLA,NVARTMP,
-     .   NGL(NEL),MAT(NEL),IPM(NPROPMI,*),INLOC
+      INTEGER NEL, NUPARAM, NUVAR,IPT,IPLA,NVARTMP,INLOC
+      INTEGER ,DIMENSION(NEL) :: NGL,MAT
+      INTEGER ,DIMENSION(NPROPMI,NUMMAT) :: IPM
       my_real
      .   TIME,TIMESTEP,UPARAM(*),SIGB(*),
      .   RHO(NEL),RHO0(NEL),VOLUME(NEL),EINT(NEL),
@@ -146,15 +148,14 @@ C        NPF,TF  : FUNCTION PARAMETER
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I,J,K,J1,J2,NFUNC,VP,II,NITER,IFAIL,
-     .        NRATE,PFUN,IPFUN,IPFLAG,YLDCHECK,
-     .        OPTE,IFUNCE,NINDX,
-     .        ILEN1(MVSIZ),IAD2(MVSIZ),ILEN2(MVSIZ),INDEX(MVSIZ),
+      INTEGER I,J,K,J1,J2,NFUNC,VP,II,NITER,IFAIL,NRATE,PFUN,IPFUN,
+     .        IPFLAG,ISMOOTH,YLDCHECK,OPTE,IFUNCE,NINDX
+      INTEGER ILEN1(MVSIZ),IAD2(MVSIZ),ILEN2(MVSIZ),INDEX(MVSIZ),
      .        IFUNC(100),IAD1(MVSIZ), IADP(MVSIZ),ILENP(MVSIZ),
      .        INDX(MVSIZ),JJ(MVSIZ), IADP2(MVSIZ),ILENP2(MVSIZ)
       INTEGER, DIMENSION(MVSIZ) :: IPOS1,IPOS2,IPOSPE,IPOSP,IPOSP2
       my_real
-     .        E11,NU,DAV,VM,R(MVSIZ),FAC,EPST,P,
+     .        E11,NU,DAV,VM,R(MVSIZ),FAC,EPST,P,EPSP1,EPSP2,
      .        E1,E2,E3,E4,E5,E6,C,CC,D,Y,YP,E42,E52,E62,EPST2,
      .        C11,G11,G21,G31,EPSR1,DPLA,EPSF,HKIN,FISOKIN,
      .        DSXX,DSYY,DSZZ,DSXY,DSYZ,
@@ -165,16 +166,16 @@ C-----------------------------------------------
      .        C1(MVSIZ),G(MVSIZ),G2(MVSIZ),G3(MVSIZ),
      .        Y1(MVSIZ),Y2(MVSIZ),H(MVSIZ),DYDX1(MVSIZ),
      .        DYDX2(MVSIZ),FAIL(MVSIZ),E(MVSIZ),
-     .        P0(MVSIZ),PFAC(MVSIZ),PSCALE(MVSIZ),
+     .        P0(MVSIZ),PFAC(MVSIZ),PSCALE(MVSIZ),RFAC(MVSIZ),
      .        PSCALE1(MVSIZ),PLA0(MVSIZ), PLAM(MVSIZ),
      .        DFDP(MVSIZ),EPSTT(MVSIZ),
      .        SIGEXX(MVSIZ),SIGEYY(MVSIZ),SIGEZZ(MVSIZ),
      .        SIGEXY(MVSIZ),SIGEYZ(MVSIZ),SIGEZX(MVSIZ),
      .        DYDXE(MVSIZ),PLAOLD(MVSIZ),
-     .        RATE(MVSIZ,2),YFAC(MVSIZ,2)
+     .        YFAC(MVSIZ,2)
       my_real
      .       PLAP(MVSIZ),SVM2(MVSIZ),DPLA_J(MVSIZ),DPLA_I(MVSIZ),
-     .       SRATE(MVSIZ),HI(MVSIZ),ESCALE12(MVSIZ),
+     .       HI(MVSIZ),ESCALE12(MVSIZ),
      .       SVM_TAB(MVSIZ)
       INTEGER :: NINDEX_PLA,NINDEX_VINTER
       INTEGER, DIMENSION(MVSIZ) :: INDEX_PLA,INDEX_VINTER
@@ -212,6 +213,7 @@ C
       VP       = NINT(UPARAM(2*NRATE + 26))  ! flag for plastic strain dependency
       IFAIL    = NINT(UPARAM(2*NRATE + 27))  ! flag rupture 
       YLDCHECK = NINT(UPARAM(2*NRATE + 28))
+      ISMOOTH  = NINT(UPARAM(2*NRATE + 29))  ! strain rate interpolation flag
 C
 #include "vectorize.inc"
       DO I=1,NEL
@@ -444,13 +446,28 @@ c-----------
             ENDDO
           ENDDO
 C
+          IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+#include    "vectorize.inc"
+            DO I=1,NEL
+              EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
+              EPSP2 = UPARAM(7+JJ(I))
+              RFAC(I) = LOG(MAX(PLAP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)
+            ENDDO
+          ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
+#include    "vectorize.inc"
+            DO I=1,NEL
+              EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
+              EPSP2 = UPARAM(7+JJ(I))
+              RFAC(I) = LOG10(MAX(PLAP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)
+            ENDDO
+          ELSE                        ! linear interpolation of strain rate
 #include "vectorize.inc"
-          DO I=1,NEL
-            RATE(I,1)=UPARAM(6+JJ(I))
-            RATE(I,2)=UPARAM(6+JJ(I)+1)
-            YFAC(I,1)=UPARAM(6+NRATE+JJ(I))*FACYLDI(I)
-            YFAC(I,2)=UPARAM(6+NRATE+JJ(I)+1)*FACYLDI(I)
-          ENDDO
+            DO I=1,NEL
+              EPSP1 = UPARAM(6+JJ(I))
+              EPSP2 = UPARAM(7+JJ(I))
+              RFAC(I)  = (EPSP(I) - EPSP1) / (EPSP2 - EPSP1)
+            ENDDO
+          END IF
 C
 #include "vectorize.inc"
           DO I=1,NEL
@@ -458,6 +475,8 @@ C
             J2 = J1+1
             IPOS1(I) = VARTMP(I,J1+2)
             IPOS2(I) = VARTMP(I,J2+2)
+            YFAC(I,1)= UPARAM(6+NRATE+J1) * FACYLDI(I)
+            YFAC(I,2)= UPARAM(6+NRATE+J2) * FACYLDI(I)
           ENDDO
           IAD1(1:NEL)  = NPF(IFUNC(JJ(1:NEL))) / 2 + 1
           ILEN1(1:NEL) = NPF(IFUNC(JJ(1:NEL))+1) / 2 - IAD1(1:NEL) - IPOS1(1:NEL)
@@ -481,11 +500,11 @@ C
               J2 = J1+1
               Y1(I)=Y1(I)*YFAC(I,1)
               Y2(I)=Y2(I)*YFAC(I,2)
-              FAC   = (EPSP(I) - RATE(I,1))/(RATE(I,2) - RATE(I,1))
+              FAC   = RFAC(I)
               CC = FAIL(I)* PFAC(I)
               YLD(I)  = (Y1(I)    + FAC*(Y2(I)-Y1(I))) * CC
-              DYDX1(I)=DYDX1(I)*YFAC(I,1)
-              DYDX2(I)=DYDX2(I)*YFAC(I,2)
+              DYDX1(I)= DYDX1(I)*YFAC(I,1)
+              DYDX2(I)= DYDX2(I)*YFAC(I,2)
               H(I) = (DYDX1(I) + FAC*(DYDX2(I)-DYDX1(I))) * CC
             ENDDO
 c
@@ -495,7 +514,7 @@ c
             DO I=1,NEL
               J1 = JJ(I)
               J2 = J1+1        
-              FAC = (EPSP(I) - RATE(I,1))/(RATE(I,2) - RATE(I,1))
+              FAC = RFAC(I)
               CC  = FAIL(I) * PFAC(I)
               DYDX1(I)=DYDX1(I)*YFAC(I,1)
               DYDX2(I)=DYDX2(I)*YFAC(I,2) 
@@ -515,7 +534,7 @@ c
               J2 = J1+1
               Y1(I) = Y1(I)*YFAC(I,1)
               Y2(I) = Y2(I)*YFAC(I,2)
-              FAC     = (EPSP(I) - RATE(I,1))/(RATE(I,2) - RATE(I,1))
+              FAC   = RFAC(I)
               YLD(I)  = FAIL(I)*(Y1(I)    + FAC*(Y2(I)-Y1(I)))
               YLD(I)  = MAX(YLD(I),EM20)
               DYDX1(I)= DYDX1(I)*YFAC(I,1)
@@ -700,14 +719,31 @@ c
                 IF (PLAP(I) >= UPARAM(6+J)) JJ(I) = J               
               ENDDO
             ENDDO  
-#include "vectorize.inc" 
-            DO II=1,NINDX                                             
-                  I = INDEX(II) 
-                FAC=UPARAM(6+JJ(I))
-                SRATE(I)=(PLAP(I) - FAC)/(UPARAM(7+JJ(I)) - FAC)
-                YFAC(I,1)=UPARAM(6+NRATE+JJ(I))*FACYLDI(I)
-                YFAC(I,2)=UPARAM(6+NRATE+JJ(I)+1)*FACYLDI(I)
-            ENDDO
+            IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+#include     "vectorize.inc" 
+              DO II=1,NINDX                                             
+                I = INDEX(II) 
+                EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
+                EPSP2 = UPARAM(7+JJ(I))
+                RFAC(I) = LOG(MAX(PLAP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)
+              ENDDO
+            ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
+#include     "vectorize.inc" 
+              DO II=1,NINDX                                             
+                I = INDEX(II) 
+                EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
+                EPSP2 = UPARAM(7+JJ(I))
+                RFAC(I) = LOG10(MAX(PLAP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)
+              ENDDO
+            ELSE                         ! linear interpolation of strain rate
+#include     "vectorize.inc" 
+              DO II=1,NINDX                                             
+                I = INDEX(II) 
+                EPSP1 = UPARAM(6+JJ(I))
+                EPSP2 = UPARAM(7+JJ(I))
+                RFAC(I) = (PLAP(I) - EPSP1) / (EPSP2 - EPSP1)
+              ENDDO
+            END IF                        ! linear interpolation of strain rate
 ! ------------------------
             NINDEX_VINTER = 0
 #include "vectorize.inc"
@@ -724,6 +760,8 @@ c
               IADP2(NINDEX_VINTER)  = NPF(IFUNC(JJ(I)+1)) / 2 + 1
               ILENP2(NINDEX_VINTER) = NPF(IFUNC(JJ(I)+1)  + 1) / 2 - IADP2(NINDEX_VINTER) - IPOSP2(NINDEX_VINTER)
               TAB_LOC(NINDEX_VINTER) = PLA(I)
+              YFAC(I,1) = UPARAM(6+NRATE+J1) * FACYLDI(I)
+              YFAC(I,2) = UPARAM(6+NRATE+J2) * FACYLDI(I)
             ENDDO
 
             CALL VINTER2(TF,IADP,IPOSP,ILENP,NINDEX_VINTER,TAB_LOC,DYDX1_LOC,Y1_LOC)
@@ -750,7 +788,7 @@ c
                 I = INDEX(II)
                 Y1(I) = Y1(I) * YFAC(I,1)
                 Y2(I) = Y2(I) * YFAC(I,2)        
-                FAC     = SRATE(I)        
+                FAC     = RFAC(I)        
                 YLD(I)  = FAIL(I)*(Y1(I)    + FAC*(Y2(I)-Y1(I)))
                 YLD(I)  = MAX(YLD(I),EM20)
                 DYDX1(I)=DYDX1(I)*YFAC(I,1)
@@ -766,27 +804,27 @@ c------------------------
               !update svm
 #include "vectorize.inc" 
               DO II=1,NINDX                                                
-                    I = INDEX(II)                                        
-                    DPLA_I(I) = DPLA_J(I)                                
-                    PLA(I)    = PLAOLD(I) + DPLA_I(I)                    
-                    PLAP(I)   = DPLA_I(I) / TIMESTEP                     
-                    R(I)      = YLD(I)/(YLD(I) +G3(I)*DPLA_I(I))         
-                    SVM       = R(I)* SVM_TAB(I)                         
+                I = INDEX(II)                                        
+                DPLA_I(I) = DPLA_J(I)                                
+                PLA(I)    = PLAOLD(I) + DPLA_I(I)                    
+                PLAP(I)   = DPLA_I(I) / TIMESTEP                     
+                R(I)      = YLD(I)/(YLD(I) +G3(I)*DPLA_I(I))         
+                SVM       = R(I)* SVM_TAB(I)                         
 
-                    F = SVM -  YLD(I) - G3(I) *DPLA_I(I)                 
-                    DF = - G3(I) -DFSR                                   
-                    DF = SIGN(MAX(ABS(DF),EM20),DF)                      
-                    IF(DPLA_I(I) > ZERO) THEN                            
-                      DPLA_J(I)=MAX( EM10 ,DPLA_I(I)-F/DF)               
-                    ELSE                                                 
-                      DPLA_J(I)=EM10                                     
-                    ENDIF                                                
-                    !--------------                                      
-                    !update yield :                                      
-                    !--------------                                      
-                    PLA(I)    = PLAOLD(I) + DPLA_J(I)                    
-                    PLAP(I)   = DPLA_J(I) / TIMESTEP                     
-                    JJ(I) = 1                                            
+                F = SVM -  YLD(I) - G3(I) *DPLA_I(I)                 
+                DF = - G3(I) -DFSR                                   
+                DF = SIGN(MAX(ABS(DF),EM20),DF)                      
+                IF(DPLA_I(I) > ZERO) THEN                            
+                  DPLA_J(I)=MAX( EM10 ,DPLA_I(I)-F/DF)               
+                ELSE                                                 
+                  DPLA_J(I)=EM10                                     
+                ENDIF                                                
+                !--------------                                      
+                !update yield :                                      
+                !--------------                                      
+                PLA(I)    = PLAOLD(I) + DPLA_J(I)                    
+                PLAP(I)   = DPLA_J(I) / TIMESTEP                     
+                JJ(I) = 1                                            
               ENDDO                                                        
               DO J=2,NRATE-1
                 DO II=1,NINDX                                             
@@ -794,14 +832,29 @@ c------------------------
                   IF(PLAP(I) >= UPARAM(6+J)) JJ(I) = J       
                 ENDDO       
               ENDDO
-#include "vectorize.inc" 
-              DO II=1,NINDX                                             
-                I = INDEX(II)  
-                FAC=UPARAM(6+JJ(I))
-                SRATE(I)=(PLAP(I) - FAC)/(UPARAM(7+JJ(I)) - FAC)
-                YFAC(I,1)=UPARAM(6+NRATE+JJ(I))*FACYLDI(I)
-                YFAC(I,2)=UPARAM(6+NRATE+JJ(I)+1)*FACYLDI(I)
-              ENDDO
+              IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+#include        "vectorize.inc"
+                DO I=1,NEL
+                  EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
+                  EPSP2 = UPARAM(7+JJ(I))
+                  RFAC(I) = LOG(MAX(PLAP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)
+                ENDDO
+              ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
+#include        "vectorize.inc"
+                DO I=1,NEL
+                  EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
+                  EPSP2 = UPARAM(7+JJ(I))
+                  RFAC(I) = LOG10(MAX(PLAP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)
+                ENDDO
+              ELSE                        ! linear interpolation of strain rate
+#include        "vectorize.inc"
+                DO II=1,NINDX                                           
+                  I = INDEX(II)  
+                  EPSP1 = UPARAM(6+JJ(I))
+                  EPSP2 = UPARAM(7+JJ(I))
+                  RFAC(I) = (PLAP(I) - EPSP1) / (EPSP2 - EPSP1)
+                ENDDO
+              END IF
 ! ------------------------
               NINDEX_VINTER = 0
 #include "vectorize.inc"
@@ -818,6 +871,8 @@ c------------------------
                 IADP2(NINDEX_VINTER)  = NPF(IFUNC(JJ(I)+1)) / 2 + 1
                 ILENP2(NINDEX_VINTER) = NPF(IFUNC(JJ(I)+1)  + 1) / 2 - IADP2(NINDEX_VINTER) - IPOSP2(NINDEX_VINTER)
                 TAB_LOC(NINDEX_VINTER) = PLA(I)
+                YFAC(I,1)=UPARAM(6+NRATE+J1)*FACYLDI(I)
+                YFAC(I,2)=UPARAM(6+NRATE+J2)*FACYLDI(I)
               ENDDO
 
               CALL VINTER2(TF,IADP,IPOSP,ILENP,NINDEX_VINTER,TAB_LOC,DYDX1_LOC,Y1_LOC)
@@ -845,7 +900,7 @@ c------------------------
                 !Y1 and Y2 for Pl SR dependency
                 Y1(I) = YFAC(I,1) * Y1(I)
                 Y2(I) = YFAC(I,2) * Y2(I)
-                FAC   = SRATE(I)         
+                FAC   = RFAC(I)         
                 YLD(I)= FAIL(I)*(Y1(I)    + FAC*(Y2(I)-Y1(I)))
                 YLD(I) = MAX(YLD(I),EM20)
                 YLD(I) = YLD(I)*MAX(ZERO,PFAC(I))
@@ -896,16 +951,32 @@ c------------------------------------------------
                 IF (PLAP(I) >= UPARAM(6+J)) JJ(I) = J               
               ENDDO
             ENDDO    
-#include "vectorize.inc" 
-            DO II=1,NINDX                                             
-              I = INDEX(II) 
-              J1 = JJ(I)
-              J2 = JJ(I)+1
-              FAC=UPARAM(6+J1)
-              SRATE(I)=(PLAP(I) - FAC)/(UPARAM(7+J1) - FAC)
-              YFAC(I,1)=UPARAM(6+NRATE+J1)*FACYLDI(I)
-              YFAC(I,2)=UPARAM(6+NRATE+J2)*FACYLDI(I)
-            ENDDO
+c
+            IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+#include      "vectorize.inc"
+              DO II=1,NINDX                                           
+                I = INDEX(II) 
+                EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
+                EPSP2 = UPARAM(7+JJ(I))
+                RFAC(I) = LOG(MAX(PLAP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)
+              ENDDO
+            ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
+#include      "vectorize.inc"
+              DO II=1,NINDX                                           
+                I = INDEX(II) 
+                EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
+                EPSP2 = UPARAM(7+JJ(I))
+                RFAC(I) = LOG10(MAX(PLAP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)
+              ENDDO
+            ELSE                        ! linear interpolation of strain rate
+#include      "vectorize.inc"
+              DO II=1,NINDX                                           
+                I = INDEX(II) 
+                EPSP1 = UPARAM(6+JJ(I))
+                EPSP2 = UPARAM(7+JJ(I))
+                RFAC(I) = (PLAP(I) - EPSP1) / (EPSP2 - EPSP1)
+              ENDDO
+            END IF
 ! ------------------------
             NINDEX_VINTER = 0
 #include "vectorize.inc"
@@ -922,25 +993,27 @@ c------------------------------------------------
               IADP2(NINDEX_VINTER)  = NPF(IFUNC(JJ(I)+1)) / 2 + 1
               ILENP2(NINDEX_VINTER) = NPF(IFUNC(JJ(I)+1)  + 1) / 2 - IADP2(NINDEX_VINTER) - IPOSP2(NINDEX_VINTER)
               TAB_LOC(NINDEX_VINTER) = PLA(I)
+              YFAC(I,1)=UPARAM(6+NRATE+J1)*FACYLDI(I)
+              YFAC(I,2)=UPARAM(6+NRATE+J2)*FACYLDI(I)
             ENDDO
 
             CALL VINTER2(TF,IADP,IPOSP,ILENP,NINDEX_VINTER,TAB_LOC,DYDX1_LOC,Y1_LOC)
             CALL VINTER2(TF,IADP2,IPOSP2,ILENP2,NINDEX_VINTER,TAB_LOC,DYDX2_LOC,Y2_LOC)
 
             DO II=1,NINDEX_VINTER  
-                I = INDEX_VINTER(II)       
-                J1 = JJ(I)
-                J2 = JJ(I)+1                                 
-                VARTMP(I,J1+2) = IPOSP(II)
-                VARTMP(I,J2+2) = IPOSP2(II)
+              I = INDEX_VINTER(II)       
+              J1 = JJ(I)
+              J2 = JJ(I)+1                                 
+              VARTMP(I,J1+2) = IPOSP(II)
+              VARTMP(I,J2+2) = IPOSP2(II)
             ENDDO
 #include "vectorize.inc"
             DO II=1,NINDEX_VINTER  
-                I = INDEX_VINTER(II)
-                Y1(I) = Y1_LOC(II)
-                Y2(I) = Y2_LOC(II)
-                DYDX1(I)=DYDX1_LOC(II)
-                DYDX2(I)=DYDX2_LOC(II)
+              I = INDEX_VINTER(II)
+              Y1(I) = Y1_LOC(II)
+              Y2(I) = Y2_LOC(II)
+              DYDX1(I)=DYDX1_LOC(II)
+              DYDX2(I)=DYDX2_LOC(II)
             ENDDO
 ! ------------------------
 #include "vectorize.inc" 
@@ -951,7 +1024,7 @@ c------------------------------------------------
               J2 = JJ(I)+1
               Y1(I) = YFAC(I,1)*Y1(I)
               Y2(I) = YFAC(I,2)*Y2(I)                        
-              FAC   = SRATE(I)        
+              FAC   = RFAC(I)        
               YLD(I)= FAIL(I)*(Y1(I)    + FAC*(Y2(I)-Y1(I)))
         
               DYDX1(I)=DYDX1(I)*YFAC(I,1)
@@ -999,27 +1072,43 @@ c------------------------------------------------
                 !--------------
                 !update yield :
                 !-------------- 
-                PLA(I)    = PLAOLD(I) + DPLA_J(I)
-                PLAP(I)   = DPLA_J(I) / TIMESTEP    
+                PLA(I)  = PLAOLD(I) + DPLA_J(I)
+                PLAP(I) = DPLA_J(I) / TIMESTEP    
                 JJ(I) = 1      
               ENDDO
               DO J=2,NRATE-1
 #include "vectorize.inc" 
                 DO II=1,NINDX                                             
-                         I = INDEX(II) 
-                           IF(PLAP(I) >= UPARAM(6+J)) JJ(I) = J
+                  I = INDEX(II) 
+                  IF(PLAP(I) >= UPARAM(6+J)) JJ(I) = J
                 ENDDO              
               ENDDO
-#include "vectorize.inc" 
-              DO II=1,NINDX                                             
-                I = INDEX(II) 
-                J1 = JJ(I)
-                J2 = J1+1
-                FAC=UPARAM(6+J1)
-                SRATE(I)=(PLAP(I) - FAC)/(UPARAM(7+J1) - FAC)
-                YFAC(I,1)=UPARAM(6+NRATE+J1)*FACYLDI(I)
-                YFAC(I,2)=UPARAM(6+NRATE+J2)*FACYLDI(I)
-              ENDDO
+c
+              IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+#include        "vectorize.inc"
+                DO II=1,NINDX                                           
+                  I = INDEX(II) 
+                  EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
+                  EPSP2 = UPARAM(7+JJ(I))
+                  RFAC(I) = LOG(MAX(PLAP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)
+                ENDDO
+              ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
+#include        "vectorize.inc"
+                DO II=1,NINDX                                           
+                  I = INDEX(II) 
+                  EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
+                  EPSP2 = UPARAM(7+JJ(I))
+                  RFAC(I) = LOG10(MAX(PLAP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)
+                ENDDO
+              ELSE                        ! linear interpolation of strain rate
+#include        "vectorize.inc"
+                DO II=1,NINDX                                           
+                  I = INDEX(II) 
+                  EPSP1 = UPARAM(6+JJ(I))
+                  EPSP2 = UPARAM(7+JJ(I))
+                  RFAC(I) = (PLAP(I) - EPSP1) / (EPSP2 - EPSP1)
+                ENDDO
+              END IF
 ! ------------------------
               NINDEX_VINTER = 0
 #include "vectorize.inc"
@@ -1036,6 +1125,8 @@ c------------------------------------------------
                 IADP2(NINDEX_VINTER)  = NPF(IFUNC(JJ(I)+1)) / 2 + 1
                 ILENP2(NINDEX_VINTER) = NPF(IFUNC(JJ(I)+1)  + 1) / 2 - IADP2(NINDEX_VINTER) - IPOSP2(NINDEX_VINTER)
                 TAB_LOC(NINDEX_VINTER) = PLA(I)
+                YFAC(I,1)=UPARAM(6+NRATE+J1)*FACYLDI(I)
+                YFAC(I,2)=UPARAM(6+NRATE+J2)*FACYLDI(I)
               ENDDO
 
               CALL VINTER2(TF,IADP,IPOSP,ILENP,NINDEX_VINTER,TAB_LOC,DYDX1_LOC,Y1_LOC)
@@ -1065,8 +1156,8 @@ c------------------------------------------------
                 J2 = JJ(I)+1
                 Y1(I) = YFAC(I,1) * Y1(I) 
                 Y2(I) = YFAC(I,2) * Y2(I) 
-                FAC   = SRATE(I)        
-                        YLD(I)= FAIL(I)*(Y1(I)    + FAC*(Y2(I)-Y1(I)))
+                FAC   = RFAC(I)        
+                YLD(I)= FAIL(I)*(Y1(I) + FAC*(Y2(I)-Y1(I)))
                 DYDX1(I)=DYDX1(I)*YFAC(I,1)
                 DYDX2(I)=DYDX2(I)*YFAC(I,2)
                 H(I)  = FAIL(I)*(DYDX1(I) + FAC*(DYDX2(I)-DYDX1(I)))
@@ -1124,16 +1215,32 @@ c------------------------------------------------
                 IF(PLAP(I) >= UPARAM(6+J)) JJ(I) = J               
               ENDDO 
             ENDDO
-#include "vectorize.inc" 
-            DO II=1,NINDX                                             
-              I = INDEX(II)
-              J1 = JJ(I)
-              J2 = J1+1
-              FAC=UPARAM(6+J1)
-              SRATE(I)=(PLAP(I) - FAC)/(UPARAM(7+J1) - FAC)
-              YFAC(I,1)=UPARAM(6+NRATE+J1)*FACYLDI(I)
-              YFAC(I,2)=UPARAM(6+NRATE+J2)*FACYLDI(I) 
-            ENDDO
+c
+            IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+#include      "vectorize.inc"
+              DO II=1,NINDX                                           
+                I = INDEX(II) 
+                EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
+                EPSP2 = UPARAM(7+JJ(I))
+                RFAC(I) = LOG(MAX(PLAP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)
+              ENDDO
+            ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
+#include      "vectorize.inc"
+              DO II=1,NINDX                                           
+                I = INDEX(II) 
+                EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
+                EPSP2 = UPARAM(7+JJ(I))
+                RFAC(I) = LOG10(MAX(PLAP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)
+              ENDDO
+            ELSE                        ! linear interpolation of strain rate
+#include      "vectorize.inc"
+              DO II=1,NINDX                                           
+                I = INDEX(II) 
+                EPSP1 = UPARAM(6+JJ(I))
+                EPSP2 = UPARAM(7+JJ(I))
+                RFAC(I) = (PLAP(I) - EPSP1) / (EPSP2 - EPSP1)
+              ENDDO
+            END IF
 ! ------------------------
             NINDEX_VINTER = 0
 #include "vectorize.inc"
@@ -1150,6 +1257,8 @@ c------------------------------------------------
               IADP2(NINDEX_VINTER)  = NPF(IFUNC(JJ(I)+1)) / 2 + 1
               ILENP2(NINDEX_VINTER) = NPF(IFUNC(JJ(I)+1)  + 1) / 2 - IADP2(NINDEX_VINTER) - IPOSP2(NINDEX_VINTER)
               TAB_LOC(NINDEX_VINTER) = PLA(I)
+              YFAC(I,1)=UPARAM(6+NRATE+J1)*FACYLDI(I)
+              YFAC(I,2)=UPARAM(6+NRATE+J2)*FACYLDI(I) 
             ENDDO
 
             CALL VINTER2(TF,IADP,IPOSP,ILENP,NINDEX_VINTER,TAB_LOC,DYDX1_LOC,Y1_LOC)
@@ -1179,7 +1288,7 @@ c------------------------------------------------
               J2 = JJ(I)+1
               Y1(I) = YFAC(I,1) * Y1(I)
               Y2(I) = YFAC(I,2) * Y2(I)
-              FAC   = SRATE(I)        
+              FAC   = RFAC(I)        
               YLD(I)= FAIL(I)*(Y1(I)    + FAC*(Y2(I)-Y1(I)))
         
               DYDX1(I)=DYDX1(I)*YFAC(I,1)
@@ -1238,16 +1347,32 @@ c------------------------------------------------
                   IF(PLAP(I) >= UPARAM(6+J)) JJ(I) = J              
                 ENDDO
               ENDDO
-#include "vectorize.inc"
-              DO II=1,NINDX                                             
-                I = INDEX(II)
-                J1 = JJ(I)
-                J2 = J1+1
-                FAC=UPARAM(6+J1)
-                SRATE(I)=(PLAP(I) - FAC)/(UPARAM(7+J1) - FAC)
-                YFAC(I,1)=UPARAM(6+NRATE+J1)*FACYLDI(I)
-                YFAC(I,2)=UPARAM(6+NRATE+J2)*FACYLDI(I)
-              ENDDO
+c
+              IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+#include        "vectorize.inc"
+                DO II=1,NINDX                                           
+                  I = INDEX(II) 
+                  EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
+                  EPSP2 = UPARAM(7+JJ(I))
+                  RFAC(I) = LOG(MAX(PLAP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)
+                ENDDO
+              ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
+#include        "vectorize.inc"
+                DO II=1,NINDX                                           
+                  I = INDEX(II) 
+                  EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
+                  EPSP2 = UPARAM(7+JJ(I))
+                  RFAC(I) = LOG10(MAX(PLAP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)
+                ENDDO
+              ELSE                        ! linear interpolation of strain rate
+#include        "vectorize.inc"
+                DO II=1,NINDX                                           
+                  I = INDEX(II) 
+                  EPSP1 = UPARAM(6+JJ(I))
+                  EPSP2 = UPARAM(7+JJ(I))
+                  RFAC(I) = (PLAP(I) - EPSP1) / (EPSP2 - EPSP1)
+                ENDDO
+              END IF
 ! ------------------------
               NINDEX_VINTER = 0
 #include "vectorize.inc"
@@ -1264,6 +1389,8 @@ c------------------------------------------------
                 IADP2(NINDEX_VINTER)  = NPF(IFUNC(JJ(I)+1)) / 2 + 1
                 ILENP2(NINDEX_VINTER) = NPF(IFUNC(JJ(I)+1)  + 1) / 2 - IADP2(NINDEX_VINTER) - IPOSP2(NINDEX_VINTER)
                 TAB_LOC(NINDEX_VINTER) = PLA(I)
+                YFAC(I,1)=UPARAM(6+NRATE+J1)*FACYLDI(I)
+                YFAC(I,2)=UPARAM(6+NRATE+J2)*FACYLDI(I)
               ENDDO
 
               CALL VINTER2(TF,IADP,IPOSP,ILENP,NINDEX_VINTER,TAB_LOC,DYDX1_LOC,Y1_LOC)
@@ -1293,7 +1420,7 @@ c------------------------------------------------
                 J2 = JJ(I)+1
                 Y1(I) = YFAC(I,1) * Y1(I)
                 Y2(I) = YFAC(I,2) * Y2(I) 
-                FAC   = SRATE(I)        
+                FAC   = RFAC(I)        
                 YLD(I)= FAIL(I)*(Y1(I)    + FAC*(Y2(I)-Y1(I)))
                 DYDX1(I)=DYDX1(I)*YFAC(I,1)
                 DYDX2(I)=DYDX2(I)*YFAC(I,2)

--- a/engine/source/materials/mat/mat036/sigeps36c.F
+++ b/engine/source/materials/mat/mat036/sigeps36c.F
@@ -142,19 +142,20 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER ::  I,J,K,N,II,J1,J2,NINDX,VP,IFAIL,OPTE,NINDEX_PLA,
-     .        NITER,NRATE,IPFUN,NFUNC,PFUN,IFUNCE,FUN1,FUN2,YLDCHECK
+     .        NITER,NRATE,IPFUN,NFUNC,PFUN,IFUNCE,FUN1,FUN2,YLDCHECK,
+     .        ISMOOTH
       INTEGER IAD1(MVSIZ),IPOS1(MVSIZ),ILEN1(MVSIZ),
      .        IAD2(MVSIZ),IPOS2(MVSIZ),ILEN2(MVSIZ),
      .        JJ(MVSIZ),INDEX(MVSIZ),IPOSP(MVSIZ),IPOSPE(MVSIZ),
      .        IFUNC(100),IADP(MVSIZ),ILENP(MVSIZ)
       INTEGER, DIMENSION(MVSIZ) :: INDEX_PLA
       my_real :: A,B,C,P,P2,R,CC,FAC,DEZZ,SVM,
-     .        HKIN,DTINV,AAA,SOUNDSP1,ALPHA,CE,EINF,
+     .        HKIN,DTINV,AAA,SOUNDSP1,ALPHA,CE,EINF,EPSP1,EPSP2,
      .        ERR,F,DF,PLA_I,Q2,YLD_I,SIGPXX,SIGPYY,SIGPXY,
      .        E1,A11,A21,G1,G31,NU11,NU21,NU_MNU,U_MNU,T_PNU,NUX,NU3,
      .        EPSMAX,EPSR1,EPSR2,EPSF,FISOKIN,S1,S2,S3,DPLA,VM2,YLD0
       my_real ::  FACT(NEL),E(MVSIZ),A1(MVSIZ),A2(MVSIZ),G(MVSIZ),
-     .        DYDX1(MVSIZ),DYDX2(MVSIZ),RATE(MVSIZ),
+     .        DYDX1(MVSIZ),DYDX2(MVSIZ),RFAC(MVSIZ),
      .        Y1(MVSIZ),Y2(MVSIZ),DR(MVSIZ),YFAC(MVSIZ,2),ESCALE(MVSIZ),
      .        AA(MVSIZ),BB(MVSIZ),DPLA_J(MVSIZ),  
      .        PP(MVSIZ),QQ(MVSIZ),FAIL(MVSIZ),H(MVSIZ),HK(MVSIZ),
@@ -199,6 +200,7 @@ C
       VP       = NINT(UPARAM(2*NRATE + 26)) ! flag for plastic strain dependency
       IFAIL    = NINT(UPARAM(2*NRATE + 27)) ! flag for failure
       YLDCHECK = NINT(UPARAM(2*NRATE + 28))
+      ISMOOTH  = NINT(UPARAM(2*NRATE + 29)) ! strain rate interpolation flag
 c-----------------------------
       IF (FISOKIN > 0) THEN
         SIGBXX => SIGB(1       :  NEL) 
@@ -356,13 +358,34 @@ c
               IF (EPSP(I) >= UPARAM(6+J)) JJ(I) = J
             ENDDO
           ENDDO
-#include "vectorize.inc"
-          DO I=1,NEL
-            FAC = UPARAM(6+JJ(I))
-            RATE(I) = (EPSP(I) - FAC)/(UPARAM(7+JJ(I)) - FAC)
-            YFAC(I,1)=UPARAM(6+NRATE+JJ(I))*FACYLDI(I)
-            YFAC(I,2)=UPARAM(6+NRATE+JJ(I)+1)*FACYLDI(I)
-          ENDDO
+          IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+#include    "vectorize.inc"
+            DO I=1,NEL
+              EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
+              EPSP2 = UPARAM(7+JJ(I))
+              RFAC(I) = LOG(MAX(EPSP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)
+              YFAC(I,1) = UPARAM(6+NRATE+JJ(I))  * FACYLDI(I)
+              YFAC(I,2) = UPARAM(7+NRATE+JJ(I))  * FACYLDI(I)
+            ENDDO
+          ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
+#include    "vectorize.inc"
+            DO I=1,NEL
+              EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
+              EPSP2 = UPARAM(7+JJ(I))
+              RFAC(I) = LOG10(MAX(EPSP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)
+              YFAC(I,1) = UPARAM(6+NRATE+JJ(I)) * FACYLDI(I)
+              YFAC(I,2) = UPARAM(7+NRATE+JJ(I)) * FACYLDI(I)
+            ENDDO
+          ELSE                        ! linear interpolation of strain rate
+#include    "vectorize.inc"
+            DO I=1,NEL
+              EPSP1 = UPARAM(6+JJ(I))
+              EPSP2 = UPARAM(7+JJ(I))
+              RFAC(I) = (EPSP(I) - EPSP1) / (EPSP2 - EPSP1)
+              YFAC(I,1) = UPARAM(6+NRATE+JJ(I)) * FACYLDI(I)
+              YFAC(I,2) = UPARAM(7+NRATE+JJ(I)) * FACYLDI(I)
+            ENDDO
+          END IF
 
 #include  "vectorize.inc"
           DO I=1,NEL
@@ -386,10 +409,10 @@ c
             DO I=1,NEL
              J1 = JJ(I)
              J2 = J1+1
-             Y1(I)=Y1(I)*YFAC(I,1)
-             Y2(I)=Y2(I)*YFAC(I,2)
-             FAC   = RATE(I)
-             YLD(I) = FAIL(I)*(Y1(I)    + FAC*(Y2(I)-Y1(I)))
+             Y1(I) = Y1(I)*YFAC(I,1)
+             Y2(I) = Y2(I)*YFAC(I,2)
+             FAC   = RFAC(I)
+             YLD(I) = FAIL(I)*(Y1(I) + FAC*(Y2(I)-Y1(I)))
              YLD(I) = MAX(YLD(I),EM20)
              DYDX1(I)=DYDX1(I)*YFAC(I,1)
              DYDX2(I)=DYDX2(I)*YFAC(I,2)
@@ -410,7 +433,7 @@ c
              J2 = J1+1
              FUN1 = IFUNC(J1)
              FUN2 = IFUNC(J2)
-             FAC   = RATE(I)
+             FAC   = RFAC(I)
              DYDX1(I)=DYDX1(I)*YFAC(I,1)
              DYDX2(I)=DYDX2(I)*YFAC(I,2)
              H(I)   = FAIL(I)*(DYDX1(I) + FAC*(DYDX2(I)-DYDX1(I)))
@@ -438,7 +461,7 @@ C           ECROUISSAGE CINEMATIQUE
               FUN2 = IFUNC(J2)
               Y1(I)=Y1(I)*YFAC(I,1)
               Y2(I)=Y2(I)*YFAC(I,2)
-              FAC   = RATE(I)
+              FAC   = RFAC(I)
               YLD(I) = FAIL(I)*(Y1(I)    + FAC*(Y2(I)-Y1(I)))
               YLD(I) = MAX(YLD(I),EM20)
               DYDX1(I)=DYDX1(I)*YFAC(I,1)
@@ -700,12 +723,33 @@ C-------------------
             IF (PLAP(I) >= UPARAM(6+J)) JJ(I) = J  
           ENDDO                                    
         ENDDO                                      
+c
+        IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+#include  "vectorize.inc"
+          DO I=1,NEL
+            EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
+            EPSP2 = UPARAM(7+JJ(I))
+            RFAC(I) = LOG(MAX(PLAP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)
+          ENDDO
+        ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
+#include  "vectorize.inc"
+          DO I=1,NEL
+            EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
+            EPSP2 = UPARAM(7+JJ(I))
+            RFAC(I) = LOG10(MAX(PLAP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)
+          ENDDO
+        ELSE                        ! linear interpolation of strain rate
+#include  "vectorize.inc"
+          DO I=1,NEL
+            EPSP1 = UPARAM(6+JJ(I))
+            EPSP2 = UPARAM(7+JJ(I))
+            RFAC(I) = (PLAP(I) - EPSP1) / (EPSP2 - EPSP1)
+          ENDDO
+        END IF
 #include  "vectorize.inc"
         DO I=1,NEL
-          FAC = UPARAM(6+JJ(I))
-          RATE(I) = (PLAP(I) - FAC)/(UPARAM(7+JJ(I)) - FAC)
-          YFAC(I,1) = UPARAM(6+NRATE+JJ(I))  *FACYLDI(I)
-          YFAC(I,2) = UPARAM(6+NRATE+JJ(I)+1)*FACYLDI(I)
+          YFAC(I,1) = UPARAM(6+NRATE+JJ(I))  * FACYLDI(I)
+          YFAC(I,2) = UPARAM(7+NRATE+JJ(I))  * FACYLDI(I)
         ENDDO
 
 #include"vectorize.inc"
@@ -731,16 +775,16 @@ c-------------------------------
           DO I=1,NEL
             J1 = JJ(I)
             J2 = J1+1
-            Y1(I)=Y1(I)*YFAC(I,1)
-            Y2(I)=Y2(I)*YFAC(I,2)
-            FAC   = RATE(I)
-            YLD(I) = FAIL(I)*(Y1(I)    + FAC*(Y2(I)-Y1(I)))
-            YLD(I) = MAX(YLD(I),EM20)
-            DYDX1(I)=DYDX1(I)*YFAC(I,1)
-            DYDX2(I)=DYDX2(I)*YFAC(I,2)
-            H(I)   = FAIL(I)*(DYDX1(I) + FAC*(DYDX2(I)-DYDX1(I)))
-            YLD(I) = YLD(I)*MAX(ZERO,PFAC(I))
-            H(I)   = H(I)*MAX(ZERO,PFAC(I))          
+            Y1(I)= Y1(I)*YFAC(I,1)
+            Y2(I)= Y2(I)*YFAC(I,2)
+            FAC  = RFAC(I)
+            YLD(I)  = FAIL(I)*(Y1(I)    + FAC*(Y2(I)-Y1(I)))
+            YLD(I)  = MAX(YLD(I),EM20)
+            DYDX1(I)= DYDX1(I)*YFAC(I,1)
+            DYDX2(I)= DYDX2(I)*YFAC(I,2)
+            H(I)    = FAIL(I)*(DYDX1(I) + FAC*(DYDX2(I)-DYDX1(I)))
+            YLD(I)  = YLD(I)*MAX(ZERO,PFAC(I))
+            H(I)    = H(I)*MAX(ZERO,PFAC(I))          
           ENDDO
           DO I=1,NEL
            J1 = JJ(I)
@@ -757,14 +801,14 @@ c-------------------------------
             J2 = J1+1
             FUN1 = IFUNC(J1)
             FUN2 = IFUNC(J2)
-            FAC   = RATE(I)
+            FAC  = RFAC(I)
             DYDX1(I)=DYDX1(I)*YFAC(I,1)
             DYDX2(I)=DYDX2(I)*YFAC(I,2)
             H(I)   = FAIL(I)*(DYDX1(I) + FAC*(DYDX2(I)-DYDX1(I)))
-            Y1(I)=TF(NPF(FUN1)+1)
-            Y2(I)=TF(NPF(FUN2)+1)
-            Y1(I)=Y1(I)*YFAC(I,1)
-            Y2(I)=Y2(I)*YFAC(I,2)
+            Y1(I)  = TF(NPF(FUN1)+1)
+            Y2(I)  = TF(NPF(FUN2)+1)
+            Y1(I)  = Y1(I)*YFAC(I,1)
+            Y2(I)  = Y2(I)*YFAC(I,2)
             YLD(I) = FAIL(I)*(Y1(I) + FAC*(Y2(I)-Y1(I)))
             YLD(I) = YLD(I)*MAX(ZERO,PFAC(I))
             H(I)   = H(I)*MAX(ZERO,PFAC(I)) 
@@ -784,19 +828,19 @@ c-------------------------------
             J2 = J1+1
             FUN1 = IFUNC(J1)
             FUN2 = IFUNC(J2)
-            Y1(I)=Y1(I)*YFAC(I,1)
-            Y2(I)=Y2(I)*YFAC(I,2)
-            FAC   = RATE(I)
-            YLD(I) = FAIL(I)*(Y1(I)    + FAC*(Y2(I)-Y1(I)))
-            YLD(I) = MAX(YLD(I),EM20)
-            DYDX1(I)=DYDX1(I)*YFAC(I,1)
-            DYDX2(I)=DYDX2(I)*YFAC(I,2)
-            H(I)   = FAIL(I)*(DYDX1(I) + FAC*(DYDX2(I)-DYDX1(I)))
-            Y1(I)=TF(NPF(FUN1)+1)
-            Y2(I)=TF(NPF(FUN2)+1)
-            Y1(I)=Y1(I)*YFAC(I,1)
-            Y2(I)=Y2(I)*YFAC(I,2)
-            YLD(I) = (ONE - FISOKIN) * YLD(I) + 
+            Y1(I)= Y1(I)*YFAC(I,1)
+            Y2(I)= Y2(I)*YFAC(I,2)
+            FAC  = RFAC(I)
+            YLD(I)  = FAIL(I)*(Y1(I)    + FAC*(Y2(I)-Y1(I)))
+            YLD(I)  = MAX(YLD(I),EM20)
+            DYDX1(I)= DYDX1(I)*YFAC(I,1)
+            DYDX2(I)= DYDX2(I)*YFAC(I,2)
+            H(I)    = FAIL(I)*(DYDX1(I) + FAC*(DYDX2(I)-DYDX1(I)))
+            Y1(I)   = TF(NPF(FUN1)+1)
+            Y2(I)   = TF(NPF(FUN2)+1)
+            Y1(I)   = Y1(I)*YFAC(I,1)
+            Y2(I)   = Y2(I)*YFAC(I,2)
+            YLD(I)  = (ONE - FISOKIN) * YLD(I) + 
      .           FISOKIN * (FAIL(I)*(Y1(I)    + FAC*(Y2(I)-Y1(I))))
             YLD(I) = YLD(I)*MAX(ZERO,PFAC(I))
             H(I)   = H(I)*MAX(ZERO,PFAC(I))      

--- a/engine/source/materials/mat/mat036/sigeps36pi.F
+++ b/engine/source/materials/mat/mat036/sigeps36pi.F
@@ -103,13 +103,11 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
+      INTEGER I,J,J1,J2,N,NINDX,IADBUF,NFUNC,IPLAS,IFAIL,MFUNCE,ISMOOTH
       INTEGER NRATE(NEL),IAD1(NEL),IPOS1(NEL),ILEN1(NEL),
      .        IAD2(NEL),IPOS2(NEL),ILEN2(NEL),JJ(NEL),
-     .        IFUNC(NEL,100),OPTE(NEL),MFUNCE
-      INTEGER I,J,J1,J2,N,NINDX,IADBUF,NFUNC,IPLAS,IFAIL
-      my_real 
-     .        G3(NEL),
-     .        DYDX1(NEL),DYDX2(NEL),RATE(NEL,2),
+     .        IFUNC(NEL,100),OPTE(NEL)
+      my_real :: G3(NEL),DYDX1(NEL),DYDX2(NEL),RATE(NEL,2),
      .        Y1(NEL),Y2(NEL),DR(NEL),YFAC(NEL,2),
      .        PP(NEL),QQ(NEL),FAIL(NEL),SVM(NEL),H(NEL),
      .        EPSMAX(NEL),EPSR1(NEL),EPSR2(NEL),
@@ -117,8 +115,7 @@ C-----------------------------------------------
      .        HK(NEL),NU(NEL),NU1(NEL),EPSF(NEL),YLD(NEL),
      .        AA(NEL),BB(NEL),CC(NEL),EINF(NEL),CE(NEL),
      .        ESCALE(NEL),DYDXE(NEL)
-      my_real
-     .        R,UMR,FAC,GS,SVM1,SHFACT
+      my_real :: R,UMR,FAC,GS,SVM1,SHFACT,EPSP1,EPSP2,RFAC
 C=======================================================================
       IPLAS  = 1                        
       SHFACT = FIVE_OVER_6
@@ -143,6 +140,7 @@ c---------------------
         EINF(I) = UPARAM(IADBUF+2*NRATE(I) + 24) 
         CE(I)   = UPARAM(IADBUF+2*NRATE(I) + 25) 
         IFAIL   = NINT(UPARAM(2*NRATE(I) + 27))    ! flag for failure
+        ISMOOTH = NINT(UPARAM(2*NRATE(I) + 29))    ! strain rate interpolation flag
 c--------------------
         IF (OPTE(I) == 1)THEN                                                     
            IF(PLA(I) > ZERO)THEN             
@@ -193,11 +191,11 @@ C-------------------
       ENDDO                                           
       DO I=1,NEL                                               
         IADBUF = IPM(7,MAT(I))-1
-        RATE(I,1)=UPARAM(IADBUF+6+JJ(I))                        
-        YFAC(I,1)=UPARAM(IADBUF+6+NRATE(I)+JJ(I))   
-        IF ( NRATE(I) > 1)THEN         
-          RATE(I,2)=UPARAM(IADBUF+6+JJ(I)+1)                      
-          YFAC(I,2)=UPARAM(IADBUF+6+NRATE(I)+JJ(I)+1)  
+        RATE(I,1) = UPARAM(IADBUF+6+JJ(I))                        
+        YFAC(I,1) = UPARAM(IADBUF+6+NRATE(I)+JJ(I))   
+        IF (NRATE(I) > 1) THEN         
+          RATE(I,2) = UPARAM(IADBUF+6+JJ(I)+1)                      
+          YFAC(I,2) = UPARAM(IADBUF+6+NRATE(I)+JJ(I)+1)  
         ENDIF           
       ENDDO                                                     
 C
@@ -210,7 +208,7 @@ C
         IPOS1(I) = VARTMP(I,J1)                                         
         IAD1(I)  = NPF(IFUNC(I,J1)) / 2 + 1                    
         ILEN1(I) = NPF(IFUNC(I,J1)+1) / 2 - IAD1(I) - IPOS1(I) 
-        IF ( NRATE(I) > 1)THEN         
+        IF (NRATE(I) > 1) THEN         
           IPOS2(I) = VARTMP(I,J2)                                           
           IAD2(I)  = NPF(IFUNC(I,J2)) / 2 + 1                    
           ILEN2(I) = NPF(IFUNC(I,J2)+1) / 2 - IAD2(I) - IPOS2(I) 
@@ -231,9 +229,21 @@ C
           J1 = JJ(I)                                              
           J2 = J1+1                                               
           Y1(I) = Y1(I)*YFAC(I,1)                                 
-          Y2(I) = Y2(I)*YFAC(I,2)                                 
-          FAC   = (EPSP(I) - RATE(I,1))/(RATE(I,2) - RATE(I,1))   
-          YLD(I)  = FAIL(I)*(Y1(I)    + FAC*(Y2(I)-Y1(I)))        
+          Y2(I) = Y2(I)*YFAC(I,2)
+          IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+            EPSP1 = MAX(RATE(I,1), EM20)
+            EPSP2 = RATE(I,2)
+            FAC   = LOG(MAX(EPSP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)   
+          ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
+            EPSP1 = MAX(RATE(I,1), EM20)
+            EPSP2 = RATE(I,2)
+            FAC   = LOG10(MAX(EPSP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)   
+          ELSE                         ! linear interpolation of strain rate
+            EPSP1 = RATE(I,1)
+            EPSP2 = RATE(I,2)
+            FAC   = (EPSP(I) - EPSP1) / (EPSP2 - EPSP1)   
+          END IF
+          YLD(I)  = FAIL(I)*(Y1(I) + FAC*(Y2(I)-Y1(I)))        
           YLD(I)  = MAX(YLD(I),EM20)                              
           DYDX1(I)= DYDX1(I)*YFAC(I,1)                            
           DYDX2(I)= DYDX2(I)*YFAC(I,2)                            

--- a/starter/source/materials/mat/mat036/hm_read_mat36.F
+++ b/starter/source/materials/mat/mat036/hm_read_mat36.F
@@ -102,7 +102,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER :: NBMAT, MAT_ID  ! Number of declared materials
       INTEGER :: I,J,VP,YLDCHECK
-      INTEGER :: RHOFLAG,ICOMP,NRATE1,NRATE,IPFUN,IFUNCE,ISRAT,
+      INTEGER :: RHOFLAG,ICOMP,NRATE1,NRATE,IPFUN,IFUNCE,ISRAT,ISMOOTH,
      .           NBLINE,NBREAD,IFAIL,OPTE,ILAW,NFUNC
       my_real :: RHO0, RHOR,E,NU,G,C1,SOUNDSP, EPSMAX,EPSR1,EPSR2,EPSF,FISOKIN,FCUT,
      .           PSCAL_UNIT,PSCALE,EINF,CE ,
@@ -131,7 +131,7 @@ Card1
 C-----------------------------------------------
 Card2
       CALL HM_GET_INTV  ('NFUNC'        ,NRATE   ,IS_AVAILABLE,LSUBMODEL)
-      CALL HM_GET_INTV  ('Fsmooth'      ,ISRAT   ,IS_AVAILABLE,LSUBMODEL)
+      CALL HM_GET_INTV  ('Fsmooth'      ,ISMOOTH ,IS_AVAILABLE,LSUBMODEL)
       CALL HM_GET_FLOATV('MAT_HARD'     ,FISOKIN ,IS_AVAILABLE, LSUBMODEL, UNITAB)
       CALL HM_GET_FLOATV('Fcut'         ,FCUT    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
       CALL HM_GET_FLOATV('MAT_Epsilon_F',EPSF    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
@@ -211,6 +211,7 @@ c
 c-------------------------
       IF (NRATE == 1) THEN
         NFUNC  = 1
+        ISMOOTH= 0
         ISRAT  = 0
         FCUT   = ZERO
         VP     = 0   !!!  no plastic strain rate dependency with single static curve
@@ -332,8 +333,9 @@ c -----------------------
       UPARAM(2*NFUNC + 26) = VP
       UPARAM(2*NFUNC + 27) = IFAIL
       UPARAM(2*NFUNC + 28) = YLDCHECK
+      UPARAM(2*NFUNC + 29) = ISMOOTH
 c
-      NUPARAM = 2*NFUNC + 28
+      NUPARAM = 2*NFUNC + 29
 c--------------------------------
       IF (RHOR == ZERO) RHOR=RHO0
       PM(1) = RHOR
@@ -383,37 +385,42 @@ C-----------
       RETURN
 C-----------
  1000 FORMAT(
-     & 5X,40H  TABULATED ELASTIC PLASTIC LAW 36      ,/,
-     & 5X,40H  --------------------------------      ,//)
+     & 5X,'    TABULATED ELASTIC PLASTIC LAW 36    ',/,
+     & 5X,'    --------------------------------    ' ,//)
  1001 FORMAT(/
      & 5X,A,/,
-     & 5X,'MATERIAL NUMBER. . . . . . . . . . . . =',I10/,
-     & 5X,'MATERIAL LAW . . . . . . . . . . . . . =',I10/)
+     & 5X,'MATERIAL NUMBER . . . . . . . . . . . . . .=',I10/,
+     & 5X,'MATERIAL LAW. . . . . . . . . . . . . . . .=',I10/)
  1002 FORMAT(
-     & 5X,'INITIAL DENSITY. . . . . . . . . . . . =',1PG20.13/)  
+     & 5X,'INITIAL DENSITY . . . . . . . . . . . . . .=',1PG20.13/)  
  1100 FORMAT(
-     & 5X,'YOUNG''S MODULUS. . . . . . . . . . . .=',1PG20.13/
-     & 5X,'POISSON''S RATIO. . . . . . . . . . . .=',1PG20.13/
-     & 5X,'MAXIMUM PLASTIC STRAIN . . . . . . . . =',1PG20.13/
-     & 5X,'TENSION FAILURE STRAIN 1 . . . . . . . =',1PG20.13/
-     & 5X,'TENSION FAILURE STRAIN 2 . . . . . . . =',1PG20.13/
-     & 5X,'MAXIMUM TENSION FAILURE STRAIN  .. . . =',1PG20.13/     
-     & 5X,'ISO-KINEMATIC HARDENING FACTOR. . . .  =',1PG20.13/
-     & 5X,'SMOOTH STRAIN RATE OPTION. . . . . . . =',I10/
-     & 5X,'STRAIN RATE CUTTING FREQUENCY . . . . .=',1PG20.13/
-     & 5X,'PLASTIC STRAIN RATE DEPENDENCY FLAG . .=',I10/
-     & 5X,40H  - FLAG_PL = 0 -> TOTAL SR DEPENDENCY         ,/,
-     & 5X,40H  - FLAG_PL = 1 -> PLASTIC SR DEPENDENCY       ,//)
+     & 5X,'YOUNG MODULUS . . . . . . . . . . . . . . .=',1PG20.13/
+     & 5X,'POISSON RATIO . . . . . . . . . . . . . . .=',1PG20.13/
+     & 5X,'MAXIMUM PLASTIC STRAIN  . . . . . . . . . .=',1PG20.13/
+     & 5X,'TENSION FAILURE STRAIN 1  . . . . . . . . .=',1PG20.13/
+     & 5X,'TENSION FAILURE STRAIN 2  . . . . . . . . .=',1PG20.13/
+     & 5X,'MAXIMUM TENSION FAILURE STRAIN  . . . . . .=',1PG20.13/     
+     & 5X,'ISO-KINEMATIC HARDENING FACTOR. . . . . . .=',1PG20.13/
+     & 5X,'SMOOTH STRAIN RATE OPTION . . . . . . . . .=',I10/
+     & 5X,'     0 -> NO SMOOTHING                      ',/,
+     & 5X,'     1 -> SMOOTH + LINEAR INTERPOLATION     ',/,
+     & 5X,'     2 -> SMOOTH + LOG_10 INTERPOLATION     ',/,
+     & 5X,'     3 -> SMOOTH + LOG_N  INTERPOLATION     ',/
+     & 5X,'STRAIN RATE CUTTING FREQUENCY . . . . . . .=',1PG20.13/
+     & 5X,'PLASTIC STRAIN RATE DEPENDENCY FLAG . . . .=',I10/
+     & 5X,'   FLAG_PL = 0 -> TOTAL SR DEPENDENCY       ',/,
+     & 5X,'   FLAG_PL = 1 -> PLASTIC SR DEPENDENCY     ',/,
+     & 5X,'STRAIN RATE INTERPOLATION FLAG. . . . . . .=',I10/)
  1200 FORMAT(
-     & 5X,'YIELD STRESS FUNCTION NUMBER. . . . . .=',I10/
-     & 5X,'YIELD SCALE FACTOR. . . . . . . . . . .=',1PG20.13/
-     & 5X,'STRAIN RATE . . . . . . . . . . . . . .=',1PG20.13)
+     & 5X,'YIELD STRESS FUNCTION NUMBER. . . . . . . .=',I10/
+     & 5X,'YIELD SCALE FACTOR. . . . . . . . . . . . .=',1PG20.13/
+     & 5X,'STRAIN RATE . . . . . . . . . . . . . . . .=',1PG20.13)
  1300 FORMAT(
-     & 5X,'PRESSURE DEPENDENT YIELD FUNCTION . . . .=',I10/
-     & 5X,'PRESSURE SCALE FACTOR. . . . . . . . .  .=',1PG20.13/
-     & 5X,'YOUNG MODULUS SCALE FACTOR FUNCTION . . .=',I10/
-     & 5X,'YOUNG MODULUS EINF . . . . . . . . . . . =',1PG20.13/
-     & 5X,'PARAMETER CE . . . . . . . . . . . . . . =',1PG20.13)
+     & 5X,'PRESSURE DEPENDENT YIELD FUNCTION . . . . .=',I10/
+     & 5X,'PRESSURE SCALE FACTOR . . . . . . . . . . .=',1PG20.13/
+     & 5X,'YOUNG MODULUS SCALE FACTOR FUNCTION . . . .=',I10/
+     & 5X,'YOUNG MODULUS EINF. . . . . . . . . . . . .=',1PG20.13/
+     & 5X,'PARAMETER CE. . . . . . . . . . . . . . . .=',1PG20.13)
 c-----------
       RETURN
       END


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

/MAT/LAW36 : add new option for tabulated yield stress interpolation using logarithmic base for strain rates

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

modified starter input (new values for ISRATE flag) and engine code for shells, solids and beams

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
