### PR TITLE
Wrong Isolid value in /STATE/BRICK/ORTHO

### DIFF
--- a/engine/source/output/sta/stat_s_ortho.F
+++ b/engine/source/output/sta/stat_s_ortho.F
@@ -120,6 +120,7 @@ c
           PID = IPART(2,IPRT)
 C          JHBE   = IGEO(10,PID)
 c
+          IF (JHBE==17.AND.IINT==2) JHBE = 18
           GBUF => ELBUF_TAB(NG)%GBUF
           LBUF => ELBUF_TAB(NG)%BUFLY(1)%LBUF(1,1,1)
           IF(IGTYP == 22) THEN


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [ ] The title of the PR is reviewed
- [ ] There is no text before the checklist section
- [ ] The following two sections are filled (or deleted)
- [ ] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Wrong Isolid value output in /STATE/BRICK/ORTHO when Isolid=18 (input)

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
wrong value corrected

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
