### PR TITLE
Fix end of spring failure filtering

### DIFF
--- a/engine/source/elements/spring/r23l108def3.F
+++ b/engine/source/elements/spring/r23l108def3.F
@@ -218,9 +218,9 @@ C
           X0DP(I)= X21DP(I)*EXX(I)+Y21DP(I)*EYX(I)+Z21DP(I)*EZX(I)
           Y0DP(I)= X21DP(I)*EXY(I)+Y21DP(I)*EYY(I)+Z21DP(I)*EZY(I)
           Z0DP(I)= X21DP(I)*EXZ(I)+Y21DP(I)*EYZ(I)+Z21DP(I)*EZZ(I)
-          X0(I)= X0DP(I)                 ! cast double vers My_real
-          Y0(I)= Y0DP(I)                 ! cast double vers My_real
-          Z0(I)= Z0DP(I)                 ! cast double vers My_real
+          X0(I)= X0DP(I)                 ! cast double to My_real
+          Y0(I)= Y0DP(I)                 ! cast double to My_real
+          Z0(I)= Z0DP(I)                 ! cast double to My_real
         ENDDO
 !
         IF (INISPRI /= 0) THEN
@@ -238,9 +238,9 @@ C
       IF (SCODVER >= 101) THEN
         IF (TT == ZERO) THEN
           DO I=1,NEL
-            X0_ERR(1,I)= X0DP(I)-X0(I)   ! difference entre double et My_real
-            X0_ERR(2,I)= Y0DP(I)-Y0(I)   ! difference entre double et My_real
-            X0_ERR(3,I)= Z0DP(I)-Z0(I)   ! difference entre double et My_real
+            X0_ERR(1,I)= X0DP(I)-X0(I)   ! difference between double and my_real
+            X0_ERR(2,I)= Y0DP(I)-Y0(I)   ! difference between double and my_real
+            X0_ERR(3,I)= Z0DP(I)-Z0(I)   ! difference between double and my_real
           ENDDO
         ENDIF
       ENDIF
@@ -254,16 +254,16 @@ C
       ENDIF
 C
       DO I=1,NEL
-        X0DP(I)= X0(I)                 ! cast My_real en double
-        Y0DP(I)= Y0(I)                 ! cast My_real en double
-        Z0DP(I)= Z0(I)                 ! cast My_real en double
+        X0DP(I)= X0(I)                 ! cast my_real to double
+        Y0DP(I)= Y0(I)                 ! cast my_real to double
+        Z0DP(I)= Z0(I)                 ! cast my_real to double
       ENDDO
 C
       IF (SCODVER >= 101) THEN
         DO I=1,NEL
-          X0DP(I)= X0DP(I) + X0_ERR(1,I) ! AL_DP doit   tre recalcul   ainsi afin de garantir la coh  rence absolue entre AL0_DP et AL_DP
-          Y0DP(I)= Y0DP(I) + X0_ERR(2,I) ! AL_DP doit   tre recalcul   ainsi afin de garantir la coh  rence absolue entre AL0_DP et AL_DP
-          Z0DP(I)= Z0DP(I) + X0_ERR(3,I) ! AL_DP doit   tre recalcul   ainsi afin de garantir la coh  rence absolue entre AL0_DP et AL_DP
+          X0DP(I)= X0DP(I) + X0_ERR(1,I) ! AL_DP must be recomputed to be sure of absolute consistency between AL0_DP and AL_DP
+          Y0DP(I)= Y0DP(I) + X0_ERR(2,I) ! AL_DP must be recomputed to be sure of absolute consistency between AL0_DP and AL_DP
+          Z0DP(I)= Z0DP(I) + X0_ERR(3,I) ! AL_DP must be recomputed to be sure of absolute consistency between AL0_DP and AL_DP
         ENDDO
       ENDIF
 C
@@ -718,7 +718,7 @@ C-----------------------------------
       ENDDO
 C
 C-------------------------------
-C     RUPTURE COUPLEE
+C     COUPLED FAILURE
 C-------------------------------
       DO I=1,NEL
         IADBUF   = IPM(7,MID(I)) - 1
@@ -728,6 +728,7 @@ C---- smoothing factor alpha = 2PI*fc*dt/(2PI*fc*dt+1) ---
         ASRATE = (2*PI*ASRATE*DT1)/(ONE+2*PI*ASRATE*DT1)
         IF (ISRATE /= 0) THEN
           IF (CRITNEW(I) < ONE) THEN 
+            CRIT(I) = MIN(CRIT(I),ONE+EM3)
             CRIT(I) = ASRATE*CRIT(I) + (ONE - ASRATE)*CRITNEW(I)
             CRITNEW(I) = MIN(CRIT(I),ONE)
           ELSE
@@ -756,7 +757,7 @@ C
 #include "lockoff.inc"
       ENDDO
 C-------------------------------
-C     PLASTICITE COUPLEE
+C     COUPLED PLASTICITY
 C-------------------------------
       CALL REPLA3(
      1   XK,      RPX,     TF,      NPF,

--- a/engine/source/elements/spring/r23l113def3.F
+++ b/engine/source/elements/spring/r23l113def3.F
@@ -188,14 +188,14 @@ C
 C
       IF (TT == ZERO) THEN
         DO I=1,NEL
-          X0(I)= ALDP(I)                   ! cast double vers My_real
+          X0(I)= ALDP(I)                   ! cast double to my_real
         ENDDO
       ENDIF
 C
       IF (SCODVER >= 101) THEN
         IF (TT == ZERO) THEN
           DO I=1,NEL
-            X0_ERR(I)= ALDP(I)-X0(I)         ! difference entre double et My_real
+            X0_ERR(I)= ALDP(I)-X0(I)         ! difference between double and my_real
           ENDDO
         ENDIF
       ENDIF
@@ -207,12 +207,12 @@ C
       ENDIF
 C
       DO I=1,NEL
-        X0DP(I)= X0(I)                     ! cast double vers My_real
+        X0DP(I)= X0(I)                     ! cast double to My_real
       ENDDO
 C
       IF (SCODVER >= 101) THEN
         DO I=1,NEL
-          X0DP(I)= X0(I) + X0_ERR(I)         ! difference entre double et My_real
+          X0DP(I)= X0(I) + X0_ERR(I)         ! difference between double and my_real
         ENDDO
       ENDIF
 C---------------------
@@ -776,7 +776,7 @@ C
         E(I) = E6(I,1)+E6(I,2)+E6(I,3)+E6(I,4)+E6(I,5)+E6(I,6)
       ENDDO
 C-------------------------------
-C     RUPTURE COUPLEE
+C     COUPLED FAILURE
 C-------------------------------
       DO I=1,NEL
         IADBUF   = IPM(7,MID(I)) - 1
@@ -784,7 +784,8 @@ C-------------------------------
 C---- smoothing factor alpha = 2PI*fc*dt/(2PI*fc*dt+1) ---
         ASRATE = (2*PI*UPARAM(IADBUF + NUPAR + 28)*DT1)/(ONE+2*PI*UPARAM(IADBUF + NUPAR + 28)*DT1)
         IF (ISRATE /= 0) THEN
-          IF (CRIT_NEW(I) < ONE) THEN           
+          IF (CRIT_NEW(I) < ONE) THEN   
+            CRIT(I) = MIN(CRIT(I),ONE+EM3)        
             CRIT(I) = ASRATE*CRIT(I) + (ONE - ASRATE)*CRIT_NEW(I)
             CRIT_NEW(I) = MIN(CRIT(I),ONE)
           ELSE
@@ -815,7 +816,7 @@ C
 #include "lockoff.inc"
       ENDDO
 C-------------------------------
-C     PLASTICITE COUPLEE
+C     COUPLED PLASTICITY
 C-------------------------------
       CALL REPLA3(
      1   XK,      RPX,     TF,      NPF,

--- a/engine/source/elements/spring/r2def3.F
+++ b/engine/source/elements/spring/r2def3.F
@@ -193,9 +193,9 @@ C
           X0DP(I)= X21DP(I)*EXX(I)+Y21DP(I)*EYX(I)+Z21DP(I)*EZX(I)
           Y0DP(I)= X21DP(I)*EXY(I)+Y21DP(I)*EYY(I)+Z21DP(I)*EZY(I)
           Z0DP(I)= X21DP(I)*EXZ(I)+Y21DP(I)*EYZ(I)+Z21DP(I)*EZZ(I)
-          X0(I)= X0DP(I)                 ! cast double vers My_real
-          Y0(I)= Y0DP(I)                 ! cast double vers My_real
-          Z0(I)= Z0DP(I)                 ! cast double vers My_real
+          X0(I)= X0DP(I)                 ! cast double to My_real
+          Y0(I)= Y0DP(I)                 ! cast double to My_real
+          Z0(I)= Z0DP(I)                 ! cast double to My_real
         ENDDO
 !
         IF (INISPRI /= 0) THEN
@@ -213,9 +213,9 @@ C
       IF (SCODVER >= 101) THEN
         IF (TT == ZERO) THEN
           DO I=1,NEL
-            X0_ERR(1,I)= X0DP(I)-X0(I)   ! difference entre double et My_real
-            X0_ERR(2,I)= Y0DP(I)-Y0(I)   ! difference entre double et My_real
-            X0_ERR(3,I)= Z0DP(I)-Z0(I)   ! difference entre double et My_real
+            X0_ERR(1,I)= X0DP(I)-X0(I)   ! difference between double and my_real
+            X0_ERR(2,I)= Y0DP(I)-Y0(I)   ! difference between double and my_real
+            X0_ERR(3,I)= Z0DP(I)-Z0(I)   ! difference between double and my_real
           ENDDO
         ENDIF
       ENDIF
@@ -236,9 +236,9 @@ C
 C
       IF (SCODVER >= 101) THEN
         DO I=1,NEL
-          X0DP(I)= X0DP(I) + X0_ERR(1,I) ! AL_DP doit   tre recalcul   ainsi afin de garantir la coh  rence absolue entre AL0_DP et AL_DP
-          Y0DP(I)= Y0DP(I) + X0_ERR(2,I) ! AL_DP doit   tre recalcul   ainsi afin de garantir la coh  rence absolue entre AL0_DP et AL_DP
-          Z0DP(I)= Z0DP(I) + X0_ERR(3,I) ! AL_DP doit   tre recalcul   ainsi afin de garantir la coh  rence absolue entre AL0_DP et AL_DP
+          X0DP(I)= X0DP(I) + X0_ERR(1,I) ! AL_DP must be recomputed to be sure of absolute consistency between AL0_DP and AL_DP
+          Y0DP(I)= Y0DP(I) + X0_ERR(2,I) ! AL_DP must be recomputed to be sure of absolute consistency between AL0_DP and AL_DP
+          Z0DP(I)= Z0DP(I) + X0_ERR(3,I) ! AL_DP must be recomputed to be sure of absolute consistency between AL0_DP and AL_DP
         ENDDO
       ENDIF
 C
@@ -647,7 +647,7 @@ C-----------------------------------
       ENDDO
 C
 C-------------------------------
-C     RUPTURE COUPLEE
+C    COUPLED FAILURE
 C-------------------------------
       DO I=1,NEL
         ISRATE = NINT(GEO(96, MGN(I)))
@@ -655,6 +655,7 @@ C---- smoothing factor alpha = 2PI*fc*dt/(2PI*fc*dt+1) ---
         ASRATE = (2*PI*GEO(97,MGN(I))*DT1)/(ONE+2*PI*GEO(97,MGN(I))*DT1)
         IF (ISRATE /= 0) THEN
           IF (CRITNEW(I) < ONE) THEN 
+            CRIT(I) = MIN(CRIT(I),ONE+EM3)
             CRIT(I) = ASRATE*CRIT(I) + (ONE - ASRATE)*CRITNEW(I)
             CRITNEW(I) = MIN(CRIT(I),ONE)
           ELSE
@@ -683,7 +684,7 @@ C
 #include "lockoff.inc"
       ENDDO
 C-------------------------------
-C     PLASTICITE COUPLEE
+C     COUPLED PLASTICITY
 C-------------------------------
       CALL REPLA3(
      1   XK,      RPX,     TF,      NPF,

--- a/engine/source/elements/spring/r4def3.F
+++ b/engine/source/elements/spring/r4def3.F
@@ -167,14 +167,14 @@ C
 C
       IF (TT == ZERO) THEN
         DO I=1,NEL
-          X0(I)= ALDP(I)                   ! cast double vers My_real
+          X0(I)= ALDP(I)                   ! cast double to My_real
         ENDDO
       ENDIF
 C
       IF (SCODVER >= 101) THEN
         IF (TT == ZERO) THEN
           DO I=1,NEL
-            X0_ERR(I)= ALDP(I)-X0(I)         ! difference entre double et My_real
+            X0_ERR(I)= ALDP(I)-X0(I)         ! difference between double and my_real
           ENDDO
         ENDIF
       ENDIF
@@ -186,12 +186,12 @@ C
       ENDIF
 C
       DO I=1,NEL
-        X0DP(I)= X0(I)                     ! cast double vers My_real
+        X0DP(I)= X0(I)                     ! cast double to My_real
       ENDDO
 C
       IF (SCODVER >= 101) THEN
         DO I=1,NEL
-          X0DP(I)= X0(I) + X0_ERR(I)         ! difference entre double et My_real
+          X0DP(I)= X0(I) + X0_ERR(I)         ! difference between double and my_real
         ENDDO
       ENDIF
 C---------------------
@@ -732,7 +732,7 @@ C
         E(I) = E6(I,1)+E6(I,2)+E6(I,3)+E6(I,4)+E6(I,5)+E6(I,6)
       ENDDO
 C-------------------------------
-C     RUPTURE COUPLEE
+C     COUPLED FAILURE
 C-------------------------------
       DO I=1,NEL
         ISRATE = INT (GEO(127,MGN(I)))
@@ -740,6 +740,7 @@ C---- smoothing factor alpha = 2PI*fc*dt/(2PI*fc*dt+1) ---
         ASRATE = (2*PI*GEO(128,MGN(I))*DT1)/(ONE+2*PI*GEO(128,MGN(I))*DT1)
         IF (ISRATE /= 0) THEN
           IF (CRIT_NEW(I) < ONE) THEN 
+            CRIT(I) = MIN(CRIT(I),ONE+EM3)
             CRIT(I) = ASRATE*CRIT(I) + (ONE - ASRATE)*CRIT_NEW(I)
             CRIT_NEW(I) = MIN(CRIT(I),ONE)
           ELSE
@@ -770,7 +771,7 @@ C
 #include "lockoff.inc"
       ENDDO
 C-------------------------------
-C     PLASTICITE COUPLEE
+C     COUPLED PLASTICITY
 C-------------------------------
       CALL REPLA3(
      1   XK,      RPX,     TF,      NPF,

--- a/engine/source/elements/spring/r6def3.F
+++ b/engine/source/elements/spring/r6def3.F
@@ -159,14 +159,14 @@ C
 C
       IF (TT == ZERO)THEN
         DO I=1,NEL
-          X0(I)= ALDP(I)                   ! cast double vers My_real
+          X0(I)= ALDP(I)                   ! cast double to My_real
         ENDDO
       ENDIF
 C
       IF (SCODVER >= 101) THEN
         IF (TT == ZERO)THEN
           DO I=1,NEL
-            X0_ERR(I)= ALDP(I)-X0(I)         ! difference entre double et My_real
+            X0_ERR(I)= ALDP(I)-X0(I)         ! difference between double and my_real
           ENDDO
         ENDIF
       ENDIF
@@ -178,12 +178,12 @@ C
       ENDIF
 C
       DO I=1,NEL
-        X0DP(I)= X0(I)                     ! cast double vers My_real
+        X0DP(I)= X0(I)                     ! cast double to my_real
       ENDDO
 C
       IF (SCODVER >= 101) THEN
         DO I=1,NEL
-          X0DP(I)= X0(I) + X0_ERR(I)         ! difference entre double et My_real
+          X0DP(I)= X0(I) + X0_ERR(I)         ! difference between double and my_real
         ENDDO
       ENDIF
 C---------------------
@@ -244,7 +244,7 @@ C
       ENDDO
 C
       NINDX = 0
-C---- Traction / Compression
+C---- Tension / Compression
       DO I=1,NEL
         IECROU(I)= IGEO(101,MGN(I))
         IFUNC(I) = IGEO(102,MGN(I))
@@ -319,7 +319,7 @@ C---      Multiaxial failure
           ENDIF
         ENDIF
       ENDDO
-C---- Cisaillement
+C---- Shear
       DO I=1,NEL
         IECROU(I)= IGEO(105,MGN(I))
         IFUNC(I) = IGEO(106,MGN(I))
@@ -513,7 +513,7 @@ C---      Multiaxial failure
         ENDIF
       ENDDO
 C
-C---  Flexion radiale
+C---  Radial bending
 C
       DO I=1,NEL
         IECROU(I)= IGEO(113,MGN(I))
@@ -596,7 +596,7 @@ C-------------------------------
         E(I) = E6(I,1)+E6(I,2)+E6(I,3)+E6(I,4)
       ENDDO
 C-------------------------------
-C     RUPTURE COUPLEE
+C     COUPLED FAILURE
 C-------------------------------
       DO I=1,NEL
         IF (IFAIL(I) == 0) THEN 
@@ -631,7 +631,7 @@ C
 #include "lockoff.inc"
       ENDDO
 C-------------------------------
-C     PLASTICITE COUPLEE
+C     COUPLED PLASTICITY
 C-------------------------------
       CALL REPLA3(
      1   XK,      RPX,     TF,      NPF,


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

For a recent development, spring failure filtering was revised. Unfortunately, something was missed. Indeed, CRIT value can take values higher than 1 leading to a wrong filtering close to spring failure. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Ensure CRIT to not overtake the value 1 before filtering. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
