### PR TITLE
Compatibility with gfortran 12

### DIFF
--- a/engine/CMake_Compilers/legacy_fortran.cmake
+++ b/engine/CMake_Compilers/legacy_fortran.cmake
@@ -60,7 +60,7 @@ set_source_files_properties( ${source_directory}/source/input/read5p.F PROPERTIE
 # set_source_files_properties( ${source_directory}/source/input/fredamp.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 # set_source_files_properties( ${source_directory}/source/input/frerbo.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 # set_source_files_properties( ${source_directory}/source/input/rdele.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
-# set_source_files_properties( ${source_directory}/source/input/freform.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
+set_source_files_properties( ${source_directory}/source/input/freform.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 # set_source_files_properties( ${source_directory}/source/input/lecdamp.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 # set_source_files_properties( ${source_directory}/source/input/frefxinp.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/input/redkey1_h3d.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )

--- a/engine/source/input/lecstat.F
+++ b/engine/source/input/lecstat.F
@@ -82,7 +82,7 @@ C-----------------------------------------------
           ! for /INISHE/FAIL, fail_ID in /FAIL card is mandatory
           ! check if fail_ID is defined in failure model
           !-------------
-          IF ( IP > 0 .and. STAT_C(8) == 1) THEN
+          IF ( STAT_C(8) == 1) THEN
 !---
             DO NG=1,NGROUP
               ITY = IPARG(5,NG)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Recently added strict compilation flags, were made even more strict with gfortran 12
(tested with gcc 12.1.0)