### PR TITLE
/INIVOL:fixing potential debugger warning when DX_BOX=EP30

### DIFF
--- a/starter/source/initial_conditions/inivol/ale_box_creation.F
+++ b/starter/source/initial_conditions/inivol/ale_box_creation.F
@@ -75,6 +75,10 @@ C-----------------------------------------------
         DY_BOX = ABS(MIN_MAX_POSITION(2) - MIN_MAX_POSITION(5))
         DZ_BOX = ABS(MIN_MAX_POSITION(3) - MIN_MAX_POSITION(6))
         
+        IF(DX_BOX == 2*EP30)DX_BOX=ZERO ! y,z plane
+        IF(DY_BOX == 2*EP30)DY_BOX=ZERO ! x,z plane
+        IF(DZ_BOX == 2*EP30)DZ_BOX=ZERO ! x,y plane        
+                
         DIST_MAX = MAX(DX_BOX,DY_BOX,DZ_BOX)
         IF(DIST_MAX==DX_BOX) LEADING_DIMENSION = 1
         IF(DIST_MAX==DY_BOX) LEADING_DIMENSION = 2


### PR DESCRIPTION
#### /INIVOL:fixing potential debugger warning when DX_BOX=EP30

#### Description of the changes
In 2D analysis, elements are defined in y,z plane. Dimension X is not used.
When entering in ale_box_creation.F min_x=MIN_MAX_DIMENSION(1) and max_x=MIN_MAX_DIMENSION(4) are then not defined (EP30). This is now correctly treated by ignoring the corresponding dimension (x dimension in case of 2D analysis) when creating the boxes.

This update is related to commit 82f062d

