### PR TITLE
issue with move funct with negative xscale

### DIFF
--- a/starter/source/tools/curve/hm_read_move_funct.F
+++ b/starter/source/tools/curve/hm_read_move_funct.F
@@ -70,7 +70,7 @@ C     NSUBMOD
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I,J,N,ID,IFIX_TMP
+      INTEGER I,J,N,ID,IFIX_TMP,CPT
       my_real
      .   SCX,SCY,SHX,SHY
       my_real, DIMENSION(:),ALLOCATABLE :: PLD_TMP
@@ -111,15 +111,15 @@ C-----------------------------------------------
                      ENDDO
                   ELSEIF(SCX < ZERO) THEN
                      ALLOCATE(PLD_TMP(NPC(N+1)))
+                     CPT = 1
                      DO J = NPC(N),NPC(N+1)-1,2
-                        PLD_TMP(J)   = PLD(NPC(N+1)-1-J)  *SCX
-                        PLD_TMP(J+1) = PLD(NPC(N+1)-J)*SCY
+                        PLD_TMP(J)   = PLD(NPC(N+1)-1-CPT)  *SCX
+                        PLD_TMP(J+1) = PLD(NPC(N+1)-CPT)*SCY
                         PLD_TMP(J)   = PLD_TMP(J)  +SHX
                         PLD_TMP(J+1) = PLD_TMP(J+1)+SHY  
+                        CPT = CPT + 2
                      ENDDO
                      DO J = NPC(N),NPC(N+1)-1,2
-                        PLD(J)   = PLD_TMP(J)
-                        PLD(J+1) = PLD_TMP(J+1)
                         PLD(J)   = PLD_TMP(J)
                         PLD(J+1) = PLD_TMP(J+1)
                         IF (FUNCRYPT(N) == 0) WRITE(IOUT,'(8X,1PG20.13,2X,1G20.13)')PLD(J),PLD(J+1)   


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
If there exists a /MOVE_FUNCT with negative Abscissa scale factor, then if there is another /FUNCT in the model, the 'transformed' function is incorrect/corrupted (values from that/those other curve(s) appear in the transformed curve), 

left below is without another curve (ok), with another curve, the transform is corrupt/incorrect, this is not just a 0000.out echo issue, the incorrect curve is used in model also (e.g. for non-linear spring etc)
![image](https://user-images.githubusercontent.com/100404030/213216240-47b49a62-82dd-4ef2-9c5b-18f825516ffa.png)

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
there were some bug when resorting abscissa in case several func in the model

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
