### PR TITLE
LAW71 add dependency on alpha for beams

### DIFF
--- a/engine/source/materials/mat/mat071/sigeps71.F
+++ b/engine/source/materials/mat/mat071/sigeps71.F
@@ -271,7 +271,7 @@ C=======================================================================
        RFSA = YLD_SAF *(SQDT+ALPHA)-CSA*TFSA
        DO I = 1,NEL
 C
-	   FM = UVAR(I,1)   ! fraction of Martensite    
+        FM = UVAR(I,1)   ! fraction of Martensite    
         GT(I) = G + FM * (GM - G) !G_n
         KT(I) = K + FM * (KM - K) !K_n
         !pressure
@@ -304,7 +304,7 @@ C   Check Austenite -----> martensite
         FASF = FS -  RFAS
         FS0 = UVAR(I,2)
         BETA      = EPSL*(TWO*GT(I)+NINE*KT(I)*ALPHA*ALPHA)
-        IF((FS - FS0) > ZERO .AND. FASS > ZERO.AND. FASF < ZERO .AND. FM < ONE )THEN
+        IF((FS - FS0) > ZERO .AND. FASS > ZERO.AND. FM <= ONE ) THEN  
         ! DFMAS = MIN(ONE, -(FS-FS0)*(ONE-FM)/(FASF-BETA*(ONE-FM) )  ) ! (should be positive)
          DB    = (TWO * (GM-G) +NINE*ALPHA*ALPHA*(KM-K)) *EPSL
          UNMXN = ONE - FM
@@ -321,14 +321,14 @@ C   Check Austenite -----> martensite
          DFMAS = MIN(ONE,DFMAS  ) ! (should be positive)
         ENDIF
 C----------------------
-C   Check marteniste -----> austenite  (dependance au tempurature a voir ...)
+C   Check marteniste -----> austenite   
 c      Unloading function
         FS = SV + THREE*ALPHA*P  - CSA*TEMP(I)
         FSAS = FS -RSSA  
         FSAF = FS -RFSA  
         FS0 = UVAR(I,3)
 
-        IF((FS - FS0) < ZERO .AND. FSAS < ZERO.AND. FSAF > ZERO )THEN 
+        IF((FS - FS0) < ZERO .AND. FSAS < ZERO .AND. FM >ZERO)THEN 
          !DFMSA =  MAX(-ONE , FM * (FS - FS0)/ (FSAF+BETA*FM) )
          DB    = (TWO * (GM-G) +NINE*ALPHA*ALPHA*(KM-K))*EPSL
          DFTR  = TWO * (GM-G)*NE+ THREE*ALPHA*(KM-K)*TRDE(I)
@@ -367,7 +367,7 @@ C----------------------
        SIGXX(I)= SXX + P
        SIGYY(I)= SYY + P
        SIGZZ(I)= SZZ + P
-	  SV =  SQRT( SXX*SXX + SYY*SYY + SZZ*SZZ ) 
+       SV =  SQRT( SXX*SXX + SYY*SYY + SZZ*SZZ ) 
        FS = SV + THREE*ALPHA*P      
        !CAUCHY STRESS
        IF(DET(I)/=zero)THEN 
@@ -422,7 +422,7 @@ C=======================================================================
        RFSA = YLD_SAF *(SQDT+ALPHA)-CSA*TFSA
        DO I = 1,NEL
 C
-	   FM = UVAR(I,1)   ! fraction of Martensite    
+        FM = UVAR(I,1)   ! fraction of Martensite    
         !pressure
         P = K * (TRDE(I) - THREE*ALPHA*EPSL*FM)
         ! n= e/ norm(e)
@@ -449,24 +449,24 @@ c loading function
        FS = SV + THREE*ALPHA*P - CAS*TEMP(I) ! loading function A--> M
        !FSS = FS - YLD_ASS 
 C----------------------
-C   Check Austenite -----> martensite  (dependance tempurature a voir ...)
+C   Check Austenite -----> martensite  
        FASS = FS -RSAS 
        FASF = FS -RFAS 
        FS0 = UVAR(I,2)
-       IF((FS - FS0) > ZERO .AND. FASS > ZERO.AND. FASF < ZERO.AND. FM < ONE ) THEN!          
+       IF((FS - FS0) > ZERO .AND. FASS > ZERO.AND. FM < ONE ) THEN!        
                 DFMAS = MIN(ONE, -(FS-FS0)*(ONE-FM)/(FASF-BETA*(ONE-FM) )  ) ! (should be positive)
        ENDIF
 C----------------------
-C   Check marteniste -----> austenite  (dependance au tempurature a voir ...)
+!   Check marteniste -----> austenite   
        FS = SV + THREE*ALPHA*P - CSA*TEMP(I) ! Unloading function M--> A
        FSAS = FS - RSSA
        FSAF = FS - RFSA
        FS0 = UVAR(I,3)
-       IF((FS - FS0) < ZERO .AND. FSAS < ZERO .AND. FSAF > ZERO ) THEN
+       IF((FS - FS0) < ZERO .AND. FSAS < ZERO  .AND. FM > ZERO) THEN ! 
                DFMSA =  MAX(-ONE , FM * (FS - FS0)/ (FSAF+BETA*FM) )  !compute marteniste fraction
        ENDIF
 C----------------------
-C      new martensite fraction        
+!      new martensite fraction        
        DFM =  DFMAS + DFMSA 
        IF(DFM < ZERO .AND. FM == ZERO) DFM = ZERO
 C----------------------

--- a/engine/source/materials/mat/mat071/sigeps71c.F
+++ b/engine/source/materials/mat/mat071/sigeps71c.F
@@ -332,7 +332,7 @@ c----------------------------------------------
            ! loading function
            FS(I) = SV(I) + THREE*ALPHA*P11(I) - CAS*TEMP(I) ! loading function A--> M
            !----------------------
-           !   Check Austenite -----> martensite  (dependance tempurature a voir ...)
+           !   Check Austenite -----> martensite  
            FASS = FS(I) -RSAS 
            FASF = FS(I) -RFAS 
            FS0  = UVAR(I,2)

--- a/engine/source/materials/mat/mat071/sigeps71pi.F
+++ b/engine/source/materials/mat/mat071/sigeps71pi.F
@@ -70,8 +70,9 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER :: I,IADBUF,KK
       INTEGER ,DIMENSION(NEL) ::EFLAG
-      my_real :: FASS,FSAS,FASF,FSAF,RSAS,RFAS,FS0,RSSA,RFSA,DFM, FSS,
-     .           SQDT,AA,BB,CC,FCT,FCTP,BETA,DGT,GS,DET,SHFACT,DFMSA,DFMAS 
+      my_real :: FASS,FSAS,FASF,FSAF,RSAS,RFAS,FS0,RSSA,RFSA,DFM, FSS,SCALE_SIG,
+     .           SQDT,AA,BB,CC,FCT,FCTP,BETA,DGT,GS,DET,SHFACT,DFMSA,DFMAS ,
+     .           delta, sol1,sol2
       my_real, DIMENSION(NEL) ::E,K,EMART,G,G2, ALPHA,EPSL,GM,KM,
      .           YLD_ASS,YLD_ASF,YLD_SAS,TINI,
      .           YLD_SAF,CAS,CSA,TSAS,TFAS, TSSA,TFSA, 
@@ -81,8 +82,9 @@ c    UVAR  2= FS0
 c    UVAR  3= FS0 
 c    UVAR 11=  TEMP
 C=======================================================================
-      SHFACT = FIVE_OVER_6       
 
+      SHFACT = FIVE_OVER_6       
+      SQDT   = SQRT(TWO/THREE)
       DO I=1,NEL                                 
         IADBUF       = IPM(7,MAT(I))-1               
         E(I)         = UPARAM(IADBUF+1)                        
@@ -125,6 +127,15 @@ C=======================================================================
         RFAS = YLD_ASF(I) -CAS(I)*TFAS(I) !end from aust to martensite
         RSSA = YLD_SAS(I) -CSA(I)*TSSA(I) !start from martensite to austenite
         RFSA = YLD_SAF(I) -CSA(I)*TFSA(I) !end from martensite to austenite
+        IF (EPSXX(I)< ZERO)THEN
+          SCALE_SIG = (ONE + ALPHA(I))/(ONE - ALPHA(I)) 
+          SCALE_SIG = (SQRT(TWO_THIRD) + ALPHA(I))/(SQRT(TWO_THIRD) - ALPHA(I)) 
+          RSAS = YLD_ASS(I) * SCALE_SIG -CAS(I)*TSAS(I) !start from aust to martensite compression
+          RFAS = YLD_ASF(I) * SCALE_SIG -CAS(I)*TFAS(I) !end from aust to martensite compression
+          RSSA = YLD_SAS(I) * SCALE_SIG -CSA(I)*TSSA(I) !start from martensite to austenite compression
+          RFSA = YLD_SAF(I) * SCALE_SIG -CSA(I)*TFSA(I) !end from martensite to austenite compression
+          EPSL(I) = EPSL(I) / SCALE_SIG
+        ENDIF
    
         IF (EFLAG(I) > ZERO)THEN ! young modulus dependent on martensite fraction
           GT(I) = G(I) + FM(I) * (GM(I)    - G(I)) !G_n
@@ -139,42 +150,42 @@ C=======================================================================
           BETA      =   ET(I)*EPSL(I)* SIGN(ONE,EPSXX(I))-(EMART(I)- E(I))*EPSXX(I) 
      .                                        + (EMART(I) - E(I)) *EPSL(I)* SIGN(ONE,EPSXX(I)) *FM(I)  
           DFMSA = ZERO
-          DFMAS = ZERO 
+          DFMAS = ZERO  
           !---------------
           !Check Austenite -----> martensite  
           !---------------
-	     FS(I)     =   ABS (SIGNXX(I) ) -CAS(I)*TEMP(I)! trial
+          FS(I)     =   ABS (SIGNXX(I) ) -CAS(I)*TEMP(I)! trial
           FASS = FS(I) -  RSAS
           FASF = FS(I) -  RFAS
           FS0  = UVAR(I,2)
-          IF((FS(I) - FS0) > ZERO .AND. FASS > ZERO.AND. FASF < ZERO .AND. FM(I) < ONE )THEN
+          IF((FS(I) - FS0) > ZERO .AND. FASS > ZERO.AND. FM(I) <= ONE )THEN   
             AA = (ONE - FM(I))*(EMART(I) - E(I))*EPSL(I)
             BB = -(FS0 - RFAS - (ONE - FM(I))*BETA* SIGN(ONE,EPSXX(I)))
             CC = -(ONE - FM(I)) * (FS(I) - FS0)
             DFMAS =  MIN(ONE , - (ONE - FM(I))*(FS(I) - FS0 ) / (FS0-RFAS - (ONE - FM(I))*E(I)*EPSL(I)  )  ) 
             DO KK = 1,3
-             FCT   = DFMAS*DFMAS *AA+ DFMAS*   BB  + CC
-             FCTP  = TWO*DFMAS *AA+ BB
-             DFMAS = DFMAS - FCT / FCTP     
+              FCT   = DFMAS*DFMAS *AA+ DFMAS*   BB  + CC
+              FCTP  = TWO*DFMAS *AA+ BB
+              DFMAS = DFMAS - FCT / FCTP     
             ENDDO
             DFMAS = MIN(ONE,DFMAS  )  
           ENDIF
           !---------------
           !Check marteniste -----> austenite
           !---------------
-	     FS(I)     =   ABS (SIGNXX(I) ) -CSA(I)*TEMP(I)! trial
+          FS(I)     =   ABS (SIGNXX(I) ) -CSA(I)*TEMP(I)! trial
           FSAS = FS(I) - RSSA
           FSAF = FS(I) - RFSA
           FS0  = UVAR(I,3)
-          IF((FS(I) - FS0) < ZERO .AND. FSAS < ZERO.AND. FSAF > ZERO .AND. FM(I) >ZERO)THEN
+          IF((FS(I) - FS0) < ZERO .AND. FSAS < ZERO .AND. FM(I) >ZERO)THEN  
             AA =  FM(I)*(EMART(I) - E(I))*EPSL(I)
             BB =  FS0-RFSA   +  FM(I)*BETA* SIGN(ONE,EPSXX(I))
             CC =  -FM(I) * (FS(I)-FS0 )
             DFMSA =  MAX(-ONE , FM(I) * ( FS(I) - FS0 ) / (FS0 - RFSA + FM (I)* E(I)*EPSL(I) ))
             DO KK = 1,3
-             FCT  = DFMSA*DFMSA *AA+ DFMSA*   BB  +CC
-             FCTP = TWO*DFMSA *AA+ BB
-             DFMSA = DFMSA - FCT / FCTP
+              FCT  = DFMSA*DFMSA *AA+ DFMSA*   BB  +CC
+              FCTP = TWO*DFMSA *AA+ BB
+              DFMSA = DFMSA - FCT / FCTP
             ENDDO
             DFMSA =  MAX(-ONE , DFMSA )
           ENDIF
@@ -182,6 +193,7 @@ C=======================================================================
          !new martensite fraction increment        
          !--------------------------
           DFM =  DFMAS + DFMSA 
+
           IF(DFM < ZERO .AND. FM(I) == ZERO) DFM = ZERO
          ! --------------------------
          ! UPDATE
@@ -190,6 +202,7 @@ C=======================================================================
           DET = DFM * (EMART(I) - E(I))
           SIGNXX(I) = SIGNXX(I) + DET * ( EPSXX(I) - EPSL(I) * (FM(I) + DFM)* SIGN(ONE,EPSXX(I))   ) 
      .                                           - ET(I) * EPSL(I) * DFM* SIGN(ONE,EPSXX(I))
+     
 
           FS(I) =  ABS (SIGNXX(I) )   
           FM(I) = FM(I) + DFM
@@ -204,12 +217,12 @@ C=======================================================================
         ELSE ! constant young modulus    
           GS   = SHFACT*G(I)                             
           !trial stress(sigma_tr_n+1)
-          SIGNXX(I) =   E(I)*(EPSXX(I) - EPSL(I)*FM(I)* SIGN(ONE,EPSXX(I)))
+          SIGNXX(I) =   E(I)*(EPSXX(I) - EPSL(I)*FM(I)* SIGN(ONE,EPSXX(I))) ! deviator of stress
           SIGNXY(I) =   GS  * EPSXY(I)
           SIGNXZ(I) =   GS  * EPSXZ(I)
 
           ETSE(I)   =   ONE                        
-	     FS(I)     =   ABS (SIGNXX(I) ) - CAS(I)*TEMP(I)! trial
+          FS(I)     =   ABS (SIGNXX(I) ) - CAS(I)*TEMP(I)! trial
           !---------------
           !Check Austenite -----> martensite  
           !---------------
@@ -218,7 +231,7 @@ C=======================================================================
           FS0 = UVAR(I,2)
           DFMSA = ZERO
           DFMAS = ZERO 
-          IF((FS(I) - FS0) > ZERO .AND. FASS > ZERO.AND. FASF < ZERO .AND. FM(I) < ONE )THEN
+          IF((FS(I) - FS0) > ZERO .AND. FASS > ZERO.AND. FM(I) < ONE )THEN
             ! transformation to martensite 
             ! compute martensite phase fraction increment
              DFMAS =  MIN(ONE , - (FS(I) - FS0 )*(ONE - FM(I)) / (FS0-RFAS - (ONE - FM(I))*E(I)*EPSL(I)  )  ) 
@@ -226,11 +239,11 @@ C=======================================================================
          !---------------
          !Check marteniste -----> austenite  
          !---------------
-	    FS(I)     =   ABS (SIGNXX(I) ) - CSA(I)*TEMP(I)! trial
+         FS(I)     =   ABS (SIGNXX(I) ) - CSA(I)*TEMP(I)! trial
          FSAS = FS(I) - RSSA  
          FSAF = FS(I) - RFSA  
          FS0 = UVAR(I,3)
-         IF((FS(I) - FS0) < ZERO .AND. FSAS < ZERO.AND. FSAF > ZERO  )THEN 
+         IF((FS(I) - FS0) < ZERO .AND. FSAS < ZERO .AND. FM(I) >ZERO )THEN 
             ! transformation to austenite 
             ! compute martensite phase fraction increment
            DFMSA =  MAX(-ONE , FM(I) * ( FS(I) - FS0 ) / (FS0 - RFSA + FM(I) * E(I)*EPSL(I) ))


### PR DESCRIPTION
LAW71 add dependency on alpha for beams

#### Description of the feature or the bug
LAW71 add dependency on alpha for beams


#### Description of the changes
LAW71 add dependency on alpha for beams, now behavior can be non symmetrical between tension and compression


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
