### PR TITLE
wrong mapping result with /INIBRI/EREF+LAW95 for tet elements

### DIFF
--- a/starter/source/elements/solid/solide10/s10jaci3.F
+++ b/starter/source/elements/solid/solide10/s10jaci3.F
@@ -192,6 +192,7 @@ C
        DO IP=1,NPT
         LBUF => ELBUF_STR%BUFLY(1)%LBUF(IP,1,1)
         CALL S10PIJSAV(PX(1,1,IP),PY(1,1,IP),PZ(1,1,IP),LBUF%PIJ,NEL)
+        LBUF%VOL(1:NEL)=VOL(1:NEL,IP)
        ENDDO
 C
       RETURN

--- a/starter/source/elements/solid/solide4/s4init3.F
+++ b/starter/source/elements/solid/solide4/s4init3.F
@@ -184,9 +184,6 @@ C
      .             PZ1    ,PZ2    ,PZ3    ,PZ4    ,GBUF%JAC_I, 
      .             DELTAX ,VOLU   ,NGL    ,PID    ,MAT       ,
      .             PM     ,LBUF%VOL0DP)
-      IF (NSIGI > 0.AND.(ISMSTR==10.OR.ISMSTR==12)) THEN
-         CALL S4JACI3(GBUF%SMSTR,GBUF%JAC_I, NEL  ) 
-      END IF
       IREP = IPARG_GR(35)
       CALL SREPLOC3(
      .         RX   ,RY   ,RZ   ,SX   ,SY   ,SZ   ,TX   ,TY   ,TZ   ,
@@ -294,6 +291,12 @@ C----------------------------------------
       CALL FAILINI(ELBUF_STR,NPTR,NPTS,NPTT,NLAY,
      .             IPM,SIGSP,NSIGI,FAIL_INI ,
      .             SIGI,NSIGS,IXS,NIXS,PTSOL,RNOISE,PERTURB,BUFMAT)
+C----------------------------------------
+c initialisation inibri/eref
+C----------------------------------------
+      IF (NSIGI > 0.AND.(ISMSTR==10.OR.ISMSTR==12)) THEN
+         CALL S4JACI3(GBUF%SMSTR,GBUF%JAC_I, GBUF%VOL,NEL  ) 
+      END IF
 C------------------------------------------
 C     CALCUL DES DT ELEMENTAIRES
 c

--- a/starter/source/elements/solid/solide4/s4jaci3.F
+++ b/starter/source/elements/solid/solide4/s4jaci3.F
@@ -26,7 +26,7 @@ Chd|-- called by -----------
 Chd|        S4INIT3                       source/elements/solid/solide4/s4init3.F
 Chd|-- calls ---------------
 Chd|====================================================================
-      SUBROUTINE S4JACI3(SAV   ,JAC_I, NEL  ) 
+      SUBROUTINE S4JACI3(SAV   ,JAC_I, VOL, NEL  ) 
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -41,6 +41,7 @@ C-----------------------------------------------
       INTEGER , INTENT(IN) :: NEL
       DOUBLE PRECISION , DIMENSION(NEL,9),INTENT(IN) :: SAV     
       my_real , DIMENSION(10,NEL),INTENT(OUT) :: JAC_I     
+      my_real , DIMENSION(NEL),   INTENT(OUT) :: VOL     
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -50,7 +51,7 @@ C-----------------------------------------------
      .   Z1(MVSIZ), Z2(MVSIZ), Z3(MVSIZ), Z4(MVSIZ),VOLDP 
 C     REAL
       my_real
-     .   VOL(MVSIZ),DET(MVSIZ),
+     .   DET(MVSIZ),
      .   PX1(MVSIZ), PX2(MVSIZ), PX3(MVSIZ), PX4(MVSIZ),  
      .   PY1(MVSIZ), PY2(MVSIZ), PY3(MVSIZ), PY4(MVSIZ),  
      .   PZ1(MVSIZ), PZ2(MVSIZ), PZ3(MVSIZ), PZ4(MVSIZ)  


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
wrong mapping result using law95 with tet elements (/INIBRI Itetetr4=3)

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
correction to get right mapping result

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
