### PR TITLE
Change IP=23 in ortho_shell to be consistent with Ls_dyna

### DIFF
--- a/starter/source/elements/shell/coque/corthini.F
+++ b/starter/source/elements/shell/coque/corthini.F
@@ -92,7 +92,7 @@ C-----------------------------------------------
       INTEGER I,II,J,JJ,N,NPT,NPTI,IGTYP,IPID,PID,ISK,IPANG,IPPHI,
      . IIGEO,IADR,IPTHK,IPPOS,IPDIR,IMAT_LY,ILAW_LY,IPPID,IPMAT,ILAY,
      . DEF_ORTH(MVSIZ),N1,N2,IRP,POS,NOD
-      my_real V(MVSIZ),E11,E12,E13,NE1
+      my_real V(MVSIZ),E11,E12,E13,NE1,VX0,VY0,VZ0
       CHARACTER*nchartitle, TITR1
 C=======================================================================
       PID = IX(NIX-1,1)
@@ -142,10 +142,13 @@ C       non orthotropic property
               VZ(I) = SKEW(3,ISK)
             ENDDO
           CASE (23)
+              VX0 = GEO(7,PID)
+              VY0 = GEO(8,PID)
+              VZ0 = GEO(9,PID)
             DO I=JFT,JLT
-              VX(I) = GEO(7,PID)
-              VY(I) = GEO(8,PID)
-              VZ(I) = GEO(9,PID)
+              VX(I) = E3Y(I)*VZ0-E3Z(I)*VY0
+              VY(I) = E3Z(I)*VX0-E3X(I)*VZ0
+              VZ(I) = E3X(I)*VY0-E3Y(I)*VX0
             ENDDO
           CASE (24)
 C--         seatbelt elements - dir1 defined by N1 and ADD_NODE (can be either N2 or N4)


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
IP=23 on orthotropic shell is not implemented as expected

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
change actual IP=23 to be consistent with Dyna AOPT=3


<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
