### PR TITLE
Add FAIL time history output for SPR_TAB and SPR_BDAMP

### DIFF
--- a/engine/source/elements/spring/r26def3.F
+++ b/engine/source/elements/spring/r26def3.F
@@ -35,7 +35,7 @@ Chd|====================================================================
      5   AL0_ERR, X1DP,    X2DP,    NGL,
      6   MGN,     EX,      EY,      EZ,
      7   XK,      XM,      XC,      AK,
-     8   NEL,     NFT,     IAD)
+     8   NEL,     NFT,     IAD,     CRIT)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -67,6 +67,8 @@ C     REAL
      .   AL0_ERR(*),EX(MVSIZ), EY(MVSIZ), EZ(MVSIZ),XK(MVSIZ),
      .   XM(MVSIZ),XC(MVSIZ),AK(MVSIZ)
       DOUBLE PRECISION X1DP(3,*),X2DP(3,*)
+      my_real, DIMENSION(NEL), INTENT(INOUT) :: 
+     .   CRIT
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -150,7 +152,11 @@ C-----
       NINDX = 0
       DO I=1,NEL
         IF (OFF(I) == ONE) THEN
+          CRIT(I) = MAX(DL(I)/(DMX(I)*XL0(I)),DL(I)/(DMN(I)*XL0(I)))
+          CRIT(I) = MIN(CRIT(I),ONE)
+          CRIT(I) = MAX(CRIT(I),ZERO)
           IF (DL(I) > DMX(I)*XL0(I) .OR. DL(I) < DMN(I)*XL0(I)) THEN
+            CRIT(I) = ONE
             OFF(I)=ZERO
             NINDX = NINDX + 1
             INDX(NINDX) = I

--- a/engine/source/elements/spring/r27def3.F
+++ b/engine/source/elements/spring/r27def3.F
@@ -34,7 +34,7 @@ Chd|====================================================================
      4   AL0_ERR, X1DP,    X2DP,    NGL,
      5   MGN,     EX,      EY,      EZ,
      6   XK,      XM,      XC,      FSCALE,
-     7   NEL,     NFT)
+     7   NEL,     NFT,     CRIT)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -65,6 +65,8 @@ C     REAL
      .   AL0_ERR(*),EX(MVSIZ),EY(MVSIZ),EZ(MVSIZ),XK(MVSIZ),
      .   XM(MVSIZ),XC(MVSIZ),FSCALE(MVSIZ)
       DOUBLE PRECISION X1DP(3,*),X2DP(3,*)
+      my_real, DIMENSION(NEL), INTENT(INOUT) :: 
+     .   CRIT
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -299,14 +301,22 @@ C     ==================================================================
         IF (OFF(I) == ONE .AND. IFAIL(I) /= 0) THEN
           IF (IFAIL(I) == 1) THEN
             IF (ITENS(I) > 0) THEN
+              CRIT(I) = MAX(DL(I)/(DMX(I)*XL0(I)),DL(I)/(DMN(I)*XL0(I)))
+              CRIT(I) = MIN(CRIT(I),ONE)
+              CRIT(I) = MAX(CRIT(I),ZERO)
               IF (DL(I) > DMX(I)*XL0(I) .OR. DL(I) < DMN(I)*XL0(I)) THEN
+                CRIT(I) = ONE
                 OFF(I) = ZERO
                 NINDX  = NINDX + 1
                 INDX(NINDX) = I
                 IDEL7NOK = 1
               ENDIF
             ELSE
+              CRIT(I) = DL(I)/(DMN(I)*XL0(I))
+              CRIT(I) = MIN(CRIT(I),ONE)
+              CRIT(I) = MAX(CRIT(I),ZERO)
               IF (DL(I) < DMN(I)*XL0(I)) THEN
+                CRIT(I) = ONE
                 OFF(I) = ZERO
                 NINDX  = NINDX + 1
                 INDX(NINDX) = I
@@ -314,15 +324,23 @@ C     ==================================================================
               ENDIF
             ENDIF
           ELSEIF (IFAIL(I) == 2) THEN
-            IF (ITENS(I) > 0) THEN 
+            IF (ITENS(I) > 0) THEN
+              CRIT(I) = MAX(F(I)/DMX(I),F(I)/DMN(I)) 
+              CRIT(I) = MIN(CRIT(I),ONE)
+              CRIT(I) = MAX(CRIT(I),ZERO)
               IF (F(I)  > DMX(I) .OR. F(I)  < DMN(I)) THEN
+                CRIT(I) = ONE
                 OFF(I) = ZERO
                 NINDX  = NINDX + 1
                 INDX(NINDX) = I
                 IDEL7NOK = 1
               ENDIF
             ELSE
+              CRIT(I) = F(I)/DMN(I)
+              CRIT(I) = MIN(CRIT(I),ONE)
+              CRIT(I) = MAX(CRIT(I),ZERO)
               IF (F(I)  < DMN(I)) THEN
+                CRIT(I) = ONE
                 OFF(I) = ZERO
                 NINDX  = NINDX + 1
                 INDX(NINDX) = I

--- a/engine/source/elements/spring/rforc3.F
+++ b/engine/source/elements/spring/rforc3.F
@@ -311,7 +311,7 @@ C
      5   GBUF%LENGTH_ERR,        X1DP,                   X2DP,                   NGL,
      6   MGN,                    EX,                     EY,                     EZ,
      7   XK,                     XM,                     XC,                     AK,
-     8   NEL,                    NFT,                    IAD)
+     8   NEL,                    NFT,                    IAD,                    GBUF%RUPTCRIT(II(1)))
 C
         DO I=JFT,JLT
           IF (GBUF%OFF(I) /= -TEN .AND. OFF(I) < ONE) GBUF%OFF(I) = OFF(I)
@@ -375,7 +375,7 @@ C
      4   GBUF%LENGTH_ERR,    X1DP,               X2DP,               NGL,
      5   MGN,                EX,                 EY,                 EZ,
      6   XK,                 XM,                 XC,                 AK,
-     7   NEL,                NFT)
+     7   NEL,                NFT,                GBUF%RUPTCRIT(II(1)))
 C
         DO I=JFT,JLT
           IF (GBUF%OFF(I) /= -TEN .AND. OFF(I) < ONE) GBUF%OFF(I) = OFF(I)

--- a/engine/source/output/th/thres.F
+++ b/engine/source/output/th/thres.F
@@ -216,6 +216,12 @@ C
                                 WWA(65)= SQRT((X(1,NODE2)-X(1,NODE1))**2 +
      .                                        (X(2,NODE2)-X(2,NODE1))**2 + 
      .                                        (X(3,NODE2)-X(3,NODE1))**2)   
+                                ! Failure criterion
+                                IF (GBUF%G_RUPTCRIT > 0) THEN 
+                                  WWA(66) = GBUF%RUPTCRIT(I)
+                                ELSE
+                                  WWA(66) = ZERO
+                                ENDIF
                                 DO L=IADV,IADV+NVAR-1
                                     K=ITHBUF(L)
                                     IJK=IJK+1
@@ -268,6 +274,12 @@ C
                                 WWA(65)= SQRT((X(1,NODE2)-X(1,NODE1))**2 +
      .                                        (X(2,NODE2)-X(2,NODE1))**2 + 
      .                                        (X(3,NODE2)-X(3,NODE1))**2)   
+                                ! Failure criterion
+                                IF (GBUF%G_RUPTCRIT > 0) THEN 
+                                  WWA(66) = GBUF%RUPTCRIT(I)
+                                ELSE
+                                  WWA(66) = ZERO
+                                ENDIF
                                 DO L=IADV,IADV+NVAR-1
                                     K=ITHBUF(L)
                                     IJK=IJK+1

--- a/starter/source/properties/spring/hm_read_prop26.F
+++ b/starter/source/properties/spring/hm_read_prop26.F
@@ -259,6 +259,7 @@ C
       PROP_TAG(IGTYP)%G_POSX = 5  !  just temp - not really used - 
       PROP_TAG(IGTYP)%G_LENGTH_ERR = 1
       PROP_TAG(IGTYP)%G_DV = 1
+      PROP_TAG(IGTYP)%G_RUPTCRIT = 1
 C
 C-----------
       RETURN

--- a/starter/source/properties/spring/hm_read_prop27.F
+++ b/starter/source/properties/spring/hm_read_prop27.F
@@ -215,6 +215,7 @@ C-----------------------------
       PROP_TAG(IGTYP)%G_NUVAR       = MAX(PROP_TAG(IGTYP)%G_NUVAR,NINT(GEO(25))) ! additional internal variables for h=6
       PROP_TAG(IGTYP)%G_DEFINI      = 1
       PROP_TAG(IGTYP)%G_FORINI      = 1
+      PROP_TAG(IGTYP)%G_RUPTCRIT = 1
 C
 C-----------------------------
 C       PRINTING OUT DATA


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Add FAIL time history output for spring properties /PROP/TYPE26 and /PROP/TYPE27

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Add RUPTCRIT in corresponding properties buffer and filling it with corresponding failure options. 

(Changes are important for 2023)

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
