### PR TITLE
Fix bad computation of forces on section with /PENTA6

### DIFF
--- a/engine/source/elements/forint.F
+++ b/engine/source/elements/forint.F
@@ -674,8 +674,6 @@ C              8 node hexa
      G         CONDN    ,CONDNSKY ,ITASK   ,IPRI        ,MAT_ELEM  ,
      H         IBID     ,DT       )
 C
-            ENDIF
-C
             IF (NSECT > 0)THEN
               K0=NSTRF(25)
               N=NINTER+NRWALL+NRBODY
@@ -701,6 +699,8 @@ C
                 K0=NSTRF(K0+24)
               ENDDO
             ENDIF
+C
+           ENDIF
           ELSEIF (JHBE == 17) THEN
 C------------------------- Isolid=19 for Salim
             IF (IPARG(36,NG)==3) THEN

--- a/starter/source/tools/sect/hm_read_sect.F
+++ b/starter/source/tools/sect/hm_read_sect.F
@@ -1251,7 +1251,7 @@ C
             IE=IGRBRIC(ISU)%ENTITY(L)
 	    IF (IE  /=  0) THEN
 	      NBNODES = ISOLNOD(IE)
-	      IF (NBNODES == 4) NBNODES = 8
+	      IF (NBNODES == 4 .OR. NBNODES == 6) NBNODES = 8
 	      TAGELEM1=0
 	      TAGELEM2=0
               TAGELEM3=0
@@ -1421,7 +1421,7 @@ c
             IE=IGRBRIC(ISU)%ENTITY(L)
 	    IF (IE  /=  0) THEN
 	      NBNODES = ISOLNOD(IE)
-	      IF (NBNODES == 4) NBNODES = 8
+	      IF (NBNODES == 4 .OR. NBNODES == 6) NBNODES = 8
 	      IF (TAGELEMS(IE) == 1) THEN
 	        DO K=2,NBNODES+1
                   IF (NBNODES == 10 .AND. K > 5) THEN


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

A bad computation of resultant forces was observed when using PENTA6 elements. This was due to the fact that SECTIOS6 and SECTIOS were called at the same time. Only the first one should be called in FORINT. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Change the ENDIF statement location to call only SECTIOS6 in FORINT. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
