### PR TITLE
/INTER/TYPE18:improve Starter behavior by checking user input

### DIFF
--- a/starter/source/interfaces/int18/hm_read_inter_type18.F
+++ b/starter/source/interfaces/int18/hm_read_inter_type18.F
@@ -220,7 +220,22 @@ c          ENDIF
             ELSE                                                           
               ISU1=GRBRIC_ID !ISU1 outgoing argument used to get nodes in grbrick  
             ENDIF                                              
-        ENDIF                                                  
+        ENDIF 
+
+!===CHECK GRBRIC_ID IS PROVIDED TO CALL LATER LECINT > INGRBRIC_DX (automatic gap)        
+
+        !Variable gap (Igap=1) requires a Group of Bricks
+        IF(IGAP == 1 .AND. GRBRIC_ID == 0)THEN
+          MSGTITL='GRBRIC_ID MUST BE DEFINED TO ENABLE VARIABLE GAP' 
+          CALL ANCMSG(MSGID=1115,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=NOINT,C1=TITR,C2=MSGTITL)            
+        ENDIF 
+
+        !Constant gap with Gap=0.0 requires a Group of Bricks
+        IF(IGAP == 1000 .AND. GRBRIC_ID == 0 .AND. GAP == ZERO)THEN
+          MSGTITL='GRBRIC_ID MUST BE DEFINED TO ESTIMATE CONSTANT GAP VALUE' 
+          CALL ANCMSG(MSGID=1115,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=NOINT,C1=TITR,C2=MSGTITL)            
+        ENDIF 
+                                                 
 !===CHECK STFAC VALUE                                               
         IF(STFAC <= ZERO .AND. ISTIFF==1)THEN                                  
              MSGTITL='STIFFNESS VALUE MUST BE DEFINED (STFVAL)'


### PR DESCRIPTION
#### /INTER/TYPE18:improve Starter behavior by checking user input

#### Description of the changes
Error message is introduced when GRBRIC_ID=0 for following cases : 
- Constant Gap formulation (Igap=0,1000) but GAP=0.0
- Variable Gap formulation (Igap=1)
In these two cases group of bricks is required to call later LECINT > INGRBRIC_DX in order to estimate automatically gap value.

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
