### PR TITLE
Fix an issue in plist_ifront

### DIFF
--- a/starter/source/spmd/node/ddtools.F
+++ b/starter/source/spmd/node/ddtools.F
@@ -173,7 +173,7 @@ C-----------------------------------------------
       TAB(1:NSPMD) = -1
       CPT=0
       IAD=IFRONT%IENTRY(N)
-
+      IF(IAD==-1) RETURN
 c if no proc set for this node     
 c nothing to do as init has been done to -1 
 


### PR DESCRIPTION
 #### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
A memory corruption was detected : when a node is yet on a processor, ientry(node) is still egual to -1


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
If the node is not yet on a processor, the plist_ifront computation is skipped

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
