### PR TITLE
Fix issues when Interface is deactivated in SPMD communication scheme

### DIFF
--- a/engine/source/interfaces/intsort/intcrit.F
+++ b/engine/source/interfaces/intsort/intcrit.F
@@ -140,6 +140,20 @@ C
               NSNFI_FLAG(I)=0
            ENDIF
         ENDIF
+
+        ! when INTERACT == 0 and NSNFI_FLAG==1 is a change in state of Sensors,
+        ! Sensor was just deactivated but SPMD Buffers where not cleaned.
+        ! Sav buffers NSNFI/NSNSI Buffers & clean the original once.
+
+        IF(INTERACT == 0 .AND.NSNFI_FLAG(I)==0)THEN       
+           ALLOCATE(NSNSI_SAV(I)%P(NSPMD))
+           ALLOCATE(NSNFI_SAV(I)%P(NSPMD))
+           NSNSI_SAV(I)%P(1:NSPMD) = NSNSI(I)%P(1:NSPMD)
+           NSNFI_SAV(I)%P(1:NSPMD) = NSNFI(I)%P(1:NSPMD)
+           NSNFI_FLAG(I)=1
+           NSNFI(I)%P(1:NSPMD) = 0
+           NSNSI(I)%P(1:NSPMD) = 0
+        ENDIF
 C
       ENDDO
 C

--- a/engine/source/mpi/interfaces/spmd_i7tool.F
+++ b/engine/source/mpi/interfaces/spmd_i7tool.F
@@ -5592,22 +5592,30 @@ C In case deactivated Interface - Flush NSNFI back to Zero
 C Issue : Restarts + INACTI + TSTART when Start timee was not reached before Restart
                INTERACT = 1
 
+               ISENS = 0
+               IF(ITYP == 7.OR.ITYP == 11.OR.ITYP == 24)  ISENS = IPARI(64,I)  ! All but ITYP == 25
+ 
+               IF (ISENS > 0) THEN               ! Sensors may be deactivated w/o INACTI            
+                  TS = SENSOR_TAB(ISENS)%TSTART
+                  IF (TS>TT) INTERACT = 0
+               ENDIF
+
                INACTI=IPARI(22,I)
                IF (INACTI==5.OR.INACTI==6.OR.INACTI==7.OR.ITYP==23.OR.INACTI==-1)THEN
 C
                ISENS = 0
-               IF(ITYP == 7.OR.ITYP == 11.OR.ITYP == 24) ! All but ITYP == 25
-     .            ISENS = IPARI(64,I)      
-                  IF (ISENS > 0) THEN            
-                    TS = SENSOR_TAB(ISENS)%TSTART
-                    IF (TS>TT) INTERACT = 0
-                  ELSE
+               IF(ITYP == 7.OR.ITYP == 11.OR.ITYP == 24)  ISENS = IPARI(64,I) ! All but ITYP == 25
+                  IF(ISENS == 0)THEN
                     STARTT = INTBUF_TAB(I)%VARIABLES(3)
                     STOPT  = INTBUF_TAB(I)%VARIABLES(11)
                    IF (STARTT>TT) INTERACT = 0
                   ENDIF
                ENDIF
-               IF(INTERACT == 0) NSNFI(I)%P(1:NSPMD) = 0
+
+               IF(INTERACT == 0)THEN
+                    NSNFI(I)%P(1:NSPMD) = 0
+                    NSNSI(I)%P(1:NSPMD) = 0
+               ENDIF
               
 
 C

--- a/engine/source/mpi/interfaces/spmd_i7xvcom2.F
+++ b/engine/source/mpi/interfaces/spmd_i7xvcom2.F
@@ -250,7 +250,7 @@ C Attention aux interfaces inactives
                   STOPT  = INTBUF_TAB(NIN)%VARIABLES(11)              
                   IF (STARTT>TT-DT2) INTERACT = 0
                ENDIF   
-C on force le nombre d entite a envoyer a 0 tant que l'interface est inactive (jusqu au retri suivant)
+                ! Number of entities to send set to 0 when interface is deactivated
                 IF (INTERACT==0) NB=0
               END IF
               LENI = LEN
@@ -308,6 +308,24 @@ C
               NIN = INTLIST(II)
               IDEB = DEBUT(NIN)
               NB = NSNSI(NIN)%P(P)
+
+              ISENS = 0
+              INTERACT = 1
+              IF(NTY == 7.OR.NTY == 11.OR.NTY == 24.OR.
+     .           NTY == 21.OR.NTY == 5.OR.NTY == 19 .OR.
+     .           NTY == 25) ISENS = IPARI(64,NIN)  
+
+              IF (ISENS > 0) THEN    ! IF INTERFACE IS ACTIVATED BY SENSOR 
+                 TS = SENSOR_TAB(ISENS)%TSTART
+                 IF (TS>TT-DT2)  INTERACT = 0
+              ELSE
+                 STARTT = INTBUF_TAB(NIN)%VARIABLES(3)
+                 STOPT  = INTBUF_TAB(NIN)%VARIABLES(11)              
+                 IF (STARTT>TT-DT2) INTERACT = 0
+              ENDIF   
+              ! Number of entities to send set to 0 when interface is deactivated
+              IF (INTERACT==0) NB=0
+
               IF(NB>0) THEN
                 NTY   =IPARI(7,NIN)
                 INTTH = IPARI(47,NIN)


### PR DESCRIPTION
Issue on remote Position & velocity send when interface got deactivated
In spmd_i7xvcom scheme : unballance between send & receive causing app to crash
This was raised after : 20dd3a70233fec9601d2b9d34b90e467e1bc131c

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
