### PR TITLE
Change initialization condition for /FAIL/TENSSTRAIN

### DIFF
--- a/engine/source/materials/fail/tensstrain/fail_tensstrain_c.F
+++ b/engine/source/materials/fail/tensstrain/fail_tensstrain_c.F
@@ -141,29 +141,28 @@ C-----------------------------------------------
       STRDEF= INT(UPARAM(10))
       STRFLAG    = 0
 c
-      IF (TIME == ZERO) THEN
+      IF (UVAR(1,1) == ZERO) THEN
         DO I=1,NEL
           UVAR(I,1) = ALDT(I) 
-
           SELECT CASE (S_FLAG)
-          CASE (2)
-            IF (IFUNC(2) /= 0)THEN
-              LAMBDA = UVAR(I,1) / EL_REF
-              FAC = SC_EL * FINTER(IFUNC(2),LAMBDA,NPF,TF,DF) 
-              UVAR(I,1) = FAC
-            ELSE
-              UVAR(I,1) = ONE
-            ENDIF
-          CASE (3)
-            IF (IFUNC(2) /= 0)THEN
-              LAMBDA = UVAR(I,1) / EL_REF
-              FAC = SC_EL * FINTER(IFUNC(2),LAMBDA,NPF,TF,DF) 
-              UVAR(I,1) = FAC
-            ELSE
-              UVAR(I,1) = ONE
-            ENDIF
-          CASE DEFAULT    ! old formulation, backward compatibility only
-            UVAR(I,1) = EPSP1
+            CASE (2)
+              IF (IFUNC(2) /= 0)THEN
+                LAMBDA = UVAR(I,1) / EL_REF
+                FAC = SC_EL * FINTER(IFUNC(2),LAMBDA,NPF,TF,DF) 
+                UVAR(I,1) = FAC
+              ELSE
+                UVAR(I,1) = ONE
+              ENDIF
+            CASE (3)
+              IF (IFUNC(2) /= 0)THEN
+                LAMBDA = UVAR(I,1) / EL_REF
+                FAC = SC_EL * FINTER(IFUNC(2),LAMBDA,NPF,TF,DF) 
+                UVAR(I,1) = FAC
+              ELSE
+                UVAR(I,1) = ONE
+              ENDIF
+            CASE DEFAULT    ! old formulation, backward compatibility only
+              UVAR(I,1) = EPSP1
           END SELECT
         ENDDO
       ENDIF

--- a/engine/source/materials/fail/tensstrain/fail_tensstrain_s.F
+++ b/engine/source/materials/fail/tensstrain/fail_tensstrain_s.F
@@ -133,9 +133,8 @@ c
 C-----------------------------------------------
 c     Initialization
 C-----------------------------------------------
-      IF (TIME == ZERO) THEN
+      IF (UVAR(1,1) == ZERO) THEN 
         DO I=1,NEL
-
           SELECT CASE (S_FLAG)
             CASE (1)  ! default - old formulation
               UVAR(I,1) = EPSP1
@@ -155,13 +154,13 @@ C-----------------------------------------------
               ELSE
                 UVAR(I,1) = ONE
               ENDIF              
-          END SELECT          
+          END SELECT
         ENDDO
       ENDIF
 c-----------------------------------------------
       DO I=1,NEL
         IF (OFF(I) < EM01) OFF(I)=ZERO
-        IF (OFF(I) < ONE)   OFF(I)=OFF(I)*FOUR_OVER_5
+        IF (OFF(I) < ONE)  OFF(I)=OFF(I)*FOUR_OVER_5
       END DO
 c----------------------------------------------
 c     Max strain transformation following input definition


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

And old initialization of UVAR(1:NEL,1) was used for /FAIL/TENSSTRAIN (TIME == ZERO). Unfortunately, it has been noticed a few years back that with some options, it can create issues as TIME is reset (like /PRELOAD). 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Change the condition to initialize UVAR(1:NEL,1).  Same kind of modifications have been made in other failure criteria. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
