### PR TITLE
Fix thpart mass computation for tetra + quadratic solids + thickshells

### DIFF
--- a/engine/source/elements/solid/solide10/s10bilan.F
+++ b/engine/source/elements/solid/solide10/s10bilan.F
@@ -31,7 +31,7 @@ Chd|====================================================================
       SUBROUTINE S10BILAN(PARTSAV,EINT,RHO,RK,VOL,
      .   VX, VY, VZ, NX, VNEW,IPARTS,
      .   GRESAV,GRTH,IGRTH,IEXPAN,EINTTH,
-     .   FILL  ,X, Y, Z,ITASK,IPARG)
+     .   FILL  ,X, Y, Z,ITASK,IPARG,OFFG)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -58,6 +58,7 @@ C     REAL
      .  X(MVSIZ,10),Y(MVSIZ,10),Z(MVSIZ,10)
       INTEGER IEXPAN,ITASK,
      .  IPARTS(*),GRTH(*),IGRTH(*),IPARG(*)
+      my_real, INTENT(IN) :: OFFG(MVSIZ)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -163,7 +164,7 @@ C
         PARTSAV(3,M)=PARTSAV(3,M) + XM(I)
         PARTSAV(4,M)=PARTSAV(4,M) + YM(I)
         PARTSAV(5,M)=PARTSAV(5,M) + ZM(I)
-        PARTSAV(6,M)=PARTSAV(6,M) + XMAS(I)
+        IF (OFFG(I) >= ONE) PARTSAV(6,M)=PARTSAV(6,M) + XMAS(I)
       ENDDO
 C
 C-----------------------------------------------

--- a/engine/source/elements/solid/solide10/s10forc3.F
+++ b/engine/source/elements/solid/solide10/s10forc3.F
@@ -554,7 +554,7 @@ C--------------------------
            CALL S10BILAN(PARTSAV,LBUF%EINT,LBUF%RHO,LBUF%RK,LBUF%VOL,
      .                   VX, VY, VZ,NX(1,1,IP),VOLN,IPARTS,
      .                   GRESAV,GRTH,IGRTH,IEXPAN,LBUF%EINTTH,
-     .                   GBUF%FILL,XX,YY,ZZ,ITASK,IPARG(1,NG))
+     .                   GBUF%FILL,XX,YY,ZZ,ITASK,IPARG(1,NG),GBUF%OFF)
         ENDIF
 C-------------------------
 C       ASSEMBLE

--- a/engine/source/elements/solid/solide20/s20bilan.F
+++ b/engine/source/elements/solid/solide20/s20bilan.F
@@ -31,7 +31,7 @@ Chd|====================================================================
       SUBROUTINE S20BILAN(PARTSAV,EINTG,RHOG, VOLG,
      .   VX, VY, VZ,IPARTS, VOL0G,
      .   GRESAV,GRTH,IGRTH,IEXPAN,EINTTH,
-     .   FILL ,X, Y, Z,ITASK,IPARG)
+     .   FILL ,X, Y, Z,ITASK,IPARG,OFFG)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -58,6 +58,7 @@ C     REAL
      .  VOLG(*),VOL0G(*),GRESAV(*),EINTTH(*),
      .  FILL(*),
      .  X(MVSIZ,*),Y(MVSIZ,*),Z(MVSIZ,*)
+      my_real, INTENT(IN) :: OFFG(MVSIZ)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -149,7 +150,7 @@ C
         PARTSAV(3,M)=PARTSAV(3,M) + XMAS(I)*VXA(I)
         PARTSAV(4,M)=PARTSAV(4,M) + XMAS(I)*VYA(I)
         PARTSAV(5,M)=PARTSAV(5,M) + XMAS(I)*VZA(I)
-        PARTSAV(6,M)=PARTSAV(6,M) + XMAS(I)
+        IF (OFFG(I) >= ONE) PARTSAV(6,M)=PARTSAV(6,M) + XMAS(I)
       ENDDO
 C
       IF(IEXPAN/=0)THEN

--- a/engine/source/elements/solid/solide20/s20forc3.F
+++ b/engine/source/elements/solid/solide20/s20forc3.F
@@ -418,7 +418,8 @@ C--------------------------
            CALL S20BILAN(PARTSAV,GBUF%EINT,GBUF%RHO,VOLG,
      .                   VX, VY, VZ,IPARTS,GBUF%VOL,
      .                   GRESAV,GRTH,IGRTH,IEXPAN,GBUF%EINTTH,
-     .                   GBUF%FILL, XX, YY, ZZ,ITASK,IPARG(1,NG))
+     .                   GBUF%FILL, XX, YY, ZZ,ITASK,IPARG(1,NG),
+     .                   GBUF%OFF)
       ENDIF
 C
 c-----------------------------

--- a/engine/source/elements/solid/solide4/s4bilan.F
+++ b/engine/source/elements/solid/solide4/s4bilan.F
@@ -33,7 +33,7 @@ Chd|====================================================================
      .   VZ1, VZ2, VZ3, VZ4, VNEW,IPARTS,GRESAV,
      .   GRTH,IGRTH,IEXPAN,EINTTH,FILL ,
      .   X1, X2, X3, X4, Y1, Y2, Y3, Y4, 
-     .   Z1, Z2, Z3, Z4,ITASK,IPARG)
+     .   Z1, Z2, Z3, Z4,ITASK,IPARG,OFFG)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -64,6 +64,7 @@ C     REAL
      .  Z1(*), Z2(*), Z3(*), Z4(*)
       INTEGER IEXPAN,ITASK,
      .  IPARTS(*),GRTH(*),IGRTH(*),IPARG(*)
+      my_real, INTENT(IN) :: OFFG(MVSIZ)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -119,7 +120,7 @@ C
         PARTSAV(3,M)=PARTSAV(3,M) + XM(I)
         PARTSAV(4,M)=PARTSAV(4,M) + YM(I)
         PARTSAV(5,M)=PARTSAV(5,M) + ZM(I)
-        PARTSAV(6,M)=PARTSAV(6,M) + XMAS(I)
+        IF (OFFG(I) >= ONE) PARTSAV(6,M)=PARTSAV(6,M) + XMAS(I)
       ENDDO 
 C-----------------------------------------------
 C     CALCUL BILAN SORTIES ADDITIONNELLES 

--- a/engine/source/elements/solid/solide4/s4forc3.F
+++ b/engine/source/elements/solid/solide4/s4forc3.F
@@ -549,7 +549,7 @@ C--------------------------
      .   VZ1, VZ2, VZ3, VZ4, VOLN,IPARTS,GRESAV,
      .   GRTH,IGRTH,IEXPAN,GBUF%EINTTH,GBUF%FILL,
      .   X1, X2, X3, X4, Y1, Y2, Y3, Y4, 
-     .   Z1, Z2, Z3, Z4,ITASK,IPARG(1,NG))
+     .   Z1, Z2, Z3, Z4,ITASK,IPARG(1,NG),OFF)
       ENDIF
 C
       IF(JLAG+JALE+JEUL == 0)RETURN

--- a/engine/source/elements/thickshell/solide16/s16bilan.F
+++ b/engine/source/elements/thickshell/solide16/s16bilan.F
@@ -31,7 +31,8 @@ Chd|====================================================================
       SUBROUTINE S16BILAN(PARTSAV,EINTG,RHOG ,VOLG  ,VOL0G  ,
      .                    VX     ,VY   ,VZ   ,IPARTS,GRESAV ,
      .                    GRTH   ,IGRTH,IEXPAN,EINTTH,FILL  ,
-     .                    X      ,Y    ,Z    ,ITASK ,IPARG  )
+     .                    X      ,Y    ,Z    ,ITASK ,IPARG  ,
+     .                    OFFG   )
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -56,6 +57,7 @@ C-----------------------------------------------
      .  VX(MVSIZ,*),VY(MVSIZ,*),VZ(MVSIZ,*),
      .  VOLG(*),VOL0G(*),GRESAV(*),EINTTH(*), FILL(*),
      .  X(MVSIZ,*),Y(MVSIZ,*),Z(MVSIZ,*)
+      my_real, INTENT(IN) :: OFFG(MVSIZ)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -145,7 +147,7 @@ C
         PARTSAV(3,M)=PARTSAV(3,M) + XMAS(I)*VXA(I)
         PARTSAV(4,M)=PARTSAV(4,M) + XMAS(I)*VYA(I)
         PARTSAV(5,M)=PARTSAV(5,M) + XMAS(I)*VZA(I)
-        PARTSAV(6,M)=PARTSAV(6,M) + XMAS(I) 
+        IF (OFFG(I) >= ONE) PARTSAV(6,M)=PARTSAV(6,M) + XMAS(I) 
       ENDDO
 C
 C-----------------------------------------------

--- a/engine/source/elements/thickshell/solide16/s16forc3.F
+++ b/engine/source/elements/thickshell/solide16/s16forc3.F
@@ -609,7 +609,8 @@ C
            CALL S16BILAN(PARTSAV,GBUF%EINT,GBUF%RHO,VOLG  ,GBUF%VOL,
      .             VX     ,VY       ,VZ      ,IPARTS     ,GRESAV    ,
      .             GRTH   ,IGRTH    ,IEXPAN  ,GBUF%EINTTH, GBUF%FILL,
-     .             XX     ,YY       ,ZZ      ,ITASK      ,IPARG(1,NG))
+     .             XX     ,YY       ,ZZ      ,ITASK      ,IPARG(1,NG),
+     .             GBUF%OFF)
       ENDIF
 C
 c-----------------------------

--- a/engine/source/elements/thickshell/solide6c/s6cbilan.F
+++ b/engine/source/elements/thickshell/solide6c/s6cbilan.F
@@ -32,7 +32,7 @@ Chd|====================================================================
      .   VXA, VYA, VZA, VA2, VNEW,IPARTS ,
      .   GRESAV,GRTH,IGRTH,OFF,IEXPAN,EINTTH,
      .   FILL, XX, YY, ZZ,
-     .   XX2,YY2,ZZ2,XY,YZ,ZX,ITASK,IPARG)
+     .   XX2,YY2,ZZ2,XY,YZ,ZX,ITASK,IPARG,OFFG)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -60,6 +60,7 @@ C     REAL
      .  XY(MVSIZ), YZ(MVSIZ), ZX(MVSIZ)
       INTEGER IEXPAN,ITASK,
      .  IPARTS(*),GRTH(*),IGRTH(*),IPARG(*)
+      my_real, INTENT(IN) :: OFFG(MVSIZ)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -104,7 +105,7 @@ C
         PARTSAV(3,M)=PARTSAV(3,M) + XM(I)
         PARTSAV(4,M)=PARTSAV(4,M) + YM(I)
         PARTSAV(5,M)=PARTSAV(5,M) + ZM(I)
-        PARTSAV(6,M)=PARTSAV(6,M) + XMAS(I)
+        IF (OFFG(I) >= ONE) PARTSAV(6,M)=PARTSAV(6,M) + XMAS(I)
       END DO
 C
 C-----------------------------------------------

--- a/engine/source/elements/thickshell/solide6c/s6cforc3.F
+++ b/engine/source/elements/thickshell/solide6c/s6cforc3.F
@@ -634,7 +634,7 @@ C--------------------------------------
      .       VGXA, VGYA, VGZA, VGA2, VOLG,IPARTS,
      .       GRESAV,GRTH,IGRTH,GBUF%OFF,IBID,GBUF%EINTTH,
      .       GBUF%FILL, XGXA, XGYA, XGZA,XGXA2,XGYA2,XGZA2,
-     .       XGXYA,XGYZA,XGZXA,ITASK,IPARG(1,NG))
+     .       XGXYA,XGYZA,XGZXA,ITASK,IPARG(1,NG),GBUF%OFF)
       ENDIF
 C--------------------------------
 C Convected frame to global frame

--- a/starter/source/elements/solid/solide/sbulk3.F
+++ b/starter/source/elements/solid/solide/sbulk3.F
@@ -208,8 +208,8 @@ C     16 nodes thick shells :
        BNS(8,I)=CV1
        DO N=9,16        
          IF(NC(I,N)/=0)THEN
-           VNSX(N-4,I)=AV2
-           BNSX(N-4,I)=CV2
+           VNSX(N-8,I)=AV2
+           BNSX(N-8,I)=CV2
          ELSE
            N1=IPERM161(N)
            N2=IPERM162(N)
@@ -248,8 +248,8 @@ C     20 nodes bricks :
        BNS(8,I)=CV1
        DO N=9,20        
          IF(NC(I,N)/=0)THEN
-           VNSX(N-4,I)=AV2
-           BNSX(N-4,I)=CV2
+           VNSX(N-8,I)=AV2
+           BNSX(N-8,I)=CV2
          ELSE
            N1=IPERM201(N)
            N2=IPERM202(N)


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [ ] The title of the PR is reviewed
- [ ] There is no text before the checklist section
- [ ] The following two sections are filled (or deleted)
- [ ] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Fix THPART mass computation when element deletion occurs for TETRA, SOLID20, and THICKSHELL

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Modification of PARTSAV mass computation + fix a sanitize bug introduced in 2015 in SBULK3.F

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
