### PR TITLE
Avoid passing invalid memory address to INTCONTP

### DIFF
--- a/engine/source/mpi/forces/spmd_i7fcom_pon.F
+++ b/engine/source/mpi/forces/spmd_i7fcom_pon.F
@@ -345,8 +345,13 @@ C routine calcul place supplementaire int20
      +          NSNFI(NIN)%P(1),NSVFI(NIN)%P(1),ISIZENV,LEN20)
           END IF
 C precomptage du nombre de contacts par processeur+calcul nsnfi total
-          CALL INTCONTP(
-     +      NI,ISKYFI(NIN)%P(1),NSNFI(NIN)%P(1),ISIZENV,NSNFITOT,LENI)
+          IF(NI > 0) THEN
+            CALL INTCONTP(NI,ISKYFI(NIN)%P,NSNFI(NIN)%P,ISIZENV,NSNFITOT,LENI)
+          ELSE
+            DO J = 1, NSPMD
+              NSNFITOT(J) = NSNFITOT(J) + NSNFI(NIN)%P(J)
+            END DO
+          ENDIF
 C ajout partie edge
           IF(NTY==20)THEN
             NI = NISKYFIE(NIN)


### PR DESCRIPTION
ISKYFI(NIN)%P(1) was passed as a dummy argument, but  P may be of size 0.
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
