### PR TITLE
/EOS, /MAT : reviewing Starter listing file

### DIFF
--- a/starter/source/materials/eos/hm_read_eos_compaction.F
+++ b/starter/source/materials/eos/hm_read_eos_compaction.F
@@ -79,12 +79,13 @@ C-----------------------------------------------
       my_real  C0,C1,C2,C3,MUMAX,BID,BUNL,MU,MUMIN
       my_real  MU0,SSP0,DF, G0, BULK,BULK2,P_, BB, POLD, MU2, MUOLD, ALPHA,DPDMU
       INTEGER IFORM, IOUTP
-      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE
+      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE, IS_AVAILABLE_RHO0
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
+      IS_AVAILABLE_RHO0 = .FALSE.
       IFORM=0
       IOUTP=1
       
@@ -104,7 +105,7 @@ C-----------------------------------------------
       CALL HM_GET_FLOATV('EOS_COM_B', BUNL, IS_AVAILABLE,LSUBMODEL,UNITAB)
 
       CALL HM_GET_FLOATV('LAW5_PSH', PSH, IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE_RHO0,LSUBMODEL,UNITAB)
 
       RHOR = PM(1)
       RHOI = PM(89)
@@ -117,12 +118,7 @@ C-----------------------------------------------
       ENDIF
             
       IF(C1 <= ZERO)THEN
-         CALL ANCMSG(MSGID=67,
-     .               MSGTYPE=MSGERROR,
-     .               ANMODE=ANINFO,
-     .               I1=IMIDEOS,
-     .               C1='/EOS/COMPACTION',
-     .               C2='C1 MUST BE POSITIVE')
+         CALL ANCMSG(MSGID=67,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=IMIDEOS,C1='/EOS/COMPACTION',C2='C1 MUST BE POSITIVE')
       ENDIF
 
       !IFORM=1 : CONSTANT unload modulus BUNL (DEFAULT)
@@ -202,6 +198,7 @@ C-----------------------------------------------
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
         WRITE(IOUT,1500)C0,C1,C2,C3,PSH,BUNL,MUMIN,MUMAX
+        IF(IS_AVAILABLE_RHO0)WRITE(IOUT,1503)PM(1)
         IF(IOUTP == 1)THEN
           IF(IFORM==10)THEN
              WRITE(IOUT,1510)
@@ -225,13 +222,15 @@ C-----------------------------------------------
      & 5X,'PRESSURE SHIFT. . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'BUNL : UNLOADING MODULUS. . . . . . . . . .=',1PG20.13/,
      & 5X,'MU_MIN : ELASTIC LIMIT. . . . . . . . . . .=',1PG20.13/,
-     & 5X,'MU_MAX : MAXIMUM COMPACTION . . . . . . . .=',1PG20.13/)
+     & 5X,'MU_MAX : MAXIMUM COMPACTION . . . . . . . .=',1PG20.13)    
  1510 FORMAT(
      & 5X,'LEGACY FORMULATION'/)
  1501 FORMAT(
      & 5X,'CONSTANT UNLOAD MODULUS'/)
  1502 FORMAT(
      & 5X,'CONTINUOUS UNLOAD MODULUS FROM C1 TO BUNL IN RANGE [MUMIN,MUMAX]'/)
+ 1503 FORMAT(     
+     & 5X,'EOS REFERENCE DENSITY . . . . . . . . . .=',1PG20.13)      
 
       RETURN
   

--- a/starter/source/materials/eos/hm_read_eos_gruneisen.F
+++ b/starter/source/materials/eos/hm_read_eos_gruneisen.F
@@ -72,12 +72,13 @@ C-----------------------------------------------
       my_real :: C, S1, S2, S3, GAMA0, A, E0, RHO0,RHOI,RHOR,FAC_L,FAC_T
       my_real :: FAC_M,FAC_C,MU,MU2,MU3,MUP1,NUM,DENOM,FAC1,DPDMU,PP,BB,AA
       my_real :: MU0, DF, SSP0, G0, FAC, FF, FG, XX, DFF, DFG
-      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE
+      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE, IS_AVAILABLE_RHO0
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
+      IS_AVAILABLE_RHO0 = .FALSE.
 
       CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
 
@@ -89,8 +90,7 @@ C-----------------------------------------------
       CALL HM_GET_FLOATV('GAMMA',GAMA0, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('MAT_A', A, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('R0E0', E0, IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_FLOATV('Refer_Rho', RHO0 ,IS_AVAILABLE,LSUBMODEL,UNITAB)
-
+      CALL HM_GET_FLOATV('Refer_Rho', RHO0 ,IS_AVAILABLE_RHO0,LSUBMODEL,UNITAB)
 
       IF(A == ZERO) A=GAMA0
 
@@ -163,7 +163,8 @@ C-----------------------------------------------
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1500)C,S1,S2,S3,GAMA0,A,E0,PM(31),PM(1)
+        WRITE(IOUT,1500)C,S1,S2,S3,GAMA0,A,E0,PM(31)
+        IF(IS_AVAILABLE_RHO0)WRITE(IOUT,1501)PM(1)
       ENDIF
 
       RETURN
@@ -179,8 +180,9 @@ C-----------------------------------------------
      & 5X,'GAMA0 . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'A . . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'INITIAL INTERNAL ENERGY PER UNIT VOLUME .=',1PG20.13/,
-     & 5X,'INITIAL PRESSURE . .  . . . . . . . . . .=',1PG20.13/,
-     & 5X,'EOS REFERENCE DENSITY . . . . . . . . . .=',1PG20.13//)
+     & 5X,'INITIAL PRESSURE . .  . . . . . . . . . .=',1PG20.13)
+ 1501 FORMAT(     
+     & 5X,'EOS REFERENCE DENSITY . . . . . . . . . .=',1PG20.13)
  
       RETURN
       END SUBROUTINE HM_READ_EOS_GRUNEISEN

--- a/starter/source/materials/eos/hm_read_eos_ideal_gas.F
+++ b/starter/source/materials/eos/hm_read_eos_ideal_gas.F
@@ -71,12 +71,13 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       my_real  GAMMA, P0,T0, E0, PSH, RHO0,FAC_L,FAC_T,FAC_M,FAC_C,Cv,MU0,PP,RHOI,RHOR,G0,SSP0,DPDMU,DF
-      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE
+      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE, IS_AVAILABLE_RHO0
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
+      IS_AVAILABLE_RHO0 = .FALSE.
 
       CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
 
@@ -84,7 +85,7 @@ C-----------------------------------------------
       CALL HM_GET_FLOATV('LAW5_P0', P0, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('LAW5_PSH', PSH, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('T_Initial', T0, IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE_RHO0,LSUBMODEL,UNITAB)
 
       RHOR = PM(1)
       RHOI = PM(89)
@@ -122,18 +123,14 @@ C-----------------------------------------------
       ! P0 <=0
       ! GAMMA <=ONE
       IF(P0 <= ZERO)THEN
-         CALL ANCMSG(MSGID=67,
-     .               MSGTYPE=MSGERROR,
-     .               ANMODE=ANINFO,
+         CALL ANCMSG(MSGID=67,MSGTYPE=MSGERROR,ANMODE=ANINFO,
      .               I1=IMIDEOS,
      .               C1='/EOS/IDEAL-GAS',
      .               C2='INITIAL PRESSURE MUST BE POSITIVE')
       ENDIF
       
       IF(GAMMA <= ONE)THEN
-         CALL ANCMSG(MSGID=67,
-     .               MSGTYPE=MSGERROR,
-     .               ANMODE=ANINFO,
+         CALL ANCMSG(MSGID=67,MSGTYPE=MSGERROR,ANMODE=ANINFO,
      .               I1=IMIDEOS,
      .               C1='/EOS/IDEAL-GAS',
      .               C2='SPECIFIC HEAT RATIO (GAMMA) MUST BE GREATER THAN 1.0')
@@ -166,8 +163,9 @@ C-----------------------------------------------
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1500)GAMMA,P0,PSH,T0,RHO0,E0,Cv
+        WRITE(IOUT,1500)GAMMA,P0,PSH,T0,E0,Cv
       ENDIF
+      IF(IS_AVAILABLE_RHO0)WRITE(IOUT,1501)PM(1)
 
       RETURN
  1000 FORMAT(
@@ -178,10 +176,11 @@ C-----------------------------------------------
      & 5X,'P0. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'PSH . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'T0. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'RHO0. . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'E0. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'COMPUTED HEAT CAPACITY (Cv) . . . . . . .=',1PG20.13/)
-
+     & 5X,'COMPUTED HEAT CAPACITY (Cv) . . . . . . .=',1PG20.13)
+ 1501 FORMAT(     
+     & 5X,'EOS REFERENCE DENSITY . . . . . . . . . .=',1PG20.13) 
+      
       RETURN
 
       END SUBROUTINE HM_READ_EOS_IDEAL_GAS

--- a/starter/source/materials/eos/hm_read_eos_ideal_gas_vt.F
+++ b/starter/source/materials/eos/hm_read_eos_ideal_gas_vt.F
@@ -80,12 +80,13 @@ C-----------------------------------------------
       my_real :: GAMMA, P0,T0, E0, PSH, RHO0,FAC_L,FAC_T,FAC_M,FAC_C,Cv,MU0,PP,RHOI,RHOR,G0,SSP0,DPDMU,DF
       my_real :: R_GAS,r_gas_, M_GAS, A0, A1, A2, A3, A4, A5, Cp
       INTEGER :: USER_CURVEID, CURVEID, JJ
-      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE
+      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE, IS_AVAILABLE_RHO0
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
+      IS_AVAILABLE_RHO0 = .FALSE.
 
       CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
 
@@ -96,7 +97,7 @@ C      CALL HM_GET_FLOATV('MAT_R', R_GAS, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('LAW5_P0', P0, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('LAW5_PSH', PSH, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('T_Initial', T0, IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE_RHO0,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('MAT_C0', A0, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('MAT_C1', A1, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('MAT_C2', A2, IS_AVAILABLE,LSUBMODEL,UNITAB)
@@ -114,19 +115,14 @@ C      CALL HM_GET_FLOATV('MAT_R', R_GAS, IS_AVAILABLE,LSUBMODEL,UNITAB)
       ENDIF
       
       IF(P0*T0 /= ZERO)THEN
-         CALL ANCMSG(MSGID=67,
-     .               MSGTYPE=MSGERROR,
-     .               ANMODE=ANINFO,
+         CALL ANCMSG(MSGID=67,MSGTYPE=MSGERROR,ANMODE=ANINFO,
      .               I1=IMIDEOS,
      .               C1='/EOS/IDEAL-GAS-VT',
      .               C2='P0 AND T0 CANNOT BE BOTH DEFINED')
       ENDIF
       
       IF(r_gas_ <= ZERO)THEN
-         CALL ANCMSG(MSGID=67,
-     .               MSGTYPE=MSGERROR,
-     .               ANMODE=ANINFO,
-     .               I1=IMIDEOS,
+         CALL ANCMSG(MSGID=67,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=IMIDEOS,
      .               C1='/EOS/IDEAL-GAS-VT',
      .               C2='GAS CONSTANT r MUST BE STRICTLY POSITIVE')
        P0 = ZERO
@@ -145,18 +141,14 @@ C      CALL HM_GET_FLOATV('MAT_R', R_GAS, IS_AVAILABLE,LSUBMODEL,UNITAB)
       ENDIF
       
       IF(P0 <= ZERO)THEN
-         CALL ANCMSG(MSGID=67,
-     .               MSGTYPE=MSGERROR,
-     .               ANMODE=ANINFO,
+         CALL ANCMSG(MSGID=67,MSGTYPE=MSGERROR,ANMODE=ANINFO,
      .               I1=IMIDEOS,
      .               C1='/EOS/IDEAL-GAS-VT',
      .               C2='INITIAL PRESSURE MUST BE POSITIVE')
       ENDIF   
       
       IF(T0 < ZERO)THEN
-         CALL ANCMSG(MSGID=67,
-     .               MSGTYPE=MSGERROR,
-     .               ANMODE=ANINFO,
+         CALL ANCMSG(MSGID=67,MSGTYPE=MSGERROR,ANMODE=ANINFO,
      .               I1=IMIDEOS,
      .               C1='/EOS/IDEAL-GAS-VT',
      .               C2='TEMPERATURE MUST BE POSITIVE (UNIT:KELVIN)')
@@ -182,9 +174,7 @@ C      CALL HM_GET_FLOATV('MAT_R', R_GAS, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CP = A0 + A1*T0 + A2*T0*T0 + A3*T0**3 + A4*T0**4
       
       IF(CP < r_GAS_)THEN
-         CALL ANCMSG(MSGID=67,
-     .               MSGTYPE=MSGERROR,
-     .               ANMODE=ANINFO,
+         CALL ANCMSG(MSGID=67,MSGTYPE=MSGERROR,ANMODE=ANINFO,
      .               I1=IMIDEOS,
      .               C1='/EOS/IDEAL-GAS-VT',
      .               C2='Cp(0) < r IS NOT EXPECTED. CHECK INPUT FUNCTION')
@@ -230,7 +220,8 @@ C      CALL HM_GET_FLOATV('MAT_R', R_GAS, IS_AVAILABLE,LSUBMODEL,UNITAB)
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1500)r_GAS_,T0,P0,PSH,RHO0,Cp,A0,A1,A2,A3,A4
+        WRITE(IOUT,1500)r_GAS_,T0,P0,PSH,Cp,A0,A1,A2,A3,A4
+        IF(IS_AVAILABLE_RHO0)WRITE(IOUT,1501)PM(1)
       ENDIF
 
       RETURN
@@ -242,14 +233,15 @@ C      CALL HM_GET_FLOATV('MAT_R', R_GAS, IS_AVAILABLE,LSUBMODEL,UNITAB)
      & 5X,'INITIAL TEMPERATURE . . . . . . . . . . .=',1PG20.13/,
      & 5X,'INITIAL PRESSURE. . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'PRESSURE SHIFT. . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'INITIAL DENSITY . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'INITIAL MASSIC HEAT CAPACTITY . . . . . .=',1PG20.13/,
      & 5X,'A0. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,     
      & 5X,'A1. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'A2. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'A3. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'A4. . . . . . . . . . . . . . . . . . . .=',1PG20.13/)
-
+     & 5X,'A4. . . . . . . . . . . . . . . . . . . .=',1PG20.13)
+ 1501 FORMAT(     
+     & 5X,'EOS REFERENCE DENSITY . . . . . . . . . .=',1PG20.13) 
+     
       RETURN
 
       END SUBROUTINE HM_READ_EOS_IDEAL_GAS_VT

--- a/starter/source/materials/eos/hm_read_eos_linear.F
+++ b/starter/source/materials/eos/hm_read_eos_linear.F
@@ -69,22 +69,21 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      my_real
-     .   C0, C1, C2, C3, C4, C5,  PSH, RHO0,RHOR,MU0,
-     .   FAC_L,FAC_T,FAC_M,FAC_C,RHOI,G0,SSP0,DPDMU
-      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE     
+      my_real C0, C1, C2, C3, C4, C5,  PSH, RHO0,RHOR,MU0, FAC_L,FAC_T,FAC_M,FAC_C,RHOI,G0,SSP0,DPDMU
+      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE , IS_AVAILABLE_RHO0    
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
+      IS_AVAILABLE_RHO0 = .FALSE.
 
       CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
 
       CALL HM_GET_FLOATV('LAW5_P0', C0, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('MAT_BULK', C1, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('LAW5_PSH', PSH, IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE_RHO0,LSUBMODEL,UNITAB)
 
       RHOR = PM(1)
       RHOI = PM(89)
@@ -133,7 +132,8 @@ C-----------------------------------------------
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1500)C0,C1,PSH,RHO0
+        WRITE(IOUT,1500)C0,C1,PSH
+        IF(IS_AVAILABLE_RHO0)WRITE(IOUT,1501)PM(1)
       ENDIF
 
       RETURN
@@ -143,8 +143,9 @@ C-----------------------------------------------
  1500 FORMAT(
      & 5X,'INITIAL PRESSURE. . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'BULK MODULUS. . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'PRESSURE SHIFT. . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'REFERENCE DENSITY . . . . . . . . . . . .=',1PG20.13//)
-
+     & 5X,'PRESSURE SHIFT. . . . . . . . . . . . . .=',1PG20.13)
+ 1501 FORMAT(     
+     & 5X,'EOS REFERENCE DENSITY . . . . . . . . . .=',1PG20.13) 
+     
       RETURN
       END

--- a/starter/source/materials/eos/hm_read_eos_lszk.F
+++ b/starter/source/materials/eos/hm_read_eos_lszk.F
@@ -71,12 +71,13 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       my_real  GAMMA, P0,T0, E0, PSH, RHO0,FAC_L,FAC_T,FAC_M,FAC_C,PSTAR, FAC_R,A,B,RHOI,RHOR,MU0,DF,SSP0,G0,DPDMU,PP
-      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE
+      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE, IS_AVAILABLE_RHO0
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
+      IS_AVAILABLE_RHO0 = .FALSE.
 
       CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
 
@@ -86,7 +87,7 @@ C-----------------------------------------------
       CALL HM_GET_FLOATV('a', A, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('b', B, IS_AVAILABLE,LSUBMODEL,UNITAB)
 
-      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE_RHO0,LSUBMODEL,UNITAB)
 
       RHOR = PM(1)
       RHOI = PM(89)
@@ -142,9 +143,7 @@ C-----------------------------------------------
       ENDIF
       
       IF(E0 < ZERO)THEN
-         CALL ANCMSG(MSGID=67,
-     .               MSGTYPE=MSGERROR,
-     .               ANMODE=ANINFO,
+         CALL ANCMSG(MSGID=67,MSGTYPE=MSGERROR,ANMODE=ANINFO,
      .               I1=IMIDEOS,
      .               C1='/EOS/LSZK',
      .               C2='PARAMETERS RESULTS INTO A NEGATIVE INITIAL ENERGY')      
@@ -169,7 +168,8 @@ C-----------------------------------------------
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1500)GAMMA,P0,PSH,A,B,RHO0
+        WRITE(IOUT,1500)GAMMA,P0,PSH,A,B
+        IF(IS_AVAILABLE_RHO0)WRITE(IOUT,1501)PM(1)
       ENDIF
 
       RETURN
@@ -181,8 +181,9 @@ C-----------------------------------------------
      & 5X,'P0. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'PSH . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'A . . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'b . . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'RHO0. . . . . . . . . . . . . . . . . . .=',1PG20.13/)
+     & 5X,'b . . . . . . . . . . . . . . . . . . . .=',1PG20.13)
+ 1501 FORMAT(     
+     & 5X,'EOS REFERENCE DENSITY . . . . . . . . . .=',1PG20.13) 
 
       RETURN
       END SUBROUTINE HM_READ_EOS_LSZK

--- a/starter/source/materials/eos/hm_read_eos_murnaghan.F
+++ b/starter/source/materials/eos/hm_read_eos_murnaghan.F
@@ -71,12 +71,13 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       my_real  GAMMA, P0,T0, E0, PSH, RHO0,FAC_L,FAC_T,FAC_M,FAC_C,K0,K1,RHOI,RHOR,MU0,DF,SSP0,G0,DPDMU
-      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE
+      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE, IS_AVAILABLE_RHO0
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
+      IS_AVAILABLE_RHO0 = .FALSE.
 
       CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
 
@@ -84,7 +85,7 @@ C-----------------------------------------------
       CALL HM_GET_FLOATV('K1', K1, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('LAW5_P0', P0, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('LAW5_PSH', PSH, IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE_RHO0,LSUBMODEL,UNITAB)
 
       RHOR = PM(1)
       RHOI = PM(89)
@@ -99,22 +100,10 @@ C-----------------------------------------------
       E0=ZERO
       
       IF(K0 <= ZERO)THEN
-         CALL ANCMSG(MSGID=67,
-     .               MSGTYPE=MSGERROR,
-     .               ANMODE=ANINFO,
-     .               I1=IMIDEOS,
+         CALL ANCMSG(MSGID=67,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=IMIDEOS,
      .               C1='/EOS/MURNAGHAN',
      .               C2='K0 MUST BE POSITIVE')
       ENDIF
-
-!      IF(K1<=ZERO)THEN
-!         CALL ANCMSG(MSGID=67,
-!     .               MSGTYPE=MSGERROR,
-!     .               ANMODE=ANINFO,
-!     .               I1=IMIDEOS,
-!     .               C1='/EOS/MURNAGHAN',
-!     .               C2='K1 MUST BE POSITIVE')
-!      ENDIF
       
       PM(32)=P0
       PM(36)=K0
@@ -147,8 +136,8 @@ C-----------------------------------------------
       SSP0 = ZERO 
       G0 = PM(22)
       RHOI = PM(89)      
-        DPDMU = K0*EXP( K1*LOG(1+MU0) )/(ONE+MU0)  
-      DPDMU=MAX(ZERO,DPDMU)
+      DPDMU = K0*EXP( K1*LOG(1+MU0) )/(ONE+MU0)  
+      DPDMU = MAX(ZERO,DPDMU)
       IF(RHOR > ZERO) SSP0 = SQRT((DPDMU + TWO_THIRD*G0)/RHOR) 
       PM(27)=SSP0
       WRITE(IOUT,1000)
@@ -156,7 +145,8 @@ C-----------------------------------------------
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1500)K0,K1,P0,PM(31),PSH,RHO0
+        WRITE(IOUT,1500)K0,K1,P0,PM(31),PSH
+        IF(IS_AVAILABLE_RHO0)WRITE(IOUT,1501)PM(1)
       ENDIF
 
       RETURN
@@ -168,8 +158,10 @@ C-----------------------------------------------
      & 5X,'K1. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'P0. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'INITIAL PRESSURE. . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'PSH . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'RHO0. . . . . . . . . . . . . . . . . . .=',1PG20.13/)
+     & 5X,'PSH . . . . . . . . . . . . . . . . . . .=',1PG20.13)
+ 1501 FORMAT(     
+     & 5X,'EOS REFERENCE DENSITY . . . . . . . . . .=',1PG20.13) 
+      
 
       RETURN
 

--- a/starter/source/materials/eos/hm_read_eos_nasg.F
+++ b/starter/source/materials/eos/hm_read_eos_nasg.F
@@ -72,13 +72,14 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       my_real  GAMMA, P0, E0, PSH, RHO0,FAC_L,FAC_T,FAC_M,FAC_C,PSTAR,RHOI,RHOR,Cv,T0,b,q,q_
       my_real  NUM,DENOM,UNPMU
-      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE
+      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE, IS_AVAILABLE_RHO0
       my_real :: PP,dPdE,DPDMU ,G0,SSP0,MU0,DF
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
+      IS_AVAILABLE_RHO0 = .FALSE.
 
       CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
 
@@ -90,7 +91,7 @@ C-----------------------------------------------
       CALL HM_GET_FLOATV('LAW5_PSH', PSH, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('LAW5_P0', P0, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('EOS_C0', Cv, IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE_RHO0,LSUBMODEL,UNITAB)
 
       !---initial density
       RHOR = PM(1)
@@ -110,18 +111,14 @@ C-----------------------------------------------
       ! GAMMA <=0
       
       IF(GAMMA <= ONE)THEN
-         CALL ANCMSG(MSGID=67,
-     .               MSGTYPE=MSGERROR,
-     .               ANMODE=ANINFO,
+         CALL ANCMSG(MSGID=67,MSGTYPE=MSGERROR,ANMODE=ANINFO,
      .               I1=IMIDEOS,
      .               C1='/EOS/NASG',
      .               C2='GAMMA MUST BE GREATER THAN 1.0')
       ENDIF
       
       IF(E0 <= ZERO)THEN
-         CALL ANCMSG(MSGID=67,
-     .               MSGTYPE=MSGERROR,
-     .               ANMODE=ANINFO,
+         CALL ANCMSG(MSGID=67,MSGTYPE=MSGERROR,ANMODE=ANINFO,
      .               I1=IMIDEOS,
      .               C1='/EOS/NASG',
      .               C2='PARAMETERS ARE RESULTING INTO A NEGATIVE ENERGY : E0')      
@@ -179,7 +176,8 @@ C-----------------------------------------------
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1500)GAMMA,b,q,PSH,PSTAR,Cv,P0,E0,RHO0
+        WRITE(IOUT,1500)GAMMA,b,q,PSH,PSTAR,Cv,P0,E0
+        IF(IS_AVAILABLE_RHO0)WRITE(IOUT,1501)PM(1)
       ENDIF
 
       RETURN
@@ -196,8 +194,9 @@ C-----------------------------------------------
      & 5X,'Cv. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'P0. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
 !     & 5X,'T0 .  . . . . . . . . . . . . . . . . . .=',1PG20.13/,     
-     & 5X,'E0 .  . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'RHO0. . . . . . . . . . . . . . . . . . .=',1PG20.13/)
+     & 5X,'E0 .  . . . . . . . . . . . . . . . . . .=',1PG20.13)
+ 1501 FORMAT(     
+     & 5X,'EOS REFERENCE DENSITY . . . . . . . . . .=',1PG20.13)     
 
       RETURN
       END

--- a/starter/source/materials/eos/hm_read_eos_noble_abel.F
+++ b/starter/source/materials/eos/hm_read_eos_noble_abel.F
@@ -73,19 +73,20 @@ C-----------------------------------------------
      .   C0, C1, C2, C3, C4, C5, E0, PSH, RHO0,
      .   FAC_L,FAC_T,FAC_M,FAC_C,BB,GAMMA,AA,PP,DENOM,MU,RHOI,RHOR,DPDMU,DPDE
       my_real MU0,MU2,DF,SSP0,G0
-      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE
+      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE, IS_AVAILABLE_RHO0
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
+      IS_AVAILABLE_RHO0 = .FALSE.
 
       CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
       CALL HM_GET_FLOATV('b_Covolume',BB, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('Gamma_Constant', GAMMA, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('E0', E0, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('LAW5_PSH', PSH ,IS_AVAILABLE,LSUBMODEL,UNITAB)      
-      CALL HM_GET_FLOATV('Refer_Rho', RHO0 ,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV('Refer_Rho', RHO0 ,IS_AVAILABLE_RHO0,LSUBMODEL,UNITAB)
 
       RHOR = PM(1)
       RHOI = PM(89)
@@ -145,7 +146,8 @@ C-----------------------------------------------
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1500)BB,GAMMA,PM(31),E0,RHO0,PSH
+        WRITE(IOUT,1500)BB,GAMMA,PM(31),E0,PSH
+        IF(IS_AVAILABLE_RHO0)WRITE(IOUT,1501)PM(1)
       ENDIF
 
       RETURN
@@ -157,8 +159,9 @@ C-----------------------------------------------
      & 5X,'GAMMA GAS CONSTANT. . . . . . . . . . . .=',1PG20.13/,
      & 5X,'INITIAL PRESSURE. . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'INITIAL INTERNAL ENERGY PER UNIT VOLUME .=',1PG20.13/,
-     & 5X,'REFERENCE DENSITY . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'PRESSURE SHIFT. . . . . . . . . . . . . .=',1PG20.13//)
+     & 5X,'PRESSURE SHIFT. . . . . . . . . . . . . .=',1PG20.13)
+ 1501 FORMAT(     
+     & 5X,'EOS REFERENCE DENSITY . . . . . . . . . .=',1PG20.13)     
 
       RETURN
       END

--- a/starter/source/materials/eos/hm_read_eos_osborne.F
+++ b/starter/source/materials/eos/hm_read_eos_osborne.F
@@ -72,12 +72,13 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       my_real  GAMMA, P0,T0, E0, PSH, RHO0,FAC_L,FAC_T,FAC_M,FAC_C, FAC_E
       my_real A1,A2,B0,B1,B2,C0,C1,D0,RHOI,RHOR,dPdmu_partial,dPdE,DF,MU0,DPDMU,A2_,G0,SSP0, DENOM
-      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE     
+      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE, IS_AVAILABLE_RHO0
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
+      IS_AVAILABLE_RHO0 = .FALSE.
 
       CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
 
@@ -92,7 +93,7 @@ C-----------------------------------------------
       CALL HM_GET_FLOATV('EOS_D0', D0, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('LAW5_P0', P0, IS_AVAILABLE,LSUBMODEL,UNITAB)
 
-      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE_RHO0,LSUBMODEL,UNITAB)
 
       RHOR = PM(1)
       RHOI = PM(89)
@@ -115,9 +116,7 @@ C-----------------------------------------------
      .   D0 <= ZERO .OR.
      .   RHO0 <= ZERO 
      .   )THEN
-         CALL ANCMSG(MSGID=67,
-     .               MSGTYPE=MSGERROR,
-     .               ANMODE=ANINFO,
+         CALL ANCMSG(MSGID=67, MSGTYPE=MSGERROR, ANMODE=ANINFO,
      .               I1=IMIDEOS,
      .               C1='/EOS/OSBORNE',
      .               C2='PARAMETERS MUST BE STRICTLY POSITIVE')
@@ -180,7 +179,8 @@ C-----------------------------------------------
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1500)A1,A2,B0,B1,B2,C0,C1,D0,P0,RHO0
+        WRITE(IOUT,1500)A1,A2,B0,B1,B2,C0,C1,D0,P0
+        IF(IS_AVAILABLE_RHO0)WRITE(IOUT,1501)PM(1)
       ENDIF
 
       RETURN
@@ -196,8 +196,9 @@ C-----------------------------------------------
      & 5X,'C0. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'C1. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'D0. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'P0. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'RHO0. . . . . . . . . . . . . . . . . . .=',1PG20.13/)
+     & 5X,'P0. . . . . . . . . . . . . . . . . . . .=',1PG20.13)
+ 1501 FORMAT(     
+     & 5X,'EOS REFERENCE DENSITY . . . . . . . . . .=',1PG20.13)      
 
       RETURN
       END

--- a/starter/source/materials/eos/hm_read_eos_polynomial.F
+++ b/starter/source/materials/eos/hm_read_eos_polynomial.F
@@ -72,12 +72,13 @@ C-----------------------------------------------
       my_real
      .   C0, C1, C2, C3, C4, C5, E0, PSH, RHO0,RHOR,MU0,
      .   FAC_L,FAC_T,FAC_M,FAC_C,RHOI, G0, SSP0, DF, DPDMU
-      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE     
+      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE, IS_AVAILABLE_RHO0     
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
+      IS_AVAILABLE_RHO0 = .FALSE.
 
       CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
 
@@ -89,7 +90,7 @@ C-----------------------------------------------
       CALL HM_GET_FLOATV('MAT_C5', C5, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('MAT_EA', E0, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('MAT_PSH', PSH, IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE_RHO0,LSUBMODEL,UNITAB)
 
       RHOR = PM(1)
       RHOI = PM(89)
@@ -147,7 +148,8 @@ C-----------------------------------------------
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1500)C0,C1,C2,C3,C4,C5,E0,PM(104),PM(89),PM(1),PSH
+        WRITE(IOUT,1500)C0,C1,C2,C3,C4,C5,E0,PM(104),PSH
+        IF(IS_AVAILABLE_RHO0)WRITE(IOUT,1501)PM(1)
       ENDIF
 
       RETURN
@@ -163,9 +165,9 @@ C-----------------------------------------------
      & 5X,'C5. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'INITIAL INTERNAL ENERGY PER UNIT VOLUME .=',1PG20.13/,
      & 5X,'INITIAL PRESSURE. . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'INITIAL DENSITY . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'REFERENCE DENSITY . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'PRESSURE SHIFT. . . . . . . . . . . . . .=',1PG20.13//)
+     & 5X,'PRESSURE SHIFT. . . . . . . . . . . . . .=',1PG20.13)
+ 1501 FORMAT(     
+     & 5X,'EOS REFERENCE DENSITY . . . . . . . . . .=',1PG20.13)      
 
       RETURN
       END

--- a/starter/source/materials/eos/hm_read_eos_puff.F
+++ b/starter/source/materials/eos/hm_read_eos_puff.F
@@ -59,7 +59,6 @@ C-----------------------------------------------
       TYPE (UNIT_TYPE_),INTENT(IN) ::UNITAB 
       INTEGER IIN,IOUT,IUNIT
       my_real PM(NPROPM)
-      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE
       TYPE(SUBMODEL_DATA), DIMENSION(NSUBMOD), INTENT(IN) :: LSUBMODEL
       INTEGER,INTENT(IN) :: IMIDEOS
 C-----------------------------------------------
@@ -74,11 +73,13 @@ C-----------------------------------------------
      .   C1, C2, C3, G0, T1, T2, ES, HH, E0, RHO0,
      .   FAC_L,FAC_T,FAC_M,FAC_C,RHOR,RHOI,MU2,
      .   XX,AA,BB,GX,PRES,EXPA,ETA,EE,CC, MU0, DF, PP ,SSP0, DPDMU, PC
+      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE, IS_AVAILABLE_RHO0     
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
+      IS_AVAILABLE_RHO0 = .FALSE.
 
       CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
 
@@ -93,7 +94,7 @@ C-----------------------------------------------
 
       CALL HM_GET_FLOATV('MAT_EOH',HH, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('MAT_EA', E0, IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE_RHO0,LSUBMODEL,UNITAB)
 
       IF(T1 == ZERO) T1=C1
 
@@ -184,7 +185,8 @@ C-----------------------------------------------
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1500)C1,C2,C3,G0,T1,T2,ES,HH,E0,PM(31),PM(1)
+        WRITE(IOUT,1500)C1,C2,C3,G0,T1,T2,ES,HH,E0,PM(31)
+        IF(IS_AVAILABLE_RHO0)WRITE(IOUT,1501)PM(1)
       ENDIF
 
       RETURN
@@ -202,8 +204,9 @@ C-----------------------------------------------
      & 5X,'SUBLIMATION ENERGY (PER UNIT VOLUME). . . .=',1PG20.13/,
      & 5X,'H . . . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'INITIAL INTERNAL ENERGY (PER UNIT VOLUME) .=',1PG20.13/,
-     & 5X,'INITIAL PRESSURE. . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'REFERENCE DENSITY . . . . . . . . . . . . .=',1PG20.13//)
+     & 5X,'INITIAL PRESSURE. . . . . . . . . . . . . .=',1PG20.13)
+ 1501 FORMAT(     
+     & 5X,'EOS REFERENCE DENSITY . . . . . . . . . .=',1PG20.13)      
 
       RETURN
       END

--- a/starter/source/materials/eos/hm_read_eos_sesame.F
+++ b/starter/source/materials/eos/hm_read_eos_sesame.F
@@ -87,18 +87,19 @@ C-----------------------------------------------
       my_real MU0,DF,SSP0,G0,DPDMU
       CHARACTER FILE*(ncharline),FILE_TMP*(ncharline)
       INTEGER :: FILE_LEN
-      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE
+      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE, IS_AVAILABLE_RHO0
       CHARACTER*nchartitle TITR        
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
+      IS_AVAILABLE_RHO0 = .FALSE.
 
       CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
 
       CALL HM_GET_FLOATV('MAT_EA', E0, IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_FLOATV('SESAME_RHO', RHO0, IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV('SESAME_RHO', RHO0, IS_AVAILABLE_RHO0,LSUBMODEL,UNITAB)
       CALL HM_GET_STRING('ISRTY',FILE, ncharline,IS_AVAILABLE)
 
       RHOR = PM(1)
@@ -153,7 +154,8 @@ C
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1500)E0,PM(1),FILE,P0,T0
+        WRITE(IOUT,1500)E0,FILE,P0,T0
+        IF(IS_AVAILABLE_RHO0)WRITE(IOUT,1501)PM(1)
       ENDIF
 
       PM(31) = P0
@@ -186,25 +188,19 @@ C
       
       RETURN
   999 CONTINUE
-      CALL ANCMSG(MSGID=19,
-     .            MSGTYPE=MSGERROR,
-     .            ANMODE=ANINFO,
-     .            I1=IMID,
-     .            C1='EOS',
-     .            C2='EOS',
-     .            C3=TITR,
-     .            C4=FILE)
+      CALL ANCMSG(MSGID=19,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=IMID,C1='EOS',C2='EOS',C3=TITR,C4=FILE)
       RETURN
       
  1000 FORMAT(
      & 5X,'  SESAME TABLE EOS     ',/,
      & 5X,'  ----------------     ',/)
  1500 FORMAT(
-     & 5X,'INITIAL INTERNAL ENERGY PER UNIT VOLUME. . .=',1PG20.13/,
-     & 5X,'REFERENCE DENSITY. . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'SESAME TABLE 301 . . . . . . . . . . . . . .=',A70/,
-     & 5X,'INITIAL PRESSURE . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'INITIAL TEMPERATURE. . . . . . . . . . . . .=',1PG20.13//)
+     & 5X,'INITIAL INTERNAL ENERGY PER UNIT VOLUME. =',1PG20.13/,
+     & 5X,'SESAME TABLE 301 . . . . . . . . . . . . =',A70/,
+     & 5X,'INITIAL PRESSURE . . . . . . . . . . . . =',1PG20.13/,
+     & 5X,'INITIAL TEMPERATURE. . . . . . . . . . . =',1PG20.13)
+ 1501 FORMAT(     
+     & 5X,'EOS REFERENCE DENSITY . . . . . . . . . .=',1PG20.13)        
 C
       RETURN
       END

--- a/starter/source/materials/eos/hm_read_eos_stiffened_gas.F
+++ b/starter/source/materials/eos/hm_read_eos_stiffened_gas.F
@@ -71,12 +71,13 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       my_real  GAMMA, P0, E0, PSH, RHO0,FAC_L,FAC_T,FAC_M,FAC_C,PSTAR,RHOI,RHOR,MU0,PP,DF,SSP0,G0,DPDMU
-      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE     
+      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE, IS_AVAILABLE_RHO0     
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
+      IS_AVAILABLE_RHO0 = .FALSE.
 
       CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
 
@@ -84,7 +85,7 @@ C-----------------------------------------------
       CALL HM_GET_FLOATV('LAW5_P0', P0, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('LAW5_PSH', PSH, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('P_star', PSTAR, IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE_RHO0,LSUBMODEL,UNITAB)
 
       RHOR = PM(1)
       RHOI = PM(89)
@@ -106,12 +107,7 @@ C-----------------------------------------------
       ! GAMMA <=0
       
       IF(GAMMA <= ONE)THEN
-         CALL ANCMSG(MSGID=67,
-     .               MSGTYPE=MSGERROR,
-     .               ANMODE=ANINFO,
-     .               I1=IMIDEOS,
-     .               C1='/EOS/STIFF-GAS',
-     .               C2='GAMMA MUST BE GREATER THAN 1.0')
+         CALL ANCMSG(MSGID=67,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=IMIDEOS,C1='/EOS/STIFF-GAS',C2='GAMMA MUST BE GREATER THAN 1.0')
       ENDIF
 
       
@@ -157,7 +153,8 @@ C-----------------------------------------------
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1500)GAMMA,P0,PSH,PSTAR,RHO0,E0
+        WRITE(IOUT,1500)GAMMA,P0,PSH,PSTAR,E0
+        IF(IS_AVAILABLE_RHO0)WRITE(IOUT,1501)PM(1)
       ENDIF
 
       RETURN
@@ -169,8 +166,9 @@ C-----------------------------------------------
      & 5X,'P0. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'PSH . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'PSTAR . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'RHO0. . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'COMPUTED E0 . . . . . . . . . . . . . . .=',1PG20.13/)
+     & 5X,'COMPUTED E0 . . . . . . . . . . . . . . .=',1PG20.13)
+ 1501 FORMAT(     
+     & 5X,'EOS REFERENCE DENSITY . . . . . . . . . .=',1PG20.13)        
 
       RETURN
       END

--- a/starter/source/materials/eos/hm_read_eos_tabulated.F
+++ b/starter/source/materials/eos/hm_read_eos_tabulated.F
@@ -73,13 +73,14 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       my_real ::  GAMMA, P0,T0, E0, PSH, RHO0,FAC_L,FAC_T,FAC_M,FAC_C,Cv,MU0,PP,RHOI,RHOR,G0,SSP0,DPDMU,DF
       my_real :: XSCALE_A, XSCALE_B, FSCALE_A, FSCALE_B
-      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE
+      LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE, IS_AVAILABLE_RHO0
       INTEGER :: A_FUN_ID, B_FUN_ID
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
+      Is_AVAILABLE_RHO0 = .FALSE.
 
       CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
 
@@ -94,22 +95,18 @@ C-----------------------------------------------
 
       CALL HM_GET_FLOATV('PSH', PSH, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('E0', E0, IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV('Refer_Rho', RHO0, IS_AVAILABLE_RHO0,LSUBMODEL,UNITAB)
 
       !MANAGING INPUT ERRORS :
       IF(A_fun_id+B_fun_id == 0)THEN
-         CALL ANCMSG(MSGID=67,
-     .               MSGTYPE=MSGERROR,
-     .               ANMODE=ANINFO,
+         CALL ANCMSG(MSGID=67,MSGTYPE=MSGERROR,ANMODE=ANINFO,
      .               I1=IMIDEOS,
      .               C1='/EOS/TABULATED',
      .               C2='NO INPUT FUNCTION')
       ENDIF
       
-      IF(RHO0 <= ZERO)THEN
-         CALL ANCMSG(MSGID=67,
-     .               MSGTYPE=MSGERROR,
-     .               ANMODE=ANINFO,
+      IF(IS_AVAILABLE_RHO0 .AND. RHO0 < ZERO)THEN
+         CALL ANCMSG(MSGID=67,MSGTYPE=MSGERROR,ANMODE=ANINFO,
      .               I1=IMIDEOS,
      .               C1='/EOS/TABULATED',
      .               C2='REFERENCE DENSITY MUST BE STRICTLY POSITIVE')
@@ -172,7 +169,8 @@ C-----------------------------------------------
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1500)A_fun_id,XSCALE_A,FSCALE_A,B_fun_id,XSCALE_B,FSCALE_B,E0,PSH,RHO0
+        WRITE(IOUT,1500)A_fun_id,XSCALE_A,FSCALE_A,B_fun_id,XSCALE_B,FSCALE_B,E0,PSH
+        IF(IS_AVAILABLE_RHO0)WRITE(IOUT,1501)PM(1)
       ENDIF
 
       RETURN
@@ -187,8 +185,9 @@ C-----------------------------------------------
      & 5X,'XSCALE_B. . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'FSCALE_B. . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'E0. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,          
-     & 5X,'PSH . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'REFERENCE DENSITY. . . . .  . . . . . . .=',1PG20.13/)
+     & 5X,'PSH . . . . . . . . . . . . . . . . . . .=',1PG20.13)
+ 1501 FORMAT(     
+     & 5X,'EOS REFERENCE DENSITY . . . . . . . . . .=',1PG20.13)       
 
       RETURN
 

--- a/starter/source/materials/eos/hm_read_eos_tillotson.F
+++ b/starter/source/materials/eos/hm_read_eos_tillotson.F
@@ -76,12 +76,13 @@ C-----------------------------------------------
       my_real :: C1, C2, A, B, ER, ES, VS, E0, RHO0,RHOI,RHOR, ALPHA, BETA,
      .           FAC_L,FAC_T,FAC_M,FAC_C,FACC1,FACC2,FACPB,MU0,MU2,DF,ETA,
      .           OMEGA,AA,BB,PP,XX,EXPA,EXPB,DPDMU, SSP0, G0
-      LOGICAL :: IS_ENCRYPTED,IS_AVAILABLE
+      LOGICAL :: IS_ENCRYPTED,IS_AVAILABLE,IS_AVAILABLE_RHO0
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
+      IS_AVAILABLE_RHO0 = .FALSE.
 
       EOS_TAG(IEOS)%NVAR = 1  !saving Region id for H2D and ANIM output                         
 
@@ -96,7 +97,7 @@ C-----------------------------------------------
       CALL HM_GET_FLOATV('E_S', ES, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('Vs', VS, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('MAT_EA', E0 ,IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_FLOATV('Refer_Rho', RHO0 ,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV('Refer_Rho', RHO0 ,IS_AVAILABLE_RHO0,LSUBMODEL,UNITAB)
 
       CALL HM_GET_FLOATV('Alpha', ALPHA ,IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('Beta', BETA ,IS_AVAILABLE,LSUBMODEL,UNITAB)
@@ -178,7 +179,8 @@ C-----------------------------------------------
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1500)C1,C2,A,B,ER,ES,VS,E0,PM(31),PM(1),ALPHA,BETA
+        WRITE(IOUT,1500)C1,C2,A,B,ER,ES,VS,E0,PM(31),ALPHA,BETA
+        IF(IS_AVAILABLE_RHO0)WRITE(IOUT,1501)PM(1)
       ENDIF
 
       RETURN
@@ -196,9 +198,10 @@ C-----------------------------------------------
      & 5X,'SUBLIMATION RELATIVE VOLUME . . . . . . .=',1PG20.13/,
      & 5X,'INITIAL INTERNAL ENERGY(PER UNIT VOLUME).=',1PG20.13/,
      & 5X,'INITIAL PRESSURE. . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'REFERENCE DENSITY. . .  . . . . . . . . .=',1PG20.13/,
      & 5X,'ALPHA . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'BETA. . . . . . . . . . . . . . . . . . .=',1PG20.13//)
+     & 5X,'BETA. . . . . . . . . . . . . . . . . . .=',1PG20.13)
+ 1501 FORMAT(     
+     & 5X,'EOS REFERENCE DENSITY . . . . . . . . . .=',1PG20.13)     
  
       RETURN
       END

--- a/starter/source/materials/mat/mat003/hm_read_mat03.F
+++ b/starter/source/materials/mat/mat003/hm_read_mat03.F
@@ -192,13 +192,14 @@ C-----------------------------------------------
       MTAG%G_TEMP  = 1
       MTAG%L_TEMP  = 1
 
-      WRITE(IOUT,1000)          
-
+      
+      WRITE(IOUT,2001) TITR,MAT_ID,3
+      WRITE(IOUT,1000)    
+              
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,2001) TITR,MAT_ID,3
-        WRITE(IOUT,2002) RHO0,RHOR 
+        WRITE(IOUT,2002)RHO0,RHOR 
         WRITE(IOUT,1300)YOUNG,ANU,G,BULK
         WRITE(IOUT,1400)CA,CB,CN,EPSM,SIGM
         WRITE(IOUT,1500)PMIN
@@ -210,9 +211,7 @@ C-----------------------------------------------
         WRITE(IOUT,2000)                                 !      
         IF(IS_ENCRYPTED)THEN                        !
           WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'     !
-        ELSE      
-          WRITE(IOUT,2001) TITR,MAT_ID,6                       
-          WRITE(IOUT,2002) RHO0,RHOR                                                  !
+        ELSE                                                       !
           WRITE(IOUT,2500)C0,C1,C2,C3,C4,C5,E0,PM(1),PSH !
         ENDIF                                            !
       ENDIF                                              !

--- a/starter/source/materials/mat/mat004/hm_read_mat04.F
+++ b/starter/source/materials/mat/mat004/hm_read_mat04.F
@@ -240,13 +240,13 @@ C     Formulation for solid elements time step computation.
       MTAG%L_EPSD = 1   
       
 C--------------------------------
+      WRITE(IOUT,2001) TITR,MAT_ID,4
       WRITE(IOUT,1000)
 
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,2001) TITR,MAT_ID,4
-        WRITE(IOUT,2002) RHO0,RHOR           
+        WRITE(IOUT,2002)RHO0,RHOR           
         WRITE(IOUT,1300)YOUNG,ANU,G,BULK
         WRITE(IOUT,1400)CA,CB,CN,EPSM,SIGM
         WRITE(IOUT,1500)PMIN
@@ -267,12 +267,7 @@ C--------------------------------
       !--------------------------------------------------!
 C
       IF(EPS0 == ZERO) THEN
-         CALL ANCMSG(MSGID=298,
-     .               MSGTYPE=MSGERROR,
-     .               ANMODE=ANINFO,
-     .               I1=4,
-     .               I2=MAT_ID,
-     .               C1=TITR)
+         CALL ANCMSG(MSGID=298,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=4,I2=MAT_ID,C1=TITR)
       ENDIF
       RETURN
  1000 FORMAT(

--- a/starter/source/materials/mat/mat005/hm_read_mat05.F
+++ b/starter/source/materials/mat/mat005/hm_read_mat05.F
@@ -261,7 +261,7 @@ C-----------------------------------------------
       IF(IS_ENCRYPTED)THEN
          WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-         WRITE(IOUT,1002) RHO0,RHOR
+         WRITE(IOUT,1002)RHO0,RHOR
          WRITE(IOUT,1300)A,B,R1,R2,W
          WRITE(IOUT,1400)D,PCJ,VCJ,E0,C0,PSH,BULK,IBFRAC
          !AFTERBURNING OPTIONAL MODEL

--- a/starter/source/materials/mat/mat006/hm_read_mat06.F
+++ b/starter/source/materials/mat/mat006/hm_read_mat06.F
@@ -167,14 +167,16 @@ C-----
 
       WRITE(IOUT,2001) TRIM(TITR),MAT_ID,6   
       WRITE(IOUT,1000)
+      
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSEIF (IS_EOS) THEN
-        WRITE(IOUT,2002) RHO0,RHOR     
+        WRITE(IOUT,2002)RHO0,RHOR
         WRITE(IOUT,1300)VIS
         WRITE(IOUT,1400)PSH
         WRITE(IOUT,1500)C0,C1,C2,C3,C4,C5,PMIN,PM(31),E0  
       ELSE
+         WRITE(IOUT,2002)RHO0,RHOR
          WRITE(IOUT,1300)VIS
          WRITE(IOUT,1501)PMIN 
       ENDIF
@@ -224,7 +226,7 @@ C--------------------------------
      & 5X,'MATERIAL LAW. . . . . . . . . . . . . .=',I10/)
  2002 FORMAT(
      & 5X,'INITIAL DENSITY . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'REFERENCE DENSITY . . . . . . . . . . .=',1PG20.13/)
+     & 5X,'REFERENCE DENSITY . . . . . . . . . . .=',1PG20.13)
 
 C--------------------------------
 C-----------

--- a/starter/source/materials/mat/mat006/hm_read_mat06_keps.F
+++ b/starter/source/materials/mat/mat006/hm_read_mat06_keps.F
@@ -198,13 +198,13 @@ C-----------------------------------------------
       PM(87)=RK0/RHO0                                      
 
 
-      WRITE(IOUT,1001)
       WRITE(IOUT,2001) TRIM(TITR),MAT_ID,6
-      WRITE(IOUT,2002) RHO0,RHOR           
+      WRITE(IOUT,1001)
                
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
+         WRITE(IOUT,2002)RHO0,RHOR         
          WRITE(IOUT,1300)VIS
          WRITE(IOUT,1501)PMIN 
       ENDIF

--- a/starter/source/materials/mat/mat010/hm_read_mat10.F
+++ b/starter/source/materials/mat/mat010/hm_read_mat10.F
@@ -345,7 +345,7 @@ C---- Buffer Size for specific element buffer allocations
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1200) RHO0,RHOR
+        WRITE(IOUT,1200)RHO0,RHOR
         WRITE(IOUT,1300)YOUNG,ANU,G
         WRITE(IOUT,1400)A0,A1,A2,AMX
         IF(IFORM == 1)THEN
@@ -365,7 +365,7 @@ C-----------
      & 5X,'MATERIAL LAW. . . . . . . . . . . . . .=',I10/)
  1200 FORMAT(
      & 5X,'INITIAL DENSITY . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'EOS REFERENCE DENSITY . . . . . . . . .=',1PG20.13/)
+     & 5X,'REFERENCE DENSITY . . . . . . . . . . .=',1PG20.13/)
  1300 FORMAT(
      & 5X,40HYOUNG'S MODULUS . . . . . . . . . . . .=,E12.4/,
      & 5X,40HPOISSON'S RATIO . . . . . . . . . . . .=,E12.4/,

--- a/starter/source/materials/mat/mat011/hm_read_mat11.F
+++ b/starter/source/materials/mat/mat011/hm_read_mat11.F
@@ -229,13 +229,14 @@ C     Already exited at input reading
 C----------------------
 C     PRINTOUT
 C----------------------
-      WRITE(IOUT, 800) TRIM(TITR),MAT_ID,11
+      WRITE(IOUT, 800)TRIM(TITR),MAT_ID,11
+      
       IF(IS_ENCRYPTED)THEN
          WRITE(IOUT,900)
          WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
          WRITE(IOUT,1000)ITYP,PSH,TSCAL
-         WRITE(IOUT, 850) RHO0, RHOR
+         WRITE(IOUT, 850) RHO0,RHOR
          SELECT CASE(ITYP)
          CASE(0)
             WRITE(IOUT,1100)GAM,P0,E0,VCRT,RCRT,PCRT,INOD
@@ -305,8 +306,8 @@ C----------------------
      & 5X,'MATERIAL NUMBER. . . . . . . . . . . . . . .=',I10/,
      & 5X,'MATERIAL LAW . . . . . . . . . . . . . . . .=',I10/)
   850 FORMAT(
-     & 5X,'INITIAL DENSITY    . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'EOS REFERENCE DENSITY. . . . . . . . . . . .=',1PG20.13/)
+     & 5X,'INITIAL DENSITY . . . . . . . . . . . .=',1PG20.13/,
+     & 5X,'REFERENCE DENSITY . . . . . . . . . . .=',1PG20.13/)
   900 FORMAT(
      & 5X,40H  LAW FOR FLUID BOUNDARY ELEMENTS       ,/,
      & 5X,40H  -------------------------------       ,/)

--- a/starter/source/materials/mat/mat011/hm_read_mat11_k_eps.F
+++ b/starter/source/materials/mat/mat011/hm_read_mat11_k_eps.F
@@ -251,13 +251,13 @@ C     Already exited at input reading
 C----------------------
 C     PRINTOUT
 C----------------------
-      WRITE(IOUT, 800) TRIM(TITR),MAT_ID,11
+      WRITE(IOUT,800)TRIM(TITR),MAT_ID,11
       IF(IS_ENCRYPTED)THEN
          WRITE(IOUT,900)
          WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
          WRITE(IOUT,1000)ITYP,PSH,TSCAL
-         WRITE(IOUT, 850) RHO0, RHOR
+         WRITE(IOUT,850) RHO0,RHOR
          SELECT CASE(ITYP)
          CASE(0)
             WRITE(IOUT,1100)GAM,P0,E0,VCRT,RCRT,PCRT,INOD
@@ -339,8 +339,8 @@ C----------------------
      & 5X,'MATERIAL NUMBER. . . . . . . . . . . . . . .=',I10/,
      & 5X,'MATERIAL LAW . . . . . . . . . . . . . . . .=',I10/)
   850 FORMAT(
-     & 5X,'INITIAL DENSITY    . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'EOS REFERENCE DENSITY. . . . . . . . . . . .=',1PG20.13/)
+     & 5X,'INITIAL DENSITY . . . . . . . . . . . .=',1PG20.13/,
+     & 5X,'REFERENCE DENSITY . . . . . . . . . . .=',1PG20.13/)
   900 FORMAT(
      & 5X,40H  LAW FOR FLUID BOUNDARY ELEMENTS       ,/,
      & 5X,40H  -------------------------------       ,/)

--- a/starter/source/materials/mat/mat012/hm_read_mat12.F
+++ b/starter/source/materials/mat/mat012/hm_read_mat12.F
@@ -209,7 +209,7 @@ C-------------------------------------
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1002) RHO0      
+        WRITE(IOUT,1002) RHO0,RHOR     
         WRITE(IOUT,1100) E11,E22,E33
         WRITE(IOUT,1200) N12,N23,N31
         WRITE(IOUT,1300) G12,G23,G31
@@ -386,7 +386,8 @@ C
      & 5X,'MATERIAL NUMBER . . . . . . . . . . . .=',I10/,
      & 5X,'MATERIAL LAW. . . . . . . . . . . . . .=',I10/)
  1002 FORMAT(
-     & 5X,'INITIAL DENSITY . . . . . . . . . . . .=',1PG20.13/)
+     & 5X,'INITIAL DENSITY . . . . . . . . . . . .=',1PG20.13/,
+     & 5X,'REFERENCE DENSITY . . . . . . . . . . .=',1PG20.13)
  1100 FORMAT(
      & 5X,'YOUNG MODULUS E11 . . . . . . . . . . .=',1PG20.13/,
      & 5X,'YOUNG MODULUS E22 . . . . . . . . . . .=',1PG20.13/,

--- a/starter/source/materials/mat/mat013/hm_read_mat13.F
+++ b/starter/source/materials/mat/mat013/hm_read_mat13.F
@@ -82,8 +82,8 @@ C-----------------------------------------------
 C     Check input encryption
       CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
 C     Initial and reference density
-      CALL HM_GET_FLOATV('MAT_RHO'    ,RHO0        ,IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('Refer_Rho'  ,RHOR        ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_RHO'   ,RHO0, IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('Refer_Rho' ,RHOR, IS_AVAILABLE, LSUBMODEL, UNITAB)
       IF (RHOR == ZERO) THEN
          RHOR = RHO0
       ENDIF
@@ -124,12 +124,12 @@ c-----------------
 c-----------------
 C--------------------------------
 C
-      WRITE(IOUT, 800) TRIM(TITR),MAT_ID,13
+      WRITE(IOUT,800)TRIM(TITR),MAT_ID,13
       WRITE(IOUT,1000)
       IF(IS_ENCRYPTED)THEN
          WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-         WRITE(IOUT, 850) RHO0
+         WRITE(IOUT, 850)RHO0,RHOR
          WRITE(IOUT,1300)YOUNG,ANU,G
       ENDIF
 C-----------
@@ -139,7 +139,8 @@ C-----------
      & 5X,'MATERIAL NUMBER. . . . . . . . . . . . =',I10/,
      & 5X,'MATERIAL LAW . . . . . . . . . . . . . =',I10/)
   850 FORMAT(
-     & 5X,'INITIAL DENSITY    . . . . . . . . . . =',1PG20.13/)
+     & 5X,'INITIAL DENSITY . . . . . . . . . . . .=',1PG20.13/,
+     & 5X,'REFERENCE DENSITY . . . . . . . . . . .=',1PG20.13/)
  1000 FORMAT(
      & 5X,'  RIGID LAW                           ',/,
      & 5X,'  ---------                           ')

--- a/starter/source/materials/mat/mat016/hm_read_mat16.F
+++ b/starter/source/materials/mat/mat016/hm_read_mat16.F
@@ -59,17 +59,18 @@ C-----------------------------------------------
 #include      "param_c.inc"
 #include      "units_c.inc"
 #include      "sysunit.inc"
+#include      "submod_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      CHARACTER*nchartitle ,INTENT(IN)             :: TITR
-      INTEGER, INTENT(IN)                          :: MAT_ID
-      INTEGER, DIMENSION(NPROPMI) ,INTENT(INOUT)   :: IPM
-      my_real, DIMENSION(NPROPM)  ,INTENT(INOUT)   :: PM
+      CHARACTER*nchartitle ,INTENT(IN) :: TITR
+      INTEGER, INTENT(IN) :: MAT_ID
+      INTEGER, DIMENSION(NPROPMI) ,INTENT(INOUT) :: IPM
+      my_real, DIMENSION(NPROPM)  ,INTENT(INOUT) :: PM
       my_real, DIMENSION(LUNIT,NUNITS) ,INTENT(IN) :: UNITAB
-      TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(INOUT)               :: MTAG
-      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT)        :: MATPARAM
+      TYPE(SUBMODEL_DATA), DIMENSION(NSUBMOD),INTENT(IN) :: LSUBMODEL
+      TYPE(MLAW_TAG_), INTENT(INOUT) :: MTAG
+      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -85,7 +86,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 !
       ILAW = 16
-      IS_ENCRYPTED   = .FALSE.
+      IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
 !-----------------------
       CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
@@ -299,9 +300,7 @@ C        WRITE(IOUT,2000)E0J,TMJ,P1J
       ENDIF
 C--------------------
       IF (EPS0 == ZERO) THEN
-         CALL ANCMSG(MSGID=298,
-     .               MSGTYPE=MSGERROR,
-     .               ANMODE=ANINFO,
+         CALL ANCMSG(MSGID=298,MSGTYPE=MSGERROR,ANMODE=ANINFO,
      .               I1=16,
      .               I2=MAT_ID,
      .               C1=TITR)
@@ -329,7 +328,7 @@ C--------------------
      & 5X,'MATERIAL LAW. . . . . . . . . . . . . .=',I10/)
  1002 FORMAT(
      & 5X,'INITIAL DENSITY . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'EOS REFERENCE DENSITY . . . . . . . . .=',1PG20.13/)
+     & 5X,'REFERENCE DENSITY . . . . . . . . . . .=',1PG20.13/)
  1300 FORMAT(
      & 5X,40HYOUNG'S MODULUS . . . . . . . . . . . .=,1PG20.13/,
      & 5X,40HPOISSON'S RATIO . . . . . . . . . . . .=,1PG20.13/,

--- a/starter/source/materials/mat/mat018/hm_read_mat18.F
+++ b/starter/source/materials/mat/mat018/hm_read_mat18.F
@@ -58,18 +58,18 @@ C-----------------------------------------------
 #include      "scr17_c.inc"
 #include      "units_c.inc"
 #include      "param_c.inc"
+#include      "submod_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       CHARACTER*nchartitle ,INTENT(IN) :: TITR
-      TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
+      TYPE(SUBMODEL_DATA), DIMENSION(NSUBMOD),INTENT(IN) :: LSUBMODEL
       my_real, DIMENSION(*), INTENT(IN) :: UNITAB
-      INTEGER, INTENT(IN)    :: MAT_ID
-c
-      INTEGER, INTENT(INOUT)   :: IPM(NPROPMI)
-      my_real, INTENT(INOUT)   :: PM(NPROPM)     
-      INTEGER, INTENT(INOUT)   :: NUPARAM,NUVAR,NFUNC,JTHE
-      TYPE(MLAW_TAG_) ,INTENT(INOUT)         :: MTAG
+      INTEGER, INTENT(IN) :: MAT_ID
+      INTEGER, INTENT(INOUT) :: IPM(NPROPMI)
+      my_real, INTENT(INOUT) :: PM(NPROPM)     
+      INTEGER, INTENT(INOUT) :: NUPARAM,NUVAR,NFUNC,JTHE
+      TYPE(MLAW_TAG_) ,INTENT(INOUT) :: MTAG
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -77,7 +77,7 @@ C-----------------------------------------------
       INTEGER :: ILAW,ITF,ISPH,IAS
       my_real :: RHOR,RHO0,T0,SPH,AS,BS,E0,TIMESCAL,TSCAL,ESCAL,KSCAL
 C=======================================================================
-      IS_ENCRYPTED   = .FALSE.
+      IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
       ILAW = 18
       JTHE = 1

--- a/starter/source/materials/mat/mat019/hm_read_mat19.F
+++ b/starter/source/materials/mat/mat019/hm_read_mat19.F
@@ -220,10 +220,10 @@ c
       CALL INIT_MAT_KEYWORD(MATPARAM,"TOTAL")
 C--------------------------------------
       WRITE(IOUT,1000) TRIM(TITR),MAT_ID,19
+      WRITE(IOUT,1100)      
       IF (IS_ENCRYPTED) THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1100)
         WRITE(IOUT,1200) RHO0
         WRITE(IOUT,1300) E11,E22,N12,G12,G23,G31,
      .                   RCOMP,ZEROSTRESS,ISENS,POROSITY

--- a/starter/source/materials/mat/mat021/hm_read_mat21.F
+++ b/starter/source/materials/mat/mat021/hm_read_mat21.F
@@ -259,7 +259,7 @@ c-------------------
      & 5X,'MATERIAL LAW. . . . . . . . . . . . . .=',I10/)
  1200 FORMAT(
      & 5X,'INITIAL DENSITY . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'EOS REFERENCE DENSITY . . . . . . . . .=',1PG20.13/)
+     & 5X,'REFERENCE DENSITY  .  . . . . . . . . .=',1PG20.13/)
  1300 FORMAT(
      & 5X,40HYOUNG'S MODULUS . . . . . . . . . . . .=,E12.4/,
      & 5X,40HPOISSON'S RATIO . . . . . . . . . . . .=,E12.4/,

--- a/starter/source/materials/mat/mat026/hm_read_mat26.F
+++ b/starter/source/materials/mat/mat026/hm_read_mat26.F
@@ -59,18 +59,19 @@ C-----------------------------------------------
 #include      "scr17_c.inc"
 #include      "units_c.inc"
 #include      "sysunit.inc"
+#include      "submod_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER, INTENT(INOUT)                       :: JTHE,MFI,IDF
-      CHARACTER*nchartitle ,INTENT(IN)             :: TITR
-      INTEGER, INTENT(IN)                          :: MAT_ID
-      INTEGER, DIMENSION(NPROPMI) ,INTENT(INOUT)   :: IPM
-      my_real, DIMENSION(NPROPM)  ,INTENT(INOUT)   :: PM
+      INTEGER, INTENT(INOUT) :: JTHE,MFI,IDF
+      CHARACTER*nchartitle ,INTENT(IN) :: TITR
+      INTEGER, INTENT(IN) :: MAT_ID
+      INTEGER, DIMENSION(NPROPMI) ,INTENT(INOUT) :: IPM
+      my_real, DIMENSION(NPROPM)  ,INTENT(INOUT) :: PM
       my_real, DIMENSION(LUNIT,NUNITS) ,INTENT(IN) :: UNITAB
-      TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      TYPE(MLAW_TAG_), INTENT(INOUT)               :: MTAG
-      my_real ,DIMENSION(*), INTENT(INOUT)         :: BUFMAT
+      TYPE(SUBMODEL_DATA), DIMENSION(NSUBMOD),INTENT(IN) :: LSUBMODEL
+      TYPE(MLAW_TAG_), INTENT(INOUT) :: MTAG
+      my_real ,DIMENSION(*), INTENT(INOUT) :: BUFMAT
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -198,7 +199,6 @@ C
         WRITE(IOUT,1200) RHO0,RHOR
         WRITE(IOUT,1300) YOUNG,ANU,G
         WRITE(IOUT,1400) CA,CB,CN,EPSM,SIGM
-!!        WRITE(IOUT,1500) TRIM(FILE),P0,T0,E0
         WRITE(IOUT,1500) FILE(1:LEN(TRIM(FILE))),P0,T0,E0
         WRITE(IOUT,1600) CC,EPS0,CM,TMELT,TMAX
       ENDIF
@@ -340,7 +340,7 @@ c-----------
      & 5X,'MATERIAL LAW. . . . . . . . . . . . . .=',I10/)
  1200 FORMAT(
      & 5X,'INITIAL DENSITY . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'EOS REFERENCE DENSITY . . . . . . . . .=',1PG20.13/)
+     & 5X,'REFERENCE DENSITY . . . . . . . . . . .=',1PG20.13/)
  1300 FORMAT(
      & 5X,40HYOUNG'S MODULUS . . . . . . . . . . . .=,E12.4/,
      & 5X,40HPOISSON'S RATIO . . . . . . . . . . . .=,E12.4/,

--- a/starter/source/materials/mat/mat040/hm_read_mat40.F
+++ b/starter/source/materials/mat/mat040/hm_read_mat40.F
@@ -186,7 +186,7 @@ c-----------------
       IF(IS_ENCRYPTED)THEN
          WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-         WRITE(IOUT, 850) RHO0, RHOR
+         WRITE(IOUT, 850) RHO0
          WRITE(IOUT,1100)AK,G0,G1,G2,G3,G4,G5,
      .        BETA1,BETA2,BETA3,BETA4,BETA5,
      .        ASTAS,BSTAS,VMISK
@@ -197,8 +197,7 @@ C
      & 5X,'MATERIAL NUMBER. . . . . . . . . . . . . . .=',I10/,
      & 5X,'MATERIAL LAW . . . . . . . . . . . . . . . .=',I10/)
   850 FORMAT(
-     & 5X,'INITIAL DENSITY    . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'EOS REFERENCE DENSITY. . . . . . . . . . . .=',1PG20.13/)
+     & 5X,'INITIAL DENSITY  . . . . . . . . . . . . . .=',1PG20.13/)
  1000 FORMAT(
      & 5X,'  MAXWELL VISCO-ELASTIC LAW ',/,
      & 5X,'  ------------------------- ',//)

--- a/starter/source/materials/mat/mat046/hm_read_mat46.F
+++ b/starter/source/materials/mat/mat046/hm_read_mat46.F
@@ -145,9 +145,9 @@ C-----------------------------------------------
 
       !===OUTPUT 
       WRITE(IOUT,1001) TRIM(TITR),MAT_ID,46
+      WRITE(IOUT,'(5X,A,//)')'  LES FLUID'
+      WRITE(IOUT,'(5X,A,//)')'  ---------'      
       IF(IS_ENCRYPTED)THEN
-        WRITE(IOUT,'(5X,A,//)')'  LES FLUID'
-        WRITE(IOUT,'(5X,A,//)')'  ---------'
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
         IF(ISGS==0)WRITE(IOUT,1000)RHO0,RHOR,SSP,VIS

--- a/starter/source/materials/mat/mat050/hm_read_mat50.F
+++ b/starter/source/materials/mat/mat050/hm_read_mat50.F
@@ -411,7 +411,7 @@ c--------------------------------------------------
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
         WRITE(IOUT,1100)
-        WRITE(IOUT,1200) RHO0,RHOR
+        WRITE(IOUT,1200) RHO0
         WRITE(IOUT,1300) E11,E22,E33,G12,G23,G31,ASRATE
 c
         WRITE(IOUT,1001)
@@ -469,8 +469,7 @@ c-----------------------------------------------------------------------
      &(5X,'MATERIAL MODEL : HONEYCOMB (VISC_HONEY) ',/,
      & 5X,'-------------------------------------------------',/)
  1200 FORMAT(
-     & 5X,'INITIAL DENSITY . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'EOS REFERENCE DENSITY . . . . . . . . .=',1PG20.13/)  
+     & 5X,'INITIAL DENSITY . . . . . . . . . . . .=',1PG20.13/)
  1300 FORMAT(
      & 5X,'E11 . . . . . . . . . . . . . . . . . .=',1PG20.13/
      & 5X,'E22 . . . . . . . . . . . . . . . . . .=',1PG20.13/

--- a/starter/source/materials/mat/mat054/hm_read_mat54.F
+++ b/starter/source/materials/mat/mat054/hm_read_mat54.F
@@ -194,7 +194,7 @@ C-----------------------------------------------
       IF (IS_ENCRYPTED) THEN
          WRITE(IOUT, '(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-         WRITE(IOUT, 850) RHO0, RHOR
+         WRITE(IOUT, 850) RHO0
          WRITE(IOUT, 1100) E, NU, AY, AZ, BY, BZ, CX
          WRITE(IOUT, 2000)
          WRITE(IOUT, 2100) NF, SFAC, SIG0, H, M
@@ -207,8 +207,7 @@ C-----------------------------------------------
      & 5X,'MATERIAL NUMBER. . . . . . . . . . . . . . .=',I10/,
      & 5X,'MATERIAL LAW . . . . . . . . . . . . . . . .=',I10/)
   850 FORMAT(
-     & 5X,'INITIAL DENSITY    . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'EOS REFERENCE DENSITY. . . . . . . . . . . .=',1PG20.13/)
+     & 5X,'INITIAL DENSITY    . . . . . . . . . . . . .=',1PG20.13/)
  1000 FORMAT(
      & 5X,'  ELASTOPLASTIC USER LAW ',/,
      & 5X,'  ---------------------- ',//)

--- a/starter/source/materials/mat/mat088/hm_read_mat88.F
+++ b/starter/source/materials/mat/mat088/hm_read_mat88.F
@@ -297,9 +297,6 @@ C-----------------
      &,5X,'SHAPE UNLOADING FACTOR. . . . . . . . . . =',1PG20.13//) 
  1500 FORMAT
      &(5X,'ITENSION : PARAMETER FOR UNLOADING . . . .=',I10/)
- 1600 FORMAT(
-     & 5X,'INITIAL DENSITY . . . . . . . . . . . . . =',1PG20.13/,
-     & 5X,'EOS REFERENCE DENSITY . . . . . . . . . . =',1PG20.13/)
 C-----------------
       RETURN
    

--- a/starter/source/materials/mat/mat102/hm_read_mat102.F
+++ b/starter/source/materials/mat/mat102/hm_read_mat102.F
@@ -113,7 +113,7 @@ C-----------------------------------------------
 
       CALL HM_GET_INTV  ('IFORM',IFORM  ,IS_AVAILABLE, LSUBMODEL) 
       
-      CALL HM_GET_FLOATV('MAT_RHO'      ,RHO0     ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_RHO'      ,RHO0  ,IS_AVAILABLE, LSUBMODEL, UNITAB)
       
       CALL HM_GET_FLOATV('MAT_E'        ,E     ,IS_AVAILABLE, LSUBMODEL, UNITAB)
       CALL HM_GET_FLOATV('MAT_NU'       ,NU    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
@@ -276,7 +276,7 @@ C
      & 5X,'MATERIAL LAW. . . . . . . . . . . . . .=',I10/)
  1002 FORMAT(
      & 5X,'INITIAL DENSITY . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'EOS REFERENCE DENSITY . . . . . . . . .=',1PG20.13/)  
+     & 5X,'REFERENCE DENSITY . . . . . . . . . . .=',1PG20.13/)  
  1100 FORMAT(
      & 5X,'YOUNG MODULUS . . . . . . . . . . . . .=',1PG20.13/
      & 5X,'POISSON RATIO . . . . . . . . . . . . .=',1PG20.13/

--- a/starter/source/materials/mat/mat103/hm_read_mat103.F
+++ b/starter/source/materials/mat/mat103/hm_read_mat103.F
@@ -196,7 +196,7 @@ C-------------------------------------------------
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1020)RHO0 
+        WRITE(IOUT,1020)RHO0,RHOR
         WRITE(IOUT,1100) E, NU, A0, M1, M2, M3, M4, M5, M7
         WRITE(IOUT,1200) FSMOOTH, FCUT, EPS0, PMIN, RCP, TINI, ETA
       ENDIF
@@ -210,7 +210,8 @@ C
      & 5X,'MATERIAL NUMBER. . . . . . . . . . . . . . .=',I10/,
      & 5X,'MATERIAL LAW . . . . . . . . . . . . . . . .=',I10/) 
  1020 FORMAT(
-     & 5X,'INITIAL DENSITY . . . . . . . . . . . . . . =',1PG20.13/)
+     & 5X,'INITIAL DENSITY . . . . . . . . . . . .=',1PG20.13/,
+     & 5X,'REFERENCE DENSITY . . . . . . . . . . .=',1PG20.13)
  1100 FORMAT(
      & 5X,'YOUNG MODULUS. . . . . . . . . . . . . . . .=',1PG20.13/
      & 5X,'POISSON RATIO. . . . . . . . . . . . . . . .=',1PG20.13/

--- a/starter/source/materials/mat/mat107/hm_read_mat107.F
+++ b/starter/source/materials/mat/mat107/hm_read_mat107.F
@@ -457,7 +457,7 @@ c--------------------------
       IF (IS_ENCRYPTED) THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1200) RHO0,RHOR
+        WRITE(IOUT,1200) RHO0
         WRITE(IOUT,1300) YOUNG1,YOUNG2,YOUNG3,NU12,NU21,G12,G23,G31
         WRITE(IOUT,1350) Ires
         WRITE(IOUT,1450) XI1,XI2,K1,K2,K3,K4,K5,K6,G1C,D1,D2
@@ -479,8 +479,7 @@ c-----------------------------------------------------------------------
      &(5X,'MATERIAL MODEL : PAPERBOARD LIGHT (PFEIFFER,2019)',/,
      & 5X,'-------------------------------------------------',/)
  1200 FORMAT(
-     & 5X,'INITIAL DENSITY . . . . . . . . . . . .=',1PG20.13/
-     & 5X,'REFERENCE DENSITY . . . . . . . . . . .=',1PG20.13/) 
+     & 5X,'INITIAL DENSITY . . . . . . . . . . . .=',1PG20.13/)
  1300 FORMAT(
      & 5X,'YOUNG MODULUS IN DIRECTION 1. . . . . .=',1PG20.13/
      & 5X,'YOUNG MODULUS IN DIRECTION 2. . . . . .=',1PG20.13/

--- a/starter/source/materials/mat/mat112/hm_read_mat112.F
+++ b/starter/source/materials/mat/mat112/hm_read_mat112.F
@@ -520,7 +520,7 @@ c--------------------------
       IF (IS_ENCRYPTED) THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1200) RHO0,RHOR
+        WRITE(IOUT,1200) RHO0
         WRITE(IOUT,1300) YOUNG1,YOUNG2,YOUNG3,NU12,NU21,G12,G23,G31
         WRITE(IOUT,1350) Ires
         WRITE(IOUT,1400) K,E3C,CC,NU1P,NU2P,NU4P,NU5P
@@ -544,8 +544,7 @@ c-----------------------------------------------------------------------
      &(5X,'MATERIAL MODEL : PAPERBOARD (XIA,2002)',/,
      & 5X,'--------------------------------------',/)
  1200 FORMAT(
-     & 5X,'INITIAL DENSITY . . . . . . . . . . . .=',1PG20.13/
-     & 5X,'REFERENCE DENSITY . . . . . . . . . . .=',1PG20.13/) 
+     & 5X,'INITIAL DENSITY . . . . . . . . . . . .=',1PG20.13/) 
  1300 FORMAT(
      & 5X,'YOUNG MODULUS IN DIRECTION 1. . . . . .=',1PG20.13/
      & 5X,'YOUNG MODULUS IN DIRECTION 2. . . . . .=',1PG20.13/


### PR DESCRIPTION
#### /EOS, /MAT : reviewing Starter listing file (output improvments)

#### Description of the changes
This update is improving Starter output for EoS and material law6. There is also a fix for /EOS/TABULATED

- EOS reference density is now an optionnal output (only if available in input file)
- /MAT/LAW6 : initial density and reference density are now output
- removing reference density when it is not expected (laws 40,50,54,107,112,...)
- Tabulated EoS : test (RHO0<=0.0) is checked only if parameter is available
- various homogenization of outputs