### PR TITLE
Add possibility to use /H3D/QUAD/HOURGLASS

### DIFF
--- a/engine/source/elements/solid_2d/quad/qhvis2.F
+++ b/engine/source/elements/solid_2d/quad/qhvis2.F
@@ -226,11 +226,9 @@ C
         EHOUR = EHOUR + EHOURT
 #include "atomend.inc"
 C
-      IF((ANIM_E(25)==1).OR.(OUTP_CS(25)==1))THEN
-        DO I=LFT,LLT
-          EANI(NFT+I) = EANI(NFT+I)+EHOU(I)/MAX(EM30,RHO(I)*AREA(I))
-        ENDDO
-      ENDIF
+      DO I=LFT,LLT
+        EANI(NFT+I) = EANI(NFT+I)+EHOU(I)/MAX(EM30,RHO(I)*AREA(I))
+      ENDDO
 C
       RETURN
       END


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

The H3D / ANIM output of hourglass energy for QUAD element was conditioned to the keyword /ANIM/QUAD/HOURGLASS avoiding the possibility to plot Hourglass energy for quads in .h3d files. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Remove a very old condition that disabled the filling of EANI table that stored the hourglass energy. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
