### PR TITLE
Fix an IO issue in the dynain option

### DIFF
--- a/starter/source/starter/check_dynain.F
+++ b/starter/source/starter/check_dynain.F
@@ -148,7 +148,7 @@ C--     Counting and storing parts id --
             DO WHILE (J<=LEN_TRIM(CARTE))
                IF(CARTE(J:J)/=' ') THEN
                  K=J
-                 DO WHILE(CARTE(K:K)/=' '.AND.K<=LEN_TRIM(CARTE))
+                 DO WHILE(CARTE(K:K)/=' '.AND.CARTE(K:K)/=CHAR(13).AND.K<=LEN_TRIM(CARTE))
                    K=K+1
                  ENDDO
                  NPRT = NPRT + 1


### PR DESCRIPTION
#### Description of the feature or the bug
In the starter if the dynain option is used, a bug can occurred (depending on the compiler) during a READ instruction.
The end of line (EOL) character is not treated correctly 


#### Description of the changes
THE EOL is now taken into account


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
