### PR TITLE
Starter & Engine: -V Option

### DIFF
--- a/engine/share/spe_inc/machine.inc
+++ b/engine/share/spe_inc/machine.inc
@@ -30,11 +30,7 @@ C ALLOC
       INTEGER IADI,IADR,IXDP,IADIF,IADRF
 C----------------------------------------------------------------------
 C
-#if CPP_mach == CPP_p4win32
-      CPUNAM ='win32'
-      ARCHTITLE='Windows 32 bits, Intel compiler'
-C
-#elif CPP_mach == CPP_p4win64
+#if CPP_mach == CPP_p4win64
 #if CPP_rel == 10
       CPUNAM ='win64 plmpi'
       ARCHTITLE='Windows 64 bits, Intel compiler, Platform MPI'
@@ -47,24 +43,6 @@ C
 #elif 1
       CPUNAM ='win64'
       ARCHTITLE='Windows 64 bits, Intel compiler'
-#endif
-C
-#elif CPP_mach == CPP_linux
-      CPUNAM ='linux32 pgi'
-      ARCHTITLE='Linux 32 bits, PGI compiler'
-C
-#elif CPP_mach == CPP_p4linux932
-      CPUNAM ='linux32'
-      ARCHTITLE='Linux 32 bits, Intel compiler'
-C
-#elif CPP_mach == CPP_linux964
-      CPUNAM ='pgi_linux64'
-      ARCHTITLE='Linux 64 bits, PGI compiler'
-C
-#elif CPP_mach == CPP_linux64_spmd
-#if CPP_rel == 60
-      CPUNAM='linux64 pgi plmpi'
-      ARCHTITLE='Linux 64 bits, PGI compiler, Platform MPI'
 #endif
 C
 #elif CPP_mach == CPP_p4linux964_spmd || CPP_mach == CPP_p4linux964
@@ -107,42 +85,6 @@ C
 #endif
 #endif
 C
-#elif CPP_mach == CPP_il
-      CPUNAM = 'linuxia64'
-      ARCHTITLE='Linux Itanium 64 bits, Intel compiler'
-C
-#elif CPP_mach == CPP_il_spmd
-#if CPP_rel == 10
-      CPUNAM = 'linuxia64 plmpi'
-      ARCHTITLE='Linux Itanium 64 bits, Intel compiler, Platform MPI'
-#elif CPP_rel == 30
-      CPUNAM = 'linuxia64 sgimpi'
-      ARCHTITLE='Linux Itanium 64 bits, Intel compiler, SGI MPI'
-#endif
-C
-#elif CPP_mach == CPP_pwr4 ||  CPP_mach == CPP_pwr4_spmd
-#if defined(MPI)
-      CPUNAM ='aix64 aixmpi'
-      ARCHTITLE='AIX 64 bits, IBM compiler, POE MPI'
-C
-#elif 1
-      CPUNAM ='aix64'
-      ARCHTITLE='AIX 64 bits, IBM compiler'
-#endif
-C
-#elif CPP_mach == CPP_sun25
-#if CPP_rel == 1000
-      CPUNAM ='solarisx64'
-      ARCHTITLE='Solaris 64 bits, SUN compiler'
-#endif
-C
-#elif CPP_mach == CPP_sol10x64_spmd
-      CPUNAM ='solarisx64 sunmpi'
-      ARCHTITLE='Solaris 64 bits, SUN compiler, SUN MPI'
-C
-#elif CPP_mach == CPP_macosx64
-      CPUNAM ='macosx'
-      ARCHTITLE='Mac OS/X 64 bits, Intel compiler'
 #elif 1
 C (elif 1) remplace (else) qui ne marche pas sur sgi6 avec des (elif)
       DATA CPUNAM /'UNKNOWN PLATFORM'/

--- a/engine/source/engine/execargcheck.F
+++ b/engine/source/engine/execargcheck.F
@@ -635,7 +635,8 @@ C-----------------------------------------------
 C machine.inc include
         INTEGER RDFLEXCOMP
         INTEGER IDUM
-
+C-----------------------------------------------
+#include "machine.inc"
 C-----------------------------------------------
 
          LBT = LEN_TRIM(BTAG)

--- a/starter/share/spe_inc/machine.inc
+++ b/starter/share/spe_inc/machine.inc
@@ -24,25 +24,10 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 C
 C----------------------------------------------------------------------
 C
-#if CPP_mach == CPP_p4win32
-      CPUNAM ='win32'
-      ARCHTITLE='Windows 32 bits, Intel compiler'
-      IBUILTIN=23
-C
-#elif CPP_mach == CPP_p4win64
+#if CPP_mach == CPP_p4win64
       CPUNAM ='win64'
       ARCHTITLE='Windows 64 bits, Intel compiler'
       IBUILTIN=22
-C
-#elif CPP_mach == CPP_linux
-      CPUNAM ='linux32 pgi'
-      ARCHTITLE='Linux 32 bits, PGI compiler'
-      IBUILTIN=9
-C
-#elif CPP_mach == CPP_p4linux932
-      CPUNAM ='linux32'
-      ARCHTITLE='Linux 32 bits, Intel compiler'
-      IBUILTIN=25
 C
 #elif CPP_mach == CPP_linux964
       CPUNAM ='pgi_linux64'
@@ -60,34 +45,8 @@ C
 #elif 1
       ARCHTITLE='Linux 64 bits, Intel compiler'
 #endif
-
       IBUILTIN=18
 C
-#elif CPP_mach == CPP_il
-      CPUNAM = 'linuxia64'
-      ARCHTITLE='Linux Itanium 64 bits, Intel compiler'
-      IBUILTIN=10
-C
-#elif CPP_mach == CPP_pwr4
-      CPUNAM ='aix64'
-      ARCHTITLE='AIX 64 bits, IBM compiler'
-      IBUILTIN = 5
-C
-#elif CPP_mach == CPP_sun25
-#if CPP_rel == 1000
-      CPUNAM ='solarisx64'
-      ARCHTITLE='Solaris 64 bits, SUN compiler'
-      IBUILTIN = 24
-#elif 1
-      DATA CPUNAM /'UNKNOWN PLATFORM'/
-      ARCHTITLE='UNKNOWN PLATFORM'
-      IBUILTIN = 1
-#endif
-C
-#elif CPP_mach == CPP_macosx64
-      CPUNAM ='macosx64'
-      ARCHTITLE='Mac OS/X 64 bits, Intel compiler'
-      IBUILTIN=26
 #elif 1
 C (elif 1) remplace (else) qui ne marche pas sur sgi6 avec des (elif)
       DATA CPUNAM /'UNKNOWN PLATFORM'/
@@ -105,18 +64,14 @@ C      BMUL0 = 0.25
       IEXPM=1
 C     IEXPM=1  allocation dynamique de memoire
 C     IEXPM=0  dimension fixe
-#if CPP_mach == CPP_c90 || CPP_mach == CPP_ymp || CPP_mach == CPP_ymp_spmd || CPP_mach == CPP_t90 || CPP_mach == CPP_t90_i3e
-      ICRAY=1
-      IRESP=0
-#else
+
       ICRAY=0
-Cow41j2 +++
       IF (IR4R8 .EQ. 1) THEN
         IRESP = 1
       ELSE
         IRESP = 0
       ENDIF
-#endif
+
 C     ICRAY=0  non cray
 C     ICRAY=1  cray (hpalloc)
       IMACH=3

--- a/starter/source/starter/execargcheck.F
+++ b/starter/source/starter/execargcheck.F
@@ -1074,7 +1074,8 @@ C machine.inc include
 
 C variables inutiles mais definies dans machine.inc
         INTEGER IBUILTIN,NSPMD,BMUL0,IEXPM,ICRAY,IRESP,IMACH,IRFORM,LENBT,READER_ID
-
+C-----------------------------------------------
+#include "machine.inc"
 C-----------------------------------------------
 
          WRITE(6,'(A,A)') ' '


### PR DESCRIPTION
machine.inc was removed from execargcheck, causing -v to give wrong answer. Clean machine.inc regarding obsolete architectures

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
