### PR TITLE
/FAIl/SYAZWAN: Add support for solid elements

### DIFF
--- a/engine/source/materials/fail/syazwan/fail_syazwan_s.F
+++ b/engine/source/materials/fail/syazwan/fail_syazwan_s.F
@@ -1,0 +1,215 @@
+Copyright>        OpenRadioss
+Copyright>        Copyright (C) 1986-2023 Altair Engineering Inc.
+Copyright>
+Copyright>        This program is free software: you can redistribute it and/or modify
+Copyright>        it under the terms of the GNU Affero General Public License as published by
+Copyright>        the Free Software Foundation, either version 3 of the License, or
+Copyright>        (at your option) any later version.
+Copyright>
+Copyright>        This program is distributed in the hope that it will be useful,
+Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+Copyright>        GNU Affero General Public License for more details.
+Copyright>
+Copyright>        You should have received a copy of the GNU Affero General Public License
+Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+Copyright>
+Copyright>
+Copyright>        Commercial Alternative: Altair Radioss Software
+Copyright>
+Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+Chd|====================================================================
+Chd|  FAIL_SYAZWAN_S                 source/materials/fail/biquad/fail_syazwan_s.F
+Chd|-- called by -----------
+Chd|        MMAIN                         source/materials/mat_share/mmain.F
+Chd|        MMAIN8                        source/materials/mat_share/mmain8.F
+Chd|        MULAW                         source/materials/mat_share/mulaw.F
+Chd|        MULAW8                        source/materials/mat_share/mulaw8.F
+Chd|        USERMAT_SOLID                 source/materials/mat_share/usermat_solid.F
+Chd|-- calls ---------------
+Chd|        FINTER                        source/tools/curve/finter.F   
+Chd|====================================================================
+      SUBROUTINE FAIL_SYAZWAN_S(
+     1     NEL     ,UPARAM   ,NUPARAM ,UVAR    ,NUVAR   ,
+     2     TIME    ,NGL      ,IP      ,DPLA    ,PLA     ,
+     3     SIGNXX  ,SIGNYY   ,SIGNZZ  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
+     4     DFMAX   ,NFUNC    ,IFUNC   ,ALDT    ,FOFF    ,
+     5     NPF     ,TF      )
+C!-----------------------------------------------
+C!   I m p l i c i t   T y p e s
+C!-----------------------------------------------
+#include      "implicit_f.inc"
+C!---------+---------+---+---+--------------------------------------------
+C! VAR     | SIZE    |TYP| RW| DEFINITION
+C!---------+---------+---+---+--------------------------------------------
+C! NEL     |  1      | I | R | SIZE OF THE ELEMENT GROUP NEL 
+C! NUPARAM |  1      | I | R | SIZE OF THE USER PARAMETER ARRAY
+C! NUVAR   |  1      | I | R | NUMBER OF FAILURE ELEMENT VARIABLES
+C!---------+---------+---+---+--------------------------------------------
+C! MFUNC   |  1      | I | R | NUMBER FUNCTION USED FOR THIS USER LAW not used
+C! KFUNC   | NFUNC   | I | R | FUNCTION INDEX not used
+C! NPF     |  *      | I | R | FUNCTION ARRAY   
+C! TF      |  *      | F | R | FUNCTION ARRAY 
+C!---------+---------+---+---+--------------------------------------------
+C! TIME    |  1      | F | R | CURRENT TIME
+C! TIMESTEP|  1      | F | R | CURRENT TIME STEP
+C! UPARAM  | NUPARAM | F | R | USER FAILURE PARAMETER ARRAY
+C!---------+---------+---+---+--------------------------------------------
+C! SIGNXX  | NEL     | F | W | NEW ELASTO PLASTIC STRESS XX
+C! SIGNYY  | NEL     | F | W | NEW ELASTO PLASTIC STRESS YY
+C! ...     |         |   |   |
+C! ...     |         |   |   |
+C!---------+---------+---+---+--------------------------------------------
+C! UVAR    |NEL*NUVAR| F |R/W| USER ELEMENT VARIABLE ARRAY
+C! FOFF     | NEL     | F |R/W| DELETED ELEMENT FLAG (=1. ON, =0. OFF)
+C!---------+---------+---+---+--------------------------------------------
+#include "mvsiz_p.inc"
+#include "scr17_c.inc"
+#include "units_c.inc"
+#include "comlock.inc"
+#include "param_c.inc"
+C!-----------------------------------------------
+      INTEGER NEL, NUPARAM, NUVAR,NGL(NEL),IP,NFUNC, IFUNC(NFUNC)
+      my_real TIME,UPARAM(NUPARAM),
+     .   SIGNXX(NEL),SIGNYY(NEL),SIGNZZ(NEL),
+     .   SIGNXY(NEL),SIGNYZ(NEL),SIGNZX(NEL),UVAR(NEL,NUVAR),
+     .   DPLA(NEL),EPSP(NEL),FOFF(NEL),DFMAX(NEL),TDELE(NEL),
+     .   PLA(NEL) ,ALDT(NEL)   
+C-----------------------------------------------
+C   VARIABLES FOR FUNCTION INTERPOLATION 
+C-----------------------------------------------
+      INTEGER, INTENT(IN) :: NPF(*)
+      my_real, INTENT(IN) :: TF(*)
+      my_real
+     .         FINTER
+      EXTERNAL FINTER
+C!-----------------------------------------------
+C!   L o c a l   V a r i a b l e s
+C!-----------------------------------------------
+      INTEGER I,J,NINDX,INST,DINIT,IFORM
+      INTEGER, DIMENSION(MVSIZ) :: INDX
+      my_real
+     .   C1     ,C2     ,C3     ,C4     ,C5     ,C6     ,
+     .   N_VAL  ,SOFTEXP,REF_LEN,REG_SCALE,DAM_SF,MAX_DAM
+      my_real
+     .   LAMBDA ,DYDX   ,FAC(NEL),DC(NEL),P      ,SVM    ,
+     .   TRIAX  ,COS3THETA,LODEP ,EPSFAIL,
+     .   DET    ,XI  ,SXX     ,SYY    ,SZZ       ,EPFMIN
+
+      !=======================================================================
+      ! - INITIALISATION OF COMPUTATION ON TIME STEP
+      !=======================================================================
+      ! Recovering failure criterion parameters
+      C1        = UPARAM(1) 
+      C2        = UPARAM(2) 
+      C3        = UPARAM(3)
+      C4        = UPARAM(4) 
+      C5        = UPARAM(5)
+      C6        = UPARAM(6)
+      IFORM     = NINT(UPARAM(7))
+      DINIT     = NINT(UPARAM(8))
+      DAM_SF    = UPARAM(9)
+      MAX_DAM   = UPARAM(10)
+      INST      = NINT(UPARAM(11))
+      N_VAL     = UPARAM(12) 
+      SOFTEXP   = UPARAM(13) 
+      REF_LEN   = UPARAM(14) 
+      REG_SCALE = UPARAM(15) 
+      EPFMIN    = UPARAM(16)
+c
+      ! At first timestep, initialization of the critical damage and 
+      ! the element size scaling factor
+      IF (UVAR(1,1) == ZERO) THEN
+        IF (IFUNC(1) > 0) THEN 
+          DO I=1,NEL
+            LAMBDA    = ALDT(I)/REF_LEN
+            UVAR(I,1) = FINTER(IFUNC(1),LAMBDA,NPF,TF,DYDX)
+            UVAR(I,1) = UVAR(I,1)*REG_SCALE
+          ENDDO
+        ELSE 
+          UVAR(1:NEL,1) = ONE
+        ENDIF
+      ENDIF
+c
+      DO I=1,NEL
+        ! Recover element size scaling
+        FAC(I)   = UVAR(I,1)
+      ENDDO
+c
+C-----------------------------------------------
+c
+      !====================================================================
+      ! - COMPUTATION OF THE DAMAGE VARIABLE EVOLUTION
+      !==================================================================== 
+      ! Initialization of element failure index
+      NINDX = 0  
+      INDX(1:NEL) = 0
+c
+      ! Loop over the elements 
+      DO I=1,NEL
+c
+        IF (FOFF(I) /= 0 .AND. DPLA(I) > ZERO) THEN
+c
+          ! Computation of hydrostatic stress, Von Mises stress, and stress triaxiality
+          P   = THIRD*(SIGNXX(I) + SIGNYY(I) + SIGNZZ(I))     
+          SXX = SIGNXX(I) - P                                 
+          SYY = SIGNYY(I) - P                                 
+          SZZ = SIGNZZ(I) - P                                 
+          SVM = HALF*(SXX**2 + SYY**2 + SZZ**2)             
+     .         + SIGNXY(I)**2+ SIGNZX(I)**2 + SIGNYZ(I)**2    
+          SVM = SQRT(THREE*SVM) 
+          TRIAX = P/MAX(EM20,SVM)
+c
+          ! Computation of Lode parameter
+          DET = SXX*SYY*SZZ + TWO*SIGNXY(I)*SIGNZX(I)*SIGNYZ(I)- 
+     .          SXX*SIGNYZ(I)**2-SZZ*SIGNXY(I)**2-SYY*SIGNZX(I)**2
+          COS3THETA = ONE/MAX(EM20,SVM**3)
+          COS3THETA = HALF*TWENTY7*DET*XI         
+          IF(COS3THETA < -ONE) COS3THETA = -ONE
+          IF(COS3THETA > ONE) COS3THETA = ONE
+          LODEP = ONE - TWO*ACOS(XI)/PI
+c
+          ! Computation of the plastic strain at failure
+          EPSFAIL = C1 + C2*TRIAX + C3*LODEP + C4*(TRIAX**2) + 
+     .              C5*(LODEP**2) + C6*TRIAX*LODEP
+          EPSFAIL = EPSFAIL*FAC(I)
+          EPSFAIL = MAX(EPFMIN,EPSFAIL)
+c
+          ! Computation of the damage variable update 
+          DFMAX(I) = DFMAX(I) + DPLA(I)/MAX(EPSFAIL,EM20)
+          DFMAX(I) = MIN(DFMAX(I),ONE) 
+c              
+          ! Check element failure    
+          IF (DFMAX(I) >= ONE) THEN
+            FOFF(I)     = 0
+            NINDX       = NINDX + 1
+            INDX(NINDX) = I
+          ENDIF
+        ENDIF
+      ENDDO
+c     
+c------------------------
+      
+       IF(NINDX>0)THEN
+         DO J=1,NINDX
+          I = INDX(J)     
+#include "lockon.inc"
+          WRITE(IOUT, 1000) NGL(I),TIME
+          WRITE(ISTDO,1100) NGL(I),TIME
+#include "lockoff.inc"
+         END DO
+       END IF         
+C---------Damage for output  0 < DFMAX < 1 --------------------
+c!       DO J=1,IR
+c!          I=JST(J)
+c!          DFMAX(I)= MIN(ONE,DFMAX(I))
+c!       ENDDO
+C------------------
+ 1000 FORMAT(1X,'DELETE SOLID ELEMENT NUMBER (SYAZWAN) el#',I10,
+     .          ' AT TIME :',1PE12.4)     
+ 1100 FORMAT(1X,'DELETE SOLID ELEMENT NUMBER (SYAZWAN) el#',I10,
+     .          ' AT TIME :',1PE12.4)     
+      RETURN
+      END

--- a/engine/source/materials/fail/syazwan/fail_syazwan_s.F
+++ b/engine/source/materials/fail/syazwan/fail_syazwan_s.F
@@ -201,11 +201,6 @@ c------------------------
 #include "lockoff.inc"
          END DO
        END IF         
-C---------Damage for output  0 < DFMAX < 1 --------------------
-c!       DO J=1,IR
-c!          I=JST(J)
-c!          DFMAX(I)= MIN(ONE,DFMAX(I))
-c!       ENDDO
 C------------------
  1000 FORMAT(1X,'DELETE SOLID ELEMENT NUMBER (SYAZWAN) el#',I10,
      .          ' AT TIME :',1PE12.4)     

--- a/engine/source/materials/mat_share/mmain.F
+++ b/engine/source/materials/mat_share/mmain.F
@@ -89,7 +89,7 @@ Chd|        FAIL_PUCK_S                   source/materials/fail/puck/fail_puck_s
 Chd|        FAIL_RTCL_S                   source/materials/fail/rtcl/fail_rtcl_s.F
 Chd|        FAIL_SAHRAEI_S                source/materials/fail/sahraei/fail_sahraei_s.F
 Chd|        FAIL_SPALLING_S               source/materials/fail/spalling/fail_spalling_s.F
-Chd|        FAIL_SYAZWAN_S                source/materials/fail/biquad/fail_syazwan_s.F
+Chd|        FAIL_SYAZWAN_S                source/materials/fail/syazwan/fail_syazwan_s.F
 Chd|        FAIL_TAB2_S                   source/materials/fail/tabulated/fail_tab2_s.F
 Chd|        FAIL_TAB_S                    source/materials/fail/tabulated/fail_tab_s.F
 Chd|        FAIL_TBUTCHER_S               source/materials/fail/tuler_butcher/fail_tbutcher_s.F

--- a/engine/source/materials/mat_share/mmain.F
+++ b/engine/source/materials/mat_share/mmain.F
@@ -89,6 +89,7 @@ Chd|        FAIL_PUCK_S                   source/materials/fail/puck/fail_puck_s
 Chd|        FAIL_RTCL_S                   source/materials/fail/rtcl/fail_rtcl_s.F
 Chd|        FAIL_SAHRAEI_S                source/materials/fail/sahraei/fail_sahraei_s.F
 Chd|        FAIL_SPALLING_S               source/materials/fail/spalling/fail_spalling_s.F
+Chd|        FAIL_SYAZWAN_S                source/materials/fail/biquad/fail_syazwan_s.F
 Chd|        FAIL_TAB2_S                   source/materials/fail/tabulated/fail_tab2_s.F
 Chd|        FAIL_TAB_S                    source/materials/fail/tabulated/fail_tab_s.F
 Chd|        FAIL_TBUTCHER_S               source/materials/fail/tuler_butcher/fail_tbutcher_s.F
@@ -2322,6 +2323,15 @@ C---- Inievo failure model
      6          EL_PLA   ,TEMPEL   ,SIGY     ,OFF      ,DFMAX    ,
      7          TDEL     ,DMG_SCALE,GBUF%UELR,IPG      ,NPG      ,
      8          LBUF%OFF ,DAMINI   ,GBUF%VOL ,INLOC    )
+c
+          ELSEIF (IRUPT == 43) THEN                                      
+C  --- Syazwan failure model             
+              CALL FAIL_SYAZWAN_S(
+     1        LLT     ,BUFMAT(IADBUF),NPARAM,UVARF    ,NVARF     ,
+     2        TT      ,NGL         ,IP       ,DPLA    ,EL_PLA    ,
+     3        SS1     ,SS2         ,SS3      ,SS4     ,SS5       ,SS6      ,
+     4        DFMAX   ,NFUNC       ,IFUNC    ,EL_LEN  ,OFF       ,
+     5        NPF     ,TF)
 c
           ELSEIF (IRUPT == 44) THEN                                        
 c --- Tsai-Wu failure model

--- a/engine/source/materials/mat_share/mmain8.F
+++ b/engine/source/materials/mat_share/mmain8.F
@@ -366,6 +366,14 @@ c  --- RTCL failure model
      2          SXX      ,SYY      ,SZZ      ,SXY      ,SYZ      ,SZX      ,
      3          NGL      ,DPLA(J1) ,UVARF    ,OFF      ,DFMAX    ,TDELE    )
 c---------
+c ---   Syazwan failure                                               
+          ELSEIF (IFAIL(II) == 43) THEN                                      
+            CALL FAIL_SYAZWAN_S(
+     1          NEL     ,BUFMAT(IADBUF)    ,NUPARAM ,UVARF   ,NVARF   ,
+     2          TT      ,NGL      ,IP      ,DPLA(J1),LBUF%PLA,
+     3          SXX     ,SYY      ,SZZ     ,SXY     ,SYZ     ,SZX     ,
+     4          DFMAX   ,NFUNC    ,IFUNC   ,DELTAX  ,OFF     ,
+     5          NPF     ,TF      )
            ENDIF
           ENDDO
 c

--- a/engine/source/materials/mat_share/mmain8.F
+++ b/engine/source/materials/mat_share/mmain8.F
@@ -31,6 +31,7 @@ Chd|        FAIL_JOHNSON                  source/materials/fail/johnson_cook/fai
 Chd|        FAIL_ORTHBIQUAD_S             source/materials/fail/orthbiquad/fail_orthbiquad_s.F
 Chd|        FAIL_RTCL_S                   source/materials/fail/rtcl/fail_rtcl_s.F
 Chd|        FAIL_SPALLING_S               source/materials/fail/spalling/fail_spalling_s.F
+Chd|        FAIL_SYAZWAN_S                source/materials/fail/syazwan/fail_syazwan_s.F
 Chd|        FAIL_TAB_S                    source/materials/fail/tabulated/fail_tab_s.F
 Chd|        FAIL_TBUTCHER_S               source/materials/fail/tuler_butcher/fail_tbutcher_s.F
 Chd|        FAIL_WIERZBICKI_S             source/materials/fail/wierzbicki/fail_wierzbicki_s.F

--- a/engine/source/materials/mat_share/mulaw.F
+++ b/engine/source/materials/mat_share/mulaw.F
@@ -1292,7 +1292,7 @@ c
      9                  SV1 ,SV2 ,SV3 ,SV4  ,SV5  ,SV6 ,
      A                  SSP ,VIS ,UVAR,OFF  ,DVOL ,VOL ,
      B                  IPM ,MAT ,EPSD,SIGY ,DPLA ,DEFP,
-     C                  AMU )
+     C                  AMU ,LBUF%DMG)
 C 
       ELSEIF (MTN == 80) THEN
         CALL SIGEPS80(

--- a/engine/source/materials/mat_share/mulaw.F
+++ b/engine/source/materials/mat_share/mulaw.F
@@ -1292,7 +1292,7 @@ c
      9                  SV1 ,SV2 ,SV3 ,SV4  ,SV5  ,SV6 ,
      A                  SSP ,VIS ,UVAR,OFF  ,DVOL ,VOL ,
      B                  IPM ,MAT ,EPSD,SIGY ,DPLA ,DEFP,
-     C                  AMU ,LBUF%DMG)
+     C                  AMU )
 C 
       ELSEIF (MTN == 80) THEN
         CALL SIGEPS80(
@@ -2101,6 +2101,14 @@ C---- Inievo failure model
      7          TDEL     ,DMG_SCALE,GBUF%UELR,IPG      ,NPG      ,
      8          LBUF%OFF ,DAMINI   ,GBUF%VOL ,INLOC    )  
 c
+          ELSEIF (IRUPT == 43) THEN                                      
+c  --- Syazwan failure model                                  
+              CALL FAIL_SYAZWAN_S(
+     1          NEL     ,UPARAMF  ,NPAR    ,UVARF   ,NVARF   ,
+     2          TT      ,NGL      ,IP      ,DPLA    ,EL_PLA  ,
+     3          S1      ,S2       ,S3      ,S4      ,S5      ,S6       , 
+     4          DFMAX   ,NFUNC    ,IFUNC   ,EL_LEN  ,OFF     ,
+     5          NPF     ,TF      )
           ELSEIF (IRUPT == 44) THEN                                      
 C---- Tsai-Wu failure model
               CALL FAIL_TSAIWU_S(

--- a/engine/source/materials/mat_share/mulaw.F
+++ b/engine/source/materials/mat_share/mulaw.F
@@ -44,6 +44,7 @@ Chd|        FAIL_ORTHSTRAIN               source/materials/fail/orthstrain/fail_
 Chd|        FAIL_RTCL_S                   source/materials/fail/rtcl/fail_rtcl_s.F
 Chd|        FAIL_SAHRAEI_S                source/materials/fail/sahraei/fail_sahraei_s.F
 Chd|        FAIL_SPALLING_S               source/materials/fail/spalling/fail_spalling_s.F
+Chd|        FAIL_SYAZWAN_S                source/materials/fail/syazwan/fail_syazwan_s.F
 Chd|        FAIL_TAB2_S                   source/materials/fail/tabulated/fail_tab2_s.F
 Chd|        FAIL_TAB_S                    source/materials/fail/tabulated/fail_tab_s.F
 Chd|        FAIL_TBUTCHER_S               source/materials/fail/tuler_butcher/fail_tbutcher_s.F

--- a/engine/source/materials/mat_share/mulaw8.F
+++ b/engine/source/materials/mat_share/mulaw8.F
@@ -35,6 +35,7 @@ Chd|        FAIL_ORTHBIQUAD_S             source/materials/fail/orthbiquad/fail_
 Chd|        FAIL_RTCL_S                   source/materials/fail/rtcl/fail_rtcl_s.F
 Chd|        FAIL_SAHRAEI_S                source/materials/fail/sahraei/fail_sahraei_s.F
 Chd|        FAIL_SPALLING_S               source/materials/fail/spalling/fail_spalling_s.F
+Chd|        FAIL_SYAZWAN_S                source/materials/fail/syazwan/fail_syazwan_s.F
 Chd|        FAIL_TAB_S                    source/materials/fail/tabulated/fail_tab_s.F
 Chd|        FAIL_TBUTCHER_S               source/materials/fail/tuler_butcher/fail_tbutcher_s.F
 Chd|        FAIL_TENSSTRAIN_S             source/materials/fail/tensstrain/fail_tensstrain_s.F

--- a/engine/source/materials/mat_share/mulaw8.F
+++ b/engine/source/materials/mat_share/mulaw8.F
@@ -1048,6 +1048,15 @@ c  --- RTCL failure model
      1          LLT      ,NPAR     ,NVARF    ,TT       ,DT1      ,BUFMAT(IADBUF),
      2          S1       ,S2       ,S3       ,S4       ,S5       ,S6       ,
      3          NGL      ,DPLA     ,UVARF    ,OFF      ,DFMAX    ,TDELE    ) 
+c
+          ELSEIF (IFAIL(II) == 43) THEN                                      
+C  --- Syazwan failure model                                  
+              CALL FAIL_SYAZWAN_S(
+     1          LLT     ,BUFMAT(IADBUF)    ,NPAR    ,UVARF   ,NVARF    ,
+     2          TT      ,NGL      ,IP      ,DPLA    ,DEFP    ,
+     3          S1      ,S2       ,S3      ,S4      ,S5      ,S6       ,
+     4          DFMAX   ,NFUNC    ,IFUNC   ,DELTAX  ,OFF    ,
+     5          NPF     ,TF      ) 
 c---------
           ENDIF ! IRUPT
 c---------

--- a/engine/source/materials/mat_share/usermat_solid.F
+++ b/engine/source/materials/mat_share/usermat_solid.F
@@ -50,6 +50,7 @@ Chd|        FAIL_ORTHSTRAIN               source/materials/fail/orthstrain/fail_
 Chd|        FAIL_RTCL_S                   source/materials/fail/rtcl/fail_rtcl_s.F
 Chd|        FAIL_SAHRAEI_S                source/materials/fail/sahraei/fail_sahraei_s.F
 Chd|        FAIL_SPALLING_S               source/materials/fail/spalling/fail_spalling_s.F
+Chd|        FAIL_SYAZWAN                  source/materials/fail/syazwan/fail_syazwan_s.F
 Chd|        FAIL_TAB2_S                   source/materials/fail/tabulated/fail_tab2_s.F
 Chd|        FAIL_TAB_S                    source/materials/fail/tabulated/fail_tab_s.F
 Chd|        FAIL_TBUTCHER_S               source/materials/fail/tuler_butcher/fail_tbutcher_s.F

--- a/engine/source/materials/mat_share/usermat_solid.F
+++ b/engine/source/materials/mat_share/usermat_solid.F
@@ -1574,6 +1574,14 @@ C---- Inievo failure model
      7          TDEL     ,DMG_SCALE,GBUF%UELR,IPG      ,NPG      ,
      8          LBUF%OFF ,DAMINI   ,GBUF%VOL ,INLOC    )  
 c
+          ELSEIF (IRUPT == 43) THEN    
+c  --- Syazwan failure model                                  
+              CALL FAIL_SYAZWAN_S(
+     1          NEL     ,UPARAMF  ,NPAR    ,UVARF   ,NVARF   ,
+     2          TT      ,NGL      ,IP      ,DPLA    ,EL_PLA  ,
+     3          S1      ,S2       ,S3      ,S4      ,S5      ,S6       , 
+     4          DFMAX   ,NFUNC    ,IFUNC   ,EL_LEN  ,OFF     ,
+     5          NPF     ,TF      )  
           ELSEIF (IRUPT == 44) THEN                                      
 C---- Tsai-Wu failure model
               CALL FAIL_TSAIWU_S(


### PR DESCRIPTION
#### Description of the feature 
Add support for solid elements in /FAIL/SYAZWAN.

#### Comments
1. There are some dummy argument that does not use explicit size because I wasn't sure how to declare e.g., NPF(*), TF(*)
2. Most of the features that are available for shell elements is not available for solid elements. This includes instability curve to initiate stress softening, and damage initialization based on linear strain path assumption (even though we can still calculate damage based on stress histories, there's no evidence that the linear strain path assumption is valid for solid elements).
