### PR TITLE
Add a starter warning message for *MAT_SPOTWELD

### DIFF
--- a/hm_cfg_files/messages/CONFIG/msg_hw_radioss_reader.txt
+++ b/hm_cfg_files/messages/CONFIG/msg_hw_radioss_reader.txt
@@ -298,4 +298,9 @@ duplicate %s id %d
 ** ERROR IN LS-DYNA IMPORT
 /MESSAGE/200031/DESCRIPTION
 Only one %s card is allowed
+
+/MESSAGE/200032/TITLE
+** WARNING IN LS-DYNA IMPORT
+/MESSAGE/200032/DESCRIPTION
+%s (id: %u, name: %s) : OPTION DAMAGE-FAILURE is ignored
 #------------------------------------------------------------------------------


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

For conversion of Dyna *MAT_SPOTWELD, a warning message is needed when damage is activ: "OPTION DAMAGE-FAILURE is ignored".

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Ignore the option "DAMAGE-FAILURE" and add a starter warning.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
