### PR TITLE
/TH/SENSOR : write sensor names to TH output file

### DIFF
--- a/engine/share/modules/sensor_mod.F
+++ b/engine/share/modules/sensor_mod.F
@@ -215,7 +215,8 @@ Chd|====================================================================
 C-----------------------------------------------
 C   m y _ r e a l
 C-----------------------------------------------
-#include      "my_real.inc"
+#include "my_real.inc"
+#include "nchar_c.inc"
 C-----------------------------------------------
 C   D e r i v e d   T y p e   D e f i n i t i o n s
 C-----------------------------------------------
@@ -239,6 +240,7 @@ C-----------------------------------------------
         INTEGER :: STATUS      !   sensor status
                                !          = 0   : deactivated
                                !          = 1   : activated at TSTART
+        CHARACTER(LEN = nchartitle) :: TITLE
         my_real :: TCRIT       !   time when activation criterion is met
         my_real :: TMIN        !   time duration of crit value before activation
         my_real :: TDELAY      !   time delay before activation (after Tmin)

--- a/engine/source/output/restart/read_sensor_tab.F
+++ b/engine/source/output/restart/read_sensor_tab.F
@@ -37,7 +37,9 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
-#include      "implicit_f.inc"
+#include "implicit_f.inc"
+#include "scr17_c.inc"
+#include "nchar_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
@@ -47,7 +49,9 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,ISEN,LEN,IAD,NFIX,NPARI,NPARR,NVAR,TYP
+      INTEGER, DIMENSION(LTITR) :: ITITLE
       my_real, DIMENSION(:), ALLOCATABLE :: HEAD,RBUF
+      CHARACTER(LEN = nchartitle) :: TITLE
       TYPE (SENSOR_STR_) ,POINTER :: SENSOR
 C=======================================================================
       NFIX = 11
@@ -102,7 +106,12 @@ c
         END IF
 c         
         DEALLOCATE (RBUF)
-
+c
+c       read sensor title
+        CALL READ_I_C(ITITLE,LTITR)
+        CALL FRETITL2(TITLE,ITITLE,LTITR)
+        SENSOR%TITLE = TITLE
+c
         TYP = SENSOR%TYPE
         IF (TYP == 29 .OR. TYP == 30 .OR. TYP == 31)THEN
 

--- a/engine/source/output/restart/write_sensor_tab.F
+++ b/engine/source/output/restart/write_sensor_tab.F
@@ -37,7 +37,9 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
-#include      "implicit_f.inc"
+#include "implicit_f.inc"
+#include "scr17_c.inc"
+#include "nchar_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
@@ -47,16 +49,20 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,ISEN,LEN,IAD,NFIX,NPARI,NPARR,NVAR,TYP
+      INTEGER, DIMENSION(LTITR) :: ITITLE
       my_real, DIMENSION(:), ALLOCATABLE :: RBUF
+      CHARACTER(LEN = nchartitle) :: TITLE
       TYPE (SENSOR_STR_) ,POINTER :: SENSOR
 C=======================================================================
       NFIX = 11
 c
       DO ISEN=1,NSENSOR
         SENSOR => SENSOR_TAB(ISEN)
+        TYP   = SENSOR%TYPE 
         NPARI = SENSOR%NPARI
         NPARR = SENSOR%NPARR
         NVAR  = SENSOR%NVAR
+        TITLE = SENSOR_TAB(ISEN)%TITLE
         
         LEN = NFIX + NPARI + NPARR + NVAR
         ALLOCATE (RBUF(LEN) )
@@ -97,7 +103,10 @@ c
         CALL WRITE_DB (RBUF,LEN)
         DEALLOCATE (RBUF)
 c
-        TYP = SENSOR%TYPE
+c       write sensor title
+        CALL FRETITL(TITLE,ITITLE,LTITR)
+        CALL WRITE_I_C(ITITLE,LTITR)
+c
         IF (TYP==29.OR.TYP==30.OR.TYP==31)THEN
           CALL WRITE_I_C(SENSOR%INTEGER_USERPARAM,NSENPARI)
           CALL WRITE_I_C(SENSOR%INTEGER_USERBUF,ISENBUF)

--- a/starter/share/modules1/sensor_mod.F
+++ b/starter/share/modules1/sensor_mod.F
@@ -102,7 +102,8 @@ Chd|====================================================================
 C-----------------------------------------------
 C   m y _ r e a l
 C-----------------------------------------------
-#include      "my_real.inc"
+#include "my_real.inc"
+#include "nchar_c.inc"
 C-----------------------------------------------
 C   D e r i v e d   T y p e   D e f i n i t i o n s
 C-----------------------------------------------
@@ -126,6 +127,7 @@ C-----------------------------------------------
         INTEGER :: STATUS      !   sensor status
                                !          = 0   : deactivated
                                !          = 1   : activated at TSTART
+        CHARACTER(LEN = nchartitle) :: TITLE
         my_real :: TCRIT       !   time when activation criterion is met
         my_real :: TMIN        !   time duration of crit value before activation
         my_real :: TDELAY      !   time delay before activation (after Tmin)

--- a/starter/source/output/th/hm_read_thgrsens.F
+++ b/starter/source/output/th/hm_read_thgrsens.F
@@ -190,9 +190,7 @@ C
         DO I=1,NNE
           N = ITHBUF(IAD)
           ITHBUF(IAD+2*NNE) = SENSOR_TAB(N)%SENS_ID
-          TITR(1:40) = '  SENSOR_ID '
-          WRITE(ID_TXT,FMT='(I10,A)')  SENSOR_TAB(N)%SENS_ID,''
-          TITR(13:40) = ID_TXT(1:20) 
+          TITR = SENSOR_TAB(N)%TITLE
 
           CALL FRETITL(TITR,ITHBUF(IAD2),40)
 

--- a/starter/source/restart/ddsplit/ddsplit.F
+++ b/starter/source/restart/ddsplit/ddsplit.F
@@ -2979,7 +2979,7 @@ C--------------------------------------------
 C Sensors
 C--------------------------------------------
       IF (NSENSOR > 0) THEN
-        CALL WRITE_SENSOR_TAB(SENSOR_TAB,NSENSOR,NODLOCAL,LEN_AM)
+        CALL WRITE_SENSOR_TAB(SENSOR_TAB,NSENSOR,NODLOCAL)
       END IF
 C--------------------------------------------
 C RBM

--- a/starter/source/tools/sensor/hm_read_sensors.F
+++ b/starter/source/tools/sensor/hm_read_sensors.F
@@ -112,7 +112,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I,ISEN,IUNIT,IFLAGUNIT,NS,TYP,UNIT_ID,SENS_ID
+      INTEGER ISEN,IUNIT,IFLAGUNIT,NS,TYP,UNIT_ID,SENS_ID
       my_real :: BID
       CHARACTER TITR*nchartitle,KEY*40,MESS*40
       INTEGER ,DIMENSION(NSENSOR)    :: SID
@@ -254,14 +254,16 @@ c---
      .                  I1=SENS_ID,
      .                  C1=TITR)        
         END SELECT 
+c
+        SENSOR_TAB(ISEN)%TITLE = TITR
 c-----------------
       END DO  ! NSENSOR
 c-------------------------------------
 c     Recherche des ID doubles  : activate this code when lecsen is removed
 c-------------------------------------
-      DO I = 1,NSENSOR
-        IF (SENSOR_TAB(I)%SENS_ID > 0)  THEN
-          SID(I) = SENSOR_TAB(I)%SENS_ID
+      DO ISEN = 1,NSENSOR
+        IF (SENSOR_TAB(ISEN)%SENS_ID > 0)  THEN
+          SID(ISEN) = SENSOR_TAB(ISEN)%SENS_ID
         END IF
       END DO
       CALL UDOUBLE(SID,1,NSENSOR,MESS,0,BID)

--- a/starter/source/tools/sensor/write_sensor_tab.F
+++ b/starter/source/tools/sensor/write_sensor_tab.F
@@ -29,7 +29,7 @@ Chd|        WRITE_DB                      source/restart/ddsplit/wrrest.F
 Chd|        WRITE_I_C                     source/output/tools/write_routines.c
 Chd|        SENSOR_MOD                    share/modules1/sensor_mod.F   
 Chd|====================================================================
-      SUBROUTINE WRITE_SENSOR_TAB(SENSOR_TAB,NSENSOR,NODLOCAL,LEN_AM)
+      SUBROUTINE WRITE_SENSOR_TAB(SENSOR_TAB,NSENSOR,NODLOCAL)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -37,20 +37,23 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
-#include      "implicit_f.inc"
+#include "implicit_f.inc"
+#include "scr17_c.inc"
+#include "nchar_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER , INTENT(IN)    :: NSENSOR
-      INTEGER , INTENT(INOUT) :: LEN_AM
       INTEGER , DIMENSION(*)  :: NODLOCAL
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR), TARGET :: SENSOR_TAB
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,ISEN,LEN,IAD,NFIX,NPARI,NPARR,NVAR,N1,N2,TYP
+      INTEGER, DIMENSION(LTITR) :: ITITLE
       INTEGER, DIMENSION(:), ALLOCATABLE :: LTEMP
       my_real, DIMENSION(:), ALLOCATABLE :: RBUF
+      CHARACTER(LEN = nchartitle) :: TITLE
       TYPE (SENSOR_STR_) ,POINTER :: SENSOR
 C=======================================================================
       NFIX = 11
@@ -61,6 +64,7 @@ c
         NPARI = SENSOR%NPARI
         NPARR = SENSOR%NPARR
         NVAR  = SENSOR%NVAR
+        TITLE = SENSOR_TAB(ISEN)%TITLE
         ALLOCATE (LTEMP(NPARI))
         LTEMP(1:NPARI) = SENSOR%IPARAM(1:NPARI)
 c       update node system N° after renumbering for sensors using nodes
@@ -128,7 +132,11 @@ c
         CALL WRITE_DB (RBUF,LEN)
         DEALLOCATE (RBUF)
         DEALLOCATE (LTEMP)
-
+c
+c       write sensor title
+        CALL FRETITL(TITLE,ITITLE,LTITR)
+        CALL WRITE_I_C(ITITLE,LTITR)
+c
         IF (TYP==29.OR.TYP==30.OR.TYP==31)THEN
           CALL WRITE_I_C(SENSOR%INTEGER_USERPARAM,NSENPARI)
           CALL WRITE_I_C(SENSOR%INTEGER_USERBUF,ISENBUF)


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

User requests writing sensor names in Time history output files instead of generic titles made of sensor ID

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

sensor name was added to sensor derived structure type and filled when reading sensor data. Sensor name pass also in restart file and is used in TH group instead of generic name

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
