### PR TITLE
Fix potential check bounds issue in /FAIL/TSAIWU and /FAIL/TSAIHILL

### DIFF
--- a/engine/source/materials/fail/tsaihill/fail_tsaihill_c.F
+++ b/engine/source/materials/fail/tsaihill/fail_tsaihill_c.F
@@ -123,7 +123,11 @@ c
           ! Compute failure index and reserve factor
           FINDEX = (SXX(I)/X11)**2 - ((SXX(I)*SYY(I))/(X11**2)) +
      .             (SYY(I)/X22)**2 + (SXY(I)/S12)**2
-          RFACTR = ONE/SQRT(FINDEX)
+          IF (FINDEX > ZERO) THEN 
+            RFACTR = ONE/SQRT(FINDEX)
+          ELSE
+            RFACTR = ZERO
+          ENDIF
 c
           ! Damage variable update
           DFMAX(I) = MIN(ONE,FINDEX)

--- a/engine/source/materials/fail/tsaihill/fail_tsaihill_s.F
+++ b/engine/source/materials/fail/tsaihill/fail_tsaihill_s.F
@@ -122,8 +122,14 @@ c
 c
           ! Compute failure index and reserve factor
           FINDEX = (SXX(I)/X11)**2 - ((SXX(I)*SYY(I))/(X11**2)) +
-     .             (SYY(I)/X22)**2 + (SXY(I)/S12)**2
-          RFACTR = ONE/SQRT(FINDEX)
+     .             (SYY(I)/X22)**2 + (SXY(I)/S12)**2 - 
+     .             ((SXX(I)*SZZ(I))/(X11**2)) + (SZZ(I)/X22)**2 + 
+     .             (SZX(I)/S12)**2
+          IF (FINDEX > ZERO) THEN 
+            RFACTR = ONE/SQRT(FINDEX)
+          ELSE
+            RFACTR = ZERO
+          ENDIF
 c
           ! Damage variable update
           DFMAX(I) = MIN(ONE,FINDEX) 

--- a/engine/source/materials/fail/tsaiwu/fail_tsaiwu_c.F
+++ b/engine/source/materials/fail/tsaiwu/fail_tsaiwu_c.F
@@ -137,7 +137,11 @@ c
 c
           ! Compute failure index and reserve factor
           FINDEX = A + B
-          RFACTR = (-B + SQRT((B**2)+FOUR*A))/(TWO*A)
+          IF (FINDEX > ZERO) THEN 
+            RFACTR = (-B + SQRT((B**2)+FOUR*A))/(TWO*A)
+          ELSE
+            RFACTR = ZERO
+          ENDIF
 c
           ! Damage variable update
           DFMAX(I) = MIN(ONE,FINDEX)

--- a/engine/source/materials/fail/tsaiwu/fail_tsaiwu_s.F
+++ b/engine/source/materials/fail/tsaiwu/fail_tsaiwu_s.F
@@ -140,7 +140,11 @@ c
 c
           ! Compute failure index and reserve factor
           FINDEX = A + B
-          RFACTR = (-B + SQRT((B**2)+FOUR*A))/(TWO*A)
+          IF (FINDEX > ZERO) THEN 
+            RFACTR = (-B + SQRT((B**2)+FOUR*A))/(TWO*A)
+          ELSE
+            RFACTR = ZERO
+          ENDIF
 c
           ! Damage variable update
           DFMAX(I) = MIN(ONE,FINDEX) 


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Potential issue detected by check bound build when using /FAIL/TSAIWU and /FAIL/TSAIHILL. RFACTR is badly computed due to a potential division by zero. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Avoid the division by zero and improve the TSAIHILL formula for solids. 

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
