### PR TITLE
Wrong number of caller/callee arguments in Sensor Init

### DIFF
--- a/starter/source/tools/sensor/inisen.F
+++ b/starter/source/tools/sensor/inisen.F
@@ -288,7 +288,7 @@ C-------------------------------------
 c----------------------------------------------------------------------
 c     Logical sensors : AND, OR, NOT, SENS - create a dependancy order
 c----------------------------------------------------------------------
-      CALL SORT_LOGICAL_SENSORS(SENSOR_TAB)
+      CALL SORT_LOGICAL_SENSORS()
 
 
 c-----------


### PR DESCRIPTION
Wrong number of caller/callee arguments in Sensor Init

#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [X] The title of the PR is reviewed
- [X] There is no text before the checklist section
- [X] The following two sections are filled (or deleted)
- [X] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->


<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
