### PR TITLE
RAD2RAD compatibility with NLOCAL

### DIFF
--- a/engine/share/modules/rad2r.F
+++ b/engine/share/modules/rad2r.F
@@ -54,7 +54,7 @@ C-----------------------------------------------
       INTEGER, DIMENSION(:), ALLOCATABLE ::      
      .      SOCKET,DBNO,NBELTN_R2R,TCNELT,TCNELTDB,TYPLNK,  
      .      OFFSET,NBELT_R2R,ROTLNK,RBYLNK,TAG_RBY,ADD_RBY,
-     .      KINLNK,TAGEL_R2R_SEND       
+     .      KINLNK,TAGEL_R2R_SEND,NLLNK,NBDOF_NL,IADD_NL       
 
       INTEGER, DIMENSION(:,:), ALLOCATABLE :: 
      .      DBN,NBEL,NBELN,TBCNEL,TBCNELDB

--- a/engine/source/coupling/rad2rad/r2r_exchange.F
+++ b/engine/source/coupling/rad2rad/r2r_exchange.F
@@ -44,12 +44,14 @@ Chd|====================================================================
      1    IEXLNK   ,IGRNOD   ,DX       ,V        ,VR        ,      
      2    A        ,AR       ,MS       ,IN       ,STX       ,STR       ,                       
      3    R2R_ON   ,DD_R2R   ,WEIGHT   ,IAD_ELEM ,FR_ELEM   ,RBY       ,
-     4    XDP      ,X        ,DD_R2R_ELEM , SDD_R2R_ELEM, OFF_SPH_R2R,NUMSPH_GLO_R2R)                         
+     4    XDP      ,X        ,DD_R2R_ELEM , SDD_R2R_ELEM, OFF_SPH_R2R  ,
+     5    NUMSPH_GLO_R2R,NLOC_DMG)                         
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE RAD2R_MOD
       USE GROUPDEF_MOD
+      USE NLOCAL_REG_MOD
 C-----------------------------------------------      
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -87,12 +89,14 @@ C     REAL
       DOUBLE PRECISION XDP(3,*)               
 !
       TYPE (GROUP_)  , TARGET, DIMENSION(NGRNOD)  :: IGRNOD
+      TYPE(NLOCAL_STR_), TARGET, INTENT(IN)  :: NLOC_DMG
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,IEX,IDP,IDG,NNG,OLD_ACTIV,BID,LENR,SIZE,NTOP
 C
       INTEGER, DIMENSION(:), POINTER :: GRNOD
+      my_real, POINTER, DIMENSION(:) :: MSNL,VNL,FNL
 C=======================================================================
 
 C------------------------------------------------------
@@ -105,9 +109,16 @@ C------------------------------------------------------
           IDP  = IEXLNK(2,IEX)                                  
           NNG  = IGRNOD(IDG)%NENTITY
           GRNOD => IGRNOD(IDG)%ENTITY
-	  IF (IRESP==1) THEN
+	  IF (NLLNK(IEX)==1) THEN
+C----------Non local coupling interface--------------------------
+            MSNL  => NLOC_DMG%MASS(1:NLOC_DMG%L_NLOC)
+            VNL  => NLOC_DMG%VNL(1:NLOC_DMG%L_NLOC) 
+            FNL  => NLOC_DMG%FNL(1:NLOC_DMG%L_NLOC,1)  
+            CALL SEND_DATA_NL_C(IDP,NBDOF_NL(IEX),IADD_NL,FNL,VNL ,     
+     .                          MSNL,NCYCLE ,IEX)
+	  ELSEIF (IRESP==1) THEN
 C----------simple precision : DX is replaced by XDP--------------	                                    
-             CALL SEND_DATA_C(
+            CALL SEND_DATA_C(
      .        IDP    ,NNG    ,GRNOD  ,A      ,AR     ,     
      .        STX    ,STR    ,V      ,VR     ,MS     ,IN     ,     
      .        XDP    ,X      ,TYPLNK(IEX),NCYCLE,RBY,TAG_RBY,
@@ -115,7 +126,7 @@ C----------simple precision : DX is replaced by XDP--------------
      .        OFF_SPH_R2R  ,NUMSPH_GLO_R2R, NRBY)
           ELSE
 C---------double precision---------------------------------------  
-             CALL SEND_DATA_C(
+            CALL SEND_DATA_C(
      .        IDP    ,NNG    ,GRNOD  ,A      ,AR     ,     
      .        STX    ,STR    ,V      ,VR     ,MS     ,IN     ,     
      .        DX     ,X      ,TYPLNK(IEX),NCYCLE,RBY,TAG_RBY,
@@ -229,7 +240,7 @@ C------------------------------------------------------
      .       STX    ,STR, TYPLNK(IEX),NCYCLE,IEX)
         END DO
 
-C----------New rad2rad HMPP - synchro SPMD-----------------------------       
+C-------New rad2rad HMPP - synchro SPMD- (not needed for NL coupling) -----       
         IF ((SDD_R2R_ELEM>0).AND.(NSPMD>1)) THEN 
          SIZE =  1 + IRODDL*1         
          LENR = IAD_ELEM(1,NSPMD+1)-IAD_ELEM(1,1)

--- a/engine/source/coupling/rad2rad/r2r_getdata.F
+++ b/engine/source/coupling/rad2rad/r2r_getdata.F
@@ -39,12 +39,13 @@ Chd|====================================================================
      .               VR      ,A       ,AR      ,MS      ,IN      ,        
      .               XDP     ,DX      ,R2R_ON  ,DD_R2R  ,WEIGHT  ,
      .               IAD_ELEM,FR_ELEM ,STIFN   , STIFR  , DD_R2R_ELEM,
-     .               SDD_R2R_ELEM)                                           
+     .               SDD_R2R_ELEM,NLOC_DMG)                                           
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE RAD2R_MOD
       USE GROUPDEF_MOD
+      USE NLOCAL_REG_MOD
 C-----------------------------------------------      
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -79,20 +80,23 @@ C
       DOUBLE PRECISION XDP(3,*) 
 !
       TYPE (GROUP_)  , TARGET, DIMENSION(NGRNOD)  :: IGRNOD
+      TYPE(NLOCAL_STR_), TARGET, INTENT(IN)  :: NLOC_DMG
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I, IEX, IDP, IDG, NNG, NB,NGLOB,LENR,SIZE,BID
-      INTEGER NBD
+      INTEGER NBD,NL_FLAG
       my_real
      .        WF, WM, WF2, WM2, WFB, WMB, WF2B, WM2B  
 C
-      INTEGER, DIMENSION(:), POINTER :: GRNOD  
+      INTEGER, DIMENSION(:), POINTER :: GRNOD
+      my_real, POINTER, DIMENSION(:) :: MSNL,FNL  
 C=======================================================================
       WF = ZERO
       WM = ZERO
       WF2= ZERO
       WM2= ZERO
+      NL_FLAG = 0
 
       IF ((R2R_SIU==1).OR.(NSPMD==1)) THEN
 C-----------------------------------------------------------------------                     
@@ -101,12 +105,19 @@ C-----------------------------------------------------------------------
         IDP  = IEXLNK(2,IEX)
         NNG  = IGRNOD(IDG)%NENTITY
         GRNOD => IGRNOD(IDG)%ENTITY
-!
-        CALL GET_FORCE_C(
-     .       IDP    ,NNG    ,GRNOD  ,WF     ,WM      ,
-     .       WF2    ,WM2    ,V      ,VR     ,A      ,AR      ,
-     .       MS     ,IN     ,X      ,XDP    ,DX     ,TYPLNK(IEX),
-     .       KINLNK(IEX),WEIGHT  ,IEX    ,IRESP, TFEXT)
+	IF (NLLNK(IEX)==1) THEN
+C-------Non local coupling interface--------------------------
+          NL_FLAG = 1
+          MSNL  => NLOC_DMG%MASS(1:NLOC_DMG%L_NLOC)
+          FNL  => NLOC_DMG%FNL(1:NLOC_DMG%L_NLOC,1)  
+          CALL GET_FORCE_NL_C(IDP    ,NBDOF_NL(IEX)  ,IADD_NL  ,FNL ,MSNL ,
+     .                        IEX)
+        ELSE
+          CALL GET_FORCE_C(IDP    ,NNG    ,GRNOD  ,WF     ,WM      ,
+     .                     WF2    ,WM2    ,V      ,VR     ,A      ,AR      ,
+     .                     MS     ,IN     ,X      ,XDP    ,DX     ,TYPLNK(IEX),
+     .                     KINLNK(IEX),WEIGHT  ,IEX    ,IRESP, TFEXT)
+        ENDIF
         IF (R2R_ON == 1)  THEN
           CALL GET_DISPL_C(IDP,NNG,GRNOD,X)
         ENDIF
@@ -117,10 +128,9 @@ C----------New rad2rad HMPP - synchro SPMD-----------------------------
          IF (SDD_R2R_ELEM>0) THEN        
            SIZE =  3+FLAG_KINE + IRODDL*(3+FLAG_KINE)         
            LENR = IAD_ELEM(1,NSPMD+1)-IAD_ELEM(1,1)         
-           CALL SPMD_EXCH_R2R_2(
-     1       A ,AR,V , VR  ,MS   ,IN,
-     2       IAD_ELEM,FR_ELEM,SIZE , WF, WF2,
-     3       LENR    ,DD_R2R,DD_R2R_ELEM,WEIGHT,FLAG_KINE)
+           CALL SPMD_EXCH_R2R_2(A ,AR,V , VR  ,MS   ,IN,
+     2                          IAD_ELEM,FR_ELEM,SIZE , WF, WF2,
+     3                          LENR    ,DD_R2R,DD_R2R_ELEM,WEIGHT,FLAG_KINE)
          ENDIF
          CALL SPMD_EXCH_WORK(WF, WF2)
          CALL SPMD_EXCH_WORK(WM, WM2)

--- a/engine/source/coupling/rad2rad/r2r_init.F
+++ b/engine/source/coupling/rad2rad/r2r_init.F
@@ -61,12 +61,14 @@ Chd|====================================================================
      3                    FR_ELEM,ADDCNEL,CNEL,IXC,IPARG,ICODT,ICODR,
      4                    IBFV,DX,RBY,NPBY,XDP,STIFN,STIFR,DD_R2R_ELEM,
      5                    SDD_R2R_ELEM,WEIGHT_MD,ILENXV,NUMSPH_GLO_R2R,
-     6                    FLG_SPHINOUT_R2R,IPARI)
+     6                    FLG_SPHINOUT_R2R,IPARI,NLOC_DMG)
 C----6---------------------------------------------------------------7---------8
 C   M o d u l e s
 C-----------------------------------------------
       USE RAD2R_MOD
       USE GROUPDEF_MOD
+      USE MESSAGE_MOD
+      USE NLOCAL_REG_MOD
 C-----------------------------------------------       
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -91,6 +93,7 @@ C-----------------------------------------------
 #include      "scr03_c.inc"
 #include      "task_c.inc"
 #include      "sphcom.inc"
+#include      "my_allocate.inc"
 C-----------------------------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
@@ -106,16 +109,19 @@ C     REAL
       DOUBLE PRECISION XDP(3,*)      
 !
       TYPE (GROUP_)  , TARGET, DIMENSION(NGRNOD)  :: IGRNOD
+      TYPE(NLOCAL_STR_), TARGET, INTENT(IN)  :: NLOC_DMG
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I, J, IEX, IDP, IDG, NNG, OFC,NFTC,INFO,TYP,ITSK
       INTEGER OMP_GET_THREAD_NUM,NUM_SOCK,SIZE_TAG_RBY,LENR,SIZE
-      INTEGER NN,N,SUM,PPID,IDEL_LOC,NSN_GLOB
+      INTEGER NN,N,SUM,PPID,IDEL_LOC,NSN_GLOB,COMPT
+      INTEGER, DIMENSION(:), ALLOCATABLE :: NDOF_NL
       CHARACTER*35 ADDR
-
 C
       INTEGER, DIMENSION(:), POINTER :: GRNOD
+      INTEGER, POINTER, DIMENSION(:) :: IDXI,POSI
+      my_real, POINTER, DIMENSION(:) :: MSNL
 C******************************************************************************C
       INFO=NUMELS+NUMELQ+NUMELC
       NBK = 0
@@ -124,7 +130,7 @@ C******************************************************************************C
      .                     (IDTMIN(11)/=3).AND.(IDTMIN(11)/=8)) THEN
         ILENXV = ILENXV + 2
       ENDIF
-                  
+C             
       IF ((R2R_SIU==1).OR.(NSPMD==1)) THEN
 C------SPH+Multidomains--------------------->
        IF (R2R_SIU==1) THEN
@@ -148,6 +154,10 @@ C------Cas SMP initialization---------------c
        ALLOCATE(TYPLNK(NR2RLNK),RBYLNK(NR2RLNK),KINLNK(NR2RLNK))
        ALLOCATE(ADD_RBY(NR2RLNK))              
        ALLOCATE(SOCKET(NTHREAD))
+       MY_ALLOCATE(NLLNK,NR2RLNK)
+       MY_ALLOCATE(NBDOF_NL,NR2RLNK)
+       NBDOF_NL(1:NR2RLNK) = 0
+C
        DO I = 1, ROOTLEN
            IROOT(I) = ICHAR(ROOTNAM(I:I))
        END DO	
@@ -201,13 +211,13 @@ C----- get info for th
 C-----                     
        CALL SEND_IBUF_C(IRUN,1)         
        OFC=NUMELS+NUMELQ
-       
+C    
        DO IEX = 1, NR2RLNK
         IDG  = IEXLNK(1,IEX)
         IDP  = IEXLNK(2,IEX)
         NNG  = IGRNOD(IDG)%NENTITY
 	NFTC = 0
-!
+!   
         GRNOD => IGRNOD(IDG)%ENTITY
 !
         IF (IDP>NBK) NBK = IDP	
@@ -216,7 +226,8 @@ C------	determination of the type of the interface
 	CALL GET_IBUF_C(TYPLNK(IEX),1)
 	CALL GET_IBUF_C(MAIN_SIDE,1)
 	CALL GET_IBUF_C(RBYLNK(IEX),1)
-	CALL GET_IBUF_C(KINLNK(IEX),1)    
+	CALL GET_IBUF_C(KINLNK(IEX),1)
+	CALL GET_IBUF_C(NLLNK(IEX),1)
 	IF (RBYLNK(IEX)==1) THEN
 	   ADD_RBY(IEX) = SIZE_TAG_RBY
 	   SIZE_TAG_RBY = SIZE_TAG_RBY + NNG
@@ -236,8 +247,34 @@ C--------------Initialisation of arrays for rlinks/cyljoints------
 	ENDIF        
 C----------------------------------------------------------------------              	
 C------	
-        CALL INIT_LINK_C(IDP,NNG,ITAB,GRNOD,X,ADDCNEL,CNEL,IXC,
+        IF (NLLNK(IEX)==1) THEN
+C-------- Coupling of non local dof
+          IDXI => NLOC_DMG%IDXI(1:NUMNOD)
+          POSI => NLOC_DMG%POSI(1:NLOC_DMG%NNOD)
+          COMPT = 0
+          MY_ALLOCATE(NDOF_NL,NNG)
+          DO I=1,NNG
+            NN = IDXI(GRNOD(I))
+            NDOF_NL(I) = POSI(NN+1)-POSI(NN)
+            COMPT = COMPT + NDOF_NL(I)
+          ENDDO
+          NBDOF_NL(IEX) = COMPT
+          ALLOCATE(IADD_NL(NBDOF_NL(IEX)))
+          COMPT = 0
+          DO I=1,NNG
+            NN = IDXI(GRNOD(I))
+            DO J=POSI(NN),POSI(NN+1)-1
+              COMPT = COMPT + 1
+              IADD_NL(COMPT) = J
+            ENDDO
+          ENDDO   
+          CALL INIT_LINK_NL_C(IDP,NNG,ITAB,GRNOD,X,NCPRI,DX,NDOF_NL,NBDOF_NL(IEX))
+          DEALLOCATE(NDOF_NL)
+        ELSE
+          CALL INIT_LINK_C(IDP,NNG,ITAB,GRNOD,X,ADDCNEL,CNEL,IXC,
      .        	OFC,INFO,TYPLNK(IEX),ICODT,ICODR,NCPRI,IRODDL,NBK,DX)
+        ENDIF
+C
        END DO
 !
        CALL INIT_ACTIV_C(R2R_ACTIV)
@@ -253,17 +290,21 @@ C----- Actualize  mass and inertia
 C
         R2RFX1 = ZERO
         R2RFX2 = ZERO
-	ALLOCATE (TAG_RBY(SIZE_TAG_RBY))
+	ALLOCATE (TAG_RBY(SIZE_TAG_RBY))     
         DO IEX = 1, NR2RLNK
           IDG  = IEXLNK(1,IEX)
           IDP  = IEXLNK(2,IEX)
           NNG  = IGRNOD(IDG)%NENTITY
           GRNOD => IGRNOD(IDG)%ENTITY
-	  IF (RBYLNK(IEX)==0) THEN
-             CALL SEND_MASS_C(IDP,NNG,GRNOD,MS,IN)
-	  ELSE 
-             CALL SEND_MASS_RBY_C(IDP,NNG,GRNOD,MS,IN,NPBY,
-     .        	NRBODY,RBY,TAG_RBY,ADD_RBY(IEX),NNPBY,NRBY)
+          IF (RBYLNK(IEX)==1) THEN
+            CALL SEND_MASS_RBY_C(IDP,NNG,GRNOD,MS,IN,NPBY,
+     .        	                 NRBODY,RBY,TAG_RBY,ADD_RBY(IEX),NNPBY,NRBY)        
+          ELSEIF (NLLNK(IEX)==1) THEN
+C---------- Coupling of non local dof
+            MSNL  => NLOC_DMG%MASS(1:NLOC_DMG%L_NLOC) 
+            CALL SEND_MASS_NL_C(IDP,NBDOF_NL(IEX),IADD_NL,MSNL)
+	  ELSE
+            CALL SEND_MASS_C(IDP,NNG,GRNOD,MS,IN)
           ENDIF     
         END DO
 C        
@@ -273,17 +314,20 @@ C
             IDP  = IEXLNK(2,IEX)
             NNG  = IGRNOD(IDG)%NENTITY
             GRNOD => IGRNOD(IDG)%ENTITY
-	    IF (RBYLNK(IEX)==0) THEN
-              CALL GET_MASS_C(IDP,NNG,GRNOD,MS,IN)
-	    ELSE   
+            IF (RBYLNK(IEX)==1) THEN  
               CALL GET_MASS_RBY_C(IDP,NNG,GRNOD,MS,IN,X,NPBY,
-     .        	NRBODY,RBY,NNPBY,NRBY)
+     .        	                  NRBODY,RBY,NNPBY,NRBY)
               CALL R2R_RBY(NNG,ITAB,GRNOD,X,MS,IN,NPBY,RBY,
-     .        	XDP,1,WEIGHT)     
-            ENDIF     
-          END DO        
+     .                     XDP,1,WEIGHT)
+            ELSEIF (NLLNK(IEX)==1) THEN
+C---------- Coupling of non local dof - mass not modifed - 
+              CALL SEND_IBUF_C(IDP,1) 
+	    ELSE
+              CALL GET_MASS_C(IDP,NNG,GRNOD,MS,IN)   
+            ENDIF  
+          END DO      
 C
-C---------------Synchronisation--------------------------------C
+C---------------Synchronisation (not needed for NL coupling)------C
           IF (NSPMD>1) THEN             
             IF (SDD_R2R_ELEM>0) THEN 
              SIZE =  3 + IRODDL*3         

--- a/engine/source/coupling/rad2rad/rad2rad_c.c
+++ b/engine/source/coupling/rad2rad/rad2rad_c.c
@@ -356,7 +356,6 @@ void syserr();
          com->vx_buf = shm + offset + 19*local_len;
          com->vr_buf = shm + offset + 22*local_len;
          com->dx_buf = shm + offset + 25*local_len;
-     
          com->buf    = shmi + offseti ;
          com->itagr  = shmi + offseti + 10;
          com->itagr2 = shmi + offseti + 10 + local_len;
@@ -674,6 +673,72 @@ void _FCALL init_link_c__(igd, nng, itab, nodbuf, x,addcnel,cnel,ixc,ofc,info,ty
 int *igd, *nng, *nodbuf, *itab,*addcnel,*cnel,*ixc,*ofc,*info,*typ,*cdt,*cdr,*print,*rddl,*nlink;
 my_real_c *x,*dx;
 {init_link_c(igd, nng, itab, nodbuf, x,addcnel,cnel,ixc,ofc,info,typ,cdt,cdr,print,rddl,nlink,dx);}
+
+void init_link_nl_c(igd, nng, itab, nodbuf, x,print,dx,ndof_nl,nb_tot_dof)
+int *igd, *nng, *nodbuf, *itab,*print,*ndof_nl,*nb_tot_dof;
+my_real_c *x,*dx;
+{
+int i,j,tt,nn,lbuf,lbuf1,init_buf[6],id;
+int *nodid,*bcs;
+my_real_c *crd;
+
+    /************************coupling for non local dof***************************/
+    /*****************************************************************************/
+    lbuf = *nb_tot_dof*sizeof(my_real_c);
+    crd  = (my_real_c *) malloc(3*lbuf);
+    lbuf1  = *nb_tot_dof*sizeof(int);   
+    nodid  = (int *) malloc(lbuf1);
+    bcs  = (int *) malloc(lbuf1);
+    printf("lbuf %d %d %d\n",*nb_tot_dof,lbuf,lbuf1);
+        
+    tt = 0;
+    for (i = 0; i < *nng; i++)
+      {
+        nn = nodbuf[i]-1;
+        for (j = 0; j < ndof_nl[i]; j++)
+          {
+           crd[3*tt]   = x[3*nn]-dx[3*nn];        
+           crd[3*tt+1] = x[3*nn+1]-dx[3*nn+1];
+           crd[3*tt+2] = x[3*nn+2]-dx[3*nn+2];        
+           nodid[tt]   = itab[nn]+10000*j;
+           bcs[tt] = 0;
+           tt++;
+          }    
+      }
+
+    id = *igd;                            
+    init_buf[0] = *igd;
+    init_buf[1] = *nb_tot_dof;
+    init_buf[2] = 0 ;
+    init_buf[3] = 0 ;
+    init_buf[4] = 0 ;    
+    init_buf[5] = *print;        
+                    
+    writer(fidw, (void *) init_buf,6*sizeof(int));                            
+    writer(fidw, (void *) nodid, lbuf1);
+    writer(fidw, (void *) bcs, lbuf1);
+    writer(fidw, (void *) crd, 3*lbuf);                      
+}
+
+void _FCALL  INIT_LINK_NL_C (igd, nng, itab, nodbuf, x,print,dx,ndof_nl,nb_tot_dof)
+int *igd, *nng, *nodbuf, *itab,*print,*ndof_nl,*nb_tot_dof;
+my_real_c *x,*dx;
+{
+    init_link_nl_c(igd, nng, itab, nodbuf, x,print,dx,ndof_nl,nb_tot_dof);
+}
+
+void _FCALL init_link_nl_c_(igd, nng, itab, nodbuf, x,print,dx,ndof_nl,nb_tot_dof)
+int *igd, *nng, *nodbuf, *itab,*print,*ndof_nl,*nb_tot_dof;
+my_real_c *x,*dx;
+{
+    init_link_nl_c(igd, nng, itab, nodbuf, x,print,dx,ndof_nl,nb_tot_dof);
+}
+
+void _FCALL init_link_nl_c__(igd, nng, itab, nodbuf, x,print,dx,ndof_nl,nb_tot_dof)
+int *igd, *nng, *nodbuf, *itab,*print,*ndof_nl,*nb_tot_dof;
+my_real_c *x,*dx;
+{init_link_nl_c(igd, nng, itab, nodbuf, x,print,dx,ndof_nl,nb_tot_dof);}
+
 
 void init_buf_spmd_c(igd, nng, itab, nodbuf, x,addcnel,cnel,ixc,ofc,tlel,lel,lelnb,tleln,leln,nbelem,tcnel,cnelem2,wgt,tcneldb,cnelemdb,info,typ,nglob)
 int *igd, *nng, *nodbuf, *itab,*addcnel,*cnel,*ixc,*ofc,*tlel,*lel,*lelnb,*tleln,*leln,*nbelem,*tcnel,*cnelem2,*wgt,*tcneldb,*cnelemdb,*info,*typ,*nglob;
@@ -1123,7 +1188,45 @@ int *idp, *nng, *nodbuf;
 my_real_c *ms, *in;
 {send_mass_c(idp, nng, nodbuf, ms, in);}
 
+void send_mass_nl_c(idp, nng, iadd_nl, ms)
+int *idp, *nng, *iadd_nl;
+my_real_c *ms;
+{
+int i, j,nn, lbuf, flag;
+my_real_c *mbuf;
 
+    writer(fidw, (void *) idp, sizeof(int));    
+    readr(fidr, (void *) &flag, sizeof(int));
+    flagrot[*idp]=0;
+    
+    lbuf = *nng*sizeof(my_real_c);
+    mbuf = (my_real_c *) malloc(lbuf);
+
+    for (i = 0; i < *nng; i++)
+      {
+       mbuf[i] = ms[iadd_nl[i]-1];
+      }
+    
+    writer(fidw, (void *) mbuf, lbuf);    
+    free(mbuf);
+}
+
+void _FCALL SEND_MASS_NL_C(idp, nng, iadd_nl, ms)
+int *idp, *nng, *iadd_nl;
+my_real_c *ms;
+{
+    send_mass_nl_c(idp, nng, iadd_nl, ms);
+}
+void send_mass_nl_c_(idp, nng, iadd_nl, ms)
+int *idp, *nng, *iadd_nl;
+my_real_c *ms;
+{
+    send_mass_nl_c(idp, nng, iadd_nl, ms);
+}
+void send_mass_nl_c__(idp, nng, iadd_nl, ms)
+int *idp, *nng, *iadd_nl;
+my_real_c *ms;
+{send_mass_nl_c(idp, nng, iadd_nl, ms);}
 
 void send_mass_rby_c(idp, nng, nodbuf, ms, in, npby, nrbody, rby, tag, add_rby, nnpby, nrby)
 int *idp, *nng, *nodbuf, *nrbody, *npby, *tag, *add_rby, *nnpby, *nrby;
@@ -1565,6 +1668,56 @@ double *dx, *dr;
 {send_data_c(idp, nng, nodbuf, fx, fr, stx, str, vx,  vr,  ms,  in,  dx, x, typ, npas, rby, tag_rby, add_rby, rbylnk, kin, dr, dt2, iex, off_sph, numsph_glo, nrby);}
 /******************************************************************/
 
+void send_data_nl_c(idp, nng, iadd_nl, fx, vx,  ms, npas, iex)
+int *idp, *nng, *iadd_nl, *npas, *iex;
+my_real_c *fx, *vx, *ms;
+{
+int rest, next, chunk;
+int i;
+
+    rest = *nng;
+    chunk = rest / nthreads;
+
+    #pragma omp parallel for schedule(static,chunk) if (chunk>350) private(i)                                
+    for (next = 0; next < rest; next++)
+      {
+       i = next;
+       com->mass_buf[off_link+i] = ms[iadd_nl[i]-1];
+       com->fx_buf[3*(off_link+i)] = fx[iadd_nl[i]-1];    
+      }
+
+    if (*npas==0)    
+      {
+        #pragma omp parallel for schedule(static,chunk) if (chunk>350) private(i)                                
+        for (next = 0; next < rest; next++)
+          {
+           i = next;
+           com->vx_buf[3*(off_link+i)] = vx[iadd_nl[i]-1];
+          }              
+      }
+             
+    off_link += rest;     
+}
+
+/******************************************************************/
+void _FCALL SEND_DATA_NL_C(idp, nng, iadd_nl, fx, vx,  ms, npas, iex)
+int *idp, *nng, *iadd_nl, *npas, *iex;
+my_real_c *fx, *vx, *ms;
+{
+    send_data_nl_c(idp, nng, iadd_nl, fx, vx,  ms, npas, iex);
+}
+void send_data_nl_c_(idp, nng, iadd_nl, fx, vx,  ms, npas, iex)
+int *idp, *nng, *iadd_nl, *npas, *iex;
+my_real_c *fx, *vx, *ms;
+{
+    send_data_nl_c(idp, nng, iadd_nl, fx, vx,  ms, npas, iex);
+}
+void send_data_nl_c__(idp, nng, iadd_nl, fx, vx,  ms, npas, iex)
+int *idp, *nng, *iadd_nl, *npas, *iex;
+my_real_c *fx, *vx, *ms;
+{send_data_nl_c(idp, nng, iadd_nl, fx, vx,  ms, npas, iex);}
+/******************************************************************/
+
 /* el51g1+++ */
 void send_data_spmd_c(idp, nng, bufr1, bufr2, bufr3, bufr4, bufr5, bufr6, bufr7, bufr8, bufr9, buf_rby, flg_rby, typ, npas, iex)
 int *idp, *nng, *typ, *npas, *flg_rby, *iex;
@@ -1818,6 +1971,43 @@ int *idp, *nng, *nodbuf, *typ, *kin, *wgt, *iex, *iresp;
 my_real_c *wf, *wm, *wf2, *wm2, *v, *vr, *fx, *fr, *ms, *in, *x, *dx;
 double *xdp,*tfext;
 {    get_force_c(idp, nng, nodbuf, wf, wm, wf2, wm2, v, vr, fx, fr, ms, in, x, xdp, dx, typ, kin, wgt, iex, iresp, tfext);}
+/******************************************************************/
+
+void get_force_nl_c(idp, nng, iadd_nl, fx, ms, iex)
+int *idp, *nng, *iadd_nl, *iex;
+my_real_c *fx, *ms;
+{
+int rest, next;
+int i, chunk;
+
+    rest = *nng;
+
+    if (*iex == 1) off_link = 0;
+                   
+    chunk = rest / nthreads;            
+    #pragma omp parallel for schedule(static,chunk) if (chunk>350) private(i)
+    for (next = 0; next < rest; next++)
+      {
+       i = next;
+       fx[iadd_nl[i]-1] = com->fx_buf[3*(off_link+i)]*ms[iadd_nl[i]-1];    
+      }       
+
+      off_link += rest;          
+}
+
+/******************************************************************/
+void _FCALL GET_FORCE_NL_C(idp, nng, iadd_nl, fx, ms, iex)
+int *idp, *nng, *iadd_nl, *iex;
+my_real_c *fx, *ms;
+{    get_force_nl_c(idp, nng, iadd_nl, fx, ms, iex);}
+void get_force_nl_c_(idp, nng, iadd_nl, fx, ms, iex)
+int *idp, *nng, *iadd_nl, *iex;
+my_real_c *fx, *ms;
+{    get_force_nl_c(idp, nng, iadd_nl, fx, ms, iex);}
+void get_force_nl_c__(idp, nng, iadd_nl, fx, ms, iex)
+int *idp, *nng, *iadd_nl, *iex;
+my_real_c *fx, *ms;
+{    get_force_nl_c(idp, nng, iadd_nl, fx, ms, iex);}
 /******************************************************************/
 
 void get_force_spmd_c(idp, nng, bufr1, bufr2, bufr3, bufr4, typ, iex, nglob)

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -5814,7 +5814,8 @@ C--- COUPLAGE RADIOSS 2 RADIOSS
      1        IEXLNK   ,IGRNOD  ,D       ,V       ,VR     ,
      2        A        ,AR      ,MS      ,IN     ,STIFN   ,STIFR  ,
      3        R2R_ON   ,DD_R2R  ,WEIGHT ,IAD_ELEM,FR_ELEM ,RBY    ,
-     4        XDP, X,DD_R2R_ELEM , SDD_R2R_ELEM,OFF_SPH_R2R,NUMSPH_GLO_R2R)
+     4        XDP      ,X       ,DD_R2R_ELEM, SDD_R2R_ELEM,OFF_SPH_R2R,
+     5        NUMSPH_GLO_R2R,NLOC_DMG)
 C
           IF (FLG_SPHINOUT_R2R/=0) THEN
             DO I=1,NUMNOD
@@ -6464,7 +6465,7 @@ C--------------------------------------------------------------C
      .                    VR      ,A       ,AR      ,MS      ,IN      ,
      .                    XDP     ,D       ,R2R_ON  ,DD_R2R  ,WEIGHT  ,
      .                    IAD_ELEM,FR_ELEM ,STIFN   ,STIFR   ,DD_R2R_ELEM  ,
-     .                    SDD_R2R_ELEM)
+     .                    SDD_R2R_ELEM,NLOC_DMG)
 
          IF (IMONM > 0) CALL STOPTIME(54,1)  
         

--- a/engine/source/engine/resol_init.F
+++ b/engine/source/engine/resol_init.F
@@ -446,7 +446,7 @@ C
      3                  FR_ELEM,ADDCNEL,CNEL,IXC,IPARG,ICODT,ICODR,
      4                  IBFV,D,RBY,NPBY,XDP,STIFN,STIFR,DD_R2R_ELEM,
      5                  SDD_R2R_ELEM,WEIGHT_MD,ILENXV,NUMSPH_GLO_R2R,
-     6                  FLG_SPHINOUT_R2R,IPARI)
+     6                  FLG_SPHINOUT_R2R,IPARI,NLOC_DMG)
         END IF
 C
         NFIA = NUMNOD*MIN(1,ANIM_V(4)+OUTP_V(4)+H3D_DATA%N_VECT_CONT)

--- a/engine/source/output/restart/read_nloc_struct.F
+++ b/engine/source/output/restart/read_nloc_struct.F
@@ -46,6 +46,7 @@ C-----------------------------------------------
 #include      "com01_c.inc"
 #include      "com04_c.inc"
 #include      "scr02_c.inc"
+#include      "rad2r_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
@@ -54,7 +55,7 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,ILOC,NNOD,L_NLOC,NUMELS_NL,NUMELC_NL,NDDMAX,
-     .        NUMELTG_NL,LCNE_NL
+     .        NUMELTG_NL,LCNE_NL,MATSIZE
       my_real, DIMENSION(:), POINTER :: FNL,STIFNL
       INTEGER, DIMENSION(8)  :: 
      .  HEAD
@@ -82,11 +83,18 @@ c
 c
       IF (ILOC > 0) THEN
 c
-        ALLOCATE (NLOC_DMG%LEN(NUMMAT))
-        ALLOCATE (NLOC_DMG%LE_MAX(NUMMAT))
-        ALLOCATE (NLOC_DMG%DENS(NUMMAT))
-        ALLOCATE (NLOC_DMG%DAMP(NUMMAT))
-        ALLOCATE (NLOC_DMG%SSPNL(NUMMAT))
+        IF (R2R_SIU > 0) THEN
+C--       multidomains - origianl nummat is used
+          MATSIZE = NUMMAT0 
+        ELSE
+          MATSIZE = NUMMAT 
+        ENDIF
+c
+        ALLOCATE (NLOC_DMG%LEN(MATSIZE))
+        ALLOCATE (NLOC_DMG%LE_MAX(MATSIZE))
+        ALLOCATE (NLOC_DMG%DENS(MATSIZE))
+        ALLOCATE (NLOC_DMG%DAMP(MATSIZE))
+        ALLOCATE (NLOC_DMG%SSPNL(MATSIZE))
         ALLOCATE (NLOC_DMG%INDX(NNOD))
         ALLOCATE (NLOC_DMG%POSI(NNOD+1))
         ALLOCATE (NLOC_DMG%IDXI(NUMNOD))
@@ -141,15 +149,15 @@ c
           ENDIF
         ENDIF
 c
-        CALL READ_DB(NLOC_DMG%DENS,NUMMAT)
+        CALL READ_DB(NLOC_DMG%DENS,MATSIZE)
 c
-        CALL READ_DB(NLOC_DMG%DAMP,NUMMAT)
+        CALL READ_DB(NLOC_DMG%DAMP,MATSIZE)
 c
-        CALL READ_DB(NLOC_DMG%LEN,NUMMAT)
+        CALL READ_DB(NLOC_DMG%LEN,MATSIZE)
 c
-        CALL READ_DB(NLOC_DMG%LE_MAX,NUMMAT)
+        CALL READ_DB(NLOC_DMG%LE_MAX,MATSIZE)
 c
-        CALL READ_DB(NLOC_DMG%SSPNL,NUMMAT)
+        CALL READ_DB(NLOC_DMG%SSPNL,MATSIZE)
 c        
         CALL READ_I_C(NLOC_DMG%INDX,NNOD)
 c        

--- a/starter/source/coupling/rad2rad/new_link.F
+++ b/starter/source/coupling/rad2rad/new_link.F
@@ -80,8 +80,9 @@ C----- Storage of new link information
        IEX_TEMP(3,NR2RLNK+1) = 0
        IEX_TEMP(4,NR2RLNK+1) = N	    	    	                 
        IEX_TEMP(5,NR2RLNK+1) = 4
-       IF (K == 2) IEX_TEMP(5,NR2RLNK+1) = 40
-       IF ((K == 3).OR.(K == 4)) THEN
+       IF (K == 2) THEN
+         IEX_TEMP(5,NR2RLNK+1) = 40
+       ELSEIF ((K == 3).OR.(K == 4)) THEN
          IF (FLG_SWALE==0) THEN
 C--> contact with void elements in subdomain - order of domains is inverted
            IEX_TEMP(3,NR2RLNK+1) = N
@@ -91,6 +92,8 @@ C--> contact with void elements in subdomain - order of domains is inverted
          ELSE
            IEX_TEMP(5,NR2RLNK+1) = 60
          ENDIF
+       ELSEIF (K == 5) THEN
+         IEX_TEMP(5,NR2RLNK+1) = 70       
        ENDIF
                 
 C----- Generation of a new link

--- a/starter/source/coupling/rad2rad/r2r_domdec.F
+++ b/starter/source/coupling/rad2rad/r2r_domdec.F
@@ -119,27 +119,29 @@ C------ Information for speedup computation
 C------      
         DO I=1,NR2RLNK      		
           IDG = IEXTER(1,I)
-          DO J=1,IGRNOD(IDG)%NENTITY
-            NJ = IGRNOD(IDG)%ENTITY(J)
-            FL_EXIT = 0
-            SPLIST=0  
-	    CALL PLIST_IFRONT(PLIST,NJ,SPLIST)
+C--  70 -> nlocal link - nodes already defined in link type 4  
+          IF (IEXTER(5,I) /= 70) THEN
+            DO J=1,IGRNOD(IDG)%NENTITY
+              NJ = IGRNOD(IDG)%ENTITY(J)
+              FL_EXIT = 0
+              SPLIST=0  
+	      CALL PLIST_IFRONT(PLIST,NJ,SPLIST)
 C
-            WRITE(REF,1302,IOSTAT=ERR) ITAB(NJ),SPLIST
-	    DO L=1,SPLIST
-              K = PLIST(L)	   
-              WRITE(REF,1303,IOSTAT=ERR) (K)
-              IF (ERR/=0) THEN
-                CALL ANCMSG(MSGID=950,
-     .          MSGTYPE=MSGERROR,
-     .          ANMODE=ANINFO_BLIND_1)
-                FL_EXIT = 1                
-                EXIT
-              ENDIF
-            ENDDO
-C
-            IF (FL_EXIT==1) EXIT            
-          END DO
+              WRITE(REF,1302,IOSTAT=ERR) ITAB(NJ),SPLIST
+	      DO L=1,SPLIST
+                K = PLIST(L)	   
+                WRITE(REF,1303,IOSTAT=ERR) (K)
+                IF (ERR/=0) THEN
+                  CALL ANCMSG(MSGID=950,
+     .            MSGTYPE=MSGERROR,
+     .            ANMODE=ANINFO_BLIND_1)
+                  FL_EXIT = 1                
+                  EXIT
+                ENDIF
+              ENDDO
+              IF (FL_EXIT==1) EXIT            
+            END DO
+          ENDIF
         END DO
 C
         CLOSE(UNIT=REF,STATUS='KEEP')
@@ -155,27 +157,30 @@ C------ Information for speedup computation
 C
         DO I=1,NR2RLNK      		
           IDG = IEXTER(1,I)
-          DO J=1,IGRNOD(IDG)%NENTITY
-            FL_EXIT = 0
-            READ(REF,1302,IOSTAT=ERR) NJS,SPLIST
-            NJ = USR2SYS(NJS,ITABM1,MESS,0)
-            DO K=1,NSPMD
-               FRONTB_R2R(NJ,K) = IDG 
-            END DO     
-            DO L=1,SPLIST	   
-              READ(REF,1303,IOSTAT=ERR) K
-              IF (ERR/=0) THEN
-                CALL ANCMSG(MSGID=950,
-     .          MSGTYPE=MSGERROR,
-     .          ANMODE=ANINFO_BLIND_1)                
-                FL_EXIT = 1
-                EXIT                
-              ENDIF
-              FRONTB_R2R(NJ,K) = -1                              
-              IF (NLOCAL(NJ,K)/=1) CALL IFRONTPLUS(NJ,K)               
-            ENDDO
-            IF (FL_EXIT==1) EXIT
-          END DO                      
+C--  70 -> nlocal link - nodes already defined in link type 4 
+          IF (IEXTER(5,I) /= 70) THEN
+            DO J=1,IGRNOD(IDG)%NENTITY
+              FL_EXIT = 0
+              READ(REF,1302,IOSTAT=ERR) NJS,SPLIST
+              NJ = USR2SYS(NJS,ITABM1,MESS,0)
+              DO K=1,NSPMD
+                 FRONTB_R2R(NJ,K) = IDG 
+              END DO     
+              DO L=1,SPLIST	   
+                READ(REF,1303,IOSTAT=ERR) K
+                IF (ERR/=0) THEN
+                  CALL ANCMSG(MSGID=950,
+     .            MSGTYPE=MSGERROR,
+     .            ANMODE=ANINFO_BLIND_1)                
+                  FL_EXIT = 1
+                  EXIT                
+                ENDIF
+                FRONTB_R2R(NJ,K) = -1                              
+                IF (NLOCAL(NJ,K)/=1) CALL IFRONTPLUS(NJ,K)               
+              ENDDO
+              IF (FL_EXIT==1) EXIT
+            END DO    
+          ENDIF                  
         END DO
         CLOSE(UNIT=REF,STATUS='KEEP')     
         

--- a/starter/source/coupling/rad2rad/r2r_group.F
+++ b/starter/source/coupling/rad2rad/r2r_group.F
@@ -51,7 +51,8 @@ Chd|====================================================================
      4           INOM_OPT,IPART_L,IAD,NALE_R2R,FLG_R2R_ERR ,
      5           PM_STACK ,IWORKSH  ,IGRBRIC2,IGRQUAD2  ,IGRSH4N2,
      6           IGRSH3N2 ,IGRTRUSS2,IGRBEAM2,IGRSPRING2,IGRNOD2 ,
-     7           IGRSURF2 ,IGRSLIN2,LSUBMODEL,ALE_EULER,IGEO_)
+     7           IGRSURF2 ,IGRSLIN2,LSUBMODEL,ALE_EULER,IGEO_,
+     7           NLOC_DMG)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -63,6 +64,7 @@ C-----------------------------------------------
       USE INOUTFILE_MOD
       USE SUBMODEL_MOD
       USE INIVOL_ARRAY_MOD
+      USE NLOCAL_REG_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -97,6 +99,7 @@ C-----------------------------------------------
      .   IPARTG(*),IXR_KJ(*),INOM_OPT(*),IPART_L(*),IAD,
      .   NALE_R2R(*),FLG_R2R_ERR,IWORKSH(*),ALE_EULER
       my_real :: PM_STACK(*)
+      TYPE (NLOCAL_STR_) ,INTENT(IN)  :: NLOC_DMG
 C-----------------------------------------------
 !      TYPE (GROUP_)  , DIMENSION(NGRNOD)  :: IGRNOD2
       TYPE (GROUP_)  , DIMENSION(NGROU)   :: IGRNOD2
@@ -107,7 +110,6 @@ C-----------------------------------------------
       TYPE (GROUP_)  , DIMENSION(NGRTRUS) :: IGRTRUSS2
       TYPE (GROUP_)  , DIMENSION(NGRBEAM) :: IGRBEAM2
       TYPE (GROUP_)  , DIMENSION(NGRSPRI) :: IGRSPRING2
-!
       TYPE (SURF_)   , DIMENSION(NSURF)   :: IGRSURF2
       TYPE (SURF_)   , DIMENSION(NSLIN)   :: IGRSLIN2
 C-----------------------------------------------
@@ -117,13 +119,13 @@ C-----------------------------------------------
       INTEGER ID_TEMP(NB_PART_SUB),NSUBDOM_LOC,P,TMP_PART(NPART)
       INTEGER, DIMENSION(:,:), ALLOCATABLE :: IGROUP_TEMP2
       INTEGER N_LNK_C,NI,GRM,GRS,MAIN,IGU,NUL,IAD_TMP,COMPT_T2
-      INTEGER MODIF,NINTER_PREC,FAC,IO_ERR,NUM_KJ,NSPCONDN,NSPHION
+      INTEGER MODIF,NINTER_PREC,FAC,IO_ERR,NUM_KJ,NSPCONDN,NSPHION,NN
       INTEGER MEMTR(NUMNOD),FLG_SPH,COUNT,NEW_NSLASH_INT,NEW_HM_NINTER,NEW_NINTSUB,NEW_NINIVOL
       CHARACTER TITR*nchartitle,NAME*100
       INTEGER NGRNOD2,NGRBRIC2,NGRQUAD2,NGRSHEL2,NGRSH3N2,NGRTRUS2,NGRBEAM2,NGRSPRI2,LENGRN,ITITLE(LTITR)
       CHARACTER NEW_TITLE(NGROU+10*NSUBDOM)*nchartitle
 
-      INTEGER, DIMENSION(:), ALLOCATABLE :: IGROUP_TEMP2_BUF
+      INTEGER, DIMENSION(:), ALLOCATABLE :: IGROUP_TEMP2_BUF,TAG_NLOCAL
       INTEGER :: LEN_TMP_NAME
       CHARACTER(len=4096) :: TMP_NAME
 C-----------------------------------------------
@@ -417,17 +419,42 @@ C--------------------------------------------------------------------C
 C---------------FLAG = 1 --> Creation of groups and links------------C
 C--------------------------------------------------------------------C
           INNOD = 0
-          DO K=1,4
+          NN = 4
+C
+C---------------Tag of nodes with nlocal dof-------------------------C
+          IF (NLOC_DMG%IMOD > 0) THEN
+            NN = 5
+            MY_ALLOCATE(TAG_NLOCAL,NUMNOD)
+            TAG_NLOCAL(1:NUMNOD) = 0
+            CALL TAGNOD_R2R_NL(IXC,IXTG,IXS,IXS10,IXS20,
+     .                         IXS16,TAG_NLOCAL,IPM)
+          ENDIF
+C
+          DO K=1,NN
             COMPT = 0
             IAD_TMP = IAD
-C---------------Storage inside buffer--------------------------------C	
-            DO J=1,NUMNOD
-              IF (TAGNO(J+NPART)==(K+N)) THEN 
-                BUF_NOD(IAD)=J
-                IAD=IAD+1
-                COMPT = COMPT+1	        
-              ENDIF
-            ENDDO
+C-----------Storage inside buffer------------------------------------C
+            IF (K < 5) THEN
+              DO J=1,NUMNOD	     
+                IF (TAGNO(J+NPART)==(K+N)) THEN 
+                  BUF_NOD(IAD)=J
+                  IAD=IAD+1
+                  COMPT = COMPT+1	        
+                ENDIF
+              ENDDO
+            ELSE
+C-----------Nodes in link type 4 + nlocal dof -> aditional link------C
+C-----------Node coupled only if nl material on both sides ----------C 
+              DO J=1,NUMNOD
+                IF ((TAG_NLOCAL(J)==1).AND.(TAGNO(J+NPART+NUMNOD) == N+1)) THEN
+                  BUF_NOD(IAD)=J
+                  IAD=IAD+1
+                  COMPT = COMPT+1	        
+                ENDIF
+              ENDDO
+              DEALLOCATE(TAG_NLOCAL)
+            ENDIF
+C
             INNOD = INNOD + COMPT   
             IF (COMPT>0) THEN
 C---------------Creation of new GRNOD + LINK ------------------------C
@@ -436,7 +463,9 @@ C---------------Creation of new GRNOD + LINK ------------------------C
               ELSEIF (K == 2) THEN
                 TITR="MULTIDOMAINS INTERFACE TYPE RBODY CONNECTION "
               ELSEIF (K == 4) THEN
-                TITR="MULTIDOMAINS INTERFACE TYPE KINEMATIC CONDITION"                
+                TITR="MULTIDOMAINS INTERFACE TYPE KINEMATIC CONDITION"
+              ELSEIF (K == 5) THEN
+                TITR="MULTIDOMAINS INTERFACE TYPE NON LOCAL"                 
               ELSE 
                 TITR="MULTIDOMAINS INTERFACE TYPE CONTACT "   
               ENDIF

--- a/starter/source/coupling/rad2rad/r2r_input.F
+++ b/starter/source/coupling/rad2rad/r2r_input.F
@@ -142,7 +142,11 @@ C--->  type = 60 -> interface type FSI------------------ -----
           ELSE
             WRITE(REF,1340) TLK
           ENDIF
-          WRITE(REF,*) ' 0.1'         
+          WRITE(REF,*) ' 0.1'
+        ELSEIF (IEXTER(5,I)==70) THEN
+C--->  type = 70 -> interface type NLOCAL--------------- -----
+          TLK = 4	 
+          WRITE(REF,1360) TLK        
 	ELSEIF (FLG_TIED(IEXTER(5,I))==1) THEN
 	  WRITE(REF,1320) IEXTER(5,I)           
 	ELSE
@@ -187,6 +191,7 @@ C--------------------------------------------------------------C
  1330 FORMAT('/LINK/TYPE',I1,'/KINE')
  1340 FORMAT('/LINK/TYPE',I1,'/FSI')
  1350 FORMAT('/LINK/TYPE',I1,'/TIED/FSI')
+ 1360 FORMAT('/LINK/TYPE',I1,'/NLOCAL')
  1400 FORMAT('',A10)
  1500 FORMAT(  3X,10I5)
  1600 FORMAT('   ',A10,I10)

--- a/starter/source/coupling/rad2rad/tagnod_r2r_nl.F
+++ b/starter/source/coupling/rad2rad/tagnod_r2r_nl.F
@@ -1,0 +1,139 @@
+Copyright>        OpenRadioss
+Copyright>        Copyright (C) 1986-2022 Altair Engineering Inc.
+Copyright>    
+Copyright>        This program is free software: you can redistribute it and/or modify
+Copyright>        it under the terms of the GNU Affero General Public License as published by
+Copyright>        the Free Software Foundation, either version 3 of the License, or
+Copyright>        (at your option) any later version.
+Copyright>    
+Copyright>        This program is distributed in the hope that it will be useful,
+Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+Copyright>        GNU Affero General Public License for more details.
+Copyright>    
+Copyright>        You should have received a copy of the GNU Affero General Public License
+Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+Copyright>    
+Copyright>    
+Copyright>        Commercial Alternative: Altair Radioss Software 
+Copyright>    
+Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss 
+Copyright>        software under a commercial license.  Contact Altair to discuss further if the 
+Copyright>        commercial version may interest you: https://www.altair.com/radioss/.  
+Chd|====================================================================
+Chd|  TAGNODS_R2R                   source/coupling/rad2rad/tagnod_r2r.F
+Chd|-- called by -----------
+Chd|        R2R_GROUP                     source/coupling/rad2rad/r2r_group.F
+Chd|-- calls ---------------
+Chd|        ANCMSG                        source/output/message/message.F
+Chd|        MESSAGE_MOD                   share/message_module/message_mod.F
+Chd|====================================================================
+      SUBROUTINE TAGNOD_R2R_NL(IXC,IXTG,IXS,IXS10,IXS20,IXS16,TAG_NLOCAL,IPM)
+C-----------------------------------------------
+C   M o d u l e s
+C-----------------------------------------------
+      USE MESSAGE_MOD
+C-----------------------------------------------
+C   I m p l i c i t   T y p e s
+C-----------------------------------------------
+#include      "implicit_f.inc"
+C-----------------------------------------------
+C   A n a l y s e   M o d u l e
+C-----------------------------------------------
+C-----------------------------------------------
+C   C o m m o n   B l o c k s
+C-----------------------------------------------
+#include      "com04_c.inc"
+#include      "param_c.inc"
+C-----------------------------------------------
+C   D u m m y   A r g u m e n t s
+C-----------------------------------------------
+      INTEGER, INTENT(IN)    :: IXC(NIXC,NUMELC),IXTG(NIXTG,NUMELTG),IXS(NIXS,NUMELS),IXS10(6,NUMELS10),
+     .                          IXS20(12,NUMELS20),IXS16(8,NUMELS16),IPM(NPROPMI,NUMMAT)
+      INTEGER, INTENT(INOUT) :: TAG_NLOCAL(NUMNOD)
+C-----------------------------------------------
+C   L o c a l   V a r i a b l e s
+C-----------------------------------------------
+      INTEGER I,J,L,NP,MID
+C=======================================================================
+C
+C-----------------------------------------------------------------------------------------------
+c-----Tag of nodes with non local dof-----------------------------------------------------------
+C-----------------------------------------------------------------------------------------------
+C
+C-----------------------------------------------------------------------------------------------
+      DO J=1,NUMELC
+        MID = IXC(1,J)
+        IF (IPM(253,MID) > 0)THEN
+          DO L=2,5
+	    TAG_NLOCAL(IXC(L,J))=1
+          ENDDO
+        ENDIF
+      ENDDO
+C-----------------------------------------------------------------------------------------------
+      DO J=1,NUMELTG
+        MID = IXTG(1,J)
+        IF (IPM(253,MID) > 0)THEN
+          DO L=2,4
+	    TAG_NLOCAL(IXTG(L,J))=1
+          ENDDO
+        ENDIF
+      ENDDO
+C-----------
+      DO J=1,NUMELS8
+        MID = IXS(1,J)
+        IF (IPM(253,MID) > 0)THEN
+          DO L=2,9
+	    TAG_NLOCAL(IXS(L,J))=1
+          ENDDO
+        ENDIF
+      ENDDO
+C-----------
+      DO I=1,NUMELS10
+        J = I + NUMELS8
+        MID = IXS(1,J)
+        IF (IPM(253,MID) > 0)THEN
+          DO L=2,9
+	    TAG_NLOCAL(IXS(L,J))=1
+          ENDDO
+          DO L=1,6
+            IF (IXS10(L,I) /= 0) THEN
+	      TAG_NLOCAL(IXS10(L,I))=1
+	    ENDIF
+          ENDDO
+        ENDIF
+      ENDDO
+C-----------
+      DO I=1,NUMELS20
+        J = I + NUMELS8 + NUMELS10
+        MID = IXS(1,J)
+        IF (IPM(253,MID) > 0)THEN
+          DO L=2,9
+	    TAG_NLOCAL(IXS(L,J)+NP)=1
+          ENDDO
+          DO L=1,12
+            IF (IXS20(L,I) /= 0) THEN
+	      TAG_NLOCAL(IXS20(L,I))=1
+	    ENDIF
+          ENDDO
+        ENDIF
+      ENDDO
+C-----------
+      DO I=1,NUMELS16
+        J = I + NUMELS8 + NUMELS10 + NUMELS20
+        MID = IXS(1,J)
+        IF (IPM(253,MID) > 0)THEN
+          DO L=2,9
+	    TAG_NLOCAL(IXS(L,J))=0
+          ENDDO
+          DO L=1,8
+            IF (IXS16(L,I) /= 0) THEN
+	      TAG_NLOCAL(IXS16(L,I))=0
+	    ENDIF
+          ENDDO
+	ENDIF
+      ENDDO
+C
+      RETURN
+C
+      END

--- a/starter/source/materials/fail/nloc_dmg_init.F
+++ b/starter/source/materials/fail/nloc_dmg_init.F
@@ -60,6 +60,7 @@ C-----------------------------------------------
 #include      "scr17_c.inc"
 #include      "units_c.inc"
 #include      "tabsiz_c.inc"
+#include      "r2r_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
@@ -85,7 +86,7 @@ C-----------------------------------------------
       INTEGER I,J,K,NG,NEL,NFT,ITY,NPTT,ILOC,INOD,NNOD,NDEPAR,IMAT,
      .        L_NLOC,POS,NDD,FORMU,N,NUMELS_NL,IGTYP,NUMELC_NL,NDDMAX,
      .        NUMELTG_NL,NPTR,NPTS,IR,IS,ISOLNOD,IO_ERR1,LEN_TMP_NAME,
-     .        WORK(70000),IDEB,IDEBS,IDEBC,IDEBT,IADBUF
+     .        WORK(70000),IDEB,IDEBS,IDEBC,IDEBT,IADBUF,MATSIZE
       INTEGER, DIMENSION(:,:), ALLOCATABLE :: TAGNOD
       INTEGER, DIMENSION(:),   ALLOCATABLE :: INDX,IDXI,NMAT,NDDL,
      .                                        POSI,ITRI,INDEX,TAGTET
@@ -94,10 +95,9 @@ C-----------------------------------------------
      .   DENS, DTMIN, LEN, SSPNL,NTH1, NTH2,
      .   Z01(11,11), WF1(11,11), ZN1(12,11),DAMP,WS,LE_MIN,
      .   DTSCA_AMS,DTSCA_CST_AMS,LE_MAX,SSP,
-     .   DTMINI_AMS,DTMINI_CST_AMS,DTMINI,
-     .   WARN_LENGHT(NUMMAT,3)
+     .   DTMINI_AMS,DTMINI_CST_AMS,DTMINI
       my_real, DIMENSION(:,:), ALLOCATABLE ::  
-     .   VOLN_S, VOLN_C, VOLN_TG
+     .   VOLN_S, VOLN_C, VOLN_TG, WARN_LENGHT
       my_real, DIMENSION(:)  , ALLOCATABLE ::  
      .   VOLN, VOLU
       my_real ,DIMENSION(:)  , POINTER     :: 
@@ -244,6 +244,14 @@ c
         ALLOCATE( TAGTET(NUMELS) )
         ALLOCATE( INDEX(NUMELS+NUMELC+NUMELTG) )
         ALLOCATE( ITRI(NUMELS+NUMELC+NUMELTG) )
+C
+        IF (NSUBDOM > 0) THEN
+C--       multidomains - origianl nummat is used
+          MATSIZE = NUMMAT0
+        ELSE
+          MATSIZE = NUMMAT
+        ENDIF
+        MY_ALLOCATE2D(WARN_LENGHT,MATSIZE,3)
 c   
         ! Initialization of variables   
         VOLN_S(1:8,1:NUMELS)   = ZERO
@@ -259,7 +267,7 @@ c
         NUMELC_NL  = 0
         NUMELTG_NL = 0
         NDDMAX     = 0
-        WARN_LENGHT(1:NUMMAT,1:3) = ZERO
+        WARN_LENGHT(1:MATSIZE,1:3) = ZERO
 c     
         ! Computation of the volume of elements 
         DO NG=1,NGROUP
@@ -614,7 +622,7 @@ C
         ENDDO
 c
         ! Checking non-local length consistency with mesh size
-        DO I = 1, NUMMAT
+        DO I = 1, MATSIZE
           IF (WARN_LENGHT(I,1) > ZERO) THEN
             CALL ANCMSG(MSGID=1812,MSGTYPE=MSGWARNING,
      .         ANMODE=ANINFO_BLIND_1,I1=IPM(1,I),R1=NLOC_DMG%LEN(I),
@@ -624,7 +632,7 @@ c
 c
         ! Printing out non-local parameters
         WRITE(IOUT,1800)
-        DO I = 1, NUMMAT
+        DO I = 1, MATSIZE
           IF (NLOC_DMG%DENS(I) > ZERO) THEN 
             WRITE(IOUT,1900) IPM(1,I),NLOC_DMG%LEN(I),NLOC_DMG%LE_MAX(I),NLOC_DMG%DENS(I),NLOC_DMG%DAMP(I)
           ENDIF

--- a/starter/source/restart/ddsplit/write_nloc_struct.F
+++ b/starter/source/restart/ddsplit/write_nloc_struct.F
@@ -45,6 +45,7 @@ C-----------------------------------------------
 #include      "com01_c.inc"
 #include      "com04_c.inc"
 #include      "param_c.inc"
+#include      "r2r_c.inc"
 C-----------------------------------------------
 C   C o m m o n   B l o c k s
 C-----------------------------------------------
@@ -63,7 +64,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,ILOC,NNOD,NNOD_L,NG,NL,NN, LNLOC_L,ND,NP,NM,N1,
      .        N2,NNO,CC,CC_L,NUMG,NUML,PROC_L,K,SHFT,TESTVAL,
-     .        L_NLOC,NDDMAX_L,OFF,LENBIS,LCNENL_L
+     .        L_NLOC,NDDMAX_L,OFF,LENBIS,LCNENL_L,MATSIZE
       INTEGER, DIMENSION(NUMNOD_L)   :: INDX_L, NDDL, IDXI_L
       INTEGER, DIMENSION(NUMNOD_L+1) :: POSI
       my_real, DIMENSION(NLOC_DMG%L_NLOC) :: MASS,UNL,MASS0
@@ -241,17 +242,25 @@ c
         HEAD(6) = NUMELTG_L
         HEAD(7) = NDDMAX_L
         HEAD(8) = LCNENL_L
+C
+        IF (NSUBDOM > 0) THEN
+C--       multidomains - origianl nummat is used
+          MATSIZE = NUMMAT0 
+        ELSE
+          MATSIZE = NUMMAT 
+        ENDIF
+C
         CALL WRITE_I_C(HEAD,8)
 c
-        CALL WRITE_DB(NLOC_DMG%DENS,NUMMAT)         ! DENS
+        CALL WRITE_DB(NLOC_DMG%DENS,MATSIZE)         ! DENS
 c
-        CALL WRITE_DB(NLOC_DMG%DAMP,NUMMAT)         ! DAMP
+        CALL WRITE_DB(NLOC_DMG%DAMP,MATSIZE)         ! DAMP
 c
-        CALL WRITE_DB(NLOC_DMG%LEN,NUMMAT)          ! LEN
+        CALL WRITE_DB(NLOC_DMG%LEN,MATSIZE)          ! LEN
 c
-        CALL WRITE_DB(NLOC_DMG%LE_MAX,NUMMAT)       ! LEN
+        CALL WRITE_DB(NLOC_DMG%LE_MAX,MATSIZE)       ! LEN
 c
-        CALL WRITE_DB(NLOC_DMG%SSPNL,NUMMAT)        ! SSPNL
+        CALL WRITE_DB(NLOC_DMG%SSPNL,MATSIZE)        ! SSPNL
 c   
         CALL WRITE_I_C(INDX_L,NNOD_L)               ! INDX_L(NNOD_L)
 c  

--- a/starter/source/starter/lectur.F
+++ b/starter/source/starter/lectur.F
@@ -3661,7 +3661,8 @@ C---  Premiere Passe -> comptage
      4           IADBUF,NALE_R2R,FLG_R2R_ERR ,
      5           STACK%PM ,IWORKSH  ,IGRBRIC ,IGRQUAD   ,IGRSH4N ,
      6           IGRSH3N  ,IGRTRUSS ,IGRBEAM ,IGRSPRING ,IGRNOD  ,
-     7           IGRSURF  ,IGRSLIN, LSUBMODEL,ALE_EULER ,IGEO)
+     7           IGRSURF  ,IGRSLIN, LSUBMODEL,ALE_EULER ,IGEO    ,
+     8           NLOC_DMG)
 C---
          ALLOCATE(IBUFTMP(IDX2)%ptr(SIBUFSSG+INNOD)   ,STAT=stat)
          IF (STAT /= 0) THEN
@@ -3687,7 +3688,8 @@ C---  Deuxieme Passe -> creation des interfaces
      4           IADBUF,NALE_R2R,FLG_R2R_ERR ,
      5           STACK%PM ,IWORKSH  ,IGRBRIC ,IGRQUAD   ,IGRSH4N ,
      6           IGRSH3N  ,IGRTRUSS ,IGRBEAM ,IGRSPRING ,IGRNOD  ,
-     7           IGRSURF  ,IGRSLIN, LSUBMODEL,ALE_EULER ,IGEO)
+     7           IGRSURF  ,IGRSLIN, LSUBMODEL,ALE_EULER ,IGEO    ,
+     8           NLOC_DMG)
 C--------------------------------------------
 C     MULTIDOMAINS - SPLIT DES TABLEAUX
 C--------------------------------------------


### PR DESCRIPTION
ENable compatibility betwenn NLOCAL method and rad2rad. NLOCAL dof are treated by rad2ad as classical dof, but new exchanges are needed.