### PR TITLE
(x)th and th files compatability : partsav array was not correctly re-initialized to zero if (x)th and th time frequency are different

### DIFF
--- a/engine/CMake_Compilers/legacy_fortran.cmake
+++ b/engine/CMake_Compilers/legacy_fortran.cmake
@@ -624,7 +624,7 @@ set_source_files_properties( ${source_directory}/source/output/th/thtrus_count.F
 # set_source_files_properties( ${source_directory}/source/output/th/thres.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 # set_source_files_properties( ${source_directory}/source/output/th/thmonv.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/output/th/thrnur.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
-set_source_files_properties( ${source_directory}/source/output/th/hist2.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
+#set_source_files_properties( ${source_directory}/source/output/th/hist2.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 # set_source_files_properties( ${source_directory}/source/output/th/thpout.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/output/th/thcoq_count.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 # set_source_files_properties( ${source_directory}/source/output/th/bcs1th_imp.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -8456,7 +8456,7 @@ C Regular animation
      9   NNFLSW        ,CRFLSW         ,FLSW           ,LOUT           ,
      B   FSAV          ,SKEW           ,ELBUF_TAB      ,CLUSTER        ,
      C   VR            ,IN             ,WEIGHT         ,FCLUSTER       ,MCLUSTER      ,
-     D   DD_IAD        ,DMAS           ,DINER          ,ACCELM         ,GAUGE         ,
+     D   DD_IAD        ,DMAS           ,ACCELM         ,GAUGE         ,
      E   IPARI         ,EANI           ,IPART          ,MATPARAM_TAB   ,
      F   IGRNOD        ,SUBSETS        ,
      G   NOM_OPT       ,AR             ,IGRSURF        ,BUFSF          ,IDATA         ,

--- a/engine/source/output/sortie_main.F
+++ b/engine/source/output/sortie_main.F
@@ -88,7 +88,7 @@ Chd|====================================================================
      9            NNFLSW    ,CRFLSW      ,FLSW       ,LOUT      ,                
      B            FSAV      ,SKEW        ,ELBUF_TAB  ,CLUSTER   ,                   
      C            VR        ,IN          ,WEIGHT     ,FCLUSTER  ,MCLUSTER ,         
-     D            DD_IAD    ,DMAS        ,DINER      ,ACCELM    ,GAUGE,             
+     D            DD_IAD    ,DMAS        ,ACCELM    ,GAUGE,             
      E            IPARI     ,EANI        ,IPART      ,MATPARAM_TAB,                                    
      F            IGRNOD    ,SUBSET      ,      
      G            NOM_OPT   ,AR          ,IGRSURF    ,BUFSF     ,IDATA    ,         
@@ -223,7 +223,7 @@ C-----------------------------------------------
      .   ISKEW(*),TAG_SKINS6(*),IRUNN_BIS
        my_real
      .   BUFNOIS(*),PARTSAV(NPSAV,*),RBY(NRBY,*),CRFLSW(*),FLSW(*),
-     .   FSAV(NTHVKI,*),SKEW(LSKEW,*), VR(3,*), IN(*), DMAS,DINER,
+     .   FSAV(NTHVKI,*),SKEW(LSKEW,*), VR(3,*), IN(*), DMAS,
      .   ACCELM(LLACCELM,*),BUFSF(*),RDATA(*),BUFMAT(*),BUFGEO(*),
      .   SPBUF(*),RIVET(*),XFRAME(NXFRAME,*),ZI_PLY(*),VGAZ(*)
       my_real
@@ -307,11 +307,13 @@ C-----------------------------------------------
       INTEGER :: LEN_TMP_NAME,LEN_TMP_NAME2
       CHARACTER(len=100) :: TMP_NAME,TMP_NAME2   
       CHARACTER FILNAMABF*100,FILNAMABF_TMP*100
+      LOGICAL :: NEED_TO_REINIT_FSAV !< boolean to re-initialize PARTSAV array 
 C=======================================================================
       IF(IPLYXFEM == 0 ) ANIM_PLY = 0
       IF(ICRACK3D > 0 ) ANIM_CRK = 1
       CPTFILE=0
       NSENSOR = SENSORS%NSENSOR
+      NEED_TO_REINIT_FSAV = .FALSE.
 C----------------------
 C       FICHIERS NOISE
 C----------------------
@@ -1000,24 +1002,24 @@ C         to avoid double points
             CALL HIST2(PM   ,D    ,X     ,V   ,A    ,
      2                 IXS  ,ELBUF,WA(N2),IPARG,SENSORS%SENSOR_TAB,
      4                 FSAV ,FLSW ,SKEW,ELBUF_TAB,CLUSTER,                                 
-     5                 PARTSAV,ACCELM,LOUT ,NSENSOR  ,MATPARAM_TAB, 
-     6                 IPARI,WEIGHT,IPART,IGRSURF,
+     5                 PARTSAV,ACCELM,NSENSOR  ,MATPARAM_TAB, 
+     6                 WEIGHT,IPART,IGRSURF,
      7                 OUTPUT%TH%ITHGRPA, OUTPUT%TH%ITHBUFA, SUBSET,GEO  ,
      8                 KXX   ,IXR,
      9                 KXSP  ,NOD2SP ,SPBUF ,
-     B                 NPARTSAV,AR   ,VR    ,DR,
-     D                 FSAVD ,IXRI   ,RIVET  ,IXP      ,
+     B                 AR   ,VR    ,DR,
+     D                 IXRI   ,RIVET  ,IXP      ,
      E                 ISKWN ,IFRAME ,XFRAME ,IXC      ,IXQ ,
      F                 OUTPUT%TH%DTHIS1(1),OUTPUT%TH%THIS1(1), IFIL, NTHGRP1(1),IXTG ,
      G                 IGEO   ,IPM   ,FXBIPM, FXBDEP, FXBVIT,
      H                 FXBACC ,IPARTL,NPARTL, IACCP , NACCP ,
      I                 IPARTH ,2     ,1     ,
-     J                 1      ,MONVOL,VOLMON,FR_MV  ,TEMP,INOD_PXFEM,
+     J                 MONVOL,VOLMON,FR_MV  ,TEMP,INOD_PXFEM,
      K                 FTHREAC,NODREAC,GRESAV  ,GAUGE  ,
-     L                 IGAUP  ,NGAUP ,AFORM(1),WEIGHT_MD,SIZE_MES,
+     L                 IGAUP  ,NGAUP ,AFORM(1),SIZE_MES,
      M                 RTHBUF ,THKE ,STACK ,ISPHIO  ,VSPHIO,
      N                 ITHFLAG,PINCH_DATA,MULTI_FVM,W,OUTPUT%TH%SITHBUFA,
-     Q                 FSAVSURF,NSEG_LOADP)
+     Q                 FSAVSURF,NSEG_LOADP,NEED_TO_REINIT_FSAV)
 
             IF (SIZE_MES==1 .AND.AFORM(1)==3 .AND.ISPMD==0 ) 
      *          CALL file_size(MULTITHFILESIZE(1))
@@ -1094,24 +1096,24 @@ C
             CALL HIST2(PM   ,D    ,X     ,V   ,A    ,
      2                 IXS  ,ELBUF,WA(N2),IPARG,SENSORS%SENSOR_TAB,
      4                 FSAV ,FLSW ,SKEW,ELBUF_TAB,CLUSTER,
-     5                 PARTSAV,ACCELM,LOUT ,NSENSOR  ,MATPARAM_TAB,
-     6                 IPARI,WEIGHT,IPART,IGRSURF,
+     5                 PARTSAV,ACCELM,NSENSOR  ,MATPARAM_TAB,
+     6                 WEIGHT,IPART,IGRSURF,
      7                 OUTPUT%TH%ITHGRPB,OUTPUT%TH%ITHBUFB,SUBSET,GEO  ,
      8                 KXX   ,IXR,
      9                 KXSP  ,NOD2SP ,SPBUF ,
-     B                 NPARTSAV,AR   ,VR    ,DR,
-     D                 FSAVD ,IXRI   ,RIVET  ,IXP ,
+     B                 AR   ,VR    ,DR,
+     D                 IXRI   ,RIVET  ,IXP ,
      E                 ISKWN ,IFRAME ,XFRAME,IXC    ,IXQ ,
      F                 OUTPUT%TH%DTHIS1(2),OUTPUT%TH%THIS1(2), IFIL, NTHGRP1(2),IXTG ,
      G                 IGEO   ,IPM   ,FXBIPM, FXBDEP, FXBVIT,
      H                 FXBACC ,IPARTL,NPARTL, IACCP , NACCP ,
      I                 IPARTH(1,(NPART+NTHPART)+1),2,1,
-     J                 1     ,MONVOL ,VOLMON,FR_MV  ,TEMP,INOD_PXFEM,
+     J                 MONVOL ,VOLMON,FR_MV  ,TEMP,INOD_PXFEM,
      K                 FTHREAC,NODREAC,GRESAV  ,GAUGE  ,
-     L                 IGAUP  ,NGAUP, AFORM(2),WEIGHT_MD,SIZE_MES,
+     L                 IGAUP  ,NGAUP, AFORM(2),SIZE_MES,
      M                 RTHBUF ,THKE ,STACK,ISPHIO  ,VSPHIO,
      N                 ITHFLAG,PINCH_DATA,MULTI_FVM,W,OUTPUT%TH%SITHBUFB,
-     Q                 FSAVSURF,NSEG_LOADP)
+     Q                 FSAVSURF,NSEG_LOADP,NEED_TO_REINIT_FSAV)
 
             IF (SIZE_MES==1 .AND.AFORM(2)==3 .AND.ISPMD==0 )
      *        CALL file_size(MULTITHFILESIZE(2))
@@ -1188,24 +1190,24 @@ C
             CALL HIST2(PM   ,D    ,X     ,V   ,A    ,
      2                 IXS  ,ELBUF,WA(N2),IPARG,SENSORS%SENSOR_TAB,
      4                 FSAV ,FLSW ,SKEW,ELBUF_TAB,CLUSTER,
-     5                 PARTSAV,ACCELM,LOUT ,NSENSOR  ,MATPARAM_TAB,
-     6                 IPARI,WEIGHT,IPART,IGRSURF,
+     5                 PARTSAV,ACCELM,NSENSOR  ,MATPARAM_TAB,
+     6                 WEIGHT,IPART,IGRSURF,
      7                 OUTPUT%TH%ITHGRPC,OUTPUT%TH%ITHBUFC,SUBSET,GEO  ,
      8                 KXX   ,IXR,
      9                 KXSP  ,NOD2SP ,SPBUF ,
-     B                 NPARTSAV,AR   ,VR    ,DR,
-     D                 FSAVD ,IXRI   ,RIVET  , IXP , 
+     B                 AR   ,VR    ,DR,
+     D                 IXRI   ,RIVET  , IXP , 
      E                 ISKWN ,IFRAME ,XFRAME,IXC    ,IXQ ,
      F                 OUTPUT%TH%DTHIS1(3),OUTPUT%TH%THIS1(3), IFIL, NTHGRP1(3),IXTG ,
      G                 IGEO   ,IPM   ,FXBIPM, FXBDEP, FXBVIT,
      H                 FXBACC ,IPARTL,NPARTL, IACCP , NACCP ,
      I                 IPARTH(1,2*(NPART+NTHPART)+1),2,1,
-     J                 1     ,MONVOL ,VOLMON,FR_MV  ,TEMP,INOD_PXFEM,
+     J                 MONVOL ,VOLMON,FR_MV  ,TEMP,INOD_PXFEM,
      K                 FTHREAC,NODREAC,GRESAV  ,GAUGE  ,
-     L                 IGAUP  ,NGAUP ,AFORM(3),WEIGHT_MD,SIZE_MES,
+     L                 IGAUP  ,NGAUP ,AFORM(3),SIZE_MES,
      M                 RTHBUF ,THKE ,STACK ,ISPHIO  ,VSPHIO,
      n                 ITHFLAG,PINCH_DATA,MULTI_FVM,W,OUTPUT%TH%SITHBUFC,
-     Q                 FSAVSURF,NSEG_LOADP)
+     Q                 FSAVSURF,NSEG_LOADP,NEED_TO_REINIT_FSAV)
 
         IF(SIZE_MES==1 .AND.
      *     AFORM(3)==3   .AND.
@@ -1278,24 +1280,24 @@ C
             CALL HIST2(PM   ,D    ,X     ,V   ,A    ,
      2                 IXS  ,ELBUF,WA(N2),IPARG,SENSORS%SENSOR_TAB,
      4                 FSAV ,FLSW ,SKEW,ELBUF_TAB,CLUSTER,
-     5                 PARTSAV,ACCELM,LOUT ,NSENSOR  ,MATPARAM_TAB,
-     6                 IPARI,WEIGHT,IPART,IGRSURF,
+     5                 PARTSAV,ACCELM,NSENSOR  ,MATPARAM_TAB,
+     6                 WEIGHT,IPART,IGRSURF,
      7                 OUTPUT%TH%ITHGRPD,OUTPUT%TH%ITHBUFD,SUBSET,GEO  ,
      8                 KXX   ,IXR,
      9                 KXSP  ,NOD2SP ,SPBUF ,
-     B                 NPARTSAV,AR   ,VR    ,DR,
-     D                 FSAVD ,IXRI   ,RIVET  , IXP,
+     B                 AR   ,VR    ,DR,
+     D                 IXRI   ,RIVET  , IXP,
      E                 ISKWN ,IFRAME ,XFRAME,IXC    ,IXQ ,
      F                 OUTPUT%TH%DTHIS1(4),OUTPUT%TH%THIS1(4), IFIL, NTHGRP1(4),IXTG ,
      G                 IGEO   ,IPM   ,FXBIPM, FXBDEP, FXBVIT,
      H                 FXBACC ,IPARTL,NPARTL, IACCP , NACCP ,
      I                 IPARTH(1,3*(NPART+NTHPART)+1),2,1,
-     J                 1      ,MONVOL ,VOLMON,FR_MV ,TEMP,INOD_PXFEM,
+     J                 MONVOL ,VOLMON,FR_MV ,TEMP,INOD_PXFEM,
      K                 FTHREAC,NODREAC,GRESAV  ,GAUGE  ,
-     L                 IGAUP  ,NGAUP ,AFORM(4),WEIGHT_MD,SIZE_MES,
+     L                 IGAUP  ,NGAUP ,AFORM(4),SIZE_MES,
      M                 RTHBUF ,THKE ,STACK ,ISPHIO  ,VSPHIO,
      N                 ITHFLAG,PINCH_DATA,MULTI_FVM,W,OUTPUT%TH%SITHBUFD,
-     Q                 FSAVSURF,NSEG_LOADP)
+     Q                 FSAVSURF,NSEG_LOADP,NEED_TO_REINIT_FSAV)
 
          IF(SIZE_MES==1 .AND.
      *     AFORM(4)==3   .AND.
@@ -1369,24 +1371,24 @@ C
             CALL HIST2(PM   ,D    ,X     ,V   ,A    ,
      2                IXS  ,ELBUF,WA(N2),IPARG,SENSORS%SENSOR_TAB,
      4                FSAV ,FLSW ,SKEW,ELBUF_TAB,CLUSTER,
-     5                PARTSAV,ACCELM,LOUT ,NSENSOR  ,MATPARAM_TAB,
-     6                IPARI,WEIGHT,IPART,IGRSURF,
+     5                PARTSAV,ACCELM,NSENSOR  ,MATPARAM_TAB,
+     6                WEIGHT,IPART,IGRSURF,
      7                OUTPUT%TH%ITHGRPE,OUTPUT%TH%ITHBUFE,SUBSET,GEO  ,
      8                KXX   ,IXR,
      9                KXSP  ,NOD2SP ,SPBUF ,
-     B                NPARTSAV,AR   ,VR    ,DR,
-     D                FSAVD ,IXRI   ,RIVET  , IXP , 
+     B                AR   ,VR    ,DR,
+     D                IXRI   ,RIVET  , IXP , 
      E                ISKWN ,IFRAME ,XFRAME,IXC    ,IXQ ,
      F                OUTPUT%TH%DTHIS1(5),OUTPUT%TH%THIS1(5), IFIL, NTHGRP1(5),IXTG ,
      G                IGEO   ,IPM   ,FXBIPM, FXBDEP, FXBVIT,
      H                FXBACC ,IPARTL,NPARTL, IACCP , NACCP ,
      I                IPARTH(1,4*(NPART+NTHPART)+1),2,1,
-     J                1      ,MONVOL ,VOLMON,FR_MV ,TEMP,INOD_PXFEM,
+     J                MONVOL ,VOLMON,FR_MV ,TEMP,INOD_PXFEM,
      K                FTHREAC,NODREAC,GRESAV  ,GAUGE  ,
-     L                IGAUP  ,NGAUP ,AFORM(5),WEIGHT_MD,SIZE_MES,
+     L                IGAUP  ,NGAUP ,AFORM(5),SIZE_MES,
      M                RTHBUF  ,THKE ,STACK  ,ISPHIO  ,VSPHIO,
      N                ITHFLAG,PINCH_DATA,MULTI_FVM,W,OUTPUT%TH%SITHBUFE,
-     Q                FSAVSURF,NSEG_LOADP)
+     Q                FSAVSURF,NSEG_LOADP,NEED_TO_REINIT_FSAV)
 
         IF(SIZE_MES==1 .AND.
      *     AFORM(5)==3   .AND.
@@ -1459,24 +1461,24 @@ C
             CALL HIST2(PM   ,D    ,X     ,V   ,A    ,
      2                IXS  ,ELBUF,WA(N2),IPARG,SENSORS%SENSOR_TAB,
      4                FSAV ,FLSW ,SKEW,ELBUF_TAB,CLUSTER,
-     5                PARTSAV,ACCELM,LOUT ,NSENSOR  ,MATPARAM_TAB,
-     6                IPARI,WEIGHT,IPART,IGRSURF,
+     5                PARTSAV,ACCELM,NSENSOR  ,MATPARAM_TAB,
+     6                WEIGHT,IPART,IGRSURF,
      7                OUTPUT%TH%ITHGRPF,OUTPUT%TH%ITHBUFF,SUBSET,GEO  ,
      8                KXX   ,IXR,
      9                KXSP  ,NOD2SP ,SPBUF ,
-     B                NPARTSAV,AR   ,VR    ,DR,
-     D                FSAVD ,IXRI   ,RIVET  , IXP , 
+     B                AR   ,VR    ,DR,
+     D                IXRI   ,RIVET  , IXP , 
      E                ISKWN ,IFRAME ,XFRAME,IXC    ,IXQ ,
      F                OUTPUT%TH%DTHIS1(6),OUTPUT%TH%THIS1(6), IFIL, NTHGRP1(6),IXTG ,
      G                IGEO   ,IPM   ,FXBIPM, FXBDEP, FXBVIT,
      H                FXBACC ,IPARTL,NPARTL, IACCP , NACCP ,
      I                IPARTH(1,5*(NPART+NTHPART)+1),2,1,
-     J                1      ,MONVOL,VOLMON,FR_MV  ,TEMP,INOD_PXFEM,
+     J                MONVOL,VOLMON,FR_MV  ,TEMP,INOD_PXFEM,
      K                FTHREAC,NODREAC,GRESAV  ,GAUGE  ,
-     L                IGAUP,NGAUP ,AFORM(6),WEIGHT_MD,SIZE_MES,
+     L                IGAUP,NGAUP ,AFORM(6),SIZE_MES,
      M                RTHBUF,THKE ,STACK  ,ISPHIO  ,VSPHIO,
      N                ITHFLAG,PINCH_DATA,MULTI_FVM,W,OUTPUT%TH%SITHBUFF,
-     Q                FSAVSURF,NSEG_LOADP)
+     Q                FSAVSURF,NSEG_LOADP,NEED_TO_REINIT_FSAV)
 
         IF(SIZE_MES==1 .AND.
      *     AFORM(6)==3   .AND.
@@ -1550,24 +1552,24 @@ C
             CALL HIST2(PM   ,D    ,X     ,V   ,A    ,
      2                IXS  ,ELBUF,WA(N2),IPARG,SENSORS%SENSOR_TAB,
      4                FSAV ,FLSW ,SKEW,ELBUF_TAB,CLUSTER,
-     5                PARTSAV,ACCELM,LOUT ,NSENSOR  ,MATPARAM_TAB,
-     6                IPARI,WEIGHT,IPART,IGRSURF,
+     5                PARTSAV,ACCELM,NSENSOR  ,MATPARAM_TAB,
+     6                WEIGHT,IPART,IGRSURF,
      7                OUTPUT%TH%ITHGRPG,OUTPUT%TH%ITHBUFG,SUBSET,GEO  ,
      8                KXX   ,IXR,
      9                KXSP  ,NOD2SP ,SPBUF ,
-     B                NPARTSAV,AR   ,VR    ,DR,
-     D                FSAVD ,IXRI   ,RIVET  ,IXP , 
+     B                AR   ,VR    ,DR,
+     D                IXRI   ,RIVET  ,IXP , 
      E                ISKWN ,IFRAME ,XFRAME,IXC    ,IXQ ,
      F                OUTPUT%TH%DTHIS1(7),OUTPUT%TH%THIS1(7), IFIL, NTHGRP1(7),IXTG ,
      G                IGEO   ,IPM   ,FXBIPM, FXBDEP, FXBVIT,
      H                FXBACC ,IPARTL,NPARTL, IACCP , NACCP ,
      I                IPARTH(1,6*(NPART+NTHPART)+1),2,1,
-     J                1     ,MONVOL ,VOLMON,FR_MV  ,TEMP,INOD_PXFEM,
+     J                MONVOL ,VOLMON,FR_MV  ,TEMP,INOD_PXFEM,
      K                FTHREAC,NODREAC,GRESAV ,GAUGE  ,
-     L                IGAUP,NGAUP ,AFORM(7),WEIGHT_MD,SIZE_MES,
+     L                IGAUP,NGAUP ,AFORM(7),SIZE_MES,
      M                RTHBUF,THKE ,STACK  ,ISPHIO  ,VSPHIO,
      N                ITHFLAG,PINCH_DATA,MULTI_FVM,W,OUTPUT%TH%SITHBUFG,
-     Q                FSAVSURF,NSEG_LOADP)
+     Q                FSAVSURF,NSEG_LOADP,NEED_TO_REINIT_FSAV)
 
         IF(SIZE_MES==1 .AND.
      *     AFORM(7)==3   .AND.
@@ -1641,24 +1643,24 @@ C
             CALL HIST2(PM   ,D    ,X     ,V   ,A    ,
      2                IXS  ,ELBUF,WA(N2),IPARG,SENSORS%SENSOR_TAB,
      4                FSAV ,FLSW ,SKEW,ELBUF_TAB,CLUSTER,
-     5                PARTSAV,ACCELM,LOUT ,NSENSOR  ,MATPARAM_TAB,
-     6                IPARI,WEIGHT,IPART,IGRSURF,
+     5                PARTSAV,ACCELM,NSENSOR  ,MATPARAM_TAB,
+     6                WEIGHT,IPART,IGRSURF,
      7                OUTPUT%TH%ITHGRPH,OUTPUT%TH%ITHBUFH,SUBSET,GEO  ,
      8                KXX   ,IXR,
      9                KXSP  ,NOD2SP ,SPBUF ,
-     B                NPARTSAV,AR   ,VR    ,DR,
-     D                FSAVD ,IXRI   ,RIVET  , IXP , 
+     B                AR   ,VR    ,DR,
+     D                IXRI   ,RIVET  , IXP , 
      E                ISKWN ,IFRAME ,XFRAME,IXC    ,IXQ ,
      F                OUTPUT%TH%DTHIS1(8),OUTPUT%TH%THIS1(8), IFIL, NTHGRP1(8),IXTG ,
      G                IGEO   ,IPM   ,FXBIPM, FXBDEP, FXBVIT,
      H                FXBACC ,IPARTL,NPARTL, IACCP , NACCP ,
      I                IPARTH(1,7*(NPART+NTHPART)+1),2,1,
-     J                1     ,MONVOL ,VOLMON,FR_MV  ,TEMP,INOD_PXFEM,
+     J                MONVOL ,VOLMON,FR_MV  ,TEMP,INOD_PXFEM,
      K                FTHREAC,NODREAC,GRESAV  ,GAUGE  ,
-     L                IGAUP  ,NGAUP ,AFORM(8),WEIGHT_MD,SIZE_MES,
+     L                IGAUP  ,NGAUP ,AFORM(8),SIZE_MES,
      M                RTHBUF ,THKE ,STACK ,ISPHIO  ,VSPHIO,
      N                ITHFLAG,PINCH_DATA,MULTI_FVM,W,OUTPUT%TH%ITHBUFH,
-     Q                FSAVSURF,NSEG_LOADP)
+     Q                FSAVSURF,NSEG_LOADP,NEED_TO_REINIT_FSAV)
 
         IF(SIZE_MES==1 .AND.
      *     AFORM(8)==3   .AND.
@@ -1731,24 +1733,24 @@ C
             CALL HIST2(PM   ,D    ,X     ,V   ,A    ,
      2                IXS  ,ELBUF,WA(N2),IPARG,SENSORS%SENSOR_TAB,
      4                FSAV ,FLSW ,SKEW,ELBUF_TAB,CLUSTER,
-     5                PARTSAV,ACCELM,LOUT ,NSENSOR  ,MATPARAM_TAB,
-     6                IPARI,WEIGHT,IPART,IGRSURF,
+     5                PARTSAV,ACCELM,NSENSOR  ,MATPARAM_TAB,
+     6                WEIGHT,IPART,IGRSURF,
      7                OUTPUT%TH%ITHGRPI,OUTPUT%TH%ITHBUFI,SUBSET,GEO  ,
      8                KXX   ,IXR,
      9                KXSP  ,NOD2SP ,SPBUF ,
-     B                NPARTSAV,AR   ,VR    ,DR,
-     D                FSAVD ,IXRI   ,RIVET  ,IXP , 
+     B                AR   ,VR    ,DR,
+     D                IXRI   ,RIVET  ,IXP , 
      E                ISKWN ,IFRAME ,XFRAME,IXC    ,IXQ ,
      F                OUTPUT%TH%DTHIS1(9),OUTPUT%TH%THIS1(9), IFIL, NTHGRP1(9),IXTG   ,
      G                IGEO   ,IPM   ,FXBIPM, FXBDEP, FXBVIT,
      H                FXBACC ,IPARTL,NPARTL, IACCP , NACCP ,
      I                IPARTH(1,8*(NPART+NTHPART)+1),2,1,
-     J                1     ,MONVOL ,VOLMON,FR_MV  ,TEMP,INOD_PXFEM,
+     J                MONVOL ,VOLMON,FR_MV  ,TEMP,INOD_PXFEM,
      K                FTHREAC,NODREAC,GRESAV  ,GAUGE  ,
-     L                IGAUP,NGAUP ,AFORM(9),WEIGHT_MD,SIZE_MES,
+     L                IGAUP,NGAUP ,AFORM(9),SIZE_MES,
      M                RTHBUF ,THKE ,STACK ,ISPHIO  ,VSPHIO,
      N                ITHFLAG,PINCH_DATA,MULTI_FVM,W,OUTPUT%TH%ITHBUFI,
-     Q                FSAVSURF,NSEG_LOADP)
+     Q                FSAVSURF,NSEG_LOADP,NEED_TO_REINIT_FSAV)
 
         IF(SIZE_MES==1 .AND.
      *     AFORM(9)==3   .AND.
@@ -1819,24 +1821,24 @@ C
         CALL HIST2(PM   ,D    ,X     ,V   ,A    ,
      2                IXS  ,ELBUF,WA(N2),IPARG,SENSORS%SENSOR_TAB,
      4                FSAV ,FLSW ,SKEW,ELBUF_TAB,CLUSTER,
-     5                PARTSAV,ACCELM,LOUT ,NSENSOR  ,MATPARAM_TAB,
-     6                IPARI,WEIGHT,IPART,IGRSURF,
+     5                PARTSAV,ACCELM,NSENSOR  ,MATPARAM_TAB,
+     6                WEIGHT,IPART,IGRSURF,
      7                OUTPUT%TH%ITHGRP,OUTPUT%TH%ITHBUF,SUBSET,GEO  ,
      8                KXX   ,IXR,
      9                KXSP  ,NOD2SP ,SPBUF ,
-     B                NPARTSAV,AR   ,VR    ,DR,
-     D                FSAVD ,IXRI   ,RIVET  , IXP , 
+     B                AR   ,VR    ,DR,
+     D                IXRI   ,RIVET  , IXP , 
      E                ISKWN ,IFRAME ,XFRAME,IXC    ,IXQ,
      F                OUTPUT%TH%DTHIS ,OUTPUT%TH%THIS,IFIL  , NTHGRP,IXTG   ,
      G                IGEO   ,IPM   ,FXBIPM, FXBDEP, FXBVIT,
      H                FXBACC ,IPARTL,NPARTL, IACCP , NACCP ,
      I                IPART ,LIPART1    ,8      ,
-     J                12    ,MONVOL ,VOLMON,FR_MV  ,TEMP,INOD_PXFEM,
+     J                MONVOL ,VOLMON,FR_MV  ,TEMP,INOD_PXFEM,
      K                FTHREAC,NODREAC,GRESAV  ,GAUGE  ,
-     L                IGAUP,NGAUP,ITFORM,WEIGHT_MD,SIZE_MES,
+     L                IGAUP,NGAUP,ITFORM,SIZE_MES,
      M                RTHBUF ,THKE ,STACK,ISPHIO  ,VSPHIO,
      N                ITHFLAG,PINCH_DATA,MULTI_FVM,W,OUTPUT%TH%SITHBUF,
-     Q                FSAVSURF,NSEG_LOADP)
+     Q                FSAVSURF,NSEG_LOADP,NEED_TO_REINIT_FSAV)
 
         IF(SIZE_MES==1 .AND.
      *     ITFORM==3   .AND.
@@ -1926,11 +1928,11 @@ C  FSAV(26) : contact elastic energy is not cumulated : only for int10 and int18
           ENDDO
       ENDIF
 
-       IF(NINTSUB > 0)THEN
+      IF(NINTSUB > 0)THEN
          DO N=1,NINTSUB
            FSAV(29,(NINTER+NRWALL+NRBODY+NSECT+NJOINT+NVOLU+NRBAG)+N) = ZERO
          END DO
-       ENDIF
+      ENDIF
 
 C Pressure/Area for /TH/SURF is reset to zero (not cumulated)
       IF(NSURF >0 ) THEN
@@ -1938,7 +1940,34 @@ C Pressure/Area for /TH/SURF is reset to zero (not cumulated)
           FSAVSURF(4:5,N) = ZERO
           NSEG_LOADP(N) = 0
         ENDDO
-       ENDIF 
+      ENDIF 
+      
+      ! -----------------------
+      ! need to re-initialize PARTSAV array after any th/abf file writting
+      IF(ISPMD==0) THEN
+        ! ---------
+        ! check if an abf file was written
+        IF(NABFILE/=0) THEN
+            DO I=1,10
+                IF(TT>TABFWR0(I)) NEED_TO_REINIT_FSAV = .TRUE.
+            ENDDO
+        ENDIF
+        ! ---------
+    
+        ! ---------
+        ! re-initialization of PARTSAV
+        IF(NEED_TO_REINIT_FSAV) THEN
+            DO M=1,NPART+NTHPART
+                DO I=1,NPSAV
+                    IF((I<23.OR.I>26.OR.I==25).AND.I/=8) THEN
+                        PARTSAV(I,M)=0
+                    ENDIF
+                END DO
+            END DO
+        ENDIF
+        ! ---------
+      ENDIF
+      ! -----------------------
 
       IF (ISPMD==0.AND.IFLAG==1) TFEXT  = TFEXT- TFEXTH
 C-----------

--- a/engine/source/output/th/hist2.F
+++ b/engine/source/output/th/hist2.F
@@ -71,24 +71,24 @@ Chd|====================================================================
       SUBROUTINE HIST2(PM      ,D         ,X        ,V        ,A         ,
      2                 IXS     ,BUFEL     ,WA       ,IPARG    ,SENSOR_TAB,
      4                 FSAV    ,FLSW      ,SKEW     ,ELBUF_TAB,CLUSTER   ,
-     5                 PARTSAV ,ACCELM    ,LOUT     ,NSENSOR  ,MATPARAM_TAB, 
-     6                 IPARI   ,WEIGHT    ,IPART    ,IGRSURF  ,
+     5                 PARTSAV ,ACCELM    ,NSENSOR  ,MATPARAM_TAB, 
+     6                 WEIGHT    ,IPART    ,IGRSURF  ,
      7                 ITHGRP  ,ITHBUF    ,SUBSET   ,GEO      ,
      8                 KXX     ,IXR       ,
      9                 KXSP    ,NOD2SP    ,SPBUF    ,
-     B                 NPARTSAV,AR        ,VR       ,DR       ,
-     D                 FSAVD   ,LRIVET    ,RIVET    ,IXP      ,
+     B                 AR        ,VR       ,DR       ,
+     D                 LRIVET    ,RIVET    ,IXP      ,
      E                 ISKWN   ,IFRAME    ,XFRAME   ,IXC      ,IXQ       ,
      F                 DTHIS0  ,THIS0     ,IFIL     ,NTHGRP2  ,IXTG      ,
      G                 IGEO    ,IPM       ,FXBIPM   ,FXBDEP   ,FXBVIT    ,
      H                 FXBACC  ,IPARTL    ,NPARTL   ,IACCP    ,NACCP     ,
      I                 IPARTH  ,NPARTH    ,NVPARTH  ,
-     J                 NVSUBTH ,MONVOL    ,VOLMON   ,FR_MV    ,TEMP,INOD ,
+     J                 MONVOL    ,VOLMON   ,FR_MV    ,TEMP,INOD ,
      K                 FTHREAC ,NODREAC   ,GRESAV   ,GAUGE    ,
-     L                 IGAUP   ,NGAUP     ,ITTYP    ,WEIGHT_MD,SIZE_MES  ,
+     L                 IGAUP   ,NGAUP     ,ITTYP    ,SIZE_MES  ,
      M                 RTHBUF  ,THKE      ,STACK    ,ISPHIO   ,VSPHIO    ,
      N                 ITHFLAG ,PINCH_DATA,MULTI_FVM,W        ,SITHBUF   ,
-     Q                 FSAVSURF,NSEG_LOADP)
+     Q                 FSAVSURF,NSEG_LOADP,NEED_TO_REINIT_FSAV)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -133,25 +133,23 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER,INTENT(IN) :: SITHBUF,NSENSOR
-      INTEGER MBUFFER, NPARTL
-      LOGICAL LOUT
+      INTEGER NPARTL
       INTEGER IXS(NIXS,NUMELS),IPARG(NPARG,NGROUP),
-     .   NPARTSAV,
-     .   IPARI(NPARI,NINTER),IGEO(NPROPGI,NUMGEO),
+     .   IGEO(NPROPGI,NUMGEO),
      .   WEIGHT(NUMNOD),IPART(LIPART1,*),
      .   ITHGRP(NITHGR,*),ITHBUF(*),
      .   IXR(NIXR,*),KXSP(NISP,*),NOD2SP(*),LRIVET(4,*),IPM(NPROPMI,NUMMAT),
      .   ISKWN(LISKN,*),IFRAME(LISKN,*),IXC(NIXC,NUMELC),IXQ(NIXQ,NUMELQ),
      .   IXTG(NIXTG,*),IFIL,NTHGRP2,FXBIPM(*),IPARTL(*),IACCP(*),
      .   NACCP(*),NPARTH,IPARTH(NPARTH,*),NVPARTH,
-     .   NVSUBTH, MONVOL(*), FR_MV(*),INOD(*),
+     .   MONVOL(*), FR_MV(*),INOD(*),
      .   NODREAC(*),KXX(NIXX,*),IGAUP(*),NGAUP(*),ITTYP,
-     .   WEIGHT_MD(NUMNOD),SIZE_MES,ISPHIO(NISPHIO,*),ITHFLAG
+     .   SIZE_MES,ISPHIO(NISPHIO,*),ITHFLAG
       my_real
      .   PM(NPROPM,NUMMAT), D(3,NUMNOD), X(3,NUMNOD), V(3,NUMNOD), A(3,NUMNOD), BUFEL(*), WA(*),
      .   FSAV(NTHVKI,*), FLSW(9,*), SKEW(LSKEW,*), PARTSAV(NPSAV,*),
      .   ACCELM(LLACCELM,*), GEO(NPROPG,*),SPBUF(*),XFRAME(NXFRAME,*),
-     .   AR(3,NUMNOD),VR(3,NUMNOD),DR(3,NUMNOD),FSAVD(NTHVKI,*),
+     .   AR(3,NUMNOD),VR(3,NUMNOD),DR(3,NUMNOD),
      .   RIVET(NRIVF,*), THKE(*),
      .   RIVOFF(NRIVET), FXBDEP(*), FXBVIT(*), FXBACC(*), VOLMON(*),
      .   TEMP(*),FTHREAC(*),GRESAV(NPSAV,*), GAUGE(LLGAUGE,NBGAUGE),RTHBUF(*),
@@ -169,23 +167,23 @@ C-----------------------------------------------
       TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(IN) :: MATPARAM_TAB
       my_real, INTENT(INOUT) :: FSAVSURF(5,NSURF)
       INTEGER, INTENT(INOUT) :: NSEG_LOADP(NSURF)
+      LOGICAL, INTENT(INOUT) :: NEED_TO_REINIT_FSAV !< boolean to re-initialize PARTSAV array 
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       LOGICAL ICOND,RIVET_BOOL
       
-      INTEGER I,J,K,L,M,N,II,JJ,IP,NP,NN,NG,ITY,NEL,NFT,N1,N2,NPT,NRWA,
-     .        JALE,FSAVMAX,PROC,NVAR,IAD,ITYP,IADV,FIRST,KRBHOL,ISKN,NNOD, ID_HIST, SEEK_ID,
-     .        MY_SIZE,IMID,IPID,JALE_FROM_MAT,JALE_FROM_PROP
+      INTEGER I,J,K,L,M,N,II,JJ,NP,NN,N1,NRWA,
+     .        JALE,FSAVMAX,NVAR,IAD,ITYP,IADV,KRBHOL,ID_HIST, SEEK_ID,
+     .        IMID,IPID,JALE_FROM_MAT,JALE_FROM_PROP
 
-      my_real XFN,SUBSAV(100),XX,YY,ZZ,XY,YZ,ZX,DET,XXMOM,YYMOM,ZZMOM,NORM, 
+      my_real XX,YY,ZZ,DET,XXMOM,YYMOM,ZZMOM, 
      .        XCG, YCG, ZCG, IXX, IYY, IZZ,IXY, IYZ, IZX,                   
-     .        JXX, JYY, JZZ, JXY, JYZ, JZX, AA, THISC,XM,YM,ZM,             
+     .        JXX, JYY, JZZ, JXY, JYZ, JZX, AA, THISC,          
      .        FSAVINT(NTHVKI,NINTER+NINTSUB),FSAVVENT(5,NVENTTOT),          
-     .        VX(3),VY(3),VN(3),X1(3),X2(3),X3(3),FLOC(3),MLOC(3),FAC ,     
-     .        ARRAY(5)                                    
-      DATA FIRST/0/
-      SAVE FIRST
+     .        FAC,ARRAY(5)                            
+      my_real, DIMENSION(100) :: SUBSAV  
+      my_real, DIMENSION(1) :: WA_LOCAL      
       REAL(KIND=8) :: THIS0_DOUBLE,TT_DOUBLE
       REAL(KIND=8) :: DTHIS0_DOUBLE,DT1_DOUBLE,THISC_DOUBLE
 C=======================================================================
@@ -213,6 +211,7 @@ C--------Multidomains : control of time history for subdomains-----------
       ENDIF      
 C-----------------------------------------------------------------------    
       IF (TT>=THISC) THEN
+        NEED_TO_REINIT_FSAV = .TRUE.
 C---------------------------
         IF (IDDOM == 0) R2R_TH_MAIN(SEEK_ID) = 1
         R2R_TH_FLAG(SEEK_ID) = 1          
@@ -250,8 +249,9 @@ C--------Multidomains : offset for th file------------------------------
               CALL FSEEK_C(SEEKC(SEEK_ID))          
             ENDIF
           ENDIF
-C-----------------------------------------------------------------------                  
-          CALL WRTDES(TT,TT,1,ITTYP,1)
+C-----------------------------------------------------------------------              
+          WA_LOCAL(1) = TT    
+          CALL WRTDES(WA_LOCAL,WA_LOCAL,1,ITTYP,1)
 C------------------------
 C         VARIABLES GLOBALES
 C------------------------
@@ -271,15 +271,6 @@ C------------------------
           WA(II+13)= ECONT+ECONT_CUMU !Contact Elastic Energy
           WA(II+14)= ECONTV ! Contact Frictional Energy
           WA(II+15)= ECONTD ! Damping Frictional Energy
-
-!   Version 2018 not released 
-c          WA(II+13)=EAMS
-c          WA(II+14)= ARRAY(1)
-c          WA(II+15)= ARRAY(2)
-c          WA(II+16)= ARRAY(3)
-c          WA(II+17)= ARRAY(4)
-c          WA(II+18)= ARRAY(5)
-
 C         NGLOBTH depends on /TH/VERS
           IF(IUNIT==IUHIS) CALL WRTDES(WA,WA,NGLOBTH,ITTYP,1)
         ENDIF  ! ISPMD==0
@@ -425,12 +416,8 @@ C-----------------------------
        IF(NSUBS>0.AND.ISPMD==0) THEN
          II=0
          DO I=1,NSUBS
-!!           NVAR=ISUBTH(NVSUBTH,I)
-!!           IAD =ISUBTH(NVSUBTH+1,I)
            NVAR=SUBSET(I)%NVARTH(ITHFLAG)
            IAD =SUBSET(I)%THIAD
-!!           NP  =ISUBS(8,I)
-!!           IP  =ISUBS(9,I)
            NP = SUBSET(I)%NTPART
            IF(NVAR>0)THEN
              DO K=1,NPSAV


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
If th and (x)th [x=a,b,c,...] frequencies are different, a issue appeared on the output : the energy was not right

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
To fix the issue, PARTSAV array must be re-initialized to zero after a (x)th/th file writting
Warnings were also removed from hist2.F routine (-Wmaybe-uninitialized warnings are still present but there are false-positive)
Hist2.F routine can now be compiled with the more restrictive compiler flags

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
