### PR TITLE
fix a simple precision issue introduced by d1b68b9a4d82e10b1a2750eb6e46c5de451c8bf5

### DIFF
--- a/engine/source/output/ecrit.F
+++ b/engine/source/output/ecrit.F
@@ -624,17 +624,16 @@ C---------------------------------
         ENDIF
 C
         CALL SPMD_RBCAST(RTMP,RTMP,10,1,0,2)
-        IF (ISPMD/=0) THEN
-          MSTOP = NINT(RTMP(1))
-          MREST = NINT(RTMP(2))
-          MDESS = NINT(RTMP(3))
-          TANIM = RTMP(4)
-          OUTPUT%TH%THIS =  RTMP(5)
-          TSTAT = RTMP(6)
-          TOUTP = RTMP(7)
-          H3D_DATA%TH3D = RTMP(9)
-          DYNAIN_DATA%TDYNAIN = RTMP(10)
-        ENDIF
+
+        MSTOP = NINT(RTMP(1))
+        MREST = NINT(RTMP(2))
+        MDESS = NINT(RTMP(3))
+        TANIM = RTMP(4)
+        OUTPUT%TH%THIS =  RTMP(5)
+        TSTAT = RTMP(6)
+        TOUTP = RTMP(7)
+        H3D_DATA%TH3D = RTMP(9)
+        DYNAIN_DATA%TDYNAIN = RTMP(10)
 
         IF(INFO > 0) CALL SPMD_EXCH_FVSTATS(MONVOL)
 


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
A hang was detected with the single precision executable in an output routine

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
In ecrit.F, a mpi communication introduced some numerical noises on the THIS value, THIS values are different between the main mpi domain and the other mpi domains. Now the sp --> dp cast is done also for the main mpi domain

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
