### PR TITLE
/LOAD/PBLAST:formulation updated (scale factor for incident wave)

### DIFF
--- a/engine/source/loads/pblast/pblast_1.F
+++ b/engine/source/loads/pblast/pblast_1.F
@@ -514,8 +514,8 @@ C-----------------------------------------------
           alpha_refl = ZERO                                                                                                                                                                           
           alpha_inci = ONE                                                                                                                                                                            
         ELSE                                                                                                                                                                                          
-          alpha_refl = cos_theta**2                           !     cos**2 X                                                                                                                          
-          alpha_inci = ONE + alpha_refl - TWO * cos_theta        ! 1 + cos**2 X -2 cosX                                                                                                               
+          alpha_refl = cos_theta**2                              ! cos**2 a                                                                                                                          
+          alpha_inci = ONE + cos_theta - TWO * alpha_refl        ! 1 + cos a -2 cos**2 a                                                                                                                 
         ENDIF                                                                                                                                                                                         
                                                                                                                                                                                                       
         !Building pressure waves from Friedlander model. (Modified model can bu introduced later if needed)                                                                                           

--- a/engine/source/loads/pblast/pblast_2.F
+++ b/engine/source/loads/pblast/pblast_2.F
@@ -511,8 +511,8 @@ C-----------------------------------------------
           alpha_refl = ZERO                                                                                                                                                                           
           alpha_inci = ONE                                                                                                                                                                            
         ELSE                                                                                                                                                                                          
-          alpha_refl = cos_theta**2                           !     cos**2 X                                                                                                                          
-          alpha_inci = ONE + alpha_refl - TWO * cos_theta        ! 1 + cos**2 X -2 cosX                                                                                                               
+          alpha_refl = cos_theta**2                              ! cos**2 a                                                                                                                          
+          alpha_inci = ONE + cos_theta - TWO * alpha_refl        ! 1 + cos a -2 cos**2 a                                                                                                                                                                                                                         
         ENDIF                                                                                                                                                                                         
                                                                                                                                                                                                       
         !Building pressure waves from Friedlander model. (Modified model can bu introduced later if needed)                                                                                           

--- a/engine/source/loads/pblast/pblast_3.F
+++ b/engine/source/loads/pblast/pblast_3.F
@@ -694,9 +694,9 @@ C-----------------------------------------------
           !Surface not facing the point of explosion                                                                                                                                                 
           alpha_refl = ZERO                                                                                                                                                                          
           alpha_inci = ONE                                                                                                                                                                           
-        ELSE                                                                                                                                                                                         
-          alpha_refl = cos_theta**2                           !     cos**2 X                                                                                                                         
-          alpha_inci = ONE + alpha_refl - TWO * cos_theta        ! 1 + cos**2 X -2 cosX                                                                                                              
+        ELSE
+          alpha_refl = cos_theta**2                              ! cos**2 a                                                                                                                         
+          alpha_inci = ONE + cos_theta - TWO * alpha_refl        ! 1 + cos a -2 cos**2 a                                                                                                                     
         ENDIF                                                                                                                                                                                        
                                                                                                                                                                                                      
         !Building pressure waves from Friedlander model. (Modified model can bu introduced later if needed)                                                                                           


### PR DESCRIPTION
#### /LOAD/PBLAST:formulation updated (scale factor for incident wave)

#### Description of the changes
A typo error was spotted in the original paper "Glenn Randers-Pehrson, Kenneth A. Bannister, Airblast Loading Model, ARL-TR1310, March 1997" It is now fixed.
Incident wave factor updated : 1+cos²a-2cos a -->  1+cos a-2cos²a

#### expected change of numerical solution : yes