### PR TITLE
Implementation of damage output with /H3D/ELEM/FAILURE

### DIFF
--- a/common_source/modules/elbufdef_mod.F
+++ b/common_source/modules/elbufdef_mod.F
@@ -1071,6 +1071,7 @@ c-------  layer variables
  
       TYPE FAIL_LOC_
         integer  ILAWF    ! type de loi de rupture
+        integer  IDFAIL
         integer  NVAR
         integer  LF_DAM
         integer  LF_DAMMX

--- a/engine/source/elements/elbuf/allocbuf_auto.F
+++ b/engine/source/elements/elbuf/allocbuf_auto.F
@@ -852,7 +852,11 @@ c-------------------------------
                 FLOC=>ELBUF_STR%BUFLY(IL)%FAIL(IR,IS,IT)%FLOC(K)  
          
                 FLOC%ILAWF = RBUF(IAD+1)                                   
-                IAD = IAD+1                                                
+                IAD = IAD+1    
+
+                FLOC%IDFAIL = RBUF(IAD+1)
+                IAD = IAD+1
+
                 NUVAR = RBUF(IAD+1)                                        
                 IAD = IAD+1                                                
                 FLOC%NVAR = NUVAR
@@ -1079,7 +1083,9 @@ c-------------------------------
               DO K = 1,NFAIL                                               
                 FLOC=>ELBUF_STR%INTLAY(IL)%FAIL(IR,IS)%FLOC(K)           
                 FLOC%ILAWF = RBUF(IAD+1)                                   
-                IAD = IAD+1                                                
+                IAD = IAD+1       
+                FLOC%IDFAIL = RBUF(IAD+1)
+                IAD = IAD+1                                         
                 NUVAR = RBUF(IAD+1)                                        
                 IAD = IAD+1                                                
                 FLOC%NVAR = NUVAR                                          

--- a/engine/source/elements/elbuf/w_elbuf_str.F
+++ b/engine/source/elements/elbuf/w_elbuf_str.F
@@ -53,7 +53,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,II,J,K,IL,IR,IS,IT,NG,NEL,NPT,L_REL,BUFLEN,NUVAR,
      .   ITY,IGTYP,ISORTH,ISRATE,ISROT,IREP,ERR,IEXPAN,ISTRA,IFAIL,   
-     .   NFAIL,IEOS,IXFEM,IVISC,IXEL,NPG,NPTT,NPTTOT,INLOC,NONL
+     .   NFAIL,IEOS,IXFEM,IVISC,IXEL,NPG,NPTT,NPTTOT,INLOC,NONL,IDFAIL
       INTEGER ! global variables
      .   G_GAMA,G_SIG,G_OFF,G_NOFF,G_EINT,G_EINS,G_TEMP,
      .   G_RHO,G_PLA,G_VOL,G_EPSD,G_QVIS,G_DELTAX,G_TB,G_RK,G_RE,
@@ -692,6 +692,7 @@ c         !-----------------------------------------------------
                   DO K = 1,NFAIL   
                     FLOC=>ELBUF_TAB(NG)%BUFLY(IL)%FAIL(IR,IS,IT)%FLOC(K)
                     IFAIL = FLOC%ILAWF
+                    IDFAIL = FLOC%IDFAIL
                     NUVAR = FLOC%NVAR
                     LF_DAM  = FLOC%LF_DAM
                     LF_DAMMX= FLOC%LF_DAMMX
@@ -882,7 +883,8 @@ c
               DO IS = 1,ELBUF%NPTS                                           
                 DO K = 1,NFAIL                                           
                   FLOC=>ELBUF_TAB(NG)%INTLAY(IL)%FAIL(IR,IS)%FLOC(K)  
-                  IFAIL = FLOC%ILAWF                                     
+                  IFAIL = FLOC%ILAWF    
+                  IDFAIL = FLOC%IDFAIL                                 
                   NUVAR = FLOC%NVAR                                      
                   RBUF_L(L_REL+1)=IFAIL                                  
                     L_REL = L_REL+1                                      

--- a/engine/source/materials/fail/hoffman/fail_hoffman_c.F
+++ b/engine/source/materials/fail/hoffman/fail_hoffman_c.F
@@ -144,7 +144,8 @@ c
           ENDIF
 c
           ! Damage variable update
-          DFMAX(I) = MIN(ONE,FINDEX)
+          FINDEX = MAX(ZERO,FINDEX)
+          DFMAX(I) = MIN(ONE ,FINDEX)
           IF (DFMAX(I) >= ONE) THEN
             NINDX = NINDX+1                                    
             INDX(NINDX) = I                                    

--- a/engine/source/materials/fail/hoffman/fail_hoffman_s.F
+++ b/engine/source/materials/fail/hoffman/fail_hoffman_s.F
@@ -143,7 +143,8 @@ c
           ENDIF
 c
           ! Damage variable update
-          DFMAX(I) = MIN(ONE,FINDEX) 
+          FINDEX   = MAX(ZERO,FINDEX)
+          DFMAX(I) = MIN(ONE ,FINDEX) 
           IF (DFMAX(I) >= ONE) THEN
             NINDX = NINDX+1                                    
             INDX(NINDX) = I                                    

--- a/engine/source/materials/fail/max_strain/fail_maxstrain_c.F
+++ b/engine/source/materials/fail/max_strain/fail_maxstrain_c.F
@@ -137,7 +137,8 @@ c
           ENDIF
 c
           ! Damage variable update
-          DFMAX(I) = MIN(ONE,FINDEX)
+          FINDEX   = MAX(ZERO,FINDEX)
+          DFMAX(I) = MIN(ONE ,FINDEX)
           IF (DFMAX(I) >= ONE) THEN
             NINDX = NINDX+1                                    
             INDX(NINDX) = I                                    

--- a/engine/source/materials/fail/max_strain/fail_maxstrain_s.F
+++ b/engine/source/materials/fail/max_strain/fail_maxstrain_s.F
@@ -137,7 +137,8 @@ c
           ENDIF
 c
           ! Damage variable update
-          DFMAX(I) = MIN(ONE,FINDEX) 
+          FINDEX   = MAX(ZERO,FINDEX)
+          DFMAX(I) = MIN(ONE ,FINDEX) 
           IF (DFMAX(I) >= ONE) THEN
             NINDX = NINDX+1                                    
             INDX(NINDX) = I                                    

--- a/engine/source/materials/fail/tsaihill/fail_tsaihill_c.F
+++ b/engine/source/materials/fail/tsaihill/fail_tsaihill_c.F
@@ -137,7 +137,8 @@ c
           ENDIF
 c
           ! Damage variable update
-          DFMAX(I) = MIN(ONE,FINDEX)
+          FINDEX   = MAX(ZERO,FINDEX)
+          DFMAX(I) = MIN(ONE ,FINDEX)
           IF (DFMAX(I) >= ONE) THEN
             NINDX = NINDX+1                                    
             INDX(NINDX) = I                                    

--- a/engine/source/materials/fail/tsaihill/fail_tsaihill_s.F
+++ b/engine/source/materials/fail/tsaihill/fail_tsaihill_s.F
@@ -136,7 +136,8 @@ c
           ENDIF
 c
           ! Damage variable update
-          DFMAX(I) = MIN(ONE,FINDEX) 
+          FINDEX   = MAX(ZERO,FINDEX)
+          DFMAX(I) = MIN(ONE ,FINDEX) 
           IF (DFMAX(I) >= ONE) THEN
             NINDX = NINDX+1                                    
             INDX(NINDX) = I                                    

--- a/engine/source/materials/fail/tsaiwu/fail_tsaiwu_c.F
+++ b/engine/source/materials/fail/tsaiwu/fail_tsaiwu_c.F
@@ -144,7 +144,8 @@ c
           ENDIF
 c
           ! Damage variable update
-          DFMAX(I) = MIN(ONE,FINDEX)
+          FINDEX   = MAX(ZERO,FINDEX)
+          DFMAX(I) = MIN(ONE ,FINDEX)
           IF (DFMAX(I) >= ONE) THEN
             NINDX = NINDX+1                                    
             INDX(NINDX) = I                                    

--- a/engine/source/materials/fail/tsaiwu/fail_tsaiwu_s.F
+++ b/engine/source/materials/fail/tsaiwu/fail_tsaiwu_s.F
@@ -143,7 +143,8 @@ c
           ENDIF
 c
           ! Damage variable update
-          DFMAX(I) = MIN(ONE,FINDEX) 
+          FINDEX   = MAX(ZERO,FINDEX)
+          DFMAX(I) = MIN(ONE ,FINDEX) 
           IF (DFMAX(I) >= ONE) THEN
             NINDX = NINDX+1                                    
             INDX(NINDX) = I                                    

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_shell_scalar_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_shell_scalar_datatype.cpp
@@ -71,7 +71,8 @@ extern "C"
 
 void c_h3d_create_shell_scalar_datatype_(int *cpt_data, char *name1, int *size1, int *info1, int *info2, char *name2, int *size2,
                                          int *layer, int *ipt, int *ply,int *nuvar, int *gauss, int *idMds, int *idMdsVar,
-                                         int *idMatMds, char *comment, int *s_comment,char *mdsUvarName,int *sizeMdsUvarName)
+                                         int *idMatMds, char *comment, int *s_comment,char *mdsUvarName,int *sizeMdsUvarName,
+                                         int *id)
 {
     char *cname,*cname2,*ccomment,*cmdsuvar;
     int cname_len,cname_len1,ccomment_len,cmdsuvar_len;
@@ -120,6 +121,8 @@ void c_h3d_create_shell_scalar_datatype_(int *cpt_data, char *name1, int *size1,
     MID_STRING[0] ='\0'; 
     char * RES_STRING = new char [100];
     RES_STRING[0] ='\0'; 
+    char * ID_STRING = new char [100];
+    ID_STRING[0] ='\0';  
 
     H3D_ID layer_pool_id = H3D_NULL_ID;
 
@@ -128,6 +131,16 @@ void c_h3d_create_shell_scalar_datatype_(int *cpt_data, char *name1, int *size1,
 #else
     RES_STRING = strcat(RES_STRING,cname);
 #endif
+
+    if(*id > 0)
+    {
+        sprintf(ID_STRING, " id %d",*id);
+#ifdef _WIN64
+        strcat_s(RES_STRING,100,ID_STRING);
+#else
+        RES_STRING = strcat(RES_STRING,ID_STRING);
+#endif
+    }
 
     if(*idMdsVar > 0 && *idMds > 0)
     {
@@ -345,19 +358,19 @@ void c_h3d_create_shell_scalar_datatype_(int *cpt_data, char *name1, int *size1,
 
 void _FCALL C_H3D_CREATE_SHELL_SCALAR_DATATYPE(int *cpt_data, char *name1, int *size1, int *info1, int *info2, char *name2, int *size2,
                                          int *layer, int *ipt, int *ply, int *nuvar, int *gauss, int *idMds, int *idMdsVar, int *idMatMds,
-                                         char *comment, int *s_comment,char *mdsUvarName,int *sizeMdsUvarName)
+                                         char *comment, int *s_comment,char *mdsUvarName,int *sizeMdsUvarName, int *id)
 {c_h3d_create_shell_scalar_datatype_ (cpt_data, name1, size1, info1, info2, name2, size2,layer,ipt,ply,nuvar,gauss,idMds,idMdsVar,idMatMds,comment,s_comment,
-                                      mdsUvarName,sizeMdsUvarName);}
+                                      mdsUvarName,sizeMdsUvarName,id);}
 
 void c_h3d_create_shell_scalar_datatype__ (int *cpt_data, char *name1, int *size1, int *info1, int *info2, char *name2, int *size2,
                                          int *layer, int *ipt, int *ply, int *nuvar, int *gauss, int *idMds, int *idMdsVar, int *idMatMds,
-                                         char *comment, int *s_comment,char *mdsUvarName,int *sizeMdsUvarName)
+                                         char *comment, int *s_comment,char *mdsUvarName,int *sizeMdsUvarName,int *id)
 {c_h3d_create_shell_scalar_datatype_ (cpt_data, name1, size1, info1, info2, name2, size2,layer,ipt,ply,nuvar,gauss,idMds,idMdsVar,idMatMds,comment,s_comment,
-                                      mdsUvarName,sizeMdsUvarName);}
+                                      mdsUvarName,sizeMdsUvarName,id);}
 
 void c_create_shell_scalar_datatype (int *cpt_data, char *name1, int *size1, int *info1, int *info2, char *name2, int *size2,
                                          int *layer, int *ipt, int *ply, int *nuvar, int *gauss, int *idMds, int *idMdsVar,int *idMatMds,
-                                         char *comment, int *s_comment,char *mdsUvarName,int *sizeMdsUvarName)
+                                         char *comment, int *s_comment,char *mdsUvarName,int *sizeMdsUvarName,int *id)
 {c_h3d_create_shell_scalar_datatype_ (cpt_data, name1, size1, info1, info2, name2, size2,layer,ipt,ply,nuvar,gauss,idMds,idMdsVar,idMatMds,comment,s_comment,
-                                      mdsUvarName,sizeMdsUvarName);}
+                                      mdsUvarName,sizeMdsUvarName,id);}
 }

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_solid_scalar_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_solid_scalar_datatype.cpp
@@ -71,7 +71,7 @@ extern "C"
 void c_h3d_create_solid_scalar_datatype_(int *cpt_data, char *name1, int *size1, int *info, char *name2, int *size2,
                                          int *layer, int *nuvar, int *ir, int *is, int *it,
                                          int *idMds, int *idMdsVar, int *idMatMds, char *comment, int *s_comment,
-                                         char *mdsUvarName, int *sizeMdsUvarName )
+                                         char *mdsUvarName, int *sizeMdsUvarName ,int *id)
 {
     char *cname,*cname2,*ccomment,*cmdsuvar;
     int cname_len,cname_len1,ccomment_len,cmdsuvar_len;
@@ -117,6 +117,8 @@ void c_h3d_create_solid_scalar_datatype_(int *cpt_data, char *name1, int *size1,
     MID_STRING[0] ='\0'; 
     char * RES_STRING = new char [100];
     RES_STRING[0] ='\0'; 
+    char * ID_STRING = new char [100];
+    ID_STRING[0] ='\0'; 
 
     H3D_ID layer_pool_id = H3D_NULL_ID;
 
@@ -125,6 +127,16 @@ void c_h3d_create_solid_scalar_datatype_(int *cpt_data, char *name1, int *size1,
 #else
     RES_STRING = strcat(RES_STRING,cname);
 #endif
+
+    if(*id > 0)
+    {
+        sprintf(ID_STRING, " id %d",*id);
+#ifdef _WIN64
+        strcat_s(RES_STRING,100,ID_STRING);
+#else
+        RES_STRING = strcat(RES_STRING,ID_STRING);
+#endif
+    }
 
     if(*idMdsVar > 0 && *idMds > 0)
     {
@@ -311,21 +323,21 @@ void c_h3d_create_solid_scalar_datatype_(int *cpt_data, char *name1, int *size1,
 void _FCALL C_H3D_CREATE_SOLID_SCALAR_DATATYPE(int *cpt_data, char *name1, int *size1, int *info, char *name2, int *size2,
                                                int *layer, int *nuvar, int *ir, int *is, int *it,
                                                int *idMds, int *idMdsVar, int *idMatMds, char *comment, int *s_comment,
-                                               char *mdsUvarName,int *sizeMdsUvarName)
+                                               char *mdsUvarName,int *sizeMdsUvarName,int *id)
 {c_h3d_create_solid_scalar_datatype_ (cpt_data, name1, size1, info, name2, size2, layer, nuvar, ir, is, it, idMds, idMdsVar,
-                                      idMatMds, comment, s_comment, mdsUvarName, sizeMdsUvarName);}
+                                      idMatMds, comment, s_comment, mdsUvarName, sizeMdsUvarName,id);}
 
 void c_h3d_create_solid_scalar_datatype__ (int *cpt_data, char *name1, int *size1, int *info, char *name2, int *size2,
                                            int *layer, int *nuvar, int *ir, int *is, int *it,
                                            int *idMds, int *idMdsVar, int *idMatMds, char *comment, int *s_comment,
-                                           char *mdsUvarName,int *sizeMdsUvarName)
+                                           char *mdsUvarName,int *sizeMdsUvarName,int *id)
 {c_h3d_create_solid_scalar_datatype_ (cpt_data, name1, size1, info, name2, size2, layer, nuvar, ir, is, it, idMds, idMdsVar,
-                                      idMatMds,comment, s_comment, mdsUvarName, sizeMdsUvarName);}
+                                      idMatMds,comment, s_comment, mdsUvarName, sizeMdsUvarName,id);}
 
 void c_create_solid_scalar_datatype (int *cpt_data, char *name1, int *size1, int *info, char *name2, int *size2,
                                      int *layer, int *nuvar, int *ir, int *is, int *it,
                                      int *idMds, int *idMdsVar, int *idMatMds, char *comment, int *s_comment,
-                                     char *mdsUvarName,int *sizeMdsUvarName)
+                                     char *mdsUvarName,int *sizeMdsUvarName,int *id)
 {c_h3d_create_solid_scalar_datatype_ (cpt_data, name1, size1, info, name2, size2, layer, nuvar, ir, is, it, idMds, idMdsVar,
-                                      idMatMds,comment, s_comment, mdsUvarName, sizeMdsUvarName);}
+                                      idMatMds,comment, s_comment, mdsUvarName, sizeMdsUvarName,id);}
 }

--- a/engine/source/output/h3d/h3d_build_fortran/create_h3d_shell_scalar.F
+++ b/engine/source/output/h3d/h3d_build_fortran/create_h3d_shell_scalar.F
@@ -31,7 +31,8 @@ Chd|====================================================================
       SUBROUTINE CREATE_H3D_SHELL_SCALAR(H3D_DATA,ID_SHELL_SCALAR ,N1       ,N2       ,ID_INPUT ,TEXT1  ,
      .                                       STEXT1       ,COMMENT    ,SCOMMENT  ,IPART    ,KEY3_GLOB ,
      .                                       LAYER    ,IPT    ,PLY             ,GAUSS    ,IUVAR       ,
-     .                                       IDMDS    ,IVARMDS,ID_MAT_MDS,MDS_LABEL, SMDS_LABEL)
+     .                                       IDMDS    ,IVARMDS,ID_MAT_MDS,MDS_LABEL, SMDS_LABEL       ,
+     .                                       ID       )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -47,7 +48,7 @@ C-----------------------------------------------
       TYPE (H3D_DATABASE) :: H3D_DATA
       INTEGER ID_SHELL_SCALAR,ID_INPUT,STEXT1,N1,N2,SCOMMENT,
      .        LAYER,IPT,PLY,IUVAR,GAUSS,IDMDS,IVARMDS,SMDS_LABEL,
-     .        ID_MAT_MDS
+     .        ID_MAT_MDS,ID
       INTEGER IPART(LIPART1,*)
       CHARACTER(LEN=STEXT1) ::  TEXT1
       CHARACTER(LEN=ncharline) :: KEY3_GLOB
@@ -87,6 +88,7 @@ C=========================================================================
       H3D_DATA%OUTPUT_LIST(H3D_DATA%N_OUTP_H3D)%MDSVAR_NAME = TRIM(MDS_LABEL)
       H3D_DATA%OUTPUT_LIST(H3D_DATA%N_OUTP_H3D)%SMDSVAR_NAME = SMDS_LABEL
       H3D_DATA%OUTPUT_LIST(H3D_DATA%N_OUTP_H3D)%GAUSS = GAUSS
+      H3D_DATA%OUTPUT_LIST(H3D_DATA%N_OUTP_H3D)%OBJECT_ID = ID
       H3D_DATA%OUTPUT_LIST(H3D_DATA%N_OUTP_H3D)%S_STRING1 = STEXT1
       H3D_DATA%OUTPUT_LIST(H3D_DATA%N_OUTP_H3D)%STRING1(1:STEXT1) = TEXT1(1:STEXT1)
       H3D_DATA%OUTPUT_LIST(H3D_DATA%N_OUTP_H3D)%S_COMMENT = SCOMMENT

--- a/engine/source/output/h3d/h3d_build_fortran/create_h3d_solid_scalar.F
+++ b/engine/source/output/h3d/h3d_build_fortran/create_h3d_solid_scalar.F
@@ -31,7 +31,8 @@ Chd|====================================================================
       SUBROUTINE CREATE_H3D_SOLID_SCALAR(H3D_DATA,ID_SOLID_SCALAR,ID_INPUT,TEXT1,STEXT1,
      .                                   COMMENT, SCOMMENT, IPART,KEY3_GLOB,
      .                                   LAYER,IR,IS,IT,IUVAR,
-     .                                   IDMDS,IVARMDS,ID_MAT_MDS,MDS_LABEL,SMDS_LABEL)
+     .                                   IDMDS,IVARMDS,ID_MAT_MDS,MDS_LABEL,SMDS_LABEL,
+     .                                   ID   )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -47,7 +48,7 @@ C-----------------------------------------------
       TYPE (H3D_DATABASE) :: H3D_DATA
       INTEGER ID_SOLID_SCALAR,ID_INPUT,STEXT1,SCOMMENT,
      .        LAYER,IUVAR,IR,IS,IT,IDMDS,IVARMDS,SMDS_LABEL,
-     .        ID_MAT_MDS
+     .        ID_MAT_MDS,ID
       INTEGER IPART(LIPART1,*)
       CHARACTER(LEN=STEXT1) ::  TEXT1
       CHARACTER(LEN=ncharline) ::  KEY3_GLOB
@@ -78,6 +79,7 @@ C=========================================================================
       H3D_DATA%OUTPUT_LIST(H3D_DATA%N_OUTP_H3D)%IR = IR
       H3D_DATA%OUTPUT_LIST(H3D_DATA%N_OUTP_H3D)%IS = IS
       H3D_DATA%OUTPUT_LIST(H3D_DATA%N_OUTP_H3D)%IT = IT
+      H3D_DATA%OUTPUT_LIST(H3D_DATA%N_OUTP_H3D)%OBJECT_ID = ID
       H3D_DATA%OUTPUT_LIST(H3D_DATA%N_OUTP_H3D)%IUVAR = IUVAR
       H3D_DATA%OUTPUT_LIST(H3D_DATA%N_OUTP_H3D)%IDMDS = IDMDS
       H3D_DATA%OUTPUT_LIST(H3D_DATA%N_OUTP_H3D)%IDMATMDS = ID_MAT_MDS

--- a/engine/source/output/h3d/h3d_build_fortran/h3d_create_datatype.F
+++ b/engine/source/output/h3d/h3d_build_fortran/h3d_create_datatype.F
@@ -119,7 +119,8 @@ c------------scalar
      .                      H3D_DATA%OUTPUT_LIST(I)%IUVAR,H3D_DATA%OUTPUT_LIST(I)%GAUSS,H3D_DATA%OUTPUT_LIST(I)%IDMDS,
      .                      H3D_DATA%OUTPUT_LIST(I)%IMDSVAR             , H3D_DATA%OUTPUT_LIST(I)%IDMATMDS ,
      .                      H3D_DATA%OUTPUT_LIST(I)%COMMENT             , H3D_DATA%OUTPUT_LIST(I)%S_COMMENT,
-     .                      H3D_DATA%OUTPUT_LIST(I)%MDSVAR_NAME         , H3D_DATA%OUTPUT_LIST(I)%SMDSVAR_NAME)
+     .                      H3D_DATA%OUTPUT_LIST(I)%MDSVAR_NAME         , H3D_DATA%OUTPUT_LIST(I)%SMDSVAR_NAME,
+     .                      H3D_DATA%OUTPUT_LIST(I)%OBJECT_ID)
               ELSEIF(H3D_DATA%OUTPUT_LIST(I)%OUTP_TYPE ==  2) THEN
 c------------vector
                   CALL C_H3D_CREATE_SHELL_VECTOR_DATATYPE(
@@ -150,7 +151,8 @@ c------------scalar
      .                      H3D_DATA%OUTPUT_LIST(I)%IS, H3D_DATA%OUTPUT_LIST(I)%IT        , H3D_DATA%OUTPUT_LIST(I)%IDMDS    ,
      .                      H3D_DATA%OUTPUT_LIST(I)%IMDSVAR                               , H3D_DATA%OUTPUT_LIST(I)%IDMATMDS ,  
      .                      H3D_DATA%OUTPUT_LIST(I)%COMMENT                               , H3D_DATA%OUTPUT_LIST(I)%S_COMMENT ,
-     .                      H3D_DATA%OUTPUT_LIST(I)%MDSVAR_NAME                           , H3D_DATA%OUTPUT_LIST(I)%SMDSVAR_NAME)
+     .                      H3D_DATA%OUTPUT_LIST(I)%MDSVAR_NAME                           , H3D_DATA%OUTPUT_LIST(I)%SMDSVAR_NAME,
+     .                      H3D_DATA%OUTPUT_LIST(I)%OBJECT_ID)
               ELSEIF(H3D_DATA%OUTPUT_LIST(I)%OUTP_TYPE ==  2) THEN
 c------------vector
                   CALL C_H3D_CREATE_SOLID_VECTOR_DATATYPE(

--- a/engine/source/output/h3d/h3d_build_fortran/lech3d.F
+++ b/engine/source/output/h3d/h3d_build_fortran/lech3d.F
@@ -147,7 +147,7 @@ C-----------------------------------------------
      .        ISHELL_NPT_CHECK,ICSTR,NPTR,NPTS,NPTT,IS_CORNER_DATA,ISH_NPT0,
      .        IS_MDSVAR_DEF,NMDSVAR_MAX,IS_MDSVAR,IS_MDSVAR_ALL,IMDSVAR,
      .        IS_MODEL_NPT,IS_MODEL_PLY,IS_MODEL_LAYER,ISKIND,IOUTER,IPEXT,
-     .        IS_ID,ID,ID_MAX,IS_ID_ALL,NINEFRIC,N19
+     .        IS_ID,ID,ID_MAX,IS_ID_ALL,NINEFRIC,N19,IRUP,IFAIL
       INTEGER MLW,NEL,NG,JTURB,NLAY,NUVAR,IPLY,IMAT,ISUBSTACK,ID_PLY_TMP
       CHARACTER  KEY2*ncharkey, KEY3*ncharkey, KEY4*ncharkey, KEY5*ncharkey, KEY6*ncharkey,
      .           KEY7*ncharkey,KEY8*ncharkey,KEY3_GLOB*ncharline,KEY3_READ*ncharline, 
@@ -185,7 +185,21 @@ c
       TYPE (H3D_NUMBER_OF_KEY) :: H3D_NUM_KEY
   
       TYPE(BUF_LAY_)  ,POINTER :: BUFLY 
+      TYPE(BUF_FAIL_) ,POINTER :: FBUF 
       INTEGER, DIMENSION(:,:), ALLOCATABLE :: IS_LAYER_MAT 
+      CHARACTER*64 TEST_CHAIN
+      CHARACTER*10 FAIL_NAME(50)
+      DATA  FAIL_NAME/
+     1 'JOHNSON    ','TBUTCHER  ','WILKINS   ','USER1     ','USER2     ',
+     2 'USER3      ','FLD       ','SPALLING  ','WIERZBICKI','TENSSTRAIN',
+     3 'ENERGY     ','          ','CHANG     ','HASHIN    ','          ',
+     4 'PUCK       ','          ','LADEVEZE  ','          ','CONNECT   ',
+     5 '           ','          ','TAB1      ','ORTHSTRAIN','NXT       ',
+     6 'SNCONNECT  ','EMC       ','ALTER     ','SAHRAEI   ','BIQUAD    ',
+     7 'FABRIC     ','HC_DSSE   ','MULLINS   ','COCKCROFT ','GURSON    ',
+     8 'VISUAL     ','TAB_OLD   ','ORTHBIQUAD','GENE1     ','RTCL      ',
+     9 'TAB2       ','INIEVO    ','SYAZWAN   ','TSAIWU    ','TSAIHILL  ',
+     A 'HOFFMAN    ','MAXSTRAIN ','          ','          ','          '/
 C=========================================================================
       IF(H3D_DATA%TH3D0 /= ZERO)  H3D_DATA%TH3D = H3D_DATA%TH3D0
       IF(H3D_DATA%TH3D_STOP0 /= EP20)  H3D_DATA%TH3D_STOP = H3D_DATA%TH3D_STOP0      
@@ -844,6 +858,8 @@ C--------------------------------------------------
             NPLY_MAX = 0
             NUVAR_MAX = 0
             NMDSVAR_MAX = 0
+C
+            ! LAYER=ALL 
             IF (IS_LAYER_ALL == 1) THEN
 	      DO K=1,NUMGEO
            	IF(IGEO(11,K) == 10 .OR. IGEO(11,K) == 11 .OR. IGEO(11,K) == 16 ) THEN
@@ -857,6 +873,7 @@ C--------------------------------------------------
               ENDDO
             ENDIF
 C
+            ! NPT=ALL
             ISH_NPT0 = 0    
             IF (IS_IPT_ALL == 1) THEN
                DO K=1,NUMGEO
@@ -874,6 +891,8 @@ C
                ENDDO
             ENDIF 
             IF(IS_IPT_ALL == 1 .AND. NIP_MAX == 0) ISHELL_NPT_CHECK = 1
+C
+            ! PLY=ALL
             ID_PLY(1:NUMGEO) = 0
             IPT_PLY(1:NUMGEO) = 0    
             IF (IS_PLY_ALL == 1) THEN
@@ -1141,6 +1160,36 @@ c
               ENDDO
             ENDDO
           ENDIF
+c
+          IF (KEY3_GLOB == 'FAILURE' .AND. IS_ID > 0) THEN
+            IRUP = 0
+            DO NG=1,NGROUP
+
+              CALL INITBUF (IPARG    ,NG     ,                    
+     2             MLW     ,NEL     ,NFT     ,IAD     ,ITY     ,  
+     3             NPT     ,JALE    ,ISMSTR  ,JEUL    ,JTURB   ,  
+     4             JTHE    ,JLAG    ,JMULT   ,JHBE    ,JIVF    ,  
+     5             NVAUX   ,JPOR    ,JCVT    ,JCLOSE  ,JPLASOL ,  
+     6             IREP    ,IINT    ,IGTYP   ,ISRAT   ,ISROT   ,  
+     7             ICSEN   ,ISORTH  ,ISORTHG ,IFAILURE,JSMS    )
+
+              NLAY = ELBUF_STR(NG)%NLAY
+              DO J = 1,NLAY
+                DO K = 1, ELBUF_STR(NG)%BUFLY(J)%NPTT
+                  DO L = 1,ELBUF_STR(NG)%NPTR
+                    DO M = 1,ELBUF_STR(NG)%NPTS
+                      FBUF => ELBUF_STR(NG)%BUFLY(J)%FAIL(L,M,K)
+                      DO IFAIL = 1,ELBUF_STR(NG)%BUFLY(J)%NFAIL
+                        IF (FBUF%FLOC(IFAIL)%IDFAIL == ID) THEN 
+                          IRUP = FBUF%FLOC(IFAIL)%ILAWF
+                        ENDIF
+                      ENDDO
+                    ENDDO
+                  ENDDO
+                ENDDO 
+              ENDDO
+            ENDDO
+          ENDIF
 C-------------------------------------------------- 
           IF(KEY2 == 'SHELL' .OR. KEY2 =='ELEM') THEN
 C-------------------------------------------------- 
@@ -1348,12 +1397,19 @@ c
      .     				       UVAR_INPUT(K))
                     IS_SKING = 1
 		   ELSE
+ 
+                   IF(KEY3_GLOB(1:7) == 'FAILURE') THEN
+                     TEST_CHAIN = ''
+                     WRITE(TEST_CHAIN,'(A,1X,A,1X,A)') TRIM(H3D_KEYWORD_SHELL_SCALAR(J)%TEXT1(1:7)),TRIM(FAIL_NAME(IRUP)),'Damage'
+                     H3D_KEYWORD_SHELL_SCALAR(J)%TEXT1 = TEST_CHAIN
+                   ENDIF
+                    
            	   CALL CREATE_H3D_SHELL_SCALAR(H3D_DATA,H3D_KEYWORD_SHELL_SCALAR(J)%ID,N1,N2,ID_INPUT,
      .     					   TRIM(H3D_KEYWORD_SHELL_SCALAR(J)%TEXT1),LEN_TRIM(H3D_KEYWORD_SHELL_SCALAR(J)%TEXT1),
      .                                             H3D_KEYWORD_SHELL_SCALAR(J)%COMMENT,80,IPART,KEY3_GLOB,
      .     					   LAYER_INPUT(K),IPT_INPUT(K),PLY_INPUT(K),GAUSS_INPUT(K),UVAR_INPUT(K),
      .                                             MDSVAR_INPUT(K),MDSVAR_INPUT1(K),MDSVAR_INPUT2(K),
-     .                                             MDS_LABEL_TMP,30)
+     .                                             MDS_LABEL_TMP,30,IDS_INPUT(K))
               END IF			   
            	  IOK_H3DKEY = 1
            	ELSEIF (IS_AVAILABLE_KEY(K) == 1 .AND. IS_VECTOR == 1) THEN
@@ -1571,12 +1627,19 @@ c
                     IS_SKING = 1
                  ELSE
                     IF (IS_MDSVAR ==1) MDS_LABEL_TMP = MDS_LABEL(MDSVAR_INPUT1(K), MDSVAR_INPUT(K))
+ 
+                    IF(KEY3_GLOB(1:7) == 'FAILURE') THEN
+                      TEST_CHAIN = ''
+                      WRITE(TEST_CHAIN,'(A,1X,A,1X,A)') TRIM(H3D_KEYWORD_SOLID_SCALAR(J)%TEXT1(1:7)),TRIM(FAIL_NAME(IRUP)),'Damage'
+                      H3D_KEYWORD_SOLID_SCALAR(J)%TEXT1 = TEST_CHAIN
+                    ENDIF
+
            	    CALL CREATE_H3D_SOLID_SCALAR(H3D_DATA,H3D_KEYWORD_SOLID_SCALAR(J)%ID,ID_INPUT,
      .     				       TRIM(H3D_KEYWORD_SOLID_SCALAR(J)%TEXT1),LEN_TRIM(H3D_KEYWORD_SOLID_SCALAR(J)%TEXT1),
      .                                         H3D_KEYWORD_SOLID_SCALAR(J)%COMMENT,80,IPART,KEY3_GLOB,
      .     				       LAYER_INPUT(K),IR_INPUT(K),IS_INPUT(K),IT_INPUT(K),
      .     				       UVAR_INPUT(K),MDSVAR_INPUT(K),MDSVAR_INPUT1(K),
-     .                                         MDSVAR_INPUT2(K),MDS_LABEL_TMP,30)
+     .                                         MDSVAR_INPUT2(K),MDS_LABEL_TMP,30,IDS_INPUT(K))
                   END IF
            	  IOK_H3DKEY = 1
            	ELSEIF (IS_AVAILABLE_KEY(K) == 1 .AND. IS_VECTOR == 1) THEN

--- a/engine/source/output/h3d/h3d_results/genh3d.F
+++ b/engine/source/output/h3d/h3d_results/genh3d.F
@@ -2273,6 +2273,7 @@ c-----
           IMDSVAR = H3D_DATA%OUTPUT_LIST(I)%IMDSVAR
           N_OUTP_DATA = H3D_DATA%OUTPUT_LIST(I)%N_OUTP
           KEYWORD = H3D_DATA%OUTPUT_LIST(I)%KEYWORD
+          OBJECT_ID = H3D_DATA%OUTPUT_LIST(I)%OBJECT_ID
 c         IF(ISPMD == 0)  print *,'shell scalar',N_OUTP_DATA,'IFUNC',IFUNC,'INFO1',INFO1,'INFO2',INFO2
 
 c         IF(ISPMD == 0)  print *,'H3D_DATA%OUTPUT_LIST(I)%PART',H3D_DATA%OUTPUT_LIST(I)%PART(1:NPART)
@@ -2288,7 +2289,8 @@ c         IF(ISPMD == 0)  print *,'H3D_DATA%OUTPUT_LIST(I)%PART',H3D_DATA%OUTPUT
      .                     STACK     ,SHELL_ID  ,SHELL_ITY     ,INFO1        ,INFO2      ,
      .                     IS_WRITEN_SHELL,IPARTC ,IPARTTG     ,LAYER        ,IPT        ,
      .                     ID_PLY     ,GAUSS     ,IUVAR ,H3D_DATA%OUTPUT_LIST(I)%PART,KEYWORD,
-     .                     D          ,MULTI_FVM ,IDMDS        ,IMDSVAR      ,MDS_MATID  )
+     .                     D          ,MULTI_FVM ,IDMDS        ,IMDSVAR      ,MDS_MATID  ,
+     .                     OBJECT_ID  )
 c
           IF (NSPMD > 1 ) THEN
             CALL STARTIME(MACRO_TIMER_SPMDH3D,1)
@@ -2438,6 +2440,7 @@ c-----
           IMDSVAR = H3D_DATA%OUTPUT_LIST(I)%IMDSVAR
           N_OUTP_DATA = H3D_DATA%OUTPUT_LIST(I)%N_OUTP
           KEYWORD = H3D_DATA%OUTPUT_LIST(I)%KEYWORD
+          OBJECT_ID = H3D_DATA%OUTPUT_LIST(I)%OBJECT_ID
 c          IF(ISPMD == 0)  print *,'solid scalar',N_OUTP_DATA,'IFUNC',IFUNC,'INFO1',INFO1,'INFO2',INFO2
 
           CALL H3D_SOLID_SCALAR(
@@ -2451,7 +2454,8 @@ c          IF(ISPMD == 0)  print *,'solid scalar',N_OUTP_DATA,'IFUNC',IFUNC,'INF
      .                    STACK     ,SOLID_ID  ,SOLID_ITY     ,IPARTS       ,LAYER      ,
      .                    IR        ,IS        ,IT            ,IUVAR        ,H3D_DATA%OUTPUT_LIST(I)%PART,
      .                    IS_WRITEN_SOLID,INFO1,KEYWORD       ,FANI_CELL    ,SFANI_CELL ,
-     .                    MULTI_FVM, H3D_DATA  ,IDMDS         ,IMDSVAR      ,MDS_MATID  )
+     .                    MULTI_FVM, H3D_DATA  ,IDMDS         ,IMDSVAR      ,MDS_MATID  ,
+     .                    OBJECT_ID)
 c
           IF (NSPMD > 1 ) THEN
             CALL STARTIME(MACRO_TIMER_SPMDH3D,1)

--- a/engine/source/output/h3d/h3d_results/h3d_shell_scalar.F
+++ b/engine/source/output/h3d/h3d_results/h3d_shell_scalar.F
@@ -45,7 +45,8 @@ Chd|====================================================================
      .                  STACK       ,ID_ELEM   ,ITY_ELEM  ,INFO1       ,INFO2      , 
      .                  IS_WRITTEN_SHELL,IPARTC,IPARTTG   ,LAYER_INPUT ,IPT_INPUT  ,
      .                  PLY_INPUT   ,GAUSS_INPUT,IUVAR_INPUT,H3D_PART  ,KEYWORD    ,
-     .                  D           , MULTI_FVM ,IDMDS    ,IMDSVAR     ,MDS_MATID  )
+     .                  D           , MULTI_FVM ,IDMDS    ,IMDSVAR     ,MDS_MATID  ,
+     .                  ID          )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -78,7 +79,7 @@ C-----------------------------------------------
      .   IADP(*),NBF_L, NBPART,IADG(NSPMD,NPART),IPM(NPROPMI,NUMMAT),
      .   IGEO(NPROPGI,NUMGEO),INVERT(*), NV46,ID_ELEM(*),ITY_ELEM(*),
      .   INFO1,INFO2,IS_WRITTEN_SHELL(*),IPARTC(NUMELC),IPARTTG(NUMELTG),H3D_PART(*),
-     .   LAYER_INPUT ,IPT_INPUT,GAUSS_INPUT,PLY_INPUT,IUVAR_INPUT,IDMDS,
+     .   LAYER_INPUT ,IPT_INPUT,GAUSS_INPUT,PLY_INPUT,IUVAR_INPUT,IDMDS,ID,
      .   MDS_MATID(*),IMDSVAR,NERCVOIS(SNERCVOIS),NESDVOIS(SNESDVOIS),LERCVOIS(SLERCVOIS),LESDVOIS(SLESDVOIS)
       TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP), TARGET :: ELBUF_TAB
       TYPE (STACK_PLY) :: STACK
@@ -125,7 +126,7 @@ C-----------------------------------------------
      .                  IS_WRITTEN_SHELL,IPARTC,IPARTTG   ,LAYER_INPUT ,IPT_INPUT  ,
      .                  PLY_INPUT   ,GAUSS_INPUT,IUVAR_INPUT,H3D_PART  ,KEYWORD    ,
      .                  D           ,NG         ,MULTI_FVM,IDMDS       ,IMDSVAR    ,
-     .                  MDS_MATID   )
+     .                  MDS_MATID   ,ID         )
       ENDDO
 C-----------------------------------------------
 

--- a/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
@@ -48,7 +48,7 @@ Chd|====================================================================
      .                  IS_WRITTEN_SHELL,IPARTC,IPARTTG   ,LAYER_INPUT ,IPT_INPUT  ,
      .                  PLY_INPUT   ,GAUSS_INPUT,IUVAR_INPUT,H3D_PART  ,KEYWORD    ,
      .                  D           ,NG         ,MULTI_FVM,IDMDS       ,IMDSVAR    ,
-     .                  MDS_MATID   )
+     .                  MDS_MATID   ,ID         )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -87,7 +87,7 @@ C-----------------------------------------------
      .   IADP(*),NBF_L, NBPART,IADG(NSPMD,NPART),IPM(NPROPMI,NUMMAT),
      .   IGEO(NPROPGI,NUMGEO),INVERT(*), NV46,ID_ELEM(*),ITY_ELEM(*),
      .   INFO1,INFO2,IS_WRITTEN_SHELL(*),IPARTC(NUMELC),IPARTTG(NUMELTG),H3D_PART(*),
-     .   LAYER_INPUT ,IPT_INPUT,GAUSS_INPUT,PLY_INPUT,IUVAR_INPUT,NG,IDMDS,
+     .   LAYER_INPUT ,IPT_INPUT,GAUSS_INPUT,PLY_INPUT,IUVAR_INPUT,NG,IDMDS,ID,
      .   MDS_MATID(*),IMDSVAR,NERCVOIS(SNERCVOIS),NESDVOIS(SNESDVOIS),LERCVOIS(SLERCVOIS),LESDVOIS(SLESDVOIS)
       TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP), TARGET :: ELBUF_TAB
       TYPE (STACK_PLY) :: STACK
@@ -108,7 +108,7 @@ C-----------------------------------------------
      .        N,K,K1,K2,JTURB,
      .        OFFSET,IHBE,NPG, MPT,IPT,IADR,IPMAT,
      .        ISUBSTACK,ITHK,ID_PLY,IOK,N1,N2,N3,N4,
-     .        IMAT,IU(4),NFRAC,IPOS,ITRIMAT,NS,IAD2,IDRAPE
+     .        IMAT,IU(4),NFRAC,IPOS,ITRIMAT,NS,IAD2,IDRAPE,NLAY_FAIL
       INTEGER PID(MVSIZ),MAT(MVSIZ),MATLY(MVSIZ*100),FAILG(100,MVSIZ),
      .        NPT_ALL,IPLY,
      .        IOK_PART(MVSIZ),JJ(5),NPGT,IUVAR,
@@ -2141,7 +2141,7 @@ c
 
 
 c ILAYER= NPT=
-              ELSEIF ( (ILAY <= NLAY .AND. ILAY > 0) .AND. (IPT <= 10 .AND. IPT > 0 ) .AND. GBUF%G_PLA > 0) THEN
+              ELSEIF ( (ILAY <= NLAY .AND. ILAY > 0) .AND. (IPT <= MPT .AND. IPT > 0 ) .AND. GBUF%G_PLA > 0) THEN
                 IF (IGTYP == 51 .OR. IGTYP == 52) THEN 
                   BUFLY => ELBUF_TAB(NG)%BUFLY(ILAY)
                   NPTT  =  BUFLY%NPTT
@@ -3187,6 +3187,208 @@ C
                ENDIF
               ENDIF ! law 25  + SHell Composite  PID
 C--------------------------------------------------
+            ELSE IF (KEYWORD == 'FAILURE') THEN 
+C--------------------------------------------------                          
+c IPLY=NULL ILAYER=NULL NPT=NULL
+              IF ( ILAY == -1 .AND. IPT == -1 .AND. IPLY == -1) THEN  
+                IF(IFAILURE > 0) THEN
+                  IF (NLAY > 1) THEN
+                    DO I=1,NEL
+                      NLAY_FAIL = 0
+                      DO N = 1,NLAY
+                	      NPTT = ELBUF_TAB(NG)%BUFLY(N)%NPTT
+                	      DO IT = 1,NPTT
+                	        DO IR = 1,NPTR						       
+                	          DO IS = 1,NPTS						       
+                	            FBUF => ELBUF_TAB(NG)%BUFLY(N)%FAIL(IR,IS,IT)	
+                              DMGMX = ZERO		
+                              DO IFAIL = 1,ELBUF_TAB(NG)%BUFLY(N)%NFAIL
+                                IF (FBUF%FLOC(IFAIL)%IDFAIL == ID) THEN 
+                                  DMGMX = FBUF%FLOC(IFAIL)%DAMMX(I)	
+                                  IS_WRITTEN_VALUE(I) = 1 
+                                  NLAY_FAIL = NLAY_FAIL + 1 
+                                ENDIF
+                              ENDDO
+                              VALUE(I) = VALUE(I) + DMGMX/(NPTT*NPTS*NPTR)
+                	          ENDDO
+                	        ENDDO
+                	      ENDDO  !  DO IT = 1,NPTT
+                      ENDDO    !  N=1,NLAY							   
+                      VALUE(I) = VALUE(I) / NLAY_FAIL
+                    ENDDO
+                  ELSEIF (MPT > 0) THEN  ! NLAY = 1						    
+                    NPTT = ELBUF_TAB(NG)%BUFLY(1)%NPTT
+                    DO I=1,NEL								   
+                      DO IT = 1,NPTT
+                        DO IR = 1,NPTR							    
+                          DO IS = 1,NPTS 						    
+                            FBUF => ELBUF_TAB(NG)%BUFLY(1)%FAIL(IR,IS,IT)		 
+                            DMGMX = ZERO
+                            DO IFAIL = 1,ELBUF_TAB(NG)%BUFLY(1)%NFAIL
+                              IF (FBUF%FLOC(IFAIL)%IDFAIL == ID) THEN 
+                                DMGMX = FBUF%FLOC(IFAIL)%DAMMX(I)	
+                                IS_WRITTEN_VALUE(I) = 1 
+                              ENDIF
+                            ENDDO		
+                            VALUE(I) = VALUE(I) + DMGMX/(NPTT*NPTS*NPTR)		     
+                          ENDDO  							     
+                        ENDDO								     
+                      ENDDO   !  N=1,NPTT							  
+                    ENDDO     !  I=1,NEL
+                  ENDIF     
+                ENDIF
+              ELSEIF ( IPLY > 0 .AND. IPT <= MPT .AND. IPT > 0 ) THEN
+c PLY=IPLY NPT=IPT
+                IF (IFAILURE > 0) THEN 
+	                DO J=1,NLAY
+                    NPTT = ELBUF_TAB(NG)%BUFLY(J)%NPTT
+                    ID_PLY = 0
+                    IF (IGTYP == 17 .OR. IGTYP == 51) THEN
+	                    ID_PLY = IGEO(1,STACK%IGEO(2+J,ISUBSTACK))
+                    ELSEIF (IGTYP == 52) THEN
+                      ID_PLY=PLY_INFO(1,STACK%IGEO(2+J,ISUBSTACK)-NUMSTACK) 
+                    ENDIF 
+                    IF (ID_PLY  == IPLY )THEN
+                      IF (IPT <= NPTT) THEN						
+                        DO I=1,NEL							    
+                          DO IR = 1, NPTR						    
+                            DO IS = 1, NPTS							    
+                              FBUF => ELBUF_TAB(NG)%BUFLY(J)%FAIL(IR,IS,IPT)		
+                              DO IFAIL = 1,ELBUF_TAB(NG)%BUFLY(J)%NFAIL
+                                IF (FBUF%FLOC(IFAIL)%IDFAIL == ID) THEN 
+                                  VALUE(I) = VALUE(I) + FBUF%FLOC(IFAIL)%DAMMX(I)/(NPTR*NPTS)	
+                                  IS_WRITTEN_VALUE(I) = 1 
+                                ENDIF
+                              ENDDO							    
+                            ENDDO							    
+                          ENDDO 					    
+                        ENDDO 
+                      ENDIF
+                    ENDIF
+                  ENDDO
+                ENDIF
+c
+              ELSEIF ( IPLY > 0 .AND. IPT == -1 ) THEN
+c PLY=IPLY NPT=-1
+                IF (IFAILURE > 0) THEN 
+	                DO J=1,NLAY
+                    NPTT = ELBUF_TAB(NG)%BUFLY(J)%NPTT
+                    ID_PLY = 0
+                    IF (IGTYP == 17 .OR. IGTYP == 51) THEN
+	                    ID_PLY = IGEO(1,STACK%IGEO(2+J,ISUBSTACK))
+                    ELSEIF (IGTYP == 52) THEN
+                      ID_PLY=PLY_INFO(1,STACK%IGEO(2+J,ISUBSTACK)-NUMSTACK) 
+                    ENDIF 
+                    IF (ID_PLY  == IPLY )THEN					
+                      DO I=1,NEL							  
+                        DO IR = 1, NPTR 						  
+                          DO IS = 1, NPTS						  
+                            DO IT = 1, NPTT							  
+                              FBUF => ELBUF_TAB(NG)%BUFLY(J)%FAIL(IR,IS,IT)
+                              DO IFAIL = 1,ELBUF_TAB(NG)%BUFLY(J)%NFAIL
+                                IF (FBUF%FLOC(IFAIL)%IDFAIL == ID) THEN 
+                                  VALUE(I) = VALUE(I) + 
+     .                                FBUF%FLOC(IFAIL)%DAMMX(I)/(NPTR*NPTS*NPTT)
+                                  IS_WRITTEN_VALUE(I) = 1 
+                                ENDIF
+                              ENDDO						  
+                            ENDDO 									  
+                          ENDDO 							  
+                        ENDDO 							  
+                      ENDDO 
+                    ENDIF
+                  ENDDO
+                ENDIF
+c
+c ILAYER=ILAY NPT=IPT 
+              ELSEIF (ILAY <= NLAY .AND. ILAY > 0 .AND. IPT <= MPT .AND. IPT > 0 ) THEN 
+                IF (IFAILURE > 0) THEN 
+                  IF (IGTYP == 51 .OR. IGTYP == 52) THEN  				  
+                    NPTT = ELBUF_TAB(NG)%BUFLY(ILAY)%NPTT
+                    IF (IPT <= NPTT) THEN				  
+                      DO I=1,NEL  
+                        DO IR = 1,NPTR							   
+                          DO IS = 1,NPTS							   
+                	          FBUF => ELBUF_TAB(NG)%BUFLY(ILAY)%FAIL(IR,IS,IPT)	
+                            DMGMX = ZERO	
+                            DO IFAIL = 1,ELBUF_TAB(NG)%BUFLY(ILAY)%NFAIL
+                              IF (FBUF%FLOC(IFAIL)%IDFAIL == ID) THEN 
+                                DMGMX = FBUF%FLOC(IFAIL)%DAMMX(I)	
+                                IS_WRITTEN_VALUE(I) = 1 
+                              ENDIF
+                            ENDDO		
+                            VALUE(I) = VALUE(I) + DMGMX/(NPTR*NPTS)			    
+                          ENDDO
+                        ENDDO								  
+                      ENDDO     !  I=1,NEL
+                    ENDIF
+                  ENDIF
+                ENDIF
+c ILAYER=IL NPT=NULL
+              ELSEIF (ILAY <= NLAY .AND. ILAY > 0 .AND. IPT == -1) THEN
+                IF (IFAILURE > 0) THEN
+                  IPT = 1
+                  IF (IGTYP == 10 .OR. IGTYP == 11 .OR. IGTYP == 16 .OR. IGTYP == 17) THEN 
+                    DO I=1,NEL	
+                      DO IR = 1,NPTR							   
+                        DO IS = 1,NPTS							   
+                	        FBUF => ELBUF_TAB(NG)%BUFLY(ILAY)%FAIL(IR,IS,1) 
+                          DMGMX = ZERO
+                          DO IFAIL = 1,ELBUF_TAB(NG)%BUFLY(ILAY)%NFAIL
+                            IF (FBUF%FLOC(IFAIL)%IDFAIL == ID) THEN 
+                              DMGMX = FBUF%FLOC(IFAIL)%DAMMX(I)	
+                              IS_WRITTEN_VALUE(I) = 1 
+                            ENDIF
+                          ENDDO
+                          VALUE(I) = VALUE(I) + DMGMX/(NPTR*NPTS)
+                        ENDDO
+                      ENDDO								  
+                    ENDDO     !  I=1,NEL
+c
+                  ELSEIF (IGTYP == 51 .OR. IGTYP == 52) THEN				      
+                    NPTT = ELBUF_TAB(NG)%BUFLY(ILAY)%NPTT
+                    DO I=1,NEL	
+                      DO IT = 1,NPTT
+                        DO IR = 1,NPTR							     
+                	        DO IS = 1,NPTS  						     
+                	          FBUF => ELBUF_TAB(NG)%BUFLY(ILAY)%FAIL(IR,IS,IT)	
+                            DMGMX = ZERO	
+                            DO IFAIL = 1,ELBUF_TAB(NG)%BUFLY(ILAY)%NFAIL
+                              IF (FBUF%FLOC(IFAIL)%IDFAIL == ID) THEN 
+                                DMGMX = FBUF%FLOC(IFAIL)%DAMMX(I)
+                                IS_WRITTEN_VALUE(I) = 1 
+                              ENDIF
+                            ENDDO
+                            VALUE(I) = VALUE(I) + DMGMX/(NPTT*NPTR*NPTS)
+                	        ENDDO
+                        ENDDO								    
+                      ENDDO  !  DO IT = 1,NPTT
+                    ENDDO    !  I=1,NEL
+                  ENDIF
+                ENDIF
+c NPT=IPT
+              ELSEIF ( IPT <= NPT .AND. IPT > 0) THEN
+                IF (IFAILURE > 0) THEN
+                  IF (IGTYP == 1 .OR. IGTYP == 9 ) THEN 
+                    DO I=1,NEL	      
+                      DO IR = 1,NPTR							   
+                        DO IS = 1,NPTS							   
+                	        FBUF => ELBUF_TAB(NG)%BUFLY(1)%FAIL(IR,IS,IPT)  
+                          DMGMX = ZERO	
+                          DO IFAIL = 1,ELBUF_TAB(NG)%BUFLY(1)%NFAIL
+                            IF (FBUF%FLOC(IFAIL)%IDFAIL == ID) THEN 
+                              DMGMX = FBUF%FLOC(IFAIL)%DAMMX(I)
+                              IS_WRITTEN_VALUE(I) = 1 
+                            ENDIF
+                          ENDDO			
+                          VALUE(I) = VALUE(I) + DMGMX/(NPTR*NPTS)				    
+                        ENDDO
+                      ENDDO								  
+                    ENDDO     !  I=1,NEL
+                  ENDIF
+                ENDIF
+              ENDIF
+C--------------------------------------------------
             ELSEIF (KEYWORD == 'DAMG/MEMB') THEN 
 C--------------------------------------------------
               IF (GBUF%G_DMG > 0) THEN
@@ -3784,7 +3986,7 @@ c
                 ENDDO
 c
               ! -- ILAYER= NPT=
-              ELSEIF ( (ILAY <= NLAY .AND. ILAY > 0) .AND. (IPT <= 10 .AND. IPT > 0 ) .AND. GBUF%G_TSAIWU > 0) THEN
+              ELSEIF ( (ILAY <= NLAY .AND. ILAY > 0) .AND. (IPT <= MPT .AND. IPT > 0 ) .AND. GBUF%G_TSAIWU > 0) THEN
                 IF (IGTYP == 51 .OR. IGTYP == 52) THEN 
                   BUFLY => ELBUF_TAB(NG)%BUFLY(ILAY)
                   NPTT  = BUFLY%NPTT

--- a/engine/source/output/h3d/h3d_results/h3d_solid_scalar.F
+++ b/engine/source/output/h3d/h3d_results/h3d_solid_scalar.F
@@ -45,7 +45,8 @@ Chd|====================================================================
      .                  STACK           ,ID_ELEM      ,ITY_ELEM  ,IPARTS      ,LAYER_INPUT ,
      .                  IR_INPUT        ,IS_INPUT     ,IT_INPUT  ,IUVAR_INPUT ,H3D_PART    ,
      .                  IS_WRITTEN_SOLID,INFO1        ,KEYWORD   ,FANI_CELL   ,SFANI_CELL  ,
-     .                  MULTI_FVM       , H3D_DATA    ,IDMDS     ,IMDSVAR     ,MDS_MATID )
+     .                  MULTI_FVM       , H3D_DATA    ,IDMDS     ,IMDSVAR     ,MDS_MATID   ,
+     .                  ID              )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -78,7 +79,7 @@ C-----------------------------------------------
       INTEGER IPARG(NPARG,*),IXS(NIXS,*),IXTG(NIXTG,*),EL2FA(*),
      .   IXQ(NIXQ,*),IFUNC,NBF,
      .   IADP(*),NBF_L, NBPART,IADG(NSPMD,*),IPM(NPROPMI,*),
-     .   IGEO(NPROPGI,*),INVERT(*), NV46,ID_ELEM(*),ITY_ELEM(*),IPARTS(*),
+     .   IGEO(NPROPGI,*),INVERT(*), NV46,ID_ELEM(*),ITY_ELEM(*),IPARTS(*),ID,
      .   H3D_PART(*),IS_WRITTEN_SOLID(*),INFO1,LAYER_INPUT,IR_INPUT,IS_INPUT,IT_INPUT,
      .   IUVAR_INPUT,SFANI_CELL,IDMDS,IMDSVAR,MDS_MATID(*)
       TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP), TARGET :: ELBUF_TAB
@@ -157,7 +158,7 @@ c
      .                  IR_INPUT        ,IS_INPUT     ,IT_INPUT  ,IUVAR_INPUT ,H3D_PART    ,
      .                  IS_WRITTEN_SOLID,INFO1        ,KEYWORD   ,FANI_CELL   ,SFANI_CELL  ,
      .                  MULTI_FVM       , H3D_DATA    ,NG        ,IDMDS       ,IMDSVAR     ,
-     .                  MDS_MATID       )
+     .                  MDS_MATID       ,ID           )
 
  900  CONTINUE   ! NG 
 C-----------------------------------------------

--- a/engine/source/output/h3d/h3d_results/h3d_solid_scalar_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_solid_scalar_1.F
@@ -51,7 +51,7 @@ Chd|====================================================================
      .                  IR_INPUT        ,IS_INPUT     ,IT_INPUT  ,IUVAR_INPUT ,H3D_PART    ,
      .                  IS_WRITTEN_SOLID,INFO1        ,KEYWORD   ,FANI_CELL   ,SFANI_CELL  ,
      .                  MULTI_FVM       , H3D_DATA    ,NG        ,IDMDS       ,IMDSVAR     ,
-     .                  MDS_MATID       )
+     .                  MDS_MATID       ,ID           )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -89,7 +89,7 @@ C-----------------------------------------------
       INTEGER IPARG(NPARG,*),IXS(NIXS,*),IXTG(NIXTG,*),EL2FA(*),
      .   IXQ(NIXQ,*),IFUNC,NBF,
      .   IADP(*),NBF_L, NBPART,IADG(NSPMD,*),IPM(NPROPMI,*),
-     .   IGEO(NPROPGI,*),INVERT(*), NV46,ID_ELEM(*),ITY_ELEM(*),IPARTS(*),
+     .   IGEO(NPROPGI,*),INVERT(*), NV46,ID_ELEM(*),ITY_ELEM(*),IPARTS(*),ID,
      .   H3D_PART(*),IS_WRITTEN_SOLID(*),INFO1,LAYER_INPUT,IR_INPUT,IS_INPUT,IT_INPUT,
      .   IUVAR_INPUT,SFANI_CELL,NG,IDMDS,IMDSVAR,MDS_MATID(*)
       TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP), TARGET :: ELBUF_TAB
@@ -123,7 +123,7 @@ C-----------------------------------------------
       INTEGER I,I1,II,J,NEL,NPTR,NPTS,NPTT,NLAY,L,IFAIL,ILAY,
      .        IR,IS,IT,IL,MLW, NUVAR,IUS,LENF,PTF,PTM,PTS,NFAIL,
      .        N,NN,K,K1,K2,JTURB,MT,IMID,IALEL,IPID,ISH3N,NNI,
-     .        NN1,NN2,NN3,NN4,NN5,NN6,NN9,NF,BUF,NVARF,
+     .        NN1,NN2,NN3,NN4,NN5,NN6,NN9,NF,BUF,NVARF,NLAY_FAIL,
      .        OFFSET,IHBE,NPTM,NPG, MPT,IPT,IADD,IADR,IPMAT,IFAILT,
      .        IIGEO,IADI,ISUBSTACK,ITHK,NERCVOIS(*),NESDVOIS(*),
      .        LERCVOIS(*),LESDVOIS(*),NB_PLYOFF,IUVAR,IDX,IPOS,ITRIMAT,
@@ -1405,6 +1405,68 @@ c ILAYER=NULL IR= IS= IT=
                 ENDIF 	
               ENDIF
 C-------------------------------------------------- 
+              ELSEIF(KEYWORD == 'FAILURE') THEN
+C--------------------------------------------------
+c ILAYER=NULL IR=NULL IS=NULL IT=NULL
+	              IF ( ILAY == -1 .AND. IR == -1 .AND. IS == -1 .AND. IT == -1) THEN 
+                  DO I = 1,NEL
+                    NLAY_FAIL = 0 
+                    DO IL=1,NLAY 
+                      NFAIL = ELBUF_TAB(NG)%BUFLY(IL)%NFAIL		
+                      DO IS=1,NPTS					
+                        DO IT=1,NPTT					
+                          DO IIR=1,NPTR			
+                            FBUF => ELBUF_TAB(NG)%BUFLY(IL)%FAIL(IIR,IS,IT)	
+                            DMGMX = ZERO
+                            DO IFAIL = 1,NFAIL
+                              IF (FBUF%FLOC(IFAIL)%IDFAIL == ID) THEN 
+                                DMGMX = FBUF%FLOC(IFAIL)%DAMMX(I)
+                                IS_WRITTEN_VALUE(I) = 1 
+                                NLAY_FAIL = NLAY_FAIL + 1 
+                              ENDIF
+                            ENDDO
+                            VALUE(I) = VALUE(I) + DMGMX/(NPTR*NPTS*NPTT)
+                          ENDDO
+                        ENDDO
+                       ENDDO
+                     ENDDO 
+                     VALUE(I) = VALUE(I)/NLAY_FAIL
+                   ENDDO
+c ILAYER=NULL IR= IS= IT=
+                ELSEIF ( ILAY == -1 .AND. IR >= 0 .AND. IR <= NPTR .AND. 
+     .                   IS >= 0 .AND.  IS <= NPTS .AND. IT >= 0 .AND. IT <= NPTT) THEN 
+                  IIR = IR
+                  IF (IIR <= NPTR.AND.IS <= NPTS.AND.IT <= NPTT) THEN	
+                    DO I = 1,NEL 
+                      NLAY_FAIL = 0 			 
+                      DO IL=1,NLAY  
+                        NFAIL = ELBUF_TAB(NG)%BUFLY(IL)%NFAIL
+                  	    FBUF => ELBUF_TAB(NG)%BUFLY(IL)%FAIL(IIR,IS,IT)
+                        DO IFAIL = 1,NFAIL
+                          IF (FBUF%FLOC(IFAIL)%IDFAIL == ID) THEN 
+                            VALUE(I) = VALUE(I) + FBUF%FLOC(IFAIL)%DAMMX(I)
+                            IS_WRITTEN_VALUE(I) = 1 
+                            NLAY_FAIL = NLAY_FAIL + 1
+                          ENDIF
+                        ENDDO			
+                      ENDDO		
+                      VALUE(I) = VALUE(I)/NLAY_FAIL			
+                    ENDDO	
+                 ENDIF 						
+                ELSEIF ( ILAY > 0 .AND. ILAY <= NLAY .AND. IR >= 0 .AND. IR <= NPTR .AND. 
+     .                   IS >= 0 .AND.  IS <= NPTS) THEN	
+                  NFAIL = ELBUF_TAB(NG)%BUFLY(ILAY)%NFAIL
+                  FBUF => ELBUF_TAB(NG)%BUFLY(ILAY)%FAIL(IR,IS,IT)	    
+                  DO I = 1,NEL   												
+                    DO IFAIL = 1,NFAIL
+                      IF (FBUF%FLOC(IFAIL)%IDFAIL == ID) THEN 
+                        VALUE(I) = FBUF%FLOC(IFAIL)%DAMMX(I)
+                        IS_WRITTEN_VALUE(I) = 1 
+                      ENDIF
+                    ENDDO
+                  ENDDO	
+                ENDIF
+C--------------------------------------------------
               ELSEIF (KEYWORD == 'DAMG') THEN
 C--------------------------------------------------
 c

--- a/engine/source/output/h3d/input_list/h3d_list_shell_scalar.F
+++ b/engine/source/output/h3d/input_list/h3d_list_shell_scalar.F
@@ -337,6 +337,18 @@ c-----------------------------------------------
       H3D_KEYWORD_SHELL_SCALAR(I)%COMMENT  = 'maximum of damage over time and of all failure criteria acting in one material'
 c-----------------------------------------------
       I = I + 1
+      H3D_KEYWORD_SHELL_SCALAR(I)%KEY3  = 'FAILURE'
+      H3D_KEYWORD_SHELL_SCALAR(I)%IS_PLY = 1
+      H3D_KEYWORD_SHELL_SCALAR(I)%IS_PLY_ALL = 1
+      H3D_KEYWORD_SHELL_SCALAR(I)%IS_LAYER = 1
+      H3D_KEYWORD_SHELL_SCALAR(I)%IS_LAYER_ALL = 1
+      H3D_KEYWORD_SHELL_SCALAR(I)%IS_IPT = 1
+      H3D_KEYWORD_SHELL_SCALAR(I)%IS_IPT_ALL = 1
+      H3D_KEYWORD_SHELL_SCALAR(I)%IS_ID = 1
+      H3D_KEYWORD_SHELL_SCALAR(I)%TEXT1  = 'Failure'
+      H3D_KEYWORD_SHELL_SCALAR(I)%COMMENT  = 'Damage of current failure criterion'
+c-----------------------------------------------
+      I = I + 1
       H3D_KEYWORD_SHELL_SCALAR(I)%KEY3  = 'DAMINI'
       H3D_KEYWORD_SHELL_SCALAR(I)%IS_PLY = 1
       H3D_KEYWORD_SHELL_SCALAR(I)%IS_PLY_ALL = 1

--- a/engine/source/output/h3d/input_list/h3d_list_solid_scalar.F
+++ b/engine/source/output/h3d/input_list/h3d_list_solid_scalar.F
@@ -351,6 +351,18 @@ c-----------------------------------------------
       H3D_KEYWORD_SOLID_SCALAR(I)%COMMENT  = 'Damage initiation'
 c-----------------------------------------------
       I = I + 1
+      H3D_KEYWORD_SOLID_SCALAR(I)%KEY3  = 'FAILURE'
+      H3D_KEYWORD_SOLID_SCALAR(I)%IS_IR  = 1
+      H3D_KEYWORD_SOLID_SCALAR(I)%IS_IR_ALL  = 1
+      H3D_KEYWORD_SOLID_SCALAR(I)%IS_IS  = 1
+      H3D_KEYWORD_SOLID_SCALAR(I)%IS_IS_ALL  = 1
+      H3D_KEYWORD_SOLID_SCALAR(I)%IS_IT  = 1
+      H3D_KEYWORD_SOLID_SCALAR(I)%IS_IT_ALL  = 1
+      H3D_KEYWORD_SOLID_SCALAR(I)%IS_ID  = 1
+      H3D_KEYWORD_SOLID_SCALAR(I)%TEXT1  = 'Failure'
+      H3D_KEYWORD_SOLID_SCALAR(I)%COMMENT  = 'Damage of current failure criterion'
+c-----------------------------------------------
+      I = I + 1
       H3D_KEYWORD_SOLID_SCALAR(I)%KEY3   = 'TSAIWU'
       H3D_KEYWORD_SOLID_SCALAR(I)%TEXT1  = 'Tsai-Wu Criterion'
 c-----------------------------------------------

--- a/starter/source/elements/elbuf_init/elbuf_ini.F
+++ b/starter/source/elements/elbuf_init/elbuf_ini.F
@@ -99,8 +99,8 @@ C-----------------------------------------------
      .   ISUBSTACK,IIGEO,IADI,IPPID,IPIDL,NPT_LAY,LEN_PLAPT,LEN_SIGPT,
      .   IPMAT,IPMAT_IPLY,NPTTOT,NUVARN,NX,LAW,IBOLTP,CRKDIR,INLOC,LNLOC,
      .   NONL, DEBUG_PRINT,IPINCH,NUVAREOS,IEOS_TYPE,IDRAPE,LLOC_SLICE,
-     .   IPNPT_LAY
-      INTEGER, ALLOCATABLE, DIMENSION(:,:) :: TFAIL
+     .   IPNPT_LAY,IDFAIL
+      INTEGER, ALLOCATABLE, DIMENSION(:,:) :: TFAIL,FAILID
       INTEGER, ALLOCATABLE, DIMENSION(:)   :: IMAT,ILAW
       TYPE(ELBUF_STRUCT_), POINTER :: ELBUF
       TYPE(BUF_MAT_)     , POINTER :: MATBUF
@@ -344,9 +344,11 @@ c
         
           MAXFLAY = 7          ! max Nb of failure models per mat
           MY_ALLOCATE2D(TFAIL,NLAY,MAXFLAY)
+          MY_ALLOCATE2D(FAILID,NLAY,MAXFLAY)
           MY_ALLOCATE(IMAT,NLAY)
           MY_ALLOCATE(ILAW,NLAY)
           TFAIL(:,:) = 0
+          FAILID(:,:) = 0
           ILAW(:)  = 0
           IMAT(:)  = 0
           IF (ITY == 1) THEN
@@ -423,8 +425,10 @@ c
               ELBUF_TAB(NG)%BUFLY(IL)%NVAR_VISC= VISC_TAG(LAW_VIS)%NUVAR
 c              ELBUF_TAB(NG)%BUFLY(IL)%NVAR_VISC= 0
               DO J = 1, NFAIL                                            
-                IRUPT = IPM(111+ (J-1)*15, IMAT(IL))   ! modele de rupture        
-                TFAIL(IL,J) = IRUPT       
+                IRUPT  = IPM(111 + (J-1)*15,IMAT(IL))   ! modele de rupture
+                IDFAIL = IPM(236 + J,IMAT(IL)) 
+                TFAIL(IL,J)  = IRUPT 
+                FAILID(IL,J) = IDFAIL      
               ENDDO                                                           
               IF (MLAW_TAG(IMAT(IL))%L_PLA == 0 .and. IPARG(10,NG) == 2) THEN
                 IPARG(10,NG) = 0  ! ICPRE
@@ -468,8 +472,10 @@ c---
               ELBUF_TAB(NG)%BUFLY(IL)%NVARTMP = 0
               ELBUF_TAB(NG)%BUFLY(IL)%NVAR_VISC=0
               DO J = 1,NFAIL                                              
-                IRUPT =  IPM(111+ (J-1)*15, NINT(PM(20+IL,IMID)))   ! modele de rupture 
-                TFAIL(IL,J) = IRUPT       
+                IRUPT  = IPM(111 + (J-1)*15, NINT(PM(20+IL,IMID)))   ! modele de rupture 
+                IDFAIL = IPM(236 + J, NINT(PM(20+IL,IMID))) 
+                TFAIL(IL,J)  = IRUPT  
+                FAILID(IL,J) = IDFAIL    
               ENDDO                                                         
             ENDDO                      
 c---
@@ -495,8 +501,10 @@ c---
               ELBUF_TAB(NG)%BUFLY(IL)%IPORO= 0  
               ELBUF_TAB(NG)%BUFLY(IL)%NFAIL = NFAIL                          
               DO J = 1,NFAIL                                              
-                IRUPT = IPM(111 + (J-1)*15, IMAT(IL))   ! modele de rupture 
-                TFAIL(IL,J) = IRUPT       
+                IRUPT  = IPM(111 + (J-1)*15, IMAT(IL))   ! modele de rupture 
+                IDFAIL = IPM(236 + J, IMAT(IL)) 
+                TFAIL(IL,J)  = IRUPT 
+                FAILID(IL,J) = IDFAIL      
               ENDDO                                                         
               IF (MLAW_TAG(IMAT(IL))%L_PLA == 0 .and. IPARG(10,NG) == 2) THEN
                 IPARG(10,NG) = 0  ! ICPRE
@@ -522,8 +530,10 @@ c---
               ELBUF_TAB(NG)%BUFLY(IL)%IPORO= 0  
               ELBUF_TAB(NG)%BUFLY(IL)%NFAIL = NFAIL                          
               DO J = 1,NFAIL                                              
-                IRUPT = IPM(111 + (J-1)*15, IMAT(IL))   ! modele de rupture 
-                TFAIL(IL,J) = IRUPT       
+                IRUPT  = IPM(111 + (J-1)*15, IMAT(IL))   ! modele de rupture 
+                IDFAIL = IPM(236 + J, IMAT(IL)) 
+                TFAIL(IL,J)  = IRUPT 
+                FAILID(IL,J) = IDFAIL      
               ENDDO                                                         
               IF (MLAW_TAG(IMAT(IL))%L_PLA == 0 .and. IPARG(10,NG) == 2) THEN
                 IPARG(10,NG) = 0  ! ICPRE
@@ -549,8 +559,10 @@ c---
             ELBUF_TAB(NG)%BUFLY(1)%IPORO= 0                                           
             ELBUF_TAB(NG)%BUFLY(1)%NFAIL = NFAIL                                     
             DO J = 1,NFAIL                                                             
-              IRUPT = IPM(111 + (J-1)*15, IMID)   ! modele de rupture                
-              TFAIL(1,J) = IRUPT                                                       
+              IRUPT  = IPM(111 + (J-1)*15, IMID)   ! modele de rupture
+              IDFAIL = IPM(236 + J, IMID)                
+              TFAIL(1,J)  = IRUPT
+              FAILID(1,J) = IDFAIL                                                       
             ENDDO                                                                     
 c---
           ENDIF                                               
@@ -582,10 +594,14 @@ c
 
                 DO J = 1,NFAIL
                   FLOC=>ELBUF_TAB(NG)%BUFLY(IL)%FAIL(IR,IS,IT)%FLOC(J)         
-                  IRUPT = TFAIL(IL,J)     
+                  IRUPT  = TFAIL(IL,J)  
+                  IDFAIL = FAILID(IL,J)   
 c
                   FLOC%ILAWF = IRUPT                                           
                   LFAIL = LFAIL + 1 
+c
+                  FLOC%IDFAIL = IDFAIL
+                  LFAIL = LFAIL + 1
 c
                   FLOC%NVAR  = FAIL_TAG(IRUPT)%NUVAR                              
                   MY_ALLOCATE(FLOC%VAR,FLOC%NVAR*NEL)
@@ -977,6 +993,7 @@ c-------------------------------------------------
      .                   IGTYP)
 c-------------------------------------------------
           DEALLOCATE(TFAIL)
+          DEALLOCATE(FAILID)
           DEALLOCATE(IMAT)
           DEALLOCATE(ILAW)
 c
@@ -1051,10 +1068,12 @@ c          print*,'nel,ISTRA, ISMSTR=',nel,ISTRA, ISMSTR
 c
           MAXFLAY = 7          ! max Nb of failure models per mat
           MY_ALLOCATE2D(TFAIL,NLAY,MAXFLAY)
+          MY_ALLOCATE2D(FAILID,NLAY,MAXFLAY)
           MY_ALLOCATE(IMAT,NLAY)
           MY_ALLOCATE(ILAW,NLAY)
 c
           TFAIL(:,:) = 0
+          FAILID(:,:) = 0
           ILAW(:)    = 0
           IMAT(:)    = 0
 c-------------------------------------------------
@@ -1229,8 +1248,10 @@ c-----------------------------------------------
               ELBUF_TAB(NG)%BUFLY(IL)%NVAR_VISC = 0
 
               DO J = 1, NFAIL                                            
-                IRUPT = IPM(111+ (J-1)*15, IMAT(IL))   ! modele de rupture      
-                TFAIL(IL,J) = IRUPT       
+                IRUPT  = IPM(111 + (J-1)*15,IMAT(IL))   ! modele de rupture 
+                IDFAIL = IPM(236 + J,IMAT(IL))
+                TFAIL(IL,J)  = IRUPT  
+                FAILID(IL,J) = IDFAIL    
               ENDDO                                                           
             ENDDO                                       
           ENDIF       
@@ -1268,6 +1289,10 @@ c
                   FLOC=>ELBUF_TAB(NG)%BUFLY(IL)%FAIL(IR,IS,IT)%FLOC(J)         
                   IRUPT = TFAIL(IL,J)     
                   FLOC%ILAWF = IRUPT
+                  LFAIL = LFAIL + 1 
+c
+                  IDFAIL = FAILID(IL,J)     
+                  FLOC%IDFAIL = IDFAIL
                   LFAIL = LFAIL + 1 
 c
                   FLOC%NVAR  = FAIL_TAG(IRUPT)%NUVAR                              
@@ -1315,7 +1340,8 @@ c---      Inter layer variables
 c
           DO I=1,NINTLAY
             DO J=1,MAXFLAY
-              TFAIL(I,J) = 0
+              TFAIL(I,J)  = 0
+              FAILID(I,J) = 0
             ENDDO
             ILAW(I) = 0
             IMAT(I) = 0
@@ -1337,8 +1363,10 @@ c            ELBUF_TAB(NG)%INTLAY(IL)%IVISC= LAW_VIS
 c            ELBUF_TAB(NG)%INTLAY(IL)%NVAR_VISC=VISC_TAG(LAW_VIS)%NUVAR       
 c            ELBUF_TAB(NG)%INTLAY(IL)%NVAR_VISC = 0                           
             DO J = 1, NFAIL                                                   
-              IRUPT = IPM(111+ (J-1)*15, IMAT(IL))   ! modele de rupture           
-              TFAIL(IL,J) = IRUPT                                             
+              IRUPT  = IPM(111 + (J-1)*15, IMAT(IL))   ! modele de rupture           
+              IDFAIL = IPM(236 + J, IMAT(IL))
+              TFAIL(IL,J)  = IRUPT 
+              FAILID(IL,J) = IDFAIL                                            
             ENDDO                                                               
           ENDDO                                                               
 c
@@ -1359,7 +1387,9 @@ c                LVISC = LVISC + NUVARV*NEL
                 DO J = 1,NFAIL                                                     
                   FLOC=>ELBUF_TAB(NG)%INTLAY(IL)%FAIL(IR,IS)%FLOC(J)           
                   IRUPT = TFAIL(IL,J)                                              
-                  FLOC%ILAWF = IRUPT                                               
+                  FLOC%ILAWF = IRUPT  
+                  IDFAIL = FAILID(IL,J)
+                  FLOC%IDFAIL = IDFAIL                                             
                   FLOC%NVAR  = FAIL_TAG(IRUPT)%NUVAR                                
                   MY_ALLOCATE(FLOC%VAR,FLOC%NVAR*NEL)
                   FLOC%VAR = ZERO                                                   
@@ -1822,6 +1852,7 @@ c-------------------------------------------------
      .                       IGTYP)
 c-------------------------------------------------
           DEALLOCATE(TFAIL)
+          DEALLOCATE(FAILID)
           DEALLOCATE(IMAT)
           DEALLOCATE(ILAW)
 c---

--- a/starter/source/materials/mat/mat104/law104_upd.F
+++ b/starter/source/materials/mat/mat104/law104_upd.F
@@ -104,15 +104,15 @@ c
         IF (ILOC>0) THEN
           NLOC_DMG%LEN(IMAT) = MAX(NLOC_DMG%LEN(IMAT), RLEN)
           CALL GET_LEMAX(NLOC_DMG%LE_MAX(IMAT),NLOC_DMG%LEN(IMAT))
+          MLAW_TAG%G_PLANL  = 1
+          MLAW_TAG%L_PLANL  = 1
+          MLAW_TAG%G_EPSDNL = 1
+          MLAW_TAG%L_EPSDNL = 1
         ENDIF
 c
         ! Tag for damage output
         MLAW_TAG%G_DMG    = 1
         MLAW_TAG%L_DMG    = 1
-        MLAW_TAG%G_PLANL  = 1
-        MLAW_TAG%L_PLANL  = 1
-        MLAW_TAG%G_EPSDNL = 1
-        MLAW_TAG%L_EPSDNL = 1
 c
         ! Update MATPARAM 
         CALL INIT_MAT_KEYWORD(MATPARAM ,"COMPRESSIBLE")

--- a/starter/source/restart/ddsplit/w_elbuf_str.F
+++ b/starter/source/restart/ddsplit/w_elbuf_str.F
@@ -52,7 +52,7 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,J,K,IL,IR,IS,IT,NG,NEL,NPT,P,L_REL,BUFLEN,NUVAR,NVARTMP,
-     .   ITY,IGTYP,ERR,IFAIL,DEBUG_PRINT,IAD,
+     .   ITY,IGTYP,ERR,IFAIL,IDFAIL,DEBUG_PRINT,IAD,
      .   NFAIL,IXFEM,IVISC,II,NINTLAY,NPG,IPT,NPTT,NPTTOT,INLOC,NONL
       INTEGER ! global variables
      .   G_GAMA,G_SIG,G_OFF,G_NOFF,G_EINT,G_EINS,G_TEMP,
@@ -774,6 +774,7 @@ c
                   DO K = 1,NFAIL   
                     FLOC=>ELBUF_TAB(NG)%BUFLY(IL)%FAIL(IR,IS,IT)%FLOC(K)
                     IFAIL = FLOC%ILAWF
+                    IDFAIL = FLOC%IDFAIL
                     NUVAR = FLOC%NVAR
                     LF_DAM= FLOC%LF_DAM
                     LF_DAMMX= FLOC%LF_DAMMX
@@ -784,6 +785,8 @@ c
 c
                     RBUF_L(L_REL+1)=IFAIL
                       L_REL = L_REL+1
+                    RBUF_L(L_REL+1)=IDFAIL
+                      L_REL = L_REL+1                      
                     RBUF_L(L_REL+1)=NUVAR
                       L_REL = L_REL+1
                     RBUF_L(L_REL+1)=LF_DAM
@@ -988,10 +991,13 @@ c
               DO IS = 1,ELBUF%NPTS                                           
                 DO K = 1,NFAIL                                           
                   FLOC=>ELBUF_TAB(NG)%INTLAY(IL)%FAIL(IR,IS)%FLOC(K)  
-                  IFAIL = FLOC%ILAWF                                     
+                  IFAIL = FLOC%ILAWF
+                  IDFAIL = FLOC%IDFAIL                                     
                   NUVAR = FLOC%NVAR                                      
                   RBUF_L(L_REL+1)=IFAIL                                  
-                    L_REL = L_REL+1                                      
+                    L_REL = L_REL+1 
+                  RBUF_L(L_REL+1)=IDFAIL                                  
+                    L_REL = L_REL+1                                                         
                   RBUF_L(L_REL+1)=NUVAR                                  
                     L_REL = L_REL+1                                      
                   RBUF_L(L_REL+1:L_REL+NEL*NUVAR)=FLOC%VAR(1:NEL*NUVAR)                        


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

There was a need to be able to output the damage variable in .h3d files for a specific failure criterion using its ID defined in the starter. This is particularly interesting when several failure criteria are attached to the same material law like for composite material laws.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Implementation of /H3D/ELEM/FAILURE/ID=XX keeping the /H3D/ELEM/DAMA options like PLY, LAYER, NPT, IR, IS , IT ... This work is done for solids and shells and was partially coded with @sebastienVilleneuve 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
