### PR TITLE
fix several issues in the shooting node algorithm

### DIFF
--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -2261,18 +2261,6 @@ C Init var parallel SMP
           ! ---------------------
 
           ! ---------------------
-          ! exchange of deactivated surfaces (ie. 4 nodes) to deactivate to deactivate the neighbourhood
-          ! ONLY FOR REMOTE SURFACE + interface type 24 or 25
-          IF(NSPMD>1.AND.(INT24USE>0.OR.NINTER25/=0)) THEN 
-            IF(ITSK==0) CALL CHECK_REMOTE_SURFACE_STATE( ITSK,
-     .                                                   SHOOT_STRUCT%NUMBER_REMOTE_SURF,SHOOT_STRUCT%REMOTE_SURF,
-     .                                                   SHOOT_STRUCT%SHIFT_INTERFACE,INTBUF_TAB,
-     .                                                   IPARI,IAD_ELEM,SHOOT_STRUCT )
-           CALL MY_BARRIER()
-          ENDIF
-          ! ---------------------
-
-          ! ---------------------
           ! loop over the surface id and deactivate the surface
           ! ONLY FOR LOCAL SURFACE / LOCAL ELEMENT
           CALL CHECK_SURFACE_STATE( ITSK,SHOOT_STRUCT%SAVE_SURFACE_NB,SHOOT_STRUCT%SAVE_SURFACE,
@@ -2288,6 +2276,18 @@ C Init var parallel SMP
      .                           SHOOT_STRUCT%SHIFT_INTERFACE,INTBUF_TAB,NEWFRONT,IPARI,GEO,
      .                           IXS,IXC,IXT,IXP,IXR,IXTG,
      .                           ADDCNEL,ITABM1,CNEL,WA(NWAFTSK),TAGEL,SHOOT_STRUCT )
+          ! ---------------------
+
+          ! ---------------------
+          ! exchange of deactivated surfaces (ie. 4 nodes) to deactivate to deactivate the neighbourhood
+          ! ONLY FOR REMOTE SURFACE + interface type 24 or 25
+          IF(INT24USE>0.OR.NINTER25/=0) THEN 
+            IF(ITSK==0) CALL CHECK_REMOTE_SURFACE_STATE( ITSK,
+     .                                                   SHOOT_STRUCT%NUMBER_REMOTE_SURF,SHOOT_STRUCT%REMOTE_SURF,
+     .                                                   SHOOT_STRUCT%SHIFT_INTERFACE,INTBUF_TAB,
+     .                                                   IPARI,IAD_ELEM,SHOOT_STRUCT )
+           CALL MY_BARRIER()
+          ENDIF
           ! ---------------------
 
           CALL CHKSTFN3N(
@@ -5365,18 +5365,6 @@ C WA local  : utilise de 1 a NUMNOD
           ! ---------------------
 
           ! ---------------------
-          ! exchange of deactivated surfaces (ie. 4 nodes) to deactivate to deactivate the neighbourhood
-          ! ONLY FOR REMOTE SURFACE + interface type 24 or 25
-          IF(NSPMD>1.AND.(INT24USE>0.OR.NINTER25/=0)) THEN 
-            IF(ITSK==0) CALL CHECK_REMOTE_SURFACE_STATE( ITSK,
-     .                                                   SHOOT_STRUCT%NUMBER_REMOTE_SURF,SHOOT_STRUCT%REMOTE_SURF,
-     .                                                   SHOOT_STRUCT%SHIFT_INTERFACE,INTBUF_TAB,
-     .                                                   IPARI,IAD_ELEM,SHOOT_STRUCT )
-           CALL MY_BARRIER()
-          ENDIF
-          ! ---------------------
-
-          ! ---------------------
           ! loop over the surface id and deactivate the surface
           ! ONLY FOR LOCAL SURFACE / LOCAL ELEMENT
           CALL CHECK_SURFACE_STATE( ITSK,SHOOT_STRUCT%SAVE_SURFACE_NB,SHOOT_STRUCT%SAVE_SURFACE,
@@ -5392,6 +5380,18 @@ C WA local  : utilise de 1 a NUMNOD
      .                           SHOOT_STRUCT%SHIFT_INTERFACE,INTBUF_TAB,NEWFRONT,IPARI,GEO,
      .                           IXS,IXC,IXT,IXP,IXR,IXTG,
      .                           ADDCNEL,ITABM1,CNEL,WA(NWAFTSK),TAGEL,SHOOT_STRUCT )
+          ! ---------------------
+
+          ! ---------------------
+          ! exchange of deactivated surfaces (ie. 4 nodes) to deactivate to deactivate the neighbourhood
+          ! ONLY FOR REMOTE SURFACE + interface type 24 or 25
+          IF(INT24USE>0.OR.NINTER25/=0) THEN 
+            IF(ITSK==0) CALL CHECK_REMOTE_SURFACE_STATE( ITSK,
+     .                                                   SHOOT_STRUCT%NUMBER_REMOTE_SURF,SHOOT_STRUCT%REMOTE_SURF,
+     .                                                   SHOOT_STRUCT%SHIFT_INTERFACE,INTBUF_TAB,
+     .                                                   IPARI,IAD_ELEM,SHOOT_STRUCT )
+           CALL MY_BARRIER()
+          ENDIF
           ! ---------------------
         ENDIF
 

--- a/engine/source/interfaces/interf/check_active_elem_edge.F
+++ b/engine/source/interfaces/interf/check_active_elem_edge.F
@@ -175,9 +175,9 @@ C-----------------------------------------------
                 ! -----------------
                 ! for interface 7 : need to check if the element has N3 & N4
                 OTHER_NODE = 0
-                IF(NUMBER_NODE>2) THEN
-                    OTHER_NODE = TAG_NODE(N3)+TAG_NODE(N4)
-                ENDIF
+                IF(NUMBER_NODE>2) OTHER_NODE = TAG_NODE(N3)
+                IF(NUMBER_NODE>3) OTHER_NODE = TAG_NODE(N4)
+
                 ! -----------------
         
                 ! -----------------

--- a/engine/source/interfaces/interf/check_remote_surface_state.F
+++ b/engine/source/interfaces/interf/check_remote_surface_state.F
@@ -108,7 +108,6 @@ C-----------------------------------------------
         DATA MSGOFF1/13014/
         DATA MSGOFF2/13015/
 C-----------------------------------------------
-
         FIRST = 1
         LAST = SURFARCE_NB 
         NUMBER_INTER = SHIFT_INTERFACE(NINTER+1,2)
@@ -117,6 +116,7 @@ C-----------------------------------------------
         S_BUFFER(1:NSPMD)%SIZE_INT_ARRAY_2D(1) = 2
         S_BUFFER(1:NSPMD)%SIZE_INT_ARRAY_2D(2) = SURFARCE_NB
         NUMBER_REMOTE_SURF(1:NSPMD) = 0
+
         ! --------------------------
         ! loop over the deactivated surface
         DO I=FIRST,LAST
@@ -127,7 +127,6 @@ C-----------------------------------------------
             ITY = IPARI(7,NIN)
             IDEL = IPARI(17,NIN)
             NRTM = IPARI(4,NIN)
-            
             ! *----*----*----*   1/2/3 surfaces need to deactivate the neighbouring deleted surface 
             ! | 1  |    |    |   the deleted surface must be deactivate 
             ! |    | 4  |    |   not sure about 4 & 5
@@ -139,11 +138,16 @@ C-----------------------------------------------
             ! | 2  |    |    |
             ! *----*----*----*
             
-            GLOCAL_SURFACE_ID = INTBUF_TAB(NIN)%MSEGLO(K)
-            IF(ITY==24.OR.ITY==25) THEN
-                CALL SURFACE_DEACTIVATION(NRTM,GLOCAL_SURFACE_ID,INTBUF_TAB(NIN)%MSEGLO,INTBUF_TAB(NIN)%MVOISIN)
+            IF(ITY==25) THEN 
+                GLOCAL_SURFACE_ID = K
+            ELSEIF(ITY==24) THEN
+                GLOCAL_SURFACE_ID = INTBUF_TAB(NIN)%MSEGLO(K)
             ENDIF
-            
+            IF(ITY==24.OR.ITY==25) THEN
+                CALL SURFACE_DEACTIVATION(ITY,NRTM,GLOCAL_SURFACE_ID,INTBUF_TAB(NIN)%MSEGLO,INTBUF_TAB(NIN)%MVOISIN)
+            ENDIF
+
+            IF(NSPMD>1) THEN            
             ! --------------
             ALREADY_DONE(1:NSPMD) = .FALSE.
             ALREADY_DONE(ISPMD+1) = .TRUE.
@@ -171,8 +175,11 @@ C-----------------------------------------------
                 ENDIF
             ENDDO
             ! --------------
+            ENDIF
         ENDDO
         ! --------------------------
+
+        IF(NSPMD>1) THEN
 #ifdef MPI
 
         ! ----------------
@@ -251,7 +258,7 @@ C-----------------------------------------------
                 ! --------------
                 GLOCAL_SURFACE_ID = R_BUFFER(PROC_ID)%INT_ARRAY_2D(1,J) ! get the global deleted surface id
                 IF(ITY==24.OR.ITY==25) THEN
-                    CALL SURFACE_DEACTIVATION(NRTM,GLOCAL_SURFACE_ID,INTBUF_TAB(NIN)%MSEGLO,INTBUF_TAB(NIN)%MVOISIN) 
+                    CALL SURFACE_DEACTIVATION(ITY,NRTM,GLOCAL_SURFACE_ID,INTBUF_TAB(NIN)%MSEGLO,INTBUF_TAB(NIN)%MVOISIN) 
                 ENDIF
                 ! --------------
             ENDDO
@@ -280,6 +287,7 @@ C-----------------------------------------------
         ENDDO
         ! ----------------
 #endif
+        ENDIF
 
         DEALLOCATE( S_BUFFER, R_BUFFER )
 

--- a/engine/source/interfaces/interf/init_nodal_state.F
+++ b/engine/source/interfaces/interf/init_nodal_state.F
@@ -476,8 +476,8 @@ C-----------------------------------------------
                     IF(ITY==7.OR.ITY==10.OR.ITY==22.OR.ITY==24.OR.ITY==25) THEN
                         LIST_NODE_ID(3) = INTBUF_TAB(NIN)%IRECTM((I-1)*NB_NODE_SURF+3) ! node id N3
                         LIST_NODE_ID(4) = INTBUF_TAB(NIN)%IRECTM((I-1)*NB_NODE_SURF+4) ! node id N4
-                        GLOBAL_NODE_ID(1) = ITAB(LIST_NODE_ID(3)) ! global node id N3
-                        GLOBAL_NODE_ID(2) = ITAB(LIST_NODE_ID(4)) ! global node id N4
+                        GLOBAL_NODE_ID(3) = ITAB(LIST_NODE_ID(3)) ! global node id N3
+                        GLOBAL_NODE_ID(4) = ITAB(LIST_NODE_ID(4)) ! global node id N4
                         NB_REAL_NODE = 4 ! number of node per surface (4 for interface type 7 / 2 for interface type 11)
                         IF(LIST_NODE_ID(3)==LIST_NODE_ID(4)) NB_REAL_NODE = 3 ! N3 and N4 equal : the surface is defined as a triangle -> only 3 nodes
                     ENDIF

--- a/engine/source/interfaces/interf/surface_deactivation.F
+++ b/engine/source/interfaces/interf/surface_deactivation.F
@@ -26,7 +26,7 @@ Chd|-- called by -----------
 Chd|        CHECK_REMOTE_SURFACE_STATE    source/interfaces/interf/check_remote_surface_state.F
 Chd|-- calls ---------------
 Chd|====================================================================
-        SUBROUTINE SURFACE_DEACTIVATION(NRTM,GLOCAL_SURFACE_ID,MSEGLO,MVOISIN)
+        SUBROUTINE SURFACE_DEACTIVATION(ITY,NRTM,GLOCAL_SURFACE_ID,MSEGLO,MVOISIN)
 !$COMMENT
 !       SURFACE_DEACTIVATION description
 !           deactivation of neighbour surface
@@ -38,7 +38,6 @@ C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
 #include      "implicit_f.inc"
-
 C-----------------------------------------------
 C   C o m m o n   B l o c k s
 C-----------------------------------------------
@@ -46,6 +45,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+        INTEGER, INTENT(in) :: ITY ! kind of interface
         INTEGER, INTENT(in) :: NRTM ! number of surface
         INTEGER, INTENT(in) :: GLOCAL_SURFACE_ID ! global id of the surface
         INTEGER, DIMENSION(NRTM), INTENT(in) :: MSEGLO ! global id of the k surface 
@@ -67,7 +67,7 @@ C-----------------------------------------------
                 
             ! --------------
             ! deactivation of the surface SURFACE_ID
-            IF(MSEGLO(J)==GLOCAL_SURFACE_ID) THEN
+            IF(ITY==24.AND.MSEGLO(J)==GLOCAL_SURFACE_ID) THEN
                 MVOISIN(1,J) = 0
                 MVOISIN(2,J) = 0
                 MVOISIN(3,J) = 0


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Several issues were introduced in PR #1431 
* for the treatment of the interface type 25 in the shooting node algorithm
* a general bug for the interface 24/25/7 with idel=1 in the  initialization of the structure
*  a general bug for the interface 24/25/7 with idel=1 for triangle element

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Use the local surface id instead of the global surface id
invert the calls of 2 routines ( check_remote_surface_state must be computed after check_surface_state)
Initialization of the structure : initialize the memory case 3 and 4 for the node 3 and 4 (instead of 1 and 2)
Triangle element : check the number of node (4 for shell / 3 for triangle)

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
