### PR TITLE
Add missing regularization method when using exponential damage in LAW124

### DIFF
--- a/engine/source/materials/mat/mat124/sigeps124.F
+++ b/engine/source/materials/mat/mat124/sigeps124.F
@@ -814,7 +814,7 @@ c
               ENDIF
             ! -> Exponential type
             ELSEIF (DTYPE == 3) THEN 
-              OMEGAT(I) = ONE - EXP(-(EPS_INEL(I)/WF))
+              OMEGAT(I) = ONE - EXP(-(H(I)*EPS_INEL(I)/WF))
             ENDIF
             OMEGAT(I) = MAX(OMEGAT(I),UVAR(I,12))
             OMEGAT(I) = MIN(MAX(OMEGAT(I),ZERO),ZEP999)


### PR DESCRIPTION

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Hillerborg regularization was not activated for exponential damage in /MAT/LAW124 due to a missing factor

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Add the missing factor H(I)

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
