### PR TITLE
Avoid some numerical noise in JohnsonCook failure model

### DIFF
--- a/engine/source/materials/fail/johnson_cook/fail_johnson.F
+++ b/engine/source/materials/fail/johnson_cook/fail_johnson.F
@@ -132,10 +132,9 @@ C
      .            +SIGNXY(I)**2 + SIGNZX(I)**2 + SIGNYZ(I)**2
            SVM=SQRT(THREE*SVM)
            EPSF = D3*P/MAX(EM20,SVM)
-           EPSF = (D1 + 
-     .             D2*EXP(EPSF))*(ONE 
-     .                    + D4*LOG(MAX(ONE,EPSP(I)/EPSP0)))
-     .                      *(ONE + D5*TSTAR(I))
+           EPSF = (D1 + D2*EXP(EPSF))
+           IF(D4>ZERO) EPSF = EPSF * (ONE + D4*LOG(MAX(ONE,EPSP(I)/EPSP0))) ! if d4=0, epsp is not correctly defined
+           IF(D5>ZERO) EPSF = EPSF * (ONE + D5*TSTAR(I)) ! if d5=0, tsart is not correctly defined
            IF(EPSF>ZERO) DFMAX(I) = DFMAX(I) + DPLA(I)/EPSF
          ENDIF
          IF(DFMAX(I)>=ONE.AND.OFF(I)==ONE) THEN

--- a/engine/source/materials/fail/johnson_cook/fail_johnson_c.F
+++ b/engine/source/materials/fail/johnson_cook/fail_johnson_c.F
@@ -121,9 +121,9 @@ c-----------------------------
           SVM = SQRT (SIGNXX(I)*SIGNXX(I) + SIGNYY(I)*SIGNYY(I)
      .              - SIGNXX(I)*SIGNYY(I) + THREE*SIGNXY(I)*SIGNXY(I))
           EPSF = D3*P/MAX(EM20,SVM)
-          EPSF = (D1 + D2*EXP(EPSF))*(ONE 
-     .               + D4*LOG(MAX(ONE,EPSP(I)/EPSP0)))
-     .               * (ONE + D5*TSTAR(I))
+          EPSF = (D1 + D2*EXP(EPSF))
+          IF(D4>ZERO) EPSF = EPSF * (ONE + D4*LOG(MAX(ONE,EPSP(I)/EPSP0))) ! if d4=0, epsp is not correctly defined
+          IF(D5>ZERO) EPSF = EPSF * (ONE + D5*TSTAR(I)) ! if d5=0, tstart is not correctly defined
           IF (EPSF > ZERO) DFMAX(I) = DFMAX(I) + DPLA(I)/EPSF  
           IF (DFMAX(I) >= ONE) THEN
             NINDX = NINDX + 1


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
When Johnson-Cook (JC) failure model is combined to material law2, numerical noise can be generated and can lead to numerical discrepancy between 2 spmd configurations

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
To remove numerical noise, the computation of EPSF variable is performed in several steps if D4 or D5 parameters are greater than 0

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
