### PR TITLE
Change element deletion code for /MAT/LAW79 to avoid checkbound issue

### DIFF
--- a/engine/source/materials/mat/mat079/sigeps79.F
+++ b/engine/source/materials/mat/mat079/sigeps79.F
@@ -33,7 +33,7 @@ Chd|====================================================================
      4      SIGOXX   ,SIGOYY   ,SIGOZZ   ,SIGOXY   ,SIGOYZ   ,SIGOZX   ,
      5      SIGNXX   ,SIGNYY   ,SIGNZZ   ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,
      6      EPSD     ,DMG      ,SOUNDSP  ,UVAR     ,OFF      ,AMU      ,
-     7      UELR     ,LOFF     ,IPG      ,NPG      ,IDEL7NOK )      
+     7      IDEL7NOK )      
 C
 C-----------------------------------------------
 C   I M P L I C I T   T Y P E S
@@ -49,7 +49,7 @@ C----------------------------------------------------------------
 C  I N P U T   A R G U M E N T S
 C----------------------------------------------------------------
       INTEGER,INTENT(IN) :: 
-     .      NEL,NUPARAM,NUVAR,NGL(NEL),IPG,NPG
+     .      NEL,NUPARAM,NUVAR,NGL(NEL)
       INTEGER, INTENT(INOUT) :: 
      .      IDEL7NOK 
       my_real,INTENT(IN) :: 
@@ -70,12 +70,12 @@ C----------------------------------------------------------------
 C  I N P U T  O U T P U T   A R G U M E N T S
 C----------------------------------------------------------------
       my_real,INTENT(INOUT) :: 
-     .      UVAR(NEL,NUVAR),LOFF(NEL),OFF(NEL),DMG(NEL),
-     .      DEFP(NEL),UELR(NEL)
+     .      UVAR(NEL,NUVAR),OFF(NEL),DMG(NEL),
+     .      DEFP(NEL)
 C----------------------------------------------------------------
 C  L O C A L  V A R I A B L E S
 C----------------------------------------------------------------
-      INTEGER I,J,NINDX,INDX(NEL),NINDX2,INDX2(NEL),IDEL,FAILIP
+      INTEGER I,J,NINDX,INDX(NEL),IDEL
       my_real
      .   G     , G2   , AA    , BB     , MM   ,
      .   NN    , CC   , EPS0  , SIGFMAX,
@@ -112,9 +112,7 @@ C
       K3      = UPARAM(17)
       BETA    = UPARAM(18)
       IDEL    = NINT(UPARAM(19))
-      FAILIP  = NINT(UPARAM(20))
-      FAILIP  = MIN(FAILIP,NPG)
-      EPSMAX  = UPARAM(21)
+      EPSMAX  = UPARAM(20)
 c
       ! Recovering internal variables
       DO I=1,NEL
@@ -184,16 +182,17 @@ C
           CE = ONE + CC*LOG(EPSD(I)/EPS0)
         ENDIF
 C
-        SIGYI(I) = CE*SIGYI(I)
-        SIGYF(I) = MIN(CE*SIGYF(I),SIGFMAX)
-        SIGY(I)  = (ONE-DMG(I))*SIGYI(I)+DMG(I)*SIGYF(I)
+         SIGYI(I) = CE*SIGYI(I)
+         SIGYF(I) = CE*SIGYF(I)
+         SIGYF(I) = MIN(SIGYF(I),SIGFMAX)
+         SIGY(I)  = (ONE-DMG(I))*SIGYI(I)+DMG(I)*SIGYF(I)
       ENDDO
 c
       !========================================================================
       ! - RADIAL RETURN
       !========================================================================
       DO I=1,NEL
-        IF (LOFF(I) == ONE .AND. OFF(I) == ONE) THEN 
+        IF (OFF(I) == ONE) THEN 
           SIGSTAR = VM(I)/SHEL
           IF (SIGSTAR < SIGY(I)) THEN
             SCALE(I) = ONE
@@ -216,10 +215,8 @@ c
       !========================================================================
       NINDX = 0
       INDX(1:NEL) = 0
-      NINDX2 = 0
-      INDX2(1:NEL) = 0 
       DO I=1,NEL
-        IF (LOFF(I) == ONE .AND. OFF(I) == ONE) THEN 
+        IF (OFF(I) == ONE) THEN 
 c
           ! Compute plastic strain at failure
           IF (D2 == ZERO) THEN
@@ -245,42 +242,24 @@ c
           ! Check element deletion
           IF (IDEL == 1) THEN 
             IF ((PSTAR(I)+TSTAR) < ZERO) THEN 
-              LOFF(I) = ZERO
-              NINDX   = NINDX + 1
+              OFF(I) = FOUR_OVER_5
+              NINDX  = NINDX + 1
               INDX(NINDX) = I
-              UELR(I) = UELR(I) + ONE 
-              IF (NINT(UELR(I)) == FAILIP) THEN 
-                OFF(I)   = FOUR_OVER_5
-                NINDX2   = NINDX2 + 1
-                INDX2(NINDX2) = I
-                IDEL7NOK = 1
-              ENDIF
+              IDEL7NOK = 1
             ENDIF 
           ELSEIF (IDEL == 2) THEN 
             IF (DEFP(I) > EPSMAX) THEN 
-              LOFF(I) = ZERO
-              NINDX   = NINDX + 1
+              OFF(I) = FOUR_OVER_5
+              NINDX  = NINDX + 1
               INDX(NINDX) = I
-              UELR(I) = UELR(I) + ONE 
-              IF (NINT(UELR(I)) == FAILIP) THEN 
-                OFF(I)   = FOUR_OVER_5
-                NINDX2   = NINDX2 + 1
-                INDX2(NINDX2) = I
-                IDEL7NOK = 1
-              ENDIF
+              IDEL7NOK = 1
             ENDIF
           ELSEIF (IDEL == 3) THEN 
             IF (DMG(I) == ONE) THEN 
-              LOFF(I) = ZERO
-              NINDX   = NINDX + 1
+              OFF(I) = FOUR_OVER_5
+              NINDX  = NINDX + 1
               INDX(NINDX) = I
-              UELR(I) = UELR(I) + ONE 
-              IF (NINT(UELR(I)) == FAILIP) THEN 
-                OFF(I)   = FOUR_OVER_5
-                NINDX2   = NINDX2 + 1
-                INDX2(NINDX2) = I
-                IDEL7NOK = 1
-              ENDIF
+              IDEL7NOK = 1
             ENDIF            
           ENDIF
         ENDIF
@@ -290,8 +269,7 @@ c
       ! - COMPUTE PRESSURE INCREMENT
       !========================================================================
       DO I=1,NEL
-        IF ((DMG(I) > DMG_OLD(I)).AND.(MU(I) > ZERO).AND.
-     .      (LOFF(I) == ONE).AND. (OFF(I) == ONE)) THEN
+        IF ((DMG(I) > DMG_OLD(I)).AND.(MU(I) > ZERO).AND.(OFF(I) == ONE)) THEN     
           P1     = K1*MU(I)
           YIELD  = (ONE-DMG(I))*SIGYI(I)+DMG(I)*SIGYF(I)
           DELTAU = (SIGYOLD(I)*SIGYOLD(I)-YIELD*YIELD)/(SIX*G)
@@ -326,24 +304,12 @@ C
       IF (NINDX>0)THEN
         DO J=1,NINDX
 #include "lockon.inc"
-          WRITE(IOUT, 1000) NGL(INDX(J)),IPG,TIME
-          WRITE(ISTDO,1000) NGL(INDX(J)),IPG,TIME
-#include "lockoff.inc"
-        ENDDO
-      ENDIF
-c
-      IF (NINDX2>0)THEN
-        DO J=1,NINDX2
-#include "lockon.inc"
-          WRITE(IOUT, 2000) NGL(INDX2(J)),TIME
-          WRITE(ISTDO,2000) NGL(INDX2(J)),TIME
+          WRITE(IOUT, 1000) NGL(INDX(J)),TIME
+          WRITE(ISTDO,1000) NGL(INDX(J)),TIME
 #include "lockoff.inc"
         ENDDO
       ENDIF
 C
- 1000 FORMAT(1X,'FOR SOLID ELEMENT NUMBER el#',I10,
-     .          ' FAILURE (J-HOLMQUIST) AT GAUSS POINT ',I5,
-     .          ' AT TIME :',1PE12.4)
- 2000 FORMAT(1X,'-- RUPTURE OF SOLID ELEMENT :',I10,' AT TIME :',1PE12.4)     
+ 1000 FORMAT(1X,'-- RUPTURE (J-HOLMQUIST) OF SOLID ELEMENT :',I10,' AT TIME :',1PE12.4)     
 C
       END

--- a/engine/source/materials/mat_share/mulaw.F
+++ b/engine/source/materials/mat_share/mulaw.F
@@ -1298,7 +1298,7 @@ c
      4                SO1      ,SO2      ,SO3      ,SO4      ,SO5      ,SO6      ,
      5                S1       ,S2       ,S3       ,S4       ,S5       ,S6       ,
      6                EPSD     ,LBUF%DMG ,SSP      ,UVAR     ,OFF      ,AMU      ,
-     7                GBUF%UELR,LBUF%OFF ,IPG      ,NPG      ,IDEL7NOK )
+     7                IDEL7NOK )
 C 
       ELSEIF (MTN == 80) THEN
         CALL SIGEPS80(

--- a/hm_cfg_files/config/CFG/radioss2023/MAT/matl79_79.cfg
+++ b/hm_cfg_files/config/CFG/radioss2023/MAT/matl79_79.cfg
@@ -40,7 +40,6 @@ ATTRIBUTES(COMMON)
     D1                              = VALUE(FLOAT, "Damage Constant");
     D2                              = VALUE(FLOAT, "Damage Exponent");
     IDEL                            = VALUE(INT  , "Element deletion flag");
-    FAILIP                          = VALUE(INT  , "Number of failed integration points prior to element deletion");
     EPSMAX                          = VALUE(FLOAT, "Critical plastic strain for element deletion");
     K1                              = VALUE(FLOAT, "Bulk Modulus");
     K2                              = VALUE(FLOAT, "Pressure Coefficient");
@@ -90,7 +89,6 @@ SKEYWORDS_IDENTIFIER(COMMON)
     NUM_COMMENTS                    = 5110;
     DUMMY                           = -1;
     IDEL                            = -1;
-    FAILIP                          = -1;
     EPSMAX                          = -1;
     IO_FLAG                         = -1;
     TITLE                           = -1;
@@ -239,8 +237,8 @@ FORMAT(radioss2023)
     CARD("%20lg%20lg%20lg%20lg",MAT_C,MAT_Epsilon_F,MAT_SIG1max_t,MAT_FCUT);
     COMMENT("#                  T                 HEL                PHEL");
     CARD("%20lg%20lg%20lg",MAT_T0,MAT_E,MAT_EPS); 
-    COMMENT("#                 D1                  D2      IDEL    FAILIP              EPSMAX");
-    CARD("%20lg%20lg%10d%10d%20lg",D1,D2,IDEL,FAILIP,EPSMAX); 
+    COMMENT("#                 D1                  D2                IDEL              EPSMAX");
+    CARD("%20lg%20lg%10s%10d%20lg",D1,D2,_BLANK_,IDEL,EPSMAX); 
     COMMENT("#                 K1                  K2                  K3                BETA");
     CARD("%20lg%20lg%20lg%20lg",K1,K2,K3,MAT_Beta); 
     if(Heat_Inp_opt!=0)

--- a/starter/source/materials/mat/mat079/hm_read_mat79.F
+++ b/starter/source/materials/mat/mat079/hm_read_mat79.F
@@ -74,7 +74,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER MATS,IFLAG1,IFLAG2,ITEMAX,IDEL,FAILIP
+      INTEGER MATS,IFLAG1,IFLAG2,ITEMAX,IDEL
       my_real
      .        SHEAR, AA, BB, MM, NN, CC, EPS0, SIGFMAX, TMAX, HEL, PHEL,
      .        D1, D2, K1, K2, K3, BETA, YOUNG, NU, RHO0, RHOR, ASRATE,
@@ -117,7 +117,6 @@ C     #D1 D2 IDEL EPSMAX
       CALL HM_GET_FLOATV('D1' , D1, IS_AVAILABLE, LSUBMODEL, UNITAB)
       CALL HM_GET_FLOATV('D2' , D2, IS_AVAILABLE, LSUBMODEL, UNITAB)
       CALL HM_GET_INTV  ('IDEL',IDEL, IS_AVAILABLE, LSUBMODEL)
-      CALL HM_GET_INTV  ('FAILIP',FAILIP, IS_AVAILABLE, LSUBMODEL)
       CALL HM_GET_FLOATV('EPSMAX',EPSMAX, IS_AVAILABLE, LSUBMODEL, UNITAB)
 C----------------------------------------------------------------
 C     #K1 K2 K3 BETA
@@ -148,8 +147,6 @@ C
       ! Check flag for element deletion
       IDEL = MIN(IDEL,3)
       IDEL = MAX(0,IDEL)
-      ! Number of failed integration points prior to solid deletion
-      FAILIP = MAX(1,FAILIP)
       ! Critical plastic strain
       IF (EPSMAX == ZERO) EPSMAX = INFINITY
       !----------------------------------------------------------
@@ -218,9 +215,8 @@ C
       UPARAM(17)= K3
       UPARAM(18)= BETA
       UPARAM(19)= IDEL
-      UPARAM(20)= FAILIP
-      UPARAM(21)= EPSMAX
-      NUPARAM= 21
+      UPARAM(20)= EPSMAX
+      NUPARAM= 20
 C
       NU=(THREE*K1-TWO*SHEAR)/(SIX*K1+TWO*SHEAR)
       YOUNG=NINE*K1*SHEAR/(THREE*K1+SHEAR)
@@ -237,7 +233,7 @@ C
       ELSE
        WRITE(IOUT,1050) RHO0
        WRITE(IOUT,1100) SHEAR, AA, BB, MM, NN, CC, EPS0, SIGFMAX
-       WRITE(IOUT,1200) TMAX, HEL, PHEL, D1, D2, IDEL, FAILIP, EPSMAX
+       WRITE(IOUT,1200) TMAX, HEL, PHEL, D1, D2, IDEL, EPSMAX
        WRITE(IOUT,1300) K1, K2, K3, BETA
        WRITE(IOUT,1400) YOUNG, NU 
        IF (ISRATE > 0) WRITE(IOUT,1500) ASRATE
@@ -274,7 +270,6 @@ C
      &  5X,'  IDEL = 1: ELEMENT DELETION IN TENSION ONLY           ',/,
      &  5X,'  IDEL = 2: ELEMENT DELETION IF PLASTIC STRAIN > EPSMAX',/,
      &  5X,'  IDEL = 3: ELEMENT DELETION IF DAMAGE = 1.0           ',/,
-     &  5X,'FAILED INT. PT. FOR ELEM. DELETION (FAILIP)=',I10/,
      &  5X,'CRITICAL PLASTIC STRAIN (EPSMAX). . . . . .=',1PG20.13/)
  1300 FORMAT(
      &  5X,'BULK MODULUS (K1) . . . . . . . . . . . . .=',1PG20.13/


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Recently added element deletion features for /MAT/LAW79 was using GBUF%UELR table. However, this could cause a checkbound issue as UELR is only allocated when a failure criterion is attached to the law. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Remove the use of GBUF%UELR table. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
