### PR TITLE
Correct wrong array index in /ANIM/SHELL/TENS/MSTRESS output definition

### DIFF
--- a/engine/source/output/anim/reader/anim_dcod_key_0.F
+++ b/engine/source/output/anim/reader/anim_dcod_key_0.F
@@ -337,9 +337,9 @@ c---
             ELSE    
               ! /TESNSOR/MSTRESS/ILAY
               READ(KEY5(1:5),'(I5)') ILAY
-              IDX = 3120 + 3*MX_PLY_ANIM + 3
               IF (ILAY > 0 .AND. ILAY <= 100) THEN
-                ANIM_STRESS(IDX+ILAY) = 1
+                ANIM_CT(IDX+ILAY) = 1
+                ANIM_STRESS(ILAY) = 1
               ELSE
                 IXITKEY=IXITKEY+1
               ENDIF


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

avoid problems in ANIM output using /ANIM/SHELL/TENS/MSTRESS option

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Corrected wrong index in ANIM arrays containing output flag and adress to output value

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
