### PR TITLE
Issue: Win64 Link

### DIFF
--- a/engine/CMake_Compilers/cmake_win64.txt
+++ b/engine/CMake_Compilers/cmake_win64.txt
@@ -131,7 +131,7 @@ set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "/O2 ${
 endif()
 
 # Linking flags
-set (CMAKE_EXE_LINKER_FLAGS " /F:1500000000 ${MKL_libraries} ${mpi_lib} libifport.lib svml_dispmt.lib libifcoremt.lib libmmt.lib Psapi.lib libvcruntime.lib" )
+set (CMAKE_EXE_LINKER_FLAGS " /F1500000000 /STACK:1500000000 ${MKL_libraries} ${mpi_lib} libifport.lib svml_dispmt.lib libifcoremt.lib libmmt.lib Psapi.lib libvcruntime.lib" )
 
 #Libraries
 set (LINK "advapi32.lib"  )

--- a/starter/CMake_Compilers/cmake_win64.txt
+++ b/starter/CMake_Compilers/cmake_win64.txt
@@ -94,7 +94,7 @@ set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS " ${pre
 endif()
 
 # Linking flags
-set (CMAKE_EXE_LINKER_FLAGS "/F:1500000000 ${reader_lib} ${MKL_Lib}  ${metis_lib} svml_dispmd.lib")
+set (CMAKE_EXE_LINKER_FLAGS "/F1500000000 /STACK:1500000000 ${reader_lib} ${MKL_Lib}  ${metis_lib} svml_dispmd.lib")
 
 #Libraries
 set (LINK "advapi32.lib")


### PR DESCRIPTION
    Depending on cmake version tool used to link change on Windows win64 build Makefile builder
    cmake 3.26.0 is using ifx
    cmake 3.20.0 is using link.exe

    Linking flags differt between both tools. This is causing on some build Stacksize not to be set properly

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
