### PR TITLE
Correction of Error message Inter type 25 when using Ivis2 with solids

### DIFF
--- a/starter/source/interfaces/inter3d1/i25sti3.F
+++ b/starter/source/interfaces/inter3d1/i25sti3.F
@@ -1060,7 +1060,7 @@ C      en SPMD il faut un element associe a l'arrete sinon erreur
        ENDIF
       END DO
 C
-      IF(IVIS2 /=0.AND.ISOL /=0) THEN
+      IF(IVIS2 ==-1.AND.ISOL /=0) THEN
               CALL ANCMSG(MSGID=2096,
      .                    MSGTYPE=MSGERROR,
      .                    ANMODE=ANINFO_BLIND_2,


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 
Correction of Error message Inter type 25 when using Ivis2 with solids (Ivis2= -1)
<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Correction of Error message Inter type 25 when using Ivis2 with solids :Ivis2 need to be equal to -1 ( Ivis2 seems can have other values different from 0 and -1 which is not in documentation)

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->


<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
