### PR TITLE
friction energy output for Inter type19 (only inter7 part is included) 

### DIFF
--- a/engine/source/mpi/interfaces/spmd_exch_efric.F
+++ b/engine/source/mpi/interfaces/spmd_exch_efric.F
@@ -187,22 +187,20 @@ C
                    LL = L+1
                    L = L + 1
                    DO N = 1, NB
-                     IF(NSVFI(NIN)%P(IDEB+N)<0)THEN
-                       BBUFS(L+1) = -NSVFI(NIN)%P(IDEB+N)
-                       IF(INTERFRIC>0)  THEN
-                           BBUFS(L+2) = EFRICFI(NIN)%P(IDEB+N)
-                           EFRICFI(NIN)%P(IDEB+N) = ZERO
-                       ELSE
-                           BBUFS(L+2) = ZERO
-                       ENDIF
-                       IF(H3D_DATA%N_SCAL_CSE_FRIC>0) THEN
-                           BBUFS(L+3) = EFRICGFI(NIN)%P(IDEB+N)
-                           EFRICGFI(NIN)%P(IDEB+N) = ZERO
-                       ELSE
-                           BBUFS(L+3) = ZERO
-                       ENDIF
-                       L = L + LEN
-                     ENDIF
+                      BBUFS(L+1) = ABS(NSVFI(NIN)%P(IDEB+N))
+                      IF(INTERFRIC>0)  THEN
+                          BBUFS(L+2) = EFRICFI(NIN)%P(IDEB+N)
+                          EFRICFI(NIN)%P(IDEB+N) = ZERO
+                      ELSE
+                          BBUFS(L+2) = ZERO
+                      ENDIF
+                      IF(H3D_DATA%N_SCAL_CSE_FRIC>0) THEN
+                          BBUFS(L+3) = EFRICGFI(NIN)%P(IDEB+N)
+                          EFRICGFI(NIN)%P(IDEB+N) = ZERO
+                      ELSE
+                          BBUFS(L+3) = ZERO
+                      ENDIF
+                      L = L + LEN
                    ENDDO
                    BBUFS(LL) = (L-LL)/LEN
                    DEBUT(NIN) = DEBUT(NIN) + NB

--- a/engine/source/mpi/interfaces/spmd_exch_press.F
+++ b/engine/source/mpi/interfaces/spmd_exch_press.F
@@ -181,7 +181,7 @@ Cel test en plus pour savoir si com globale necessaire entre les 2 procs
                 L = L + 1
                 DO N = 1, NB
                   IF(NSVFI(NIN)%P(IDEB+N)<0)THEN
-C noeud generant une force
+C node generating force
                     BBUFS(L+1) = -NSVFI(NIN)%P(IDEB+N)
                     BBUFS(L+2) = FNCONTI(NIN)%P(1,IDEB+N)
                     BBUFS(L+3) = FNCONTI(NIN)%P(2,IDEB+N)
@@ -208,6 +208,29 @@ C noeud generant une force
                     FTCONTI(NIN)%P(1,IDEB+N) = ZERO
                     FTCONTI(NIN)%P(2,IDEB+N) = ZERO
                     FTCONTI(NIN)%P(3,IDEB+N) = ZERO  
+                    L = L + LEN
+                  ELSEIF(INTERFRIC > 0.OR.N_SCAL_CSE_EFRIC>0) THEN
+C node not generating force but energy is cumulated
+                    BBUFS(L+1) = NSVFI(NIN)%P(IDEB+N)
+                    BBUFS(L+2) = ZERO
+                    BBUFS(L+3) = ZERO
+                    BBUFS(L+4) = ZERO
+                    BBUFS(L+5) = ZERO
+                    BBUFS(L+6) = ZERO
+                    BBUFS(L+7) = ZERO
+                    LF = 7
+                    IF(INTERFRIC>0) THEN
+                        BBUFS(L+LF+1) = EFRICFI(NIN)%P(IDEB+N)
+                        EFRICFI(NIN)%P(IDEB+N) = ZERO
+                        LF=LF+1
+                    ELSEIF(NINEFRIC>0) THEN
+                        BBUFS(L+LF+1) = ZERO
+                        LF=LF+1
+                    ENDIF
+                    IF(N_SCAL_CSE_EFRIC>0) THEN
+                        BBUFS(L+LF+1) = EFRICGFI(NIN)%P(IDEB+N)
+                        EFRICGFI(NIN)%P(IDEB+N) = ZERO
+                    ENDIF
                     L = L + LEN
                   ENDIF
                 ENDDO

--- a/engine/source/output/h3d/h3d_build_fortran/lech3d.F
+++ b/engine/source/output/h3d/h3d_build_fortran/lech3d.F
@@ -151,7 +151,7 @@ C-----------------------------------------------
      .        ISHELL_NPT_CHECK,ICSTR,NPTR,NPTS,NPTT,IS_CORNER_DATA,ISH_NPT0,
      .        IS_MDSVAR_DEF,NMDSVAR_MAX,IS_MDSVAR,IS_MDSVAR_ALL,IMDSVAR,
      .        IS_MODEL_NPT,IS_MODEL_PLY,IS_MODEL_LAYER,ISKIND,IOUTER,IPEXT,
-     .        IS_ID,ID,ID_MAX,IS_ID_ALL,NINEFRIC
+     .        IS_ID,ID,ID_MAX,IS_ID_ALL,NINEFRIC,N19
       INTEGER MLW,NEL,NG,JTURB,NLAY,NUVAR,IPLY,IMAT,ISUBSTACK,ID_PLY_TMP
       CHARACTER  KEY2*ncharkey, KEY3*ncharkey, KEY4*ncharkey, KEY5*ncharkey, KEY6*ncharkey,
      .           KEY7*ncharkey,KEY8*ncharkey,KEY3_GLOB*ncharline,KEY3_READ*ncharline, 
@@ -741,30 +741,51 @@ c                             H3D_DATA%OUTPUT_LIST(I)%INTER = K
                                 H3D_DATA%N_SCAL_SKID = NINTERSKID
                                 H3D_DATA%N_SKID_INTER(K) = NINTERSKID
                              ELSEIF(KEY3_GLOB(1:8) == 'CSE_FRIC' ) THEN
-                                NINEFRIC = NINEFRIC +1
+                                IF(NINEFRIC == 0) NINEFRIC = NINEFRIC +1
                                 H3D_DATA%N_SCAL_CSE_FRICINT = NINEFRIC
                                 H3D_DATA%N_CSE_FRIC_INTER(K) = NINEFRIC
                              ENDIF
-                             EXIT 
                             ENDIF
                           ENDDO
                        ENDIF
            	    ENDIF
            	  ELSE
 	 	   IF(NINTER_MAX /= 0)THEN
+                     NINEFRIC = 0
 	 	     DO K=1,NINTER_MAX
-	 	  	CPT_H3D = CPT_H3D + 1
-c
-	 	  	INTER_INPUT(CPT_H3D) = K
-           		IS_AVAILABLE_KEY(CPT_H3D) = 1
                         IF(KEY3_GLOB(1:4) == 'SKID' ) THEN 
+	 	           CPT_H3D = CPT_H3D + 1
+c
+	 	  	   INTER_INPUT(CPT_H3D) = K
+           		   IS_AVAILABLE_KEY(CPT_H3D) = 1
                            H3D_DATA%N_SKID_INTER(K) = K
                         ELSEIF(KEY3_GLOB(1:8) == 'CSE_FRIC' ) THEN
-                           H3D_DATA%N_CSE_FRIC_INTER(K) = K
+                           N19 = IPARI(71,K) 
+                           IF(N19 <= 0) THEN
+                              IF(H3D_DATA%N_CSE_FRIC_INTER(K) ==0) THEN
+                                 NINEFRIC = NINEFRIC +1
+	 	                 CPT_H3D = CPT_H3D + 1
+c
+	 	  	         INTER_INPUT(CPT_H3D) = K
+           		         IS_AVAILABLE_KEY(CPT_H3D) = 1
+                                 H3D_DATA%N_CSE_FRIC_INTER(K) = K
+                              ENDIF
+                           ELSEIF(N19 > 0 ) THEN
+                             IF(H3D_DATA%N_CSE_FRIC_INTER(N19) ==0) THEN
+                               NINEFRIC = NINEFRIC +1
+	 	               CPT_H3D = CPT_H3D + 1
+c
+	 	  	       INTER_INPUT(CPT_H3D) = N19
+           		       IS_AVAILABLE_KEY(CPT_H3D) = 1
+                               H3D_DATA%N_CSE_FRIC_INTER(K) = N19
+                             ELSE
+                               H3D_DATA%N_CSE_FRIC_INTER(K) = N19
+                             ENDIF
+                           ENDIF
                         ENDIF
 	 	     ENDDO
                      IF(KEY3_GLOB(1:4) == 'SKID' ) H3D_DATA%N_SCAL_SKID = NINTER
-                     IF(KEY3_GLOB(1:8) == 'CSE_FRIC' ) H3D_DATA%N_SCAL_CSE_FRICINT = NINTER
+                     IF(KEY3_GLOB(1:8) == 'CSE_FRIC' ) H3D_DATA%N_SCAL_CSE_FRICINT = NINEFRIC
            	   ENDIF
            	  ENDIF
            	ELSE


### PR DESCRIPTION
#### Checklist
<!------ for each task in the least below, complete the task and add a mark [x] -->
- [x] The title of the PR is reviewed
- [x] There is no text before the checklist section
- [x] The following two sections are filled (or deleted)
- [x] This PR has been previewed 

<!------ Provide a general summary of your changes in the Title above -->
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Adding the Friction energy output for interface type 19 ( only the friction of interface type 7 is taken into account) 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
<!--- If there is a design document, link to it here -->
Adding the Friction energy output for interface type 19 : store the energy output from interfaces type 7 in the right output array corresponding to the interface type 19 

<!--- Pull requests will be accepted only if:  -->
<!--- - the checklist is completed --> 
<!--- - they contain one commit (please squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
