### PR TITLE
Fix timestep computation in starter for /MAT/LAW53

### DIFF
--- a/starter/source/materials/mat/mat053/hm_read_mat53.F
+++ b/starter/source/materials/mat/mat053/hm_read_mat53.F
@@ -95,7 +95,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       my_real
      .      E11, E22, N12, G12, G23, G13,FAC1,FAC2,FAC3,FAC4,FAC5,
-     .      FAC_L,FAC_T,FAC_M,FAC_C,DMIN,DMAX
+     .      FAC_L,FAC_T,FAC_M,FAC_C,DMIN,DMAX,SSP
       INTEGER NRATE,J,I,IFLAG
       my_real :: RHO0, RHOR, FAC_UNIT
       LOGICAL :: IS_AVAILABLE,IS_ENCRYPTED
@@ -143,8 +143,10 @@ C-----------------------------------------------
 
       !---DEFAULT VALUES
       IF(RHOR == ZERO)RHOR=RHO0
-      PM(1) =RHOR
-      PM(89)=RHO0  
+      PM(1)  = RHOR
+      PM(89) = RHO0  
+      SSP    = SQRT(MAX(E11,E22,G12,G23)/RHO0)
+      PM(27) = SSP
       IF (FAC1 == ZERO) FAC1 = ONE*FAC_UNIT
       IF (FAC2 == ZERO) FAC2 = ONE*FAC_UNIT
       IF (FAC3 == ZERO) FAC3 = ONE*FAC_UNIT
@@ -163,6 +165,8 @@ C-----------------------------------------------
       UPARAM(9)=FAC4
       UPARAM(10)=FAC5      
       !Formulation for solid elements time step computation.
+      PARMAT(1)  = MAX(E11,E22,G12,G23)
+      PARMAT(2)  = MAX(E11,E22)
       PARMAT(16) = 1
       DMIN = E11*E22   
       DMAX = MAX(E11,E22)


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Timestep in starter was badly estimated for /MAT/LAW53 (10E+21 in the test case). 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Add the estimation of the soundspeed in the reading routine for table PM(27) + add some missing data in PARMAT table. Now the timestep is correctly estimated. 

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
