### PR TITLE
Add number of eroded element in /TH/PART and /TH/SUBS

### DIFF
--- a/engine/source/elements/sh3n/coque3n/c3bilan.F
+++ b/engine/source/elements/sh3n/coque3n/c3bilan.F
@@ -464,7 +464,14 @@ C
             ENDIF
          ENDDO
        ENDIF
-    
+C
+      DO I = JFT,JLT
+        MX = IPARTTG(I)
+        IF (OFF(I)==ZERO) THEN 
+          PARTSAV(25,MX) = PARTSAV(25,MX) + ONE
+        ENDIF
+      ENDDO
+C 
       CALL SENSOR_ENERGY_BILAN(JFT,JLT,EI,EK,OFF,IPARTTG,ITASK) 
 C---
       RETURN

--- a/engine/source/elements/shell/coque/cbilan.F
+++ b/engine/source/elements/shell/coque/cbilan.F
@@ -460,6 +460,14 @@ C
             ENDIF
          ENDDO
       ENDIF
+C
+      DO I = JFT,JLT
+        MX = IPARTC(I)
+        IF (OFF(I)==ZERO) THEN 
+          PARTSAV(25,MX) = PARTSAV(25,MX) + ONE
+        ENDIF
+      ENDDO
+C
       CALL SENSOR_ENERGY_BILAN(JFT,JLT,EI,EK,OFF,IPARTC,ITASK)      
 C---
       RETURN

--- a/engine/source/elements/solid/solide/sbilan.F
+++ b/engine/source/elements/solid/solide/sbilan.F
@@ -310,7 +310,14 @@ C
             OFF_L(I) = ONE
           ENDIF
       ENDDO
-
+C
+      DO I = 1,NEL
+        M=IPARTS(I)
+        IF (OFF(I) < ONE) THEN 
+          PARTSAV(25,M) = PARTSAV(25,M) + ONE
+        ENDIF
+      ENDDO
+C
       CALL SENSOR_ENERGY_BILAN(1,NEL,EI,EK,OFF_L,IPARTS,ITASK)      
 C
 C-----------

--- a/engine/source/elements/solid/solide/srbilan.F
+++ b/engine/source/elements/solid/solide/srbilan.F
@@ -228,7 +228,14 @@ C
             OFF_L(I) = ONE
           ENDIF
       ENDDO
-
+C
+      DO I = LFT,LLT
+        M=IPARTS(I)
+        IF (OFF(I) < ONE) THEN 
+          PARTSAV(25,M) = PARTSAV(25,M) + ONE
+        ENDIF
+      ENDDO
+C
       CALL SENSOR_ENERGY_BILAN(LFT,LLT,EI,EK,OFF_L,IPARTS,ITASK)    
 C
       RETURN

--- a/engine/source/elements/solid/solide10/s10bilan.F
+++ b/engine/source/elements/solid/solide10/s10bilan.F
@@ -311,6 +311,14 @@ C
       ENDIF
 
       OFF_L(LFT:LLT) = ONE
+C
+      DO I = LFT,LLT
+        M=IPARTS(I)
+        IF (OFFG(I) < ONE) THEN 
+          PARTSAV(25,M) = PARTSAV(25,M) + ONE
+        ENDIF
+      ENDDO
+C
       CALL SENSOR_ENERGY_BILAN(LFT,LLT,EI,EK,OFF_L,IPARTS,ITASK)  
 C
       RETURN

--- a/engine/source/elements/solid/solide20/s20bilan.F
+++ b/engine/source/elements/solid/solide20/s20bilan.F
@@ -289,6 +289,14 @@ C-----------------------------------------------
 C-----------------------------------------------
 C
       OFF_L(LFT:LLT) = ONE
+C
+      DO I = LFT,LLT
+        M=IPARTS(I)
+        IF (OFFG(I) < ONE) THEN 
+          PARTSAV(25,M) = PARTSAV(25,M) + ONE
+        ENDIF
+      ENDDO
+C
       CALL SENSOR_ENERGY_BILAN(LFT,LLT,EI,EK,OFF_L,IPARTS,ITASK) 
 C
       RETURN

--- a/engine/source/elements/solid/solide4/s4bilan.F
+++ b/engine/source/elements/solid/solide4/s4bilan.F
@@ -214,6 +214,14 @@ C
       ENDIF
 
       OFF_L(LFT:LLT) = ONE
+C
+      DO I = LFT,LLT
+        M=IPARTS(I)
+        IF (OFFG(I) < ONE) THEN 
+          PARTSAV(25,M) = PARTSAV(25,M) + ONE
+        ENDIF
+      ENDDO
+C
       CALL SENSOR_ENERGY_BILAN(LFT,LLT,EI,EK,OFF_L,IPARTS,ITASK) 
 C
       RETURN

--- a/engine/source/elements/thickshell/solide16/s16bilan.F
+++ b/engine/source/elements/thickshell/solide16/s16bilan.F
@@ -286,6 +286,14 @@ C
       ENDIF
 
       OFF_L(LFT:LLT) = ONE
+C
+      DO I = LFT,LLT
+        M=IPARTS(I)
+        IF (OFFG(I) < ONE) THEN 
+          PARTSAV(25,M) = PARTSAV(25,M) + ONE
+        ENDIF
+      ENDDO
+C
       CALL SENSOR_ENERGY_BILAN(LFT,LLT,EI,EK,OFF_L,IPARTS,ITASK) 
 C-----------
       RETURN

--- a/engine/source/elements/thickshell/solide6c/s6cbilan.F
+++ b/engine/source/elements/thickshell/solide6c/s6cbilan.F
@@ -96,7 +96,6 @@ C
       ENDDO
 C
       DO I=LFT,LLT
-        IF(OFF(I) < ONE) CYCLE
         M=IPARTS(I)
         PARTSAV(1,M)=PARTSAV(1,M) + EI(I)
         PARTSAV(2,M)=PARTSAV(2,M) + EK(I)
@@ -192,6 +191,14 @@ C
             OFF_L(I) = ONE
           ENDIF
       ENDDO
+C
+      DO I = LFT,LLT
+        M=IPARTS(I)
+        IF (OFFG(I) < ONE) THEN 
+          PARTSAV(25,M) = PARTSAV(25,M) + ONE
+        ENDIF
+      ENDDO
+C
       CALL SENSOR_ENERGY_BILAN(LFT,LLT,EI,EK,OFF_L,IPARTS,ITASK) 
 C
       RETURN

--- a/engine/source/output/th/hist2.F
+++ b/engine/source/output/th/hist2.F
@@ -283,7 +283,7 @@ C-----------------------------
          ELSE
           II=0                                  
           DO I=1,NPART+NTHPART                  
-            NVAR=IPARTH(NVPARTH,I)               
+            NVAR=IPARTH(NVPARTH,I)   
             IAD =IPARTH(NVPARTH+1,I)             
             IF (I > NPART) THEN               
               DO J=1,NPSAV                       
@@ -332,7 +332,7 @@ C---------------------------------------
                 ELSEIF(K==5)THEN
                   WA(II)=PARTSAV(K,I)                
                 ELSEIF(K==6)THEN
-                  WA(II)=PARTSAV(6,I)+PARTSAV(25,I)
+                  WA(II)=PARTSAV(6,I)
                 ELSEIF(K==7)THEN
                   WA(II)=PARTSAV(8,I)
                 ELSEIF(K==8)THEN
@@ -387,6 +387,8 @@ C                                    [Izx Iyz Izz]   {ZZMOM}
      .             + JXY*XXMOM*YYMOM+JYZ*YYMOM*ZZMOM+JZX*XXMOM*ZZMOM )
                 ELSEIF(K==24)THEN
                   WA(II)=PARTSAV(22,I)
+                ELSEIF(K==25) THEN 
+                  WA(II)=PARTSAV(25,I)
                 ELSEIF(K > 0 .AND. SIZE(PARTSAV,1) >= K) THEN
                   WA(II)=PARTSAV(K,I)
                 ELSE 
@@ -456,7 +458,7 @@ C-----------------------------
                IF(K==1)THEN
                  WA(II)=SUBSAV(1)+SUBSAV(24)+SUBSAV(26)
                ELSEIF(K==6)THEN
-                 WA(II)=SUBSAV(6)+SUBSAV(25)
+                 WA(II)=SUBSAV(6)
                ELSEIF(K==7)THEN
                  WA(II)=SUBSAV(8)
                ELSEIF(K==8)THEN
@@ -514,6 +516,8 @@ C                                    [Izx Iyz Izz]   {ZZMOM}
      .            + IXY*XXMOM*YYMOM+IYZ*YYMOM*ZZMOM+IZX*XXMOM*ZZMOM )
               ELSEIF(K==24)THEN
                  WA(II)=SUBSAV(22)
+              ELSEIF(K==25) THEN 
+                 WA(II)=SUBSAV(25)
                ELSEIF(K > 0) THEN
                  WA(II)=SUBSAV(K)
                ELSE 
@@ -1324,7 +1328,7 @@ C---------------------------------------
             DO M=1,NPART+NTHPART
 C remise a zero apres gather sur toute les parts ou on ne cumule pas
               DO I=1,NPSAV
-                IF((I<23.OR.I>26).AND.I/=8 .AND. NABFILE==0
+                IF((I<23.OR.I>26.OR.I==25).AND.I/=8 .AND. NABFILE==0
      .               .AND. (MSTOP /= 1 .OR. ICTLSTOP == 1) )
      .            PARTSAV(I,M)=0
               END DO
@@ -1346,7 +1350,7 @@ C-------------------------
           JALE = MAX(JALE_FROM_MAT, JALE_FROM_PROP)
           IF(JALE == 0 .OR. (JALE > 0 .AND. ICOND))THEN
             DO I=1,NPSAV
-              IF((I < 23.OR.I > 26) .AND. I /= 8 .AND. NABFILE==0 .AND.(MSTOP /= 1 .OR. ICTLSTOP == 1) ) THEN
+              IF((I < 23.OR.I > 26.OR.I==25) .AND. I /= 8 .AND. NABFILE==0 .AND.(MSTOP /= 1 .OR. ICTLSTOP == 1) ) THEN
                 PARTSAV(I,M)=0
               ENDIF
             END DO

--- a/starter/source/output/th/hm_read_thgrou.F
+++ b/starter/source/output/th/hm_read_thgrou.F
@@ -1090,7 +1090,7 @@ C   part
      . 'MASS    ','HE      ','TURBKE  ','XCG     ','YCG     ',
      . 'ZCG     ','XXMOM   ','YYMOM   ','ZZMOM   ','IXX     ',
      . 'IYY     ','IZZ     ','IXY     ','IYZ     ','IZX     ',
-     . 'RIE     ','KERB    ','RKERB   ','RKE     ','UNUSED  ',
+     . 'RIE     ','KERB    ','RKERB   ','RKE     ','ERODED  ',
      . 'UNUSED  ','UNUSED  ','HEAT    '/
 C   rivets
       DATA VARRIV/


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

There is a need to plot in time history files, for PART and SUBSET, the number of eroded elements. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Store the number of eroded elements for parts/subsets made of solids and shells in PARTSAV (case 25) to plot it in time history files. Moreover, a bad internal energy computation was found for PENT6 thickshells and was corrected. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
