### PR TITLE
Issue in Global to local node conversion in Engine

### DIFF
--- a/engine/source/system/sysfus.F
+++ b/engine/source/system/sysfus.F
@@ -126,10 +126,21 @@ C-----------------------------------------------
       INTEGER JINF, JSUP, J
 C-----------------------------------------------
 C
-      IF ((NUMNOD==0).OR.(IU-ITABM1(1)<0)) THEN
+      ! Check exit parameters
+
+      ! 1st NUMNOD=0
+      IF (NUMNOD==0) THEN
         SYSFUS2=0
         RETURN
       END IF
+
+      ! 2nd NodeID is lower than smallest NodeID.
+      IF ( IU-ITABM1(1)<0 ) THEN
+        SYSFUS2=0
+        RETURN
+      ENDIF
+
+
       JINF=1
       JSUP=NUMNOD
       J=MIN(1,NUMNOD/2)


### PR DESCRIPTION
Compilers may evaluate an if expression before applying condition.
Here the First condition applies, Number of node on domain is zero,
But second condition implies the opposite.

This fix separates the 2 conditions to avoid issues.

#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [X] The title of the PR is reviewed
- [X] There is no text before the checklist section
- [X] The following two sections are filled (or deleted)
- [X] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->


<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
