### PR TITLE
/LOAD/PFLUID & /LOAD/PBLAST : omp fix for FEXT array (H3D|ANIM)

### DIFF
--- a/engine/source/loads/general/pfluid/pfluid.F
+++ b/engine/source/loads/general/pfluid/pfluid.F
@@ -238,43 +238,44 @@ C---------------------------------------
               !-node_1
               A(1,N1)=A(1,N1)+FX                                                                   
               A(2,N1)=A(2,N1)+FY                                                                   
-              A(3,N1)=A(3,N1)+FZ                                                                   
-              IF(IANIM  > 0) THEN                                                                 
-                FEXT(1,N1) = FEXT(1,N1)+FX                                                         
-                FEXT(2,N1) = FEXT(2,N1)+FY                                                         
-                FEXT(3,N1) = FEXT(3,N1)+FZ                                                         
-              ENDIF                                                                                
+              A(3,N1)=A(3,N1)+FZ                                                                                                                                               
               !-node_2
               A(1,N2)=A(1,N2)+FX                                                                   
               A(2,N2)=A(2,N2)+FY                                                                   
-              A(3,N2)=A(3,N2)+FZ                                                                   
-              IF(IANIM  > 0) THEN                                                                 
-                FEXT(1,N2) = FEXT(1,N2)+FX                                                         
-                FEXT(2,N2) = FEXT(2,N2)+FY                                                         
-                FEXT(3,N2) = FEXT(3,N2)+FZ                                                         
-              ENDIF                                                                                
+              A(3,N2)=A(3,N2)+FZ                                                                                                                                               
               !-node_3
               A(1,N3)=A(1,N3)+FX                                                                   
               A(2,N3)=A(2,N3)+FY                                                                   
-              A(3,N3)=A(3,N3)+FZ                                                                   
-              IF(IANIM  > 0) THEN                                                                 
-                FEXT(1,N3) = FEXT(1,N3)+FX                                                         
-                FEXT(2,N3) = FEXT(2,N3)+FY                                                         
-                FEXT(3,N3) = FEXT(3,N3)+FZ                                                         
-              ENDIF                                                                                
+              A(3,N3)=A(3,N3)+FZ                                                                                                                                                  
               !-node_4
               A(1,N4)=A(1,N4)+FX                                                                   
               A(2,N4)=A(2,N4)+FY                                                                   
-              A(3,N4)=A(3,N4)+FZ                                                                   
-              IF(IANIM  > 0) THEN                                                                 
-                FEXT(1,N4) = FEXT(1,N4)+FX                                                         
-                FEXT(2,N4) = FEXT(2,N4)+FY                                                         
-                FEXT(3,N4) = FEXT(3,N4)+FZ                                                         
-              ENDIF                                                                                
+              A(3,N4)=A(3,N4)+FZ  
+                                                                                
               !External Force Work
               TFEXTT=TFEXTT+DT1*(FX*(V(1,N1)+V(1,N2)+V(1,N3)+V(1,N4))
      +                          +FY*(V(2,N1)+V(2,N2)+V(2,N3)+V(2,N4))
      +                          +FZ*(V(3,N1)+V(3,N2)+V(3,N3)+V(3,N4)))
+     
+              IF(IANIM  > 0) THEN  
+#include "lockon.inc"
+                FEXT(1,N1) = FEXT(1,N1)+FX                                                         
+                FEXT(2,N1) = FEXT(2,N1)+FY                                                         
+                FEXT(3,N1) = FEXT(3,N1)+FZ    
+                !                                                                             
+                FEXT(1,N2) = FEXT(1,N2)+FX                                                         
+                FEXT(2,N2) = FEXT(2,N2)+FY                                                         
+                FEXT(3,N2) = FEXT(3,N2)+FZ  
+                !
+                FEXT(1,N3) = FEXT(1,N3)+FX                                                         
+                FEXT(2,N3) = FEXT(2,N3)+FY                                                         
+                FEXT(3,N3) = FEXT(3,N3)+FZ
+                !
+                FEXT(1,N4) = FEXT(1,N4)+FX                                                         
+                FEXT(2,N4) = FEXT(2,N4)+FY                                                         
+                FEXT(3,N4) = FEXT(3,N4)+FZ                                      
+#include "lockoff.inc"                                                                    
+              ENDIF         
 
             !---TRIANGLE--------------------------------------------                                                                                                     
             ELSE     
@@ -355,34 +356,36 @@ C---------------------------------------
               !-node_1
               A(1,N1)=A(1,N1)+FX                                                                    
               A(2,N1)=A(2,N1)+FY                                                                    
-              A(3,N1)=A(3,N1)+FZ                                                                    
-              IF(IANIM  > 0) THEN                                                                  
-                FEXT(1,N1) = FEXT(1,N1)+FX                                                          
-                FEXT(2,N1) = FEXT(2,N1)+FY                                                          
-                FEXT(3,N1) = FEXT(3,N1)+FZ                                                          
-              ENDIF                                                                                 
+              A(3,N1)=A(3,N1)+FZ                                                                                                                                                    
               !-node_2
               A(1,N2)=A(1,N2)+FX                                                                    
               A(2,N2)=A(2,N2)+FY                                                                    
-              A(3,N2)=A(3,N2)+FZ                                                                    
-              IF(IANIM  > 0) THEN                                                                  
-                FEXT(1,N2) = FEXT(1,N2)+FX                                                          
-                FEXT(2,N2) = FEXT(2,N2)+FY                                                          
-                FEXT(3,N2) = FEXT(3,N2)+FZ                                                          
-              ENDIF                                                                                 
+              A(3,N2)=A(3,N2)+FZ                                                                                                                                                   
               !-node_3
               A(1,N3)=A(1,N3)+FX                                                                    
               A(2,N3)=A(2,N3)+FY                                                                    
               A(3,N3)=A(3,N3)+FZ                                                                    
-              IF(IANIM  > 0) THEN                                                                  
-                FEXT(1,N3) = FEXT(1,N3)+FX                                                          
-                FEXT(2,N3) = FEXT(2,N3)+FY                                                          
-                FEXT(3,N3) = FEXT(3,N3)+FZ                                                          
-              ENDIF                                            
+                                                         
               !External Force Work
               TFEXTT=TFEXTT+DT1*(FX*(V(1,N1)+V(1,N2)+V(1,N3))  
      +                          +FY*(V(2,N1)+V(2,N2)+V(2,N3))  
-     +                          +FZ*(V(3,N1)+V(3,N2)+V(3,N3)))    
+     +                          +FZ*(V(3,N1)+V(3,N2)+V(3,N3)))   
+
+              IF(IANIM  > 0) THEN  
+#include "lockon.inc"
+                FEXT(1,N1) = FEXT(1,N1)+FX                                                         
+                FEXT(2,N1) = FEXT(2,N1)+FY                                                         
+                FEXT(3,N1) = FEXT(3,N1)+FZ    
+                !                                                                             
+                FEXT(1,N2) = FEXT(1,N2)+FX                                                         
+                FEXT(2,N2) = FEXT(2,N2)+FY                                                         
+                FEXT(3,N2) = FEXT(3,N2)+FZ  
+                !
+                FEXT(1,N3) = FEXT(1,N3)+FX                                                         
+                FEXT(2,N3) = FEXT(2,N3)+FY                                                         
+                FEXT(3,N3) = FEXT(3,N3)+FZ                                     
+#include "lockoff.inc"                                                                    
+              ENDIF        
                                                        
             ENDIF! quadrangle / triangle                                                                                  
           ENDDO !next I   
@@ -532,49 +535,49 @@ C---------------------------------------
                FSKY(1,IAD) = FX
                FSKY(2,IAD) = FY
                FSKY(3,IAD) = FZ
-               IF(IANIM  > 0) THEN
-                 FEXT(1,N1) = FEXT(1,N1)+FX
-                 FEXT(2,N1) = FEXT(2,N1)+FY
-                 FEXT(3,N1) = FEXT(3,N1)+FZ
-               ENDIF
 
                !NODE_2 : storing nodal force in FSKY array (it will be assembled later)
                IAD = IADC(ILOADP(4,NL)+4*(I-1)+1)
                FSKY(1,IAD) = FX
                FSKY(2,IAD) = FY
                FSKY(3,IAD) = FZ
-               IF(IANIM  > 0) THEN
-                 FEXT(1,N2) = FEXT(1,N2)+FX
-                 FEXT(2,N2) = FEXT(2,N2)+FY
-                 FEXT(3,N2) = FEXT(3,N2)+FZ
-               ENDIF
 
                !NODE_3 : storing nodal force in FSKY array (it will be assembled later)
                IAD = IADC(ILOADP(4,NL)+4*(I-1)+2)
                FSKY(1,IAD) = FX
                FSKY(2,IAD) = FY
                FSKY(3,IAD) = FZ
-               IF(IANIM  > 0) THEN
-                 FEXT(1,N3) = FEXT(1,N3)+FX
-                 FEXT(2,N3) = FEXT(2,N3)+FY
-                 FEXT(3,N3) = FEXT(3,N3)+FZ
-               ENDIF
 
                !NODE_4 : storing nodal force in FSKY array (it will be assembled later)
                IAD = IADC(ILOADP(4,NL)+4*(I-1)+3)
                FSKY(1,IAD) = FX
                FSKY(2,IAD) = FY
                FSKY(3,IAD) = FZ
-               IF(IANIM  > 0) THEN
-                 FEXT(1,N4) = FEXT(1,N4)+FX
-                 FEXT(2,N4) = FEXT(2,N4)+FY
-                 FEXT(3,N4) = FEXT(3,N4)+FZ
-               ENDIF
 
                !External force work
                TFEXTT=TFEXTT+DT1*(FX*(V(1,N1)+V(1,N2)+V(1,N3)+V(1,N4))
      +                           +FY*(V(2,N1)+V(2,N2)+V(2,N3)+V(2,N4))
      +                           +FZ*(V(3,N1)+V(3,N2)+V(3,N3)+V(3,N4)))
+     
+              IF(IANIM  > 0) THEN  
+#include "lockon.inc"
+                FEXT(1,N1) = FEXT(1,N1)+FX                                                         
+                FEXT(2,N1) = FEXT(2,N1)+FY                                                         
+                FEXT(3,N1) = FEXT(3,N1)+FZ    
+                !                                                                             
+                FEXT(1,N2) = FEXT(1,N2)+FX                                                         
+                FEXT(2,N2) = FEXT(2,N2)+FY                                                         
+                FEXT(3,N2) = FEXT(3,N2)+FZ  
+                !
+                FEXT(1,N3) = FEXT(1,N3)+FX                                                         
+                FEXT(2,N3) = FEXT(2,N3)+FY                                                         
+                FEXT(3,N3) = FEXT(3,N3)+FZ
+                !
+                FEXT(1,N4) = FEXT(1,N4)+FX                                                         
+                FEXT(2,N4) = FEXT(2,N4)+FY                                                         
+                FEXT(3,N4) = FEXT(3,N4)+FZ                                      
+#include "lockoff.inc"                                                                    
+              ENDIF       
 
              ELSE
 
@@ -657,38 +660,40 @@ C---------------------------------------
                FSKY(1,IAD) = FX
                FSKY(2,IAD) = FY
                FSKY(3,IAD) = FZ
-               IF(IANIM  > 0) THEN
-                 FEXT(1,N1) = FEXT(1,N1)+FX
-                 FEXT(2,N1) = FEXT(2,N1)+FY
-                 FEXT(3,N1) = FEXT(3,N1)+FZ
-               ENDIF
 
                !NODE_2 : storing nodal force in FSKY array (it will be assembled later)
                IAD = IADC(ILOADP(4,NL)+4*(I-1)+1)
                FSKY(1,IAD) = FX
                FSKY(2,IAD) = FY
                FSKY(3,IAD) = FZ
-               IF(IANIM  > 0) THEN
-                 FEXT(1,N2) = FEXT(1,N2)+FX
-                 FEXT(2,N2) = FEXT(2,N2)+FY
-                 FEXT(3,N2) = FEXT(3,N2)+FZ
-               ENDIF
 
                !NODE_3 : storing nodal force in FSKY array (it will be assembled later)
                IAD = IADC(ILOADP(4,NL)+4*(I-1)+2)
                FSKY(1,IAD) = FX
                FSKY(2,IAD) = FY
                FSKY(3,IAD) = FZ
-               IF(IANIM  > 0) THEN
-                 FEXT(1,N3) = FEXT(1,N3)+FX
-                 FEXT(2,N3) = FEXT(2,N3)+FY
-                 FEXT(3,N3) = FEXT(3,N3)+FZ
-               ENDIF
 
                !external force work
                TFEXTT=TFEXTT+DT1*(FX*(V(1,N1)+V(1,N2)+V(1,N3))
      +                           +FY*(V(2,N1)+V(2,N2)+V(2,N3))
      +                           +FZ*(V(3,N1)+V(3,N2)+V(3,N3)))
+     
+              IF(IANIM  > 0) THEN  
+#include "lockon.inc"
+                FEXT(1,N1) = FEXT(1,N1)+FX                                                         
+                FEXT(2,N1) = FEXT(2,N1)+FY                                                         
+                FEXT(3,N1) = FEXT(3,N1)+FZ    
+                !                                                                             
+                FEXT(1,N2) = FEXT(1,N2)+FX                                                         
+                FEXT(2,N2) = FEXT(2,N2)+FY                                                         
+                FEXT(3,N2) = FEXT(3,N2)+FZ  
+                !
+                FEXT(1,N3) = FEXT(1,N3)+FX                                                         
+                FEXT(2,N3) = FEXT(2,N3)+FY                                                         
+                FEXT(3,N3) = FEXT(3,N3)+FZ                                  
+#include "lockoff.inc"                                                                    
+              ENDIF  
+                   
              ENDIF
            ENDDO!next I
 !$OMP END DO           
@@ -806,49 +811,49 @@ C-----------------------------------
                FSKYV(IAD,1) = FX
                FSKYV(IAD,2) = FY
                FSKYV(IAD,3) = FZ
-               IF(IANIM  > 0) THEN
-                 FEXT(1,N1) = FEXT(1,N1)+FX
-                 FEXT(2,N1) = FEXT(2,N1)+FY
-                 FEXT(3,N1) = FEXT(3,N1)+FZ
-               ENDIF
 
                !NODE_2 : storing nodal force in FSKY array (it will be assembled later)
                IAD = IADC(ILOADP(4,NL)+4*(I-1)+1)
                FSKYV(IAD,1) = FX
                FSKYV(IAD,2) = FY
                FSKYV(IAD,3) = FZ
-               IF(IANIM  > 0) THEN
-                 FEXT(1,N2) = FEXT(1,N2)+FX
-                 FEXT(2,N2) = FEXT(2,N2)+FY
-                 FEXT(3,N2) = FEXT(3,N2)+FZ
-               ENDIF
 
                !NODE_3 : storing nodal force in FSKY array (it will be assembled later)
                IAD = IADC(ILOADP(4,NL)+4*(I-1)+2)
                FSKYV(IAD,1) = FX
                FSKYV(IAD,2) = FY
                FSKYV(IAD,3) = FZ
-               IF(IANIM  > 0) THEN
-                 FEXT(1,N3) = FEXT(1,N3)+FX
-                 FEXT(2,N3) = FEXT(2,N3)+FY
-                 FEXT(3,N3) = FEXT(3,N3)+FZ
-               ENDIF
 
                !NODE_4 : storing nodal force in FSKY array (it will be assembled later)
                IAD = IADC(ILOADP(4,NL)+4*(I-1)+3)
                FSKYV(IAD,1) = FX
                FSKYV(IAD,2) = FY
                FSKYV(IAD,3) = FZ
-               IF(IANIM  > 0) THEN
-                 FEXT(1,N4) = FEXT(1,N4)+FX
-                 FEXT(2,N4) = FEXT(2,N4)+FY
-                 FEXT(3,N4) = FEXT(3,N4)+FZ
-               ENDIF
                
                !external force work               
                TFEXTT=TFEXTT+DT1*(FX*(V(1,N1)+V(1,N2)+V(1,N3)+V(1,N4))
      +                           +FY*(V(2,N1)+V(2,N2)+V(2,N3)+V(2,N4))
      +                           +FZ*(V(3,N1)+V(3,N2)+V(3,N3)+V(3,N4)))
+     
+              IF(IANIM  > 0) THEN  
+#include "lockon.inc"
+                FEXT(1,N1) = FEXT(1,N1)+FX                                                         
+                FEXT(2,N1) = FEXT(2,N1)+FY                                                         
+                FEXT(3,N1) = FEXT(3,N1)+FZ    
+                !                                                                             
+                FEXT(1,N2) = FEXT(1,N2)+FX                                                         
+                FEXT(2,N2) = FEXT(2,N2)+FY                                                         
+                FEXT(3,N2) = FEXT(3,N2)+FZ  
+                !
+                FEXT(1,N3) = FEXT(1,N3)+FX                                                         
+                FEXT(2,N3) = FEXT(2,N3)+FY                                                         
+                FEXT(3,N3) = FEXT(3,N3)+FZ
+                !
+                FEXT(1,N4) = FEXT(1,N4)+FX                                                         
+                FEXT(2,N4) = FEXT(2,N4)+FY                                                         
+                FEXT(3,N4) = FEXT(3,N4)+FZ                                      
+#include "lockoff.inc"                                                                    
+              ENDIF       
                
              ELSE
 
@@ -932,9 +937,11 @@ C-----------------------------------
                FSKYV(IAD,2) = FY
                FSKYV(IAD,3) = FZ
                IF(IANIM  > 0) THEN
+#include "lockon.inc"               
                  FEXT(1,N1) = FEXT(1,N1)+FX
                  FEXT(2,N1) = FEXT(2,N1)+FY
                  FEXT(3,N1) = FEXT(3,N1)+FZ
+#include "lockoff.inc"                 
                ENDIF
 
                !NODE_2 : storing nodal force in FSKY array (it will be assembled later)
@@ -943,9 +950,11 @@ C-----------------------------------
                FSKYV(IAD,2) = FY
                FSKYV(IAD,3) = FZ
                IF(IANIM  > 0) THEN
+#include "lockon.inc"               
                  FEXT(1,N2) = FEXT(1,N2)+FX
                  FEXT(2,N2) = FEXT(2,N2)+FY
                  FEXT(3,N2) = FEXT(3,N2)+FZ
+#include "lockoff.inc"                 
                ENDIF
 
                !NODE_3 : storing nodal force in FSKY array (it will be assembled later)
@@ -954,9 +963,11 @@ C-----------------------------------
                FSKYV(IAD,2) = FY
                FSKYV(IAD,3) = FZ
                IF(IANIM  > 0) THEN
+#include "lockon.inc"               
                  FEXT(1,N3) = FEXT(1,N3)+FX
                  FEXT(2,N3) = FEXT(2,N3)+FY
                  FEXT(3,N3) = FEXT(3,N3)+FZ
+#include "lockoff.inc"                 
                ENDIF
                
                !external force work

--- a/engine/source/loads/pblast/pblast_1.F
+++ b/engine/source/loads/pblast/pblast_1.F
@@ -602,33 +602,31 @@ C-----------------------------------------------
                                                                                                    
       !-------------------------------------------!                                                
       !   ANIMATION FILE                          !                                                
-      !-------------------------------------------!                                                
-      IF(IANIM>0) THEN                                                                             
-        IF(IANIM > 0) THEN  
-!$OMP DO SCHEDULE(GUIDED,MVSIZ) 
-          DO I = 1,ISIZ_SEG                                                                        
-            N1=PBLAST_TAB(IL)%N(1,I)                                                                              
-            N2=PBLAST_TAB(IL)%N(2,I)                                                                              
-            N3=PBLAST_TAB(IL)%N(3,I)                                                                              
-            N4=PBLAST_TAB(IL)%N(4,I)                                                                              
-            FEXT(1,N1) = FEXT(1,N1)+PBLAST_TAB(IL)%FX(I)                                                          
-            FEXT(2,N1) = FEXT(2,N1)+PBLAST_TAB(IL)%FY(I)                                                          
-            FEXT(3,N1) = FEXT(3,N1)+PBLAST_TAB(IL)%FZ(I)                                                          
-            FEXT(1,N2) = FEXT(1,N2)+PBLAST_TAB(IL)%FX(I)                                                          
-            FEXT(2,N2) = FEXT(2,N2)+PBLAST_TAB(IL)%FY(I)                                                          
-            FEXT(3,N2) = FEXT(3,N2)+PBLAST_TAB(IL)%FZ(I)                                                          
-            FEXT(1,N3) = FEXT(1,N3)+PBLAST_TAB(IL)%FX(I)                                                          
-            FEXT(2,N3) = FEXT(2,N3)+PBLAST_TAB(IL)%FY(I)                                                          
-            FEXT(3,N3) = FEXT(3,N3)+PBLAST_TAB(IL)%FZ(I)                                                          
-            IF(PBLAST_TAB(IL)%NPt(I)==FOUR)THEN                                                                   
-              FEXT(1,N4) = FEXT(1,N4)+PBLAST_TAB(IL)%FX(I)                                                        
-              FEXT(2,N4) = FEXT(2,N4)+PBLAST_TAB(IL)%FY(I)                                                        
-              FEXT(3,N4) = FEXT(3,N4)+PBLAST_TAB(IL)%FZ(I)                                                        
-            ENDIF                                                                                  
-          ENDDO
-!$OMP END DO                                                                                               
-        ENDIF                                                                                      
-      ENDIF                                                                                        
+      !-------------------------------------------!                                                                                                                          
+!$OMP SINGLE
+      IF(IANIM > 0) THEN  
+        DO I = 1,ISIZ_SEG                                                                        
+          N1=PBLAST_TAB(IL)%N(1,I)                                                                              
+          N2=PBLAST_TAB(IL)%N(2,I)                                                                              
+          N3=PBLAST_TAB(IL)%N(3,I)                                                                              
+          N4=PBLAST_TAB(IL)%N(4,I)                                                                              
+          FEXT(1,N1) = FEXT(1,N1)+PBLAST_TAB(IL)%FX(I)                                                          
+          FEXT(2,N1) = FEXT(2,N1)+PBLAST_TAB(IL)%FY(I)                                                          
+          FEXT(3,N1) = FEXT(3,N1)+PBLAST_TAB(IL)%FZ(I)                                                          
+          FEXT(1,N2) = FEXT(1,N2)+PBLAST_TAB(IL)%FX(I)                                                          
+          FEXT(2,N2) = FEXT(2,N2)+PBLAST_TAB(IL)%FY(I)                                                          
+          FEXT(3,N2) = FEXT(3,N2)+PBLAST_TAB(IL)%FZ(I)                                                          
+          FEXT(1,N3) = FEXT(1,N3)+PBLAST_TAB(IL)%FX(I)                                                          
+          FEXT(2,N3) = FEXT(2,N3)+PBLAST_TAB(IL)%FY(I)                                                          
+          FEXT(3,N3) = FEXT(3,N3)+PBLAST_TAB(IL)%FZ(I)                                                          
+          IF(PBLAST_TAB(IL)%NPt(I)==FOUR)THEN                                                                   
+            FEXT(1,N4) = FEXT(1,N4)+PBLAST_TAB(IL)%FX(I)                                                        
+            FEXT(2,N4) = FEXT(2,N4)+PBLAST_TAB(IL)%FY(I)                                                        
+            FEXT(3,N4) = FEXT(3,N4)+PBLAST_TAB(IL)%FZ(I)                                                        
+          ENDIF                                                                                  
+        ENDDO                                                                                           
+      ENDIF  
+!$OMP END SINGLE                                                                                                                                                                                
 
  9000 CONTINUE      
       RETURN

--- a/engine/source/loads/pblast/pblast_2.F
+++ b/engine/source/loads/pblast/pblast_2.F
@@ -600,32 +600,30 @@ C-----------------------------------------------
       !-------------------------------------------!                                                
       !   ANIMATION FILE                          !                                                
       !-------------------------------------------!                                                
-      IF(IANIM>0) THEN                                                                             
-        IF(IANIM > 0) THEN  
-!$OMP DO SCHEDULE(GUIDED,MVSIZ) 
-          DO I = 1,ISIZ_SEG                                                                        
-            N1=PBLAST_TAB(IL)%N(1,I)                                                                              
-            N2=PBLAST_TAB(IL)%N(2,I)                                                                              
-            N3=PBLAST_TAB(IL)%N(3,I)                                                                              
-            N4=PBLAST_TAB(IL)%N(4,I)                                                                              
-            FEXT(1,N1) = FEXT(1,N1)+PBLAST_TAB(IL)%FX(I)                                                          
-            FEXT(2,N1) = FEXT(2,N1)+PBLAST_TAB(IL)%FY(I)                                                          
-            FEXT(3,N1) = FEXT(3,N1)+PBLAST_TAB(IL)%FZ(I)                                                          
-            FEXT(1,N2) = FEXT(1,N2)+PBLAST_TAB(IL)%FX(I)                                                          
-            FEXT(2,N2) = FEXT(2,N2)+PBLAST_TAB(IL)%FY(I)                                                          
-            FEXT(3,N2) = FEXT(3,N2)+PBLAST_TAB(IL)%FZ(I)                                                          
-            FEXT(1,N3) = FEXT(1,N3)+PBLAST_TAB(IL)%FX(I)                                                          
-            FEXT(2,N3) = FEXT(2,N3)+PBLAST_TAB(IL)%FY(I)                                                          
-            FEXT(3,N3) = FEXT(3,N3)+PBLAST_TAB(IL)%FZ(I)                                                          
-            IF(PBLAST_TAB(IL)%NPt(I)==FOUR)THEN                                                                   
-              FEXT(1,N4) = FEXT(1,N4)+PBLAST_TAB(IL)%FX(I)                                                        
-              FEXT(2,N4) = FEXT(2,N4)+PBLAST_TAB(IL)%FY(I)                                                        
-              FEXT(3,N4) = FEXT(3,N4)+PBLAST_TAB(IL)%FZ(I)                                                        
-            ENDIF                                                                                  
-          ENDDO
-!$OMP END DO                                                                                               
-        ENDIF                                                                                      
-      ENDIF                                                                                        
+!$OMP SINGLE                                                                        
+      IF(IANIM > 0) THEN  
+        DO I = 1,ISIZ_SEG                                                                        
+          N1=PBLAST_TAB(IL)%N(1,I)                                                                              
+          N2=PBLAST_TAB(IL)%N(2,I)                                                                              
+          N3=PBLAST_TAB(IL)%N(3,I)                                                                              
+          N4=PBLAST_TAB(IL)%N(4,I)                                                                              
+          FEXT(1,N1) = FEXT(1,N1)+PBLAST_TAB(IL)%FX(I)                                                          
+          FEXT(2,N1) = FEXT(2,N1)+PBLAST_TAB(IL)%FY(I)                                                          
+          FEXT(3,N1) = FEXT(3,N1)+PBLAST_TAB(IL)%FZ(I)                                                          
+          FEXT(1,N2) = FEXT(1,N2)+PBLAST_TAB(IL)%FX(I)                                                          
+          FEXT(2,N2) = FEXT(2,N2)+PBLAST_TAB(IL)%FY(I)                                                          
+          FEXT(3,N2) = FEXT(3,N2)+PBLAST_TAB(IL)%FZ(I)                                                          
+          FEXT(1,N3) = FEXT(1,N3)+PBLAST_TAB(IL)%FX(I)                                                          
+          FEXT(2,N3) = FEXT(2,N3)+PBLAST_TAB(IL)%FY(I)                                                          
+          FEXT(3,N3) = FEXT(3,N3)+PBLAST_TAB(IL)%FZ(I)                                                          
+          IF(PBLAST_TAB(IL)%NPt(I)==FOUR)THEN                                                                   
+            FEXT(1,N4) = FEXT(1,N4)+PBLAST_TAB(IL)%FX(I)                                                        
+            FEXT(2,N4) = FEXT(2,N4)+PBLAST_TAB(IL)%FY(I)                                                        
+            FEXT(3,N4) = FEXT(3,N4)+PBLAST_TAB(IL)%FZ(I)                                                        
+          ENDIF                                                                                  
+        ENDDO                                                                                            
+      ENDIF                                                                                                                                                                       
+!$OMP END SINGLE
 
  9000 CONTINUE      
       RETURN

--- a/engine/source/loads/pblast/pblast_3.F
+++ b/engine/source/loads/pblast/pblast_3.F
@@ -784,32 +784,30 @@ C-----------------------------------------------
       !-------------------------------------------!                                                 
       !   ANIMATION FILE                          !                                                 
       !-------------------------------------------!                                                 
-      IF(IANIM>0) THEN                                                                              
-        IF(IANIM > 0) THEN  
-!$OMP DO SCHEDULE(GUIDED,MVSIZ)                                                                                
-          DO I = 1,ISIZ_SEG                                                                         
-            N1=PBLAST_TAB(IL)%N(1,I)                                                                               
-            N2=PBLAST_TAB(IL)%N(2,I)                                                                               
-            N3=PBLAST_TAB(IL)%N(3,I)                                                                               
-            N4=PBLAST_TAB(IL)%N(4,I)                                                                               
-            FEXT(1,N1) = FEXT(1,N1)+PBLAST_TAB(IL)%FX(I)                                                           
-            FEXT(2,N1) = FEXT(2,N1)+PBLAST_TAB(IL)%FY(I)                                                           
-            FEXT(3,N1) = FEXT(3,N1)+PBLAST_TAB(IL)%FZ(I)                                                           
-            FEXT(1,N2) = FEXT(1,N2)+PBLAST_TAB(IL)%FX(I)                                                           
-            FEXT(2,N2) = FEXT(2,N2)+PBLAST_TAB(IL)%FY(I)                                                           
-            FEXT(3,N2) = FEXT(3,N2)+PBLAST_TAB(IL)%FZ(I)                                                           
-            FEXT(1,N3) = FEXT(1,N3)+PBLAST_TAB(IL)%FX(I)                                                           
-            FEXT(2,N3) = FEXT(2,N3)+PBLAST_TAB(IL)%FY(I)                                                           
-            FEXT(3,N3) = FEXT(3,N3)+PBLAST_TAB(IL)%FZ(I)                                                           
-            IF(PBLAST_TAB(IL)%NPt(I)==FOUR)THEN                                                                    
-              FEXT(1,N4) = FEXT(1,N4)+PBLAST_TAB(IL)%FX(I)                                                         
-              FEXT(2,N4) = FEXT(2,N4)+PBLAST_TAB(IL)%FY(I)                                                         
-              FEXT(3,N4) = FEXT(3,N4)+PBLAST_TAB(IL)%FZ(I)                                                         
-            ENDIF                                                                                   
-          ENDDO                                                                                     
-!$OMP END DO        
-        ENDIF                                                                                       
-      ENDIF                                                                                         
+!$OMP SINGLE  
+      IF(IANIM>0) THEN                                                                                                                                                         
+        DO I = 1,ISIZ_SEG                                                                         
+          N1=PBLAST_TAB(IL)%N(1,I)                                                                               
+          N2=PBLAST_TAB(IL)%N(2,I)                                                                               
+          N3=PBLAST_TAB(IL)%N(3,I)                                                                               
+          N4=PBLAST_TAB(IL)%N(4,I)                                                                               
+          FEXT(1,N1) = FEXT(1,N1)+PBLAST_TAB(IL)%FX(I)                                                           
+          FEXT(2,N1) = FEXT(2,N1)+PBLAST_TAB(IL)%FY(I)                                                           
+          FEXT(3,N1) = FEXT(3,N1)+PBLAST_TAB(IL)%FZ(I)                                                           
+          FEXT(1,N2) = FEXT(1,N2)+PBLAST_TAB(IL)%FX(I)                                                           
+          FEXT(2,N2) = FEXT(2,N2)+PBLAST_TAB(IL)%FY(I)                                                           
+          FEXT(3,N2) = FEXT(3,N2)+PBLAST_TAB(IL)%FZ(I)                                                           
+          FEXT(1,N3) = FEXT(1,N3)+PBLAST_TAB(IL)%FX(I)                                                           
+          FEXT(2,N3) = FEXT(2,N3)+PBLAST_TAB(IL)%FY(I)                                                           
+          FEXT(3,N3) = FEXT(3,N3)+PBLAST_TAB(IL)%FZ(I)                                                           
+          IF(PBLAST_TAB(IL)%NPt(I)==FOUR)THEN                                                                    
+            FEXT(1,N4) = FEXT(1,N4)+PBLAST_TAB(IL)%FX(I)                                                         
+            FEXT(2,N4) = FEXT(2,N4)+PBLAST_TAB(IL)%FY(I)                                                         
+            FEXT(3,N4) = FEXT(3,N4)+PBLAST_TAB(IL)%FZ(I)                                                         
+          ENDIF                                                                                   
+        ENDDO                                                                                                                                                                                
+       ENDIF                                                                                         
+!$OMP END SINGLE
 
  9000 CONTINUE 
       RETURN


### PR DESCRIPTION

#### /LOAD/PFLUID & /LOAD/PBLAST : omp fix for FEXT array (H3D|ANIM)


#### Description of the changes
A potential issue was introduced with bc545cacb89c8adc43ba8a00301184e6e76d8baf (PBLAST omp parallelization) and 86c067655e4b97b7aaba9b6e0f021dd77c6cd747 (PFLUID omp parallelization). It is related to post-treatment of External Forces with /H3D/NODA/FEXT or /ANIM/VECT/FEXT . Numerical solution is not affected. This potential issue only affect output contour in H3D or ANIM files.
This present change is updating source code for PFLUID and PBLAST options to prevent from any "data race" when writing into array FEXT(1:3, 1:NUMNOD)

