### PR TITLE
Change hourglass output name in h3d for QUAD elements

### DIFF
--- a/engine/source/output/h3d/input_list/h3d_list_quad_scalar.F
+++ b/engine/source/output/h3d/input_list/h3d_list_quad_scalar.F
@@ -147,7 +147,7 @@ c-----------------------------------------------
 c-----------------------------------------------
       I = I + 1
       H3D_KEYWORD_QUAD_SCALAR(I)%KEY3  = 'HOURGLASS'
-      H3D_KEYWORD_QUAD_SCALAR(I)%TEXT1  = 'Hourglass Energy'
+      H3D_KEYWORD_QUAD_SCALAR(I)%TEXT1  = 'Hourglass Energy per unit mass'
 c-----------------------------------------------
       IF (MULTI_FVM%IS_USED) THEN
 c


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

In h3d output files, for quads element, energy of Hourglass appeared under the name "Hourglass Energy" however, it should be "Hourglass Energy per unit mass" to be consistent with the unit. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Change the title to "Hourglass Energy per unit mass"

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
