### PR TITLE
automatic correction  of inconsistent Trarot_Mi in /RBE3

### DIFF
--- a/starter/source/constraints/general/rbe3/hm_read_rbe3.F
+++ b/starter/source/constraints/general/rbe3/hm_read_rbe3.F
@@ -396,7 +396,7 @@ C-----------------------------------------------
      .   TITR
 C
       my_real
-     .   W,WMIN
+     .   W,WMIN,IN_T
 C-----------------------------------------------
 C     FRBE3(1-3,I) : tw(i)
 C     FRBE3(4-6,I) : rw(i)
@@ -416,6 +416,23 @@ C----- re-ordering by hierrrchy (only 1 level)
         
         ID=NOM_OPT(1,I)
         CALL FRETITL2(TITR,NOM_OPT(LNOPT1-LTITR+1,I),LTITR)
+C------ check if solid node for all independent        
+        IF (IROT>0) THEN
+          IN_T = ZERO
+          DO J=1,NM
+            M= LRBE3(IAD+J)
+            IN_T = IN_T + IN(M)
+          ENDDO
+          IF (IN_T<EM20) THEN
+             CALL ANCMSG(MSGID=3009,
+     .                   MSGTYPE=MSGWARNING,
+     .                   ANMODE=ANINFO_BLIND_1,
+     .                   I1=ID,
+     .                   C1=TITR)
+            IROT = 0
+            IRBE3(6,I) = 0
+          END IF
+         END IF !(IROT>0) THEN
         CALL RBE3CHK(LRBE3(IAD+1),LRBE3(NMT+IAD+1) ,NS     ,X      ,
      .               FRBE3(6*IAD+1),SKEW    ,NM   ,IROT  ,IMO, WMIN,
      .               IERR1 )

--- a/starter/source/output/message/starter_message_description.txt
+++ b/starter/source/output/message/starter_message_description.txt
@@ -14689,6 +14689,14 @@ Parameter ALPHA should be lower than square root of 2/3 (0.8164965809)
    %i1="/PROP"
    INVALID ISH3N= %d   
 
+/MESSAGE/3009/TITLE
+** WARNING IN RBE3 ELEMENT
+
+/MESSAGE/3009/DESCRIPTION
+   -- RBE3 ID: %d
+   -- RBE3 TITLE: %s
+   %i1="/RBE3"
+   Inconsistent rotational DOFs defined in Trarot_Mi are removed
 
 /MESSAGE/9998/TITLE
 ** MESSAGE WITH NO CATEGORY


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
in case of rotational dofs defined in Trarot_Mi of /RBE3 but all independent nodes are solids, this might change the moment distribution, then the result.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
automatic correction of above inconsistent define in /RBE3

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
