### PR TITLE
Remove transverse shear from plastic behavior in /MAT/LAW104 for shells

### DIFF
--- a/engine/source/materials/mat/mat104/mat104c_ldam_newton.F
+++ b/engine/source/materials/mat/mat104/mat104c_ldam_newton.F
@@ -82,21 +82,21 @@ c
      .   DTEMP,FCOSH,FSINH,DPDT,DLAM,DDEP
       DOUBLE PRECISION :: 
      .   DSDRDJ2,DSDRDJ3,
-     .   DJ3DSXX,DJ3DSYY,DJ3DSXY,DJ3DSZZ,DJ3DSYZ,DJ3DSZX,
+     .   DJ3DSXX,DJ3DSYY,DJ3DSXY,DJ3DSZZ,
      .   DJ2DSXX,DJ2DSYY,DJ2DSXY,NORMSIG,
      .   DFDSXX,DFDSYY,DFDSXY,DYLD_DPLA_NL,
-     .   NORMXX,NORMYY,NORMXY,NORMZZ,NORMYZ,NORMZX,
+     .   NORMXX,NORMYY,NORMXY,NORMZZ,
      .   SDPLA,DPHI_DTRSIG,SIG_DFDSIG,DFDSIG2,SDV_DFDSIG,
      .   DPHI_DSIG,DPHI_DYLD,DPHI_DFDR,DF_DFS,DFS_DFT,DPHI_DFT,
      .   DPHI_DFS,DFN_DLAM,DFSH_DLAM,DFG_DLAM,DFT_DLAM,
      .   DFN,DFSH,DFG,DFT,DYLD_DPLA,DYLD_DTEMP,DTEMP_DLAM
 C
       DOUBLE PRECISION, DIMENSION(NEL) ::
-     .   DSIGXX,DSIGYY,DSIGXY,DSIGYZ,DSIGZX,TRSIG,TRDEP,
-     .   SXX,SYY,SXY,SZZ,SYZ,SZX,SIGM,J2,J3,SIGDR,YLD,WEITEMP,
+     .   DSIGXX,DSIGYY,DSIGXY,TRSIG,TRDEP,
+     .   SXX,SYY,SXY,SZZ,SIGM,J2,J3,SIGDR,YLD,WEITEMP,
      .   HARDP,FHARD,FRATE,FTHERM,DTHERM,FDR,PHI0,D,TRIAX,
      .   FDAM,PHI,FT,FS,FG,FN,FSH,DPLA_DLAM,DPHI_DLAM,DEZZ,ETAT,
-     .   SIGDR2,YLD2I,DPXX,DPYY,DPZZ,DPXY,DPYZ,DPZX
+     .   SIGDR2,YLD2I,DPXX,DPYY,DPZZ,DPXY
 C
       DOUBLE PRECISION, DIMENSION(NEL) :: 
      .   DLAM_NL,DDPNL,PLAP_NL,DPLA_NL,PLA_NL
@@ -270,15 +270,11 @@ c
         SYY(I)    = SIGNYY(I) + SIGM(I)
         SZZ(I)    = SIGM(I)
         SXY(I)    = SIGNXY(I)
-        SYZ(I)    = SIGNYZ(I)
-        SZX(I)    = SIGNZX(I)
         DEZZ(I)   = -NNU*DEPSXX(I) - NNU*DEPSYY(I)
         ! Second deviatoric invariant
-        J2(I) = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 )
-     .          +       SXY(I)**2 + SYZ(I)**2 + SZX(I)**2
+        J2(I) = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 ) + SXY(I)**2 
         ! Third deviatoric invariant
-        J3(I)  = SXX(I)*SYY(I)*SZZ(I) + SXY(I)*SYZ(I)*SZX(I) * TWO
-     .         - SXX(I)*SYZ(I)**2 - SYY(I)*SZX(I)**2 - SZZ(I)*SXY(I)**2 
+        J3(I)  = SXX(I)*SYY(I)*SZZ(I) - SZZ(I)*SXY(I)**2 
         ! Drucker equivalent stress
         FDR(I) = J2(I)**3 - CDR*(J3(I)**2)
         ! Checking equivalent stress values
@@ -344,8 +340,6 @@ c
         DPYY(I)   = ZERO
         DPZZ(I)   = ZERO
         DPXY(I)   = ZERO
-        DPYZ(I)   = ZERO
-        DPZX(I)   = ZERO
       ENDDO
 c        
       ! Loop over the iterations     
@@ -383,9 +377,7 @@ c
           ! Computation of the Eulerian norm of the stress tensor
           NORMSIG = SQRT(SIGNXX(I)*SIGNXX(I)
      .                 + SIGNYY(I)*SIGNYY(I)
-     .            + TWO*SIGNXY(I)*SIGNXY(I)
-     .            + TWO*SIGNYZ(I)*SIGNYZ(I)
-     .            + TWO*SIGNZX(I)*SIGNZX(I))
+     .             + TWO*SIGNXY(I)*SIGNXY(I))
 c 
           ! Derivative with respect to Fdr 
           FDR(I)     =  (J2(I)/(NORMSIG**2))**3 - CDR*((J3(I)/(NORMSIG**3))**2)       
@@ -393,25 +385,21 @@ c
           DSDRDJ2    =  DPHI_DFDR*THREE*(J2(I)/(NORMSIG**2))**2                             
           DSDRDJ3    = -DPHI_DFDR*TWO*CDR*(J3(I)/(NORMSIG**3))                   
           ! dJ3/dSig                                                        
-          DJ3DSXX =  TWO_THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .             -  THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
-     .             -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)                 
-          DJ3DSYY = - THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .             + TWO_THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
-     .             -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)             
-          DJ3DSZZ = - THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .              - THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
+          DJ3DSXX =  TWO_THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .                -  THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
+     .                -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)                 
+          DJ3DSYY =    - THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .             + TWO_THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
+     .                -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)             
+          DJ3DSZZ =    - THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .                 - THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
      .             + TWO_THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)
-          DJ3DSXY = TWO*(SXX(I)*SXY(I) + SXY(I)*SYY(I) + SZX(I)*SYZ(I))/(NORMSIG**2)                   
-          DJ3DSYZ = TWO*(SXY(I)*SZX(I) + SYY(I)*SYZ(I) + SYZ(I)*SZZ(I))/(NORMSIG**2)                     
-          DJ3DSZX = TWO*(SXX(I)*SZX(I) + SXY(I)*SYZ(I) + SZX(I)*SZZ(I))/(NORMSIG**2)                      
+          DJ3DSXY = TWO*(SXX(I)*SXY(I) + SXY(I)*SYY(I))/(NORMSIG**2)                   
           ! dPhi/dSig
           NORMXX  = DSDRDJ2*SXX(I)/NORMSIG + DSDRDJ3*DJ3DSXX + DPHI_DTRSIG
           NORMYY  = DSDRDJ2*SYY(I)/NORMSIG + DSDRDJ3*DJ3DSYY + DPHI_DTRSIG
           NORMZZ  = DSDRDJ2*SZZ(I)/NORMSIG + DSDRDJ3*DJ3DSZZ + DPHI_DTRSIG
           NORMXY  = TWO*DSDRDJ2*SXY(I)/NORMSIG + DSDRDJ3*DJ3DSXY
-          NORMYZ  = TWO*DSDRDJ2*SYZ(I)/NORMSIG + DSDRDJ3*DJ3DSYZ
-          NORMZX  = TWO*DSDRDJ2*SZX(I)/NORMSIG + DSDRDJ3*DJ3DSZX 
 c          
           ! 2 - Computation of DPHI_DLAMBDA
           !---------------------------------------------------------
@@ -422,8 +410,6 @@ c
           DFDSIG2 = NORMXX * (ONE-D(I))*(A11*NORMXX + A12*NORMYY)
      .            + NORMYY * (ONE-D(I))*(A11*NORMYY + A12*NORMXX)
      .            + NORMXY * (ONE-D(I))* NORMXY * G
-     .            + NORMYZ * (ONE-D(I))* NORMYZ * GS(I)
-     .            + NORMZX * (ONE-D(I))* NORMZX * GS(I)   
 c     
           !   b) Derivatives with respect to plastic strain P 			
           !   ------------------------------------------------
@@ -441,14 +427,10 @@ c
           SDV_DFDSIG = SXX(I) * NORMXX
      .               + SYY(I) * NORMYY
      .               + SZZ(I) * NORMZZ
-     .               + SXY(I) * NORMXY
-     .               + SYZ(I) * NORMYZ
-     .               + SZX(I) * NORMZX        
+     .               + SXY(I) * NORMXY        
           SIG_DFDSIG = SIGNXX(I) * NORMXX
      .               + SIGNYY(I) * NORMYY
-     .               + SIGNXY(I) * NORMXY
-     .               + SIGNYZ(I) * NORMYZ
-     .               + SIGNZX(I) * NORMZX         
+     .               + SIGNXY(I) * NORMXY       
           DPLA_DLAM(I) = SIG_DFDSIG / ((ONE - FT(I))*YLD(I)) 
 c          
           !  c) Derivatives with respect to the temperature TEMP 
@@ -545,8 +527,6 @@ c
           DPYY(I)  = DLAM * NORMYY
           DPZZ(I)  = DLAM * NORMZZ
           DPXY(I)  = DLAM * NORMXY
-          DPYZ(I)  = DLAM * NORMYZ
-          DPZX(I)  = DLAM * NORMZX   
           TRDEP(I) = DPXX(I) + DPYY(I) + DPZZ(I)   
 c          
           ! Cumulated plastic strain and strain rate update         
@@ -578,7 +558,7 @@ c
             OMEGA   = MAX(ZERO,OMEGA)
             OMEGA   = MIN(ONE,OMEGA)
             SDPLA   = SXX(I)*DPXX(I) + SYY(I)*DPYY(I) + SZZ(I)*DPZZ(I)
-     .              + SXY(I)*DPXY(I) + SYZ(I)*DPYZ(I) + SZX(I)*DPZX(I)
+     .              + SXY(I)*DPXY(I)
             FSH(I)  = FSH(I) + KW*OMEGA*FT(I)*(SDPLA/SIGDR(I))
           ENDIF
           FSH(I) = MAX(FSH(I),ZERO)
@@ -615,22 +595,16 @@ c
           SIGNXX(I) = SIGNXX(I) - (ONE-D(I))*(A11*DPXX(I) + A12*DPYY(I))
           SIGNYY(I) = SIGNYY(I) - (ONE-D(I))*(A11*DPYY(I) + A12*DPXX(I)) 
           SIGNXY(I) = SIGNXY(I) - (ONE-D(I))*DPXY(I)*G
-          SIGNYZ(I) = SIGNYZ(I) - (ONE-D(I))*DPYZ(I)*GS(I)
-          SIGNZX(I) = SIGNZX(I) - (ONE-D(I))*DPZX(I)*GS(I) 
           TRSIG(I)  = SIGNXX(I) + SIGNYY(I)
           SIGM(I)   = -TRSIG(I) * THIRD
           SXX(I)    = SIGNXX(I) + SIGM(I)
           SYY(I)    = SIGNYY(I) + SIGM(I)
           SZZ(I)    = SIGM(I)
           SXY(I)    = SIGNXY(I)
-          SYZ(I)    = SIGNYZ(I)
-          SZX(I)    = SIGNZX(I)
 c          
           ! Drucker equivalent stress update
-          J2(I)    = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 )
-     .             +         SXY(I)**2 + SYZ(I)**2 + SZX(I)**2
-          J3(I)    = SXX(I) * SYY(I) * SZZ(I) + TWO   * SXY(I) * SYZ(I) * SZX(I)
-     .             - SXX(I) * SYZ(I)**2 - SYY(I) * SZX(I)**2 - SZZ(I) * SXY(I)**2 
+          J2(I)    = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 ) + SXY(I)**2
+          J3(I)    = SXX(I) * SYY(I) * SZZ(I) - SZZ(I) * SXY(I)**2 
           FDR(I)   = J2(I)**3 - CDR*(J3(I)**2)
           SIGDR(I) = KDR * EXP((ONE/SIX)*LOG(FDR(I)))
           ! Computation of the stress triaxiality and the etaT factor

--- a/engine/source/materials/mat/mat104/mat104c_ldam_nice.F
+++ b/engine/source/materials/mat/mat104/mat104c_ldam_nice.F
@@ -82,19 +82,19 @@ c
      .   H,LDAV,TRDFDS,SIGVM,SIGDR2,YLD2I,OMEGA,
      .   DTEMP,FCOSH,FSINH,DPDT,DLAM,DDEP
       DOUBLE PRECISION :: 
-     .   DPXX,DPYY,DPXY,DPYZ,DPZX,DPZZ,DSDRDJ2,DSDRDJ3,
-     .   DJ3DSXX,DJ3DSYY,DJ3DSXY,DJ3DSZZ,DJ3DSYZ,DJ3DSZX,
+     .   DPXX,DPYY,DPXY,DPZZ,DSDRDJ2,DSDRDJ3,
+     .   DJ3DSXX,DJ3DSYY,DJ3DSXY,DJ3DSZZ,
      .   DJ2DSXX,DJ2DSYY,DJ2DSXY,
      .   DFDSXX,DFDSYY,DFDSXY,DYLD_DPLA_NL,
-     .   NORMXX,NORMYY,NORMXY,NORMZZ,NORMYZ,NORMZX,
+     .   NORMXX,NORMYY,NORMXY,NORMZZ,
      .   DENOM,DPHI,SDPLA,DPHI_DTRSIG,SDV_DFDSIG,SIG_DFDSIG,DFDSIG2,
      .   DPHI_DSIG,DPHI_DYLD,DPHI_DFDR,DPHI_DFS,DFS_DFT,
      .   DFN_DLAM,DFSH_DLAM,DFG_DLAM,DFT_DLAM,DFDPLA,NORMSIG,
      .   DFN,DFSH,DFG,DFT,DYLD_DPLA,DYLD_DTEMP,DTEMP_DLAM
 c
       DOUBLE PRECISION, DIMENSION(NEL) ::
-     .   DSIGXX,DSIGYY,DSIGXY,DSIGYZ,DSIGZX,TRSIG,TRDEP,
-     .   SXX,SYY,SXY,SZZ,SYZ,SZX,SIGM,J2,J3,SIGDR,YLD,WEITEMP,
+     .   DSIGXX,DSIGYY,DSIGXY,TRSIG,TRDEP,
+     .   SXX,SYY,SXY,SZZ,SIGM,J2,J3,SIGDR,YLD,WEITEMP,
      .   HARDP,FHARD,FRATE,FTHERM,FDR,D,TRIAX,ETAT,
      .   FDAM,PHI0,PHI,FT,FS,FG,FN,FSH,DPLA_DLAM,DEZZ
 c
@@ -274,15 +274,11 @@ c
         SYY(I)    = SIGNYY(I) + SIGM(I)
         SZZ(I)    = SIGM(I)
         SXY(I)    = SIGNXY(I)
-        SYZ(I)    = SIGNYZ(I)
-        SZX(I)    = SIGNZX(I)
         DEZZ(I)   = -NNU*DEPSXX(I) - NNU*DEPSYY(I)
         ! Second deviatoric invariant
-        J2(I) = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 )
-     .          +       SXY(I)**2 + SYZ(I)**2 + SZX(I)**2
+        J2(I) = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 ) + SXY(I)**2 
         ! Third deviatoric invariant
-        J3(I)  = SXX(I)*SYY(I)*SZZ(I) + SXY(I)*SYZ(I)*SZX(I) * TWO
-     .         - SXX(I)*SYZ(I)**2 - SYY(I)*SZX(I)**2 - SZZ(I)*SXY(I)**2 
+        J3(I)  = SXX(I)*SYY(I)*SZZ(I) - SZZ(I)*SXY(I)**2 
         ! Drucker equivalent stress
         FDR(I) = J2(I)**3 - CDR*(J3(I)**2)
         ! Checking equivalent stress values
@@ -340,8 +336,6 @@ c
         DSIGXX(I) = (ONE-D(I))*(A11*DEPSXX(I) + A12*DEPSYY(I))
         DSIGYY(I) = (ONE-D(I))*(A11*DEPSYY(I) + A12*DEPSXX(I))
         DSIGXY(I) = (ONE-D(I))*(DEPSXY(I)*G)
-        DSIGYZ(I) = (ONE-D(I))*(DEPSYZ(I)*GS(I))
-        DSIGZX(I) = (ONE-D(I))*(DEPSZX(I)*GS(I))
         DLAM      = ZERO         
 c
         ! Computation of Drucker equivalent stress of the previous stress tensor
@@ -351,12 +345,8 @@ c
         SYY(I)    = SIGOYY(I) + SIGM(I)
         SZZ(I)    = SIGM(I)
         SXY(I)    = SIGOXY(I)
-        SYZ(I)    = SIGOYZ(I)
-        SZX(I)    = SIGOZX(I)
-        J2(I)     = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2)
-     .          +           SXY(I)**2 + SYZ(I)**2 + SZX(I)**2
-        J3(I)     = SXX(I)*SYY(I)*SZZ(I) + SXY(I)*SYZ(I)*SZX(I) * TWO
-     .            - SXX(I)*SYZ(I)**2 - SYY(I)*SZX(I)**2 - SZZ(I)*SXY(I)**2          
+        J2(I)     = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2) + SXY(I)**2 
+        J3(I)     = SXX(I)*SYY(I)*SZZ(I) - SZZ(I)*SXY(I)**2          
         FDR(I)    = J2(I)**3 - CDR*(J3(I)**2)
         SIGDR(I)  = KDR * EXP((ONE/SIX)*LOG(FDR(I)))  
         ! Computation of the stress triaxiality and the etaT factor
@@ -371,13 +361,13 @@ c
         ! a plastic multiplier allowing to update internal variables to satisfy
         ! the consistency condition. 
         ! Its expression is : DLAMBDA = - (PHI + DPHI) / DPHI_DLAMBDA
-	! -> PHI  : current value of yield function (known)
+	      ! -> PHI  : current value of yield function (known)
         ! -> DPHI : yield function prediction (to compute)
         ! -> DPHI_DLAMBDA : derivative of PHI with respect to DLAMBDA by taking
         !                   into account of internal variables kinetic : 
         !                   plasticity, temperature and damage (to compute)
 c        
-	! 1 - Computation of DPHI_DSIG the normal to the yield surface
+	      ! 1 - Computation of DPHI_DSIG the normal to the yield surface
         !-------------------------------------------------------------  
 c        
         ! Computation of the normal to the yield criterion NORM
@@ -397,9 +387,7 @@ c
         ! Computation of the Eulerian norm of the stress tensor
         NORMSIG = SQRT(SIGOXX(I)*SIGOXX(I)
      .               + SIGOYY(I)*SIGOYY(I)
-     .          + TWO*SIGOXY(I)*SIGOXY(I)
-     .          + TWO*SIGOYZ(I)*SIGOYZ(I)
-     .          + TWO*SIGOZX(I)*SIGOZX(I))
+     .           + TWO*SIGOXY(I)*SIGOXY(I))
 c 
         ! Derivative with respect to Fdr 
         FDR(I)     =  (J2(I)/(NORMSIG**2))**3 - CDR*((J3(I)/(NORMSIG**3))**2)       
@@ -407,25 +395,22 @@ c
         DSDRDJ2    =  DPHI_DFDR*THREE*(J2(I)/(NORMSIG**2))**2                             
         DSDRDJ3    = -DPHI_DFDR*TWO*CDR*(J3(I)/(NORMSIG**3))                   
         ! dJ3/dSig                                                        
-        DJ3DSXX =  TWO_THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .           -  THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
-     .           -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)                 
-        DJ3DSYY = - THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .           + TWO_THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
-     .           -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)             
-        DJ3DSZZ = - THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .            - THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
+        DJ3DSXX =  TWO_THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .              -  THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
+     .              -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)                 
+        DJ3DSYY =    - THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .           + TWO_THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
+     .              -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)             
+        DJ3DSZZ =    - THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .               - THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
      .           + TWO_THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2) 
-        DJ3DSXY = TWO*(SXX(I)*SXY(I) + SXY(I)*SYY(I) + SZX(I)*SYZ(I))/(NORMSIG**2)                   
-        DJ3DSYZ = TWO*(SXY(I)*SZX(I) + SYY(I)*SYZ(I) + SYZ(I)*SZZ(I))/(NORMSIG**2)                     
-        DJ3DSZX = TWO*(SXX(I)*SZX(I) + SXY(I)*SYZ(I) + SZX(I)*SZZ(I))/(NORMSIG**2)                      
+        DJ3DSXY =  TWO*(SXX(I)*SXY(I) + SXY(I)*SYY(I))/(NORMSIG**2)                   
+                   
         ! dPhi/dSig
         NORMXX  = DSDRDJ2*SXX(I)/NORMSIG + DSDRDJ3*DJ3DSXX + DPHI_DTRSIG
         NORMYY  = DSDRDJ2*SYY(I)/NORMSIG + DSDRDJ3*DJ3DSYY + DPHI_DTRSIG
         NORMZZ  = DSDRDJ2*SZZ(I)/NORMSIG + DSDRDJ3*DJ3DSZZ + DPHI_DTRSIG
         NORMXY  = TWO*DSDRDJ2*SXY(I)/NORMSIG + DSDRDJ3*DJ3DSXY
-        NORMYZ  = TWO*DSDRDJ2*SYZ(I)/NORMSIG + DSDRDJ3*DJ3DSYZ
-        NORMZX  = TWO*DSDRDJ2*SZX(I)/NORMSIG + DSDRDJ3*DJ3DSZX     
 c        
         ! Restoring previous value of the yield function
         PHI(I) = PHI0(I)
@@ -434,8 +419,6 @@ c
         DPHI = NORMXX * DSIGXX(I)  
      .       + NORMYY * DSIGYY(I)   
      .       + NORMXY * DSIGXY(I)
-     .       + NORMYZ * DSIGYZ(I)
-     .       + NORMZX * DSIGZX(I)
 c  
         ! 2 - Computation of DPHI_DLAMBDA
         !---------------------------------------------------------
@@ -446,8 +429,6 @@ c
         DFDSIG2 = NORMXX * (ONE-D(I))*(A11*NORMXX + A12*NORMYY)
      .          + NORMYY * (ONE-D(I))*(A11*NORMYY + A12*NORMXX)
      .          + NORMXY * (ONE-D(I))* NORMXY * G
-     .          + NORMYZ * (ONE-D(I))* NORMYZ * GS(I)
-     .          + NORMZX * (ONE-D(I))* NORMZX * GS(I)  
 c  
         !   b) Derivatives with respect to plastic strain P 			
         !   ------------------------------------------------
@@ -471,14 +452,10 @@ c
         SDV_DFDSIG = SXX(I) * NORMXX
      .             + SYY(I) * NORMYY
      .             + SZZ(I) * NORMZZ
-     .             + SXY(I) * NORMXY
-     .             + SYZ(I) * NORMYZ
-     .             + SZX(I) * NORMZX        
+     .             + SXY(I) * NORMXY      
         SIG_DFDSIG = SIGOXX(I) * NORMXX
      .             + SIGOYY(I) * NORMYY
-     .             + SIGOXY(I) * NORMXY
-     .             + SIGOYZ(I) * NORMYZ
-     .             + SIGOZX(I) * NORMZX         
+     .             + SIGOXY(I) * NORMXY        
         DPLA_DLAM(I) = SIG_DFDSIG / ((ONE - FT(I))*YLD(I)) 
 c        
         !  c) Derivatives with respect to the temperature TEMP 
@@ -579,8 +556,6 @@ c
         DPYY     = DLAM * NORMYY
         DPZZ     = DLAM * NORMZZ
         DPXY     = DLAM * NORMXY
-        DPYZ     = DLAM * NORMYZ
-        DPZX     = DLAM * NORMZX 
         TRDEP(I) = DPXX + DPYY + DPZZ
 c        
         ! Cumulated plastic strain and strain rate update
@@ -612,7 +587,7 @@ c
           OMEGA  = MAX(ZERO,OMEGA)
           OMEGA  = MIN(ONE,OMEGA)
           SDPLA  = SXX(I)*DPXX + SYY(I)*DPYY + SZZ(I)*DPZZ
-     .           + SXY(I)*DPXY + SYZ(I)*DPYZ + SZX(I)*DPZX
+     .           + SXY(I)*DPXY
           FSH(I) = FSH(I) + KW*OMEGA*FT(I)*(SDPLA/SIGDR(I))
         ENDIF
         FSH(I) = MAX(FSH(I),ZERO)
@@ -648,23 +623,17 @@ c
         ! Elasto-plastic stresses update   
         SIGNXX(I) = SIGOXX(I) + DSIGXX(I) - (ONE-D(I))*(A11*DPXX + A12*DPYY)
         SIGNYY(I) = SIGOYY(I) + DSIGYY(I) - (ONE-D(I))*(A11*DPYY + A12*DPXX) 
-        SIGNXY(I) = SIGOXY(I) + DSIGXY(I) - (ONE-D(I))*DPXY*G
-        SIGNYZ(I) = SIGOYZ(I) + DSIGYZ(I) - (ONE-D(I))*DPYZ*GS(I)
-        SIGNZX(I) = SIGOZX(I) + DSIGZX(I) - (ONE-D(I))*DPZX*GS(I)     
+        SIGNXY(I) = SIGOXY(I) + DSIGXY(I) - (ONE-D(I))*DPXY*G  
         TRSIG(I)  = SIGNXX(I) + SIGNYY(I)
         SIGM(I)   = -TRSIG(I) * THIRD
         SXX(I)    = SIGNXX(I) + SIGM(I)
         SYY(I)    = SIGNYY(I) + SIGM(I)
         SZZ(I)    = SIGM(I)
         SXY(I)    = SIGNXY(I)
-        SYZ(I)    = SIGNYZ(I)
-        SZX(I)    = SIGNZX(I) 
 c        
         ! Drucker equivalent stress update
-        J2(I)    = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 )
-     .             +         SXY(I)**2 + SYZ(I)**2 + SZX(I)**2
-        J3(I)    = SXX(I) * SYY(I) * SZZ(I) + TWO   * SXY(I) * SYZ(I) * SZX(I)
-     .             - SXX(I) * SYZ(I)**2 - SYY(I) * SZX(I)**2 - SZZ(I) * SXY(I)**2 
+        J2(I)    = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 ) + SXY(I)**2
+        J3(I)    = SXX(I) * SYY(I) * SZZ(I) - SZZ(I) * SXY(I)**2 
         FDR(I)   = J2(I)**3 - CDR*(J3(I)**2)
         SIGDR(I) = KDR * EXP((ONE/SIX)*LOG(FDR(I)))
         ! Computation of the stress triaxiality and the etaT factor

--- a/engine/source/materials/mat/mat104/mat104c_nldam_newton.F
+++ b/engine/source/materials/mat/mat104/mat104c_nldam_newton.F
@@ -82,7 +82,7 @@ c
      .   DTEMP,FCOSH,FSINH,DPDT,DLAM,DDEP
       DOUBLE PRECISION ::
      .   DSDRDJ2,DSDRDJ3,
-     .   DJ3DSXX,DJ3DSYY,DJ3DSXY,DJ3DSZZ,DJ3DSYZ,DJ3DSZX,
+     .   DJ3DSXX,DJ3DSYY,DJ3DSXY,DJ3DSZZ,
      .   DJ2DSXX,DJ2DSYY,DJ2DSXY,NORMSIG,
      .   DFDSXX,DFDSYY,DFDSXY,DYLD_DPLA_NL,
      .   SDPLA,DPHI_DTRSIG,DFDSIG2,SDV_DFDSIG,
@@ -91,12 +91,12 @@ c
      .   DFN,DFSH,DFG,DFT,DYLD_DPLA,DYLD_DTEMP,DTEMP_DLAM
 c
       DOUBLE PRECISION, DIMENSION(NEL) ::
-     .   DSIGXX,DSIGYY,DSIGXY,DSIGYZ,DSIGZX,TRSIG,TRDEP,TRDFDS,
-     .   SXX,SYY,SXY,SZZ,SYZ,SZX,SIGM,J2,J3,SIGDR,YLD,WEITEMP,
+     .   DSIGXX,DSIGYY,DSIGXY,TRSIG,TRDEP,TRDFDS,
+     .   SXX,SYY,SXY,SZZ,SIGM,J2,J3,SIGDR,YLD,WEITEMP,
      .   HARDP,FHARD,FRATE,FTHERM,DTHERM,FDR,PHI0,TRIAX,D,
      .   FDAM,PHI,FT,FS,FG,FN,FSH,DPLA_DLAM,DPHI_DLAM,DEZZ,ETAT,
-     .   NORMXX,NORMYY,NORMXY,NORMZZ,NORMYZ,NORMZX,SIG_DFDSIG,
-     .   DPXX,DPYY,DPXY,DPYZ,DPZX,DPZZ,SIGDR2,YLD2I
+     .   NORMXX,NORMYY,NORMXY,NORMZZ,SIG_DFDSIG,
+     .   DPXX,DPYY,DPXY,DPZZ,SIGDR2,YLD2I
 c
       DOUBLE PRECISION, DIMENSION(NEL) :: 
      .   DLAM_NL,DDPNL,PLAP_NL,DPLA_NL,PLA_NL
@@ -249,15 +249,8 @@ c
         SYY(I)  = SIGOYY(I) + SIGM(I)
         SZZ(I)  = SIGM(I)
         SXY(I)  = SIGOXY(I)
-        SYZ(I)  = SIGOYZ(I)
-        SZX(I)  = SIGOZX(I)
-        J2(I) = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 )
-     .          +       SXY(I)**2 + SYZ(I)**2 + SZX(I)**2
-        J3(I) = SXX(I) * SYY(I) * SZZ(I)  
-     .        + SXY(I) * SYZ(I) * SZX(I) * TWO
-     .        - SXX(I) * SYZ(I)**2
-     .        - SYY(I) * SZX(I)**2
-     .        - SZZ(I) * SXY(I)**2 
+        J2(I) = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 ) + SXY(I)**2 
+        J3(I) = SXX(I) * SYY(I) * SZZ(I) - SZZ(I) * SXY(I)**2 
 c
         FDR(I) = J2(I)**3 - CDR*(J3(I)**2)
         IF (FDR(I) > ZERO) THEN
@@ -293,9 +286,7 @@ c
         ! Computation of the Eulerian norm of the stress tensor
         NORMSIG = SQRT(SIGOXX(I)*SIGOXX(I)
      .               + SIGOYY(I)*SIGOYY(I) 
-     .          + TWO*SIGOXY(I)*SIGOXY(I)
-     .          + TWO*SIGOYZ(I)*SIGOYZ(I)
-     .          + TWO*SIGOZX(I)*SIGOZX(I)) 
+     .          + TWO*SIGOXY(I)*SIGOXY(I)) 
 c
         ! Computation of the norm to the yield surface
         IF (NORMSIG>ZERO) THEN  
@@ -305,35 +296,30 @@ c
           DSDRDJ2     = DPHI_DFDR*THREE*(J2(I)/(NORMSIG**2))**2                             
           DSDRDJ3     = -DPHI_DFDR*TWO*CDR*(J3(I)/(NORMSIG**3))                    
 c       dJ3/dS
-          DJ3DSXX =  TWO_THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .             -  THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
-     .             -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)                 
-          DJ3DSYY = - THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .             + TWO_THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
-     .             -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)             
-          DJ3DSZZ = - THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .              - THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
+          DJ3DSXX =  TWO_THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .                -  THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
+     .                -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)                 
+          DJ3DSYY =    - THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .             + TWO_THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
+     .                -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)             
+          DJ3DSZZ =    - THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .                 - THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
      .             + TWO_THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)
-          DJ3DSXY = TWO*(SXX(I)*SXY(I) + SXY(I)*SYY(I) + SZX(I)*SYZ(I))/(NORMSIG**2)                  
-          DJ3DSYZ = TWO*(SXY(I)*SZX(I) + SYY(I)*SYZ(I) + SYZ(I)*SZZ(I))/(NORMSIG**2)                    
-          DJ3DSZX = TWO*(SXX(I)*SZX(I) + SXY(I)*SYZ(I) + SZX(I)*SZZ(I))/(NORMSIG**2)   
+          DJ3DSXY =  TWO*(SXX(I)*SXY(I) + SXY(I)*SYY(I))/(NORMSIG**2)                  
+c 
         ! dPhi/dSig
           NORMXX(I)  = DSDRDJ2*SXX(I)/NORMSIG + DSDRDJ3*DJ3DSXX + DPHI_DTRSIG
           NORMYY(I)  = DSDRDJ2*SYY(I)/NORMSIG + DSDRDJ3*DJ3DSYY + DPHI_DTRSIG
           NORMZZ(I)  = DSDRDJ2*SZZ(I)/NORMSIG + DSDRDJ3*DJ3DSZZ + DPHI_DTRSIG
           NORMXY(I)  = TWO*DSDRDJ2*SXY(I)/NORMSIG + DSDRDJ3*DJ3DSXY
-          NORMYZ(I)  = TWO*DSDRDJ2*SYZ(I)/NORMSIG + DSDRDJ3*DJ3DSYZ
-          NORMZX(I)  = TWO*DSDRDJ2*SZX(I)/NORMSIG + DSDRDJ3*DJ3DSZX  
           TRDFDS(I)  = NORMXX(I) + NORMYY(I) + NORMZZ(I)    
           SIG_DFDSIG(I) = SIGOXX(I)*NORMXX(I) + SIGOYY(I)*NORMYY(I)
-     .                  + SIGOXY(I)*NORMXY(I) + SIGOYZ(I)*NORMYZ(I) + SIGOZX(I)*NORMZX(I)
+     .                  + SIGOXY(I)*NORMXY(I)
         ELSE
           NORMXX(I)     = ZERO
           NORMYY(I)     = ZERO
           NORMZZ(I)     = ZERO
           NORMXY(I)     = ZERO
-          NORMYZ(I)     = ZERO
-          NORMZX(I)     = ZERO
           TRDFDS(I)     = ZERO
           SIG_DFDSIG(I) = ZERO
         ENDIF
@@ -370,7 +356,7 @@ c
           OMEGA  = MAX(OMEGA,ZERO)
           OMEGA  = MIN(OMEGA,ONE)
           SDPLA  = (SXX(I)*NORMXX(I)+SYY(I)*NORMYY(I)+ SZZ(I)*NORMZZ(I)
-     .            + SXY(I)*NORMXY(I)+SYZ(I)*NORMYZ(I)+ SZX(I)*NORMZX(I))
+     .            + SXY(I)*NORMXY(I))
      .            * DLAM_NL(I)  
           FSH(I) = FSH(I) + KW*OMEGA*FT(I)*(SDPLA/SIGDR(I))
         ENDIF
@@ -436,14 +422,10 @@ c
         SYY(I)    = SIGNYY(I) + SIGM(I)
         SZZ(I)    = SIGM(I)
         SXY(I)    = SIGNXY(I)
-        SYZ(I)    = SIGNYZ(I)
-        SZX(I)    = SIGNZX(I)
         ! Second deviatoric invariant
-        J2(I) = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 )
-     .          +       SXY(I)**2 + SYZ(I)**2 + SZX(I)**2
+        J2(I) = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 ) + SXY(I)**2 
         ! Third deviatoric invariant
-        J3(I)  = SXX(I)*SYY(I)*SZZ(I) + SXY(I)*SYZ(I)*SZX(I) * TWO
-     .         - SXX(I)*SYZ(I)**2 - SYY(I)*SZX(I)**2 - SZZ(I)*SXY(I)**2 
+        J3(I)  = SXX(I)*SYY(I)*SZZ(I) - SZZ(I)*SXY(I)**2 
         ! Drucker equivalent stress
         FDR(I) = J2(I)**3 - CDR*(J3(I)**2)
         ! Checking equivalent stress values
@@ -519,8 +501,6 @@ c
         DPYY(I)   = ZERO
         DPZZ(I)   = ZERO
         DPXY(I)   = ZERO
-        DPYZ(I)   = ZERO
-        DPZX(I)   = ZERO
       ENDDO
 c        
       ! Loop over the iterations     
@@ -534,12 +514,12 @@ c
           ! the consistency condition using the backward Euler implicit method
           ! with a Newton-Raphson iterative procedure
           ! Its expression at each iteration is : DLAMBDA = - PHI/DPHI_DLAMBDA
-	  ! -> PHI          : current value of yield function (known)
+	        ! -> PHI          : current value of yield function (known)
           ! -> DPHI_DLAMBDA : derivative of PHI with respect to DLAMBDA by taking
           !                   into account of internal variables kinetic : 
           !                   plasticity, temperature and damage (to compute)
 c        
-	  ! 1 - Computation of DPHI_DSIG the normal to the yield surface
+	        ! 1 - Computation of DPHI_DSIG the normal to the yield surface
           !-------------------------------------------------------------
           ! Computation of the normal to the yield criterion NORM
           ! flow direction (derivative dPhi / Dsig) 
@@ -558,9 +538,7 @@ c
           ! Computation of the Eulerian norm of the stress tensor
           NORMSIG = SQRT(SIGNXX(I)*SIGNXX(I)
      .                 + SIGNYY(I)*SIGNYY(I)
-     .            + TWO*SIGNXY(I)*SIGNXY(I)
-     .            + TWO*SIGNYZ(I)*SIGNYZ(I)
-     .            + TWO*SIGNZX(I)*SIGNZX(I))
+     .            + TWO*SIGNXY(I)*SIGNXY(I))
 c 
           ! Derivative with respect to Fdr 
           FDR(I)     =  (J2(I)/(NORMSIG**2))**3 - CDR*((J3(I)/(NORMSIG**3))**2)       
@@ -568,25 +546,21 @@ c
           DSDRDJ2    =  DPHI_DFDR*THREE*(J2(I)/(NORMSIG**2))**2                             
           DSDRDJ3    = -DPHI_DFDR*TWO*CDR*(J3(I)/(NORMSIG**3))                   
           ! dJ3/dSig                                                        
-          DJ3DSXX =  TWO_THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .             -  THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
-     .             -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)                 
-          DJ3DSYY = - THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .             + TWO_THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
-     .             -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)             
-          DJ3DSZZ = - THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .              - THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
+          DJ3DSXX =  TWO_THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .                -  THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
+     .                -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)                 
+          DJ3DSYY =    - THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .             + TWO_THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
+     .                -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)             
+          DJ3DSZZ =    - THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .                 - THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
      .             + TWO_THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)
-          DJ3DSXY = TWO*(SXX(I)*SXY(I) + SXY(I)*SYY(I) + SZX(I)*SYZ(I))/(NORMSIG**2)                   
-          DJ3DSYZ = TWO*(SXY(I)*SZX(I) + SYY(I)*SYZ(I) + SYZ(I)*SZZ(I))/(NORMSIG**2)                     
-          DJ3DSZX = TWO*(SXX(I)*SZX(I) + SXY(I)*SYZ(I) + SZX(I)*SZZ(I))/(NORMSIG**2)                      
+          DJ3DSXY =  TWO*(SXX(I)*SXY(I) + SXY(I)*SYY(I))/(NORMSIG**2)                                      
           ! dPhi/dSig
           NORMXX(I) = DSDRDJ2*SXX(I)/NORMSIG + DSDRDJ3*DJ3DSXX + DPHI_DTRSIG
           NORMYY(I) = DSDRDJ2*SYY(I)/NORMSIG + DSDRDJ3*DJ3DSYY + DPHI_DTRSIG
           NORMZZ(I) = DSDRDJ2*SZZ(I)/NORMSIG + DSDRDJ3*DJ3DSZZ + DPHI_DTRSIG
           NORMXY(I) = TWO*DSDRDJ2*SXY(I)/NORMSIG + DSDRDJ3*DJ3DSXY
-          NORMYZ(I) = TWO*DSDRDJ2*SYZ(I)/NORMSIG + DSDRDJ3*DJ3DSYZ
-          NORMZX(I) = TWO*DSDRDJ2*SZX(I)/NORMSIG + DSDRDJ3*DJ3DSZX 
 c          
           ! 2 - Computation of DPHI_DLAMBDA
           !---------------------------------------------------------
@@ -596,9 +570,7 @@ c
           TRDFDS(I) = NORMXX(I) + NORMYY(I) + NORMZZ(I)  
           DFDSIG2 = NORMXX(I) * (ONE-D(I))*(A11*NORMXX(I) + A12*NORMYY(I))
      .            + NORMYY(I) * (ONE-D(I))*(A11*NORMYY(I) + A12*NORMXX(I))
-     .            + NORMXY(I) * (ONE-D(I))* NORMXY(I) * G
-     .            + NORMYZ(I) * (ONE-D(I))* NORMYZ(I) * GS(I)
-     .            + NORMZX(I) * (ONE-D(I))* NORMZX(I) * GS(I)   
+     .            + NORMXY(I) * (ONE-D(I))* NORMXY(I) * G 
 c     
           !   b) Derivatives with respect to plastic strain P 			
           !   ------------------------------------------------
@@ -612,9 +584,7 @@ c
           !     -------------------------------------------       
           SIG_DFDSIG(I) = SIGNXX(I) * NORMXX(I)
      .                  + SIGNYY(I) * NORMYY(I)
-     .                  + SIGNXY(I) * NORMXY(I)
-     .                  + SIGNYZ(I) * NORMYZ(I)
-     .                  + SIGNZX(I) * NORMZX(I)        
+     .                  + SIGNXY(I) * NORMXY(I)     
           DPLA_DLAM(I) = SIG_DFDSIG(I) / ((ONE - FT(I))*YLD(I)) 
 c          
           !  c) Derivative with respect to the yield stress
@@ -633,25 +603,19 @@ c
           DPXX(I)  = DLAM * NORMXX(I)
           DPYY(I)  = DLAM * NORMYY(I)
           DPZZ(I)  = DLAM * NORMZZ(I)
-          DPXY(I)  = DLAM * NORMXY(I)
-          DPYZ(I)  = DLAM * NORMYZ(I)
-          DPZX(I)  = DLAM * NORMZX(I)  
+          DPXY(I)  = DLAM * NORMXY(I) 
           TRDEP(I) = DPXX(I) + DPYY(I) + DPZZ(I)   
 c          
           ! Elasto-plastic stresses update   
           SIGNXX(I) = SIGNXX(I) - (ONE-D(I))*(A11*DPXX(I) + A12*DPYY(I))
           SIGNYY(I) = SIGNYY(I) - (ONE-D(I))*(A11*DPYY(I) + A12*DPXX(I))
           SIGNXY(I) = SIGNXY(I) - (ONE-D(I))*DPXY(I)*G
-          SIGNYZ(I) = SIGNYZ(I) - (ONE-D(I))*DPYZ(I)*GS(I)
-          SIGNZX(I) = SIGNZX(I) - (ONE-D(I))*DPZX(I)*GS(I)
           TRSIG(I)  = SIGNXX(I) + SIGNYY(I)
           SIGM(I)   = -TRSIG(I) * THIRD
           SXX(I)    = SIGNXX(I) + SIGM(I)
           SYY(I)    = SIGNYY(I) + SIGM(I)
           SZZ(I)    = SIGM(I)
-          SXY(I)    = SIGNXY(I)
-          SYZ(I)    = SIGNYZ(I)
-          SZX(I)    = SIGNZX(I)    
+          SXY(I)    = SIGNXY(I) 
 c          
           ! Cumulated plastic strain and strain rate update         
           DDEP    = (DLAM/((ONE - FT(I))*YLD(I)))*SIG_DFDSIG(I)
@@ -659,10 +623,8 @@ c
           PLA(I)  = PLA(I) + DDEP 
 c          
           ! Drucker equivalent stress update
-          J2(I)    = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 )
-     .             +         SXY(I)**2 + SYZ(I)**2 + SZX(I)**2
-          J3(I)    = SXX(I) * SYY(I) * SZZ(I) + TWO   * SXY(I) * SYZ(I) * SZX(I)
-     .             - SXX(I) * SYZ(I)**2 - SYY(I) * SZX(I)**2 - SZZ(I) * SXY(I)**2 
+          J2(I)    = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 ) + SXY(I)**2 
+          J3(I)    = SXX(I) * SYY(I) * SZZ(I) - SZZ(I) * SXY(I)**2 
           FDR(I)   = J2(I)**3 - CDR*(J3(I)**2)
           SIGDR(I) = KDR * EXP((ONE/SIX)*LOG(FDR(I)))
           ! Computation of the stress triaxiality and the etaT factor

--- a/engine/source/materials/mat/mat104/mat104c_nldam_nice.F
+++ b/engine/source/materials/mat/mat104/mat104c_nldam_nice.F
@@ -82,8 +82,8 @@ c
      .   DTI,H,LDAV,SIGVM,SIGDR2,YLD2I,OMEGA,
      .   DTEMP,FCOSH,FSINH,DPDT,DLAM,DDEP
       DOUBLE PRECISION :: 
-     .   DPXX,DPYY,DPXY,DPYZ,DPZX,DPZZ,DSDRDJ2,DSDRDJ3,
-     .   DJ3DSXX,DJ3DSYY,DJ3DSXY,DJ3DSZZ,DJ3DSYZ,DJ3DSZX,
+     .   DPXX,DPYY,DPXY,DPZZ,DSDRDJ2,DSDRDJ3,
+     .   DJ3DSXX,DJ3DSYY,DJ3DSXY,DJ3DSZZ,
      .   DJ2DSXX,DJ2DSYY,DJ2DSXY,
      .   DFDSXX,DFDSYY,DFDSXY,DYLD_DPLA_NL,
      .   DENOM,DPHI,SDPLA,SDV_DFDSIG,DFDSIG2,
@@ -92,11 +92,11 @@ c
      .   DFN,DFSH,DFG,DFT,DYLD_DPLA,DYLD_DTEMP,DTEMP_DLAM
 c
       DOUBLE PRECISION, DIMENSION(NEL) ::
-     .   DSIGXX,DSIGYY,DSIGXY,DSIGYZ,DSIGZX,TRSIG,TRDEP,
-     .   SXX,SYY,SXY,SZZ,SYZ,SZX,SIGM,J2,J3,SIGDR,YLD,WEITEMP,TRDFDS,
+     .   DSIGXX,DSIGYY,DSIGXY,TRSIG,TRDEP,
+     .   SXX,SYY,SXY,SZZ,SIGM,J2,J3,SIGDR,YLD,WEITEMP,TRDFDS,
      .   HARDP,FHARD,FRATE,FTHERM,FDR,D,TRIAX,ETAT,SIGDR_OLD,
      .   FDAM,PHI0,PHI,FT,FS,FG,FN,FSH,DPLA_DLAM,DEZZ,DPHI_DTRSIG,
-     .   NORMXX,NORMYY,NORMXY,NORMZZ,NORMYZ,NORMZX,SIG_DFDSIG
+     .   NORMXX,NORMYY,NORMXY,NORMZZ,SIG_DFDSIG
 c
       DOUBLE PRECISION, DIMENSION(NEL) :: 
      .   DLAM_NL,DDPNL,PLAP_NL,DPLA_NL,PLA_NL
@@ -251,15 +251,8 @@ c
         SYY(I)  = SIGOYY(I) + SIGM(I)
         SZZ(I)  = SIGM(I)
         SXY(I)  = SIGOXY(I)
-        SYZ(I)  = SIGOYZ(I)
-        SZX(I)  = SIGOZX(I)
-        J2(I)   = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 )
-     .          +       SXY(I)**2 + SYZ(I)**2 + SZX(I)**2
-        J3(I)   = SXX(I) * SYY(I) * SZZ(I)  
-     .          + SXY(I) * SYZ(I) * SZX(I) * TWO
-     .          - SXX(I) * SYZ(I)**2
-     .          - SYY(I) * SZX(I)**2
-     .          - SZZ(I) * SXY(I)**2 
+        J2(I)   = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2) + SXY(I)**2 
+        J3(I)   = SXX(I) * SYY(I) * SZZ(I) - SZZ(I) * SXY(I)**2 
 c
         FDR(I) = J2(I)**3 - CDR*(J3(I)**2)
         IF (FDR(I) > ZERO) THEN
@@ -296,9 +289,7 @@ c
         ! Computation of the Eulerian norm of the stress tensor
         NORMSIG = SQRT(SIGOXX(I)*SIGOXX(I)
      .               + SIGOYY(I)*SIGOYY(I) 
-     .          + TWO*SIGOXY(I)*SIGOXY(I)
-     .          + TWO*SIGOYZ(I)*SIGOYZ(I)
-     .          + TWO*SIGOZX(I)*SIGOZX(I))      
+     .          + TWO*SIGOXY(I)*SIGOXY(I))      
 c     
         ! Computation of the norm to the yield surface
         IF (NORMSIG>ZERO) THEN  
@@ -308,35 +299,29 @@ c
           DSDRDJ2     = DPHI_DFDR*THREE*(J2(I)/(NORMSIG**2))**2                             
           DSDRDJ3     = -DPHI_DFDR*TWO*CDR*(J3(I)/(NORMSIG**3))                    
           ! dJ3/dS
-          DJ3DSXX =  TWO_THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .             -  THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
-     .             -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)                 
-          DJ3DSYY = - THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .             + TWO_THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
-     .             -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)             
-          DJ3DSZZ = - THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .              - THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
+          DJ3DSXX =  TWO_THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .                -  THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
+     .                -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)                 
+          DJ3DSYY =    - THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .             + TWO_THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
+     .                -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)             
+          DJ3DSZZ =    - THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .                 - THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
      .             + TWO_THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)       
-          DJ3DSXY = TWO*(SXX(I)*SXY(I) + SXY(I)*SYY(I) + SZX(I)*SYZ(I))/(NORMSIG**2)                  
-          DJ3DSYZ = TWO*(SXY(I)*SZX(I) + SYY(I)*SYZ(I) + SYZ(I)*SZZ(I))/(NORMSIG**2)                    
-          DJ3DSZX = TWO*(SXX(I)*SZX(I) + SXY(I)*SYZ(I) + SZX(I)*SZZ(I))/(NORMSIG**2)   
+          DJ3DSXY =  TWO*(SXX(I)*SXY(I) + SXY(I)*SYY(I))/(NORMSIG**2)   
           ! dPhi/dSig
           NORMXX(I)  = DSDRDJ2*SXX(I)/NORMSIG + DSDRDJ3*DJ3DSXX + DPHI_DTRSIG(I)
           NORMYY(I)  = DSDRDJ2*SYY(I)/NORMSIG + DSDRDJ3*DJ3DSYY + DPHI_DTRSIG(I)
           NORMZZ(I)  = DSDRDJ2*SZZ(I)/NORMSIG + DSDRDJ3*DJ3DSZZ + DPHI_DTRSIG(I)
           NORMXY(I)  = TWO*DSDRDJ2*SXY(I)/NORMSIG + DSDRDJ3*DJ3DSXY
-          NORMYZ(I)  = TWO*DSDRDJ2*SYZ(I)/NORMSIG + DSDRDJ3*DJ3DSYZ
-          NORMZX(I)  = TWO*DSDRDJ2*SZX(I)/NORMSIG + DSDRDJ3*DJ3DSZX  
           TRDFDS(I)  = NORMXX(I) + NORMYY(I) + NORMZZ(I)    
           SIG_DFDSIG(I) = SIGOXX(I)*NORMXX(I) + SIGOYY(I)*NORMYY(I)
-     .                  + SIGOXY(I)*NORMXY(I) + SIGOYZ(I)*NORMYZ(I) + SIGOZX(I)*NORMZX(I)
+     .                  + SIGOXY(I)*NORMXY(I) 
         ELSE
           NORMXX(I)     = ZERO
           NORMYY(I)     = ZERO
           NORMZZ(I)     = ZERO
           NORMXY(I)     = ZERO
-          NORMYZ(I)     = ZERO
-          NORMZX(I)     = ZERO
           TRDFDS(I)     = ZERO
           SIG_DFDSIG(I) = ZERO
         ENDIF
@@ -373,8 +358,7 @@ c
           OMEGA  = MAX(OMEGA,ZERO)
           OMEGA  = MIN(OMEGA,ONE)
           SDPLA  = (SXX(I)*NORMXX(I)+SYY(I)*NORMYY(I)+ SZZ(I)*NORMZZ(I)
-     .            + SXY(I)*NORMXY(I)+SYZ(I)*NORMYZ(I)+ SZX(I)*NORMZX(I))
-     .            * DLAM_NL(I)  
+     .            + SXY(I)*NORMXY(I))* DLAM_NL(I)  
           FSH(I) = FSH(I) + KW*OMEGA*FT(I)*(SDPLA/SIGDR(I))
         ENDIF
         FSH(I) = MAX(FSH(I),ZERO)
@@ -439,14 +423,10 @@ c
         SYY(I)    = SIGNYY(I) + SIGM(I)
         SZZ(I)    = SIGM(I)
         SXY(I)    = SIGNXY(I)
-        SYZ(I)    = SIGNYZ(I)
-        SZX(I)    = SIGNZX(I)
         ! Second deviatoric invariant
-        J2(I) = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2)
-     .          +       SXY(I)**2 + SYZ(I)**2 + SZX(I)**2
+        J2(I) = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2) + SXY(I)**2 
         ! Third deviatoric invariant
-        J3(I)  = SXX(I)*SYY(I)*SZZ(I) + SXY(I)*SYZ(I)*SZX(I) * TWO
-     .         - SXX(I)*SYZ(I)**2 - SYY(I)*SZX(I)**2 - SZZ(I)*SXY(I)**2 
+        J3(I)  = SXX(I)*SYY(I)*SZZ(I) - SZZ(I)*SXY(I)**2 
         ! Drucker equivalent stress
         FDR(I) = J2(I)**3 - CDR*(J3(I)**2)
         ! Checking equivalent stress values
@@ -513,22 +493,20 @@ c
         ! Computation of the trial stress increment
         DSIGXX(I) = (ONE-D(I))*(A11*DEPSXX(I) + A12*DEPSYY(I))
         DSIGYY(I) = (ONE-D(I))*(A11*DEPSYY(I) + A12*DEPSXX(I))
-        DSIGXY(I) = (ONE-D(I))*(DEPSXY(I)*G)  
-        DSIGYZ(I) = (ONE-D(I))*(DEPSYZ(I)*GS(I))
-        DSIGZX(I) = (ONE-D(I))*(DEPSZX(I)*GS(I))
+        DSIGXY(I) = (ONE-D(I))*(DEPSXY(I)*G)
         DLAM      = ZERO      
 c        
         ! Note     : in this part, the purpose is to compute for each iteration
         ! a plastic multiplier allowing to update internal variables to satisfy
         ! the consistency condition. 
         ! Its expression is : DLAMBDA = - (PHI + DPHI) / DPHI_DLAMBDA
-	! -> PHI  : current value of yield function (known)
+	      ! -> PHI  : current value of yield function (known)
         ! -> DPHI : yield function prediction (to compute)
         ! -> DPHI_DLAMBDA : derivative of PHI with respect to DLAMBDA by taking
         !                   into account of internal variables kinetic : 
         !                   plasticity, temperature and damage (to compute)
 c        
-	! 1 - Computation of DPHI_DSIG the normal to the yield surface
+	      ! 1 - Computation of DPHI_DSIG the normal to the yield surface
         !-------------------------------------------------------------  
 c
         ! DPHI_DSIG already computed above
@@ -540,8 +518,6 @@ c
         DPHI = NORMXX(I) * DSIGXX(I)  
      .       + NORMYY(I) * DSIGYY(I)   
      .       + NORMXY(I) * DSIGXY(I)
-     .       + NORMYZ(I) * DSIGYZ(I)
-     .       + NORMZX(I) * DSIGZX(I)
 c  
         ! 2 - Computation of DPHI_DLAMBDA
         !---------------------------------------------------------
@@ -550,9 +526,7 @@ c
         !   --------------------------------------------------------
         DFDSIG2   = NORMXX(I) * (ONE-D(I))*(A11*NORMXX(I) + A12*NORMYY(I))
      .            + NORMYY(I) * (ONE-D(I))*(A11*NORMYY(I) + A12*NORMXX(I))
-     .            + NORMXY(I) * (ONE-D(I))* NORMXY(I) * G
-     .            + NORMYZ(I) * (ONE-D(I))* NORMYZ(I) * GS(I)
-     .            + NORMZX(I) * (ONE-D(I))* NORMZX(I) * GS(I)  
+     .            + NORMXY(I) * (ONE-D(I))* NORMXY(I) * G  
 c  
         !   b) Derivatives with respect to plastic strain P 			
         !   ------------------------------------------------
@@ -588,24 +562,18 @@ c
         DPYY     = DLAM * NORMYY(I)
         DPZZ     = DLAM * NORMZZ(I)
         DPXY     = DLAM * NORMXY(I)
-        DPYZ     = DLAM * NORMYZ(I)
-        DPZX     = DLAM * NORMZX(I)
         TRDEP(I) = DPXX + DPYY + DPZZ          
 c        
         ! Elasto-plastic stresses update   
         SIGNXX(I) = SIGOXX(I) + DSIGXX(I) - (ONE-D(I))*(A11*DPXX + A12*DPYY)
         SIGNYY(I) = SIGOYY(I) + DSIGYY(I) - (ONE-D(I))*(A11*DPYY + A12*DPXX) 
         SIGNXY(I) = SIGOXY(I) + DSIGXY(I) - (ONE-D(I))*DPXY*G
-        SIGNYZ(I) = SIGOYZ(I) + DSIGYZ(I) - (ONE-D(I))*DPYZ*GS(I)
-        SIGNZX(I) = SIGOZX(I) + DSIGZX(I) - (ONE-D(I))*DPZX*GS(I)      
         TRSIG(I)  = SIGNXX(I) + SIGNYY(I)
         SIGM(I)   = -TRSIG(I) * THIRD
         SXX(I)    = SIGNXX(I) + SIGM(I)
         SYY(I)    = SIGNYY(I) + SIGM(I)
         SZZ(I)    = SIGM(I)
         SXY(I)    = SIGNXY(I)
-        SYZ(I)    = SIGNYZ(I)
-        SZX(I)    = SIGNZX(I)    
 c        
         ! Cumulated plastic strain and strain rate update
         DDEP     = (DLAM/((ONE - FT(I))*YLD(I)))*SIG_DFDSIG(I)
@@ -613,10 +581,8 @@ c
         PLA(I)   = PLA(I)  + DDEP  
 c        
         ! Drucker equivalent stress update
-        J2(I)    = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 )
-     .             +         SXY(I)**2 + SYZ(I)**2 + SZX(I)**2
-        J3(I)    = SXX(I) * SYY(I) * SZZ(I) + TWO   * SXY(I) * SYZ(I) * SZX(I)
-     .             - SXX(I) * SYZ(I)**2 - SYY(I) * SZX(I)**2 - SZZ(I) * SXY(I)**2 
+        J2(I)    = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2) + SXY(I)**2
+        J3(I)    = SXX(I) * SYY(I) * SZZ(I) - SZZ(I) * SXY(I)**2 
         FDR(I)   = J2(I)**3 - CDR*(J3(I)**2)
         SIGDR(I) = KDR * EXP((ONE/SIX)*LOG(FDR(I)))  
         ! Computation of the stress triaxiality and the etaT factor

--- a/engine/source/materials/mat/mat104/mat104c_nodam_newton.F
+++ b/engine/source/materials/mat/mat104/mat104c_nodam_newton.F
@@ -82,19 +82,19 @@ c
      .   DTEMP,FCOSH,FSINH,DPDT,DLAM,DDEP,DEPXX,DEPYY
       my_real 
      .   DSDRDJ2,DSDRDJ3,
-     .   DJ3DSXX,DJ3DSYY,DJ3DSXY,DJ3DSZZ,DJ3DSYZ,DJ3DSZX,
+     .   DJ3DSXX,DJ3DSYY,DJ3DSXY,DJ3DSZZ,
      .   DJ2DSXX,DJ2DSYY,DJ2DSXY,
      .   DFDSXX,DFDSYY,DFDSXY,
-     .   NORMXX,NORMYY,NORMXY,NORMZZ,NORMYZ,NORMZX,
+     .   NORMXX,NORMYY,NORMXY,NORMZZ,
      .   DENOM,DPHI,DPHI_DTRSIG,SIG_DFDSIG,DFDSIG2,
      .   DPHI_DSIG,DPHI_DYLD,DPHI_DFDR,DPDT_NL,
      .   DYLD_DPLA,DYLD_DTEMP,DTEMP_DLAM,DLAM_NL    
 c
       my_real, DIMENSION(NEL) ::
-     .   DSIGXX,DSIGYY,DSIGXY,DSIGYZ,DSIGZX,TRSIG,TRDEP,
-     .   SXX,SYY,SXY,SZZ,SYZ,SZX,SIGM,J2,J3,SIGDR,YLD,WEITEMP,
+     .   DSIGXX,DSIGYY,DSIGXY,TRSIG,TRDEP,
+     .   SXX,SYY,SXY,SZZ,SIGM,J2,J3,SIGDR,YLD,WEITEMP,
      .   HARDP,FHARD,FRATE,FTHERM,FDR,PHI0,PHI,DPLA_DLAM,
-     .   DEZZ,DPHI_DLAM,DPXX,DPYY,DPXY,DPYZ,DPZX,DPZZ,SIGDR2,YLD2I
+     .   DEZZ,DPHI_DLAM,DPXX,DPYY,DPXY,DPZZ,SIGDR2,YLD2I
       !=======================================================================
       !       DRUCKER MATERIAL LAW WITH NO DAMAGE
       !=======================================================================
@@ -208,15 +208,11 @@ c
         SYY(I)    = SIGNYY(I) + SIGM(I)
         SZZ(I)    = SIGM(I)
         SXY(I)    = SIGNXY(I)
-        SYZ(I)    = SIGNYZ(I)
-        SZX(I)    = SIGNZX(I)
         DEZZ(I)   = -NNU*DEPSXX(I) - NNU*DEPSYY(I)
         ! Second deviatoric invariant
-        J2(I) = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 )
-     .          +       SXY(I)**2 + SYZ(I)**2 + SZX(I)**2
+        J2(I) = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 ) + SXY(I)**2 
         ! Third deviatoric invariant
-        J3(I)  = SXX(I)*SYY(I)*SZZ(I) + SXY(I)*SYZ(I)*SZX(I) * TWO
-     .         - SXX(I)*SYZ(I)**2 - SYY(I)*SZX(I)**2 - SZZ(I)*SXY(I)**2 
+        J3(I)  = SXX(I)*SYY(I)*SZZ(I) - SZZ(I)*SXY(I)**2 
         ! Drucker equivalent stress
         FDR(I) = J2(I)**3 - CDR*(J3(I)**2)
         ! Checking equivalent stress values
@@ -262,8 +258,6 @@ c
         DPYY(I)   = ZERO
         DPZZ(I)   = ZERO
         DPXY(I)   = ZERO
-        DPYZ(I)   = ZERO
-        DPZX(I)   = ZERO
       ENDDO  
 c     
       ! Loop over the iterations     
@@ -278,12 +272,12 @@ c
           ! the consistency condition using the backward Euler implicit method
           ! with a Newton-Raphson iterative procedure
           ! Its expression at each iteration is : DLAMBDA = - PHI/DPHI_DLAMBDA
-	  ! -> PHI          : current value of yield function (known)
+	        ! -> PHI          : current value of yield function (known)
           ! -> DPHI_DLAMBDA : derivative of PHI with respect to DLAMBDA by taking
           !                   into account of internal variables kinetic : 
           !                   plasticity, temperature and damage (to compute)
 c        
-	  ! 1 - Computation of DPHI_DSIG the normal to the yield surface
+	        ! 1 - Computation of DPHI_DSIG the normal to the yield surface
           !-------------------------------------------------------------
           ! Computation of the normal to the yield criterion NORM
           ! flow direction (derivative dPhi / Dsig) 
@@ -298,9 +292,7 @@ c
           ! Computation of the Eulerian norm of the stress tensor
           NORMSIG = SQRT(SIGNXX(I)*SIGNXX(I)
      .                 + SIGNYY(I)*SIGNYY(I)
-     .            + TWO*SIGNXY(I)*SIGNXY(I)
-     .            + TWO*SIGNYZ(I)*SIGNYZ(I)
-     .            + TWO*SIGNZX(I)*SIGNZX(I)) 
+     .            + TWO*SIGNXY(I)*SIGNXY(I)) 
 c 
           ! Derivative with respect to Fdr 
           FDR(I)     =  (J2(I)/(NORMSIG**2))**3 - CDR*((J3(I)/(NORMSIG**3))**2)       
@@ -308,25 +300,21 @@ c
           DSDRDJ2    =  DPHI_DFDR*THREE*(J2(I)/(NORMSIG**2))**2                             
           DSDRDJ3    = -DPHI_DFDR*TWO*CDR*(J3(I)/(NORMSIG**3))                   
           ! dJ3/dSig                                                        
-          DJ3DSXX =  TWO_THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .             -  THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
-     .             -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)                 
-          DJ3DSYY = - THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .             + TWO_THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
-     .             -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)             
-          DJ3DSZZ = - THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .              - THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
+          DJ3DSXX =  TWO_THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .                -  THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
+     .                -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)                 
+          DJ3DSYY =    - THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .             + TWO_THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
+     .                -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)             
+          DJ3DSZZ =    - THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .                 - THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
      .             + TWO_THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2) 
-          DJ3DSXY = TWO*(SXX(I)*SXY(I) + SXY(I)*SYY(I) + SZX(I)*SYZ(I))/(NORMSIG**2)                   
-          DJ3DSYZ = TWO*(SXY(I)*SZX(I) + SYY(I)*SYZ(I) + SYZ(I)*SZZ(I))/(NORMSIG**2)                     
-          DJ3DSZX = TWO*(SXX(I)*SZX(I) + SXY(I)*SYZ(I) + SZX(I)*SZZ(I))/(NORMSIG**2)                      
+          DJ3DSXY =  TWO*(SXX(I)*SXY(I) + SXY(I)*SYY(I))/(NORMSIG**2)                      
           ! dPhi/dSig
           NORMXX  = DSDRDJ2*SXX(I)/NORMSIG + DSDRDJ3*DJ3DSXX
           NORMYY  = DSDRDJ2*SYY(I)/NORMSIG + DSDRDJ3*DJ3DSYY
           NORMZZ  = DSDRDJ2*SZZ(I)/NORMSIG + DSDRDJ3*DJ3DSZZ
           NORMXY  = TWO*DSDRDJ2*SXY(I)/NORMSIG + DSDRDJ3*DJ3DSXY
-          NORMYZ  = TWO*DSDRDJ2*SYZ(I)/NORMSIG + DSDRDJ3*DJ3DSYZ
-          NORMZX  = TWO*DSDRDJ2*SZX(I)/NORMSIG + DSDRDJ3*DJ3DSZX 
 c          
           ! 2 - Computation of DPHI_DLAMBDA
           !---------------------------------------------------------
@@ -335,9 +323,7 @@ c
           !   --------------------------------------------------------
           DFDSIG2 = NORMXX * (A11*NORMXX + A12*NORMYY)
      .            + NORMYY * (A11*NORMYY + A12*NORMXX)
-     .            + NORMXY * NORMXY * G
-     .            + NORMYZ * NORMYZ * GS(I)
-     .            + NORMZX * NORMZX * GS(I)         
+     .            + NORMXY * NORMXY * G     
 c         
           !   b) Derivatives with respect to plastic strain P 			
           !   ------------------------------------------------  
@@ -351,9 +337,7 @@ c
           !     -------------------------------------------   
           SIG_DFDSIG = SIGNXX(I) * NORMXX
      .               + SIGNYY(I) * NORMYY
-     .               + SIGNXY(I) * NORMXY
-     .               + SIGNYZ(I) * NORMYZ
-     .               + SIGNZX(I) * NORMZX         
+     .               + SIGNXY(I) * NORMXY       
           DPLA_DLAM(I) = SIG_DFDSIG / YLD(I)         
 c          
           !  c) Derivatives with respect to the temperature TEMP 
@@ -392,23 +376,17 @@ c
           DPYY(I) = DLAM * NORMYY
           DPZZ(I) = DLAM * NORMZZ
           DPXY(I) = DLAM * NORMXY
-          DPYZ(I) = DLAM * NORMYZ
-          DPZX(I) = DLAM * NORMZX
 c          
           ! Elasto-plastic stresses update   
           SIGNXX(I) = SIGNXX(I) - (A11*DPXX(I) + A12*DPYY(I))
           SIGNYY(I) = SIGNYY(I) - (A11*DPYY(I) + A12*DPXX(I))
           SIGNXY(I) = SIGNXY(I) - DPXY(I)*G
-          SIGNYZ(I) = SIGNYZ(I) - DPYZ(I)*GS(I)
-          SIGNZX(I) = SIGNZX(I) - DPZX(I)*GS(I)
           TRSIG(I)  = SIGNXX(I) + SIGNYY(I)
           SIGM(I)   = -TRSIG(I) * THIRD
           SXX(I)    = SIGNXX(I) + SIGM(I)
           SYY(I)    = SIGNYY(I) + SIGM(I)
           SZZ(I)    = SIGM(I)
-          SXY(I)    = SIGNXY(I)
-          SYZ(I)    = SIGNYZ(I)
-          SZX(I)    = SIGNZX(I)   
+          SXY(I)    = SIGNXY(I)  
 c          
           ! Cumulated plastic strain and strain rate update           
           DDEP    = (DLAM/YLD(I))*SIG_DFDSIG
@@ -416,10 +394,8 @@ c
           PLA(I)  = PLA(I) + DDEP 
 c          
           ! Drucker equivalent stress update
-          J2(I)    = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 )
-     .             +         SXY(I)**2 + SYZ(I)**2 + SZX(I)**2
-          J3(I)    = SXX(I) * SYY(I) * SZZ(I) + TWO   * SXY(I) * SYZ(I) * SZX(I)
-     .             - SXX(I) * SYZ(I)**2 - SYY(I) * SZX(I)**2 - SZZ(I) * SXY(I)**2 
+          J2(I)    = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 ) + SXY(I)**2 
+          J3(I)    = SXX(I) * SYY(I) * SZZ(I) - SZZ(I) * SXY(I)**2 
           FDR(I)   = J2(I)**3 - CDR*(J3(I)**2)
           SIGDR(I) = KDR * EXP((ONE/SIX)*LOG(FDR(I)))
 c          
@@ -474,44 +450,34 @@ c
           DPHI_DSIG = TWO*SIGDR(I)*YLD2I(I)   
           NORMSIG = SQRT(SIGNXX(I)*SIGNXX(I)
      .                 + SIGNYY(I)*SIGNYY(I)
-     .            + TWO*SIGNXY(I)*SIGNXY(I)
-     .            + TWO*SIGNYZ(I)*SIGNYZ(I)
-     .            + TWO*SIGNZX(I)*SIGNZX(I))
+     .             + TWO*SIGNXY(I)*SIGNXY(I))
           IF (NORMSIG>EM10) THEN  
             FDR(I)     =  (J2(I)/(NORMSIG**2))**3 - CDR*((J3(I)/(NORMSIG**3))**2)       
             DPHI_DFDR  =  DPHI_DSIG*KDR*(ONE/SIX)*EXP(-(FIVE/SIX)*LOG(FDR(I)))             
             DSDRDJ2    =  DPHI_DFDR*THREE*(J2(I)/(NORMSIG**2))**2                             
             DSDRDJ3    = -DPHI_DFDR*TWO*CDR*(J3(I)/(NORMSIG**3))                                                   
-            DJ3DSXX =  TWO_THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .               -  THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
-     .               -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)                 
-            DJ3DSYY = - THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .               + TWO_THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
-     .               -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)             
-            DJ3DSZZ = - THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .                - THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
+            DJ3DSXX =  TWO_THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .                  -  THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
+     .                  -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)                 
+            DJ3DSYY =    - THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .               + TWO_THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
+     .                  -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)             
+            DJ3DSZZ =    - THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .                   - THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
      .               + TWO_THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2) 
-            DJ3DSXY = TWO*(SXX(I)*SXY(I) + SXY(I)*SYY(I) + SZX(I)*SYZ(I))/(NORMSIG**2)                   
-            DJ3DSYZ = TWO*(SXY(I)*SZX(I) + SYY(I)*SYZ(I) + SYZ(I)*SZZ(I))/(NORMSIG**2)                     
-            DJ3DSZX = TWO*(SXX(I)*SZX(I) + SXY(I)*SYZ(I) + SZX(I)*SZZ(I))/(NORMSIG**2)                      
+            DJ3DSXY =  TWO*(SXX(I)*SXY(I) + SXY(I)*SYY(I))/(NORMSIG**2)                                      
             NORMXX  = DSDRDJ2*SXX(I)/NORMSIG + DSDRDJ3*DJ3DSXX
             NORMYY  = DSDRDJ2*SYY(I)/NORMSIG + DSDRDJ3*DJ3DSYY
             NORMZZ  = DSDRDJ2*SZZ(I)/NORMSIG + DSDRDJ3*DJ3DSZZ
             NORMXY  = TWO*DSDRDJ2*SXY(I)/NORMSIG + DSDRDJ3*DJ3DSXY
-            NORMYZ  = TWO*DSDRDJ2*SYZ(I)/NORMSIG + DSDRDJ3*DJ3DSYZ
-            NORMZX  = TWO*DSDRDJ2*SZX(I)/NORMSIG + DSDRDJ3*DJ3DSZX 
             SIG_DFDSIG = SIGNXX(I) * NORMXX
      .                 + SIGNYY(I) * NORMYY
      .                 + SIGNXY(I) * NORMXY
-     .                 + SIGNYZ(I) * NORMYZ
-     .                 + SIGNZX(I) * NORMZX 
           ELSE
             NORMXX  = ZERO
             NORMYY  = ZERO
             NORMZZ  = ZERO
             NORMXY  = ZERO
-            NORMYZ  = ZERO
-            NORMZX  = ZERO
             SIG_DFDSIG = ZERO
           ENDIF
           IF (SIG_DFDSIG /= ZERO) THEN

--- a/engine/source/materials/mat/mat104/mat104c_nodam_nice.F
+++ b/engine/source/materials/mat/mat104/mat104c_nodam_nice.F
@@ -82,18 +82,18 @@ c
      .   H,LDAV,TRDFDS,SIGVM,SIGDR2,YLD2I,OMEGA,
      .   DTEMP,FCOSH,FSINH,DPDT,DLAM,DDEP,DEPXX,DEPYY
       my_real 
-     .   DPXX,DPYY,DPXY,DPYZ,DPZX,DPZZ,DSDRDJ2,DSDRDJ3,
-     .   DJ3DSXX,DJ3DSYY,DJ3DSXY,DJ3DSZZ,DJ3DSYZ,DJ3DSZX,
+     .   DPXX,DPYY,DPXY,DPZZ,DSDRDJ2,DSDRDJ3,
+     .   DJ3DSXX,DJ3DSYY,DJ3DSXY,DJ3DSZZ,
      .   DJ2DSXX,DJ2DSYY,DJ2DSXY,
      .   DFDSXX,DFDSYY,DFDSXY,
-     .   NORMXX,NORMYY,NORMXY,NORMZZ,NORMYZ,NORMZX,
+     .   NORMXX,NORMYY,NORMXY,NORMZZ,
      .   DENOM,DPHI,DPHI_DTRSIG,SIG_DFDSIG,DFDSIG2,
      .   DPHI_DSIG,DPHI_DYLD,DPHI_DFDR,DPDT_NL,
      .   DYLD_DPLA,DYLD_DTEMP,DTEMP_DLAM,DLAM_NL
 c
       my_real, DIMENSION(NEL) ::
-     .   DSIGXX,DSIGYY,DSIGXY,DSIGYZ,DSIGZX,TRSIG,TRDEP,
-     .   SXX,SYY,SXY,SZZ,SYZ,SZX,SIGM,J2,J3,SIGDR,YLD,WEITEMP,
+     .   DSIGXX,DSIGYY,DSIGXY,TRSIG,TRDEP,
+     .   SXX,SYY,SXY,SZZ,SIGM,J2,J3,SIGDR,YLD,WEITEMP,
      .   HARDP,FHARD,FRATE,FTHERM,FDR,PHI0,PHI,DPLA_DLAM,
      .   DEZZ
       !=======================================================================
@@ -214,15 +214,11 @@ c
         SYY(I)    = SIGNYY(I) + SIGM(I)
         SZZ(I)    = SIGM(I)
         SXY(I)    = SIGNXY(I)
-        SYZ(I)    = SIGNYZ(I)
-        SZX(I)    = SIGNZX(I)
         DEZZ(I)   = -NNU*DEPSXX(I) - NNU*DEPSYY(I)
         ! Second deviatoric invariant
-        J2(I) = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 )
-     .          +       SXY(I)**2 + SYZ(I)**2 + SZX(I)**2
+        J2(I) = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 ) + SXY(I)**2 
         ! Third deviatoric invariant
-        J3(I)  = SXX(I)*SYY(I)*SZZ(I) + SXY(I)*SYZ(I)*SZX(I) * TWO
-     .         - SXX(I)*SYZ(I)**2 - SYY(I)*SZX(I)**2 - SZZ(I)*SXY(I)**2 
+        J3(I)  = SXX(I)*SYY(I)*SZZ(I) - SZZ(I)*SXY(I)**2 
         ! Drucker equivalent stress
         FDR(I) = J2(I)**3 - CDR*(J3(I)**2)
         ! Checking equivalent stress values
@@ -260,8 +256,6 @@ c
         DSIGXX(I) = A11*DEPSXX(I) + A12*DEPSYY(I)
         DSIGYY(I) = A11*DEPSYY(I) + A12*DEPSXX(I)
         DSIGXY(I) = DEPSXY(I)*G  
-        DSIGYZ(I) = DEPSYZ(I)*GS(I)
-        DSIGZX(I) = DEPSZX(I)*GS(I)  
         DLAM      = ZERO 
 c        
         ! Computation of Drucker equivalent stress of the previous stress tensor
@@ -271,12 +265,8 @@ c
         SYY(I)    = SIGOYY(I) + SIGM(I)
         SZZ(I)    = SIGM(I)
         SXY(I)    = SIGOXY(I)
-        SYZ(I)    = SIGOYZ(I)
-        SZX(I)    = SIGOZX(I)
-        J2(I)     = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2)
-     .          +           SXY(I)**2 + SYZ(I)**2 + SZX(I)**2
-        J3(I)     = SXX(I)*SYY(I)*SZZ(I) + SXY(I)*SYZ(I)*SZX(I) * TWO
-     .            - SXX(I)*SYZ(I)**2 - SYY(I)*SZX(I)**2 - SZZ(I)*SXY(I)**2          
+        J2(I)     = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2) + SXY(I)**2 
+        J3(I)     = SXX(I)*SYY(I)*SZZ(I) - SZZ(I)*SXY(I)**2          
         FDR(I)    = J2(I)**3 - CDR*(J3(I)**2)
         SIGDR(I)  = KDR * EXP((ONE/SIX)*LOG(FDR(I))) 
 c        
@@ -308,9 +298,7 @@ c
         ! Computation of the Eulerian norm of the stress tensor
         NORMSIG = SQRT(SIGOXX(I)*SIGOXX(I)
      .               + SIGOYY(I)*SIGOYY(I)
-     .          + TWO*SIGOXY(I)*SIGOXY(I)
-     .          + TWO*SIGOYZ(I)*SIGOYZ(I)
-     .          + TWO*SIGOZX(I)*SIGOZX(I))
+     .          + TWO*SIGOXY(I)*SIGOXY(I))
 c     
         ! Derivative with respect to Fdr 
         FDR(I)     =  (J2(I)/(NORMSIG**2))**3 - CDR*((J3(I)/(NORMSIG**3))**2)       
@@ -318,25 +306,21 @@ c
         DSDRDJ2    =  DPHI_DFDR*THREE*(J2(I)/(NORMSIG**2))**2                             
         DSDRDJ3    = -DPHI_DFDR*TWO*CDR*(J3(I)/(NORMSIG**3))                   
         ! dJ3/dSig                                                        
-        DJ3DSXX =  TWO_THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .           -  THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
-     .           -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)                 
-        DJ3DSYY = - THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .           + TWO_THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
-     .           -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)             
-        DJ3DSZZ = - THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .            - THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
+        DJ3DSXX =  TWO_THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .              -  THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
+     .              -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)                 
+        DJ3DSYY =    - THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .           + TWO_THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
+     .              -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)             
+        DJ3DSZZ =    - THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .               - THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
      .           + TWO_THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2) 
-        DJ3DSXY = TWO*(SXX(I)*SXY(I) + SXY(I)*SYY(I) + SZX(I)*SYZ(I))/(NORMSIG**2)                   
-        DJ3DSYZ = TWO*(SXY(I)*SZX(I) + SYY(I)*SYZ(I) + SYZ(I)*SZZ(I))/(NORMSIG**2)                     
-        DJ3DSZX = TWO*(SXX(I)*SZX(I) + SXY(I)*SYZ(I) + SZX(I)*SZZ(I))/(NORMSIG**2)                      
+        DJ3DSXY =  TWO*(SXX(I)*SXY(I) + SXY(I)*SYY(I))/(NORMSIG**2)               
         ! dPhi/dSig
         NORMXX  = DSDRDJ2*SXX(I)/NORMSIG + DSDRDJ3*DJ3DSXX
         NORMYY  = DSDRDJ2*SYY(I)/NORMSIG + DSDRDJ3*DJ3DSYY
         NORMZZ  = DSDRDJ2*SZZ(I)/NORMSIG + DSDRDJ3*DJ3DSZZ
         NORMXY  = TWO*DSDRDJ2*SXY(I)/NORMSIG + DSDRDJ3*DJ3DSXY
-        NORMYZ  = TWO*DSDRDJ2*SYZ(I)/NORMSIG + DSDRDJ3*DJ3DSYZ
-        NORMZX  = TWO*DSDRDJ2*SZX(I)/NORMSIG + DSDRDJ3*DJ3DSZX
 c        
         ! Restoring previous value of the yield function
         PHI(I) = PHI0(I)
@@ -344,9 +328,7 @@ c
         ! Computation of yield surface trial increment DPHI       
         DPHI = NORMXX * DSIGXX(I)  
      .       + NORMYY * DSIGYY(I)   
-     .       + NORMXY * DSIGXY(I)
-     .       + NORMYZ * DSIGYZ(I)
-     .       + NORMZX * DSIGZX(I)          
+     .       + NORMXY * DSIGXY(I)      
 c             
         ! 2 - Computation of DPHI_DLAMBDA
         !---------------------------------------------------------
@@ -356,8 +338,6 @@ c
         DFDSIG2 = NORMXX * (A11*NORMXX + A12*NORMYY)
      .          + NORMYY * (A11*NORMYY + A12*NORMXX)
      .          + NORMXY * NORMXY * G
-     .          + NORMYZ * NORMYZ * GS(I)
-     .          + NORMZX * NORMZX * GS(I)
 c     
         !   b) Derivatives with respect to plastic strain P 			
         !   ------------------------------------------------
@@ -371,9 +351,7 @@ c
         !     -------------------------------------------
         SIG_DFDSIG = SIGOXX(I) * NORMXX
      .             + SIGOYY(I) * NORMYY
-     .             + SIGOXY(I) * NORMXY
-     .             + SIGOYZ(I) * NORMYZ
-     .             + SIGOZX(I) * NORMZX         
+     .             + SIGOXY(I) * NORMXY        
         DPLA_DLAM(I) = SIG_DFDSIG / YLD(I)  
 c        
         !  c) Derivatives with respect to the temperature TEMP 
@@ -414,23 +392,17 @@ c
         DPYY = DLAM * NORMYY
         DPZZ = DLAM * NORMZZ
         DPXY = DLAM * NORMXY
-        DPYZ = DLAM * NORMYZ
-        DPZX = DLAM * NORMZX  
 c        
         ! Elasto-plastic stresses update   
         SIGNXX(I) = SIGOXX(I) + DSIGXX(I) - (A11*DPXX + A12*DPYY)
         SIGNYY(I) = SIGOYY(I) + DSIGYY(I) - (A11*DPYY + A12*DPXX)      
         SIGNXY(I) = SIGOXY(I) + DSIGXY(I) - DPXY*G
-        SIGNYZ(I) = SIGOYZ(I) + DSIGYZ(I) - DPYZ*GS(I)
-        SIGNZX(I) = SIGOZX(I) + DSIGZX(I) - DPZX*GS(I)
         TRSIG(I)  = SIGNXX(I) + SIGNYY(I)
         SIGM(I)   = -TRSIG(I) * THIRD
         SXX(I)    = SIGNXX(I) + SIGM(I)
         SYY(I)    = SIGNYY(I) + SIGM(I)
         SZZ(I)    = SIGM(I)
         SXY(I)    = SIGNXY(I)
-        SYZ(I)    = SIGNYZ(I)
-        SZX(I)    = SIGNZX(I)
 c  
         ! Cumulated plastic strain and strain rate update
         DDEP    = (DLAM/YLD(I))*SIG_DFDSIG
@@ -438,10 +410,8 @@ c
         PLA(I)  = PLA(I)  + DDEP  
 c        
         ! Drucker equivalent stress update
-        J2(I)    = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 )
-     .             +         SXY(I)**2 + SYZ(I)**2 + SZX(I)**2
-        J3(I)    = SXX(I) * SYY(I) * SZZ(I) + TWO   * SXY(I) * SYZ(I) * SZX(I)
-     .             - SXX(I) * SYZ(I)**2 - SYY(I) * SZX(I)**2 - SZZ(I) * SXY(I)**2 
+        J2(I)    = HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2 ) + SXY(I)**2 
+        J3(I)    = SXX(I) * SYY(I) * SZZ(I) - SZZ(I) * SXY(I)**2 
         FDR(I)   = J2(I)**3 - CDR*(J3(I)**2)
         SIGDR(I) = KDR * EXP((ONE/SIX)*LOG(FDR(I)))
 c        
@@ -497,44 +467,34 @@ c
           DPHI_DSIG = TWO*SIGDR(I)*YLD2I   
           NORMSIG = SQRT(SIGNXX(I)*SIGNXX(I)
      .                 + SIGNYY(I)*SIGNYY(I)
-     .            + TWO*SIGNXY(I)*SIGNXY(I)
-     .            + TWO*SIGNYZ(I)*SIGNYZ(I)
-     .            + TWO*SIGNZX(I)*SIGNZX(I))
+     .            + TWO*SIGNXY(I)*SIGNXY(I))
           IF (NORMSIG>EM10) THEN  
             FDR(I)     =  (J2(I)/(NORMSIG**2))**3 - CDR*((J3(I)/(NORMSIG**3))**2)   
             DPHI_DFDR  =  DPHI_DSIG*KDR*(ONE/SIX)*EXP(-(FIVE/SIX)*LOG(FDR(I)))             
             DSDRDJ2    =  DPHI_DFDR*THREE*(J2(I)/(NORMSIG**2))**2                             
             DSDRDJ3    = -DPHI_DFDR*TWO*CDR*(J3(I)/(NORMSIG**3))                                                   
-            DJ3DSXX =  TWO_THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .               -  THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
-     .               -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)                 
-            DJ3DSYY = - THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .               + TWO_THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
-     .               -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)             
-            DJ3DSZZ = - THIRD*(SYY(I)*SZZ(I)-SYZ(I)**2)/(NORMSIG**2)
-     .                - THIRD*(SXX(I)*SZZ(I)-SZX(I)**2)/(NORMSIG**2)
+            DJ3DSXX =  TWO_THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .                   - THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
+     .                   - THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)                 
+            DJ3DSYY =    - THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .               + TWO_THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
+     .                  -  THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2)             
+            DJ3DSZZ =    - THIRD*(SYY(I)*SZZ(I))/(NORMSIG**2)
+     .                   - THIRD*(SXX(I)*SZZ(I))/(NORMSIG**2)
      .               + TWO_THIRD*(SXX(I)*SYY(I)-SXY(I)**2)/(NORMSIG**2) 
-            DJ3DSXY = TWO*(SXX(I)*SXY(I) + SXY(I)*SYY(I) + SZX(I)*SYZ(I))/(NORMSIG**2)                   
-            DJ3DSYZ = TWO*(SXY(I)*SZX(I) + SYY(I)*SYZ(I) + SYZ(I)*SZZ(I))/(NORMSIG**2)                     
-            DJ3DSZX = TWO*(SXX(I)*SZX(I) + SXY(I)*SYZ(I) + SZX(I)*SZZ(I))/(NORMSIG**2)                      
+            DJ3DSXY =  TWO*(SXX(I)*SXY(I) + SXY(I)*SYY(I))/(NORMSIG**2)                   
             NORMXX  = DSDRDJ2*SXX(I)/NORMSIG + DSDRDJ3*DJ3DSXX
             NORMYY  = DSDRDJ2*SYY(I)/NORMSIG + DSDRDJ3*DJ3DSYY
             NORMZZ  = DSDRDJ2*SZZ(I)/NORMSIG + DSDRDJ3*DJ3DSZZ
             NORMXY  = TWO*DSDRDJ2*SXY(I)/NORMSIG + DSDRDJ3*DJ3DSXY
-            NORMYZ  = TWO*DSDRDJ2*SYZ(I)/NORMSIG + DSDRDJ3*DJ3DSYZ
-            NORMZX  = TWO*DSDRDJ2*SZX(I)/NORMSIG + DSDRDJ3*DJ3DSZX 
             SIG_DFDSIG = SIGNXX(I) * NORMXX
      .                 + SIGNYY(I) * NORMYY
      .                 + SIGNXY(I) * NORMXY
-     .                 + SIGNYZ(I) * NORMYZ
-     .                 + SIGNZX(I) * NORMZX 
           ELSE
             NORMXX  = ZERO
             NORMYY  = ZERO
             NORMZZ  = ZERO
             NORMXY  = ZERO
-            NORMYZ  = ZERO
-            NORMZX  = ZERO
             SIG_DFDSIG = ZERO
           ENDIF
           IF (SIG_DFDSIG /= ZERO) THEN


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Transverse shear in plastic behavior was considered in /MAT/LAW104 instead of remaining purely elastic as expected. This leads to strong instability in bending when using Ishell = 1,2 and 4. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->

Remove transverse shear from plastic behavior in all routines of /MAT/LAW104. 

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
