### PR TITLE
Correct logarythmic strain rate interpolation in law36

### DIFF
--- a/engine/source/materials/mat/mat036/sigeps36.F
+++ b/engine/source/materials/mat/mat036/sigeps36.F
@@ -444,19 +444,12 @@ c-----------
             ENDDO
           ENDDO
 C
-          IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+          IF (ISMOOTH == 2) THEN      ! log_n  based interpolation of strain rate
 #include    "vectorize.inc"
             DO I=1,NEL
               EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
               EPSP2 = UPARAM(7+JJ(I))
-              RFAC(I) = LOG(MAX(PLAP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)
-            ENDDO
-          ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
-#include    "vectorize.inc"
-            DO I=1,NEL
-              EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
-              EPSP2 = UPARAM(7+JJ(I))
-              RFAC(I) = LOG10(MAX(PLAP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)
+              RFAC(I) = LOG(MAX(EPSP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)
             ENDDO
           ELSE                        ! linear interpolation of strain rate
 #include "vectorize.inc"
@@ -496,9 +489,9 @@ C
             DO I=1,NEL
               J1 = JJ(I)
               J2 = J1+1
-              Y1(I)=Y1(I)*YFAC(I,1)
-              Y2(I)=Y2(I)*YFAC(I,2)
-              FAC   = RFAC(I)
+              Y1(I)= Y1(I)*YFAC(I,1)
+              Y2(I)= Y2(I)*YFAC(I,2)
+              FAC  = RFAC(I)
               CC = FAIL(I)* PFAC(I)
               YLD(I)  = (Y1(I)    + FAC*(Y2(I)-Y1(I))) * CC
               DYDX1(I)= DYDX1(I)*YFAC(I,1)
@@ -717,21 +710,13 @@ c
                 IF (PLAP(I) >= UPARAM(6+J)) JJ(I) = J               
               ENDDO
             ENDDO  
-            IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+            IF (ISMOOTH == 2) THEN       ! log_n  based interpolation of strain rate
 #include     "vectorize.inc" 
               DO II=1,NINDX                                             
                 I = INDEX(II) 
                 EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
                 EPSP2 = UPARAM(7+JJ(I))
                 RFAC(I) = LOG(MAX(PLAP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)
-              ENDDO
-            ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
-#include     "vectorize.inc" 
-              DO II=1,NINDX                                             
-                I = INDEX(II) 
-                EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
-                EPSP2 = UPARAM(7+JJ(I))
-                RFAC(I) = LOG10(MAX(PLAP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)
               ENDDO
             ELSE                         ! linear interpolation of strain rate
 #include     "vectorize.inc" 
@@ -830,19 +815,12 @@ c------------------------
                   IF(PLAP(I) >= UPARAM(6+J)) JJ(I) = J       
                 ENDDO       
               ENDDO
-              IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+              IF (ISMOOTH == 2) THEN       ! log_n  based interpolation of strain rate
 #include        "vectorize.inc"
                 DO I=1,NEL
                   EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
                   EPSP2 = UPARAM(7+JJ(I))
                   RFAC(I) = LOG(MAX(PLAP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)
-                ENDDO
-              ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
-#include        "vectorize.inc"
-                DO I=1,NEL
-                  EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
-                  EPSP2 = UPARAM(7+JJ(I))
-                  RFAC(I) = LOG10(MAX(PLAP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)
                 ENDDO
               ELSE                        ! linear interpolation of strain rate
 #include        "vectorize.inc"
@@ -950,21 +928,13 @@ c------------------------------------------------
               ENDDO
             ENDDO    
 c
-            IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+            IF (ISMOOTH == 2) THEN       ! log_n  based interpolation of strain rate
 #include      "vectorize.inc"
               DO II=1,NINDX                                           
                 I = INDEX(II) 
                 EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
                 EPSP2 = UPARAM(7+JJ(I))
                 RFAC(I) = LOG(MAX(PLAP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)
-              ENDDO
-            ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
-#include      "vectorize.inc"
-              DO II=1,NINDX                                           
-                I = INDEX(II) 
-                EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
-                EPSP2 = UPARAM(7+JJ(I))
-                RFAC(I) = LOG10(MAX(PLAP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)
               ENDDO
             ELSE                        ! linear interpolation of strain rate
 #include      "vectorize.inc"
@@ -1082,21 +1052,13 @@ c
                 ENDDO              
               ENDDO
 c
-              IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+              IF (ISMOOTH == 2) THEN       ! log_n  based interpolation of strain rate
 #include        "vectorize.inc"
                 DO II=1,NINDX                                           
                   I = INDEX(II) 
                   EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
                   EPSP2 = UPARAM(7+JJ(I))
                   RFAC(I) = LOG(MAX(PLAP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)
-                ENDDO
-              ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
-#include        "vectorize.inc"
-                DO II=1,NINDX                                           
-                  I = INDEX(II) 
-                  EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
-                  EPSP2 = UPARAM(7+JJ(I))
-                  RFAC(I) = LOG10(MAX(PLAP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)
                 ENDDO
               ELSE                        ! linear interpolation of strain rate
 #include        "vectorize.inc"
@@ -1214,21 +1176,13 @@ c------------------------------------------------
               ENDDO 
             ENDDO
 c
-            IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+            IF (ISMOOTH == 2) THEN       ! log_n  based interpolation of strain rate
 #include      "vectorize.inc"
               DO II=1,NINDX                                           
                 I = INDEX(II) 
                 EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
                 EPSP2 = UPARAM(7+JJ(I))
                 RFAC(I) = LOG(MAX(PLAP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)
-              ENDDO
-            ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
-#include      "vectorize.inc"
-              DO II=1,NINDX                                           
-                I = INDEX(II) 
-                EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
-                EPSP2 = UPARAM(7+JJ(I))
-                RFAC(I) = LOG10(MAX(PLAP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)
               ENDDO
             ELSE                        ! linear interpolation of strain rate
 #include      "vectorize.inc"
@@ -1346,21 +1300,13 @@ c
                 ENDDO
               ENDDO
 c
-              IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+              IF (ISMOOTH == 2) THEN       ! log_n  based interpolation of strain rate
 #include        "vectorize.inc"
                 DO II=1,NINDX                                           
                   I = INDEX(II) 
                   EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
                   EPSP2 = UPARAM(7+JJ(I))
                   RFAC(I) = LOG(MAX(PLAP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)
-                ENDDO
-              ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
-#include        "vectorize.inc"
-                DO II=1,NINDX                                           
-                  I = INDEX(II) 
-                  EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
-                  EPSP2 = UPARAM(7+JJ(I))
-                  RFAC(I) = LOG10(MAX(PLAP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)
                 ENDDO
               ELSE                        ! linear interpolation of strain rate
 #include        "vectorize.inc"

--- a/engine/source/materials/mat/mat036/sigeps36c.F
+++ b/engine/source/materials/mat/mat036/sigeps36c.F
@@ -354,7 +354,7 @@ c
               IF (EPSP(I) >= UPARAM(6+J)) JJ(I) = J
             ENDDO
           ENDDO
-          IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+          IF (ISMOOTH == 2) THEN      ! log_n  based interpolation of strain rate
 #include    "vectorize.inc"
             DO I=1,NEL
               EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
@@ -362,15 +362,6 @@ c
               RFAC(I) = LOG(MAX(EPSP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)
               YFAC(I,1) = UPARAM(6+NRATE+JJ(I))  * FACYLDI(I)
               YFAC(I,2) = UPARAM(7+NRATE+JJ(I))  * FACYLDI(I)
-            ENDDO
-          ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
-#include    "vectorize.inc"
-            DO I=1,NEL
-              EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
-              EPSP2 = UPARAM(7+JJ(I))
-              RFAC(I) = LOG10(MAX(EPSP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)
-              YFAC(I,1) = UPARAM(6+NRATE+JJ(I)) * FACYLDI(I)
-              YFAC(I,2) = UPARAM(7+NRATE+JJ(I)) * FACYLDI(I)
             ENDDO
           ELSE                        ! linear interpolation of strain rate
 #include    "vectorize.inc"
@@ -720,19 +711,12 @@ C-------------------
           ENDDO                                    
         ENDDO                                      
 c
-        IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+        IF (ISMOOTH == 2) THEN       ! log_n  based interpolation of strain rate
 #include  "vectorize.inc"
           DO I=1,NEL
             EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
             EPSP2 = UPARAM(7+JJ(I))
             RFAC(I) = LOG(MAX(PLAP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)
-          ENDDO
-        ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
-#include  "vectorize.inc"
-          DO I=1,NEL
-            EPSP1 = MAX(UPARAM(6+JJ(I)), EM20)
-            EPSP2 = UPARAM(7+JJ(I))
-            RFAC(I) = LOG10(MAX(PLAP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)
           ENDDO
         ELSE                        ! linear interpolation of strain rate
 #include  "vectorize.inc"

--- a/engine/source/materials/mat/mat036/sigeps36pi.F
+++ b/engine/source/materials/mat/mat036/sigeps36pi.F
@@ -228,14 +228,10 @@ C
           J2 = J1+1                                               
           Y1(I) = Y1(I)*YFAC(I,1)                                 
           Y2(I) = Y2(I)*YFAC(I,2)
-          IF (ISMOOTH == 3) THEN       ! log_n  based interpolation of strain rate
+          IF (ISMOOTH == 2) THEN       ! log_n  based interpolation of strain rate
             EPSP1 = MAX(RATE(I,1), EM20)
             EPSP2 = RATE(I,2)
             FAC   = LOG(MAX(EPSP(I),EM20)/EPSP1) / LOG(EPSP2/EPSP1)   
-          ELSE IF (ISMOOTH == 2) THEN  ! log_10 based interpolation of strain rate
-            EPSP1 = MAX(RATE(I,1), EM20)
-            EPSP2 = RATE(I,2)
-            FAC   = LOG10(MAX(EPSP(I),EM20)/EPSP1) / LOG10(EPSP2/EPSP1)   
           ELSE                         ! linear interpolation of strain rate
             EPSP1 = RATE(I,1)
             EPSP2 = RATE(I,2)

--- a/starter/source/materials/mat/mat036/hm_read_mat36.F
+++ b/starter/source/materials/mat/mat036/hm_read_mat36.F
@@ -399,8 +399,7 @@ C-----------
      & 5X,'SMOOTH STRAIN RATE OPTION . . . . . . . . .=',I10/
      & 5X,'     0 -> NO SMOOTHING                      ',/,
      & 5X,'     1 -> SMOOTH + LINEAR INTERPOLATION     ',/,
-     & 5X,'     2 -> SMOOTH + LOG_10 INTERPOLATION     ',/,
-     & 5X,'     3 -> SMOOTH + LOG_N  INTERPOLATION     ',/
+     & 5X,'     2 -> SMOOTH + LOG_N  INTERPOLATION     ',/
      & 5X,'STRAIN RATE CUTTING FREQUENCY . . . . . . .=',1PG20.13/
      & 5X,'PLASTIC STRAIN RATE DEPENDENCY FLAG . . . .=',I10/
      & 5X,'   FLAG_PL = 0 -> TOTAL SR DEPENDENCY       ',/,


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Option description was modified : logarythmic strain rate interpolation is only using base n log 

corrected strain rate interpolation in solids

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Ismooth input parameter has changed, according to the new input doc

strain rate value used for interpolation was corrected for solid elements (total strain rate instead of plastic strain rate) 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
