### PR TITLE
Issue in Time History Restart writing routine

### DIFF
--- a/engine/source/output/th/write_th_restart.F
+++ b/engine/source/output/th/write_th_restart.F
@@ -43,7 +43,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-        TYPE(TH_),INTENT(INOUT) :: TH   ! TH Type 
+        TYPE(TH_),INTENT(IN) :: TH   ! TH Type 
 C-----------------------------------------------
         CALL WRITE_I_C(TH%NITHGR,  1)
         CALL WRITE_I_C(TH%SITHGRP, 1) 


### PR DESCRIPTION
On commit : bc63ffea6a38d814e4e758112526af9c12408017 Intent(INOUT) was used in Restart writing routine, but it should be INTENT(IN) Buffer is not modified & caller routine has INTENT(IN).

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
