### PR TITLE
Fix Isolid=14 out of plane number of integration points

### DIFF
--- a/starter/source/elements/elbuf_init/elbuf_ini.F
+++ b/starter/source/elements/elbuf_init/elbuf_ini.F
@@ -271,10 +271,7 @@ c              plan = (r,s), layers = t
 c              ICS=ICSIG/100
 c              ICT=MOD(ICSIG/10,10)
 c              ICR=MOD(ICSIG,10)
-              IF (TSH_ORT == 0) THEN
-                NLAY = NPTT
-                NPTT = 1
-              ELSEIF (ICSTR == 1) THEN   
+              IF (ICSTR == 1) THEN   
                  NLAY = NPTR
                  NPTR = NPTS
                  NPTS = NPTT


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

The number of out of plane number of integration point is not consistent with documentation for /PROP/TYPE20. 


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Remove a wrong condition loop in elbuf_ini.F.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
