### PR TITLE
LAW88  ,  wrong behavior in Shear 

### DIFF
--- a/engine/source/materials/mat/mat088/sigeps88c.F
+++ b/engine/source/materials/mat/mat088/sigeps88c.F
@@ -113,6 +113,7 @@ C initialization
       IF(TIME == ZERO)THEN
          UVAR(1:NEL,1:NUVAR) = ZERO 
          UVAR(1:NEL,1) = ONE 
+         UVAR(1:NEL,18)= ONE 
       ENDIF      
       G_INI = THREE_HALF*RBULK*(ONE - TWO*NU)/(ONE + NU)
 C
@@ -241,9 +242,11 @@ C
            UVAR(I,17)= MAX(UVAR(I,17), ECURENT(I)) 
            DEINT(I) = ECURENT(I) - UVAR(I,16)
            UVAR(I,16) = ECURENT(I)
-           IF(DEINT(I) >= ZERO) THEN
+           IF(DEINT(I) >= ZERO .OR. DEPS_EQ(I) >= ZERO) THEN
               NE_L = NE_L + 1 
               INDX_L(NE_L) = I
+              UVAR(I,19) = 1
+              IF(UVAR(I,18) == ONE )UVAR(I,17) = UVAR(I,16) 
            ELSE
               NE_UNL = NE_UNL + 1 
               INDX_UNL(NE_UNL) = I
@@ -256,6 +259,8 @@ C
 C  global      
                     T1(I) = DAM*T1(I)
                     T2(I) = DAM*T2(I)
+                    UVAR(I,19) = -1
+                    UVAR(I,18) = DAM
               ENDIF
       ENDDO
 C-------------------------------------------------------------                                  


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
/MAT/LAW88 for shell :  The introduction of hysterisis effect lead to wrong behavior in Shear qa test.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

/MAT/LAW88 + Shell :  Improving the  criteria check of loading and unloading.

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
