### PR TITLE
Fix checkbounds issues for /FAIL/BIQUAD + add Density output for shells

### DIFF
--- a/engine/source/materials/fail/biquad/fail_biquad_c.F
+++ b/engine/source/materials/fail/biquad/fail_biquad_c.F
@@ -143,20 +143,24 @@ C-----------------------------------------------
 C
 C!  Initialization
        IF (NFUNC > 0) THEN 
-         IF ((NUVAR == 3).AND.(UVAR(1,3)==ZERO)) THEN 
-           DO I=1,NEL
-             UVAR(I,3) = ALDT(I) 
-             LAMBDA = UVAR(I,3) / REF_EL_LEN
-             FAC = FINTER(IFUNC(1),LAMBDA,NPF,TF,DYDX) 
-             UVAR(I,3) = FAC
-           ENDDO
-         ELSEIF ((NUVAR == 9).AND.(UVAR(1,9)==ZERO)) THEN 
-           DO I=1,NEL
-             UVAR(I,9) = ALDT(I) 
-             LAMBDA = UVAR(I,9) / REF_EL_LEN
-             FAC = FINTER(IFUNC(1),LAMBDA,NPF,TF,DYDX) 
-             UVAR(I,9) = FAC
-           ENDDO
+         IF (NUVAR == 3) THEN 
+           IF (UVAR(1,3)==ZERO) THEN 
+             DO I=1,NEL
+               UVAR(I,3) = ALDT(I) 
+               LAMBDA = UVAR(I,3) / REF_EL_LEN
+               FAC = FINTER(IFUNC(1),LAMBDA,NPF,TF,DYDX) 
+               UVAR(I,3) = FAC
+             ENDDO
+           ENDIF
+         ELSEIF (NUVAR == 9) THEN 
+           IF (UVAR(1,9)==ZERO) THEN 
+             DO I=1,NEL
+               UVAR(I,9) = ALDT(I) 
+               LAMBDA = UVAR(I,9) / REF_EL_LEN
+               FAC = FINTER(IFUNC(1),LAMBDA,NPF,TF,DYDX) 
+               UVAR(I,9) = FAC
+             ENDDO
+           ENDIF
          ENDIF
        ENDIF
 C-----------------------------------------------

--- a/engine/source/materials/fail/biquad/fail_biquad_s.F
+++ b/engine/source/materials/fail/biquad/fail_biquad_s.F
@@ -122,22 +122,26 @@ C-----------------------------------------------
 C!  Initialization
 C-----------------------------------------------
        IF (MFUNC > 0) THEN 
-         IF ((NUVAR == 3).AND.(UVAR(1,3)==ZERO)) THEN 
-           DO I=1,NEL
-             UVAR(I,3) = ALDT(I) 
-             LAMBDA = UVAR(I,3) / REF_EL_LEN
-             FAC = FINTER(KFUNC(1),LAMBDA,NPF,TF,DF) 
-             UVAR(I,3) = FAC
-           ENDDO
-         ELSEIF ((NUVAR == 9).AND.(UVAR(1,9)==ZERO)) THEN 
-           DO I=1,NEL
-             UVAR(I,9) = ALDT(I) 
-             LAMBDA = UVAR(I,9) / REF_EL_LEN
-             FAC = FINTER(KFUNC(1),LAMBDA,NPF,TF,DF) 
-             UVAR(I,9) = FAC
-           ENDDO
-         ENDIF
-       ENDIF
+        IF (NUVAR == 3) THEN 
+          IF (UVAR(1,3)==ZERO) THEN 
+            DO I=1,NEL
+              UVAR(I,3) = ALDT(I) 
+              LAMBDA = UVAR(I,3) / REF_EL_LEN
+              FAC = FINTER(KFUNC(1),LAMBDA,NPF,TF,DF) 
+              UVAR(I,3) = FAC
+            ENDDO
+          ENDIF
+        ELSEIF (NUVAR == 9) THEN 
+          IF (UVAR(1,9)==ZERO) THEN 
+            DO I=1,NEL
+              UVAR(I,9) = ALDT(I) 
+              LAMBDA = UVAR(I,9) / REF_EL_LEN
+              FAC = FINTER(KFUNC(1),LAMBDA,NPF,TF,DF) 
+              UVAR(I,9) = FAC
+            ENDDO
+          ENDIF
+        ENDIF
+      ENDIF
 C-----------------------------------------------
 c! fast degradation
         DO I=1,NEL

--- a/engine/source/output/anim/generate/dfuncc.F
+++ b/engine/source/output/anim/generate/dfuncc.F
@@ -1068,10 +1068,22 @@ cc                  IPT = IABS(NPT)/2 + 1
               ENDIF  
                           
 c---
-            ELSEIF (IFUNC == 2 .AND. MLW == 151) THEN
-              DO I=LFT,LLT
-                EVAR(I) = GBUF%RHO(I) 
-              ENDDO               
+            ELSEIF (IFUNC == 2) THEN
+              IF (MLW == 151) THEN 
+                DO I=LFT,LLT
+                  EVAR(I) = GBUF%RHO(I) 
+                ENDDO 
+              ELSE 
+                IF (ITY == 3) THEN 
+                  DO I=LFT,LLT
+                    EVAR(I) = PM(1,IXC(1,NFT+I))
+                  ENDDO
+                ELSEIF (ITY == 7) THEN 
+                  DO I=LFT,LLT
+                    EVAR(I) = PM(1,IXTG(1,NFT+I))
+                  ENDDO
+                ENDIF 
+              ENDIF          
 c---
             ELSEIF (IFUNC == 3 .AND. MLW == 151) THEN
               DO I=LFT,LLT

--- a/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
@@ -360,12 +360,19 @@ C--------------------------------------------------
             ELSEIF (KEYWORD == 'DENS') THEN   ! DENS
 C--------------------------------------------------
                IF (MLW /= 151) THEN
-                  IF (ITHK >0) THEN
-                     DO I=1,NEL
-                        VALUE(I) = GBUF%RHO(I) 
-                        IS_WRITTEN_VALUE(I) = 1
-                     ENDDO
-                  ENDIF
+                 IF (ITY == 3) THEN 
+                   DO I=1,NEL
+                     N = I + NFT
+                     VALUE(I) = PM(1,IXC(1,N))
+                     IS_WRITTEN_VALUE(I) = 1
+                   ENDDO   
+                 ELSEIF(ITY == 7) THEN 
+                   DO I=1,NEL
+                     N = I + NFT
+                     VALUE(I) = PM(1,IXTG(1,N)) 
+                     IS_WRITTEN_VALUE(I) = 1
+                   ENDDO 
+                 ENDIF
                ELSE
                   DO I=1,NEL
                      VALUE(I) = MULTI_FVM%RHO(I + NFT)


### PR DESCRIPTION
Add density output for shells in ANIM and H3D files

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Fix checkbounds issues with /FAIL/BIQUAD and add Density output for shells in ANIM and H3D files

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Change the condition to store the initial element size and add the density storage for outputs. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
