### PR TITLE
Add missing dependencies to the Apptainer definition file

### DIFF
--- a/Apptainer/openradioss.def
+++ b/Apptainer/openradioss.def
@@ -5,7 +5,8 @@ From: rockylinux:9
 dnf group install -y "Development Tools"
 dnf install -y \
 gcc gcc-gfortran gcc-c++ make cmake perl git-lfs \
-wget git patch diffutils libxcrypt-compat
+wget git patch diffutils libxcrypt-compat \
+which python
 
 cd /tmp
 wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.2.tar.gz

--- a/Apptainer/openradioss_intel.def
+++ b/Apptainer/openradioss_intel.def
@@ -9,7 +9,7 @@ dnf group install -y "Development Tools"
 dnf install -y \
 gcc gcc-gfortran gcc-c++ make perl git-lfs \
 wget git patch diffutils \
-pkgconfig libxcrypt-compat procps
+pkgconfig libxcrypt-compat procps which
 dnf install -y --enablerepo=devel compat-libpthread-nonshared
 
 cd /tmp


### PR DESCRIPTION
#### Description of the feature or the bug
The Apptainer build fails due to missing `which` and `python` commands not found. Add those as dependencies to fix early build failures.


#### Description of the changes
Add the `which` and `python` packages to the Apptainer definition file.

Any feedback is welcome. Regards,
Fer