### PR TITLE
Law58 : engineering stress output in TH using user variables USR1,USR2

### DIFF
--- a/engine/source/materials/mat/mat058/sigeps58c.F
+++ b/engine/source/materials/mat/mat058/sigeps58c.F
@@ -571,8 +571,6 @@ C---
 #include "vectorize.inc"
         DO  J=1,NINDX
           I=INDEX(J)
-          UVAR(I,1) = SIGNXX(I) + SIGVXX(I)
-          UVAR(I,2) = SIGNYY(I) + SIGVYY(I)
           UVAR(I,3) = SIGNXY(I) + SIGVXY(I)
           TAN_PHI(I)= DEPSXY(I)
           UVAR(I,6) = DEPSXY(I)
@@ -1657,8 +1655,6 @@ C---
 #include "vectorize.inc"
       DO  J=1,NINDX
         I=INDEX(J)
-        UVAR(I,1) = SIGNXX(I) + SIGVXX(I)
-        UVAR(I,2) = SIGNYY(I) + SIGVYY(I)
         UVAR(I,3) = SIGNXY(I) + SIGVXY(I)
         TAN_PHI(I) = DEPSXY(I)
         UVAR(I,6)  = DEPSXY(I)

--- a/engine/source/materials/mat/mat058/sigeps58c.F
+++ b/engine/source/materials/mat/mat058/sigeps58c.F
@@ -506,10 +506,13 @@ C------------------------------------------------------------------
           RFAC = NC / EC2
           RFAT = NT / ET2
 C---      contraintes membrane       
-          SIGC = RFAC * FC * LC(I) / DC
-          SIGT = RFAT * FT * LT(I) / DT
-          SIGNXX(I) = SIGC
-          SIGNYY(I) = SIGT
+          SIGC = FC * LC(I) / DC
+          SIGT = FT * LT(I) / DT
+          SIGNXX(I) = SIGC * RFAC
+          SIGNYY(I) = SIGT * RFAT
+c
+          UVAR(I,1)  = SIGC
+          UVAR(I,2)  = SIGT
           UVAR(I,15) = DC
           UVAR(I,16) = DT
 C---      contraintes cisaillement      
@@ -1507,10 +1510,14 @@ c
         RFAC = ONE / EC2
         RFAT = ONE / ET2
 C---    contraintes membrane       
-        SIGC = RFAC * FC * LC(I) / DC
-        SIGT = RFAT * FT * LT(I) / DT
-        SIGNXX(I) = SIGC
-        SIGNYY(I) = SIGT
+c
+        SIGC = FC * LC(I) / DC
+        SIGT = FT * LT(I) / DT
+        SIGNXX(I) = SIGC * RFAC
+        SIGNYY(I) = SIGT * RFAT
+c
+        UVAR(I,1)  = SIGC
+        UVAR(I,2)  = SIGT
         UVAR(I,15) = DC
         UVAR(I,16) = DT
 C------------------------------------------------------------------


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

user needs output of engineering stress instead of true stress in user variables 1 and 2

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

update of previous code correction : delete old calculation of UVAR(1),UVAR(2) which were still overwritting engineering stress by true stress

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
