### PR TITLE
improve robustness of law1 w/ high Poisson ratio in single precision …

### DIFF
--- a/engine/source/elements/solid/solide10/s10forc3.F
+++ b/engine/source/elements/solid/solide10/s10forc3.F
@@ -217,7 +217,7 @@ C
      .    MFYY(MVSIZ,5),MFYZ(MVSIZ,5),MFZY(MVSIZ,5),
      .    MFZZ(MVSIZ,5),MFZX(MVSIZ,5),MFXZ(MVSIZ,5),DIVDE(MVSIZ),
      .    NU(MVSIZ),FAC(MVSIZ),FACP(MVSIZ),E0(MVSIZ),C1,DVM(MVSIZ),
-     .    VISP(MVSIZ)
+     .    VISP(MVSIZ),FACDB
 c
       my_real VARNL(NEL),DELTAX4(MVSIZ)
 c     Flag Bolt Preloading
@@ -327,7 +327,9 @@ C
          RHO0_1 =PM( 1,MX)
          IF (PM(21,MX)>0.49) IPLAW1=1
          IF (IPLAW1==1) THEN
-           FACP(LFT:LLT)=TWO*PM(21,MX)
+           FACDB = ONE- ZEP02
+           FACDB = MIN(FACDB,TWO*PM(21,MX))
+           FACP(LFT:LLT)=FACDB
            VISP(LFT:LLT)=TWO
            CNS2 = ZEP02
            IF (IGEO(35,NGEO(1))>0) CNS2=CNS2-ABS(GEO(17,NGEO(1)))

--- a/engine/source/materials/mat/mat001/m1lawtot.F
+++ b/engine/source/materials/mat/mat001/m1lawtot.F
@@ -63,6 +63,7 @@ C-----------------------------------------------
 #include      "com08_c.inc"
 #include      "param_c.inc"
 #include      "sms_c.inc"
+#include      "scr05_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
@@ -144,6 +145,17 @@ C------------[F] = [MF]+ 1 ----ISMSTR10,11,12
        END IF !(ISELECT>0) THEN
         CALL M1ISMSTR10_PON(NEL   , ES1 , ES2 ,ES3 ,ES4  ,
      1                     ES5   ,ES6  ,EPSTH, C1  ,G   ,SIGTMP)
+        IF(IPRES==1.AND.IRESP==1)THEN 
+          DO I=1,NEL
+           FF = -MIN(SIG(I,1),SIG(I,2),SIG(I,3))
+           FACG = MAX(ONE,FF/G2_11)
+           IF (FACG>ONE) FACG = ONEP2*FACG
+           SIGTMP(I,4)= FACG*SIGTMP(I,4)
+           SIGTMP(I,5)= FACG*SIGTMP(I,5)
+           SIGTMP(I,6)= FACG*SIGTMP(I,6)
+           G(I) = FACG*G(I)
+          END DO
+        END IF !(IPRES==1)THEN 
         SIG(1:NEL,1:6)=SIGTMP(1:NEL,1:6)
       ELSEIF (ISMSTR == 12) THEN
         NLAR = 0


### PR DESCRIPTION
…for solid elements

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
robustness issue of single precision on simple compression test with law1 +high Poisson ratio

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
robustness improvement of single precision when law1+high Poisson ratio used by tetra10 or Isolid=24

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
