### PR TITLE
lecstack_plyf.F:cleaning

### DIFF
--- a/common_source/modules/ale/ale_mod.F
+++ b/common_source/modules/ale/ale_mod.F
@@ -219,7 +219,7 @@ C-----------------------------------------------
             this%GRID%VGZ = ZERO
             this%GRID%VGY0 = ZERO
             this%GRID%VGZ0 = ZERO            
-            this%GRID%NWALE_ENGINE = 0
+            this%GRID%NWALE_ENGINE = -1
             this%GRID%NWALE_RST = 0
             this%GRID%NWALE = 0   
             !---ALE%UPWIND

--- a/starter/source/properties/composite_options/stack/lecstack_ply.F
+++ b/starter/source/properties/composite_options/stack/lecstack_ply.F
@@ -34,17 +34,16 @@ Chd|        HM_OPTION_START               source/devtools/hm_reader/hm_option_st
 Chd|        HM_READ_STACK                 source/stack/hm_read_stack.F  
 Chd|        LCGEO19                       source/elements/shell/coque/lcgeo19.F
 Chd|        VDOUBLE                       source/system/sysfus.F        
-Chd|        ALE_MOD                       ../common_source/modules/ale/ale_mod.F
 Chd|        ELBUFTAG_MOD                  share/modules1/elbuftag_mod.F 
 Chd|        HM_OPTION_READ_MOD            share/modules1/hm_option_read_mod.F
 Chd|        MESSAGE_MOD                   share/message_module/message_mod.F
 Chd|        STACK_MOD                     share/modules1/stack_mod.F    
 Chd|        SUBMODEL_MOD                  share/modules1/submodel_mod.F 
 Chd|====================================================================
-      SUBROUTINE LECSTACK_PLY(GEO   ,X     ,IX         ,PM    ,ITABM1  ,
-     .                       ISKN   ,IGEO  ,IPM        ,NPC   ,PLD     ,
-     .                       UNITAB ,RTRANS,LSUBMODEL  ,IPART ,IDRAPEID,
-     .                       PLY_INFO ,STACK_INFO,  NUMGEO_STACK,NPROP_STACK)
+      SUBROUTINE LECSTACK_PLY(GEO_STACK ,X           ,IX           ,PM          ,ITABM1  ,
+     .                       ISKN       ,IGEO_STACK  ,IPM          ,NPC         ,PLD     ,
+     .                       UNITAB     ,RTRANS      ,LSUBMODEL    ,IPART       ,IDRAPEID,
+     .                       PLY_INFO   ,STACK_INFO  ,NUMGEO_STACK ,NPROP_STACK)
 C============================================================================
 C   M o d u l e s
 C-----------------------------------------------
@@ -55,7 +54,6 @@ C-----------------------------------------------
       USE STACK_MOD
       USE HM_OPTION_READ_MOD
       USE SUBMODEL_MOD
-      USE ALE_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -74,65 +72,46 @@ C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       TYPE (UNIT_TYPE_),INTENT(IN) ::UNITAB 
       INTEGER IX(*),ITABM1(*),ISKN(LISKN,*),
-     .        IGEO(NPROPGI,NUMGEO),IPM(NPROPMI,NUMMAT),NPC(*),
+     .        IGEO_STACK(NPROPGI,NUMSTACK + NUMPLY),IPM(NPROPMI,NUMMAT),NPC(*),
      .        IPART(LIPART1,*),IDRAPEID(*),PLY_INFO(2,NUMPLY),
      .        NPROP_STACK,NUMGEO_STACK(NUMGEO+NUMSTACK)
-      my_real
-     .   GEO(NPROPG,NUMGEO), X(*), PM(NPROPM,NUMMAT),
-     .   PLD(*),RTRANS(NTRANSF,*)
+      my_real GEO_STACK(NPROPG,NUMSTACK+NUMPLY), X(*), PM(NPROPM,NUMMAT),PLD(*),RTRANS(NTRANSF,*)
       TYPE(STACK_INFO_ ) , DIMENSION (1:NPROP_STACK) :: STACK_INFO
       TYPE(SUBMODEL_DATA), DIMENSION(NSUBMOD), INTENT(IN) :: LSUBMODEL
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      CHARACTER LAW_ID*4
-      INTEGER I, IG, IGTYP, ISMSTR, NIP, J, IR1X, IR1Y, IR1Z, IREP,
-     .   IR2X, IR2Y, IR2Z, ISHEAR, IRX, IROT, IMODE, IP, ISTRAIN,I8PT,
-     .   ISK,ITU,IRB,IHON,IHBE,IPLAST,ITHK,IDF,IHBEOUTP,K,N,
-     .   IGFLU, IDS, NSHELL, NSHSUP, NSHINF, FLGBADI, NBADI,IUNIT,UID,
-     .   NSST_D, NSST_DS, NPSH, ICPRE, ICSTR ,NPTS,ISEN,ISORTH,
-     .   PID1,IPID1, IHGFLU, IHBE_OLD,NSTACK,IGMAT,I3,ISTACK,NUMS
-      INTEGER ISH3N,IFLAGUNIT,ICXFEM, JPID,N1,IPOS,I_INJECT,ISROT,MLAWLY,MID,SUB_ID,
-     .        PROP_SHELL,PROP_TSHEL,PROP_SOLID,PROP_SPH,PROP_BEAM,
-     .        IAD_KNOT,IPDIR
-     
-      INTEGER JPID1,JPID2,NISUB,IPISUB,II
-      my_real
-     .    FN, FT, DX, ANGL,PUN,HTEST,HCLOS,CVIS,RBID,VX,VY,VZ,
-     .    FAC_L,FAC_T,FAC_M, TMIN,TMAX,DT,THICKT,IERREL,DN_P,ZSHIFT
-      CHARACTER IDTITL*nchartitle, MESS*40,KEY*ncharkey, KEY2*ncharkey,
-     .          STRING*ncharfield,TITR1*nchartitle,
-     .          CHROT*7
-      DATA NSHELL /0/, NSHSUP /0/, NSHINF /0/
+      LOGICAL lFOUND
+      CHARACTER IDTITL*nchartitle, MESS*40, TITR1*nchartitle
+      INTEGER I, IG,IGTYP,J,IP,ISTRAIN,I8PT,ISK,ITU,IRB,IHON,IHBE,IPLAST,ITHK,K,N,IDS, IUNIT,UID,ISORTH
+      INTEGER NSTACK,ISTACK,NUMS,IFLAGUNIT,JPID,N1,SUB_ID,PID1,JPID1,JPID2,NISUB,II
+      my_real ANGL,RBID,FAC_L
 C-----------------------------------------------
 C   E x t e r n a l   F u n c t i o n s
 C-----------------------------------------------
       INTEGER USR2SYS
       DATA MESS/'PID DEFINITION                          '/
-      DATA PUN/0.1/
-      DATA IDF /1/
 C----------------------
 C     GEO(3) : ISMSTR
-C     GEO(5) : DT (ISMSTR=3 SAUF SOLIDES)
-C     GEO(7) : VX  coques/solides ortho - vecteur de reference
+C     GEO(5) : DT (ISMSTR=3 expect for solid elems)
+C     GEO(7) : VX  shell/solids ortho - reference vector
 C     GEO(8) : VY
 C     GEO(9) : VZ
-C     GEO(11): ISTRAIN (COQUE)
+C     GEO(11): ISTRAIN (shell)
 C     GEO(12): IGTYP      ->    IGEO(11)
 C     GEO(35): ITHK
 C     GEO(37): ISHEAR
 C     GEO(38): FSHEAR
 C     GEO(39): IPLAST
 C     GEO(40): IG    v50  ->    IGEO(1)
-C     GEO(20:34) : Milieu poreux (briques)
-C     GEO(129): HCLOS (briques)
-C     GEO(130): HTEST (briques)
-C     GEO(131:170): LIBRE
+C     GEO(20:34) : Milieu poreux (bricks)
+C     GEO(129): HCLOS (bricks)
+C     GEO(130): HTEST (bricks)
+C     GEO(131:170): FREE
 C     GEO(171): IHBE
 C     GEO(212): ANGLE BETWEEN two orthotropy directions (DIR1,DIR2) for 
 C               the PID52 with LAW58
 C-------------------
-C    nouveau stockage:
 C    IGEO(1)  : IG
 C    IGEO(2)  : ISK
 C    IGEO(3)  : ISEN
@@ -167,47 +146,34 @@ C               =2 ORTHOTROPY ANGLE DEFINED AT STACK LEVEL ( /PROP/TYPE19/51/52 
 C=======================================================================
       WRITE(IOUT,1000)
 C----------------------
-      NBADI  = 0
-      NSST_D = 0
-      NSST_DS= 0
-      NPSH   = 0
-      CVIS =ZERO
-      IAD_KNOT = 0
-      SUB_ID = 0
-      
-C
-c----------      
-C       
+      SUB_ID = 0    
+      RBID=ZERO
+c----------            
       CALL HM_OPTION_START('/STACK')
-      DO 600 I=1,NUMSTACK 
-        CALL HM_OPTION_READ_KEY(LSUBMODEL, OPTION_ID = IG, UNIT_ID = UID, OPTION_TITR = IDTITL)
-        IGFLU = 0
-        IF(ALE%GLOBAL%ICAA == 1)IGFLU=1
+      DO I=1,NUMSTACK 
+        CALL HM_OPTION_READ_KEY(LSUBMODEL, OPTION_ID=IG, UNIT_ID=UID, OPTION_TITR=IDTITL)
         ISORTH = 0
-        IHGFLU = 0
         IFLAGUNIT = 0
-!
+
         DO IUNIT=1,NUNITS
           IF (UNITAB%UNIT_ID(IUNIT) == UID) THEN
             IFLAGUNIT = 1
             EXIT
           ENDIF
         ENDDO
-C
-        IF (UID/=0.AND.IFLAGUNIT==0) THEN
+
+        IF (UID /= 0 .AND. IFLAGUNIT == 0) THEN
           CALL ANCMSG(MSGID=659,ANMODE=ANINFO,MSGTYPE=MSGERROR,
-     .                I2=UID,I1=IG,C1='STACK',
-     .                 C2='STACK',
-     .                 C3=IDTITL)
-        ENDIF
-!!     
+     .                I1=IG, I2=UID,
+     .                C1='STACK', C2='STACK', C3=IDTITL)
+        ENDIF    
+
 !       Stack + ply are belong to /PROP/PCOMPP 
-!!
         IGTYP = 52  ! belong to /PROP/PCOMP - TYPE52              
 C
 C new shell property (stack based with multi NPT through one layer 
 C---------------
-C      COQUE GENERIQUE
+C      GENERIC SHELL
 C----------------------
 C
 C----------------------------------------------------------------
@@ -217,26 +183,22 @@ C                    -VARIABLE MATERIAL  (BUT LAW 25 OR 27 ONLY)
 C                    -VARIABLE NUMBER OF INTEGRATION POINTS THROUGH ONE LAYER
 C---------------------------------------------------------------- 
           NUMS = NUMGEO_STACK(NUMGEO + I)
-!!          CALL LCGEO51(GEO(1,I),IGEO(1,I),PM,IPM,ISKN,UNITAB,IUNIT,
-!!     .                RTRANS,LSUBMODEL,SUB_ID, ISTACK,STACK_INFO(NUMS) )
           CALL HM_READ_STACK(
-     .           GEO(1,I) ,IGEO(1,I) ,PM       ,IPM      ,ISKN     ,
-     .           IG       ,RTRANS   ,SUB_ID   ,STACK_INFO(NUMS)   ,
-     .           IDTITL   ,UNITAB    ,LSUBMODEL)
+     .           GEO_STACK(1,I) ,IGEO_STACK(1,I) ,PM       ,IPM      ,ISKN     ,
+     .           IG             ,RTRANS          ,SUB_ID   ,STACK_INFO(NUMS)   ,
+     .           IDTITL         ,UNITAB          ,LSUBMODEL)
      
 C--------   Variables stored in element buffer        
 c----   Shells
 C should be done for pccomp
 C-------------------------------
-C  Double stockage temporaire : GEO() / IGEO() : a supprimer a terme 
+C  temporary double storage : GEO() / IGEO() : may be optimized & deleted later 
 !!! ---------------------
-C
-        IGEO(17,I)=ISORTH
-        IF(GEO(39,I)/=ZERO.AND.IGEO( 9,I)== 0)IGEO( 9,I)=NINT(GEO(39,I))
-        IF(GEO(171,I)/=ZERO.AND.IGEO(10,I)== 0)
-     .     IGEO(10,I)=NINT(GEO(171,I))    
+        IGEO_STACK(17,I)=ISORTH
+        IF(GEO_STACK(39,I) /= ZERO .AND. IGEO_STACK(9,I) == 0) IGEO_STACK( 9,I)=NINT(GEO_STACK(39,I))
+        IF(GEO_STACK(171,I) /= ZERO .AND. IGEO_STACK(10,I) == 0) IGEO_STACK(10,I)=NINT(GEO_STACK(171,I))    
 C      
- 600  CONTINUE
+      END DO!next I
 C
 C-------------------------------
 C  Objet /PLY
@@ -245,10 +207,7 @@ C-------------------------------
       CALL HM_OPTION_START('/PLY')
       DO II = 1, NUMPLY  
          CALL HM_OPTION_READ_KEY(LSUBMODEL, OPTION_ID = IG, UNIT_ID = UID, OPTION_TITR = IDTITL)
-         IGFLU = 0
-         IF(ALE%GLOBAL%ICAA == 1)I GFLU = 1
          ISORTH = 0
-         IHGFLU = 0
          IFLAGUNIT = 0
          DO IUNIT=1,NUNITS
             IF (UNITAB%UNIT_ID(IUNIT) == UID) THEN
@@ -259,127 +218,111 @@ C-------------------------------
 c     call BIDON2 to avoid optimization issue on FAC_L variable from compiler (issue
 c     observed after global code compilation with -openmp flag
         CALL BIDON2(FAC_L)
-        IF (UID/=0.AND.IFLAGUNIT==0) THEN
+        IF (UID /=0 .AND. IFLAGUNIT == 0) THEN
            CALL ANCMSG(MSGID=659,ANMODE=ANINFO,MSGTYPE=MSGERROR,
-     .          I2=UID, I1=IG,C1='PLY',
-     .          C2='PLY',
-     .          C3=IDTITL)
+     .                 I1=IG, I2=UID, 
+     .                 C1='PLY',C2='PLY',C3=IDTITL)
         ENDIF
         IGTYP = 19
         I = I + 1   
-        IHBE=0
-        ISMSTR=0
-        ISROT=0
-        IGMAT =0      
-        IGEO( 1,I)=IG
+        IHBE = 0
+        IGEO_STACK( 1,I) = IG
         ISTACK = 1
 C
-        CALL FRETITL(IDTITL,IGEO(NPROPGI-LTITR+1,I),LTITR)        
+        CALL FRETITL(IDTITL,IGEO_STACK(NPROPGI-LTITR+1,I),LTITR)        
 C
-        CALL LCGEO19(GEO(1,I), IGEO(1,I), PM, IPM, UNITAB, IUNIT, ISTACK,
-     .       IDRAPEID, LSUBMODEL)
-        IF (IGEO(4,I)>10) THEN
-           CALL ANCMSG(MSGID=1146,
-     .          MSGTYPE=MSGERROR,
-     .          ANMODE=ANINFO,
-     .          I1=IG,
-     .          C1=IDTITL)
+        CALL LCGEO19(GEO_STACK(1,I), IGEO_STACK(1,I), PM, IPM, UNITAB, IUNIT, ISTACK,IDRAPEID, LSUBMODEL)
+        IF(IGEO_STACK(4,I) > 10) THEN
+           CALL ANCMSG(MSGID=1146,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=IG,C1=IDTITL)
            CALL ARRET(2)
         ENDIF
         PLY_INFO(1,II) = IG
-        PLY_INFO(2,II) = IGEO(4,I)
-        IGEO(1,I) =IG     
+        PLY_INFO(2,II) = IGEO_STACK(4,I)
+        IGEO_STACK(1,I) =IG     
       ENDDO
 C
-C-------------------------------
+C-------------------------------cy
       NPLYMAX = MAX(NPLYMAX,NUMPLY)
 C------------------------------
-C Precalcul SQRT
-C------------------------------
       DO I = 1, NUMSTACK
-        GEO(100,I) = SQRT(GEO(38,I))      ! SHFSR
+        GEO_STACK(100,I) = SQRT(GEO_STACK(38,I))      ! SHFSR
       END DO
 C------------------------------
 C
       DO I = 1,NUMSTACK
-        IGTYP=IGEO(11,I)
+        IGTYP=IGEO_STACK(11,I)
         NUMS= NUMGEO_STACK(NUMGEO + I)
-        IF (IGTYP == 52) THEN
-          N1 = IGEO(4,I)
-          DO 100 J =1 , N1
+        IF(IGTYP == 52) THEN
+          N1 = IGEO_STACK(4,I)
+          DO J =1 , N1
 C ply of stack JPID              
             JPID = STACK_INFO(NUMS)%PID(J)
-            IF (JPID > 0) THEN
+            IF(JPID > 0)THEN
+              lFOUND = .FALSE.
               DO K=1,NUMPLY
-                IF (IGEO(1,NUMSTACK + K) == JPID) THEN
+                IF (IGEO_STACK(1,NUMSTACK + K) == JPID) THEN
                     STACK_INFO(NUMS)%PID(J) = NUMSTACK + K
 C tag if the ply is in the  stack  
-                    IDS = IGEO(42,NUMSTACK  + K)
-                    IGEO(42 ,NUMSTACK + K) = I
+                    IDS = IGEO_STACK(42,NUMSTACK  + K)
+                    IGEO_STACK(42 ,NUMSTACK + K) = I
                     IF(IDS > 0 .AND. IDS /= I) THEN 
-                       CALL FRETITL2(TITR1,
-     .                       IGEO(NPROPGI-LTITR+1,NUMSTACK+I),LTITR)
-                       CALL ANCMSG(MSGID=1148,
-     .                    MSGTYPE=MSGERROR,
-     .                    ANMODE=ANINFO_BLIND_1,
-     .                    I1=IGEO(1,NUMSTACK + K),C1=TITR1,
-     .                    C2='PLY',
-     .                    I2= IGEO(1,IDS),
-     .                    I3= IGEO(1,I))
+                       CALL FRETITL2(TITR1,IGEO_STACK(NPROPGI-LTITR+1,NUMSTACK+I),LTITR)
+                       CALL ANCMSG(MSGID=1148,MSGTYPE=MSGERROR,ANMODE=ANINFO_BLIND_1,
+     .                    I1=IGEO_STACK(1,NUMSTACK + K), I2= IGEO_STACK(1,IDS), I3= IGEO_STACK(1,I),
+     .                    C1=TITR1, C2='PLY')
                     ENDIF
-                  GOTO 100
+                  lFOUND = .TRUE.
+                  EXIT
                 ENDIF
               ENDDO
-              CALL FRETITL2(TITR1,IGEO(NPROPGI-LTITR+1,I),LTITR)
-              CALL ANCMSG(MSGID=1149,
-     .                    MSGTYPE=MSGERROR,
-     .                    ANMODE=ANINFO_BLIND_1,
-     .                    I1=IGEO(1,I),C1=TITR1,
-     .                    C2='STACK',
-     .                    I2=JPID)
-            ENDIF
- 100      CONTINUE
+              IF(.NOT.lFOUND)THEN
+                CALL FRETITL2(TITR1,IGEO_STACK(NPROPGI-LTITR+1,I),LTITR)
+                CALL ANCMSG(MSGID=1149,MSGTYPE=MSGERROR,ANMODE=ANINFO_BLIND_1,
+     .                      I1=IGEO_STACK(1,I), I2=JPID,
+     .                      C1=TITR1, C2='STACK')
+              ENDIF
+            ENDIF!(JPID > 0)
+          END DO!next J
 C interface substack
-          NISUB = IGEO(44,I) 
+          NISUB = IGEO_STACK(44,I) 
           IF (NISUB > 0) THEN
-            DO 110 J =1 , NISUB
+            DO J =1 , NISUB
               JPID1 = STACK_INFO(NUMS)%ISUB( 3*(J-1) + 1 )
               JPID2 = STACK_INFO(NUMS)%ISUB( 3*(J-1) + 2 )
               IF (JPID1 > 0 .OR. JPID2 > 0) THEN
                 DO K=1,NUMPLY 
                   NSTACK = 0
-                  IF (IGEO(1,NUMSTACK + K) == JPID1) THEN
+                  lFOUND=.FALSE.
+                  IF (IGEO_STACK(1,NUMSTACK + K) == JPID1) THEN
                     STACK_INFO(NUMS)%ISUB (3*(J-1) + 1) = NUMSTACK  + K
-                    GOTO 110
-                  ELSEIF (IGEO(1,NUMSTACK + K) == JPID2) THEN 
+                    lFOUND=.TRUE.
+                    EXIT !next J
+                  ELSEIF (IGEO_STACK(1,NUMSTACK + K) == JPID2) THEN 
                     STACK_INFO(NUMS)%ISUB (3*(J-1) + 2) = NUMSTACK  + K
-                    GOTO 110
+                    lFOUND=.TRUE.
+                    EXIT !next J
                   ENDIF
                 ENDDO
-                CALL FRETITL2(TITR1,IGEO(NPROPGI-LTITR+1,I),LTITR)
-                CALL ANCMSG(MSGID=1149,
-     .                      MSGTYPE=MSGERROR,
-     .                      ANMODE=ANINFO_BLIND_1,
-     .                      I1=IGEO(1,I),C1=TITR1,
-     .                      C2='STACK',
-     .                      I2=JPID1)
-                CALL FRETITL2(TITR1,IGEO(NPROPGI-LTITR+1,I),LTITR)
-                CALL ANCMSG(MSGID=1149,
-     .                      MSGTYPE=MSGERROR,
-     .                      ANMODE=ANINFO_BLIND_1,
-     .                      I1=IGEO(1,I),C1=TITR1,
-     .                      C2='STACK',
-     .                      I2=JPID2)
+                IF(.NOT.lFOUND)THEN
+                  CALL FRETITL2(TITR1,IGEO_STACK(NPROPGI-LTITR+1,I),LTITR)
+                  CALL ANCMSG(MSGID=1149,MSGTYPE=MSGERROR,ANMODE=ANINFO_BLIND_1,
+     .                        I1=IGEO_STACK(1,I), I2=JPID1,
+     .                        C1=TITR1, C2='STACK')
+                  CALL FRETITL2(TITR1,IGEO_STACK(NPROPGI-LTITR+1,I),LTITR)
+                  CALL ANCMSG(MSGID=1149,MSGTYPE=MSGERROR,ANMODE=ANINFO_BLIND_1,
+     .                        I1=IGEO_STACK(1,I), I2=JPID2,
+     .                        C1=TITR1, C2='STACK')
+                ENDIF
               ENDIF ! IF (JPID1 > 0 .OR. JPID2 > 0)
- 110        CONTINUE 
+            ENDDO !next J 
           ENDIF ! IF (NISUB > 0)
 C
           DO J=1,N1
             JPID = STACK_INFO(NUMS)%PID(J)
-            STACK_INFO(NUMS)%THK(J)  = GEO(1,JPID)
-            STACK_INFO(NUMS)%ANG(J)  = STACK_INFO(NUMS)%ANG(J) + GEO(2,JPID)
-            STACK_INFO(NUMS)%DIR(J)  = GEO(212,JPID) ! angle (DIR1,DIR2) - for compatibility of law58 with PID51)
-            STACK_INFO(NUMS)%MID(J)  = IGEO(101,JPID)
+            STACK_INFO(NUMS)%THK(J)  = GEO_STACK(1,JPID)
+            STACK_INFO(NUMS)%ANG(J)  = STACK_INFO(NUMS)%ANG(J) + GEO_STACK(2,JPID)
+            STACK_INFO(NUMS)%DIR(J)  = GEO_STACK(212,JPID) ! angle (DIR1,DIR2) - for compatibility of law58 with PID51)
+            STACK_INFO(NUMS)%MID(J)  = IGEO_STACK(101,JPID)
           ENDDO
 ! 
        ENDIF 
@@ -391,13 +334,13 @@ C-------------------------------------
       I = 0
       J = 0
 c      CALL ANCNTS(IDS,I)
-      CALL VDOUBLE(IGEO(1,1),NPROPGI,NUMSTACK,MESS,0,RBID)
-      CALL VDOUBLE(IGEO(1,NUMSTACK+1),NPROPGI,NUMPLY,MESS,0,RBID)
+      CALL VDOUBLE(IGEO_STACK(1,1),NPROPGI,NUMSTACK,MESS,0,RBID)
+      CALL VDOUBLE(IGEO_STACK(1,NUMSTACK+1),NPROPGI,NUMPLY,MESS,0,RBID)
 C
 C-----------
       RETURN
 C-----------
  1000 FORMAT(//
      & 5X,'    STACK OBJECT FOR PLY-BASED SHELL ELEMENT  SETS'/,
-     & 5X,'    -------------'//) 
+     & 5X,'    ----------------------------------------------'//) 
       END

--- a/starter/source/stack/hm_read_stack.F
+++ b/starter/source/stack/hm_read_stack.F
@@ -40,9 +40,9 @@ Chd|        STACK_MOD                     share/modules1/stack_mod.F
 Chd|        SUBMODEL_MOD                  share/modules1/submodel_mod.F 
 Chd|====================================================================
       SUBROUTINE HM_READ_STACK(
-     .           GEO      ,IGEO     ,PM       ,IPM       ,ISKN     ,  
-     .           PROP_ID  ,RTRANS   ,SUB_ID   ,STACK_INFO,
-     .           TITR     ,UNITAB   ,LSUBMODEL)
+     .           GEO_STACK ,IGEO_STACK ,PM        ,IPM       ,ISKN     ,  
+     .           PROP_ID   ,RTRANS     ,SUB_ID    ,STACK_INFO,
+     .           TITR      ,UNITAB     ,LSUBMODEL)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -70,11 +70,11 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER, INTENT(IN) :: PROP_ID,SUB_ID
-      INTEGER, INTENT(INOUT) :: IGEO(NPROPGI)
-      INTEGER, INTENT(IN) :: IPM(NPROPMI,*)
+      INTEGER, INTENT(INOUT) :: IGEO_STACK(NPROPGI)
+      INTEGER, INTENT(IN) :: IPM(NPROPMI,NUMMAT)
       INTEGER :: ISKN(LISKN,*)
-      my_real, INTENT(INOUT) :: GEO(NPROPG)
-      my_real, INTENT(IN) ::  PM(NPROPM,*),RTRANS(NTRANSF,*)
+      my_real, INTENT(INOUT) :: GEO_STACK(NPROPG)
+      my_real, INTENT(IN) ::  PM(NPROPM,NUMMAT),RTRANS(NTRANSF,*)
       CHARACTER(LEN = nchartitle) :: TITR
       TYPE (UNIT_TYPE_), INTENT(IN) :: UNITAB
       TYPE (SUBMODEL_DATA), DIMENSION(NSUBMOD), INTENT(IN) :: LSUBMODEL
@@ -348,52 +348,52 @@ C     isub stack
   300   CONTINUE
       ENDIF 
 c--------------------------------------------
-      IF (DM == ZERO) IGEO(31) = 1
-      IGEO(1)  = PROP_ID
-      IGEO(2)  = ISK
-      IGEO(4)  = NPLY
-      IGEO(5)  = ISMSTR
-      IGEO(6)  = IORTH  ! IREP
-      IGEO(10) = ISHELL
-      IGEO(11) = IGTYP
-      IGEO(18) = ISH3N
-      IGEO(20) = ISROT
-      IGEO(43) = NSUB   ! number of substack               
-      IGEO(44) = NISUB  ! number of interface 
-      IGEO(47) = IINT
-      IGEO(48) = 0 
-      IGEO(98) = IGMAT
-      IGEO(99) = IPOS
-      IGEO(14) = IRP
+      IF (DM == ZERO) IGEO_STACK(31) = 1
+      IGEO_STACK(1)  = PROP_ID
+      IGEO_STACK(2)  = ISK
+      IGEO_STACK(4)  = NPLY
+      IGEO_STACK(5)  = ISMSTR
+      IGEO_STACK(6)  = IORTH  ! IREP
+      IGEO_STACK(10) = ISHELL
+      IGEO_STACK(11) = IGTYP
+      IGEO_STACK(18) = ISH3N
+      IGEO_STACK(20) = ISROT
+      IGEO_STACK(43) = NSUB   ! number of substack               
+      IGEO_STACK(44) = NISUB  ! number of interface 
+      IGEO_STACK(47) = IINT
+      IGEO_STACK(48) = 0 
+      IGEO_STACK(98) = IGMAT
+      IGEO_STACK(99) = IPOS
+      IGEO_STACK(14) = IRP
 c
-      GEO(3)  = ISMSTR
-      GEO(6)  = NPLY    ! double stockage
-      GEO(7)  = VX
-      GEO(8)  = VY
-      GEO(9)  = VZ
-      GEO(11) = ISTRAIN
-      GEO(12) = IGTYP
-      GEO(13) = HM
-      GEO(14) = HF
-      GEO(15) = HR
-      GEO(16) = DM
-      GEO(17) = DN
-      GEO(35) = ITHK
-      GEO(37) = ISHEAR
-      GEO(39) = IPLAST
-      GEO(38) = ASHEAR
-      GEO(42) = ZERO
-      GEO(43) = ONE
-      GEO(199)= ZSHIFT
-      GEO(212) = GEO(212) * PI / HUNDRED80
+      GEO_STACK(3)  = ISMSTR
+      GEO_STACK(6)  = NPLY    ! double stockage
+      GEO_STACK(7)  = VX
+      GEO_STACK(8)  = VY
+      GEO_STACK(9)  = VZ
+      GEO_STACK(11) = ISTRAIN
+      GEO_STACK(12) = IGTYP
+      GEO_STACK(13) = HM
+      GEO_STACK(14) = HF
+      GEO_STACK(15) = HR
+      GEO_STACK(16) = DM
+      GEO_STACK(17) = DN
+      GEO_STACK(35) = ITHK
+      GEO_STACK(37) = ISHEAR
+      GEO_STACK(39) = IPLAST
+      GEO_STACK(38) = ASHEAR
+      GEO_STACK(42) = ZERO
+      GEO_STACK(43) = ONE
+      GEO_STACK(199)= ZSHIFT
+      GEO_STACK(212) = GEO_STACK(212) * PI / HUNDRED80
       IF (ISHELL==0) THEN
-        GEO(171) = 0
+        GEO_STACK(171) = 0
       ELSEIF (ISHELL == 1) THEN
-        GEO(171)=1
+        GEO_STACK(171)=1
       ELSEIF (ISHELL == 2) THEN
-        GEO(171)=0
+        GEO_STACK(171)=0
       ELSEIF (ISHELL >= 3 .AND. ISHELL < 100 .AND. ISHELL /= 4) THEN
-        GEO(171)=ISHELL-1
+        GEO_STACK(171)=ISHELL-1
       ENDIF      
 c--------------------------------------------
 c     OUTPUT 
@@ -405,22 +405,22 @@ c--------------------------------------------
         IF (ISK == 0) THEN
           IF (ISHELL > 11 .AND. ISHELL < 29) THEN
             WRITE(IOUT,2100)ISTRAIN,ISMSTR,ISHELL,ISH3N,ISROT,
-     .               GEO(16),GEO(13),GEO(38),ISHEAR,ITHK,
-     .               IPLAST,IORTH,GEO(7),GEO(8),GEO(9),IGEO(47),IGEO(14)
+     .               GEO_STACK(16),GEO_STACK(13),GEO_STACK(38),ISHEAR,ITHK,
+     .               IPLAST,IORTH,GEO_STACK(7),GEO_STACK(8),GEO_STACK(9),IGEO_STACK(47),IGEO_STACK(14)
           ELSE 
             WRITE(IOUT,2200)ISTRAIN,ISMSTR,ISHELL,ISH3N,ISROT,
      .               HM,HF,HR,DM,ASHEAR,
      .               ISHEAR,ITHK,IPLAST,IORTH,
-     .               VX,VY,VZ,IINT,IGEO(14)
+     .               VX,VY,VZ,IINT,IGEO_STACK(14)
           ENDIF
         ELSE
           IF (ISHELL > 11 .AND. ISHELL < 29) THEN 
             WRITE(IOUT,2300)ISTRAIN,ISMSTR,ISHELL,ISH3N,ISROT,
-     .               GEO(16),GEO(13),GEO(38),ISHEAR,ITHK,
-     .               IPLAST,IORTH,IDSK,IGEO(47),IGEO(14)
+     .               GEO_STACK(16),GEO_STACK(13),GEO_STACK(38),ISHEAR,ITHK,
+     .               IPLAST,IORTH,IDSK,IGEO_STACK(47),IGEO_STACK(14)
           ELSE
             WRITE(IOUT,2400)ISTRAIN,ISMSTR,ISHELL,ISH3N,HM,HF,HR,DM,
-     .            ASHEAR,ISHEAR,ITHK,IPLAST,IORTH,IDSK,IINT,IGEO(14)
+     .            ASHEAR,ISHEAR,ITHK,IPLAST,IORTH,IDSK,IINT,IGEO_STACK(14)
           ENDIF
         ENDIF
 c---


### PR DESCRIPTION
#### Fix 2 potential issues introduced with 1713b67e96955bfd341c821c9c00dcd725a4cae4 

#### Description of the changes

LECSTACK_PLY.F:
- Array size  (2nd dimension) is now set to the correct value.  IGEO(NPROPGI,**NUMSTACK + NUMPLY**) instead of IGEO(NPROPGI,**NUMGEO**). This may prevent debugger from detecting (false) out of bounds issue.
- By the way related subroutine was cleaned.
- arguments IGEO and GEO were renamed to IGEO_STACK & GEO_STACK (also in hm_read_stack.F)

ALE_MOD
Initialization of ALE%GRID%NWALE_ENGINE to -1 (This initialization fix is related to /ALE/GRID option in Engine file )
