### PR TITLE
/INTER/TYPE18 : fix for INACTI initalization in lecint.F

### DIFF
--- a/starter/source/interfaces/interf1/lecint.F
+++ b/starter/source/interfaces/interf1/lecint.F
@@ -631,6 +631,7 @@ C=======================================================================
         NOINT  = IPARI(15,NI)
         IS1    = IPARI(13,NI)/10
         IGAP   = IPARI(21,NI)
+        INACTI = IPARI(22,NI)
         ILAGM  = IPARI(33,NI)
         IS2    = MOD(IPARI(13,NI),10)
         ISU1   = IPARI(45,NI)


### PR DESCRIPTION
#### /INTER/TYPE18 : fix for INACTI initalization in lecint.F

#### Description of the changes
INACTI integer is now correctly defined in the loop : INACTI = IPARI(22,NI)
This integer is required to define TYPE18 boolean : IF(NTYP==7 .AND. INACTI==7 )TYPE18=.TRUE.
This bug may have been silent if last interface from input file had INACTI=7