### PR TITLE
improve robustness of law1 w/ high Poisson ratio of solid elements

### DIFF
--- a/engine/source/elements/solid/solide10/nsvis_sm12.F
+++ b/engine/source/elements/solid/solide10/nsvis_sm12.F
@@ -26,7 +26,7 @@ Chd|-- called by -----------
 Chd|        S10FORC3                      source/elements/solid/solide10/s10forc3.F
 Chd|-- calls ---------------
 Chd|====================================================================
-      SUBROUTINE NSVIS_SM12(OFFG ,MU0,SSP  ,VOL  ,D1   ,
+      SUBROUTINE NSVIS_SM12(OFFG ,MU ,SSP  ,VOL  ,D1   ,
      .                      D2   ,D3  ,D4    ,D5  ,D6   ,
      .                      VOL0 ,RHO0,STI   ,NEL   ) 
 C-----------------------------------------------
@@ -50,7 +50,7 @@ C     REAL
      .                   D1, D2, D3,D4, D5, D6,SSP
       my_real, DIMENSION(NEL),INTENT(IN) :: OFFG,VOL0
       my_real, DIMENSION(MVSIZ),INTENT(INOUT) :: STI
-      my_real, INTENT(IN) :: RHO0,MU0
+      my_real, INTENT(IN) :: RHO0,MU
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -58,7 +58,7 @@ C-----------------------------------------------
 C     REAL
       my_real
      .   DD, AL, CNS1, CNS2, CNS3,
-     .   DAV, PVIS, NRHO,MU,JAC,FAC,TOL
+     .   DAV, PVIS, NRHO,JAC,FAC,TOL
 #ifdef MYREAL8 
       my_real, PARAMETER :: REAL_THREE = 3.0D0
       my_real, PARAMETER :: REAL_ONE = 1.0D0
@@ -67,7 +67,6 @@ C     REAL
       my_real, PARAMETER :: REAL_ONE = 1.0
 #endif
 C-----------------------------------------------
-        MU=ZEP02-MU0
         TOL = ONE-EM02
       IF (MU>ZERO) THEN
         DO I=1,NEL
@@ -85,8 +84,6 @@ C-----------------------------------------------
           SVIS(I,4)=SVIS(I,4) + CNS3 * D4(I)
           SVIS(I,5)=SVIS(I,5) + CNS3 * D5(I)
           SVIS(I,6)=SVIS(I,6) + CNS3 * D6(I)
-          FAC =SQRT(ONE+MU*MU)-MU 
-          STI(I) = STI(I)/FAC/FAC
         ENDDO
       END IF !(MU>ZERO) THEN
 C      

--- a/engine/source/elements/solid/solide10/s10forc3.F
+++ b/engine/source/elements/solid/solide10/s10forc3.F
@@ -214,7 +214,8 @@ C
      .    MFXX(MVSIZ,5),MFXY(MVSIZ,5),MFYX(MVSIZ,5),
      .    MFYY(MVSIZ,5),MFYZ(MVSIZ,5),MFZY(MVSIZ,5),
      .    MFZZ(MVSIZ,5),MFZX(MVSIZ,5),MFXZ(MVSIZ,5),DIVDE(MVSIZ),
-     .    NU(MVSIZ),FAC(MVSIZ),FACP(MVSIZ),E0(MVSIZ),C1,DVM(MVSIZ)
+     .    NU(MVSIZ),FAC(MVSIZ),FACP(MVSIZ),E0(MVSIZ),C1,DVM(MVSIZ),
+     .    VISP(MVSIZ)
 c
       my_real VARNL(NEL)
 c     Flag Bolt Preloading
@@ -314,14 +315,25 @@ C-----------
      A   CONDEG   ,GBUF%G_EPSD)
 C     
       IPLAW1 = 0
+      CNS2 = ZERO
       IF (ISM12_11>0 .AND.IDTMIN(1)==3) THEN
          MX = IXS(1,NF1)
          RHO0_1 =PM( 1,MX)
          IF (PM(21,MX)>0.49) IPLAW1=1
-         NU(LFT:LLT)=MIN(HALF,PM(21,MX))
-         FACP(LFT:LLT)=TWO*PM(21,MX)
-         CNS2 = ZERO
-         IF (IGEO(35,NGEO(1))>0) CNS2=ABS(GEO(17,NGEO(1)))
+         IF (IPLAW1==1) THEN
+           FACP(LFT:LLT)=TWO*PM(21,MX)
+           VISP(LFT:LLT)=TWO
+           CNS2 = ZEP02
+           IF (IGEO(35,NGEO(1))>0) CNS2=CNS2-ABS(GEO(17,NGEO(1)))
+         END IF 
+      ELSEIF (ISMSTR==10.AND.MTN==1) THEN
+         MX = IXS(1,NF1)
+         RHO0_1 =PM( 1,MX)
+         IF (PM(21,MX)>0.49) THEN
+           VISP(LFT:LLT)=TWO
+           CNS2 = ZEP02
+           IF (IGEO(35,NGEO(1))>0) CNS2=CNS2-ABS(GEO(17,NGEO(1)))
+         END IF 
       END IF 
 C     
       CALL S10NX3(NX)
@@ -555,8 +567,6 @@ C-----------  return to global system
      .                                D6  ,LBUF%STRA,WXX ,WYY ,WZZ,
      .                                OFF ,NEL      )
 C--------------------------
-C     BILANS PAR MATERIAU
-C--------------------------
         IFLAG=MOD(NCYCLE,NCPRI)
         IF(IOUTPRT>0)THEN
            CALL S10BILAN(PARTSAV,LBUF%EINT,LBUF%RHO,LBUF%RK,LBUF%VOL,
@@ -565,12 +575,10 @@ C--------------------------
      .                   GBUF%FILL,XX,YY,ZZ,ITASK,IPARG(1,NG),GBUF%OFF)
         ENDIF
 C-------------------------
-C       ASSEMBLE
-C-------------------------
-        IF (IPLAW1>0) 
-     .     CALL NSVIS_SM12(GBUF%OFF ,CNS2,CXX  ,VOLN ,DXX     ,
-     .                      DYY     ,DZZ    ,D4    ,D5  ,D6   ,
-     .                      LBUF%VOL,RHO0_1,STI   ,NEL   ) 
+        IF (CNS2>ZERO)
+     .     CALL NSVIS_SM12(VISP  ,CNS2,CXX  ,VOLN ,DXX     ,
+     .                     DYY     ,DZZ    ,D4    ,D5  ,D6   ,
+     .                     LBUF%VOL,RHO0_1,STI   ,NEL   ) 
 C----------------------------
 C       INTERNAL FORCES
 C----------------------------

--- a/engine/source/elements/solid/solide8e/s8eforc3.F
+++ b/engine/source/elements/solid/solide8e/s8eforc3.F
@@ -159,7 +159,7 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER IXS(NIXS,*), IPARG(NPARG,NGROUP),NPF(*),
-     .    IADS(8,*),IPARTS(*), IPM(NPROPMI,*),GRTH(*),IGRTH(*),IGEO(*),
+     .    IADS(8,*),IPARTS(*), IPM(NPROPMI,*),GRTH(*),IGRTH(*),IGEO(NPROPGI,*),
      .    IOUTPRT
 C          
       INTEGER NELTST,ITYPTST,OFFSET,NEL,ICP, 
@@ -171,7 +171,7 @@ C
      .   DT2T
 C
       my_real
-     .   PM(NPROPM,*), GEO(*), X(*), A(*), V(*), MS(*), W(*), 
+     .   PM(NPROPM,*), GEO(NPROPG,*), X(*), A(*), V(*), MS(*), W(*), 
      .   FLUX(6,*),FLU1(*), VEUL(*), FV(*), TF(*), 
      .   PARTSAV(*),STIFN(*), FSKY(*),EANI(*),BUFMAT(*),
      .   F11(MVSIZ),F21(MVSIZ),F31(MVSIZ),
@@ -320,7 +320,7 @@ c-----------------------------------------------------
      .   BZZ1(MVSIZ),BZZ2(MVSIZ),BZZ3(MVSIZ),BZZ4(MVSIZ),
      .   BZZ5(MVSIZ),BZZ6(MVSIZ),BZZ7(MVSIZ),BZZ8(MVSIZ)
 C
-      INTEGER NNEGA,INDEX(MVSIZ),ISELECT,ipr,iel,ISEL_V,ISM12_11
+      INTEGER NNEGA,INDEX(MVSIZ),ISELECT,ipr,iel,ISEL_V,ISM12_11,ICPT
       my_real
      .   PXY1(MVSIZ),PXY2(MVSIZ),PXY3(MVSIZ),PXY4(MVSIZ),
      .   PXY5(MVSIZ),PXY6(MVSIZ),PXY7(MVSIZ),PXY8(MVSIZ),
@@ -360,7 +360,7 @@ C
      .   PX3H1(MVSIZ), PX3H2(MVSIZ), PX3H3(MVSIZ),PX3H4(MVSIZ),  
      .   PX4H1(MVSIZ), PX4H2(MVSIZ), PX4H3(MVSIZ),PX4H4(MVSIZ),  
      .   SIGP(NEL,6),AMU(MVSIZ),JR_1(MVSIZ),JS_1(MVSIZ),JT_1(MVSIZ),
-     .   FLD(MVSIZ),CAQ,SIG_A(MVSIZ,3),RHO0
+     .   FLD(MVSIZ),CAQ,SIG_A(MVSIZ,3),RHO0,NUT(MVSIZ),RHO0_1,CNS2,NU0
       DOUBLE PRECISION 
      .   VOLP(MVSIZ,NNPT)
 
@@ -468,6 +468,8 @@ C-------v termes will be calculated like HEPH
       ELSE
        ISELECT=0
       ENDIF
+      ICPT = ICP
+      IF (MTN==1.AND.ISMSTR>=11) ICPT=0
 c      ipr=0
 c      iel=1        
 C-----------
@@ -550,11 +552,12 @@ C-----------
       ENDDO
       IF(JTHE < 0) THEM(LFT:LLT,1:8) =ZERO
 
+      MX = MXT(LFT)
+      NU0=PM(21,MX)
       IF (ICP == 2) THEN
-       MX = MXT(LFT)
        C1 =PM(32,MX)
        DO I=LFT,LLT
-        NU(I)=MIN(HALF,PM(21,MX))
+        NU(I)=MIN(HALF,NU0)
         E0(I) =THREE*(ONE-TWO*NU(I))*C1
        ENDDO
 c------ Sigy of GBUF%SIG is not good, take the ip of min(e_ps) 
@@ -572,9 +575,8 @@ c------ Sigy of GBUF%SIG is not good, take the ip of min(e_ps)
         ENDDO
        END IF
       ELSEIF (ICP > 0 .OR.ISELECT >1.OR.ISEL_V>0) THEN
-       MX = MXT(LFT)
        DO I=LFT,LLT
-        NU(I)=MIN(HALF,PM(21,MX))
+        NU(I)=MIN(HALF,NU0)
        ENDDO
       ENDIF 
       IF (ISELECT >1.OR.ISEL_V>0) THEN
@@ -582,6 +584,18 @@ c------ Sigy of GBUF%SIG is not good, take the ip of min(e_ps)
         NU1(I) = NU(I)/(ONE - NU(I))
        ENDDO
       ENDIF 
+      CNS2 = ZERO
+      NUT(LFT:LLT) =NU0
+      IF (ICP==1.AND.MTN==1.AND.(ISMSTR==10.OR.ISMSTR==12)) THEN
+        DO I=LFT,LLT
+          NUT(I) = TWO_THIRD*NU0*NU0
+        ENDDO
+        IF (ISMSTR==12) THEN
+          RHO0_1 =PM( 1,MX)
+          CNS2 = ZEP02
+          IF (IGEO(35,NGEO(1))>0) CNS2=CNS2-ABS(GEO(17,NGEO(1)))
+        END IF
+      END IF
       CALL S8EPRST_INI(PR ,PS ,PT )
 C-------now [B](Pij) is always in global system w/ ISMSTR10
       IF (ISMSTR >= 10.AND.ISMSTR <= 12) THEN
@@ -771,7 +785,7 @@ C
      .    VZ0(1,5), VZ0(1,6), VZ0(1,7), VZ0(1,8),
      .    MFXX(1,IP), MFXY(1,IP), MFXZ(1,IP), MFYX(1,IP), 
      .    MFYY(1,IP), MFYZ(1,IP), MFZX(1,IP), MFZY(1,IP),
-     .    MFZZ(1,IP),ICP ,DETF0 ,JFAC(1,IP) ,NU ,ISELECT,IDEG,
+     .    MFZZ(1,IP),ICP ,DETF0 ,JFAC(1,IP) ,NUT,ISELECT,IDEG,
      .    BXX(1,IP),BYY(1,IP),BZZ(1,IP),GBUF%OFF)
 C     
          IF (JCVT > 0.AND.(ISMSTR==10.OR.ISMSTR==12)) THEN
@@ -1149,7 +1163,7 @@ C--------- modified [B] is saved in GBUF%ETOTSH verify for Ismstr=11 !!!!!
      .    VZ0(1,5), VZ0(1,6), VZ0(1,7), VZ0(1,8),
      .    MFXX(1,IP), MFXY(1,IP), MFXZ(1,IP), MFYX(1,IP), 
      .    MFYY(1,IP), MFYZ(1,IP), MFZX(1,IP), MFZY(1,IP),
-     .    MFZZ(1,IP),ICP ,DETF0 ,JFAC(1,IP) ,NU ,ISELECT,IDEG,
+     .    MFZZ(1,IP),ICPT,DETF0 ,JFAC(1,IP) ,NU ,ISELECT,IDEG,
      .    BXX(1,IP),BYY(1,IP),BZZ(1,IP),GBUF%OFF)
          ELSEIF (ISMSTR==12) THEN
           CALL S8EDEFOT12(
@@ -1183,7 +1197,7 @@ C--------- modified [B] is saved in GBUF%ETOTSH verify for Ismstr=11 !!!!!
      .    R11, R12, R13, R21, R22, R23, R31, R32, R33,
      .    MFXX(1,IP), MFXY(1,IP), MFXZ(1,IP), MFYX(1,IP), 
      .    MFYY(1,IP), MFYZ(1,IP), MFZX(1,IP), MFZY(1,IP),
-     .    MFZZ(1,IP),ICP  ,DETF0 ,JFAC(1,IP) ,NU ,IDEG ,
+     .    MFZZ(1,IP),ICPT ,DETF0 ,JFAC(1,IP) ,NU ,IDEG ,
      .    GBUF%OFF,ISEL_V ,ISELECT )
          END IF !(ISMSTR==11) THEN
          CALL S8EDEFO3(
@@ -1327,6 +1341,10 @@ C
      .    LBUF%PIJ, SIG_A,LBUF%EINT,VOLN,DXX, DYY, DZZ,
      .    LBUF%SIG, S1 ,S2  ,S3  ,LLT,GBUF%OFF)
       END IF
+      IF (CNS2 > ZERO) 
+     .     CALL NSVIS_SM12(GBUF%OFF ,CNS2,CXX  ,VOLN ,DXX     ,
+     .                      DYY     ,DZZ    ,D4    ,D5  ,D6   ,
+     .                      LBUF%VOL,RHO0_1,STI   ,NEL   ) 
 C----------------------------
 C     INTERNAL FORCES
 C----------------------------
@@ -1354,7 +1372,7 @@ C----------------------------
      .   PZY1, PZY2, PZY3, PZY4, PZY5, PZY6, PZY7, PZY8,
      .   F11,F21,F31,F12,F22,F32,F13,F23,F33,F14,F24,F34,
      .   F15,F25,F35,F16,F26,F36,F17,F27,F37,F18,F28,F38,
-     .   VOLN,QVIS,ICP,JFAC(1,IP),NEL,ISELECT,IDEG,SIG_A,ISEL_V) 
+     .   VOLN,QVIS,ICPT,JFAC(1,IP),NEL,ISELECT,IDEG,SIG_A,ISEL_V) 
           CALL S8EFMOY3(
      .         LBUF%SIG,
      .         VOLN   ,QVIS   ,PP     ,LBUF%EINT,LBUF%RHO,LBUF%QVIS,
@@ -1433,7 +1451,7 @@ c-------------------
         END DO 
        END DO
       END IF   ! IOFFS == 1
-      IF(ICP==1.AND.ISMSTR/=10.AND.ISMSTR/=12) THEN
+      IF(ICPT==1.AND.ISMSTR/=10.AND.ISMSTR/=12) THEN
        CALL S8ZFINTP3(
      .   PXC1, PXC2, PXC3, PXC4,
      .   PYC1, PYC2, PYC3, PYC4,
@@ -1488,7 +1506,7 @@ C-----------------------------
          DO I=LFT,LLT
           CAQ=GBUF%RHO(I)*VOLG(I)**THIRD
           FLD(I)=FOURTH*EM02*CAQ*CXX(I)*OFFG(I)
-                  IF (ISMSTR==12.AND.GBUF%OFF(I) > ONE) FLD(I)=ZERO
+          IF (ISMSTR==12.AND.GBUF%OFF(I) > ONE) FLD(I)=ZERO
          ENDDO
         CALL S8EVIS3(
      .   VZ1, VZ2, VZ3, VZ4, VZ5, VZ6, VZ7, VZ8,
@@ -1506,7 +1524,7 @@ C-----------------------------
      .   PX2H1, PX2H2, PX2H3, PX2H4,
      .   PX3H1, PX3H2, PX3H3, PX3H4, 
      .   PX4H1, PX4H2, PX4H3, PX4H4,
-     .   JT_1 ,  JR_1, JS_1 ,PM(21,MX),FLD )
+     .   JT_1 ,  JR_1, JS_1 ,NU0,FLD )
       ENDIF
 C--------------------------
 C       BILANS PAR MATERIAU

--- a/engine/source/elements/solid/solidez/szforc3.F
+++ b/engine/source/elements/solid/solidez/szforc3.F
@@ -141,7 +141,7 @@ C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER IXS(NIXS,*),IPARG(NPARG,*), NPF(*),IADS(8,*),
      .        IPARTS(*),IPM(NPROPMI,*),ITASK,IMATVIS,GRTH(*),IGRTH(*),
-     .        IGEO(*), TAGPRT_SMS(*)        
+     .        IGEO(NPROPGI,*), TAGPRT_SMS(*)        
       INTEGER NELTST,ITYPTST,OFFSET,NEL ,ICP, NDDIM,
      .        NVC,ISTRAIN,IEXPAN,NG,NPTS,IOUTPRT,NALE(*),H3D_STRAIN
 
@@ -150,7 +150,7 @@ C-----------------------------------------------
       my_real
      .   DT2T
       my_real
-     .   PM(NPROPM,*), GEO(*), X(*), A(*), V(*), MS(*), W(*), 
+     .   PM(NPROPM,*), GEO(NPROPG,*), X(*), A(*), V(3,*), MS(*), W(*), 
      .   FLUX(6,*), FSKYM(*),
      .   FLU1(*), VEUL(*), FV(*), TF(*), BUFMAT(*),
      .   PARTSAV(*),STIFN(*), FSKY(*),EANI(*),MSNF(*),
@@ -266,7 +266,7 @@ C 8-nodes solid connectivities
      .  R1_FREE(MVSIZ),R3_DAM(MVSIZ),R4_FREE(MVSIZ),OFFG0(MVSIZ),AMU(MVSIZ),
      .  XGXA(MVSIZ),XGYA(MVSIZ),XGZA(MVSIZ),
      .  XGXYA(MVSIZ),XGYZA(MVSIZ),XGZXA(MVSIZ),
-     .  XGXA2(MVSIZ),XGYA2(MVSIZ),XGZA2(MVSIZ)
+     .  XGXA2(MVSIZ),XGYA2(MVSIZ),XGZA2(MVSIZ),CNS2,RHO0_1
       my_real, 
      .  DIMENSION(:), POINTER :: EINT
 C-----
@@ -275,7 +275,7 @@ C-----
 C-----
 C----- 
 C     IBOLTP : flag bolt preloading
-      INTEGER IBOLTP,NBPRELD,IMAT,ISM12_11
+      INTEGER IBOLTP,NBPRELD,IMAT,ISM12_11,MX
       my_real, DIMENSION(:), ALLOCATABLE :: VAR_REG
       my_real, DIMENSION(:), POINTER :: BPRELD,DNL
       my_real :: P(MVSIZ)      
@@ -331,6 +331,13 @@ C Gather nodal variables and compute rotation
      .   XGXA2,XGYA2,XGZA2,XGXYA,XGYZA,XGZXA,IPARG(1,NG),
      .   GBUF%GAMA_R) 
 C
+      CNS2 = ZERO
+      IF (ICP==1.AND.MTN==1.AND.ISMSTR==12) THEN
+         MX = MXT(LFT)
+         RHO0_1 =PM( 1,MX)
+         CNS2 = ZEP02
+         IF (IGEO(35,NGEO(1))>0) CNS2=CNS2-ABS(GEO(17,NGEO(1)))
+      END IF
 C Total strain Pij are in global system for ISMSTR=10,12 and in local system for ISMSTR=11
       IF ((ISMSTR >= 10.AND.ISMSTR <= 12).AND.JLAG > 0) THEN
         CALL SGCOOR3(TT,8,X,IXS(1,NF1),
@@ -706,6 +713,10 @@ C
      .   GBUF%HOURG,JAC1,JAC5,JAC9,GBUF%EINT,GBUF%VOL,SIGY,SIGN,SIGO,ICP,
      .   LBUF%PLA,IMATVIS,ET ,R3_DAM,NEL,GBUF%STRHG,ISTRAIN)
       END IF !(ISORTH>0) THEN
+      IF (CNS2 > ZERO) 
+     .     CALL NSVIS_SM12(GBUF%OFF ,CNS2,CXX  ,VOLN ,DXX     ,
+     .                     DYY     ,DZZ    ,D4    ,D5  ,D6   ,
+     .                     LBUF%VOL,RHO0_1 ,STI   ,NEL   ) 
 C 
       IF(JCLOSE /= 0) CALL FE_CLOSE(
      1   HH,      GBUF%RHO,VOLN,    VX1,

--- a/engine/source/elements/solid/solidez/szhour3.F
+++ b/engine/source/elements/solid/solidez/szhour3.F
@@ -93,7 +93,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I, MX, J,K,IET, MT
+      INTEGER I, MX, J,K,IET, MT,IPLAST
       my_real
      .   CAQ(MVSIZ), FCL(MVSIZ), FCQ(MVSIZ),DEINT(MVSIZ),
      .   H11(MVSIZ), H22(MVSIZ), H33(MVSIZ),
@@ -134,6 +134,7 @@ C +++ MAT Visco-----
       NU=PM(21,MX)
       G0=PM(22,MX)
       C1=PM(32,MX)
+      IPLAST = ELBUF_STR%GBUF%G_PLA
       SELECT CASE (MTN)
 C  +++ MAT Hydro---
         CASE (3,4,6,70) 
@@ -155,6 +156,16 @@ C  +++ MAT Hyper-elas----Et>1
       END SELECT
 C        
 C
+      IF (MTN==1.AND.ICP==1.AND.(ISMSTR>=10)) THEN           
+        DO I=LFT,LLT
+          FF = -MIN(SIG0(I,1),SIG0(I,2),SIG0(I,3))
+          FAC1 = MAX(ONE,HALF*FF/G0)
+          FAC = ONE          
+          IF (FAC1>ONE) FAC = ONEP2*FAC1         
+          GG(I)=FAC*GG(I)     
+        ENDDO
+      END IF
+C----
       IF (IET > 1 .AND. MATVIS>0 ) THEN
        CALL SZETFAC(LFT,LLT,IET,MTN,ET,GG )
       ELSEIF (MATVIS==1.AND.ISMSTR<10) THEN
@@ -209,9 +220,15 @@ C------now when IHKT=2, w.r.t. Isolid=1, fac=0.2*0.006666 ~0.001
          FCL(I)=ZEP00666666667*FCL(I)*CXX(I)
        ENDDO
       END IF
-C
 C------ w/ Prony, use Icpre=0 anyway
       IF (MATVIS>2) THEN
+       DO I=LFT,LLT
+        NU1(I) =TWO/(ONE-NU)
+        NU2(I) =NU*NU1(I)
+        NU3(I) =TWO_THIRD*(ONE + NU)
+        NU4(I) =NU
+       ENDDO
+      ELSEIF(MTN==1.AND.(ISMSTR>=10))THEN
        DO I=LFT,LLT
         NU1(I) =TWO/(ONE-NU)
         NU2(I) =NU*NU1(I)
@@ -362,7 +379,7 @@ C         SIGY(I) = 1.0E+30
         FHOUR(I,3,3) = FHOUR(I,3,3)*OFF(I)
         FHOUR(I,3,4) = FHOUR(I,3,4)*OFF(I)
        ENDDO
-      IF (MATVIS==0) 
+      IF (IPLAST==1) 
      .   CALL SZSVM(JR0,JS0,JT0,FHOUR,SIGY,SIGOLD,NU4,SMO1,SMO2,NEL) 
       !-----------For energy calculation------------
       IF(JLAG==1)THEN
@@ -457,10 +474,10 @@ C
        FHOUR(I,3,3) = FHOUR(I,3,3) + DFHOUR(I,3,3)
        FHOUR(I,3,4) = FHOUR(I,3,4) + DFHOUR(I,3,4)
       ENDDO
-      IF (MATVIS==0) 
+      IF (IPLAST==1) 
      .    CALL SZSVM(JR0,JS0,JT0,FHOUR,SIGY,SIG0,NU4,SM1,SM2,NEL) 
       !-----------ELASTIC-PLASTIC yield criterion------------
-      IF (MATVIS==0) THEN
+      IF (IPLAST==1) THEN
       DO I=LFT,LLT
         IF (SM1(I)>SIGY(I).AND.DEINT(I)>0) THEN
          SMO  = ZEP9*SMO1(I)+EM01*SMO2(I)
@@ -991,7 +1008,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I, MX, J,K,IET, MT
+      INTEGER I, MX, J,K,IET, MT,IPLAST
       my_real
      .   CAQ(MVSIZ), FCL(MVSIZ), FCQ(MVSIZ),DEINT(MVSIZ),
      .   H11(MVSIZ), H22(MVSIZ), H33(MVSIZ),
@@ -1018,6 +1035,7 @@ C-----------------------------------------------
 C-----------------------------------------------
        IET =IINT
        COEFH = ZEP9999   
+       IPLAST = ELBUF_STR%GBUF%G_PLA
 C---- attention : r->eta; s->zeta; t->ksi------------
 
 C +++ MAT Visco-----
@@ -1272,7 +1290,7 @@ C         SIGY(I) = 1.0E+30
         FHOUR(I,3,3) = FHOUR(I,3,3)*OFF(I)
         FHOUR(I,3,4) = FHOUR(I,3,4)*OFF(I)
        ENDDO
-      IF (MATVIS==0) 
+      IF (IPLAST==1) 
      .   CALL SZSVM_OR(JR0,JS0,JT0,CC,CG,G33,FHOUR,SIGY,SIGOLD,NU,SMO1,SMO2,NEL) 
       !-----------For energy calculation------------
       IF(JLAG==1)THEN
@@ -1338,10 +1356,10 @@ C
        FHOUR(I,3,3) = FHOUR(I,3,3) + DFHOUR(I,3,3)
        FHOUR(I,3,4) = FHOUR(I,3,4) + DFHOUR(I,3,4)
       ENDDO
-      IF (MATVIS==0) 
+      IF (IPLAST==1) 
      .    CALL SZSVM_OR(JR0,JS0,JT0,CC,CG,G33,FHOUR,SIGY,SIG0,NU,SM1,SM2,NEL) 
       !-----------ELASTIC-PLASTIC yield criterion------------
-      IF (MATVIS==0) THEN
+      IF (IPLAST==1) THEN
       DO I=LFT,LLT
         IF (SM1(I)>SIGY(I).AND.DEINT(I)>0) THEN
          SMO  = ZEP9*SMO1(I)+EM01*SMO2(I)

--- a/engine/source/materials/mat/mat001/m1law.F
+++ b/engine/source/materials/mat/mat001/m1law.F
@@ -359,7 +359,7 @@ C
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I, MX, J,IBID,NLAR,INDEX(MVSIZ),NSM
+      INTEGER I, MX, J,IBID,NLAR,INDEX(MVSIZ),NSM,IPRES
       my_real
      .   RHO0(MVSIZ), 
      .   G(MVSIZ), G1(MVSIZ), G2(MVSIZ),
@@ -371,13 +371,15 @@ C-----------------------------------------------
      .    BID1, BID2, BID3, DTA,  YM, DPDMP,FACQ0,
      .    RHO0_1,C1_1,G2_11,
      .    SV(3),P3,P2,
-     .    EPSTH11(MVSIZ),SIGTMP(MVSIZ,6)
+     .    EPSTH11(MVSIZ),SIGTMP(MVSIZ,6),FACG,FF,FRHO
 C-----------------------------------------------
       FACQ0 = ONE
       MX = MAT(LFT)
       RHO0_1 =PM( 1,MX)
       C1_1   =PM(32,MX)
       G2_11 = TWO*PM(22,MX)
+      IPRES=0
+      IF (PM(21,MX)>0.49)IPRES=1 
       DO I=LFT,LLT
         RHO0(I) =RHO0_1
         G(I)    =PM(22,MX)*OFF(I)
@@ -475,11 +477,26 @@ C--------switch to Ismstr11
               SIGTMP(I,5)=G(I)*ES5(I)
               SIGTMP(I,6)=G(I)*ES6(I)
             ENDDO
+            IF(IPRES==1)THEN 
 #include "vectorize.inc"
-            DO J=1,NSM
-             I = INDEX(J)
-             SIG(I,1:6)=SIGL(I,1:6) + SIGTMP(J,1:6)
-            END DO
+              DO J=1,NSM
+               I = INDEX(J)
+               FF = -MIN(SIG(I,1),SIG(I,2),SIG(I,3))
+               FACG = MAX(ONE,FF/G2_11)
+               IF (FACG>ONE) FACG = ONEP2*FACG
+               FRHO = RHOREF(I)/RHO0_1
+               IF (FRHO<ONEP01) FACG = ONE
+               SIG(I,1:3)=SIGL(I,1:3) + SIGTMP(J,1:3)
+               SIG(I,4:6)=SIGL(I,4:6) + FACG*SIGTMP(J,4:6)
+               G(I) = FACG*G(I)
+              END DO
+            ELSE
+#include "vectorize.inc"
+              DO J=1,NSM
+               I = INDEX(J)
+               SIG(I,1:6)=SIGL(I,1:6) + SIGTMP(J,1:6)
+              END DO
+            END IF!(IPRES==1)THEN 
           ELSE
 		   IF (ISELECT>0) THEN
             DO I=LFT,LLT


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
law1 with high Poisson ratio (quasi-uncompressible) has the difficulties with simple compression tests due to local buckling phenomena, improvements have been done to make solid elements tetra10,hexa isolid=24,18 to be more robustness in this situations using total Lagrange type strain formulations (Ismstr=10,11,12).     

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
