### PR TITLE
/LOAD/PBLAST:parith_on fix when time>Tstop

### DIFF
--- a/common_source/modules/pblast_mod.F
+++ b/common_source/modules/pblast_mod.F
@@ -45,6 +45,7 @@ Chd|====================================================================
 
       TYPE PBLAST_STRUCT_
         INTEGER SIZ
+        LOGICAL IS_RESET
         my_real, ALLOCATABLE,DIMENSION(:)    :: PRES      ! pressure output(workarray)
         my_real, ALLOCATABLE,DIMENSION(:)    :: cos_theta ! angle on structural face
         my_real, ALLOCATABLE,DIMENSION(:)    :: P_inci,P_refl,ta,t0,decay_inci,decay_refl ! Friedlander parameters  
@@ -145,6 +146,7 @@ C-----------------------------------------------
       !--------------------------------------
       DO I=1,NLOADP_B
         CALL READ_I_C(PBLAST_TAB(I)%SIZ,1)
+        PBLAST_TAB(I)%IS_RESET = .FALSE.
       ENDDO
       !--------------------------------------
       !     READING REAL BUFFER (local segments only)

--- a/engine/source/loads/general/pfluid/pfluid.F
+++ b/engine/source/loads/general/pfluid/pfluid.F
@@ -233,7 +233,13 @@ C---------------------------------------
               FX=FX*FOURTH
               FY=FY*FOURTH
               FZ=FZ*FOURTH                                  
-              
+                                                                                             
+              !External Force Work
+              TFEXTT=TFEXTT+DT1*(FX*(V(1,N1)+V(1,N2)+V(1,N3)+V(1,N4))
+     +                          +FY*(V(2,N1)+V(2,N2)+V(2,N3)+V(2,N4))
+     +                          +FZ*(V(3,N1)+V(3,N2)+V(3,N3)+V(3,N4)))
+     
+#include "lockon.inc"
               !/PARITH/OFF: force is direcctly added in A array. It will be dividedby nodal mass later
               !-node_1
               A(1,N1)=A(1,N1)+FX                                                                   
@@ -251,14 +257,8 @@ C---------------------------------------
               A(1,N4)=A(1,N4)+FX                                                                   
               A(2,N4)=A(2,N4)+FY                                                                   
               A(3,N4)=A(3,N4)+FZ  
-                                                                                
-              !External Force Work
-              TFEXTT=TFEXTT+DT1*(FX*(V(1,N1)+V(1,N2)+V(1,N3)+V(1,N4))
-     +                          +FY*(V(2,N1)+V(2,N2)+V(2,N3)+V(2,N4))
-     +                          +FZ*(V(3,N1)+V(3,N2)+V(3,N3)+V(3,N4)))
-     
-              IF(IANIM  > 0) THEN  
-#include "lockon.inc"
+
+              IF(IANIM  > 0) THEN                
                 FEXT(1,N1) = FEXT(1,N1)+FX                                                         
                 FEXT(2,N1) = FEXT(2,N1)+FY                                                         
                 FEXT(3,N1) = FEXT(3,N1)+FZ    
@@ -273,9 +273,10 @@ C---------------------------------------
                 !
                 FEXT(1,N4) = FEXT(1,N4)+FX                                                         
                 FEXT(2,N4) = FEXT(2,N4)+FY                                                         
-                FEXT(3,N4) = FEXT(3,N4)+FZ                                      
+                FEXT(3,N4) = FEXT(3,N4)+FZ  
+              ENDIF                                                         
 #include "lockoff.inc"                                                                    
-              ENDIF         
+    
 
             !---TRIANGLE--------------------------------------------                                                                                                     
             ELSE     

--- a/engine/source/loads/pblast/pblast.F
+++ b/engine/source/loads/pblast/pblast.F
@@ -78,8 +78,9 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-       INTEGER NL, ABAC_ID, NDT, NDT0, ID
+       INTEGER :: NL, ABAC_ID, NDT, NDT0, ID, II, IJK, NN(4), NNOD, IAD , IL
        my_real :: T0INF_LOC, TFEXT_LOC, T_STOP, TDET
+       LOGICAL :: IS_RESET
 C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
@@ -110,14 +111,18 @@ C-----------------------------------------------
        !----------------------------------------------- 
        DO NL=NLOADP_F+1, NLOADP_F+NLOADP_B
 
-         ABAC_ID = ILOADP(07,NL)
-         ID      = ILOADP(08,NL) !user_id
-         NDT     = PBLAST_NDT
-         NDT0    = ILOADP(10,NL)
-         IF(NDT0/=0) NDT = NDT0
-         TDET    =  FAC(01,NL)
-         T_STOP  =  FAC(13,NL)
+         ABAC_ID  = ILOADP(07,NL)
+         ID       = ILOADP(08,NL) !user_id
+         NDT      = PBLAST_NDT
+         NDT0     = ILOADP(10,NL)
+         TDET     = FAC(01,NL)
+         T_STOP   = FAC(13,NL)
          
+         IL       = NL-NLOADP_F
+         IS_RESET = PBLAST_TAB(IL)%IS_RESET
+
+         IF(NDT0/=0) NDT = NDT0
+                  
          TFEXT_LOC = ZERO
          T0INF_LOC = EP20
 
@@ -144,6 +149,35 @@ C-----------------------------------------------
      3                       ITAB    ,H3D_DATA ,NL       ,T0INF_LOC ,TFEXT_LOC)
      
              END SELECT 
+             
+         ELSEIF(TT > T_STOP)THEN         
+         
+           IF(.NOT. IS_RESET)THEN
+            ! FLUSH fsky array to 0.
+!$OMP DO SCHEDULE(GUIDED,MVSIZ)           
+             DO II = 1,ILOADP(1,NL)/4
+               !nodes of structural face : N1,N2,N3,N4
+               NN(1)=LLOADP(ILOADP(4,NL)+4*(II-1))
+               NN(2)=LLOADP(ILOADP(4,NL)+4*(II-1)+1)
+               NN(3)=LLOADP(ILOADP(4,NL)+4*(II-1)+2)
+               NN(4)=LLOADP(ILOADP(4,NL)+4*(II-1)+3)
+               IF(NN(4) /= 0 .AND.
+     .            NN(1) /= NN(2) .AND. NN(1) /= NN(3) .AND. NN(1) /= NN(4) .AND.
+     .            NN(2) /= NN(3) .AND. NN(2) /= NN(4) .AND.
+     .            NN(3) /= NN(4) )THEN
+                 NNOD=4
+               ELSE
+                 NNOD=3
+               ENDIF
+               DO IJK=1,NNOD
+                 IAD = IADC(ILOADP(4,NL)+4*(II-1)+(IJK-1))  ! node indexes in FSKY related to current option /LOAD/PBLAST
+                 FSKY(1:3,IAD) = ZERO
+               ENDDO
+               PBLAST_TAB(IL)%IS_RESET = .TRUE.
+             ENDDO! next II
+!$OMP END DO          
+           ENDIF!(.NOT. IS_RESET)
+         
          ENDIF
 
 #include "lockon.inc"

--- a/engine/source/loads/pblast/pblast_1.F
+++ b/engine/source/loads/pblast/pblast_1.F
@@ -81,7 +81,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER N1, ISK, N2, N3, N4,IL,IS,
      .        IERR,ICODE,IAD,I,
-     .        IANIM,IZ_UPDATE,ABAC_ID,ISIZ_SEG,IERR1,
+     .        IANIM_OR_H3D,IZ_UPDATE,ABAC_ID,ISIZ_SEG,IERR1,
      .        Phi_I, ID, ITA_SHIFT,
      .        NITER,ITER,IMODEL,NN(4)
      
@@ -129,7 +129,7 @@ C-----------------------------------------------
 C-----------------------------------------------,
 C   S o u r c e   C o d e
 C-----------------------------------------------
-      IANIM = ANIM_V(5)+OUTP_V(5)+H3D_DATA%N_VECT_FINT + ANIM_V(6)+OUTP_V(6)+H3D_DATA%N_VECT_FEXT   !output
+      IANIM_OR_H3D = ANIM_V(5)+OUTP_V(5)+H3D_DATA%N_VECT_FINT + ANIM_V(6)+OUTP_V(6)+H3D_DATA%N_VECT_FEXT   !output
 
       !Index Bijection                                                                                  
       Z1_ = 0.500000000000000                                                                           
@@ -185,35 +185,38 @@ C-----------------------------------------------
         NN(4)=N4                                                                                                                                                                       
                                                                                                                                                                                                       
         IF(N4==0 .OR. N3==N4 )THEN                                                                                                                                                                    
-          !3 NODE SEGMENT                                                                                                                                                                            
+          !3-NODE-SEGMENT                                                                                                                                                                            
           PBLAST_TAB(IL)%NPt(I)   = THREE  
           NPT = THREE                                                                                                                                                                          
-          !Segment Zentrum                                                                                                                                                                            
+          !Segment Centroid                                                                                                                                                                            
           Zx = X(1,N1)+X(1,N2)+X(1,N3)                                                                                                                                                                
           Zy = X(2,N1)+X(2,N2)+X(2,N3)                                                                                                                                                                
           Zz = X(3,N1)+X(3,N2)+X(3,N3)                                                                                                                                                                
           Zx = Zx*THIRD                                                                                                                                                                               
           Zy = Zy*THIRD                                                                                                                                                                               
-          Zz = Zz*THIRD                                                                                                                                                                               
+          Zz = Zz*THIRD  
+          !Normal vector : (NX,NY,NZ) = 2*S*n where |n|=1.0                                                                                                                                                                             
           NX = (X(2,N3)-X(2,N1))*(X(3,N3)-X(3,N2)) - (X(3,N3)-X(3,N1))*(X(2,N3)-X(2,N2))                                                                                                              
           NY = (X(3,N3)-X(3,N1))*(X(1,N3)-X(1,N2)) - (X(1,N3)-X(1,N1))*(X(3,N3)-X(3,N2))                                                                                                              
-          NZ = (X(1,N3)-X(1,N1))*(X(2,N3)-X(2,N2)) - (X(2,N3)-X(2,N1))*(X(1,N3)-X(1,N2))                                                                                                              
+          NZ = (X(1,N3)-X(1,N1))*(X(2,N3)-X(2,N2)) - (X(2,N3)-X(2,N1))*(X(1,N3)-X(1,N2))
+          !NORM = 2*S                                                                                                              
           NORM = SQRT(NX*NX+NY*NY+NZ*NZ)                                                                                                                                                              
         ELSE                                                                                                                                                                                          
-          !4 NODE SEGMENT                                                                                                                                                                            
+          !4-NODE-SEGMENT                                                                                                                                                                            
           PBLAST_TAB(IL)%NPt(I)   = FOUR  
           NPT = FOUR                                                                                                                                                                           
-          !Segment Zentrum                                                                                                                                                                            
+          !Face Centroid                                                                                                                                                                           
           Zx = X(1,N1)+X(1,N2)+X(1,N3)+X(1,N4)                                                                                                                                                        
           Zy = X(2,N1)+X(2,N2)+X(2,N3)+X(2,N4)                                                                                                                                                        
           Zz = X(3,N1)+X(3,N2)+X(3,N3)+X(3,N4)                                                                                                                                                        
           Zx = Zx*FOURTH                                                                                                                                                                              
           Zy = Zy*FOURTH                                                                                                                                                                              
           Zz = Zz*FOURTH                                                                                                                                                                              
-          !Normal                                                                                                                                                                                     
+          !Normal vector (NX,NY,NZ) = 2*S*n where |n|=1.0
           NX = (X(2,N3)-X(2,N1))*(X(3,N4)-X(3,N2)) - (X(3,N3)-X(3,N1))*(X(2,N4)-X(2,N2))                                                                                                              
           NY = (X(3,N3)-X(3,N1))*(X(1,N4)-X(1,N2)) - (X(1,N3)-X(1,N1))*(X(3,N4)-X(3,N2))                                                                                                              
-          NZ = (X(1,N3)-X(1,N1))*(X(2,N4)-X(2,N2)) - (X(2,N3)-X(2,N1))*(X(1,N4)-X(1,N2))                                                                                                              
+          NZ = (X(1,N3)-X(1,N1))*(X(2,N4)-X(2,N2)) - (X(2,N3)-X(2,N1))*(X(1,N4)-X(1,N2)) 
+          !NORM = 2*S                                                                                                             
           NORM = SQRT(NX*NX+NY*NY+NZ*NZ)                                                                                                                                                              
         ENDIF     
                                                                                                                                                                                                           
@@ -529,30 +532,36 @@ C-----------------------------------------------
         P = MAX(P,PMIN)                                                                                                                                                                               
         IF (NUMSKINP > 0) PBLAST_TAB(IL)%PRES(I) = P                                                                                                                                                  
 
-        !!Expand Pressure load to nodes   
-        FF(1) = -P * HALF*NX / NPT                                                                                                                                          
-        FF(2) = -P * HALF*NY / NPT  
-        FF(3) = -P * HALF*NZ / NPT  
-        PBLAST_TAB(IL)%FX(I) = FF(1)                                                                                                                                                                 
-        PBLAST_TAB(IL)%FY(I) = FF(2)                                                                                                                                                                  
-        PBLAST_TAB(IL)%FZ(I) = FF(3)                                                                                                                                                                  
+        !!Expand Pressure load to nodes
+        ! FF is nodal force which applied on each node N1,N2,N3, and also N4 if relevant
+        ! FF = FF_elem / NPT = Pload.S.n / NPT  where n is the unitary normal vector
+        ! NX,NY,NZ = 2S.n (in all cases:quadrangles & triangles)
+        FF(1) = -P * HALF*NX / NPT       !  -P*S/NPT . nx
+        FF(2) = -P * HALF*NY / NPT       !  -P*S/NPT . ny
+        FF(3) = -P * HALF*NZ / NPT       !  -P*S/NPT . nz
+        !storing force for one node of the current face (for assembly below)
+        PBLAST_TAB(IL)%FX(I) = FF(1)
+        PBLAST_TAB(IL)%FY(I) = FF(2)
+        PBLAST_TAB(IL)%FZ(I) = FF(3)
 
-        TFEXT_LOC=TFEXT_LOC+DT1*(   FF(1) * SUM(  V( 1, NN(1:NINT(NPT))  )  )                                                                                                                           
-     +                            + FF(2) * SUM(  V( 2, NN(1:NINT(NPT))  )  )                                                                                                                           
-     +                            + FF(3) * SUM(  V( 3, NN(1:NINT(NPT))  )  )                                                                                                                           
-     +                          )  
+        !External Force work
+        ! on a given node : DW = <F,V>*dt
+        ! for this current 4-node or 3-node face :   DW = sum(   <F_k,V_k>*dt       k=1,NPT)   where F_k=Fel/NPT
+        TFEXT_LOC=TFEXT_LOC+DT1*(FF(1)*SUM(V(1,NN(1:NINT(NPT)))) +FF(2)*SUM(V(2,NN(1:NINT(NPT)))) +FF(3)*SUM(V(3,NN(1:NINT(NPT)))))
 
       ENDDO!next I                                                                                                                                                                                    
 !$OMP END DO
          
       CALL MY_BARRIER() 
                  
-      !-------------------------------------------!                                                
-      !   ASSEMBLY                                !                                                
-      !-------------------------------------------!                                                
-      ! SPMD/SMP Parith/OFF                                                                        
+      !-------------------------------------------------------------------!
+      !   FORCE ASSEMBLY                                                  !
+      !     /PARITH/OFF : F directly added in A(1:3,1:NUMNOD).            !
+      !     /PARITH/ON  : F added FSKY & and automatically treated later  !      
+      !-------------------------------------------------------------------!
+      ! SPMD/SMP Parith/OFF
       IF(IPARIT==0) THEN 
-!$OMP DO SCHEDULE(GUIDED,MVSIZ)
+!$OMP SINGLE
         DO I = 1,ISIZ_SEG                                                                          
           N1=LLOADP(ILOADP(4,NL)+4*(I-1))                                                          
           N2=LLOADP(ILOADP(4,NL)+4*(I-1)+1)                                                        
@@ -573,7 +582,7 @@ C-----------------------------------------------
             A(3,N4)=A(3,N4)+PBLAST_TAB(IL)%FZ(I)                                                                  
           ENDIF                                                                                    
         ENDDO 
-!$OMP END DO                                                                                             
+!$OMP END SINGLE
       ELSE     
 !$OMP DO SCHEDULE(GUIDED,MVSIZ) 
         DO I = 1,ISIZ_SEG                                                                          
@@ -601,10 +610,11 @@ C-----------------------------------------------
                                                                                                    
                                                                                                    
       !-------------------------------------------!                                                
-      !   ANIMATION FILE                          !                                                
-      !-------------------------------------------!                                                                                                                          
+      !   ANIMATION FILE   /ANIM/VECT/FEXT        !
+      !   H3D FILE         /H3D/NODA/FEXT         !
+      !-------------------------------------------!                                                                                                                       
 !$OMP SINGLE
-      IF(IANIM > 0) THEN  
+      IF(IANIM_OR_H3D>0) THEN
         DO I = 1,ISIZ_SEG                                                                        
           N1=PBLAST_TAB(IL)%N(1,I)                                                                              
           N2=PBLAST_TAB(IL)%N(2,I)                                                                              

--- a/engine/source/loads/pblast/pblast_2.F
+++ b/engine/source/loads/pblast/pblast_2.F
@@ -549,7 +549,7 @@ C-----------------------------------------------
       !-------------------------------------------!                                                
       ! SPMD/SMP Parith/OFF                                                                        
       IF(IPARIT==0) THEN 
-!$OMP DO SCHEDULE(GUIDED,MVSIZ)
+!$OMP SINGLE
         DO I = 1,ISIZ_SEG                                                                          
           N1=LLOADP(ILOADP(4,NL)+4*(I-1))                                                          
           N2=LLOADP(ILOADP(4,NL)+4*(I-1)+1)                                                        
@@ -570,7 +570,7 @@ C-----------------------------------------------
             A(3,N4)=A(3,N4)+PBLAST_TAB(IL)%FZ(I)                                                                  
           ENDIF                                                                                    
         ENDDO 
-!$OMP END DO                                                                                             
+!$OMP END SINGLE                                                                                        
       ELSE     
 !$OMP DO SCHEDULE(GUIDED,MVSIZ) 
         DO I = 1,ISIZ_SEG                                                                          

--- a/engine/source/loads/pblast/pblast_3.F
+++ b/engine/source/loads/pblast/pblast_3.F
@@ -81,7 +81,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER N1, ISK, N2, N3, N4,IL,IS,
      .        IERR,ICODE,IAD,I,
-     .        IANIM,IZ_UPDATE,ABAC_ID,ISIZ_SEG,IERR1,
+     .        IANIM_OR_H3D,IZ_UPDATE,ABAC_ID,ISIZ_SEG,IERR1,
      .        Phi_I, ID, ITA_SHIFT,
      .        NITER,ITER,IMODEL,ITMP
      
@@ -178,7 +178,7 @@ C-----------------------------------------------,
 C   S o u r c e   C o d e
 C-----------------------------------------------
       TFEXT_LOC = ZERO
-      IANIM = ANIM_V(5)+OUTP_V(5)+H3D_DATA%N_VECT_FINT + ANIM_V(6)+OUTP_V(6)+H3D_DATA%N_VECT_FEXT   !output
+      IANIM_OR_H3D = ANIM_V(5)+OUTP_V(5)+H3D_DATA%N_VECT_FINT + ANIM_V(6)+OUTP_V(6)+H3D_DATA%N_VECT_FEXT   !output
 
       !Z Range (tables)                                                
       Z1_ = 0.500000000000000                                          
@@ -242,35 +242,38 @@ C-----------------------------------------------
         N4=LLOADP(ILOADP(4,NL)+4*(I-1)+3)                                                                                                                                                            
                                                                                                                                                                                                      
         IF(N4==0 .OR. N3==N4 )THEN                                                                                                                                                                   
-          !3 NODE SEGMENT                                                                                                                                                                           
+          !3-NODE-SEGMENT                                                                                                                                                                           
           PBLAST_TAB(IL)%NPt(I) = THREE  
           NPT = THREE                                                                                                                                                                         
-          !Segment Zentrum                                                                                                                                                                           
+          !Segment centroid                                                                                                                                                                           
           Zx = X(1,N1)+X(1,N2)+X(1,N3)                                                                                                                                                               
           Zy = X(2,N1)+X(2,N2)+X(2,N3)                                                                                                                                                               
           Zz = X(3,N1)+X(3,N2)+X(3,N3)                                                                                                                                                               
           Zx = Zx*THIRD                                                                                                                                                                              
           Zy = Zy*THIRD                                                                                                                                                                              
-          Zz = Zz*THIRD                                                                                                                                                                              
+          Zz = Zz*THIRD  
+          !Normal vector (NX,NY,NZ) = 2*S*n where |n|=1.0                                                                                                                                                                            
           NX = (X(2,N3)-X(2,N1))*(X(3,N3)-X(3,N2)) - (X(3,N3)-X(3,N1))*(X(2,N3)-X(2,N2))                                                                                                             
           NY = (X(3,N3)-X(3,N1))*(X(1,N3)-X(1,N2)) - (X(1,N3)-X(1,N1))*(X(3,N3)-X(3,N2))                                                                                                             
-          NZ = (X(1,N3)-X(1,N1))*(X(2,N3)-X(2,N2)) - (X(2,N3)-X(2,N1))*(X(1,N3)-X(1,N2))                                                                                                             
+          NZ = (X(1,N3)-X(1,N1))*(X(2,N3)-X(2,N2)) - (X(2,N3)-X(2,N1))*(X(1,N3)-X(1,N2)) 
+          !NORM = 2*S                                                                                                              
           NORM = SQRT(NX*NX+NY*NY+NZ*NZ)                                                                                                                                                             
         ELSE                                                                                                                                                                                         
-          !4 NODE SEGMENT                                                                                                                                                                           
+          !4-NODE-SEGMENT                                                                                                                                                                           
           PBLAST_TAB(IL)%NPt(I) = FOUR  
           NPT = FOUR                                                                                                                                                                          
-          !Segment Zentrum                                                                                                                                                                           
+          !Segment centroid                                                                                                                                                                           
           Zx = X(1,N1)+X(1,N2)+X(1,N3)+X(1,N4)                                                                                                                                                       
           Zy = X(2,N1)+X(2,N2)+X(2,N3)+X(2,N4)                                                                                                                                                       
           Zz = X(3,N1)+X(3,N2)+X(3,N3)+X(3,N4)                                                                                                                                                       
           Zx = Zx*FOURTH                                                                                                                                                                             
           Zy = Zy*FOURTH                                                                                                                                                                             
           Zz = Zz*FOURTH                                                                                                                                                                             
-          !Normal                                                                                                                                                                                    
+          !Normal vector (NX,NY,NZ) = 2*S*n where |n|=1.0                                                                                                                                                                                    
           NX = (X(2,N3)-X(2,N1))*(X(3,N4)-X(3,N2)) - (X(3,N3)-X(3,N1))*(X(2,N4)-X(2,N2))                                                                                                             
           NY = (X(3,N3)-X(3,N1))*(X(1,N4)-X(1,N2)) - (X(1,N3)-X(1,N1))*(X(3,N4)-X(3,N2))                                                                                                             
-          NZ = (X(1,N3)-X(1,N1))*(X(2,N4)-X(2,N2)) - (X(2,N3)-X(2,N1))*(X(1,N4)-X(1,N2))                                                                                                             
+          NZ = (X(1,N3)-X(1,N1))*(X(2,N4)-X(2,N2)) - (X(2,N3)-X(2,N1))*(X(1,N4)-X(1,N2))
+          !NORM = 2*S                                                                                                               
           NORM = SQRT(NX*NX+NY*NY+NZ*NZ)                                                                                                                                                             
         ENDIF        
         NN(1)=N1
@@ -704,8 +707,7 @@ C-----------------------------------------------
           WAVE_REFL =  P_refl*(ONE-(TT_STAR-T_A)/DT_0)*exp(-DECAY_refl*(TT_STAR-T_A)/DT_0)                                                                                                           
 !          write(*,FMT='(A,5e30.16)') "TT_STAR,TA,P_refl,I_refl,WAVE_refl=", TT_STAR,T_A,P_refl,I_refl,WAVE_refl                                                                                     
 !          write(*,FMT='(A,5e30.16)') "(ONE-(TT_STAR-T_A)/I_refl), exp    =", (ONE-(TT_STAR-T_A)/I_refl),  exp(-(TT_STAR-T_A)/I_refl)                                                                
-        ELSE                                                                                                                                                                                         
-         !TO-DO METTRE UNE OPTION POUR ARRETER LE CHARGEMENT QUAND TT_STAR>=T0                                                                                                                       
+        ELSE                                                                                                                     
           WAVE_INCI = ZERO                                                                                                                                                                           
           WAVE_REFL = ZERO                                                                                                                                                                           
         ENDIF                                                                                                                                                                                        
@@ -718,6 +720,9 @@ C-----------------------------------------------
         PBLAST_TAB(IL)%FY(I)= -P * HALF*NY / NPT                                                                                                                                                                 
         PBLAST_TAB(IL)%FZ(I)= -P * HALF*NZ / NPT                                                                                                                                                                 
 
+        !External Force work
+        ! on a given node : DW = <F,V>*dt
+        ! for this current 4-node or 3-node face :   DW = sum(   <F_k,V_k>*dt       k=1,NPT)   where F_k=Fel/NPT
         TFEXT_LOC=TFEXT_LOC+DT1*(   PBLAST_TAB(IL)%FX(I) * SUM(  V( 1, NN(1:NINT(NPt))  )  )                                                                                                                          
      +                            + PBLAST_TAB(IL)%FY(I) * SUM(  V( 2, NN(1:NINT(NPt))  )  )                                                                                                                          
      +                            + PBLAST_TAB(IL)%FZ(I) * SUM(  V( 3, NN(1:NINT(NPt))  )  )                                                                                                                          
@@ -728,12 +733,14 @@ C-----------------------------------------------
 
       CALL MY_BARRIER() 
                       
-      !-------------------------------------------!                                                 
-      !   ASSEMBLY                                !                                                 
-      !-------------------------------------------!                                                 
+      !-------------------------------------------------------------------!
+      !   FORCE ASSEMBLY                                                  !
+      !     /PARITH/OFF : F directly added in A(1:3,1:NUMNOD).            !
+      !     /PARITH/ON  : F added FSKY & and automatically treated later  !      
+      !-------------------------------------------------------------------!
       ! SPMD/SMP Parith/OFF                                                                         
       IF(IPARIT==0) THEN  
-!$OMP DO SCHEDULE(GUIDED,MVSIZ)                                                                                
+!$OMP SINGLE                                                                               
         DO I = 1,ISIZ_SEG                                                                           
           N1=LLOADP(ILOADP(4,NL)+4*(I-1))                                                           
           N2=LLOADP(ILOADP(4,NL)+4*(I-1)+1)                                                         
@@ -754,7 +761,7 @@ C-----------------------------------------------
             A(3,N4)=A(3,N4)+PBLAST_TAB(IL)%FZ(I)                                                                   
           ENDIF                                                                                     
         ENDDO                                                                                       
-!$OMP END DO        
+!$OMP END SINGLE       
       ELSE    
 !$OMP DO SCHEDULE(GUIDED,MVSIZ)                                                                                            
         DO I = 1,ISIZ_SEG                                                                           
@@ -781,11 +788,13 @@ C-----------------------------------------------
       ENDIF !IPARIT                                                                                 
                                                                                                     
                                                                                                     
-      !-------------------------------------------!                                                 
-      !   ANIMATION FILE                          !                                                 
-      !-------------------------------------------!                                                 
+      !-------------------------------------------!                                                
+      !   ANIMATION FILE   /ANIM/VECT/FEXT        !
+      !   H3D FILE         /H3D/NODA/FEXT         !
+      !-------------------------------------------! 
+                                              
 !$OMP SINGLE  
-      IF(IANIM>0) THEN                                                                                                                                                         
+      IF(IANIM_OR_H3D>0) THEN                                                                                                                                                          
         DO I = 1,ISIZ_SEG                                                                         
           N1=PBLAST_TAB(IL)%N(1,I)                                                                               
           N2=PBLAST_TAB(IL)%N(2,I)                                                                               

--- a/starter/source/loads/general/pfluid/hm_read_pfluid.F
+++ b/starter/source/loads/general/pfluid/hm_read_pfluid.F
@@ -77,7 +77,7 @@ C-----------------------------------------------
       TYPE (UNIT_TYPE_),INTENT(IN) ::UNITAB 
       INTEGER NPC(SNPC),IFRAME(LISKN,NUMFRAM+1),
      .        NUMLOADP, ILOADP(SIZLOADP,NLOADP), LLOADP(SLLOADP)
-      my_real FACLOADP(LFACLOAD,NUMLOADP)
+      my_real FACLOADP(LFACLOAD,NLOADP)
 C-----------------------------------------------
       TYPE (SURF_)   ,TARGET, DIMENSION(NSURF)   :: IGRSURF
       TYPE(SUBMODEL_DATA),INTENT(IN)::LSUBMODEL(NSUBMOD)

--- a/starter/source/loads/pblast/hm_read_pblast.F
+++ b/starter/source/loads/pblast/hm_read_pblast.F
@@ -82,8 +82,8 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       TYPE (UNIT_TYPE_),INTENT(IN) ::UNITAB 
-      INTEGER ITAB(NUMNOD), ITABM1(NUMNOD), NUMLOADP, ILOADP(SIZLOADP,NUMLOADP), IBUFLOADP(*)
-      my_real FACLOADP(LFACLOAD,NUMLOADP)
+      INTEGER ITAB(NUMNOD), ITABM1(NUMNOD), NUMLOADP, ILOADP(SIZLOADP,NLOADP), IBUFLOADP(*)
+      my_real FACLOADP(LFACLOAD,NLOADP)
       my_real, INTENT(IN) :: X(3,NUMNOD)
       TYPE(SUBMODEL_DATA), DIMENSION(NSUBMOD), INTENT(IN) :: LSUBMODEL
       my_real, INTENT(INOUT) :: BUFSF(SBUFSF)


### PR DESCRIPTION
#### /LOAD/PBLAST:parith_on fix when time>Tstop

#### Description of the changes
- FSKY array is reset to 0. when time > Tstop. This change is following Tstop introduction with 66f61b7a8cb2b23572b2c6319147e272d19c043c
- prevent from data race in array A(1:3,1:NUMNOD) with parith_off option
- source cleaning : setting correct argument size in reader subroutine NUMLOADP->NLOADP

