### PR TITLE
Remove TIME==ZERO conditions from failure criteria for compatibility with PRELOAD

### DIFF
--- a/engine/source/materials/fail/biquad/fail_biquad_c.F
+++ b/engine/source/materials/fail/biquad/fail_biquad_c.F
@@ -142,20 +142,22 @@ C-----------------------------------------------
        EPS_FAIL2    = ZERO
 C
 C!  Initialization
-       IF (TIME == ZERO .AND. NFUNC > 0) THEN
-        DO I=1,NEL
-          IF (NUVAR == 3) THEN
-            UVAR(I,3) = ALDT(I) 
-            LAMBDA = UVAR(I,3) / REF_EL_LEN
-            FAC = FINTER(IFUNC(1),LAMBDA,NPF,TF,DYDX) 
-            UVAR(I,3) = FAC
-          ELSEIF (NUVAR ==9) THEN
-            UVAR(I,9) = ALDT(I) 
-            LAMBDA = UVAR(I,9) / REF_EL_LEN
-            FAC = FINTER(IFUNC(1),LAMBDA,NPF,TF,DYDX) 
-            UVAR(I,9) = FAC
-          ENDIF
-        ENDDO
+       IF (NFUNC > 0) THEN 
+         IF ((NUVAR == 3).AND.(UVAR(1,3)==ZERO)) THEN 
+           DO I=1,NEL
+             UVAR(I,3) = ALDT(I) 
+             LAMBDA = UVAR(I,3) / REF_EL_LEN
+             FAC = FINTER(IFUNC(1),LAMBDA,NPF,TF,DYDX) 
+             UVAR(I,3) = FAC
+           ENDDO
+         ELSEIF ((NUVAR == 9).AND.(UVAR(1,9)==ZERO)) THEN 
+           DO I=1,NEL
+             UVAR(I,9) = ALDT(I) 
+             LAMBDA = UVAR(I,9) / REF_EL_LEN
+             FAC = FINTER(IFUNC(1),LAMBDA,NPF,TF,DYDX) 
+             UVAR(I,9) = FAC
+           ENDDO
+         ENDIF
        ENDIF
 C-----------------------------------------------
        IF(FLAG_PERTURB == 0) THEN

--- a/engine/source/materials/fail/biquad/fail_biquad_s.F
+++ b/engine/source/materials/fail/biquad/fail_biquad_s.F
@@ -121,20 +121,22 @@ C!--------------------------------------------------------------
 C-----------------------------------------------
 C!  Initialization
 C-----------------------------------------------
-       IF (TIME == ZERO .AND. MFUNC > 0) THEN
-        DO I=1,NEL
-          IF (NUVAR == 3) THEN
-            UVAR(I,3) = ALDT(I) 
-            LAMBDA = UVAR(I,3) / REF_EL_LEN
-            FAC = FINTER(KFUNC(1),LAMBDA,NPF,TF,DF) 
-            UVAR(I,3) = FAC
-          ELSEIF (NUVAR ==9) THEN
-            UVAR(I,9) = ALDT(I) 
-            LAMBDA = UVAR(I,9) / REF_EL_LEN
-            FAC = FINTER(KFUNC(1),LAMBDA,NPF,TF,DF) 
-            UVAR(I,9) = FAC
-          ENDIF
-        ENDDO
+       IF (MFUNC > 0) THEN 
+         IF ((NUVAR == 3).AND.(UVAR(1,3)==ZERO)) THEN 
+           DO I=1,NEL
+             UVAR(I,3) = ALDT(I) 
+             LAMBDA = UVAR(I,3) / REF_EL_LEN
+             FAC = FINTER(KFUNC(1),LAMBDA,NPF,TF,DF) 
+             UVAR(I,3) = FAC
+           ENDDO
+         ELSEIF ((NUVAR == 9).AND.(UVAR(1,9)==ZERO)) THEN 
+           DO I=1,NEL
+             UVAR(I,9) = ALDT(I) 
+             LAMBDA = UVAR(I,9) / REF_EL_LEN
+             FAC = FINTER(KFUNC(1),LAMBDA,NPF,TF,DF) 
+             UVAR(I,9) = FAC
+           ENDDO
+         ENDIF
        ENDIF
 C-----------------------------------------------
 c! fast degradation

--- a/engine/source/materials/fail/connect/fail_connect.F
+++ b/engine/source/materials/fail/connect/fail_connect.F
@@ -122,13 +122,17 @@ C-----------------------------------------------
 C     USER VARIABLES INITIALIZATION
 C-----------------------------------------------
       IF (ISIGI == ZERO) THEN
-        IF (TIME == ZERO) THEN
+        IF ((UVAR(1,6) == ZERO).AND.(OFFL(1) == ONE)) THEN 
           DO I=1,NEL
-            UVAR(I,6)= ONE         
+            UVAR(I,6)= ONE  
+          ENDDO
+        ENDIF
+        IF (UVAR(1,13) == ZERO) THEN
+          DO I=1,NEL         
             UVAR(I,13)= AREA(I)  
-          ENDDO   
-        ENDIF     
-      ENDIF  
+          ENDDO  
+        ENDIF 
+      ENDIF 
 C-----------------------------------------------
       DO I=1,NEL
         DAM1(I) = UVAR(I,7)                   

--- a/engine/source/materials/fail/gene1/fail_gene1_c.F
+++ b/engine/source/materials/fail/gene1/fail_gene1_c.F
@@ -210,25 +210,27 @@ c
       ENDIF       
 c      
       ! At initial time, compute the element size regularization factor
-      IF (ISIGI == 0 .and. TIME == ZERO) THEN
-        IF (fct_IDel > 0) THEN 
-          DO I=1,NEL   
-            LAMBDA      = ALDT(I)/El_ref
-            FAC         = FINTER(KFUNC(IREG),LAMBDA,NPF,TF,DF) 
-            UVAR(I,1)   = FAC*Fscale_el
-          ENDDO
-        ELSE
-          UVAR(1:NEL,1) = ONE
+      IF (ISIGI == 0) THEN 
+        IF (UVAR(1,1)==ZERO) THEN 
+          IF (fct_IDel > 0) THEN 
+            DO I=1,NEL   
+              LAMBDA      = ALDT(I)/El_ref
+              FAC         = FINTER(KFUNC(IREG),LAMBDA,NPF,TF,DF) 
+              UVAR(I,1)   = FAC*Fscale_el
+            ENDDO
+          ELSE
+            UVAR(1:NEL,1) = ONE
+          ENDIF
         ENDIF  
-        UVAR(1:NEL,6) = THK0(1:NEL)
-        UVAR(1:NEL,7) = THKLYL(1:NEL)
-        UVAR(1:NEL,8) = ALDT(1:NEL)
+        IF ((UVAR(1,5) == ZERO).AND.(FOFF(1) /= 0)) UVAR(1:NEL,5) = ONE
+        IF (UVAR(1,6) == ZERO) UVAR(1:NEL,6) = THK0(1:NEL)
+        IF (UVAR(1,7) == ZERO) UVAR(1:NEL,7) = THKLYL(1:NEL)
+        IF (UVAR(1,8) == ZERO) UVAR(1:NEL,8) = ALDT(1:NEL)
       ENDIF
 c
       ! Checking element failure and recovering user variable
       DO I=1,NEL
        ! Integration point failure
-       IF (TIME == ZERO) UVAR(I,5) = ONE
        IF (UVAR(I,5) < ONE .AND. UVAR(I,5) >= EM08) THEN 
          UVAR(I,5) = UVAR(I,5) - ONE/NSTEP
        ENDIF

--- a/engine/source/materials/fail/gene1/fail_gene1_s.F
+++ b/engine/source/materials/fail/gene1/fail_gene1_s.F
@@ -211,23 +211,25 @@ c
       ENDIF       
 c      
       ! At initial time, compute the element size regularization factor
-      IF (ISIGI == 0 .and. TIME == ZERO) THEN
-        IF (fct_IDel > 0) THEN 
-          DO I=1,NEL   
-            LAMBDA      = ALDT(I)/El_ref
-            FAC         = FINTER(KFUNC(IREG),LAMBDA,NPF,TF,DF) 
-            UVAR(I,1)   = FAC*Fscale_el
-          ENDDO
-        ELSE
-          UVAR(1:NEL,1) = ONE
-        ENDIF
-        UVAR(1:NEL,8) = ALDT(1:NEL)
+      IF (ISIGI == 0) THEN 
+        IF (UVAR(1,1)==ZERO) THEN 
+          IF (fct_IDel > 0) THEN 
+            DO I=1,NEL   
+              LAMBDA      = ALDT(I)/El_ref
+              FAC         = FINTER(KFUNC(IREG),LAMBDA,NPF,TF,DF) 
+              UVAR(I,1)   = FAC*Fscale_el
+            ENDDO
+          ELSE
+            UVAR(1:NEL,1) = ONE
+          ENDIF
+        ENDIF  
+        IF (UVAR(1,5) == ZERO.AND.(OFF(1) /= ZERO)) UVAR(1:NEL,5) = ONE
+        IF (UVAR(1,8) == ZERO) UVAR(1:NEL,8) = ALDT(1:NEL)
       ENDIF
 c
       ! Checking element failure and recovering user variable
       DO I=1,NEL
        ! Integration point failure
-       IF (TIME == ZERO) UVAR(I,5) = ONE
        IF (UVAR(I,5) < ONE .AND. UVAR(I,5) >= EM08) THEN 
          UVAR(I,5) = UVAR(I,5) - ONE/NSTEP
        ENDIF

--- a/engine/source/materials/fail/ladeveze/fail_ladeveze.F
+++ b/engine/source/materials/fail/ladeveze/fail_ladeveze.F
@@ -128,10 +128,10 @@ C-----------------------------------------------
 C     USER VARIABLES INITIALIZATION
 C-----------------------------------------------
       IF(ISIGI == ZERO)THEN 
-        IF(TIME==ZERO)THEN
-         DO I=1,NEL
-          UVAR(I,12)  = ONE
-         ENDDO   
+        IF ((UVAR(1,12)==ZERO).AND.(OFF(1)==ONE)) THEN
+          DO I=1,NEL
+            UVAR(I,12) = ONE
+          ENDDO   
         ENDIF    
       ENDIF   
 C-----------------------------------------------

--- a/engine/source/materials/fail/orthstrain/fail_orthstrain_c.F
+++ b/engine/source/materials/fail/orthstrain/fail_orthstrain_c.F
@@ -236,7 +236,7 @@ c----------------------------------------------
 c     Element size scale factor
       FSIZE => UVAR(1:NEL,32)
 c
-      IF (TIME == ZERO) THEN
+      IF (FSIZE(1)==ZERO) THEN
         IF (IFUNC_SIZ > 0) THEN
 	        ESCAL(1:NEL) = ALDT(1:NEL) / REF_SIZ
           IPOSP(1:NEL) = 0

--- a/engine/source/materials/fail/puck/fail_puck_s.F
+++ b/engine/source/materials/fail/puck/fail_puck_s.F
@@ -136,10 +136,10 @@ C-----------------------------------------------
 C     USER VARIABLES INITIALIZATION
 C-----------------------------------------------
       IF(ISIGI == 0)THEN
-        IF(TIME == ZERO)THEN
-         DO I=1,NEL
-          UVAR(I,8)  = ONE
-         ENDDO   
+        IF ((UVAR(1,8) == ZERO).AND.(OFF(1) == ONE)) THEN
+          DO I=1,NEL
+            UVAR(I,8)  = ONE
+          ENDDO   
         ENDIF    
       ENDIF 
 C-----------------------------------------------

--- a/engine/source/materials/fail/snconnect/fail_snconnect.F
+++ b/engine/source/materials/fail/snconnect/fail_snconnect.F
@@ -121,7 +121,7 @@ C=======================================================================
       IFUN3N  = IFUNC(3)
       IFUN3T  = IFUNC(4)
 C-----------------------------------------------
-      IF (TIME == ZERO) THEN
+      IF (UVAR(1,3) == ZERO) THEN
         DO I=1,NEL
           UVAR(I,3)= AREA(I)    ! initial area at time = 0
         ENDDO   

--- a/engine/source/materials/fail/tabulated/fail_tab_old_c.F
+++ b/engine/source/materials/fail/tabulated/fail_tab_old_c.F
@@ -92,7 +92,7 @@ C UVAR(1) = DAMAGE
 C UVAR(2) = initial characteristic el. length
 C UVAR(3) = IPOS variable for element length scale function interpolation
 C=======================================================================
-      IF (TIME == ZERO) THEN
+      IF (UVAR(1,2) == ZERO) THEN
         UVAR(1:NEL,2) = ALDT(1:NEL) 
       ENDIF
 c---------------------------

--- a/engine/source/materials/fail/tabulated/fail_tab_old_xfem.F
+++ b/engine/source/materials/fail/tabulated/fail_tab_old_xfem.F
@@ -102,7 +102,7 @@ C-----------------------------------------------
       INDX = 0
       SIGM_PS = ONE/SQRT(THREE)
 
-      IF (TIME == ZERO) THEN
+      IF (UVAR(1,2) == ZERO) THEN
         UVAR(1:NEL,2) = ALDT(1:NEL) 
       ENDIF
 C-----------------------------------------------

--- a/engine/source/materials/fail/tabulated/fail_tab_xfem.F
+++ b/engine/source/materials/fail/tabulated/fail_tab_xfem.F
@@ -150,11 +150,9 @@ C-----------------------------------------------
       INDX = 0
       SIGM_PS = ONE/SQRT(THREE)
 
-      IF (TIME == ZERO) THEN
+      IF (UVAR(1,5) == ZERO) THEN
        DO I=1,NEL
-         UVAR(I,4) = ZERO
          UVAR(I,5) = ALDT(I) 
-         DMG_FLAG_INT(I) = 0
        ENDDO
       ENDIF
 C-----------------------------------------------

--- a/engine/source/materials/fail/tuler_butcher/fail_tbutcher_s.F
+++ b/engine/source/materials/fail/tuler_butcher/fail_tbutcher_s.F
@@ -128,11 +128,6 @@ c=======================================================================
       SIGR  = UPARAM(3)
       IFLAG = INT(UPARAM(5))
 
-      IF(TIME == ZERO)THEN
-        DO I=1,NEL
-         TDELE(I)  = ZERO
-        ENDDO   
-      ENDIF 
 C-----------------------------------------------
       IDEL=0
       IDEV=0

--- a/engine/source/materials/fail/wierzbicki/fail_wierzbicki_s.F
+++ b/engine/source/materials/fail/wierzbicki/fail_wierzbicki_s.F
@@ -115,12 +115,6 @@ C--------------------------------------------------------------
       CN = UPARAM(6)
       IFLAG = INT(UPARAM(8))
       IMOY  = INT( UPARAM(9))
-C         
-      IF(TIME == ZERO)THEN
-        DO I=1,NEL
-         TDELE(I)  = ZERO
-        ENDDO   
-      ENDIF 
 Cc
       IDEL=0
       IDEV=0


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

After the discovery of an incompatibility of /FAIL/TENSSTRAIN with PRELOAD due to TIME == ZERO conditions at initialization, the same issue has been detected in several other failure criteria. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Remove/Replace the TIME == ZERO condition from the failure criteria. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
