### PR TITLE
Changes in build scripts

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -2,7 +2,8 @@
   "environments": [
     {
       "RAD_CFG_PATH": "${projectDir}\\hm_cfg_files",
-      "PATH": "${projectDir}\\extlib\\hm_reader\\win64;${projectDir}\\extlib\\h3d\\lib\\win64;${env.PATH}"
+      "PATH": "${projectDir}\\extlib\\hm_reader\\win64;${env.PATH}",
+      "RAD_H3D_PATH": "${projectDir}\\extlib\\h3d\\lib\\win64"
     }
   ],
   "configurations": [

--- a/engine/CMake_Compilers/cmake_win64.txt
+++ b/engine/CMake_Compilers/cmake_win64.txt
@@ -115,13 +115,13 @@ set(Fortran "/fpp  /extend-source /assume:buffered_io")
 
 if ( debug STREQUAL "1" )
 # Fortran
-set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS " /fp:precise /Qopenmp /O1 /Qftz /fpp /extend-source /assume:buffered_io /debug:all  ${precision_flag} ${Fortran} ${mpi_flag} ${MUMPS_flags} -DMETIS5 ${cppmach} ${cpprel}" )
+set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS " /Qopenmp /Od /debug:all /Qftz /fpp /extend-source /assume:buffered_io ${precision_flag} ${Fortran} ${mpi_flag} ${MUMPS_flags} -DMETIS5 ${cppmach} ${cpprel}" )
 
 # C source files
-set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS "/fp:precise /Qopenmp /O1 /Qftz /debug:all ${precision_flag} -DMETIS5 ${h3d_inc} ${mpi_flag} ${MUMPS_flags} ${cppmach} ${cpprel}" )
+set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS "/Qopenmp /Od /debug:all /Qftz ${precision_flag} -DMETIS5 ${h3d_inc} ${mpi_flag} ${MUMPS_flags} ${cppmach} ${cpprel}" )
 
 # CXX source files
-set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "/fp:precise /Qopenmp /O1 /Qftz /debug:all ${precision_flag} -DMETIS5 ${h3d_inc}  ${mpi_flag} ${MUMPS_flags} ${cppmach} ${cpprel} /Qstd=c++11" )
+set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "/Qopenmp /Od /debug:all /Qftz ${precision_flag} -DMETIS5 ${h3d_inc} ${mpi_flag} ${MUMPS_flags} ${cppmach} ${cpprel} /Qstd=c++11" )
 
 else ()
 

--- a/engine/build_script.sh
+++ b/engine/build_script.sh
@@ -83,6 +83,7 @@ verbose=""
 mumps_root=""
 scalapack_root=""
 lapack_root=""
+com=0
 
 if [ $number_of_arguments = 0 ]
 then
@@ -106,6 +107,15 @@ else
          pmpi=`echo $var|awk -F '=' '{print $2}'`
          dmpi=_${pmpi}
          MPI=-DMPI=${pmpi}
+
+         if [ "$pmpi" != "smp" ]
+         then
+            dmpi=_${pmpi}
+            MPI=-DMPI=${pmpi}
+         else 
+            pmpi="SMP Only"
+         fi
+
        fi
 
        if [ "$arg" == "-mpi-os" ]
@@ -200,6 +210,7 @@ else
 
        if [ "$arg" == "-c" ]
        then
+         com=1 
          dc="-DCOM=1"
          cf="_c"
          vers=`cat CMake_Compilers_c/cmake_eng_version.txt | awk -F '\"' '{print $2}' `
@@ -287,7 +298,13 @@ echo " "
 cd ${build_directory}
 
 # Get compiler settings
-source ../CMake_Compilers/cmake_${arch}_compilers.sh
+if [ $com = 1 ]
+then
+    source ../CMake_Compilers_c/cmake_${arch}_compilers.sh
+else
+    source ../CMake_Compilers/cmake_${arch}_compilers.sh
+fi
+
 Fortran_path=`which $Fortran_comp`
 C_path=`which $C_comp`
 CPP_path=`which $CPP_comp`

--- a/starter/CMake_Compilers/cmake_win64.txt
+++ b/starter/CMake_Compilers/cmake_win64.txt
@@ -77,13 +77,13 @@ set(Fortran "/fpp /extend-source /assume:buffered_io")
 if ( debug STREQUAL "1" )
  
 # Fortran
-set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS " ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} -DCPP_comp=f90 /fpp /fp:precise /O1 /debug:all /Qftz /extend-source /Qopenmp  ${ADF} /traceback" )
+set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS " ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} -DCPP_comp=f90 /fpp /Od /debug:all /Qftz /extend-source /assume:buffered_io /Qopenmp  ${ADF} /traceback" )
 
 # C source files
-set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS " ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} /nologo  /fp:precise /O1 /debug:all /Qftz  /Qopenmp /traceback " )
+set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS " ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} /nologo /Od /debug:all /Qftz  /Qopenmp /traceback " )
 
 # CXX source files
-set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS " ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} /nologo  /fp:precise /O1 /debug:all /Qftz  /Qopenmp /traceback" )
+set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS " ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} /nologo /Od /debug:all /Qftz  /Qopenmp /traceback" )
 
 else ()
 
@@ -112,11 +112,13 @@ set (F_O1_compiler_flags " ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} /exte
 set (F_O1_compiler_flags_no_omp " ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} /extend-source /O1 /Qopenmp /fp:precise /Qftz")
 set (F_O2_compiler_flags_no_omp " ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} /extend-source /O2 /Qopenmp /fp:precise /Qftz")
 
-set_source_files_properties( ${source_directory}/source/starter/lectur.F PROPERTIES COMPILE_FLAGS ${F_O1_compiler_flags} )
+if ( debug STREQUAL "0" )
+  set_source_files_properties( ${source_directory}/source/starter/lectur.F PROPERTIES COMPILE_FLAGS ${F_O1_compiler_flags} )
 
-set_source_files_properties( ${source_directory}/source/tools/sect/prelecsec.F PROPERTIES COMPILE_FLAGS ${F_O2_compiler_flags_no_omp} )
+  set_source_files_properties( ${source_directory}/source/tools/sect/prelecsec.F PROPERTIES COMPILE_FLAGS ${F_O2_compiler_flags_no_omp} )
 
-set_source_files_properties( ${source_directory}/source/elements/sph/nbsph.F PROPERTIES COMPILE_FLAGS ${F_O1_compiler_flags_no_omp} )
+  set_source_files_properties( ${source_directory}/source/elements/sph/nbsph.F PROPERTIES COMPILE_FLAGS ${F_O1_compiler_flags_no_omp} )
+endif()
 
 
 

--- a/starter/build_script.sh
+++ b/starter/build_script.sh
@@ -55,7 +55,7 @@ number_of_arguments=$#
 clean=0
 verbose=""
 st_vers="starter"
-
+com=0
 
 if [ $number_of_arguments = 0 ]
 then
@@ -115,6 +115,7 @@ else
 
        if [ "$arg" == "-c" ]
        then
+         com=1
          dc="-DCOM=1"
          cf="_c"
          vers=`cat CMake_Compilers_c/cmake_st_version.txt | awk -F '\"' '{print $2}' `
@@ -213,8 +214,13 @@ echo " "
 cd ${build_directory}
 
 # Get compiler settings
-source ../CMake_Compilers/cmake_${arch}_compilers.sh
-
+if [ $com = 1 ]
+then
+    source ../CMake_Compilers_c/cmake_${arch}_compilers.sh
+else
+    source ../CMake_Compilers/cmake_${arch}_compilers.sh
+fi
+  
 Fortran_path=`which $Fortran_comp`
 C_path=`which $C_comp`
 CPP_path=`which $CPP_comp`


### PR DESCRIPTION
Windows Visual Studio : Add H3D Support in CMakeSettings.json Debug runs can benefit of H3D Library
Windows Visual Studio : Debug Version : wrong debug flags on Windows - Visual Studio debugger cannot run.

Build scripts : issue on SMP build

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
