### PR TITLE
Windows Issue in cmake_win64.txt and new build scripts

### DIFF
--- a/engine/CMake_Compilers/cmake_win64.txt
+++ b/engine/CMake_Compilers/cmake_win64.txt
@@ -109,13 +109,13 @@ set(Fortran "/fpp  /extend-source /assume:buffered_io")
 
 if ( debug STREQUAL "1" )
 # Fortran
-set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS " /fp:precise /Qopenmp /O1 /Qftz /extend-source /debug:all  ${precision_flag} ${Fortran} ${mpi_flag} ${MUMPS_flags} -DMETIS5 ${cppmach} ${cpprel}" )
+set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS " /fp:precise /Qopenmp /O1 /Qftz /fpp /extend-source /assume:buffered_io /debug:all  ${precision_flag} ${Fortran} ${mpi_flag} ${MUMPS_flags} -DMETIS5 ${cppmach} ${cpprel}" )
 
 # C source files
-set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS "/fp:precise /Qopenmp /O1 /Qftz /extend-source /debug:all ${precision_flag} -DMETIS5 ${h3d_inc} ${mpi_flag} ${MUMPS_flags} ${cppmach} ${cpprel}" )
+set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS "/fp:precise /Qopenmp /O1 /Qftz /debug:all ${precision_flag} -DMETIS5 ${h3d_inc} ${mpi_flag} ${MUMPS_flags} ${cppmach} ${cpprel}" )
 
 # CXX source files
-set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "/fp:precise /Qopenmp /O1 /Qftz /extend-source /debug:all ${precision_flag} -DMETIS5 ${h3d_inc}  ${mpi_flag} ${MUMPS_flags} ${cppmach} ${cpprel} /Qstd=c++11" )
+set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "/fp:precise /Qopenmp /O1 /Qftz /debug:all ${precision_flag} -DMETIS5 ${h3d_inc}  ${mpi_flag} ${MUMPS_flags} ${cppmach} ${cpprel} /Qstd=c++11" )
 
 else ()
 
@@ -131,7 +131,7 @@ set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "/O2 ${
 endif()
 
 # Linking flags
-set (CMAKE_EXE_LINKER_FLAGS " /STACK:1500000000 ${MKL_libraries} ${mpi_lib} libifport.lib svml_dispmt.lib libifcoremt.lib libmmt.lib Psapi.lib libvcruntime.lib" )
+set (CMAKE_EXE_LINKER_FLAGS " /F:1500000000 ${MKL_libraries} ${mpi_lib} libifport.lib svml_dispmt.lib libifcoremt.lib libmmt.lib Psapi.lib libvcruntime.lib" )
 
 #Libraries
 set (LINK "advapi32.lib"  )

--- a/engine/CMake_Compilers/cmake_win64_compilers.bat
+++ b/engine/CMake_Compilers/cmake_win64_compilers.bat
@@ -1,0 +1,5 @@
+set Fortran_comp=ifx.exe
+set C_comp=icx.exe
+set CPP_comp=icx.exe
+set CXX_comp=icx.exe
+

--- a/engine/build_windows.bat
+++ b/engine/build_windows.bat
@@ -1,0 +1,150 @@
+echo OFF
+
+REM Variable setting
+set arch=win64
+set prec=dp
+set debug=0
+set static=0
+set MPI="-DMPI=smp"
+set pmpi=SMP
+set got_mpi=0
+set sp_suffix=
+set mpi_suffix=
+set verbose=
+set clean=0
+set jobs=1
+set jobsv=1
+
+IF (%1) == () GOTO ERROR
+
+:ARG_LOOP
+IF (%1) == () GOTO END_ARG_LOOP
+
+   IF %1==-prec (
+       set prec=%2 
+    )
+
+   IF %1==-debug (
+       set debug=%2
+   )
+
+   IF %1==-static-link (
+       set static=1
+   )
+
+   IF %1==-mpi (
+       set MPI="-DMPI=%2"
+       set pmi=%2
+       set got_mpi=1
+   )
+
+   IF %1==-verbose (
+       set verbose=-v
+   )
+
+   IF %1==-clean (
+       set clean=1
+   )
+
+   IF %1==-nt (
+       set jobs=%2
+       set jobsv=%2
+       )
+   )
+
+SHIFT
+GOTO ARG_LOOP
+
+:END_ARG_LOOP
+
+
+if %jobsv%==all ( set jobs=0)
+
+
+Rem Engine name
+if %prec%==sp   ( set sp_suffix=_sp)
+if %debug%==1   ( set debug_suffix=_db)
+if %debug%==2   ( set debug_suffix=_db)
+if %got_mpi%==1 ( set mpi_suffix=_%pmi%)
+
+
+set engine=engine_%arch%%mpi_suffix%%sp_suffix%%debug_suffix%.exe
+
+Rem Create build directory
+
+set build_directory=cbuild_%arch%%sp_suffix%%debug_suffix%_ninja
+
+Ren clean
+if %clean%==1 (
+  echo.
+  echo Cleaning %build_directory%
+  RMDIR /S /Q %build_directory%
+  goto END
+)
+
+echo.
+echo Build OpenRadioss Engine
+echo -------------------------
+echo.
+echo  Build Arguments :
+echo  arch =                 : %arch%
+echo  MPI =                  : %pmpi%
+echo  precision =            : %prec%
+echo  debug =                : %debug%
+echo  static_link =          : %static_link%
+echo.
+echo  Running on             : %jobsv% Threads
+echo.
+echo  verbose=               : %verbose%
+echo.
+echo  Build directory:  %build_directory%
+echo.
+
+if exist %build_directory% (
+
+  cd  %build_directory%
+
+) else (
+
+  mkdir %build_directory%
+  cd  %build_directory%
+)
+
+Rem Load Compiler settings
+call ..\CMake_Compilers\cmake_%arch%_compilers.bat
+
+
+
+cmake -G Ninja -Darch=%arch% -Dprecision=%prec% %MPI% -Ddebug=%debug%  -Dstatic_link=%static% -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_COMPILER=%Fortran_comp% -DCMAKE_C_COMPILER=%C_comp% -DCMAKE_CPP_COMPILER=%CPP_comp% -DCMAKE_CXX_COMPILER=%CXX_comp% ..
+ninja %verbose% -j %jobs%
+
+if exist %engine% (
+  echo.
+  echo Copy %engine% in exec directory
+  copy %engine% ..\..\exec
+)
+
+cd ..
+
+GOTO END
+
+:ERROR
+
+  echo Use with arguments : 
+  echo     -arch=[build architecture]          : set architecture : default  Windows 64 bit
+  echo     -mpi=[smp,impi]                     : set MPI version
+  echo     -prec=[dp,sp]                       : set precision - dp (default),sp
+  echo     -static-link                        : Compiler runtime is linked in binary
+  echo     -debug=[0,1]                        : debug version 0 no debug flags (default), 1 usual debug flag )
+  echo.
+  echo Execution control 
+  echo     -nt [N,all]        : Run build with N Threads, all : takes all ressources of machine
+  echo     -verbose           : Verbose build
+  echo     -clean             : clean build directory
+  echo.
+
+:END
+echo.
+echo Terminating
+echo.
+

--- a/starter/CMakeLists.txt
+++ b/starter/CMakeLists.txt
@@ -16,8 +16,6 @@ enable_language (Fortran)
 enable_language (C)
 enable_language (CXX)
 
-
-
 if ( NOT DEFINED COM) 
 set (cdir "" )
 else()

--- a/starter/CMake_Compilers/cmake_win64.txt
+++ b/starter/CMake_Compilers/cmake_win64.txt
@@ -72,13 +72,13 @@ set(Fortran "/fpp /extend-source /assume:buffered_io")
 if ( debug STREQUAL "1" )
  
 # Fortran
-set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS " ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} -DCPP_comp=f90 /Qcpp  /fp:precise /O1 /debug:all /Qftz /extend-source /Qopenmp /traceback  ${ADF} " )
+set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS " ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} -DCPP_comp=f90 /fpp /fp:precise /O1 /debug:all /Qftz /extend-source /Qopenmp  ${ADF} /traceback" )
 
 # C source files
-set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS " ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} /nologo $(FPP_FLAG) /fp:precise /O1 /debug:all /Qftz /extend-source /Qopenmp /traceback " )
+set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS " ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} /nologo  /fp:precise /O1 /debug:all /Qftz  /Qopenmp /traceback " )
 
 # CXX source files
-set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS " ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} /nologo $(FPP_FLAG) /fp:precise /O1 /debug:all /Qftz /extend-source /Qopenmp /traceback" )
+set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS " ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} /nologo  /fp:precise /O1 /debug:all /Qftz  /Qopenmp /traceback" )
 
 else ()
 
@@ -94,7 +94,7 @@ set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS " ${pre
 endif()
 
 # Linking flags
-set (CMAKE_EXE_LINKER_FLAGS " /defaultlib:libiomp5md.lib /nodefaultlib:vcomp.lib /nodefaultlib:vcompd.lib /STACK:1500000000 ${reader_lib} ${MKL_Lib}  ${metis_lib} svml_dispmd.lib")
+set (CMAKE_EXE_LINKER_FLAGS "/F:1500000000 ${reader_lib} ${MKL_Lib}  ${metis_lib} svml_dispmd.lib")
 
 #Libraries
 set (LINK "advapi32.lib")

--- a/starter/CMake_Compilers/cmake_win64_compilers.bat
+++ b/starter/CMake_Compilers/cmake_win64_compilers.bat
@@ -1,0 +1,5 @@
+set Fortran_comp=ifx.exe
+set C_comp=icx.exe
+set CPP_comp=icx.exe
+set CXX_comp=icx.exe
+

--- a/starter/build_windows.bat
+++ b/starter/build_windows.bat
@@ -1,0 +1,136 @@
+echo OFF
+
+REM Variable setting
+set arch=win64
+set prec=dp
+set debug=0
+set static=0
+set verbose=
+set clean=0
+set jobs=1
+set jobsv=1
+
+IF (%1) == () GOTO ERROR
+
+:ARG_LOOP
+IF (%1) == () GOTO END_ARG_LOOP
+
+   IF %1==-prec (
+       set prec=%2 
+    )
+
+   IF %1==-debug (
+       set debug=%2
+   )
+
+   IF %1==-static-link (
+       set static=1
+   )
+
+   IF %1==-verbose (
+       set verbose=-v
+   )
+
+   IF %1==-clean (
+       set clean=1
+   )
+
+   IF %1==-nt (
+       set jobs=%2
+       set jobsv=%2
+       )
+   )
+
+SHIFT
+GOTO ARG_LOOP
+
+:END_ARG_LOOP
+
+
+if %jobsv%==all ( set jobs=0)
+
+
+Rem Starter name
+if %prec%==sp ( set sp_suffix=_sp)
+if %debug%==1 ( set debug_suffix=_db)
+if %debug%==2 ( set debug_suffix=_db)
+
+set starter=starter_%arch%%sp_suffix%%debug_suffix%.exe
+
+Rem Create build directory
+
+
+set build_directory=cbuild_%arch%%sp_suffix%%debug_suffix%_ninja
+
+Ren clean
+if %clean%==1 (
+  echo.
+  echo Cleaning %build_directory%
+  RMDIR /S /Q %build_directory%
+  goto END
+)
+
+echo.
+echo Build OpenRadioss Starter
+echo --------------------------
+echo.
+echo  Build Arguments :
+echo  arch =                 : %arch%
+echo  precision =            : %prec%
+echo  debug =                : %debug%
+echo  static_link =          : %static_link%
+echo.
+echo  Running on             : %jobsv% Threads
+echo.
+echo  verbose=               : %verbose%
+echo.
+echo  Build directory:  %build_directory%
+echo.
+
+if exist %build_directory% (
+
+  cd  %build_directory%
+
+) else (
+
+  mkdir %build_directory%
+  cd  %build_directory%
+)
+
+Rem Load Compiler settings
+call ..\CMake_Compilers\cmake_%arch%_compilers.bat
+
+
+
+cmake -G Ninja -Darch=%arch% -Dprecision=%prec% -Ddebug=%debug%  -Dstatic_link=%static% -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_COMPILER=%Fortran_comp% -DCMAKE_C_COMPILER=%C_comp% -DCMAKE_CPP_COMPILER=%CPP_comp% -DCMAKE_CXX_COMPILER=%CXX_comp% ..
+ninja %verbose% -j %jobs%
+
+if exist %starter% (
+  echo.
+  echo Copy %starter% in exec directory
+  copy %starter% ..\..\exec
+)
+
+cd ..
+
+GOTO END
+
+:ERROR
+
+  echo Use with arguments : 
+  echo     -arch=[build architecture]          : set architecture : default  Windows 64 bit
+  echo     -prec=[dp,sp]                       : set precision - dp (default),sp
+  echo     -static-link                        : Compiler runtime is linked in binary
+  echo     -debug=[0,1]                        : debug version 0 no debug flags (default), 1 usual debug flag )
+  echo.
+  echo Execution control 
+  echo     -nt [N,all]        : Run build with N Threads, all : takes all ressources of machine
+  echo     -verbose           : Verbose build
+  echo     -clean             : clean build directory
+  echo.
+
+:END
+echo.
+echo Terminating
+echo.
+


### PR DESCRIPTION
cmake_win64.txt : with a3d293ab964b429f5731dd5fe2b7b33a83bad842 link method changed Stacksize setting was no more taken into account.

Create Windows native batch scripts for Starter and Engine to compile Radioss out of cygwin.
