### PR TITLE
various bugs found with address sanitizers

### DIFF
--- a/starter/source/constraints/general/mpc/hm_read_mpc.F
+++ b/starter/source/constraints/general/mpc/hm_read_mpc.F
@@ -127,7 +127,8 @@ C
           IF (COEF==ZERO) COEF = ONE
           RBUF  (KF) = COEF
           NOSYS = USR2SYS(NOD,ITABM,MESS,ID)
-          IF (NS10E>0.AND.ITAGND(NOSYS)/=0) THEN
+          IF (NS10E>0) THEN 
+            IF(ITAGND(NOSYS)/=0) THEN
 C------- error out	
            CALL ANCMSG(MSGID=1208,
      .                MSGTYPE=MSGERROR,
@@ -136,6 +137,7 @@ C------- error out
      .                C1='MPC ',
      .                I2=ID,
      .                C2='MPC ')
+            ENDIF
           END IF
           CALL KINSET(512,ITAB(NOSYS),IKINE(NOSYS),7,0,IKINE1LAG(NOSYS))
           IBUFNN(KF) = NOSYS

--- a/starter/source/constraints/general/rbe3/hm_read_rbe3.F
+++ b/starter/source/constraints/general/rbe3/hm_read_rbe3.F
@@ -181,7 +181,8 @@ C
         IC2=J6(4)*4 +J6(5)*2 +J6(6)
         IC =IC1*512+IC2*64
         IF (IC==0) IC =7*512+7*64
-        IF (NS10E > 0.AND.ITAGND(NS)/=0) THEN
+        IF (NS10E > 0) THEN
+          IF(ITAGND(NS)/=0) THEN
 C------- error out      
           CALL ANCMSG(MSGID=1208,
      .                MSGTYPE=MSGERROR,
@@ -190,6 +191,7 @@ C------- error out
      .                C1='RBE3 ',
      .                I2=NUSER,
      .                C2='RBE3 ')
+          ENDIF
         END IF
         IRBE3(3,I) = NS
         IRBE3(4,I) = IC

--- a/starter/source/constraints/general/rwall/hm_read_rwall_lagmul.F
+++ b/starter/source/constraints/general/rwall/hm_read_rwall_lagmul.F
@@ -304,7 +304,9 @@ C
         NSL = 0
         DO I = 1,NUMNOD
           IF (LPRW(K+I) > 0) THEN
-            IF (NS10E > 0 .AND. ITAGND(I) /= 0) CYCLE
+            IF (NS10E > 0) THEN
+               IF(ITAGND(I) /= 0) CYCLE
+            ENDIF
             NSL = NSL+1
             LPRW(K+NSL) = I
             IF (IDDLEVEL == 0) THEN

--- a/starter/source/constraints/general/rwall/hm_read_rwall_therm.F
+++ b/starter/source/constraints/general/rwall/hm_read_rwall_therm.F
@@ -267,7 +267,9 @@ C
         NSL = 0
         DO I = 1,NUMNOD
           IF (LPRW(K+I) > 0) THEN
-            IF (NS10E > 0 .AND. ITAGND(I) /= 0) CYCLE
+            IF (NS10E > 0) THEN
+              IF(ITAGND(I) /= 0) CYCLE
+            ENDIF
             NSL = NSL+1
             LPRW(K+NSL) = I
             IF (IDDLEVEL == 0) THEN

--- a/starter/source/elements/initia/scaleini.F
+++ b/starter/source/elements/initia/scaleini.F
@@ -116,17 +116,18 @@ c
 
 
             DO ILAY = 1,NLAY
-             DO IT=1,NPTT             
-              DO IS=1,NPTS
-               DO IR=1,NPTR
-                KK = NPTR*NPTS*NPTT*(ILAY-1)+ NPTR*NPTS*(IT-1)+NPTR*(IS-1)+IR
-                LBUF => ELBUF_STR%BUFLY(ILAY)%LBUF(IR,IS,IT)                         
-                LBUF%FAC_YLD(I) =   SIGSP(IIS+ KK ,JJ)  
-               ENDDO !R
-              ENDDO !S
-             ENDDO !T
-
-            ENDDO
+              IF(ELBUF_STR%BUFLY(ILAY)%L_FAC_YLD > 0 ) THEN
+                DO IT=1,NPTT
+                  DO IS=1,NPTS
+                   DO IR=1,NPTR
+                    KK = NPTR*NPTS*NPTT*(ILAY-1)+ NPTR*NPTS*(IT-1)+NPTR*(IS-1)+IR
+                    LBUF => ELBUF_STR%BUFLY(ILAY)%LBUF(IR,IS,IT) 
+                    LBUF%FAC_YLD(I) =   SIGSP(IIS+ KK ,JJ) 
+                   ENDDO !R
+                  ENDDO !S
+                ENDDO !T
+              ENDIF
+           ENDDO
         ENDIF                                                              
       ENDDO !  I=LFT,LLT                                                           
 c-----------

--- a/starter/source/elements/solid/solide/sgrtails.F
+++ b/starter/source/elements/solid/solide/sgrtails.F
@@ -150,7 +150,7 @@ C--------------------------------------------------------------
 C         BORNAGE DES GROUPES DE MVSIZ
 C--------------------------------------------------------------
       MY_ALLOCATE(INDEXS2,NUMELS)
-
+      nullify(MATPARAM)
       INDEXS2(1:NUMELS)=PERMUTATION%SOLID(1:NUMELS)
       NGR1 = NGROUP + 1
 C
@@ -1361,7 +1361,8 @@ C------ compatibility w/ AMS
         END IF
 C-------
         ! remove incompatibility for Itet4 = 3 
-        IF (ISSN < 10 .AND. ITET4 == 3 .AND.MATPARAM%STRAIN_FORMULATION==2) THEN 
+        IF (ISSN < 10 .AND. ITET4 == 3 .AND. ASSOCIATED(MATPARAM)) THEN
+          IF(MATPARAM%STRAIN_FORMULATION==2) THEN 
           CALL ANCMSG(MSGID=2037,
      .                MSGTYPE=MSGWARNING,
      .                ANMODE=ANINFO_BLIND_2,
@@ -1369,6 +1370,7 @@ C-------
      .                I2=ISSN,    
      .                PRMOD=MSG_CUMU)
           ISSN = 10
+          ENDIF
         ENDIF
 C-------------------------------------------------
 C STOCKAGE IPARG


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
Few bug fixes of issues found with `-fsanitize=address`
<!--- Describe the problem, ideally from the user viewpoint -->
- Invalid write into unallocated arrays in materials
- invalid read from unallocated arrays in some `hm_*` routines
