### PR TITLE
/TH/SURF:check blank IDs

### DIFF
--- a/engine/source/output/th/thsurf.F
+++ b/engine/source/output/th/thsurf.F
@@ -27,7 +27,7 @@ Chd|        HIST2                         source/output/th/hist2.F
 Chd|-- calls ---------------
 Chd|        WRTDES                        source/output/th/wrtdes.F     
 Chd|====================================================================
-      SUBROUTINE THSURF(J1  ,J2  ,L1   ,L2   ,ITHBUF,
+      SUBROUTINE THSURF(J1  ,J2        ,L1    ,L2   ,ITHBUF,
      .                  WA  ,FSAVSURF  ,IFORM )
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
@@ -40,16 +40,18 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER J1,J2,L1,L2
-      INTEGER ITHBUF(*),IFORM
-      my_real
-     .        WA(*),FSAVSURF(5,*)
+      INTEGER,INTENT(IN) :: J1,J2,L1,L2
+      INTEGER,INTENT(IN) :: ITHBUF(*),IFORM
+      my_real, INTENT(INOUT) :: WA(*)
+      my_real, INTENT(IN) :: FSAVSURF(5,*)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,J,K,L,II
-C------------------------------------
-C GATHER DEJA EFFECTUE, SEUL P0 ECRIT 
+C-----------------------------------------------
+C   S o u r c e   L i n e s
+C-----------------------------------------------
+C GATHERING DONE. PROC/ISPMD==0 IS WRITING 
 C------------------------------------
       IF (ISPMD == 0) THEN
         II = 0
@@ -63,11 +65,13 @@ C
         II = 0
         DO J=J1,J2
              I=ITHBUF(J)
-             DO L=L1,L2
-                K=ITHBUF(L) 
-                II=II+1
-                WA(II)=FSAVSURF(K,I)
-             ENDDO
+             IF(I > 0)THEN
+               DO L=L1,L2
+                  K=ITHBUF(L) 
+                  II=II+1
+                  WA(II)=FSAVSURF(K,I)
+               ENDDO
+             ENDIF
         ENDDO
         IF(II>0)CALL WRTDES(WA,WA,II,IFORM,1)
       ENDIF

--- a/starter/source/output/th/hm_read_thgrou.F
+++ b/starter/source/output/th/hm_read_thgrou.F
@@ -52,21 +52,21 @@ Chd|        SENSOR_MOD                    share/modules1/sensor_mod.F
 Chd|        SUBMODEL_MOD                  share/modules1/submodel_mod.F 
 Chd|====================================================================
       SUBROUTINE HM_READ_THGROU(
-     1      ITHGRP,ITHBUF,ITAB   ,ITABM1 ,IXTG  ,
-     2      IXS   ,IXQ   ,IXC    ,IXT   ,IXP   ,IXR   ,
-     3      KXX   ,IXX   ,IPART  ,IFI   ,
-     4      NTHWA ,KXSP  ,IXRI  ,ISKWN ,IFRAME ,
-     5      NTHGRP2 ,PATHID ,SUTHID ,FXBIPM ,IPARTH ,NPARTH ,
-     6      NVPARTH ,NVSUBTH,IMERGE ,ITHVAR ,
-     7      FLAGABF,NVARABF ,NOM_OPT,PTR_NOPT_FXBY,PTR_NOPT_INTER,
-     8      PTR_NOPT_RWALL,PTR_NOPT_SECT,PTR_NOPT_JOINT,
-     9      PTR_NOPT_MONV,PTR_NOPT_ACC,PTR_NOPT_SKW,PTR_NOPT_GAU,
-     A      PTR_NOPT_CLUS,PTR_NOPT_SPHIO,ISPHIO,RFI,T_MONVOL,
-     B      IGRSURF ,SUBSET ,ITHFLAG,NPBY,LSUBMODEL,IPARG,
-     C      IPARTS  ,IPARTQ ,IPARTC ,IPARTT  ,IPARTP  ,IPARTR ,
-     D      IPARTG  ,IPARTX ,IPARTSP ,IPARTIG3D, LITHBUFMX,
-     E      MAP_TABLES, IFLAG,PTR_NOPT_SLIPRING,PTR_NOPT_RETRACTOR,SENSORS,
-     F      INTERFACES,IPARI)
+     1      ITHGRP        ,ITHBUF        ,ITAB             ,ITABM1            ,IXTG          ,
+     2      IXS           ,IXQ           ,IXC              ,IXT               ,IXP           ,
+     3      IXR           ,KXX           ,IXX              ,IPART             ,IFI           ,
+     4      NTHWA         ,KXSP          ,IXRI             ,ISKWN             ,IFRAME        ,
+     5      NTHGRP2       ,PATHID        ,SUTHID           ,FXBIPM            ,IPARTH        ,
+     6      NPARTH        ,NVPARTH       ,NVSUBTH          ,IMERGE            ,ITHVAR        ,
+     7      FLAGABF       ,NVARABF       ,NOM_OPT          ,PTR_NOPT_FXBY     ,PTR_NOPT_INTER,
+     8      PTR_NOPT_RWALL,PTR_NOPT_SECT ,PTR_NOPT_JOINT   ,
+     9      PTR_NOPT_MONV ,PTR_NOPT_ACC  ,PTR_NOPT_SKW     ,PTR_NOPT_GAU,
+     A      PTR_NOPT_CLUS ,PTR_NOPT_SPHIO,ISPHIO           ,RFI               ,T_MONVOL      ,
+     B      IGRSURF       ,SUBSET        ,ITHFLAG          ,NPBY              ,LSUBMODEL     ,IPARG,
+     C      IPARTS        ,IPARTQ        ,IPARTC           ,IPARTT            ,IPARTP        ,IPARTR ,
+     D      IPARTG        ,IPARTX        ,IPARTSP          ,IPARTIG3D         ,LITHBUFMX     ,
+     E      MAP_TABLES    ,IFLAG         ,PTR_NOPT_SLIPRING,PTR_NOPT_RETRACTOR,SENSORS       ,
+     F      INTERFACES    ,IPARI)
 C-----------------------------------------------
       USE MESSAGE_MOD
       USE GROUPDEF_MOD
@@ -96,13 +96,13 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER,INTENT(IN) :: LITHBUFMX
-      INTEGER ITAB(*),ITABM1(*), IFLAG,
-     .        IXS(NIXS,*),IXQ(NIXQ,*),IXC(NIXC,*),IXT(NIXT,*),
-     .        IXP(NIXP,*),IXR(NIXR,*),IXTG(NIXTG,*),KXX(NIXX,*),
+      INTEGER ITAB(NUMNOD),ITABM1(*), IFLAG,
+     .        IXS(NIXS,NUMELS),IXQ(NIXQ,NUMELQ),IXC(NIXC,NUMELC),IXT(NIXT,NUMELT),
+     .        IXP(NIXP,NUMELP),IXR(NIXR,NUMELR),IXTG(NIXTG,NUMELTG),KXX(NIXX,*),
      .        IXX(*),IPART(LIPART1,*),ITHGRP(NITHGR,*),ITHBUF(LITHBUFMX),
      .        IMERGE(*),
      .        IFI,NTHWA,KXSP(NISP,*),IXRI(4,*),
-     .        IFRAME(LISKN,*), NTHGRP2,PATHID(*),SUTHID(*),
+     .        IFRAME(LISKN,NUMFRAM+1), NTHGRP2,PATHID(*),SUTHID(*),
      .        FXBIPM(NBIPM,*),ISKWN(LISKN,*),
      .        NPARTH,IPARTH(NPARTH,*),NVPARTH,ITYP,
      .        NVSUBTH,ITHVAR(*),FLAGABF,NVARABF,
@@ -134,7 +134,6 @@ C-----------------------------------------------
      .        NVALL,TAGP,TAGS,IFIX_TMP,IBID,NIN
       CHARACTER TITR*nchartitle,MESS*40,KEY*ncharline,COPT*ncharline,
      .        TITR1*nchartitle
-C
       INTEGER NVARN,NVARS,NVARC,NVART,NVARP,NVARR,NVARUR
       INTEGER NVARNS,NVARSPH
       INTEGER NVARIN,NVARRW,NVARRB,NVARAC,NVARSE,NVARJO,NVARFX,NVARFXM
@@ -555,6 +554,7 @@ C
      .'IE_MAT2 ','DEN_MAT2','VOL_MAT2','PLA_MAT2','TEM_MAT2'/
 C Definition of VARS6 : strain for /PROP/TYPE22
 C=======================================================================
+      
       DO J=1,200
         IF (J <= 9) THEN
           WRITE(CHJ,'(I1.1)')J
@@ -1653,6 +1653,7 @@ C=======================================================================
       TAGS=0
       IBID = 0
       BID = 0
+      NSNE = 0
 C-----------------------------------------------
 C  Brick
 C ------------------------------------------

--- a/starter/source/output/th/hm_read_thgrsurf.F
+++ b/starter/source/output/th/hm_read_thgrsurf.F
@@ -39,17 +39,21 @@ Chd|        MESSAGE_MOD                   share/message_module/message_mod.F
 Chd|        SUBMODEL_MOD                  share/modules1/submodel_mod.F 
 Chd|====================================================================
       SUBROUTINE HM_READ_THGRSURF(
-     1      ITYP  ,KEY    ,
-     3      IAD   ,IFI    ,ITHGRP,ITHBUF ,
-     4      NV    ,VARE  ,NUM    ,VARG  ,NVG    ,
-     5      IVARG ,NSNE,NV0,ITHVAR,FLAGABF,NVARABF,
-     6      IGRSURF,IGS,LSUBMODEL)
+     1      ITYP   ,KEY    ,
+     3      IAD    ,IFI    ,ITHGRP   ,ITHBUF ,
+     4      NV     ,VARE   ,NUM      ,VARG   ,NVG     ,
+     5      IVARG  ,NSNE   ,NV0      ,ITHVAR ,FLAGABF ,NVARABF,
+     6      IGRSURF,IGS    ,LSUBMODEL)
+C-----------------------------------------------
+C   D e s c r i p t i o n
+C-----------------------------------------------
+C Starter Reader for option /TH/SURF
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
-      USE GROUPDEF_MOD
-      USE MESSAGE_MOD
-      USE SUBMODEL_MOD
+      USE GROUPDEF_MOD , only : SURF_
+      USE MESSAGE_MOD , only : ANCMSG, aninfo_blind_1, MSGERROR
+      USE SUBMODEL_MOD , only : SUBMODEL_DATA
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -67,20 +71,19 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER ITYP,
-     .        ITHGRP(NITHGR),ITHBUF(*),
-     .        IFI,IAD,NV,NUM,NVG,NSNE  ,IVARG(18,*),
-     .        NV0,ITHVAR(*),FLAGABF,NVARABF,IGS
-      CHARACTER*10 VARE(NV),KEY,VARG(NVG)
-      TYPE (SURF_)   , DIMENSION(NSURF)   :: IGRSURF
-      TYPE(SUBMODEL_DATA) LSUBMODEL(NSUBMOD)
+      INTEGER,INTENT(IN) :: ITYP,NV,NUM,NVG,IVARG(18,*),NV0,FLAGABF
+      INTEGER,INTENT(INOUT) :: ITHGRP(NITHGR), IGS, IFI, IAD, NSNE, NVARABF, ITHVAR(*), ITHBUF(*)
+      CHARACTER*10,INTENT(IN) :: VARE(NV),KEY,VARG(NVG)
+      TYPE (SURF_),INTENT(INOUT), DIMENSION(NSURF)   :: IGRSURF
+      TYPE(SUBMODEL_DATA),INTENT(IN) :: LSUBMODEL(NSUBMOD)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER J,JJ, I,ISU,ID,NNE,NOSYS,NTOT,KK,IER,
      .        OK,IGRS,NSU,K,L,JREC,CONT,IAD0,IADV,NTRI,
      .        IFITMP,IADFIN,NVAR,M,N,IAD1,IAD2,ISK,IPROC,ITITLE(LTITR),
-     .        IDS,IDSMAX,AIRBAG_OUTPUT
+     .        IDS,IDSMAX,AIRBAG_OUTPUT,
+     .        NUM_FOUND
       CHARACTER TITR*nchartitle,MESS*40
       LOGICAL IS_AVAILABLE
 C-----------------------------------------------
@@ -90,8 +93,7 @@ C-----------------------------------------------
       INTEGER R2R_LISTCNT,R2R_EXIST
       DATA MESS/'TH GROUP DEFINITION                     '/
 C-----------------------------------------------
-C
-C
+C   S o u r c e   L i n e s
 C-----------------------------------------------
       ID=ITHGRP(1)
       CALL FRETITL2(TITR,ITHGRP(NITHGR-LTITR+1),LTITR)
@@ -105,12 +107,9 @@ C-----------------------------------------------
       IF (NVAR>0) NVAR = HM_THVARC(VARE,NV,ITHBUF(IAD),VARG,NVG,IVARG,NV0,ID,TITR ,LSUBMODEL)                       
 
       IF(NVAR == 0) THEN
-        IF(ITYP /= 116)
-     .    CALL ANCMSG(MSGID=1109,
-     .      MSGTYPE=MSGERROR,
-     .      ANMODE=ANINFO_BLIND_1,
-     .      I1=ID,
-     .      C1=TITR )
+        IF(ITYP /= 116)THEN
+         CALL ANCMSG(MSGID=1109,MSGTYPE=MSGERROR,ANMODE=ANINFO_BLIND_1,I1=ID,C1=TITR )
+        ENDIF
         IGS = IGS - 1
         ITHGRP(1:NITHGR)=0
       ELSE
@@ -130,55 +129,51 @@ C-----------------------------------------------
         AIRBAG_OUTPUT = 0
         DO JJ = ITHGRP(7),ITHGRP(5)
             IF(ITHBUF(JJ) ==2.OR.ITHBUF(JJ) ==3) AIRBAG_OUTPUT = 1
-         ENDDO
+        ENDDO
       
 C
-          DO K = 1,IDSMAX
-            CALL HM_GET_INT_ARRAY_INDEX('ids',IDS,K,IS_AVAILABLE,LSUBMODEL) 
-
-            IF(IDS/=0)THEN
-              IF (NSUBDOM>0) THEN
-C----------->Multidomaines - on saute si l'entite n'existe plus--------	
-	       IF(R2R_EXIST(ITYP,IDS)==0) GOTO 150
-	      ENDIF
-C----------------------------------------------------------------------		  
-              N=0
-              DO J=1,NUM
-                IF(IDS == IGRSURF(J)%ID)THEN
-                   N=J
-                   IGRSURF(J)%TH_SURF=1          
-                   IF(AIRBAG_OUTPUT > 0) IGRSURF(J)%TH_SURF=2
-                ENDIF
-              ENDDO
-              IF(N==0)THEN
-                 CALL FRETITL2(TITR,ITHGRP(NITHGR-LTITR+1),LTITR)
-                 CALL ANCMSG(MSGID=257,
-     .                       MSGTYPE=MSGERROR,
-     .                       ANMODE=ANINFO_BLIND_1,
-     .                       I1=ITHGRP(1),
-     .                       C1=TITR,
-     .                       C2=KEY,
-     .                       I2=IDS)
-              ENDIF 
-              NSNE=NSNE+1
-              ITHBUF(IAD)=N
-              IAD=IAD+1
-            ENDIF
-150	    CONTINUE
-          ENDDO
+        NUM_FOUND=0
+        DO K = 1,IDSMAX
+          CALL HM_GET_INT_ARRAY_INDEX('ids',IDS,K,IS_AVAILABLE,LSUBMODEL) 
+          N=0
+          IF(IDS/=0)THEN
+            IF (NSUBDOM>0) THEN
+              ! Multidomain : skip if entity does not exist---------------	
+              IF(R2R_EXIST(ITYP,IDS)==0) CYCLE !next K
+	    ENDIF		  
+            DO J=1,NUM
+              IF(IDS == IGRSURF(J)%ID)THEN
+                 N=J
+                 IGRSURF(J)%TH_SURF=1          
+                 IF(AIRBAG_OUTPUT > 0) IGRSURF(J)%TH_SURF=2
+                 NUM_FOUND=NUM_FOUND+1
+                 EXIT
+              ENDIF
+            ENDDO
+            NSNE=NSNE+1
+            ITHBUF(IAD)=N
+            IAD=IAD+1
+          ENDIF
+          IF(N == 0)THEN
+            CALL FRETITL2(TITR,ITHGRP(NITHGR-LTITR+1),LTITR)
+            CALL ANCMSG(MSGID=257, MSGTYPE=MSGERROR, ANMODE=ANINFO_BLIND_1, I1=ITHGRP(1), I2=IDS, C1=TITR, C2=KEY)
+          ENDIF             
+        ENDDO !next K
 C
         IAD = ITHGRP(5)
-        CALL HORD(ITHBUF(IAD),NNE)
+        CALL HORD(ITHBUF(IAD),NUM_FOUND)
 C
         DO I=1,NNE
           N=ITHBUF(IAD)
-          ITHBUF(IAD+2*NNE)=IGRSURF(N)%ID
-          DO J=1,40
-            CALL FRETITL(IGRSURF(N)%TITLE,ITITLE,LTITR)
-            ITHBUF(IAD2+J-1)=ITITLE(J)
-          ENDDO
-          IAD=IAD+1
-          IAD2=IAD2+40
+          IF(N > 0)THEN
+            ITHBUF(IAD+2*NNE)=IGRSURF(N)%ID
+            DO J=1,40
+              CALL FRETITL(IGRSURF(N)%TITLE,ITITLE,LTITR)
+              ITHBUF(IAD2+J-1)=ITITLE(J)
+            ENDDO
+            IAD=IAD+1
+            IAD2=IAD2+40
+          ENDIF
         ENDDO
 C
         IAD=IAD2


### PR DESCRIPTION
#### /TH/SURF:check blank IDs

#### Description of the changes
Starter is now checking user IDs to prevent from blank IDs.
This will ensure correct writing in TH file during Engine execution.
An error message, id=257, has already been displayed if ID does not exist. Now same message is displayed if ID is left blank (For Reader, blank means '0')