### PR TITLE
Correct true to engineering strain conversion in ANIM output for law58

### DIFF
--- a/engine/source/output/anim/generate/dfuncc.F
+++ b/engine/source/output/anim/generate/dfuncc.F
@@ -1259,14 +1259,14 @@ c
                 IF (MLW == 58 .or. MLW == 158) THEN                                                        
                   DO I=LFT,LLT                                                             
                     DO IR = 1, NPTR                                                        
-                     DO IS = 1, NPTS                                                       
-                      UVAR=>ELBUF_TAB(NG)%BUFLY(IL)%MAT(IR,IS,IPT)%VAR                     
-                      IF(IUS==3.OR.IUS==4)THEN                                             
-                       EVAR(I) = EVAR(I) + LOG(UVAR(I1 + I)+ONE)/NPG                       
-                      ELSE                                                                 
-                       EVAR(I) = EVAR(I) + UVAR(I1 + I)/NPG                               
-                      ENDIF                                                                
-                     ENDDO                                                                 
+                      DO IS = 1, NPTS                                                      
+                        UVAR=>ELBUF_TAB(NG)%BUFLY(IL)%MAT(IR,IS,IPT)%VAR                   
+                        IF (IUS==3 .OR. IUS==4) THEN  ! convert true to eng strain                                           
+                          EVAR(I) = EVAR(I) + EXP(UVAR(I1+I) - ONE) / NPG                     
+                        ELSE                                                               
+                          EVAR(I) = EVAR(I) + UVAR(I1 + I) / NPG                             
+                        ENDIF                                                              
+                      ENDDO                                                                
                     ENDDO                                                                  
                   ENDDO                                                                    
                 ELSE                                                                       


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Avoid runtime error when invalid float is calculated for TH output of user variables in law58

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Conversion of true strain to engineering was calculated inversely, resulting in negative value under log function. It's corrected

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
