### PR TITLE
/MAT/LAW58 : modify fiber stress output from true to engineering stre…

### DIFF
--- a/engine/source/materials/mat/mat058/sigeps58c.F
+++ b/engine/source/materials/mat/mat058/sigeps58c.F
@@ -506,10 +506,13 @@ C------------------------------------------------------------------
           RFAC = NC / EC2
           RFAT = NT / ET2
 C---      contraintes membrane       
-          SIGC = RFAC * FC * LC(I) / DC
-          SIGT = RFAT * FT * LT(I) / DT
-          SIGNXX(I) = SIGC
-          SIGNYY(I) = SIGT
+          SIGC = FC * LC(I) / DC
+          SIGT = FT * LT(I) / DT
+          SIGNXX(I) = SIGC * RFAC
+          SIGNYY(I) = SIGT * RFAT
+c
+          UVAR(I,1)  = SIGC
+          UVAR(I,2)  = SIGT
           UVAR(I,15) = DC
           UVAR(I,16) = DT
 C---      contraintes cisaillement      
@@ -1507,10 +1510,14 @@ c
         RFAC = ONE / EC2
         RFAT = ONE / ET2
 C---    contraintes membrane       
-        SIGC = RFAC * FC * LC(I) / DC
-        SIGT = RFAT * FT * LT(I) / DT
-        SIGNXX(I) = SIGC
-        SIGNYY(I) = SIGT
+c
+        SIGC = FC * LC(I) / DC
+        SIGT = FT * LT(I) / DT
+        SIGNXX(I) = SIGC * RFAC
+        SIGNYY(I) = SIGT * RFAT
+c
+        UVAR(I,1)  = SIGC
+        UVAR(I,2)  = SIGT
         UVAR(I,15) = DC
         UVAR(I,16) = DT
 C------------------------------------------------------------------


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

user request was to change the fiber stress output from true to engineering stress, to reflect input definition which is expressed in terms of engineering strain-stress relationship.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

small change in sigeps58c.F to save engineering stress in user variables before changing them to true stress

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
