### PR TITLE
i7remnode issue : the size of the array INSERTED_NODE is not correct

### DIFF
--- a/starter/source/interfaces/inter3d1/i7remnode.F
+++ b/starter/source/interfaces/inter3d1/i7remnode.F
@@ -1604,8 +1604,7 @@ C--------dim first
                                 DO J=1,NNOD
                                     NM = INTBUF_TAB(N)%IRECTM(4*(II-1)+J)
                                     IF (POINTS_I2N(NM,1)==0) CYCLE
-                                    MAX_INSERTED_NODE = MAX( MAX_INSERTED_NODE,POINTS_I2N(NM,2)-POINTS_I2N(NM,1) )
-                                    
+                                    MAX_INSERTED_NODE = MAX( MAX_INSERTED_NODE,POINTS_I2N(NM,2)-POINTS_I2N(NM,1)+1 )                                    
                                 ENDDO
                             ENDDO
 
@@ -1614,9 +1613,6 @@ C--------dim first
                             ELSE
                               SIZE_INSERTED_NODE =  4 * NRTM *MAX_INSERTED_NODE
                             ENDIF
-C FOR TESTING ONLY: uncomment the following line to force reallocation
-C                          SIZE_INSERTED_NODE = MAX_INSERTED_NODE
-C
 
                             MY_ALLOCATE(INSERTED_NODE,SIZE_INSERTED_NODE) 
 
@@ -1639,10 +1635,10 @@ C
                                     NNOD=4
                                 END IF   
                                
-                                IF(JJJ + MAX_INSERTED_NODE > SIZE_INSERTED_NODE) THEN
+                                IF(JJJ + NNOD * MAX_INSERTED_NODE > SIZE_INSERTED_NODE) THEN
 C extend INSERTED_NODE if needed
                                   OLDSIZE = SIZE_INSERTED_NODE
-                                  SIZE_INSERTED_NODE = SIZE_INSERTED_NODE  + MAX(NRTM,MAX_INSERTED_NODE)
+                                  SIZE_INSERTED_NODE = SIZE_INSERTED_NODE  + MIN(NRTM,10*NNOD*MAX_INSERTED_NODE)
                                   MY_ALLOCATE(TMP,SIZE_INSERTED_NODE)
                                   TMP(1:OLDSIZE) = INSERTED_NODE(1:OLDSIZE)
 !                                 move_alloc deallocates TMP


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
In i7remnode routine, the size of INSERTED_NODE is not correct

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Fix the size issue

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
