### PR TITLE
Reverted changes to spacing in the reporting for Young's, Poisson's and Shear

### DIFF
--- a/starter/source/materials/mat/mat002/hm_read_mat02.F
+++ b/starter/source/materials/mat/mat002/hm_read_mat02.F
@@ -621,7 +621,7 @@ C-----------
  1300 FORMAT(
      & 5X,'YOUNG''S MODULUS . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'POISSON''S RATIO . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'SHEAR MODULUS. . . . . . . . . . . . . .=',1PG20.13//)
+     & 5X,'SHEAR MODULUS . . . . . . . . . . . . .=',1PG20.13//)
  1400 FORMAT(
      & 5X,'JOHNSON COOK MODEL :',/,
      & 5X,'YIELD COEFFICIENT A . . . . . . . . . .=',1PG20.13/,
@@ -644,8 +644,8 @@ C-----------
  1407 FORMAT(
      & 5X,'PREDEFINED VALUES USED FOR. . . . . . .: ',A/,
      & 5X,'DENSITY . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'YOUNG''S MODULUS. . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'POISSON''S RATIO. . . . . . . . . . . .=',1PG20.13/,
+     & 5X,'YOUNG''S MODULUS . . . . . . . . . . . .=',1PG20.13/,
+     & 5X,'POISSON''S RATIO . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'SHEAR MODULUS . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'YIELD STRESS. . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'ULTIMATE STRESS (UTS) . . . . . . . . .=',1PG20.13/,


### PR DESCRIPTION


#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Reverted changes to spacing in the reporting for Young's, Poisson's and Shear made in commit b183c50, since these cause misalignment in 0000.out, while the changes made in that commit look like they have corrected alignment in source, they do not account for the escaped ' characters in young's and poisson's, so misalignment occurs in output

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
