### PR TITLE
Add history effect in recently implemented composites failure criteria

### DIFF
--- a/engine/source/materials/fail/hoffman/fail_hoffman_c.F
+++ b/engine/source/materials/fail/hoffman/fail_hoffman_c.F
@@ -145,7 +145,7 @@ c
 c
           ! Damage variable update
           FINDEX = MAX(ZERO,FINDEX)
-          DFMAX(I) = MIN(ONE ,FINDEX)
+          DFMAX(I) = MIN(ONE ,MAX(FINDEX,DFMAX(I)))
           IF (DFMAX(I) >= ONE) THEN
             NINDX = NINDX+1                                    
             INDX(NINDX) = I                                    

--- a/engine/source/materials/fail/hoffman/fail_hoffman_s.F
+++ b/engine/source/materials/fail/hoffman/fail_hoffman_s.F
@@ -144,7 +144,7 @@ c
 c
           ! Damage variable update
           FINDEX   = MAX(ZERO,FINDEX)
-          DFMAX(I) = MIN(ONE ,FINDEX) 
+          DFMAX(I) = MIN(ONE ,MAX(FINDEX,DFMAX(I))) 
           IF (DFMAX(I) >= ONE) THEN
             NINDX = NINDX+1                                    
             INDX(NINDX) = I                                    

--- a/engine/source/materials/fail/max_strain/fail_maxstrain_c.F
+++ b/engine/source/materials/fail/max_strain/fail_maxstrain_c.F
@@ -138,7 +138,7 @@ c
 c
           ! Damage variable update
           FINDEX   = MAX(ZERO,FINDEX)
-          DFMAX(I) = MIN(ONE ,FINDEX)
+          DFMAX(I) = MIN(ONE ,MAX(FINDEX,DFMAX(I)))
           IF (DFMAX(I) >= ONE) THEN
             NINDX = NINDX+1                                    
             INDX(NINDX) = I                                    

--- a/engine/source/materials/fail/max_strain/fail_maxstrain_s.F
+++ b/engine/source/materials/fail/max_strain/fail_maxstrain_s.F
@@ -138,7 +138,7 @@ c
 c
           ! Damage variable update
           FINDEX   = MAX(ZERO,FINDEX)
-          DFMAX(I) = MIN(ONE ,FINDEX) 
+          DFMAX(I) = MIN(ONE ,MAX(FINDEX,DFMAX(I))) 
           IF (DFMAX(I) >= ONE) THEN
             NINDX = NINDX+1                                    
             INDX(NINDX) = I                                    

--- a/engine/source/materials/fail/tsaihill/fail_tsaihill_c.F
+++ b/engine/source/materials/fail/tsaihill/fail_tsaihill_c.F
@@ -138,7 +138,7 @@ c
 c
           ! Damage variable update
           FINDEX   = MAX(ZERO,FINDEX)
-          DFMAX(I) = MIN(ONE ,FINDEX)
+          DFMAX(I) = MIN(ONE ,MAX(FINDEX,DFMAX(I)))
           IF (DFMAX(I) >= ONE) THEN
             NINDX = NINDX+1                                    
             INDX(NINDX) = I                                    

--- a/engine/source/materials/fail/tsaihill/fail_tsaihill_s.F
+++ b/engine/source/materials/fail/tsaihill/fail_tsaihill_s.F
@@ -137,7 +137,7 @@ c
 c
           ! Damage variable update
           FINDEX   = MAX(ZERO,FINDEX)
-          DFMAX(I) = MIN(ONE ,FINDEX) 
+          DFMAX(I) = MIN(ONE ,MAX(FINDEX,DFMAX(I))) 
           IF (DFMAX(I) >= ONE) THEN
             NINDX = NINDX+1                                    
             INDX(NINDX) = I                                    

--- a/engine/source/materials/fail/tsaiwu/fail_tsaiwu_c.F
+++ b/engine/source/materials/fail/tsaiwu/fail_tsaiwu_c.F
@@ -145,7 +145,7 @@ c
 c
           ! Damage variable update
           FINDEX   = MAX(ZERO,FINDEX)
-          DFMAX(I) = MIN(ONE ,FINDEX)
+          DFMAX(I) = MIN(ONE ,MAX(FINDEX,DFMAX(I)))
           IF (DFMAX(I) >= ONE) THEN
             NINDX = NINDX+1                                    
             INDX(NINDX) = I                                    

--- a/engine/source/materials/fail/tsaiwu/fail_tsaiwu_s.F
+++ b/engine/source/materials/fail/tsaiwu/fail_tsaiwu_s.F
@@ -144,7 +144,7 @@ c
 c
           ! Damage variable update
           FINDEX   = MAX(ZERO,FINDEX)
-          DFMAX(I) = MIN(ONE ,FINDEX) 
+          DFMAX(I) = MIN(ONE ,MAX(FINDEX,DFMAX(I))) 
           IF (DFMAX(I) >= ONE) THEN
             NINDX = NINDX+1                                    
             INDX(NINDX) = I                                    


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

History effect was not taken into account into recently implemented composite failure models. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Add the history effect my maximizing the damage variable accounting for its previous value. It does not affect the current results at all. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
