### PR TITLE
Split the IGRSURF%NODES array on the different processors

### DIFF
--- a/common_source/modules/groupdef_mod.F
+++ b/common_source/modules/groupdef_mod.F
@@ -735,6 +735,7 @@ C-----------------------------------------------------------------------
         INTEGER   , DIMENSION(:,:), ALLOCATABLE :: NODES  ! dim =(NSEG,4) -SURF
 !                                                         ! dim =(NSEG,2) -LINE
         INTEGER   , DIMENSION(:),   ALLOCATABLE :: PROC   ! dim = (NSEG)
+        INTEGER   , DIMENSION(:),   ALLOCATABLE :: LOCAL_SEG   ! dim = (NSEG)
 !                               field to store the processor ID  (/LINE only)
 !
 !   1. Set processor only when no element is set in lines

--- a/common_source/tools/set_operation/set_tools.cpp
+++ b/common_source/tools/set_operation/set_tools.cpp
@@ -33,6 +33,7 @@ using namespace std;
 #define union_2_sorted_sets_ UNION_2_SORTED_SETS
 #define intersect_2_sorted_sets_ INTERSECT_2_SORTED_SETS
 #define difference_2_sorted_sets_ DIFFERENCE_2_SORTED_SETS
+#define count_member_list_ COUNT_MEMBER_LIST
 
 
 #endif
@@ -140,6 +141,33 @@ extern "C" {
                               result);
     
     *result_size = fin-result;
+  }
+/* -----------------------------------------------------------------------------------------------------
+    count_member_list : count the number of appeareance of union_list's members in the merged_list
+   -----------------------------------------------------------------------------------------------------
+    int * union_list : input - size=size_union_list
+    int * size_union_list : input - size of union_list
+    int * merged_list : input - size=size_merged_list
+    int * size_merged_list : input - size of merged_list
+    int * number_appearance : output - number of appearance of the union_list's members in the merged_list
+    int * proc_id : output - processor id of the segment
+   ------------------------------------------------------------------------------------------------ */
+  void _FCALL count_member_list_(int * union_list, int * size_union_list,
+                                 int * merged_list, int * size_merged_list,
+                                 int * number_appearance, int * proc_id )
+  {
+    int max_number_appearance = 0 ; 
+    for(int i=0; i<*size_union_list ; i++)
+    {
+        int my_value = union_list[i] ;
+        int mycount = std::count ( merged_list,  merged_list+ *size_merged_list, my_value);
+        number_appearance[i] = mycount ;
+        if(max_number_appearance<mycount)
+        {
+            *proc_id = i+1 ;
+            max_number_appearance = mycount;
+        }
+    }
   }
 
 

--- a/starter/source/restart/ddsplit/c_isurf_str.F
+++ b/starter/source/restart/ddsplit/c_isurf_str.F
@@ -27,12 +27,11 @@ Chd|        DDSPLIT                       source/restart/ddsplit/ddsplit.F
 Chd|-- calls ---------------
 Chd|        GROUPDEF_MOD                  ../common_source/modules/groupdef_mod.F
 Chd|====================================================================
-      SUBROUTINE C_ISURF_STR(IGRSURF ,LEN_IA ,CEP  ,CEL  ,PROC,
-     .                       NODLOCAL,LENISURF_L)
+        SUBROUTINE C_ISURF_STR(PROC,LENISURF_L,NSPMD,IGRSURF_PROC)
 C-----------------------------------------------
 C   M o d u l e s
 C----------------------------------------------- 
-      USE GROUPDEF_MOD
+        USE GROUPDEF_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -45,112 +44,53 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER LEN_IA,CEP(*),CEL(*),PROC,NODLOCAL(*),LENISURF_L
-!
-      TYPE (SURF_) , DIMENSION(NSURF) :: IGRSURF
+        INTEGER, INTENT(IN) :: PROC !< processor id
+        INTEGER, INTENT(INOUT) :: LENISURF_L !< size of surface buffer written in the restart
+        INTEGER, INTENT(IN) :: NSPMD !<  number of processor
+        TYPE(SURF_), DIMENSION(NSURF,NSPMD), INTENT(IN) :: IGRSURF_PROC !< surface structure per proc, size =NSURF*NSPMS
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER ISU,I,J,K,ERR,NSEG,ELTYP,ELEM,ESHIFT,
-     .        L_SURF,ID,TYPE,ID_MADYMO,IAD_BUFR,
-     .        NB_MADYMO,TYPE_MADYMO,LEVEL,TH_SURF,ISH4N3N,NSEG_R2R_ALL,
-     .        NSEG_R2R_SHARE,NOD,ITITLE(LTITR),NSEG_L(NSURF)
-      CHARACTER(LEN=nchartitle) ::  TITR
+        INTEGER :: ISU
+        INTEGER :: L_SURF
 C-----------------------------------------------
+        L_SURF = 0
 !
-! COUNT LOCAL SEGMENTS "NSEG_L"
-!
-      L_SURF = 0
-!
-      DO ISU=1,NSURF
-        ID          = IGRSURF(ISU)%ID
-        NSEG        = IGRSURF(ISU)%NSEG
-        TYPE        = IGRSURF(ISU)%TYPE
-        ID_MADYMO   = IGRSURF(ISU)%ID_MADYMO
-        IAD_BUFR    = IGRSURF(ISU)%IAD_BUFR
-        NB_MADYMO   = IGRSURF(ISU)%NB_MADYMO
-        TYPE_MADYMO = IGRSURF(ISU)%TYPE_MADYMO
-        LEVEL       = IGRSURF(ISU)%LEVEL
-        TH_SURF     = IGRSURF(ISU)%TH_SURF
-        ISH4N3N     = IGRSURF(ISU)%ISH4N3N
-        NSEG_R2R_ALL   = IGRSURF(ISU)%NSEG_R2R_ALL
-        NSEG_R2R_SHARE = IGRSURF(ISU)%NSEG_R2R_SHARE
+        DO ISU=1,NSURF
 !
 ! surf storage
 !
 !        IGRSURF_L(L_SURF+1) = ID
-          L_SURF = L_SURF+1
+            L_SURF = L_SURF+1
 !        IGRSURF_L(L_SURF+1) = NSEG_L(ISU)
-          L_SURF = L_SURF+1
+            L_SURF = L_SURF+1
 !        IGRSURF_L(L_SURF+1) = TYPE
-          L_SURF = L_SURF+1
+            L_SURF = L_SURF+1
 !        IGRSURF_L(L_SURF+1) = ID_MADYMO
-          L_SURF = L_SURF+1
+            L_SURF = L_SURF+1
 !        IGRSURF_L(L_SURF+1) = IAD_BUFR
-          L_SURF = L_SURF+1
+            L_SURF = L_SURF+1
 !        IGRSURF_L(L_SURF+1) = NB_MADYMO
-          L_SURF = L_SURF+1
+            L_SURF = L_SURF+1
 !        IGRSURF_L(L_SURF+1) = TYPE_MADYMO
-          L_SURF = L_SURF+1
+            L_SURF = L_SURF+1
 !        IGRSURF_L(L_SURF+1) = LEVEL
-          L_SURF = L_SURF+1
+            L_SURF = L_SURF+1
 !        IGRSURF_L(L_SURF+1) = TH_SURF
-          L_SURF = L_SURF+1
+            L_SURF = L_SURF+1
 !        IGRSURF_L(L_SURF+1) = ISH4N3N
-          L_SURF = L_SURF+1
+            L_SURF = L_SURF+1
 !        IGRSURF_L(L_SURF+1) = NSEG_R2R_ALL
-          L_SURF = L_SURF+1
+            L_SURF = L_SURF+1
 !        IGRSURF_L(L_SURF+1) = NSEG_R2R_SHARE
-          L_SURF = L_SURF+1
+            L_SURF = L_SURF+1
 !
 ! SURF ENTITIES (NODES, ELTYP, ELEM)
 !
-        DO J=1,NSEG
-          ELTYP = IGRSURF(ISU)%ELTYP(J)
-          ELEM  = IGRSURF(ISU)%ELEM(J)
-          IF (ELEM > 0) THEN
-            IF (ELTYP == 1) THEN
-              ESHIFT = 0
-            ELSEIF (ELTYP == 2) THEN
-              ESHIFT = NUMELS
-            ELSEIF (ELTYP == 3) THEN
-              ESHIFT = NUMELS+NUMELQ
-            ELSEIF (ELTYP == 7) THEN
-              ESHIFT = NUMELS+NUMELQ+NUMELC+NUMELT+NUMELP+NUMELR
-            ENDIF
-            ELEM = ELEM + ESHIFT
-            IF (CEP(ELEM) == PROC) THEN
-              DO K=1,4
-!                NOD = IGRSURF(ISU)%NODES(J,K)
-!                IF(NOD > 0)THEN;IGRSURF_L(L_SURF+1) = NODLOCAL(NOD)
-!	        ELSE;           IGRSURF_L(L_SURF+1) = 0
-!	        ENDIF
-                L_SURF = L_SURF+1
-              ENDDO
-!              IGRSURF_L(L_SURF+1) = ELTYP
-              L_SURF = L_SURF+1
-!              IGRSURF_L(L_SURF+1) = CEL(ELEM)
-              L_SURF = L_SURF+1
-            ENDIF ! IF (CEP(ELEM) == PROC)
-          ELSE  !!! all the rest
-            IF (PROC == 0) THEN
-              DO K=1,4
-!                NOD = IGRSURF(ISU)%NODES(J,K)
-!                IF(NOD > 0)THEN;IGRSURF_L(L_SURF+1) = NODLOCAL(NOD)
-!	        ELSE;           IGRSURF_L(L_SURF+1) = 0
-!	        ENDIF
-                L_SURF = L_SURF+1
-              ENDDO
-!              IGRSURF_L(L_SURF+1) = 0
-              L_SURF = L_SURF+1
-!              IGRSURF_L(L_SURF+1) = 0
-              L_SURF = L_SURF+1
-            ENDIF ! IF (PROC == 0)
-          ENDIF ! IF (ELEM > 0) THEN
-        ENDDO ! DO J=1,NSEG
-      ENDDO ! DO ISU=1,NSURF
+            L_SURF = 6*IGRSURF_PROC(ISU,PROC+1)%NSEG + L_SURF
+        ENDDO
 !---------
-      LENISURF_L = L_SURF
+        LENISURF_L = L_SURF
 !---------
-      RETURN
-      END
+        RETURN
+        END SUBROUTINE C_ISURF_STR

--- a/starter/source/restart/ddsplit/ddsplit.F
+++ b/starter/source/restart/ddsplit/ddsplit.F
@@ -266,7 +266,7 @@ Chd|        USER_WINDOWS_MOD              ../common_source/modules/user_windows_
 Chd|        XFEM2DEF_MOD                  ../common_source/modules/xfem2def_mod.F
 Chd|====================================================================
       SUBROUTINE DDSPLIT(
-     1   P            ,CEP          ,CEL            ,IGEO         ,MATPARAM_TAB,
+     1   P            ,CEP          ,CEL           ,IGEO         ,MATPARAM_TAB,
      2   IPM          ,ICODE        ,ISKEW          ,ISKN         ,INSEL       ,
      3   IBCSLAG      ,IPART        ,IPARTS         ,IPARTQ       ,IPARTC      ,
      4   IPARTT       ,IPARTP       ,IPARTR         ,IPARTTG     ,
@@ -452,14 +452,15 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       TYPE (UNIT_TYPE_),INTENT(IN) ::UNITAB
-      INTEGER, INTENT(IN) :: LEN_CEP ! size of CEP
+      INTEGER, INTENT(IN) :: LEN_CEP !< size of CEP
+      INTEGER, DIMENSION(SCEL), INTENT(IN) :: CEL !< connectivity global element id --> local element 
       INTEGER P,
      .        LIBAGALE, LENTHG, LENLAS, NPTS,LEN,
      .        LBUFMAT, LBUFGEO, LBUFSF, LENXLAS, LNOM_OPT,
      .        LENVOLU, NTHWA, NAIRWA, NMNT, I2NSNT,
      .        L_MUL_LAG1, L_MUL_LAG, LWASPIO,PM1SPH,
      .        LCNI2G, PM1SHF, I11FLAG,LENTHGR,NCRKPART,
-     .        CEP(LEN_CEP),CEL(*),IGEO(*), IPM(*),
+     .        CEP(LEN_CEP),IGEO(*), IPM(*),
      .        ICODE(*),ISKEW(*),ISKN(*),INSEL(*),IBCSLAG(*),
      .        IPART(*),IPARTS(*),IPARTQ(*),IPARTC(*),IPARTT(*),
      .        IPARTP(*),IPARTR(*),IPARTTG(*),IPARTX(*),
@@ -1133,8 +1134,8 @@ C--------------------------------------
      3         CEL         ,NODLOCAL    ,P-1         ,LENIGRNOD_L,LENIGRBRIC_L ,
      4         LENIGRQUAD_L,LENIGRSH4N_L,LENIGRTRUS_L,LENIGRBEAM_L,LENIGRSPRI_L,
      5         LENIGRSH3N_L,FRONTB_R2R  ,NUMNOD_L)
-      CALL C_ISURF_STR(IGRSURF ,LEN_IA    ,CEP  ,CEL  ,P-1,
-     .                 NODLOCAL,LENISURF_L)
+      CALL C_ISURF_STR(P-1,LENISURF_L,NSPMD,IGRSURF_PROC)
+
       CALL C_ISLIN_STR(IGRSLIN ,P-1, LENISLIN_L)
 C--------------------------------------------
 C count Buffer interface
@@ -2081,8 +2082,11 @@ C--------------------------------------
      .                 IGRSH3N ,IGRTRUSS ,IGRBEAM ,IGRSPRING ,IGRPART   ,
      .                 CEP     ,CEL      ,NODLOCAL,P-1       ,FRONTB_R2R,
      .                 NUMNOD_L )
-      CALL W_ISURF_STR(IGRSURF ,LEN_IA ,CEP  ,CEL  ,P-1,
-     .                 NODLOCAL,LENISURF_L)
+      CALL W_ISURF_STR(LEN_IA,P-1,NUMNOD,NSURF,NUMELS,
+     .                 NUMELQ,NUMELC,NUMELT,NUMELP,NUMELR,
+     .                 NODLOCAL,SCEL,CEL,LTITR,LENISURF_L,
+     .                 NSPMD,IGRSURF,IGRSURF_PROC)
+
       CALL W_ISLIN_STR(IGRSLIN ,LEN_IA , P-1, NODLOCAL)
 C--------------------------------------
 C Elem multi-brins

--- a/starter/source/restart/ddsplit/w_isurf_str.F
+++ b/starter/source/restart/ddsplit/w_isurf_str.F
@@ -29,12 +29,14 @@ Chd|        FRETITL                       source/starter/freform.F
 Chd|        WRITE_I_C                     source/output/tools/write_routines.c
 Chd|        GROUPDEF_MOD                  ../common_source/modules/groupdef_mod.F
 Chd|====================================================================
-      SUBROUTINE W_ISURF_STR(IGRSURF ,LEN_IA ,CEP  ,CEL  ,PROC,
-     .                       NODLOCAL,LENISURF_L)
+        SUBROUTINE W_ISURF_STR( LEN_IA,PROC,NUMNOD,NSURF,NUMELS,
+     .                          NUMELQ,NUMELC,NUMELT,NUMELP,NUMELR,
+     .                          NODLOCAL,SCEL,CEL,LTITR,LENISURF_L,
+     .                          NSPMD,IGRSURF,IGRSURF_PROC)
 C-----------------------------------------------
 C   M o d u l e s
 C----------------------------------------------- 
-      USE GROUPDEF_MOD
+        USE GROUPDEF_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -42,150 +44,130 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   C o m m o n   B l o c k s
 C-----------------------------------------------
-#include      "com04_c.inc"
-#include      "scr17_c.inc"
+#include "nchar_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER LEN_IA,CEP(*),CEL(*),PROC,NODLOCAL(*),LENISURF_L
-!
-      TYPE (SURF_) , DIMENSION(NSURF) :: IGRSURF
+        INTEGER, INTENT(INOUT) :: LEN_IA!< size of the restart
+        INTEGER, INTENT(IN) :: PROC !< processor id
+        INTEGER, INTENT(IN) :: NUMNOD !< number of node
+        INTEGER, INTENT(IN) :: NSURF  !< number of surface
+        INTEGER, INTENT(IN) :: NUMELS !< number of solid
+        INTEGER, INTENT(IN) :: NUMELQ !< number of quad
+        INTEGER, INTENT(IN) :: NUMELC !< number of shell
+        INTEGER, INTENT(IN) :: NUMELT !< number of truss
+        INTEGER, INTENT(IN) :: NUMELP !< number of beam
+        INTEGER, INTENT(IN) :: NUMELR !< number of spring
+        INTEGER, DIMENSION(NUMNOD), INTENT(IN) :: NODLOCAL !< array to convert global node id to local node id
+        INTEGER, INTENT(IN) :: SCEL !< size of CEL
+        INTEGER, DIMENSION(SCEL), INTENT(IN) :: CEL !< connectivity global element id --> local element id
+        INTEGER, INTENT(IN) :: LENISURF_L !< size of surface buffer written in the restart
+        INTEGER, INTENT(IN) :: LTITR !< size of ititle integer array
+        INTEGER, INTENT(IN) :: NSPMD !<  number of processor
+        TYPE (SURF_) , DIMENSION(NSURF) :: IGRSURF !< surface structure, size =NSURF
+        TYPE(SURF_), DIMENSION(NSURF,NSPMD), INTENT(IN) :: IGRSURF_PROC !< surface structure per proc, size =NSURF*NSPMS
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER ISU,I,J,K,ERR,NSEG,ELTYP,ELEM,ESHIFT,
-     .        L_SURF,ID,TYPE,ID_MADYMO,IAD_BUFR,
-     .        NB_MADYMO,TYPE_MADYMO,LEVEL,TH_SURF,ISH4N3N,NSEG_R2R_ALL,
-     .        NSEG_R2R_SHARE,NOD,ITITLE(LTITR),NSEG_L(NSURF)
-      CHARACTER(LEN=nchartitle) :: TITR
-      INTEGER, ALLOCATABLE, DIMENSION (:)  ::  IGRSURF_L
+        INTEGER :: ISU,J,K,ERR,NSEG
+        INTEGER :: L_SURF,ID,TYPE,ID_MADYMO,IAD_BUFR
+        INTEGER :: NB_MADYMO,TYPE_MADYMO,LEVEL,TH_SURF,ISH4N3N,NSEG_R2R_ALL
+        INTEGER :: NSEG_R2R_SHARE
+        INTEGER, DIMENSION(LTITR) :: ITITLE
+        INTEGER, DIMENSION(NSURF) :: NSEG_L
+        CHARACTER(LEN=nchartitle) :: TITR
+        INTEGER, ALLOCATABLE, DIMENSION (:)  ::  IGRSURF_L
+
+        INTEGER :: JJ
+        INTEGER :: NODE_ID,LOCAL_NODE_ID,ELEM,ELTYP
+        INTEGER, DIMENSION(0:7) :: OFFSET ! offset array
 C-----------------------------------------------
 !=======================================================================
-      DO ISU=1,NSURF
-        TITR    = IGRSURF(ISU)%TITLE
-        CALL FRETITL(TITR,ITITLE,LTITR)
-        CALL WRITE_I_C(ITITLE,LTITR)
-      ENDDO ! DO ISU=1,NSURF
-      LEN_IA = LEN_IA + NSURF
+        OFFSET(0:7) = 0
+        OFFSET(1) = 0 ! offset for solid
+        OFFSET(2) = NUMELS ! offset for quad
+        OFFSET(3) = NUMELS+NUMELQ ! offset for shell   
+        OFFSET(7) = NUMELS+NUMELQ+ NUMELC+NUMELT+NUMELP+NUMELR ! offset for triangle
+
+        DO ISU=1,NSURF
+            TITR    = IGRSURF(ISU)%TITLE
+            CALL FRETITL(TITR,ITITLE,LTITR)
+            CALL WRITE_I_C(ITITLE,LTITR)
+        ENDDO ! DO ISU=1,NSURF
+        LEN_IA = LEN_IA + NSURF
 !
-      ERR = 0
-      ALLOCATE (IGRSURF_L(LENISURF_L), STAT=ERR)
+        ERR = 0
+        ALLOCATE (IGRSURF_L(LENISURF_L), STAT=ERR)
 !
 ! COUNT LOCAL SEGMENTS "NSEG_L"
 !
-      DO ISU=1,NSURF
-        NSEG      = IGRSURF(ISU)%NSEG
-        NSEG_L(ISU) = 0
-        DO J=1,NSEG
-          ELTYP = IGRSURF(ISU)%ELTYP(J)
-          ELEM  = IGRSURF(ISU)%ELEM(J)
-          IF (ELEM > 0) THEN
-            IF (ELTYP == 1) THEN
-              ESHIFT = 0
-            ELSEIF (ELTYP == 2) THEN
-              ESHIFT = NUMELS
-            ELSEIF (ELTYP == 3) THEN
-              ESHIFT = NUMELS+NUMELQ
-            ELSEIF (ELTYP == 7) THEN
-              ESHIFT = NUMELS+NUMELQ+NUMELC+NUMELT+NUMELP+NUMELR
-            ENDIF
-            ELEM = ELEM + ESHIFT
-            IF (CEP(ELEM) == PROC) NSEG_L(ISU) = NSEG_L(ISU) + 1
-          ELSEIF (PROC == 0) THEN  !!! all the rest
-            NSEG_L(ISU) = NSEG_L(ISU) + 1
-          ENDIF ! IF (ELEM > 0) THEN
-        ENDDO ! DO J=1,NSEG
-      ENDDO ! DO ISU=1,NSURF
+        DO ISU=1,NSURF
+            NSEG      = IGRSURF(ISU)%NSEG
+            NSEG_L(ISU) = IGRSURF_PROC(ISU,PROC+1)%NSEG
+        ENDDO
+        L_SURF = 0
 !
-      L_SURF = 0
-!
-      DO ISU=1,NSURF
-        ID          = IGRSURF(ISU)%ID
-        NSEG        = IGRSURF(ISU)%NSEG
-        TYPE        = IGRSURF(ISU)%TYPE
-        ID_MADYMO   = IGRSURF(ISU)%ID_MADYMO
-        IAD_BUFR    = IGRSURF(ISU)%IAD_BUFR
-        NB_MADYMO   = IGRSURF(ISU)%NB_MADYMO
-        TYPE_MADYMO = IGRSURF(ISU)%TYPE_MADYMO
-        LEVEL       = IGRSURF(ISU)%LEVEL
-        TH_SURF     = IGRSURF(ISU)%TH_SURF
-        ISH4N3N     = IGRSURF(ISU)%ISH4N3N
-        NSEG_R2R_ALL   = IGRSURF(ISU)%NSEG_R2R_ALL
-        NSEG_R2R_SHARE = IGRSURF(ISU)%NSEG_R2R_SHARE
+        DO ISU=1,NSURF
+            ID          = IGRSURF(ISU)%ID
+            NSEG        = IGRSURF(ISU)%NSEG
+            TYPE        = IGRSURF(ISU)%TYPE
+            ID_MADYMO   = IGRSURF(ISU)%ID_MADYMO
+            IAD_BUFR    = IGRSURF(ISU)%IAD_BUFR
+            NB_MADYMO   = IGRSURF(ISU)%NB_MADYMO
+            TYPE_MADYMO = IGRSURF(ISU)%TYPE_MADYMO
+            LEVEL       = IGRSURF(ISU)%LEVEL
+            TH_SURF     = IGRSURF(ISU)%TH_SURF
+            ISH4N3N     = IGRSURF(ISU)%ISH4N3N
+            NSEG_R2R_ALL   = IGRSURF(ISU)%NSEG_R2R_ALL
+            NSEG_R2R_SHARE = IGRSURF(ISU)%NSEG_R2R_SHARE
 !
 ! surf storage
 !
-        IGRSURF_L(L_SURF+1) = ID
-          L_SURF = L_SURF+1
-        IGRSURF_L(L_SURF+1) = NSEG_L(ISU)
-          L_SURF = L_SURF+1
-        IGRSURF_L(L_SURF+1) = TYPE
-          L_SURF = L_SURF+1
-        IGRSURF_L(L_SURF+1) = ID_MADYMO
-          L_SURF = L_SURF+1
-        IGRSURF_L(L_SURF+1) = IAD_BUFR
-          L_SURF = L_SURF+1
-        IGRSURF_L(L_SURF+1) = NB_MADYMO
-          L_SURF = L_SURF+1
-        IGRSURF_L(L_SURF+1) = TYPE_MADYMO
-          L_SURF = L_SURF+1
-        IGRSURF_L(L_SURF+1) = LEVEL
-          L_SURF = L_SURF+1
-        IGRSURF_L(L_SURF+1) = TH_SURF
-          L_SURF = L_SURF+1
-        IGRSURF_L(L_SURF+1) = ISH4N3N
-          L_SURF = L_SURF+1
-        IGRSURF_L(L_SURF+1) = NSEG_R2R_ALL
-          L_SURF = L_SURF+1
-        IGRSURF_L(L_SURF+1) = NSEG_R2R_SHARE
-          L_SURF = L_SURF+1
-!
-! SURF ENTITIES (NODES, ELTYP, ELEM)
-!
-        DO J=1,NSEG
-          ELTYP = IGRSURF(ISU)%ELTYP(J)
-          ELEM  = IGRSURF(ISU)%ELEM(J)
-          IF (ELEM > 0) THEN
-            IF (ELTYP == 1) THEN
-              ESHIFT = 0
-            ELSEIF (ELTYP == 2) THEN
-              ESHIFT = NUMELS
-            ELSEIF (ELTYP == 3) THEN
-              ESHIFT = NUMELS+NUMELQ
-            ELSEIF (ELTYP == 7) THEN
-              ESHIFT = NUMELS+NUMELQ+NUMELC+NUMELT+NUMELP+NUMELR
-            ENDIF
-            ELEM = ELEM + ESHIFT
-            IF (CEP(ELEM) == PROC) THEN
-              DO K=1,4
-                NOD = IGRSURF(ISU)%NODES(J,K)
-                IF(NOD > 0)THEN;IGRSURF_L(L_SURF+1) = NODLOCAL(NOD)
-	        ELSE;           IGRSURF_L(L_SURF+1) = 0
-	        ENDIF
+            IGRSURF_L(L_SURF+1) = ID
+            L_SURF = L_SURF+1
+            IGRSURF_L(L_SURF+1) = NSEG_L(ISU)
+            L_SURF = L_SURF+1
+            IGRSURF_L(L_SURF+1) = TYPE
+            L_SURF = L_SURF+1
+            IGRSURF_L(L_SURF+1) = ID_MADYMO
+            L_SURF = L_SURF+1
+            IGRSURF_L(L_SURF+1) = IAD_BUFR
+            L_SURF = L_SURF+1
+            IGRSURF_L(L_SURF+1) = NB_MADYMO
+            L_SURF = L_SURF+1
+            IGRSURF_L(L_SURF+1) = TYPE_MADYMO
+            L_SURF = L_SURF+1
+            IGRSURF_L(L_SURF+1) = LEVEL
+            L_SURF = L_SURF+1
+            IGRSURF_L(L_SURF+1) = TH_SURF
+            L_SURF = L_SURF+1
+            IGRSURF_L(L_SURF+1) = ISH4N3N
+            L_SURF = L_SURF+1
+            IGRSURF_L(L_SURF+1) = NSEG_R2R_ALL
+            L_SURF = L_SURF+1
+            IGRSURF_L(L_SURF+1) = NSEG_R2R_SHARE
+            L_SURF = L_SURF+1
+            DO JJ=1,IGRSURF_PROC(ISU,PROC+1)%NSEG
+                J = IGRSURF_PROC(ISU,PROC+1)%LOCAL_SEG(JJ)
+                DO K=1,4
+                    NODE_ID = IGRSURF(ISU)%NODES(J,K)
+                    IF(NODE_ID/=0) THEN
+                        LOCAL_NODE_ID = NODLOCAL(NODE_ID)
+                    ELSE
+                        LOCAL_NODE_ID = 0
+                    ENDIF
+                    IGRSURF_L(L_SURF+1) = LOCAL_NODE_ID
+                    L_SURF = L_SURF+1
+                ENDDO
+                ELTYP = IGRSURF_PROC(ISU,PROC+1)%ELTYP(JJ)
+                ELEM = IGRSURF_PROC(ISU,PROC+1)%ELEM(JJ) + OFFSET(ELTYP)
+                IF(ELEM/=0) ELEM = CEL(ELEM)           
+                IGRSURF_L(L_SURF+1) = ELTYP
                 L_SURF = L_SURF+1
-              ENDDO
-              IGRSURF_L(L_SURF+1) = ELTYP
-              L_SURF = L_SURF+1
-              IGRSURF_L(L_SURF+1) = CEL(ELEM)
-              L_SURF = L_SURF+1
-            ENDIF ! IF (CEP(ELEM) == PROC)
-          ELSE  !!! all the rest
-            IF (PROC == 0) THEN
-              DO K=1,4
-                NOD = IGRSURF(ISU)%NODES(J,K)
-                IF(NOD > 0)THEN;IGRSURF_L(L_SURF+1) = NODLOCAL(NOD)
-	        ELSE;           IGRSURF_L(L_SURF+1) = 0
-	        ENDIF
+                IGRSURF_L(L_SURF+1) = ELEM
                 L_SURF = L_SURF+1
-              ENDDO
-              IGRSURF_L(L_SURF+1) = 0
-              L_SURF = L_SURF+1
-              IGRSURF_L(L_SURF+1) = 0
-              L_SURF = L_SURF+1
-            ENDIF ! IF (PROC == 0)
-          ENDIF ! IF (ELEM > 0) THEN
-        ENDDO ! DO J=1,NSEG
-      ENDDO ! DO ISU=1,NSURF
+            ENDDO
+        ENDDO
 !---------
       CALL WRITE_I_C(IGRSURF_L,L_SURF)
 !---------
@@ -194,4 +176,4 @@ C-----------------------------------------------
       LEN_IA = LEN_IA + L_SURF
 !---------
       RETURN
-      END
+      END SUBROUTINE W_ISURF_STR

--- a/starter/source/spmd/deallocate_igrsurf_split.F
+++ b/starter/source/spmd/deallocate_igrsurf_split.F
@@ -20,6 +20,10 @@ Copyright>
 Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
 Copyright>        software under a commercial license.  Contact Altair to discuss further if the
 Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+!> \brief This routine deallocates the local IGSURF_PROC arrays
+!!
+!! \details loop over the NVOLU airbaig and NSURF surfaces to deallote the structure
+!!
 Chd|====================================================================
 Chd|  DEALLOCATE_IGRSURF_SPLIT      source/spmd/deallocate_igrsurf_split.F
 Chd|-- called by -----------
@@ -65,14 +69,13 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-        INTEGER :: NV,IS,NN,J
-        INTEGER :: ITY,II,PROC,K1
-        INTEGER :: OFFC,OFFTG   
-        INTEGER, DIMENSION(NSPMD) :: JJ
+        INTEGER :: NV,IS
+        INTEGER :: PROC,K1
 C-----------------------------------------------------
 C   S o u r c e  L i n e s
 C-----------------------------------------------------
-        !       --------------------------------------
+        ! --------------------------------------
+        ! Airbag
         K1 = 1
         DO NV=1,NVOLU                   !       NVOLU = number of volume
                 IS = T_MONVOL(NV)%EXT_SURFID  
@@ -88,7 +91,19 @@ C-----------------------------------------------------
                 ! deallocation of NUMBER_TRI_PER_PROC :
                  DEALLOCATE( T_MONVOL(NV)%NUMBER_TRI_PER_PROC )
                 ! --------------------
-        ENDDO        
-        !       --------------------------------------
+        ENDDO   
+        ! --------------------------------------  
+
+
+        ! --------------------------------------    
+        ! Surface 
+        DO IS=1,NSURF
+            DO PROC=1,NSPMD
+                IF(ALLOCATED( IGRSURF_PROC(IS,PROC)%LOCAL_SEG )) DEALLOCATE( IGRSURF_PROC(IS,PROC)%LOCAL_SEG )
+                IF(ALLOCATED( IGRSURF_PROC(IS,PROC)%ELTYP ))DEALLOCATE( IGRSURF_PROC(IS,PROC)%ELTYP ) 
+                IF(ALLOCATED( IGRSURF_PROC(IS,PROC)%ELEM ))DEALLOCATE( IGRSURF_PROC(IS,PROC)%ELEM ) 
+            ENDDO
+        ENDDO
+        ! --------------------------------------
         RETURN
         END SUBROUTINE DEALLOCATE_IGRSURF_SPLIT

--- a/starter/source/spmd/igrsurf_split.F
+++ b/starter/source/spmd/igrsurf_split.F
@@ -29,23 +29,24 @@ Chd|        IFRONTPLUS                    source/spmd/node/frontplus.F
 Chd|        GROUPDEF_MOD                  ../common_source/modules/groupdef_mod.F
 Chd|        MONVOL_STRUCT_MOD             share/modules1/monvol_struct_mod.F
 Chd|====================================================================
-        SUBROUTINE IGRSURF_SPLIT(CEP,T_MONVOL,IGRSURF,IGRSURF_PROC)
+        SUBROUTINE IGRSURF_SPLIT(SCEP,CEP,T_MONVOL,IGRSURF,IGRSURF_PROC)
 !$COMMENT
-!       IGSURF_SPLIT description
-!       IGSURF_SPLIT splits the global IGSURF array into local 
-!                    IGSURF_PROC arrays in order to save 
-!                    CPU time in ddsplit routine (avoid NSPMD 
-!                    treatments)
-!       
-!       IGSURF_SPLIT organization :
-!       - 1rst step : count the number of element per surface 
-!                     on a given processor and allocate the 
-!                     IGRSURF_PROC structure
-!       - 2nd step : fill the structure
+! IGSURF_SPLIT description
+! IGSURF_SPLIT splits the global IGSURF array into local 
+!              IGSURF_PROC arrays in order to save 
+!              CPU time in ddsplit routine (avoid NSPMD 
+!              treatments)
+! 
+! IGSURF_SPLIT organization :
+! - 1rst step : count the number of element per surface 
+!               on a given processor and allocate the 
+!               IGRSURF_PROC structure
+! - 2nd step : fill the structure
 !$ENDCOMMENT
         
         USE GROUPDEF_MOD
         USE MONVOL_STRUCT_MOD
+        USE ARRAY_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -59,141 +60,351 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-        INTEGER, DIMENSION(*), INTENT(IN) :: CEP
-        TYPE(SURF_), DIMENSION(NSURF), INTENT(IN) :: IGRSURF
-        TYPE(SURF_), DIMENSION(NSURF,NSPMD), INTENT(INOUT) :: IGRSURF_PROC
-        TYPE(MONVOL_STRUCT_), DIMENSION(NVOLU), INTENT(INOUT) :: T_MONVOL
+        INTEGER, INTENT(IN) :: SCEP !< size of CEP array
+        INTEGER, DIMENSION(SCEP), INTENT(IN) :: CEP !< connectivity element --> processor
+        TYPE(SURF_), DIMENSION(NSURF), INTENT(INOUT) :: IGRSURF !< surface structure, size =NSURF
+        TYPE(SURF_), DIMENSION(NSURF,NSPMD), INTENT(INOUT) :: IGRSURF_PROC !< surface structure per proc , size =NSURF,NSPMD
+        TYPE(MONVOL_STRUCT_), DIMENSION(NVOLU), INTENT(INOUT) :: T_MONVOL !< monitor volume structure, size =NVOLU
 
-!       -*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-**-*-*-*-*-*-*-*-*-*-*-*-*
-!       CEP    : integer ; dimension=NUMNOD
-!                CEP gives the id processor of an element
+! -*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-**-*-*-*-*-*-*-*-*-*-*-*-*
+! CEP    : integer ; dimension=NUMNOD
+!          CEP gives the id processor of an element
 
-!                   monitor volume array
-!       IGRSURF : SURF_ ; dimension=NSURF
-!                 global surface property array
-!                 %ELTYP --> type of element (shell, triangle...)
-!                 %ELEM  --> element id
-!                 %NSEG --> total element number
-!       IGRSURF_PROC : SURF_ ; dimension=NSURF*NSPMD
-!                 local surface property array (=IGRSURF for each proc)
-!                 %ELTYP --> type of element (shell, triangle...)
-!                 %ELEM  --> element id
-!                 %NSEG --> total element number
-!       -*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-**-*-*-*-*-*-*-*-*-*-*-*-*
+!             monitor volume array
+! IGRSURF : SURF_ ; dimension=NSURF
+!           global surface property array
+!           %ELTYP --> type of element (shell, triangle...)
+!           %ELEM  --> element id
+!           %NSEG --> total element number
+! IGRSURF_PROC : SURF_ ; dimension=NSURF*NSPMD
+!           local surface property array (=IGRSURF for each proc)
+!           %ELTYP --> type of element (shell, triangle...)
+!           %ELEM  --> element id
+!           %NSEG --> total element number
+! -*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-**-*-*-*-*-*-*-*-*-*-*-*-*
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-        INTEGER :: NV,IS,NN,J
+        INTEGER :: NV,IS,NN,J,K,SHIFT
         INTEGER :: ITY,II,PROC,K1
-        INTEGER :: OFFC,OFFTG   
+        INTEGER :: OFFC,OFFTG,OFFS,OFFQ
         INTEGER, DIMENSION(NSPMD) :: JJ
         INTEGER :: NJ,NJ1,NJ2,NJ3
-        INTEGER :: NSN,NODE_ID,NJET
+        INTEGER :: NODE_ID,NJET
         INTEGER :: I_AM_HERE
+        LOGICAL, DIMENSION(NSURF) :: ALREADY_DONE
+        LOGICAL, DIMENSION(:), ALLOCATABLE :: I_NEED_IT
+        TYPE(array_type), DIMENSION(:), ALLOCATABLE :: PROC_LIST_PER_NODE
+
+        INTEGER :: UP_BOUND
+        INTEGER :: INDEX_PROC,NUMBER_PROC
+        INTEGER :: SIZE_MERGED_LIST,SIZE_PROC_LIST,SIZE_UNION_PROC_LIST 
+        INTEGER, DIMENSION(:), ALLOCATABLE :: MERGED_LIST
+        INTEGER, DIMENSION(NSPMD) :: UNION_PROC_LIST,PROC_LIST,NUMBER_APPEARANCE
+        INTEGER :: ELEM_ID 
+        INTEGER, DIMENSION(0:7) :: OFFSET ! offset array
 C-----------------------------------------------------
 C   S o u r c e  L i n e s
 C-----------------------------------------------------
-        !       --------------------------------------
-        !       offset for the CEP array
-        OFFC = NUMELS+NUMELQ    
-        OFFTG = NUMELS+NUMELQ+ NUMELC+NUMELT+NUMELP+NUMELR
 
-        !       1st step : count the number of element per proc and allocate the structure
+        ! --------------------------------------
+        ! offset for the CEP array
+        OFFS = 0 ! offset for solid
+        OFFQ = NUMELS ! offset for quad
+        OFFC = NUMELS+NUMELQ ! offset for shell   
+        OFFTG = NUMELS+NUMELQ+ NUMELC+NUMELT+NUMELP+NUMELR ! offset for triangle
+        OFFSET(0:7) = 0
+        OFFSET(1) = OFFS
+        OFFSET(2) = OFFQ
+        OFFSET(3) = OFFC
+        OFFSET(7) = OFFTG
+
+        ALREADY_DONE(1:NSURF) = .FALSE.
+        ! 1st step : count the number of element per proc and allocate the structure
         K1 = 1
 
-        DO NV=1,NVOLU                   !       NVOLU = number of volume
-                IS = T_MONVOL(NV)%EXT_SURFID       !       id of the surface 
-                NN = IGRSURF(IS)%NSEG   !       number of element per surface
-                JJ(1:NSPMD) = 0         !       proc index
-                IGRSURF_PROC(IS,1:NSPMD)%NSEG = 0
-                DO J=1,NN
-                        ITY = IGRSURF(IS)%ELTYP(J)      !       type of the element 
-                        II  = IGRSURF(IS)%ELEM(J)       !       id of the element
-                        PROC = 0                        !       id of the proc /= 0 if ITY = 3 or 7
-                        IF(ITY==3) THEN
-                                PROC = CEP(OFFC+II) + 1
-                        ELSEIF(ITY==7) THEN
-                                PROC = CEP(OFFTG+II) + 1
-                        ENDIF
-                        IF(PROC>0) THEN
-                                JJ(PROC) = JJ(PROC) + 1
-                        ENDIF
-                ENDDO
-                ! -----------------------------
-                !       allocation : several MONVOL can refer to the same surface ID
-                DO PROC=1,NSPMD
-                        IF(.NOT.ALLOCATED(IGRSURF_PROC(IS,PROC)%ELTYP).AND.JJ(PROC)>0) THEN
-                                IGRSURF_PROC(IS,PROC)%NSEG = JJ(PROC)
-                                ALLOCATE( IGRSURF_PROC(IS,PROC)%ELTYP( JJ(PROC) ) )
-                                ALLOCATE( IGRSURF_PROC(IS,PROC)%ELEM( JJ(PROC) ) )
-                        ENDIF
-                        ! -----------------------------
-                        !   force the NJ1, NJ2, NJ3 nodes on the processor PROC
-                        IF(JJ(PROC)>0) THEN
-                            NJET = T_MONVOL(NV)%NJET
-                            DO NJ = 1, NJET
-                                NJ1 = T_MONVOL(NV)%IBAGJET(5, NJ)
-                                NJ2 = T_MONVOL(NV)%IBAGJET(6, NJ)
-                                NJ3 = T_MONVOL(NV)%IBAGJET(7, NJ)
-                                IF (NJ1 /= 0) CALL IFRONTPLUS(NJ1, PROC)
-                                IF (NJ2 /= 0) CALL IFRONTPLUS(NJ2, PROC)
-                                IF (NJ3 /= 0) CALL IFRONTPLUS(NJ3, PROC)
-                            ENDDO
+        IGRSURF_PROC(1:NSURF,1:NSPMD)%NSEG = 0
 
-                            IF (T_MONVOL(NV)%NB_FILL_TRI > 0) THEN
-                                DO J = 1, T_MONVOL(NV)%NB_FILL_TRI
-                                    I_AM_HERE = 0
-                                    NODE_ID = T_MONVOL(NV)%FILL_TRI(3 * (J - 1) + 1)
-                                    IF (NODE_ID > 0) THEN
+        DO NV=1,NVOLU ! NVOLU = number of volume
+            IS = T_MONVOL(NV)%EXT_SURFID ! id of the surface 
+            NN = IGRSURF(IS)%NSEG   ! number of element per surface
+            JJ(1:NSPMD) = 0         ! proc index
+            IGRSURF_PROC(IS,1:NSPMD)%NSEG = 0
+            ALREADY_DONE(IS) = .TRUE.
+            DO J=1,NN
+                ITY = IGRSURF(IS)%ELTYP(J)      ! type of the element 
+                II  = IGRSURF(IS)%ELEM(J)       ! id of the element
+                PROC = 0                        ! id of the proc /= 0 if ITY = 3 or 7
+                IF(ITY==3) THEN
+                    PROC = CEP(OFFC+II) + 1
+                ELSEIF(ITY==7) THEN
+                    PROC = CEP(OFFTG+II) + 1
+                ENDIF
+                IF(PROC>0) THEN
+                    JJ(PROC) = JJ(PROC) + 1
+                ENDIF
+            ENDDO
+            ! -----------------------------
+            ! allocation : several MONVOL can refer to the same surface ID
+            DO PROC=1,NSPMD
+                IF(.NOT.ALLOCATED(IGRSURF_PROC(IS,PROC)%ELTYP).AND.JJ(PROC)>0) THEN
+                    IGRSURF_PROC(IS,PROC)%NSEG = JJ(PROC)
+                    ALLOCATE( IGRSURF_PROC(IS,PROC)%ELTYP( JJ(PROC) ) )
+                    ALLOCATE( IGRSURF_PROC(IS,PROC)%ELEM( JJ(PROC) ) )
+                    ALLOCATE( IGRSURF_PROC(IS,PROC)%LOCAL_SEG(  JJ(PROC) ) )
+                ENDIF
+                ! -----------------------------
+                ! force the NJ1, NJ2, NJ3 nodes on the processor PROC
+                IF(JJ(PROC)>0) THEN
+                    NJET = T_MONVOL(NV)%NJET
+                    DO NJ = 1, NJET
+                        NJ1 = T_MONVOL(NV)%IBAGJET(5, NJ)
+                        NJ2 = T_MONVOL(NV)%IBAGJET(6, NJ)
+                        NJ3 = T_MONVOL(NV)%IBAGJET(7, NJ)
+                        IF (NJ1 /= 0) CALL IFRONTPLUS(NJ1, PROC)
+                        IF (NJ2 /= 0) CALL IFRONTPLUS(NJ2, PROC)
+                        IF (NJ3 /= 0) CALL IFRONTPLUS(NJ3, PROC)
+                    ENDDO
+
+                    IF (T_MONVOL(NV)%NB_FILL_TRI > 0) THEN
+                        DO J = 1, T_MONVOL(NV)%NB_FILL_TRI
+                            I_AM_HERE = 0
+                            NODE_ID = T_MONVOL(NV)%FILL_TRI(3 * (J - 1) + 1)
+                            IF (NODE_ID > 0) THEN
+                                CALL IFRONTPLUS(NODE_ID, PROC)
+                                I_AM_HERE = I_AM_HERE + 1
+                            ENDIF
+                            NODE_ID = T_MONVOL(NV)%FILL_TRI(3 * (J - 1) + 2)
+                            IF (NODE_ID > 0) THEN
+                                CALL IFRONTPLUS(NODE_ID, PROC)
+                                I_AM_HERE = I_AM_HERE + 1
+                            ENDIF
+                            NODE_ID = T_MONVOL(NV)%FILL_TRI(3 * (J - 1) + 3)
+                            IF (NODE_ID > 0) THEN
+                                CALL IFRONTPLUS(NODE_ID, PROC)
+                                I_AM_HERE = I_AM_HERE + 1
+                            ENDIF
+                            IF( I_AM_HERE==3 ) THEN
+                                T_MONVOL(NV)%NUMBER_TRI_PER_PROC(PROC) = 
+     .                          T_MONVOL(NV)%NUMBER_TRI_PER_PROC(PROC) + 1
+                            ENDIF
+                        ENDDO
+                    ENDIF
+                    ! -----------------------------
+                ENDIF
+            ENDDO
+                ! -----------------------------
+                K1 = K1 + NIMV
+        ENDDO
+        ! --------------------------------------
+        ! 2nd step : fill the structure
+        K1 = 1
+        DO NV=1,NVOLU                   ! NVOLU = number of volume
+            IS = T_MONVOL(NV)%EXT_SURFID      ! id of the surface 
+            NN = IGRSURF(IS)%NSEG   ! number of element per surface
+            JJ(1:NSPMD) = 0                 ! proc index
+            DO J=1,NN
+                ITY = IGRSURF(IS)%ELTYP(J)      ! type of the element 
+                II  = IGRSURF(IS)%ELEM(J)       ! id of the element
+                PROC = 0                        ! id of the proc /= 0 if ITY = 3 or 7
+                IF(ITY==3) THEN
+                     PROC = CEP(OFFC+II) + 1
+                ELSEIF(ITY==7) THEN
+                     PROC = CEP(OFFTG+II) + 1
+                ENDIF
+                IF(PROC>0) THEN
+                    JJ(PROC) = JJ(PROC) + 1
+                    IGRSURF_PROC(IS,PROC)%ELTYP(JJ(PROC)) = ITY
+                    IGRSURF_PROC(IS,PROC)%ELEM(JJ(PROC)) = II
+                    IGRSURF_PROC(IS,PROC)%LOCAL_SEG( JJ(PROC) ) = J
+                ENDIF
+            ENDDO
+            K1 = K1 + NIMV
+        ENDDO
+        ! --------------------------------------
+        ALLOCATE( I_NEED_IT(NUMNOD) )
+        ALLOCATE( PROC_LIST_PER_NODE(NUMNOD) )
+        I_NEED_IT(1:NUMNOD) = .FALSE.
+        DO IS=1,NSURF
+            IF(.NOT.ALREADY_DONE(IS)) THEN
+                NN = IGRSURF(IS)%NSEG ! number of segment
+                ALLOCATE( IGRSURF(IS)%PROC(NN) )
+                IGRSURF(IS)%PROC(1:NN) = 0
+                IGRSURF_PROC(IS,1:NSPMD)%NSEG = 0
+                ! -------------
+                ! loop over the segment of the surface
+                DO J=1,NN
+                    ITY = IGRSURF(IS)%ELTYP(J)      ! type of the element 
+                    II  = IGRSURF(IS)%ELEM(J)       ! id of the element                 
+                    ! -------------
+                    ! find on which processor the segment is defined
+                    ! if ity/=0 (segment belongs to an element) --> the processor is given by CEP array
+                    IF(ITY==0) THEN ! segment is not related to a element --> need to find the list of proc where the nodes are set
+                        UP_BOUND = 4
+                        IF(N2D/=0) UP_BOUND = 2
+                        ! -------------
+                        ! loop over the 4 nodes of the segment
+                        DO K=1,UP_BOUND
+                            NODE_ID = IGRSURF(IS)%NODES(J,K)
+                            IF(NODE_ID/=0) THEN
+                                IF(.NOT.I_NEED_IT(NODE_ID)) THEN ! if true, already computed
+                                    I_NEED_IT(NODE_ID) = .TRUE.
+                                    NUMBER_PROC = 0
+                                    CALL PLIST_IFRONT(PROC_LIST,NODE_ID,NUMBER_PROC) ! compute the list of proc
+                                    PROC_LIST_PER_NODE(NODE_ID)%SIZE_INT_ARRAY_1D = NUMBER_PROC
+                                    CALL ALLOC_1D_ARRAY(PROC_LIST_PER_NODE(NODE_ID))
+                                    PROC_LIST_PER_NODE(NODE_ID)%INT_ARRAY_1D(1:NUMBER_PROC) = PROC_LIST(1:NUMBER_PROC)
+                                ENDIF
+                            ENDIF
+                        ENDDO
+                        ! -------------
+                    ENDIF
+                    ! -------------
+                ENDDO
+                ! -------------
+            ENDIF
+        ENDDO
+        ! --------------------------------------
+        ! loop over the surface to find where the nodes ared defined
+        ! if ity/=0 --> use the CEP array
+        ! if ity=0 --> compute the union of processor list of the 4 nodes
+        !              merge the processor lists in 1 list
+        !              if there are several processor in the merged list, need to find the processor with the highest occurence
+        DO IS=1,NSURF
+            IF(.NOT.ALREADY_DONE(IS)) THEN
+                 IGRSURF_PROC(IS,1:NSPMD)%NSEG = 0
+                NN = IGRSURF(IS)%NSEG ! number of segment
+                ! -------------
+                ! loop over the segment of the surface
+                DO J=1,NN
+                    ITY = IGRSURF(IS)%ELTYP(J)      ! type of the element 
+                    II  = IGRSURF(IS)%ELEM(J)       ! id of the element
+                    PROC = 0                        
+                    ! -------------
+                    ! find on which processor the segment is defined
+                    ! if ity/=0 (segment belongs to an element) --> the processor is given by CEP array
+                    IF(ITY==1) THEN ! solid
+                        PROC = CEP(II) + 1
+                    ELSEIF(ITY==2) THEN ! quad
+                        PROC = CEP(OFFS+II) + 1
+                    ELSEIF(ITY==3) THEN ! shell
+                        PROC = CEP(OFFC+II) + 1
+                    ELSEIF(ITY==7) THEN ! triangle
+                        PROC = CEP(OFFTG+II) + 1
+                    ELSEIF(ITY==0) THEN ! segment is not related to a element
+                        UP_BOUND = 4
+                        IF(IGRSURF(IS)%NODES(J,3)==IGRSURF(IS)%NODES(J,4)) UP_BOUND = 3
+                        IF(N2D/=0) UP_BOUND = 2
+                        SIZE_MERGED_LIST = 0
+                        ! ------------
+                        ! compute the size of merged list
+                        DO K=1,UP_BOUND
+                            NODE_ID = IGRSURF(IS)%NODES(J,K)
+                            IF(NODE_ID/=0) THEN
+                                SIZE_MERGED_LIST = SIZE_MERGED_LIST + PROC_LIST_PER_NODE(NODE_ID)%SIZE_INT_ARRAY_1D
+                            ENDIF
+                        ENDDO
+                        ! ------------
+                        ALLOCATE( MERGED_LIST(SIZE_MERGED_LIST) )
+                        MERGED_LIST(1:SIZE_MERGED_LIST) = -1
+                        NODE_ID = IGRSURF(IS)%NODES(J,1)
+                        SIZE_UNION_PROC_LIST = 0   
+                        IF(NODE_ID/=0) THEN     
+                            ! ------------
+                            ! merge of processor list           
+                            MERGED_LIST(1:PROC_LIST_PER_NODE(NODE_ID)%SIZE_INT_ARRAY_1D) = 
+     .                       PROC_LIST_PER_NODE(NODE_ID)%INT_ARRAY_1D(1:PROC_LIST_PER_NODE(NODE_ID)%SIZE_INT_ARRAY_1D)
+                            SHIFT = PROC_LIST_PER_NODE(NODE_ID)%SIZE_INT_ARRAY_1D
+
+                            PROC_LIST(1:PROC_LIST_PER_NODE(NODE_ID)%SIZE_INT_ARRAY_1D) = 
+     .                       PROC_LIST_PER_NODE(NODE_ID)%INT_ARRAY_1D(1:PROC_LIST_PER_NODE(NODE_ID)%SIZE_INT_ARRAY_1D)
+                            SIZE_PROC_LIST = PROC_LIST_PER_NODE(NODE_ID)%SIZE_INT_ARRAY_1D
+                            SIZE_UNION_PROC_LIST = 0
+                            ! ------------
+                            ! merge + union computation
+                            DO K=2,UP_BOUND     
+                                NODE_ID = IGRSURF(IS)%NODES(J,K)        
+
+                                MERGED_LIST(SHIFT+1:SHIFT+PROC_LIST_PER_NODE(NODE_ID)%SIZE_INT_ARRAY_1D) = 
+     .                             PROC_LIST_PER_NODE(NODE_ID)%INT_ARRAY_1D(1:PROC_LIST_PER_NODE(NODE_ID)%SIZE_INT_ARRAY_1D)
+                                SHIFT = SHIFT + PROC_LIST_PER_NODE(NODE_ID)%SIZE_INT_ARRAY_1D
+
+                                CALL UNION_2_SORTED_SETS(PROC_LIST, SIZE_PROC_LIST,
+     .                             PROC_LIST_PER_NODE(NODE_ID)%INT_ARRAY_1D, PROC_LIST_PER_NODE(NODE_ID)%SIZE_INT_ARRAY_1D,
+     .                             UNION_PROC_LIST, SIZE_UNION_PROC_LIST )
+                                PROC_LIST(1:SIZE_UNION_PROC_LIST) = UNION_PROC_LIST(1:SIZE_UNION_PROC_LIST)
+                                SIZE_PROC_LIST = SIZE_UNION_PROC_LIST
+                            ENDDO
+                            ! ------------
+                        ENDIF
+
+                        ! ------------
+                        ! find the leading processor 
+                        NUMBER_APPEARANCE(1:NSPMD) = 0
+                        IF(SIZE_UNION_PROC_LIST>0) THEN
+                            CALL COUNT_MEMBER_LIST( UNION_PROC_LIST, SIZE_UNION_PROC_LIST,
+     .                                          MERGED_LIST, SIZE_MERGED_LIST,
+     .                                          NUMBER_APPEARANCE, INDEX_PROC )
+                            PROC = UNION_PROC_LIST(INDEX_PROC)
+                            ! ------------
+                            ! if all the nodes are not defined on PROC, need to add it on PROC
+                            IF( NUMBER_APPEARANCE(INDEX_PROC)/=UP_BOUND ) THEN
+                                DO K=1,UP_BOUND     
+                                    NODE_ID = IGRSURF(IS)%NODES(J,K)   
+                                    IF(NODE_ID/=0) THEN 
                                         CALL IFRONTPLUS(NODE_ID, PROC)
-                                        I_AM_HERE = I_AM_HERE + 1
-                                    ENDIF
-                                    NODE_ID = T_MONVOL(NV)%FILL_TRI(3 * (J - 1) + 2)
-                                    IF (NODE_ID > 0) THEN
-                                        CALL IFRONTPLUS(NODE_ID, PROC)
-                                        I_AM_HERE = I_AM_HERE + 1
-                                    ENDIF
-                                    NODE_ID = T_MONVOL(NV)%FILL_TRI(3 * (J - 1) + 3)
-                                    IF (NODE_ID > 0) THEN
-                                        CALL IFRONTPLUS(NODE_ID, PROC)
-                                        I_AM_HERE = I_AM_HERE + 1
-                                    ENDIF
-                                    IF( I_AM_HERE==3 ) THEN
-                                        T_MONVOL(NV)%NUMBER_TRI_PER_PROC(PROC) = 
-     .                                      T_MONVOL(NV)%NUMBER_TRI_PER_PROC(PROC) + 1
+    
+                                        NUMBER_PROC = 0
+                                        CALL PLIST_IFRONT(PROC_LIST,NODE_ID,NUMBER_PROC)
+                                        CALL DEALLOC_1D_ARRAY(PROC_LIST_PER_NODE(NODE_ID))
+                                        PROC_LIST_PER_NODE(NODE_ID)%SIZE_INT_ARRAY_1D = NUMBER_PROC
+                                        CALL ALLOC_1D_ARRAY(PROC_LIST_PER_NODE(NODE_ID))
+                                        PROC_LIST_PER_NODE(NODE_ID)%INT_ARRAY_1D(1:NUMBER_PROC) = PROC_LIST(1:NUMBER_PROC)
                                     ENDIF
                                 ENDDO
                             ENDIF
-                        ! -----------------------------
+                            ! ------------
                         ENDIF
+                        ! ------------
+                        DEALLOCATE( MERGED_LIST )
+                    ENDIF
+                    ! -------------
+                    ! save the processor for the segment J
+                    IF(PROC>0) THEN
+                        IGRSURF_PROC(IS,PROC)%NSEG = IGRSURF_PROC(IS,PROC)%NSEG + 1
+                        IGRSURF(IS)%PROC(J) = PROC
+                    ENDIF
                 ENDDO
-                ! -----------------------------
-                K1 = K1 + NIMV
+                ! -------------
+            ENDIF
         ENDDO
-        !       --------------------------------------
-        !       2nd step : fill the structure
-        K1 = 1
-        DO NV=1,NVOLU                   !       NVOLU = number of volume
-                IS = T_MONVOL(NV)%EXT_SURFID      !       id of the surface 
-                NN = IGRSURF(IS)%NSEG   !       number of element per surface
-                JJ(1:NSPMD) = 0                 !       proc index
+        ! --------------------------------------
+        ! loop over the surface to save the IGRSURF% data into IGRSURF_PROC% structure
+        DO IS=1,NSURF
+            IF(.NOT.ALREADY_DONE(IS)) THEN
+                JJ(1:NSPMD) = 0
+                DO J=1,NSPMD
+                    ALLOCATE( IGRSURF_PROC(IS,J)%ELTYP( IGRSURF_PROC(IS,J)%NSEG ) )
+                    ALLOCATE( IGRSURF_PROC(IS,J)%ELEM( IGRSURF_PROC(IS,J)%NSEG ) )
+                    ALLOCATE( IGRSURF_PROC(IS,J)%LOCAL_SEG( IGRSURF_PROC(IS,J)%NSEG ) )
+                ENDDO
+                NN = IGRSURF(IS)%NSEG ! number of segment
                 DO J=1,NN
-                        ITY = IGRSURF(IS)%ELTYP(J)      !       type of the element 
-                        II  = IGRSURF(IS)%ELEM(J)       !       id of the element
-                        PROC = 0                        !       id of the proc /= 0 if ITY = 3 or 7
-                        IF(ITY==3) THEN
-                                PROC = CEP(OFFC+II) + 1
-                        ELSEIF(ITY==7) THEN
-                                PROC = CEP(OFFTG+II) + 1
-                        ENDIF
-                        IF(PROC>0) THEN
-                                JJ(PROC) = JJ(PROC) + 1
-                                IGRSURF_PROC(IS,PROC)%ELTYP(JJ(PROC)) = ITY
-                                IGRSURF_PROC(IS,PROC)%ELEM(JJ(PROC)) = II
-                        ENDIF
+                    PROC = IGRSURF(IS)%PROC(J)
+                    IF(PROC/=0) THEN
+                        JJ(PROC) = JJ(PROC) + 1
+                        ITY = IGRSURF(IS)%ELTYP(J)
+                        IGRSURF_PROC(IS,PROC)%ELTYP( JJ(PROC) ) = ITY ! type of segment
+                        ELEM_ID = IGRSURF(IS)%ELEM(J) 
+                        IGRSURF_PROC(IS,PROC)%ELEM( JJ(PROC) ) = ELEM_ID ! element id
+                        IGRSURF_PROC(IS,PROC)%LOCAL_SEG( JJ(PROC) ) = J ! pointer from IGRSURF_PROC to IGRSURF
+                    ENDIF
                 ENDDO
-                K1 = K1 + NIMV
+            ENDIF
         ENDDO
-        !       --------------------------------------
+        ! --------------------------------------
+        DEALLOCATE( I_NEED_IT )
+        DEALLOCATE( PROC_LIST_PER_NODE )
+
         RETURN
         END SUBROUTINE IGRSURF_SPLIT

--- a/starter/source/starter/lectur.F
+++ b/starter/source/starter/lectur.F
@@ -10088,7 +10088,7 @@ c build structure surfaces specific Inlet Outlet
 !     Split the surface & add the MONVOL nodes
 !     on a given processor
 !--------------------------------------------
-          IF(NVOLU>0) CALL IGRSURF_SPLIT(CEP,T_MONVOL,IGRSURF,IGRSURF_PROC)
+      CALL IGRSURF_SPLIT(SCEP,CEP,T_MONVOL,IGRSURF,IGRSURF_PROC)
 C--------------------------------------------
 C     DOMAIN DECOMPOSITION 2 (DEFINITION DES FRONTIERES)
 C--------------------------------------------
@@ -10649,7 +10649,7 @@ c
 
 
           CALL DDSPLIT(
-     1         P            ,CEP         ,CEL            ,IGEO        ,MATPARAM_TAB,
+     1         P            ,CEP         ,CEL           ,IGEO        ,MATPARAM_TAB,
      2         IPM          ,ICODE       ,ISKEW          ,ISKWN       ,BID13      ,
      3         IBCSLAG      ,IPART       ,IPARTS         ,IPARTQ      ,IPARTC     ,
      4         IPARTT       ,IPARTP      ,IPARTR         ,IPARTG     ,
@@ -10686,7 +10686,7 @@ c
      Z                       KXSP        ,IXSP           ,NOD2SP      ,CEPSP      ,    
      a         NTHWA        ,NAIRWA      ,NMNT           ,L_MUL_LAG1  ,L_MUL_LAG  ,    
      b         LWASPIO      ,IPARTSP     ,ISPCOND        ,PM1SPH      ,                
-     c         WMA          ,    
+     c         WMA          ,
      d         EIGIPM       ,EIGIBUF     ,EIGRPM         ,    
      e         IFLOW        ,RFLOW       ,pMEMFLOW       ,IEXLNK      ,FASOLFR    ,    
      f         IPARTTH      ,    
@@ -10753,10 +10753,8 @@ c
       ENDIF     ! <-- end of restart file writing
 !   -------------------------------------------------------------
 C
-      IF(NVOLU>0) THEN
-        CALL DEALLOCATE_IGRSURF_SPLIT(T_MONVOL,IGRSURF_PROC)
-        DEALLOCATE( IGRSURF_PROC )
-      ENDIF
+      CALL DEALLOCATE_IGRSURF_SPLIT(T_MONVOL,IGRSURF_PROC)
+      DEALLOCATE( IGRSURF_PROC )
 
       IF( (NUMELS>0).AND.(IALE+IEULER+ITHERM+IALELAG/=0) ) CALL DEALLOCATE_SPLIT_CFD_SOLIDE(ALE_ELM)
       DEALLOCATE( ALE_ELM )


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
IGRSURF(:)%NODES was not correctly split on the different processors : only the segments related to an element were split.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
If the segments of the surface are not related to elements, we need to find which processor will compute the segment
* if the nodes of the segment are only on 1 processor --> this processor will compute the segment
* if the nodes are on different processors --> the processor with the highest number of node will compute the segment (if needed, nodes will be added to this processor)

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
