### PR TITLE
wrong strain output due to factor 2 in shear and remove fld_tdh in us…

### DIFF
--- a/engine/source/materials/mat_share/usermat_solid.F
+++ b/engine/source/materials/mat_share/usermat_solid.F
@@ -1380,12 +1380,6 @@ C   user3
 !!!
             ENDIF
           ELSEIF (IRUPT == 7)THEN                                        
-                  CALL FAIL_FLD_TSH(
-     1            LLT       ,NPAR      ,NVARF     ,NFUNC    ,IFUNC      ,
-     2            NPF       ,TF        ,TT        ,DT1      ,UPARAMF,   
-     3            UVARF     ,NGL       ,IPG       ,ILAY     ,IPTT         ,
-     5            ES1       ,ES2       ,ES4       ,ES5      ,ES6          ,
-     6            OFF       ,FOFF      ,FLD_IDX   ,DAM      ,DFMAX     )
           ELSEIF (IRUPT == 8)THEN                                         
 C---- Johnson cook + spalling          
               CALL FAIL_SPALLING_S(LLT ,NPAR,NVARF,NFUNC,IFUNC,

--- a/engine/source/output/h3d/h3d_results/h3d_fld_tsh.F
+++ b/engine/source/output/h3d/h3d_results/h3d_fld_tsh.F
@@ -90,7 +90,7 @@ C-----------------------------------------------
         DAM    => FBUF%FLOC(IFAIL)%DAM
         ES1(1:NEL) = EVAR(1,1:NEL)
         ES2(1:NEL) = EVAR(2,1:NEL)
-        ES4(1:NEL) = EVAR(3,1:NEL)
+        ES4(1:NEL) = TWO*EVAR(3,1:NEL)
          CALL FAIL_FLD_TSH(
      1            NEL       ,NPAR      ,NVARF     ,NFUNC    ,IFUNC      ,
      2            NPF       ,TF        ,TT        ,DT1      ,UPARAMF,   


### PR DESCRIPTION
…er_law

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
wrong output (/H3D/SOLID/FLDZ/OUTER) due to factor 2 with shear

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Correction done for shear and remove the useless calling in user's law with FLD for thick-shell

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
