### PR TITLE
correct applied pressure distribution on segment nodes in /LOAD/PCYL

### DIFF
--- a/engine/source/loads/general/load_pcyl/press_seg3.F
+++ b/engine/source/loads/general/load_pcyl/press_seg3.F
@@ -36,7 +36,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER :: NPT
       my_real :: A11,A12,A21,A22,B1,B2,DET,ALPHA,BETA,GAMMA,F1,F2,R,S,
-     .           R1,R2,R3,RMAX,P1,P2,P3,DYDX,COSP,SINP
+     .   R1,R2,R3,RMAX,P1,P2,P3,DYDX,NX,NY,NZ,NORM,COSP,SINP
       my_real, DIMENSION(3) :: AB,AC,AN,P,AP,BP,CP
       my_real, DIMENSION(2) :: XX
 c-----------------------------------------------
@@ -96,6 +96,7 @@ c
       DET = A11*A22 - A12*A21
       R   = (A22 * B1 - A12 * B2) / DET
       S   = (A11 * B2 - A21 * B1) / DET
+      ! P = projection of axe origin N1 on ABC plane following direction DIR
       P(1)= A(1) + R*AB(1) + S*AC(1)
       P(2)= A(2) + R*AB(2) + S*AC(2)
       P(3)= A(3) + R*AB(3) + S*AC(3)
@@ -113,24 +114,42 @@ c
       R3 = SQRT(CP(1)**2 + CP(2)**2 + CP(3)**2)
       COSP = (DIR(1) * AP(1) + DIR(2) * AP(2) + DIR(3) * AP(3)) / MAX(R1,EM20)
       SINP = MAX(SQRT(ONE - COSP**2), EM20)
-      R1 = R1 / SINP
-      R2 = R2 / SINP 
-      R3 = R3 / SINP 
 c
       XX(2) = TT    ! Time
+c     pressure in 1st point of 3N sub-segment
+      COSP = (DIR(1) * AP(1) + DIR(2) * AP(2) + DIR(3) * AP(3)) / MAX(R1,EM20)
+      SINP = MAX(SQRT(ONE - COSP**2), EM20)
+      R1   = R1 * SINP
       IF (R1 <=  RMAX) THEN
         XX(1) = R1
         CALL TABLE_INTERP_DYDX(TABLE(IFUNC),XX,2,P1,DYDX)
       END IF
+c     pressure in 2nd point of 3N sub-segment
+      COSP = (DIR(1) * BP(1) + DIR(2) * BP(2) + DIR(3) * BP(3)) / MAX(R2,EM20)
+      SINP = MAX(SQRT(ONE - COSP**2), EM20)
+      R2   = R2 * SINP
       IF (R2 <= RMAX) THEN
         XX(1) = R2
         CALL TABLE_INTERP_DYDX(TABLE(IFUNC),XX,2,P2,DYDX)
       END IF
+c     pressure in 3rd point of 3N sub-segment
+      COSP = (DIR(1) * CP(1) + DIR(2) * CP(2) + DIR(3) * CP(3)) / MAX(R3,EM20)
+      SINP = MAX(SQRT(ONE - COSP**2), EM20)
+      R3   = R3 * SINP
       IF (R3 <= RMAX) THEN
         XX(1) = R3
         CALL TABLE_INTERP_DYDX(TABLE(IFUNC),XX,2,P3,DYDX)
       END IF
-      PRESS = (P1 + P2 + P3) * SINP * THIRD
+      PRESS = (P1 + P2 + P3) * THIRD
+      IF (PRESS > ZERO) THEN
+c       calculate cos(angle) between cylinder axis and segment normal to scale pressure
+        NX = AB(2) * AC(3) - AB(3) *  AC(2)
+        NY = AB(3) * AC(1) - AB(1) *  AC(3)
+        NZ = AB(1) * AC(2) - AB(2) *  AC(1)
+        NORM  = SQRT(NX**2 + NY**2 + NZ**2)
+        COSP  = ABS(NX * ALPHA + NY * BETA + NZ * GAMMA) / NORM
+        PRESS = PRESS * COSP
+      END IF
 c-----------      
       RETURN
       END

--- a/engine/source/loads/general/load_pcyl/pressure_cyl.F
+++ b/engine/source/loads/general/load_pcyl/pressure_cyl.F
@@ -81,18 +81,19 @@ c
         RMAX = TABLE(IFUN)%X(1)%VALUES(NPOINT)
         M1   = IFRAME(1,IFRA)
         M2   = IFRAME(2,IFRA)
-        DIRX = X(1,M2) - X(1,M1)
-        DIRY = X(2,M2) - X(2,M1)
-        DIRZ = X(3,M2) - X(3,M1)
+        DIRX = X(1,M1) - X(1,M2)
+        DIRY = X(2,M1) - X(2,M2)
+        DIRZ = X(3,M1) - X(3,M2)
         LEN  = SQRT(DIRX**2 + DIRY**2 + DIRZ**2)
         ! SEGP beam axis
         DIR(1) = DIRX / LEN
         DIR(2) = DIRY / LEN
         DIR(3) = DIRZ / LEN
-        P0(1)  = X(1,M1)
-        P0(2)  = X(2,M1)
-        P0(3)  = X(3,M1)
+        P0(1)  = X(1,M2)
+        P0(2)  = X(2,M2)
+        P0(3)  = X(3,M2)
         DO J = 1,NSEG
+          PRESS = ZERO
           N1   = LOADS%LOAD_CYL(I)%SEGNOD(J,1)
           N2   = LOADS%LOAD_CYL(I)%SEGNOD(J,2)
           N3   = LOADS%LOAD_CYL(I)%SEGNOD(J,3)
@@ -113,7 +114,8 @@ c
             NX = (C(2)-A(2))*(C(3)-B(3)) - (C(3)-A(3))*(C(2)-B(2))
             NY = (C(3)-A(3))*(C(1)-B(1)) - (C(1)-A(1))*(C(3)-B(3))
             NZ = (C(1)-A(1))*(C(2)-B(2)) - (C(2)-A(2))*(C(1)-B(1))
-            PRESS = PRESS * ONE_OVER_6
+            PRESS = SEGP * ONE_OVER_6
+            PRESS = PRESS * YFAC
             FX = PRESS * NX
             FY = PRESS * NY
             FZ = PRESS * NZ
@@ -129,31 +131,30 @@ c
             M(1) = (X(1,N1) + X(1,N2) + X(1,N3) + X(1,N4)) * FOURTH
             M(2) = (X(2,N1) + X(2,N2) + X(2,N3) + X(2,N4)) * FOURTH
             M(3) = (X(3,N1) + X(3,N2) + X(3,N3) + X(3,N4)) * FOURTH
-            PRESS = ZERO
 c           1st internal triangle 
             CALL PRESS_SEG3(A       ,B      ,M      ,P0      ,DIR    , 
      .                      IFUN    ,TABLE  ,XFACR  ,XFACT   ,SEGP   )
-            PRESS = PRESS + SEGP
+            PRESS = PRESS + SEGP * FOURTH
 c           2nd internal triangle 
             CALL PRESS_SEG3(B       ,C      ,M      ,P0      ,DIR    , 
      .                      IFUN    ,TABLE  ,XFACR  ,XFACT   ,SEGP   )
-            PRESS = PRESS + SEGP
+            PRESS = PRESS + SEGP * FOURTH
 c           3rd internal triangle 
             CALL PRESS_SEG3(C       ,D      ,M      ,P0      ,DIR    , 
      .                      IFUN    ,TABLE  ,XFACR  ,XFACT   ,SEGP   )
-            PRESS = PRESS + SEGP
+            PRESS = PRESS + SEGP * FOURTH
 c           4th internal triangle 
             CALL PRESS_SEG3(D       ,A      ,M      ,P0      ,DIR    , 
      .                      IFUN    ,TABLE  ,XFACR  ,XFACT   ,SEGP   )
-            PRESS = PRESS + SEGP
-            PRESS = ABS(PRESS) * ONE_OVER_8
-c            
+            PRESS = PRESS + SEGP * FOURTH
+c           normal to segment = vector prod of 2 diagonals  
             NX = (C(2)-A(2))*(D(3)-B(3)) - (C(3)-A(3))*(D(2)-B(2))
             NY = (C(3)-A(3))*(D(1)-B(1)) - (C(1)-A(1))*(D(3)-B(3))
             NZ = (C(1)-A(1))*(D(2)-B(2)) - (C(2)-A(2))*(D(1)-B(1))
-            FX = PRESS * YFAC * NX
-            FY = PRESS * YFAC * NY
-            FZ = PRESS * YFAC * NZ
+            PRESS = ABS(PRESS) * YFAC * ONE_OVER_8
+            FX = PRESS * NX
+            FY = PRESS * NY
+            FZ = PRESS * NZ
             TFEXTT = TFEXTT 
      .             + (FX*(V(1,N1) + V(1,N2) + V(1,N3) + V(1,N4))
      .             +  FY*(V(2,N1) + V(2,N2) + V(2,N3) + V(2,N4))


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

corrected pressure distribution between mesh nodes when using /LOAD/PCYL option

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Two bugs were corrected:
1) pressure value in each point depending on distance from cylindrical axis was wrong
2) final pressure  applied on segment nodes  was equal to sum pressures in four subtriangles instead of the mean value

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
