### PR TITLE
fix a 2D issue in accele.F routine

### DIFF
--- a/engine/source/assembly/accele.F
+++ b/engine/source/assembly/accele.F
@@ -26,10 +26,10 @@ Chd|-- called by -----------
 Chd|        RESOL                         source/engine/resol.F         
 Chd|-- calls ---------------
 Chd|====================================================================
-      SUBROUTINE ACCELE(
+        SUBROUTINE ACCELE(
      1                  A       ,AR    ,V    ,MS      ,IN   ,
-     2                  NODFT   ,NODLT ,ITAB ,NALE   ,MS_2D  ,
-     3                  NPBY   )
+     2                  NODFT   ,NODLT ,SIZE_NALE      ,NALE   ,MS_2D  ,
+     3                  SIZE_NPBY, NPBY   )
 C-----------------------------------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -44,106 +44,103 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER NODFT, NODLT, ITAB(*),NALE(*),NPBY(NNPBY,*)
-      my_real
-     .   A(3,NUMNOD) ,
-     .   V(3,NUMNOD) ,
-     .   AR(3,NUMNOD),
-     .   MS(NUMNOD)  ,
-     .   IN(*),MS_2D(NUMNOD)
+        INTEGER, INTENT(IN) ::NODFT  !< first node for smp //
+        INTEGER, INTENT(IN) :: NODLT !< last node for smp // 
+        INTEGER, INTENT(IN) :: SIZE_NALE !< size of NALE array
+        INTEGER, INTENT(IN) :: SIZE_NPBY !< 2nd dimension of NPBY array
+        INTEGER, DIMENSION(SIZE_NALE), INTENT(IN) :: NALE !< array of ALE node (1 if the node is related to ALE computation
+        INTEGER, DIMENSION(NNPBY,SIZE_NPBY), INTENT(IN) :: NPBY !< rigid body array
+        my_real, DIMENSION(3,NUMNOD), INTENT(INOUT) :: A,V,AR !< acceleration, velocity and  angular acceleration
+        my_real, DIMENSION(NUMNOD), INTENT(INOUT) :: MS,IN,MS_2D !< mass and inertia
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER  J,K,N,I,MSR
-      my_real
-     .         RTMP
+      INTEGER :: N,I,MSR
+      my_real :: RTMP
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------     
       
       !------------------------------------------------!
-      !       CALCUL DES  ACCELERATIONS (TRANSLATIONS) !
-      !------------------------------------------------!
-!#include      "vectorize.inc"
+      !       acceleration computation 
+      !------------------------------------------------!       
+        IF(N2D == 0) THEN
+            DO N=NODFT,NODLT
+                IF(MS(N)>ZERO) THEN
+                    RTMP = ONE / MS(N)
+                    A(1,N) = A(1,N) * RTMP
+                    A(2,N) = A(2,N) * RTMP
+                    A(3,N) = A(3,N) * RTMP
+                ELSE
+                    A(1,N) = ZERO
+                    A(2,N) = ZERO
+                    A(3,N) = ZERO
+                    IF(NMULT/=0) THEN
+                        V(1,N) = ZERO
+                        V(2,N) = ZERO
+                        V(3,N) = ZERO
+                    ENDIF
+                ENDIF
+            ENDDO
+        ELSE
+            DO I=1,NRBODY        
+                MSR = NPBY(1,I)
+                IF(MSR>0) THEN
+                    MS(MSR) = MS_2D(MSR)
+                ENDIF
+            ENDDO
+            DO N=NODFT,NODLT
+                IF(MS(N)>ZERO) THEN
+                    RTMP = ONE / MS(N)
+                    A(1,N) = A(1,N) * RTMP
+                    A(2,N) = A(2,N) * RTMP
+                    A(3,N) = A(3,N) * RTMP
+                ELSE
+                    A(1,N) = ZERO
+                    A(2,N) = ZERO
+                    A(3,N) = ZERO
+                    IF(NMULT/=0) THEN
+                        V(1,N) = ZERO
+                        V(2,N) = ZERO
+                        V(3,N) = ZERO
+                    ENDIF
+                ENDIF
+            ENDDO
+        ENDIF
 
-      IF(N2D == 0) THEN
-        DO N=NODFT,NODLT
-          IF(MS(N)>ZERO) THEN
-            RTMP = ONE / MS(N)
-            A(1,N) = A(1,N) * RTMP
-            A(2,N) = A(2,N) * RTMP
-            A(3,N) = A(3,N) * RTMP
-          ELSE
-            A(1,N) = ZERO
-            A(2,N) = ZERO
-            A(3,N) = ZERO
-            IF(NMULT/=0) THEN
-              V(1,N) = ZERO
-              V(2,N) = ZERO
-              V(3,N) = ZERO
-            ENDIF
-          ENDIF
-        ENDDO
-       ELSE
-        DO I=1,NRBODY
-          MSR = NPBY(1,I)
-          MS(MSR) = MS_2D(MSR)
-        ENDDO
-        DO N=NODFT,NODLT
-          IF(MS(N)>ZERO) THEN
-            RTMP = ONE / MS(N)
-            A(1,N) = A(1,N) * RTMP
-            A(2,N) = A(2,N) * RTMP
-            A(3,N) = A(3,N) * RTMP
-          ELSE
-            A(1,N) = ZERO
-            A(2,N) = ZERO
-            A(3,N) = ZERO
-            IF(NMULT/=0) THEN
-              V(1,N) = ZERO
-              V(2,N) = ZERO
-              V(3,N) = ZERO
-            ENDIF
-          ENDIF
-        ENDDO
-       ENDIF
-
       !------------------------------------------------!
-      !       CALCUL DES  ACCELERATIONS (ROTATIONS)    !
+      !       angular acceleration computation 
       !------------------------------------------------!
-      IF (IRODDL/=0) THEN
+        IF (IRODDL/=0) THEN
 #include      "vectorize.inc"
-        DO N=NODFT,NODLT
-          IF(IN(N)>ZERO) THEN
-            RTMP = ONE / IN(N)
-            AR(1,N) = AR(1,N) * RTMP
-            AR(2,N) = AR(2,N) * RTMP
-            AR(3,N) = AR(3,N) * RTMP
-          ELSE
-            AR(1,N) = ZERO
-            AR(2,N) = ZERO
-            AR(3,N) = ZERO      
-          ENDIF
-        ENDDO
-      ENDIF
+            DO N=NODFT,NODLT
+                IF(IN(N)>ZERO) THEN
+                    RTMP = ONE / IN(N)
+                    AR(1,N) = AR(1,N) * RTMP
+                    AR(2,N) = AR(2,N) * RTMP
+                    AR(3,N) = AR(3,N) * RTMP
+                ELSE
+                    AR(1,N) = ZERO
+                    AR(2,N) = ZERO
+                    AR(3,N) = ZERO      
+                ENDIF
+            ENDDO
+        ENDIF
 
       !------------------------------------------------!
       !      FVM DOES NOT NEED ACCEL AND VEL           !
       !------------------------------------------------!      
-      IF(INT22>0)THEN
+        IF(INT22>0)THEN
 #include      "vectorize.inc"
-        DO N=NODFT,NODLT
-          IF(NALE(N)/=0)THEN
-            A( 1:3,N) = ZERO
-            AR(1:3,N) = ZERO
-            MS(N)     = ZERO
-          ENDIF
-        ENDDO     
-      ENDIF
+            DO N=NODFT,NODLT
+                IF(NALE(N)/=0)THEN
+                    A( 1:3,N) = ZERO
+                    AR(1:3,N) = ZERO
+                    MS(N)     = ZERO
+                ENDIF
+            ENDDO     
+        ENDIF      
+      !------------------------------------------------!    
       
-      !------------------------------------------------!
-
-      
-      
-      RETURN
-      END
+        RETURN
+        END SUBROUTINE ACCELE

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -1205,6 +1205,8 @@ C-------------------------------------------------------------------------------
         INTEGER :: SIZE_ADDCNEL ! size of addcnel array
         INTEGER :: SIZE_CNEL ! size of cnel array
         LOGICAL :: GLOBAL_ACTIVE_ALE_ELEMENT
+
+        INTEGER :: SIZE_NPBY
       DATA IUN/1/
 C-----------------------------------------------------------------------------------       
 C Uncomment for Debug - ITAB is copied in Debug Module.
@@ -1273,6 +1275,7 @@ c
 C-----------------------------------------------
 C     I N I T I A L I S A T I O N S
 C----------------------------------------------
+      SIZE_NPBY = SNPBY/NNPBY
       ALLOCATE(IKINE(NUMNOD))
 C -------------------------------------------------------------------        
 C User Libraries get the possibility to use GET_U_NOD_X & GET_U_NOD_V in user elements properties (Solids & Springs)
@@ -6966,10 +6969,10 @@ C-----------------------------------------------
      2                       NODFTSK, NODLTSK, ITAB, MSNF , MS   ,
      3                       ALE_CONNECTIVITY%NALE     )     
         ENDIF
-
+        
         CALL ACCELE(A       ,AR      ,V    ,MS     ,IN     ,
-     2              NODFTSK ,NODLTSK ,ITAB ,ALE_CONNECTIVITY%NALE   ,MS_2D  ,
-     3              NPBY   )
+     2              NODFTSK ,NODLTSK ,ALE%GLOBAL%SNALE ,ALE_CONNECTIVITY%NALE   ,MS_2D  ,
+     3              SIZE_NPBY,NPBY   )
 C
         IF(IPLYXFEM > 0 )
      .    CALL PLY_ACCELE(INOD_PXFEM,MS_PLY,ZI_PLY,MS,


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
A segfault appeared in 2D analysis : the main node ID of a rigid body can be less than 0 if the rigid body is not computed by the current processor. In 3D analysis, the computation is skipped. The condition was missing in 2D analysis

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Add the condition to avoid the segfault 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
