### PR TITLE
Fix checkpoint restart issue with FLOC buffer missing value

### DIFF
--- a/engine/source/elements/elbuf/copy_elbuf_1.F
+++ b/engine/source/elements/elbuf/copy_elbuf_1.F
@@ -79,7 +79,7 @@ C-----------------------------------------------
      .   L_DAM,L_DSUM,L_DGLO,L_EPE,L_EPC,L_XST,L_SSP,L_Z,L_FRAC,L_VISC,
      .   L_THK,L_FOR,L_MOM,L_SMSTR,L_BFRAC,L_DMG,LF_DAM,LF_DAMMX,LF_TDEL,
      .   LF_INDX,LF_OFF,L_FORTH,L_EINTTH,L_SEQ,L_SIGPLY,L_FAC_YLD,L_ABURN,
-     .   L_MU,L_PLANL,L_EPSDNL,L_DMGSCL,L_TSAIWU,LF_DAMINI
+     .   L_MU,L_PLANL,L_EPSDNL,L_DMGSCL,L_TSAIWU,LF_DAMINI,IFAIL,IDFAIL
       TYPE(BUF_LAY_)  , POINTER :: BUFLY
       TYPE(L_BUFEL_)  , POINTER :: LBUF
       TYPE(G_BUFEL_)  , POINTER :: GBUFS,GBUFT
@@ -431,8 +431,12 @@ c-------------------------------
                   DO K = 1,NFAIL                                            
                    FLOCS=>ELBUF_SRC(NG)%BUFLY(IL)%FAIL(IR,IS,IT)%FLOC(K)      
                    FLOCT=>ELBUF_TGT(NG)%BUFLY(IL)%FAIL(IR,IS,IT)%FLOC(K)
-                   NUVAR = FLOCS%NVAR        
-                   FLOCT%NVAR = NUVAR        
+                   IFAIL  = FLOCS%ILAWF  
+                   FLOCT%ILAWF  = IFAIL
+                   IDFAIL = FLOCS%IDFAIL 
+                   FLOCT%IDFAIL = IDFAIL
+                   NUVAR  = FLOCS%NVAR 
+                   FLOCT%NVAR   = NUVAR        
                    FLOCT%VAR(1:NEL*NUVAR) = FLOCS%VAR(1:NEL*NUVAR) 
 c
                    LF_DAM = FLOCS%LF_DAM 

--- a/engine/source/elements/elbuf/w_elbuf_str.F
+++ b/engine/source/elements/elbuf/w_elbuf_str.F
@@ -703,6 +703,8 @@ c         !-----------------------------------------------------
 c
                     RBUF_L(L_REL+1)=IFAIL
                       L_REL = L_REL+1
+                    RBUF_L(L_REL+1)=IDFAIL
+                      L_REL = L_REL+1
                     RBUF_L(L_REL+1)=NUVAR
                       L_REL = L_REL+1
                     RBUF_L(L_REL+1)=LF_DAM
@@ -887,7 +889,9 @@ c
                   IDFAIL = FLOC%IDFAIL                                 
                   NUVAR = FLOC%NVAR                                      
                   RBUF_L(L_REL+1)=IFAIL                                  
-                    L_REL = L_REL+1                                      
+                    L_REL = L_REL+1 
+                  RBUF_L(L_REL+1)=IDFAIL                                 
+                    L_REL = L_REL+1                     
                   RBUF_L(L_REL+1)=NUVAR                                  
                     L_REL = L_REL+1                                      
                   RBUF_L(L_REL+1:L_REL+NEL*NUVAR)=                       


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

A missing value of failure criterion buffer was not written in the restart file which causes issue in restart simulation. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Add the missing lines in the restart file writing sources + fix a bug found in element buffer copy from implicit to implicit

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
