### PR TITLE
law 120 damage correction + DAMG for H3D output

### DIFF
--- a/engine/source/materials/mat/mat120/sigeps120.F
+++ b/engine/source/materials/mat/mat120/sigeps120.F
@@ -40,7 +40,7 @@ Chd|====================================================================
      5           DEPSXX  ,DEPSYY  ,DEPSZZ  ,DEPSXY  ,DEPSYZ  ,DEPSZX  ,
      6           SIGOXX  ,SIGOYY  ,SIGOZZ  ,SIGOXY  ,SIGOYZ  ,SIGOZX  ,
      7           SIGNXX  ,SIGNYY  ,SIGNZZ  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
-     8           JTHE    ,INLOC   ,DPLANL  ,DMG)
+     8           JTHE    ,INLOC   ,DPLANL  ,DMG     ,DMG_SCALE)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -68,7 +68,7 @@ C----------------------------------------------------------------
      .         SIGOXX,SIGOYY,SIGOZZ,SIGOXY,SIGOYZ,SIGOZX
       my_real, DIMENSION(NEL) ,INTENT(INOUT) :: EPSD,SOUNDSP,
      .         SIGNXX,SIGNYY,SIGNZZ,SIGNXY,SIGNYZ,SIGNZX
-      my_real ,DIMENSION(NEL)         ,INTENT(INOUT) :: PLA,DPLANL,OFF,DMG
+      my_real ,DIMENSION(NEL)         ,INTENT(INOUT) :: PLA,DPLANL,OFF,DMG,DMG_SCALE
       my_real ,DIMENSION(NEL,NUVAR)   ,INTENT(INOUT) :: UVAR
       INTEGER ,DIMENSION(NEL,NVARTMP) ,INTENT(INOUT) :: VARTMP
       TYPE(TTABLE) ,DIMENSION(NTABLE) ,INTENT(IN)    :: TABLE
@@ -91,7 +91,7 @@ c------------------------------------------------------------------
      5         SIGOXX  ,SIGOYY  ,SIGOZZ  ,SIGOXY  ,SIGOYZ  ,SIGOZX  ,
      6         SIGNXX  ,SIGNYY  ,SIGNZZ  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
      7         NUMTABL ,ITABLE  ,TABLE   ,NVARTMP ,VARTMP  ,TEMP    ,
-     8         JTHE    ,INLOC   ,DPLANL  ,DMG)
+     8         JTHE    ,INLOC   ,DPLANL  ,DMG     , DMG_SCALE)
         ELSE                     ! tabulated Von-Mises formulation
           CALL SIGEPS120_TAB_VM(
      1         NEL     ,NGL     ,NUPARAM ,NUVAR   ,TIME    ,TIMESTEP,
@@ -101,7 +101,7 @@ c------------------------------------------------------------------
      5         SIGOXX  ,SIGOYY  ,SIGOZZ  ,SIGOXY  ,SIGOYZ  ,SIGOZX  ,
      6         SIGNXX  ,SIGNYY  ,SIGNZZ  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
      7         NTABLE  ,ITABLE  ,TABLE   ,NVARTMP ,VARTMP  ,TEMP    ,
-     8         JTHE    ,INLOC   ,DPLANL  ,DMG)
+     8         JTHE    ,INLOC   ,DPLANL  ,DMG     , DMG_SCALE)
         END IF
 c
       ELSE
@@ -114,7 +114,7 @@ c
      4         DEPSXX  ,DEPSYY  ,DEPSZZ  ,DEPSXY  ,DEPSYZ  ,DEPSZX  ,
      5         SIGOXX  ,SIGOYY  ,SIGOZZ  ,SIGOXY  ,SIGOYZ  ,SIGOZX  ,
      6         SIGNXX  ,SIGNYY  ,SIGNZZ  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
-     7         INLOC   ,DPLANL  ,DMG)
+     7         INLOC   ,DPLANL  ,DMG     , DMG_SCALE)
         ELSE                     ! analytical Von-Mises formulation
           CALL SIGEPS120_VM(
      1         NEL     ,NGL     ,NUPARAM ,NUVAR   ,TIME    ,TIMESTEP,
@@ -123,7 +123,7 @@ c
      4         DEPSXX  ,DEPSYY  ,DEPSZZ  ,DEPSXY  ,DEPSYZ  ,DEPSZX  ,
      5         SIGOXX  ,SIGOYY  ,SIGOZZ  ,SIGOXY  ,SIGOYZ  ,SIGOZX  ,
      6         SIGNXX  ,SIGNYY  ,SIGNZZ  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
-     7         INLOC   ,DPLANL  ,DMG)
+     7         INLOC   ,DPLANL  ,DMG     , DMG_SCALE)
         END IF
       END IF
 c-----------------------------------------------------------------

--- a/engine/source/materials/mat/mat120/sigeps120_dp.F
+++ b/engine/source/materials/mat/mat120/sigeps120_dp.F
@@ -33,7 +33,7 @@ Chd|====================================================================
      4      DEPSXX  ,DEPSYY  ,DEPSZZ  ,DEPSXY  ,DEPSYZ  ,DEPSZX  ,
      5      SIGOXX  ,SIGOYY  ,SIGOZZ  ,SIGOXY  ,SIGOYZ  ,SIGOZX  ,
      6      SIGNXX  ,SIGNYY  ,SIGNZZ  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
-     7      INLOC   ,DPLANL  ,DMG)
+     7      INLOC   ,DPLANL  ,DMG     ,DMG_SCALE)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -58,7 +58,7 @@ c
       my_real ,DIMENSION(NEL) ,INTENT(OUT) :: EPSD,SOUNDSP
       my_real ,DIMENSION(NEL) ,INTENT(OUT) :: 
      .         SIGNXX,SIGNYY,SIGNZZ,SIGNXY,SIGNYZ,SIGNZX
-      my_real ,DIMENSION(NEL) ,INTENT(INOUT) :: OFF,PLA,DPLANL,DMG
+      my_real ,DIMENSION(NEL) ,INTENT(INOUT) :: OFF,PLA,DPLANL,DMG,DMG_SCALE
       my_real ,DIMENSION(NEL,NUVAR) ,INTENT(INOUT) :: UVAR
 C----------------------------------------------------------------
 C  L O C A L  V A R I B L E S
@@ -76,7 +76,7 @@ c     Local variables
      .   GAMC,GAMF,NP_XX,NP_YY,NP_ZZ,NP_XY,NP_YZ,NP_ZX,
      .   NF_XX,NF_YY,NF_ZZ,NF_XY,NF_YZ,NF_ZX,DPXX,DPYY,DPZZ,DPXY,DPYZ,DPZX
       my_real ,DIMENSION(NEL) :: I1,J2,A1,A2,YLD,PHI,DAM,FDAM,JCRATE,
-     .   SXX,SYY,SZZ,SXY,SYZ,SZX,DPLA,JCR_LOG,GAMMA,DGAMM,PLA_NL,DPDT_NL
+     .   SXX,SYY,SZZ,SXY,SYZ,SZX,DPLA,JCR_LOG,GAMMA,GAMMAV,DGAMM,PLA_NL,DPDT_NL
 c--------------------------------
 c     Material parameters
 c--------------------------------
@@ -172,19 +172,20 @@ c
 c------------------------------------------------------------------
 c     Computation of the nominal trial stress tensor (non damaged)
 c------------------------------------------------------------------
-      DAM (1:NEL) = DMG(1:NEL)
-      FDAM(1:NEL) = ONE - DAM(1:NEL)
+      DAM (1:NEL) = DMG(1:NEL)  
+      DPLA(1:NEL)   = ZERO          
+
 c
       DO I = 1,NEL
         IF (OFF(I) < 0.001) OFF(I) = ZERO
         IF (OFF(I) < ONE)    OFF(I) = OFF(I)*FOUR_OVER_5
         IF (OFF(I) == ONE) THEN
-          SIGNXX(I) = SIGOXX(I)/FDAM(I) + C11*DEPSXX(I) + C12*(DEPSYY(I) + DEPSZZ(I))
-          SIGNYY(I) = SIGOYY(I)/FDAM(I) + C11*DEPSYY(I) + C12*(DEPSXX(I) + DEPSZZ(I))
-          SIGNZZ(I) = SIGOZZ(I)/FDAM(I) + C11*DEPSZZ(I) + C12*(DEPSXX(I) + DEPSYY(I))
-          SIGNXY(I) = SIGOXY(I)/FDAM(I) + DEPSXY(I)*G 
-          SIGNYZ(I) = SIGOYZ(I)/FDAM(I) + DEPSYZ(I)*G
-          SIGNZX(I) = SIGOZX(I)/FDAM(I) + DEPSZX(I)*G
+          SIGNXX(I) = SIGOXX(I) + C11*DEPSXX(I) + C12*(DEPSYY(I) + DEPSZZ(I))
+          SIGNYY(I) = SIGOYY(I) + C11*DEPSYY(I) + C12*(DEPSXX(I) + DEPSZZ(I))
+          SIGNZZ(I) = SIGOZZ(I) + C11*DEPSZZ(I) + C12*(DEPSXX(I) + DEPSYY(I))
+          SIGNXY(I) = SIGOXY(I) + DEPSXY(I)*G 
+          SIGNYZ(I) = SIGOYZ(I) + DEPSYZ(I)*G
+          SIGNZX(I) = SIGOZX(I) + DEPSZX(I)*G
           I1(I)     = SIGNXX(I) + SIGNYY(I) + SIGNZZ(I)
 c
           SXX(I) = SIGNXX(I) - I1(I) * THIRD
@@ -250,7 +251,6 @@ c
         NITER   = 4
 c
         DO ITER = 1,NITER
-
           ! normal to non associated plastic flow surface = d_psi/d_sig
           JP    = THIRD * AS * I1P
           TP    = TWO  * JP
@@ -281,7 +281,6 @@ c
           DFDPLA    = THIRD*(SQR3*A1H*YLD0*I1(I) + A2H*I1P**2)
 
           DPLA_DLAM = TWO*SQRT((J2(I) + TP*AS*I1(I)))
-          DPLA_DLAM = DPLA_DLAM / FDAM(I)
 c
           DPHI_DLAM = DFDLAM + (DFDPLA - TWO*YLD(I)*DYLD_DPLA)*DPLA_DLAM
 c----------------------------------------------------------------
@@ -302,7 +301,7 @@ c----------------------------------------------------------------
           SIGNYZ(I) = SIGNYZ(I) - G2*DPYZ  
           SIGNZX(I) = SIGNZX(I) - G2*DPZX
 c
-          ! Plastic strain increments update
+          ! Plastic strain increments update                       
           DDEP   = DLAM * DPLA_DLAM
           DPLA(I)= MAX(ZERO, DPLA(I) + DDEP)
           PLA(I) = PLA(I) + DDEP
@@ -327,6 +326,7 @@ c----------------------
           PHI(I) = J2(I) + FDP - YLD(I)**2
         END DO  ! Newton iterations
 c
+        !GAMMAV(I) = SQRT(TWO* ( DEPXX(I)**2 + DEPYY(I)**2 + DEPZZ(I)**2))
         UVAR(I,4) = PHI(I) / YLD0**2
       ENDDO   ! II = 1,NINDX
 c---------------------------------------------------------------------
@@ -343,11 +343,11 @@ c---------------------------------------------------------------------
           END IF
         ELSE
           IF (INLOC == 1) THEN
-            DGAMM(1:NEL)  = DPLANL(1:NEL) * FDAM(1:NEL)
+            DGAMM(1:NEL)  = DPLANL(1:NEL) * DMG_SCALE(1:NEL)  
             UVAR(1:NEL,1) = UVAR(1:NEL,1) + DGAMM(1:NEL)
             GAMMA (1:NEL) = UVAR(1:NEL,1)
           ELSE
-            DGAMM(1:NEL)  = DPLA(1:NEL) * FDAM(1:NEL)
+            DGAMM(1:NEL)  = DPLA(1:NEL) * DMG_SCALE(1:NEL) 
             UVAR(1:NEL,1) = UVAR(1:NEL,1) + DGAMM(1:NEL)
             GAMMA (1:NEL) = UVAR(1:NEL,1)
           END IF
@@ -355,14 +355,15 @@ c---------------------------------------------------------------------
 c
         DO II = 1,NINDX
           I = INDX(II)
-c
+          TRIAX = ZERO
+          FACT = ONE
           FACR = ONE + D_JC * JCR_LOG(I)  ! total strain rate factor on damage
-          IF (ITRX == 1) THEN
-            TRIAX = THIRD * I1(I) / SQRT(THREE*J2(I))
+          IF ( J2(I)/= ZERO)TRIAX = THIRD * I1(I) / SQRT(THREE*J2(I))
+          IF (ITRX == 1 ) THEN
             FACT  = EXP(-D_TRX*TRIAX)
-          ELSE IF (I1(I) <= ZERO) THEN  ! ITRX = 2 => no triaxiality influence in compression
-            FACT = ONE
-          END IF
+          ELSE
+           IF (TRIAX > ZERO )FACT  = EXP(-D_TRX*TRIAX)
+          ENDIF
           GAMC = (D1C + D2C * FACT) * FACR
           GAMF = (D1F + D2F * FACT) * FACR
           IF (GAMMA(I) > GAMC) THEN
@@ -383,15 +384,9 @@ c
             DMG(I) = DAM(I)
           END IF ! GAMMA > GAMC
         ENDDO
-c       Update damaged stress
-        DO I = 1, NEL
-          FACD = ONE - DAM(I)
-          SIGNXX(I) = SIGNXX(I) * FACD
-          SIGNYY(I) = SIGNYY(I) * FACD
-          SIGNZZ(I) = SIGNZZ(I) * FACD
-          SIGNXY(I) = SIGNXY(I) * FACD
-          SIGNYZ(I) = SIGNYZ(I) * FACD
-          SIGNZX(I) = SIGNZX(I) * FACD        
+c       Update damaged stress 
+        DO I = 1, NEL         
+          DMG_SCALE(I) = ONE - DAM(I)   
         END DO
       END IF
 c-------------------------

--- a/engine/source/materials/mat/mat120/sigeps120_tab_dp.F
+++ b/engine/source/materials/mat/mat120/sigeps120_tab_dp.F
@@ -37,7 +37,7 @@ Chd|====================================================================
      5      SIGOXX  ,SIGOYY  ,SIGOZZ  ,SIGOXY  ,SIGOYZ  ,SIGOZX  ,
      6      SIGNXX  ,SIGNYY  ,SIGNZZ  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
      7      NUMTABL ,ITABLE  ,TABLE   ,NVARTMP ,VARTMP  ,TEMP    ,
-     8      JTHE    ,INLOC   ,DPLANL  ,DMG)
+     8      JTHE    ,INLOC   ,DPLANL  ,DMG     ,DMG_SCALE)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -71,7 +71,7 @@ c
      .         SIGNXX,SIGNYY,SIGNZZ,SIGNXY,SIGNYZ,SIGNZX
       INTEGER,DIMENSION(NEL,NVARTMP) ,INTENT(INOUT) :: VARTMP
       my_real ,DIMENSION(NEL,NUVAR)   ,INTENT(INOUT) :: UVAR
-      my_real ,DIMENSION(NEL) ,INTENT(INOUT) :: OFF,PLA,DPLANL,DMG
+      my_real ,DIMENSION(NEL) ,INTENT(INOUT) :: OFF,PLA,DPLANL,DMG,DMG_SCALE
       TYPE(TTABLE), DIMENSION(NTABLE) ::  TABLE
 C----------------------------------------------------------------
 C  L O C A L  V A R I B L E S
@@ -92,7 +92,7 @@ c     Local variables
      .   DLAM,DDEP,DFDLAM,DFDPLA,DPLA_DLAM,DPHI_DLAM,
      .   GAMC,GAMF,NP_XX,NP_YY,NP_ZZ,NP_XY,NP_YZ,NP_ZX,
      .   NF_XX,NF_YY,NF_ZZ,NF_XY,NF_YZ,NF_ZX,DPXX,DPYY,DPZZ,DPXY,DPYZ,DPZX
-      my_real ,DIMENSION(NEL) :: I1,J2,A1,A2,YLD,PHI,DAM,FDAM,JCRATE,
+      my_real ,DIMENSION(NEL) :: I1,J2,A1,A2,YLD,PHI,DAM,JCRATE,
      .   SXX,SYY,SZZ,SXY,SYZ,SZX,DPLA,JCR_LOG,GAMMA,DGAMM,HARDP,FDP,
      .   YLD_I,HARDP_I,PLA_NL,DPDT_NL
 c--------------------------------
@@ -192,19 +192,19 @@ c
 c------------------------------------------------------------------
 c     Computation of the nominal trial stress tensor (non damaged)
 c------------------------------------------------------------------
-      DAM (1:NEL) = DMG(1:NEL)
-      FDAM(1:NEL) = ONE - DAM(1:NEL)
+      DAM (1:NEL) = DMG(1:NEL)  
+      DPLA(1:NEL)   = ZERO          
 c
       DO I = 1,NEL
         IF (OFF(I) < 0.001) OFF(I) = ZERO
         IF (OFF(I) < ONE)    OFF(I) = OFF(I)*FOUR_OVER_5
         IF (OFF(I) == ONE) THEN
-          SIGNXX(I) = SIGOXX(I)/FDAM(I) + C11*DEPSXX(I) + C12*(DEPSYY(I) + DEPSZZ(I))
-          SIGNYY(I) = SIGOYY(I)/FDAM(I) + C11*DEPSYY(I) + C12*(DEPSXX(I) + DEPSZZ(I))
-          SIGNZZ(I) = SIGOZZ(I)/FDAM(I) + C11*DEPSZZ(I) + C12*(DEPSXX(I) + DEPSYY(I))
-          SIGNXY(I) = SIGOXY(I)/FDAM(I) + DEPSXY(I)*G 
-          SIGNYZ(I) = SIGOYZ(I)/FDAM(I) + DEPSYZ(I)*G
-          SIGNZX(I) = SIGOZX(I)/FDAM(I) + DEPSZX(I)*G
+          SIGNXX(I) = SIGOXX(I) + C11*DEPSXX(I) + C12*(DEPSYY(I) + DEPSZZ(I))
+          SIGNYY(I) = SIGOYY(I) + C11*DEPSYY(I) + C12*(DEPSXX(I) + DEPSZZ(I))
+          SIGNZZ(I) = SIGOZZ(I) + C11*DEPSZZ(I) + C12*(DEPSXX(I) + DEPSYY(I))
+          SIGNXY(I) = SIGOXY(I) + DEPSXY(I)*G 
+          SIGNYZ(I) = SIGOYZ(I) + DEPSYZ(I)*G
+          SIGNZX(I) = SIGOZX(I) + DEPSZX(I)*G
           I1(I)     = SIGNXX(I) + SIGNYY(I) + SIGNZZ(I)
 c
           SXX(I) = SIGNXX(I) - I1(I) * THIRD
@@ -343,7 +343,6 @@ c
             DFDPLA    = THIRD*(SQR3*A1H*YLD0*I1(I) + A2H*I1P**2)
 
             DPLA_DLAM = TWO*SQRT((J2(I) + TP*AS*I1(I)))
-            DPLA_DLAM = DPLA_DLAM / FDAM(I)
 c
             DPHI_DLAM = DFDLAM + (DFDPLA - TWO*YLD(I)*HARDP(I))*DPLA_DLAM            
 c----------------------------------------------------------------
@@ -463,11 +462,11 @@ c---------------------------------------------------------------------
           END IF
         ELSE
           IF (INLOC == 1) THEN
-            DGAMM(1:NEL)  = DPLANL(1:NEL) * FDAM(1:NEL)
+            DGAMM(1:NEL)  = DPLANL(1:NEL) * DMG_SCALE(1:NEL)  
             UVAR(1:NEL,1) = UVAR(1:NEL,1) + DGAMM(1:NEL)
             GAMMA (1:NEL) = UVAR(1:NEL,1)
           ELSE
-            DGAMM(1:NEL)  = DPLA(1:NEL) * FDAM(1:NEL)
+            DGAMM(1:NEL)  = DPLA(1:NEL) * DMG_SCALE(1:NEL)  
             UVAR(1:NEL,1) = UVAR(1:NEL,1) + DGAMM(1:NEL)
             GAMMA (1:NEL) = UVAR(1:NEL,1)
           END IF
@@ -476,13 +475,15 @@ c
         DO II = 1,NINDX
           I = INDX(II)
 c
+          TRIAX = ZERO
+          FACT = ONE
           FACR = ONE + D_JC * JCR_LOG(I)  ! total strain rate factor on damage
-          IF (ITRX == 1) THEN
-            TRIAX = THIRD * I1(I) / SQRT(THREE*J2(I))
+          IF ( J2(I)/= ZERO)TRIAX = THIRD * I1(I) / SQRT(THREE*J2(I))
+          IF (ITRX == 1 ) THEN
             FACT  = EXP(-D_TRX*TRIAX)
-          ELSE IF (I1(I) <= ZERO) THEN  ! ITRX = 2 => no triaxiality influence in compression
-            FACT = ONE
-          END IF
+          ELSE
+           IF (TRIAX > ZERO )FACT  = EXP(-D_TRX*TRIAX)
+          ENDIF
           GAMC = (D1C + D2C * FACT) * FACR
           GAMF = (D1F + D2F * FACT) * FACR
           IF (GAMMA(I) > GAMC) THEN
@@ -505,13 +506,7 @@ c
         ENDDO
 c       Update damaged stress
         DO I = 1, NEL
-          FACD = ONE - DAM(I)
-          SIGNXX(I) = SIGNXX(I) * FACD
-          SIGNYY(I) = SIGNYY(I) * FACD
-          SIGNZZ(I) = SIGNZZ(I) * FACD
-          SIGNXY(I) = SIGNXY(I) * FACD
-          SIGNYZ(I) = SIGNYZ(I) * FACD
-          SIGNZX(I) = SIGNZX(I) * FACD        
+          DMG_SCALE(I) = ONE - DAM(I)   
         END DO
       END IF
 c-------------------------

--- a/engine/source/materials/mat/mat120/sigeps120_tab_vm.F
+++ b/engine/source/materials/mat/mat120/sigeps120_tab_vm.F
@@ -37,7 +37,7 @@ Chd|====================================================================
      5      SIGOXX  ,SIGOYY  ,SIGOZZ  ,SIGOXY  ,SIGOYZ  ,SIGOZX  ,
      6      SIGNXX  ,SIGNYY  ,SIGNZZ  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
      7      NUMTABL ,ITABLE  ,TABLE   ,NVARTMP ,VARTMP  ,TEMP    ,
-     8      JTHE    ,INLOC   ,DPLANL  ,DMG)
+     8      JTHE    ,INLOC   ,DPLANL  ,DMG     ,DMG_SCALE)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -71,7 +71,7 @@ c
      .         SIGNXX,SIGNYY,SIGNZZ,SIGNXY,SIGNYZ,SIGNZX
       INTEGER ,DIMENSION(NEL,NVARTMP) ,INTENT(INOUT) :: VARTMP
       my_real ,DIMENSION(NEL,NUVAR)   ,INTENT(INOUT) :: UVAR
-      my_real ,DIMENSION(NEL) ,INTENT(INOUT) :: OFF,PLA,DPLANL,DMG
+      my_real ,DIMENSION(NEL) ,INTENT(INOUT) :: OFF,PLA,DPLANL,DMG,DMG_SCALE
       TYPE(TTABLE), DIMENSION(NTABLE) ::  TABLE
 C----------------------------------------------------------------
 C  L O C A L  V A R I B L E S
@@ -92,7 +92,7 @@ c     Local variables
      .   DLAM,DDEP,DFDLAM,DPLA_DLAM,DPHI_DLAM,
      .   GAMC,GAMF,NP_XX,NP_YY,NP_ZZ,NP_XY,NP_YZ,NP_ZX,
      .   NF_XX,NF_YY,NF_ZZ,NF_XY,NF_YZ,NF_ZX,DPXX,DPYY,DPZZ,DPXY,DPYZ,DPZX
-      my_real ,DIMENSION(NEL) :: I1,J2,YLD,PHI,DAM,FDAM,JCRATE,
+      my_real ,DIMENSION(NEL) :: I1,J2,YLD,PHI,DAM,JCRATE,
      .   SXX,SYY,SZZ,SXY,SYZ,SZX,DPLA,JCR_LOG,GAMMA,DGAMM,HARDP,FVM,
      .   YLD_I,HARDP_I,PLA_NL,DPDT_NL
 c--------------------------------
@@ -192,19 +192,19 @@ c
 c------------------------------------------------------------------
 c     Computation of the nominal trial stress tensor (non damaged)
 c------------------------------------------------------------------
-      DAM (1:NEL) = DMG(1:NEL)
-      FDAM(1:NEL) = ONE - DAM(1:NEL)
+      DAM (1:NEL) = DMG(1:NEL)  
+      DPLA(1:NEL)   = ZERO          
 c
       DO I = 1,NEL
         IF (OFF(I) < 0.001) OFF(I) = ZERO
         IF (OFF(I) < ONE)    OFF(I) = OFF(I)*FOUR_OVER_5
         IF (OFF(I) == ONE) THEN
-          SIGNXX(I) = SIGOXX(I)/FDAM(I) + C11*DEPSXX(I) + C12*(DEPSYY(I) + DEPSZZ(I))
-          SIGNYY(I) = SIGOYY(I)/FDAM(I) + C11*DEPSYY(I) + C12*(DEPSXX(I) + DEPSZZ(I))
-          SIGNZZ(I) = SIGOZZ(I)/FDAM(I) + C11*DEPSZZ(I) + C12*(DEPSXX(I) + DEPSYY(I))
-          SIGNXY(I) = SIGOXY(I)/FDAM(I) + DEPSXY(I)*G 
-          SIGNYZ(I) = SIGOYZ(I)/FDAM(I) + DEPSYZ(I)*G
-          SIGNZX(I) = SIGOZX(I)/FDAM(I) + DEPSZX(I)*G
+          SIGNXX(I) = SIGOXX(I) + C11*DEPSXX(I) + C12*(DEPSYY(I) + DEPSZZ(I))
+          SIGNYY(I) = SIGOYY(I) + C11*DEPSYY(I) + C12*(DEPSXX(I) + DEPSZZ(I))
+          SIGNZZ(I) = SIGOZZ(I) + C11*DEPSZZ(I) + C12*(DEPSXX(I) + DEPSYY(I))
+          SIGNXY(I) = SIGOXY(I) + DEPSXY(I)*G 
+          SIGNYZ(I) = SIGOYZ(I) + DEPSYZ(I)*G
+          SIGNZX(I) = SIGOZX(I) + DEPSZX(I)*G
           I1(I)     = SIGNXX(I) + SIGNYY(I) + SIGNZZ(I)
 c
           SXX(I) = SIGNXX(I) - I1(I) * THIRD
@@ -340,7 +340,6 @@ c
      .             -(NF_XY*NP_XY + NF_YZ*NP_YZ + NF_ZX*NP_ZX)*TWO*G2
 c
             DPLA_DLAM = TWO*SQRT((J2(I) + TP*AS*I1(I)))
-            DPLA_DLAM = DPLA_DLAM / FDAM(I)
             DPHI_DLAM = DFDLAM - TWO*YLD(I)*HARDP(I)*DPLA_DLAM
 c----------------------------------------------------------------
             DLAM = -PHI(I) / DPHI_DLAM
@@ -457,11 +456,11 @@ c---------------------------------------------------------------------
           END IF
         ELSE
           IF (INLOC == 1) THEN
-            DGAMM(1:NEL)  = DPLANL(1:NEL) * FDAM(1:NEL)
+            DGAMM(1:NEL)  = DPLANL(1:NEL) * DMG_SCALE(1:NEL)
             UVAR(1:NEL,1) = UVAR(1:NEL,1) + DGAMM(1:NEL)
             GAMMA (1:NEL) = UVAR(1:NEL,1)
           ELSE
-            DGAMM(1:NEL)  = DPLA(1:NEL) * FDAM(1:NEL)
+            DGAMM(1:NEL)  = DPLA(1:NEL) * DMG_SCALE(1:NEL)
             UVAR(1:NEL,1) = UVAR(1:NEL,1) + DGAMM(1:NEL)
             GAMMA (1:NEL) = UVAR(1:NEL,1)
           END IF
@@ -470,13 +469,15 @@ c
         DO II = 1,NINDX
           I = INDX(II)
 c
+          TRIAX = ZERO
+          FACT = ONE
           FACR = ONE + D_JC * JCR_LOG(I)  ! total strain rate factor on damage
-          IF (ITRX == 1) THEN
-            TRIAX = THIRD * I1(I) / SQRT(THREE*J2(I))
+          IF ( J2(I)/= ZERO)TRIAX = THIRD * I1(I) / SQRT(THREE*J2(I))
+          IF (ITRX == 1 ) THEN
             FACT  = EXP(-D_TRX*TRIAX)
-          ELSE IF (I1(I) <= ZERO) THEN  ! ITRX = 2 => no triaxiality influence in compression
-            FACT = ONE
-          END IF
+          ELSE
+           IF (TRIAX > ZERO )FACT  = EXP(-D_TRX*TRIAX)
+          ENDIF
           GAMC = (D1C + D2C * FACT) * FACR
           GAMF = (D1F + D2F * FACT) * FACR
           IF (GAMMA(I) > GAMC) THEN
@@ -499,13 +500,7 @@ c
         ENDDO
 c       Update damaged stress
         DO I = 1, NEL
-          FACD = ONE - DAM(I)
-          SIGNXX(I) = SIGNXX(I) * FACD
-          SIGNYY(I) = SIGNYY(I) * FACD
-          SIGNZZ(I) = SIGNZZ(I) * FACD
-          SIGNXY(I) = SIGNXY(I) * FACD
-          SIGNYZ(I) = SIGNYZ(I) * FACD
-          SIGNZX(I) = SIGNZX(I) * FACD        
+          DMG_SCALE(I) = ONE - DAM(I)   
         END DO
       END IF
 c-------------------------

--- a/engine/source/materials/mat/mat120/sigeps120_vm.F
+++ b/engine/source/materials/mat/mat120/sigeps120_vm.F
@@ -33,7 +33,7 @@ Chd|====================================================================
      4      DEPSXX  ,DEPSYY  ,DEPSZZ  ,DEPSXY  ,DEPSYZ  ,DEPSZX  ,
      5      SIGOXX  ,SIGOYY  ,SIGOZZ  ,SIGOXY  ,SIGOYZ  ,SIGOZX  ,
      6      SIGNXX  ,SIGNYY  ,SIGNZZ  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
-     7      INLOC   ,DPLANL  ,DMG)
+     7      INLOC   ,DPLANL  ,DMG     , DMG_SCALE)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -58,7 +58,7 @@ c
       my_real ,DIMENSION(NEL) ,INTENT(OUT) :: EPSD,SOUNDSP
       my_real ,DIMENSION(NEL) ,INTENT(OUT) :: 
      .         SIGNXX,SIGNYY,SIGNZZ,SIGNXY,SIGNYZ,SIGNZX
-      my_real ,DIMENSION(NEL) ,INTENT(INOUT) :: OFF,PLA,DPLANL,DMG
+      my_real ,DIMENSION(NEL) ,INTENT(INOUT) :: OFF,PLA,DPLANL,DMG,DMG_SCALE
       my_real ,DIMENSION(NEL,NUVAR) ,INTENT(INOUT) :: UVAR
 C----------------------------------------------------------------
 C  L O C A L  V A R I B L E S
@@ -75,7 +75,7 @@ c     Local variables
      .   DLAM,DDEP,DFDLAM,DYLD_DPLA,DPLA_DLAM,DPHI_DLAM,
      .   GAMC,GAMF,NP_XX,NP_YY,NP_ZZ,NP_XY,NP_YZ,NP_ZX,
      .   NF_XX,NF_YY,NF_ZZ,NF_XY,NF_YZ,NF_ZX,DPXX,DPYY,DPZZ,DPXY,DPYZ,DPZX
-      my_real ,DIMENSION(NEL) :: I1,J2,YLD,PHI,DAM,FDAM,JCRATE,
+      my_real ,DIMENSION(NEL) :: I1,J2,YLD,PHI,DAM,JCRATE,
      .   SXX,SYY,SZZ,SXY,SYZ,SZX,DPLA,JCR_LOG,GAMMA,DGAMM,PLA_NL,DPDT_NL
 c--------------------------------
 c     Material parameters
@@ -172,19 +172,19 @@ c
 c------------------------------------------------------------------
 c     Computation of the nominal trial stress tensor (non damaged)
 c------------------------------------------------------------------
-      DAM (1:NEL) = DMG(1:NEL)
-      FDAM(1:NEL) = ONE - DAM(1:NEL)
+      DAM (1:NEL) = DMG(1:NEL)  
+      DPLA(1:NEL)   = ZERO          
 c
       DO I = 1,NEL
         IF (OFF(I) < 0.001) OFF(I) = ZERO
         IF (OFF(I) < ONE)    OFF(I) = OFF(I)*FOUR_OVER_5
         IF (OFF(I) == ONE) THEN
-          SIGNXX(I) = SIGOXX(I)/FDAM(I) + C11*DEPSXX(I) + C12*(DEPSYY(I) + DEPSZZ(I))
-          SIGNYY(I) = SIGOYY(I)/FDAM(I) + C11*DEPSYY(I) + C12*(DEPSXX(I) + DEPSZZ(I))
-          SIGNZZ(I) = SIGOZZ(I)/FDAM(I) + C11*DEPSZZ(I) + C12*(DEPSXX(I) + DEPSYY(I))
-          SIGNXY(I) = SIGOXY(I)/FDAM(I) + DEPSXY(I)*G 
-          SIGNYZ(I) = SIGOYZ(I)/FDAM(I) + DEPSYZ(I)*G
-          SIGNZX(I) = SIGOZX(I)/FDAM(I) + DEPSZX(I)*G
+          SIGNXX(I) = SIGOXX(I)  + C11*DEPSXX(I) + C12*(DEPSYY(I) + DEPSZZ(I))
+          SIGNYY(I) = SIGOYY(I)  + C11*DEPSYY(I) + C12*(DEPSXX(I) + DEPSZZ(I))
+          SIGNZZ(I) = SIGOZZ(I)  + C11*DEPSZZ(I) + C12*(DEPSXX(I) + DEPSYY(I))
+          SIGNXY(I) = SIGOXY(I)  + DEPSXY(I)*G 
+          SIGNYZ(I) = SIGOYZ(I)  + DEPSYZ(I)*G
+          SIGNZX(I) = SIGOZX(I)  + DEPSZX(I)*G
           I1(I)     = SIGNXX(I) + SIGNYY(I) + SIGNZZ(I)
 c
           SXX(I) = SIGNXX(I) - I1(I) * THIRD
@@ -279,7 +279,6 @@ c
 c
           DYLD_DPLA = (HH + BETA*QQ*EXP(-BETA*PLA(I))) * JCRATE(I)
           DPLA_DLAM = TWO*SQRT((J2(I) + TP*AS*I1(I)))
-          DPLA_DLAM = DPLA_DLAM / FDAM(I)
           DPHI_DLAM = DFDLAM - TWO*YLD(I)*DYLD_DPLA*DPLA_DLAM
 c----------------------------------------------------------------
           DLAM = -PHI(I) / DPHI_DLAM
@@ -339,11 +338,11 @@ c---------------------------------------------------------------------
           END IF
         ELSE
           IF (INLOC == 1) THEN
-            DGAMM(1:NEL)  = DPLANL(1:NEL) * FDAM(1:NEL)
+            DGAMM(1:NEL)  = DPLANL(1:NEL) * DMG_SCALE(1:NEL)  
             UVAR(1:NEL,1) = UVAR(1:NEL,1) + DGAMM(1:NEL)
             GAMMA (1:NEL) = UVAR(1:NEL,1)
           ELSE
-            DGAMM(1:NEL)  = DPLA(1:NEL) * FDAM(1:NEL)
+            DGAMM(1:NEL)  = DPLA(1:NEL) * DMG_SCALE(1:NEL)  
             UVAR(1:NEL,1) = UVAR(1:NEL,1) + DGAMM(1:NEL)
             GAMMA (1:NEL) = UVAR(1:NEL,1)
           END IF
@@ -352,13 +351,15 @@ c
         DO II = 1,NINDX
           I = INDX(II)
 c
+          TRIAX = ZERO
+          FACT = ONE
           FACR = ONE + D_JC * JCR_LOG(I)  ! total strain rate factor on damage
-          IF (ITRX == 1) THEN
-            TRIAX = THIRD * I1(I) / SQRT(THREE*J2(I))
+          IF ( J2(I)/= ZERO)TRIAX = THIRD * I1(I) / SQRT(THREE*J2(I))
+          IF (ITRX == 1 ) THEN
             FACT  = EXP(-D_TRX*TRIAX)
-          ELSE IF (I1(I) <= ZERO) THEN  ! ITRX = 2 => no triaxiality influence in compression
-            FACT = ONE
-          END IF
+          ELSE
+           IF (TRIAX > ZERO )FACT  = EXP(-D_TRX*TRIAX)
+          ENDIF
           GAMC = (D1C + D2C * FACT) * FACR
           GAMF = (D1F + D2F * FACT) * FACR
           IF (GAMMA(I) > GAMC) THEN
@@ -381,13 +382,7 @@ c
         ENDDO
 c       Update damaged stress
         DO I = 1, NEL
-          FACD = ONE - DAM(I)
-          SIGNXX(I) = SIGNXX(I) * FACD
-          SIGNYY(I) = SIGNYY(I) * FACD
-          SIGNZZ(I) = SIGNZZ(I) * FACD
-          SIGNXY(I) = SIGNXY(I) * FACD
-          SIGNYZ(I) = SIGNYZ(I) * FACD
-          SIGNZX(I) = SIGNZX(I) * FACD        
+          DMG_SCALE(I) = ONE - DAM(I)   
         END DO
       END IF
 c-------------------------

--- a/engine/source/materials/mat_share/mulaw.F
+++ b/engine/source/materials/mat_share/mulaw.F
@@ -1716,7 +1716,7 @@ c       TAPO (toughened adhesive polymer)
      .                 DE1    ,DE2    ,DE3    ,DE4    ,DE5    ,DE6    ,
      .                 SO1    ,SO2    ,SO3    ,SO4    ,SO5    ,SO6    ,
      .                 S1     ,S2     ,S3     ,S4     ,S5     ,S6     ,
-     .                 JTHE   ,INLOC  ,VARNL  ,LBUF%DMG)
+     .                 JTHE   ,INLOC  ,VARNL  ,LBUF%DMG     ,DMG_SCALE)
 c
       ELSEIF (MTN == 121) THEN 
 c 

--- a/starter/source/materials/mat/mat120/hm_read_mat120.F
+++ b/starter/source/materials/mat/mat120/hm_read_mat120.F
@@ -158,8 +158,8 @@ c-------------------
       END IF
       IF (EXP_N == ZERO) EXP_N = ONE  
       IF (IFORM == 0) IFORM = 1  
-      IF (ITRX  == 0) ITRX  = 1  
-      IF (IDAM  == 0) IDAM  = 1  
+      IF (ITRX  == 0) ITRX  = 2  
+      IF (IDAM  == 0) IDAM  = 2  
       IF (XSCALE == ZERO) THEN
         CALL HM_GET_FLOATV_DIM('MAT_Xscale' ,XSCALE_UNIT ,IS_AVAILABLE, LSUBMODEL, UNITAB)
         XSCALE = ONE * XSCALE_UNIT
@@ -247,11 +247,14 @@ C     Formulation for solid elements time step computation.
 c-----------------
 c     Element buffer variable allocation
 c-----------------
-      MTAG%G_PLA   = 1
-      MTAG%L_PLA   = 1
-      MTAG%L_EPSD  = 1
-      MTAG%G_EPSD  = 1
-      MTAG%L_DMG   = 1
+      MTAG%G_PLA    = 1
+      MTAG%L_PLA    = 1
+      MTAG%L_EPSD   = 1
+      MTAG%G_EPSD   = 1
+      MTAG%L_DMG    = 1
+      MTAG%G_DMG    = 1
+      MTAG%L_DMGSCL = 1
+
       CALL INIT_MAT_KEYWORD(MATPARAM ,"COMPRESSIBLE")
       CALL INIT_MAT_KEYWORD(MATPARAM ,"INCREMENTAL" )
       CALL INIT_MAT_KEYWORD(MATPARAM ,"LARGE_STRAIN")


### PR DESCRIPTION
LAW120: correct damage and the dependency of triaxiality
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


Correction of the dependence on triaxiality, plus bug correction (variable initialization) 
Add DAMG for H3D output
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
