### PR TITLE
airbags: upper bound for VOLMON array

### DIFF
--- a/engine/source/airbag/fvbag0.F
+++ b/engine/source/airbag/fvbag0.F
@@ -225,7 +225,7 @@ C
             KIA7=KIA6+NTGA
             KIA8=KIA7+8*NBA
 C
-            KRA1=KR9 +NNT
+            KRA1=MIN(SVOLMON, KR9 +NNT)
             KRA2=KRA1+NNA
             KRA3=KRA2+NNA
             KRA4=KRA3+NNA

--- a/engine/source/airbag/fvupd.F
+++ b/engine/source/airbag/fvupd.F
@@ -184,7 +184,7 @@ C
             KIA7=KIA6+NTGA
             KIA8=KIA7+8*NBA
 C
-            KRA5=KR1+7*(NNS+NNI)+4*(NTG+NTGI)+6*NNA
+            KRA5=MIN(SVOLMON, KR1+7*(NNS+NNI)+4*(NTG+NTGI)+6*NNA)
             KRA6=KRA5+3*NNA
 C
             NFVMERGE(1)=0


### PR DESCRIPTION
#### airbags: upper bound for VOLMON array

#### Description of the changes
An unsed argument may be defined from an array for which index is out of bound.
This may lead to a debugger issue when using compiler tools such as "check bounds".
This is following commit 762d8ce50694fd6edca5194d2326696bfa15808c when VOLMON(*) was replaced with VOLMON(SMONVOL). This is not affecting numerical solution but only behavior of debug tools.

Is is now ensure that index is not taller than upper bound in this specific case. 

