### PR TITLE
SOL2SPH : bug fix with PROP/TYPE22

### DIFF
--- a/starter/source/elements/reader/hm_read_solid.F
+++ b/starter/source/elements/reader/hm_read_solid.F
@@ -867,22 +867,26 @@ C--------------------------------------------------
           CALL ANCMSG(MSGID=509,ANMODE=ANINFO,MSGTYPE=MSGERROR,
      .                I1=IXS(11,I),C1=LINE,C2='/SOLID')
         ENDIF
-        NSPHDIR=IGEO(37,IPART(2,IPARTS(I)))
-        IF(IXS(6,I)+IXS(7,I)+IXS(8,I)+IXS(9,I)==0)THEN
-          NT=0
-          DO IT=1,NSPHDIR
-            NT=NT+IT
-            NSPHSOL=NSPHSOL+NT
-          END DO
-        ELSEIF(IXS(8,I)+IXS(9,I)==0)THEN
-          NT=0
-          DO IT=1,NSPHDIR
-            NT=NT+IT
-          END DO
-          NSPHSOL=NSPHSOL+NSPHDIR*NT
-        ELSE
-          NSPHSOL=NSPHSOL+NSPHDIR*NSPHDIR*NSPHDIR
+C
+        IF (IPART(2,IPARTS(I)) > 0) THEN
+          NSPHDIR=IGEO(37,IPART(2,IPARTS(I)))
+          IF(IXS(6,I)+IXS(7,I)+IXS(8,I)+IXS(9,I)==0)THEN
+            NT=0
+            DO IT=1,NSPHDIR
+              NT=NT+IT
+              NSPHSOL=NSPHSOL+NT
+            END DO
+          ELSEIF(IXS(8,I)+IXS(9,I)==0)THEN
+            NT=0
+            DO IT=1,NSPHDIR
+              NT=NT+IT
+            END DO
+            NSPHSOL=NSPHSOL+NSPHDIR*NT
+          ELSE
+            NSPHSOL=NSPHSOL+NSPHDIR*NSPHDIR*NSPHDIR
+          ENDIF
         ENDIF
+C
       ENDDO
 C
         FLAG_FMT = 0


### PR DESCRIPTION
Small buf fix for SOL2SPH : some properties not compatible with SOL2SPH are not preread so IPART(2) can be equal to zero in some cases that generates seg fault.
