### PR TITLE
INTER/TYPE21: change the order of summation of areas

### DIFF
--- a/engine/source/mpi/output/spmd_flush_accel.F
+++ b/engine/source/mpi/output/spmd_flush_accel.F
@@ -186,10 +186,10 @@ c     Convert A in integer
         S2 = MOD(S1 + S2    ,ROOT)
       ENDDO
 C     (s2 << 16) | s1
-      CHECKSUM = IOR(S2 * TWO_POWER_16,S1)
+      IF(S1 < 0) S1 = S1 + TWO_POWER_16
+      CHECKSUM = IOR(ISHFT(S2, 16), IAND(S1, (TWO_POWER_16-1)))
       DEALLOCATE(TMP)
       WRITE(IOUT,*) NCYCLE, "CHECKSUM:",CHECKSUM
-c     WRITE(6,*)    NCYCLE, "CHECKSUM:",CHECKSUM
 
       END
 

--- a/starter/source/interfaces/inter3d1/i21els3.F
+++ b/starter/source/interfaces/inter3d1/i21els3.F
@@ -295,11 +295,10 @@ C
              DO J= KNOD2ELC(NSV(I))+1,KNOD2ELC(NSV(I)+1)
                NB_CONTRIB = NB_CONTRIB + 1
                IE = NOD2ELC(J)
-               CONTRIB_KEY(NB_CONTRIB) = IXC(NIXC,IE) ! UID
+               CONTRIB_KEY(NB_CONTRIB) = -IXC(NIXC,IE) ! -UID
                CONTRIB_VALUE(NB_CONTRIB) = IE 
              ENDDO
              CALL STLSORT_INT_INT(NB_CONTRIB,CONTRIB_KEY,CONTRIB_VALUE)
-
              DO J = 1,NB_CONTRIB
                IE = CONTRIB_VALUE(J)
                SX1 = X(1,IXC(4,IE)) - X(1,IXC(2,IE))
@@ -325,7 +324,7 @@ C overwrite
              DO J= KNOD2ELTG(NSV(I))+1,KNOD2ELTG(NSV(I)+1)
                NB_CONTRIB = NB_CONTRIB + 1
                IE = NOD2ELTG(J)
-               CONTRIB_KEY(NB_CONTRIB) = IXTG(NIXTG,IE) ! UID
+               CONTRIB_KEY(NB_CONTRIB) = -IXTG(NIXTG,IE) ! UID
                CONTRIB_VALUE(NB_CONTRIB) = IE 
              ENDDO
              CALL STLSORT_INT_INT(NB_CONTRIB,CONTRIB_KEY,CONTRIB_VALUE)
@@ -362,11 +361,10 @@ C overwrite
              DO J= KNOD2ELC(NSV(I))+1,KNOD2ELC(NSV(I)+1)
                NB_CONTRIB = NB_CONTRIB + 1
                IE = NOD2ELC(J)
-               CONTRIB_KEY(NB_CONTRIB) = IXC(NIXC,IE) ! UID
+               CONTRIB_KEY(NB_CONTRIB) = -IXC(NIXC,IE) ! UID
                CONTRIB_VALUE(NB_CONTRIB) = IE 
              ENDDO
              CALL STLSORT_INT_INT(NB_CONTRIB,CONTRIB_KEY,CONTRIB_VALUE)
-
              DO J = 1,NB_CONTRIB
                IE = CONTRIB_VALUE(J)
 
@@ -400,7 +398,7 @@ C
              DO J= KNOD2ELTG(NSV(I))+1,KNOD2ELTG(NSV(I)+1)
                NB_CONTRIB = NB_CONTRIB + 1
                IE = NOD2ELTG(J)
-               CONTRIB_KEY(NB_CONTRIB) = IXTG(NIXTG,IE) ! UID
+               CONTRIB_KEY(NB_CONTRIB) = -IXTG(NIXTG,IE) ! UID
                CONTRIB_VALUE(NB_CONTRIB) = IE 
              ENDDO
              CALL STLSORT_INT_INT(NB_CONTRIB,CONTRIB_KEY,CONTRIB_VALUE)
@@ -445,7 +443,7 @@ C
              DO J= KNOD2ELS(NSV(I))+1,KNOD2ELS(NSV(I)+1)
                NB_CONTRIB = NB_CONTRIB + 1
                IE = NOD2ELS(J)
-               CONTRIB_KEY(NB_CONTRIB) = IXS(NIXS,IE) ! UID
+               CONTRIB_KEY(NB_CONTRIB) = -IXS(NIXS,IE) ! UID
                CONTRIB_VALUE(NB_CONTRIB) = IE 
              ENDDO
              CALL STLSORT_INT_INT(NB_CONTRIB,CONTRIB_KEY,CONTRIB_VALUE)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
- Change the order of the summation of areas (minimize numerical changes)
- fix possible integer overflow in Adler32 checksum algorithm
