### PR TITLE
make "thick" in /PART avaible for 1D elements

### DIFF
--- a/starter/source/interfaces/inter3d1/i11sti3.F
+++ b/starter/source/interfaces/inter3d1/i11sti3.F
@@ -112,7 +112,7 @@ C-----------------------------------------------
      .   GET_U_GEO,SX1,SY1,SZ1,SX2,SY2,SZ2,SX3,SY3,SZ3,
      .   X1,Y1,Z1,X2,Y2,Z2,X3,Y3,Z3,X4,Y4,Z4,X5,Y5,Z5,X6,Y6,Z6,X7,Y7,Z7,X8,Y8,Z8,
      .   XX1(4),XX2(4), XX3(4) ,FACE(6),
-     .   N_1, N_2, N_3
+     .   N_1, N_2, N_3,DX1
 C-----------------------------------------------
       EXTERNAL GET_U_GEO
 C     Stiffness: stiffness of the shell if the segment belongs
@@ -338,10 +338,16 @@ C------------------------------------
 C
           MT=IXT(1,NELT)
           MG=IXT(4,NELT)
+          IP = IPARTT(NELT)
+          IF (THK_PART(IP) > ZERO ) THEN
+            DX1=THK_PART(IP)
+          ELSE
+            DX1=SQRT(GEO(1,MG))
+          END IF
           DX=SQRT(GEO(1,MG))
-          GAP_SM(I)=MAX(GAP_SM(I),HALF*DX)
+          GAP_SM(I)=MAX(GAP_SM(I),HALF*DX1)
           GAPS1=MAX(GAPS1,GAP_SM(I))
-          GAPMN = MIN(GAPMN,DX)
+          GAPMN = MIN(GAPMN,DX1)
           DXM=DXM+DX
           NDX=NDX+1
           IF(MT>0)THEN
@@ -388,10 +394,16 @@ C------------------------------------
 C
           MT=IXP(1,NELP)
           MG=IXP(5,NELP)
+          IP = IPARTT(NELP)
+          IF (THK_PART(IP) > ZERO ) THEN
+            DX1=THK_PART(IP)
+          ELSE
+            DX1=SQRT(GEO(1,MG))
+          END IF
           DX=SQRT(GEO(1,MG))
-          GAP_SM(I)=MAX(GAP_SM(I),HALF*DX)
+          GAP_SM(I)=MAX(GAP_SM(I),HALF*DX1)
           GAPS1=MAX(GAPS1,GAP_SM(I))
-          GAPMN = MIN(GAPMN,DX)
+          GAPMN = MIN(GAPMN,DX1)
           DXM=DXM+DX
           NDX=NDX+1
           IF(MT>0)THEN
@@ -438,6 +450,13 @@ C------------------------------------
 C
           MG=IXR(1,NELR)
           MT = IXR(5,NELR)
+          IP = IPARTT(NELR)
+          IF (THK_PART(IP) > ZERO ) THEN
+            DX1=THK_PART(IP)
+            GAP_SM(I)=MAX(GAP_SM(I),HALF*DX1)
+            GAPS1=MAX(GAPS1,GAP_SM(I))
+            GAPMN = MIN(GAPMN,DX1)
+          END IF
           IF(MG>0)THEN
             IGTYP=NINT(GEO(12,MG))
             IF(IGTYP==4.OR.IGTYP==12)THEN

--- a/starter/source/interfaces/inter3d1/i24sti3.F
+++ b/starter/source/interfaces/inter3d1/i24sti3.F
@@ -50,7 +50,8 @@ Chd|====================================================================
      G PEN_OLD,IPARTNS  ,IPARTS   ,IGEO    ,FILLSOL ,
      H PM_STACK, IWORKSH ,INTFRIC ,TAGPRT_FRIC,IPARTFRICS,
      G IPARTFRICM,INTBUF_FRIC_TAB ,INTNITSCHE,NRTS,IRECTS,
-     I IELNRTS ,ADRECTS ,FACNRTS  ,NMN       ,MSR )
+     I IELNRTS ,ADRECTS ,FACNRTS  ,NMN       ,MSR ,
+     J IPARTT ,IPARTP   ,IPARTR   )
 C-----------------------------------------------
 C   M o d u l e s
 C----------------------------------------------- 
@@ -94,6 +95,9 @@ C     REAL
      .   AREAS(*),THK(*),THK_PART(*),PEN_OLD(5,NSN), FILLSOL(*),
      .   PM_STACK(20,*)
       INTEGER ID,IPARTNS(*),IPARTS(*)
+      INTEGER, DIMENSION(NUMELT), INTENT(IN) :: IPARTT
+      INTEGER, DIMENSION(NUMELP), INTENT(IN) :: IPARTP
+      INTEGER, DIMENSION(NUMELR), INTENT(IN) :: IPARTR
       CHARACTER*nchartitle,
      .   TITR
       TYPE(INTBUF_FRIC_STRUCT_) INTBUF_FRIC_TAB(*)
@@ -221,15 +225,36 @@ C-----for case of coating shell--
 C-------
       DO I=1,NUMELT
         MG=IXT(4,I)
-        DX=HALF*SQRT(GEO(1,MG))
+        IP = IPARTT(I)
+        IF ( THK_PART(IP) > ZERO ) THEN
+          DX=HALF*THK_PART(IP)
+        ELSE
+          DX=HALF*SQRT(GEO(1,MG))
+        END IF
         WA(IXT(2,I))=MAX(WA(IXT(2,I)),DX)
         WA(IXT(3,I))=MAX(WA(IXT(3,I)),DX)
       ENDDO
       DO I=1,NUMELP
         MG=IXP(5,I)
-        DX=0.5*SQRT(GEO(1,MG))
+        IP = IPARTP(I)
+        IF ( THK_PART(IP) > ZERO ) THEN
+          DX=HALF*THK_PART(IP)
+        ELSE
+          DX=HALF*SQRT(GEO(1,MG))
+        END IF
         WA(IXP(2,I))=MAX(WA(IXP(2,I)),DX)
         WA(IXP(3,I))=MAX(WA(IXP(3,I)),DX)
+      ENDDO
+      DO I=1,NUMELR
+        IP = IPARTR(I)
+        IF ( THK_PART(IP) > ZERO ) THEN
+          MG=IXR(1,I)
+          IGTYP = IGEO(11,MG)
+          DX=HALF*THK_PART(IP)
+          WA(IXR(2,I))=MAX(WA(IXR(2,I)),DX)
+          WA(IXR(3,I))=MAX(WA(IXR(3,I)),DX)
+          IF (IGTYP==12) WA(IXR(4,I))=MAX(WA(IXR(4,I)),DX)
+       END IF
       ENDDO
       DO I=1,NSN
         GAP_S(I)=GAPSCALE * WA(NSV(I))
@@ -1933,7 +1958,8 @@ Chd|====================================================================
      3 NOINT ,NSN   ,NSV   ,IXTG  ,IXT   ,
      6 IXP   ,IPART ,IPARTC,IPARTTG,THK  ,
      D THK_PART,IXR ,ITAB  ,IXS10 ,IXS16 ,
-     E IXS20 ,NMN   ,MSR   ,LL_S  ,LL_M  )
+     E IXS20 ,NMN   ,MSR   ,LL_S  ,LL_M  ,
+     J IPARTT,IPARTP,IPARTR,IGEO  )
 C-----------------------------------------------
       USE MESSAGE_MOD
 C
@@ -1957,6 +1983,10 @@ C-----------------------------------------------
      .   NSV(*), IXTG(NIXTG,*), IXT(NIXT,*), IXP(NIXP,*),
      .   IXR(NIXR,*) ,IPART(LIPART1,*), IPARTC(*), IPARTTG(*),
      .   ITAB(*), IXS10(6,*), IXS16(8,*), IXS20(12,*)
+      INTEGER, DIMENSION(NUMELT), INTENT(IN) :: IPARTT
+      INTEGER, DIMENSION(NUMELP), INTENT(IN) :: IPARTP
+      INTEGER, DIMENSION(NUMELR), INTENT(IN) :: IPARTR
+      INTEGER, DIMENSION(NPROPGI,NUMGEO) ,INTENT(IN):: IGEO
 C     REAL
       my_real
      .   X(3,*), PM(NPROPM,*), GEO(NPROPG,*), WA(*),
@@ -1966,7 +1996,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I, J, N, MT, JJ, JJJ, NELC,
      .   MG, NUM, NPT, LL, L, NN, NELTG,N1,N2,N3,N4,IE,
-     .   IP, NLEV, MYLEV, K, P, R, T,IAD
+     .   IP, NLEV, MYLEV, K, P, R, T,IAD,IGTYP
 C     REAL
       my_real
      .   AREA, VOL, DX, GAPM, DDX
@@ -2013,16 +2043,37 @@ C----SHELLS ------------
 C----truss------------
       DO I=1,NUMELT
         MG=IXT(4,I)
-        DX=SQRT(GEO(1,MG))
+        IP = IPARTT(I)
+        IF ( THK_PART(IP) > ZERO ) THEN
+          DX=THK_PART(IP)
+        ELSE
+          DX=SQRT(GEO(1,MG))
+        END IF
         WA(IXT(2,I))=MIN(WA(IXT(2,I)),DX)
         WA(IXT(3,I))=MIN(WA(IXT(3,I)),DX)
       ENDDO
 C----beam------------
       DO I=1,NUMELP
         MG=IXP(5,I)
-        DX=SQRT(GEO(1,MG))
+        IP = IPARTP(I)
+        IF ( THK_PART(IP) > ZERO ) THEN
+          DX=THK_PART(IP)
+        ELSE
+          DX=SQRT(GEO(1,MG))
+        END IF
         WA(IXP(2,I))=MIN(WA(IXP(2,I)),DX)
         WA(IXP(3,I))=MIN(WA(IXP(3,I)),DX)
+      ENDDO
+      DO I=1,NUMELR
+        IP = IPARTR(I)
+        IF ( THK_PART(IP) > ZERO ) THEN
+          MG=IXR(1,I)
+          IGTYP = IGEO(11,MG)
+          DX=THK_PART(IP)
+          WA(IXR(2,I))=MAX(WA(IXR(2,I)),DX)
+          WA(IXR(3,I))=MAX(WA(IXR(3,I)),DX)
+          IF (IGTYP==12) WA(IXR(4,I))=MAX(WA(IXR(4,I)),DX)
+       END IF
       ENDDO
 C----solides------------     
       DO I=1,NUMELS

--- a/starter/source/interfaces/inter3d1/i25sti3.F
+++ b/starter/source/interfaces/inter3d1/i25sti3.F
@@ -52,7 +52,8 @@ Chd|====================================================================
      H PM_STACK  , IWORKSH   ,PERCENT_SIZE,GAP_S_L ,GAP_M_L    ,
      I KNOD2EL1D ,NOD2EL1D   ,INTFRIC   ,TAGPRT_FRIC,IPARTFRICS,
      J IPARTFRICM,INTBUF_FRIC_TAB,IVIS2 ,GAPM_MX   ,GAPS_MX    ,
-     K GAPM_L_MX ,GAPS_L_MX  ,IPARTSM   ,DRAD      )
+     K GAPM_L_MX ,GAPS_L_MX  ,IPARTSM   ,DRAD      ,IPARTT     ,
+     J IPARTP    ,IPARTR   )
 C-----------------------------------------------
       USE INTBUF_FRIC_MOD
       USE MESSAGE_MOD
@@ -96,6 +97,9 @@ C     REAL
      .   AREAS(*),THK(*),THK_PART(*),PEN_OLD(5,NSN), FILLSOL(*),
      .   PM_STACK(20,*),GAP_S_L(*),GAP_M_L(*)
       INTEGER ID,IPARTS(*)
+      INTEGER, DIMENSION(NUMELT), INTENT(IN) :: IPARTT
+      INTEGER, DIMENSION(NUMELP), INTENT(IN) :: IPARTP
+      INTEGER, DIMENSION(NUMELR), INTENT(IN) :: IPARTR
       CHARACTER*nchartitle,
      .   TITR
       TYPE(INTBUF_FRIC_STRUCT_) INTBUF_FRIC_TAB(*)
@@ -249,15 +253,36 @@ C       MSEGTYP==0 <=> Solide
 C-------
       DO I=1,NUMELT
         MG=IXT(4,I)
-        DX=HALF*SQRT(GEO(1,MG))
+        IP = IPARTT(I)
+        IF ( THK_PART(IP) > ZERO ) THEN
+          DX=HALF*THK_PART(IP)
+        ELSE
+          DX=HALF*SQRT(GEO(1,MG))
+        END IF
         WA(IXT(2,I))=MAX(WA(IXT(2,I)),DX)
         WA(IXT(3,I))=MAX(WA(IXT(3,I)),DX)
       ENDDO
       DO I=1,NUMELP
         MG=IXP(5,I)
-        DX=0.5*SQRT(GEO(1,MG))
+        IP = IPARTP(I)
+        IF ( THK_PART(IP) > ZERO ) THEN
+          DX=HALF*THK_PART(IP)
+        ELSE
+          DX=HALF*SQRT(GEO(1,MG))
+        END IF
         WA(IXP(2,I))=MAX(WA(IXP(2,I)),DX)
         WA(IXP(3,I))=MAX(WA(IXP(3,I)),DX)
+      ENDDO
+      DO I=1,NUMELR
+        IP = IPARTR(I)
+        IF ( THK_PART(IP) > ZERO ) THEN
+          MG=IXR(1,I)
+          IGTYP = IGEO(11,MG)
+          DX=HALF*THK_PART(IP)
+          WA(IXR(2,I))=MAX(WA(IXR(2,I)),DX)
+          WA(IXR(3,I))=MAX(WA(IXR(3,I)),DX)
+          IF (IGTYP==12) WA(IXR(4,I))=MAX(WA(IXR(4,I)),DX)
+       END IF
       ENDDO
       DO I=1,NSN
         GAP_S(I)=GAPSCALE * WA(NSV(I))

--- a/starter/source/interfaces/inter3d1/i7sti3.F
+++ b/starter/source/interfaces/inter3d1/i7sti3.F
@@ -55,7 +55,8 @@ Chd|====================================================================
      E              DRAD       ,IGEO   ,FILLSOL       ,PM_STACK ,IWORKSH  ,
      F              IT19       ,KXIG3D ,IXIG3D        ,INTFRIC  ,IPARTS   ,
      G              TAGPRT_FRIC,IPARTFRICS,IPARTFRICM ,INTBUF_FRIC_TAB,NRT_IGE,
-     I              IREM_GAP   ,GAPM_MX,GAPS_MX       ,GAPM_L_MX,GAPS_L_MX)
+     I              IREM_GAP   ,GAPM_MX,GAPS_MX       ,GAPM_L_MX,GAPS_L_MX,
+     J              IPARTT     ,IPARTP ,IPARTR        )
 C-----------------------------------------------
 C   M o d u l e s
 C----------------------------------------------- 
@@ -100,6 +101,9 @@ C-----------------------------------------------
      .   MS(*),WA(*),GAP_S(*),GAP_M(*),
      .   AREAS(*),THK(*),THK_PART(*),
      .   GAP_S_L(*),GAP_M_L(*), FILLSOL(*),PM_STACK(20,*)
+      INTEGER, DIMENSION(NUMELT), INTENT(IN) :: IPARTT
+      INTEGER, DIMENSION(NUMELP), INTENT(IN) :: IPARTP
+      INTEGER, DIMENSION(NUMELR), INTENT(IN) :: IPARTR
       INTEGER ID
       CHARACTER*nchartitle, TITR
       TYPE(INTBUF_FRIC_STRUCT_) INTBUF_FRIC_TAB(*)
@@ -250,15 +254,36 @@ C------------------------------------
        ENDDO
        DO I=1,NUMELT
         MG=IXT(4,I)
-        DX=HALF*SQRT(GEO(1,MG))
+        IP = IPARTT(I)
+        IF ( THK_PART(IP) > ZERO ) THEN
+          DX=HALF*THK_PART(IP)
+        ELSE
+          DX=HALF*SQRT(GEO(1,MG))
+        END IF
         WA(IXT(2,I))=MAX(WA(IXT(2,I)),DX)
         WA(IXT(3,I))=MAX(WA(IXT(3,I)),DX)
        ENDDO
        DO I=1,NUMELP
         MG=IXP(5,I)
-        DX=0.5*SQRT(GEO(1,MG))
+        IP = IPARTP(I)
+        IF ( THK_PART(IP) > ZERO ) THEN
+          DX=HALF*THK_PART(IP)
+        ELSE
+          DX=HALF*SQRT(GEO(1,MG))
+        END IF
         WA(IXP(2,I))=MAX(WA(IXP(2,I)),DX)
         WA(IXP(3,I))=MAX(WA(IXP(3,I)),DX)
+       ENDDO
+       DO I=1,NUMELR
+         IP = IPARTR(I)
+         IF ( THK_PART(IP) > ZERO ) THEN
+           MG=IXR(1,I)
+           IGTYP = IGEO(11,MG)
+           DX=HALF*THK_PART(IP)
+           WA(IXR(2,I))=MAX(WA(IXR(2,I)),DX)
+           WA(IXR(3,I))=MAX(WA(IXR(3,I)),DX)
+           IF (IGTYP==12) WA(IXR(4,I))=MAX(WA(IXR(4,I)),DX)
+        END IF
        ENDDO
        DO I=1,NSN
          GAP_S(I)=GAPSCALE * WA(NSV(I))

--- a/starter/source/interfaces/inter3d1/inint3.F
+++ b/starter/source/interfaces/inter3d1/inint3.F
@@ -666,7 +666,8 @@ C----------------
      F    DRAD             ,IGEO                    ,FILLSOL          ,PM_STACK         , IWORKSH         ,
      G    IT19             ,KXIG3D                  ,IXIG3D           ,IPARI(72)        , IPARTS          ,
      H    TAGPRT_FRIC      ,INTBUF_TAB%IPARTFRICS   ,INTBUF_TAB%IPARTFRICM ,INTBUF_FRIC_TAB,NRTM_IGE      ,
-     I    IPARI(63)        ,GAPM_MX                 ,GAPS_MX          ,GAPM_L_MX        ,GAPS_L_MX)
+     I    IPARI(63)        ,GAPM_MX                 ,GAPS_MX          ,GAPM_L_MX        ,GAPS_L_MX        ,
+     J    IPARTT           ,IPARTP                  ,IPARTR           )
        IPARI(21) = IGAP 
 C
 C----------------
@@ -915,7 +916,8 @@ C
      F            DRAD       ,IGEO                    ,FILLSOL          ,PM_STACK        ,IWORKSH ,
      G            IT19       ,BID                     ,BID              ,IBIDON          ,IPARTS  ,
      H            IBIDON     ,IBIDON                  ,IBIDON           ,IBIDON          ,IBIDON  ,
-     I            IPARI(63)  ,GAPM_MX                 ,GAPS_MX          ,GAPM_L_MX        ,GAPS_L_MX)
+     I            IPARI(63)  ,GAPM_MX                 ,GAPS_MX          ,GAPM_L_MX        ,GAPS_L_MX,
+     J            IPARTT     ,IPARTP                  ,IPARTR        )
 C
 C      IL FAUT ENCORE FAIRE ONE BUCKET SORT DANS LE STARTER
 C
@@ -1511,7 +1513,8 @@ C----  INTBUF_TAB%CRIT V/A is used temporarily for sorting and Pen-max
      G INTBUF_TAB%PENE_OLD  ,IPARTNS     ,IPARTS      , IGEO      ,FILLSOL   ,
      H PM_STACK  ,IWORKSH    ,IPARI(72)  ,TAGPRT_FRIC   , INTBUF_TAB%IPARTFRICS,
      G INTBUF_TAB%IPARTFRICM,INTBUF_FRIC_TAB,IPARI(86) , NRTS   ,INTBUF_TAB%IRECTS ,
-     I INTBUF_TAB%IELNRTS,INTBUF_TAB%ADRECTS,INTBUF_TAB%FACNRTS,NMN,INTBUF_TAB%MSR )        
+     I INTBUF_TAB%IELNRTS,INTBUF_TAB%ADRECTS,INTBUF_TAB%FACNRTS,NMN,INTBUF_TAB%MSR ,
+     J IPARTT   ,IPARTP   ,IPARTR  )  
        IPARI(21) = IGAP
 C---------GAP_S for fictive nodes       
         IF (NSNE >0) THEN
@@ -1540,7 +1543,7 @@ C------------------
      4 IXP       ,IPART     ,IPARTC      ,IPARTTG    ,THK          ,
      D THK_PART  ,IXR       ,ITAB        ,IXS10      ,IXS16        ,
      E IXS20     ,NMN       ,INTBUF_TAB%MSR,INTBUF_TAB%NOD_2RY_LGTH,
-     F INTBUF_TAB%NOD_MAS_LGTH)
+     F INTBUF_TAB%NOD_MAS_LGTH,IPARTT,IPARTP,IPARTR  ,IGEO         )
         CALL I24FICS_INI(INTBUF_TAB%IRTSE   ,NSNE    ,INTBUF_TAB%IS2SE   ,INTBUF_TAB%NSV    ,
      1                  INTBUF_TAB%IS2PT ,NSN     ,INTBUF_TAB%NOD_2RY_LGTH   )
        END IF
@@ -1887,7 +1890,8 @@ C-----------------------------------------------------------
      H PM_STACK   ,IWORKSH          ,INTBUF_TAB%VARIABLES(28),INTBUF_TAB%GAP_SL,INTBUF_TAB%GAP_ML,
      I KNOD2EL1D  ,NOD2EL1D         ,IPARI(72)       ,TAGPRT_FRIC    ,INTBUF_TAB%IPARTFRICS   ,
      J INTBUF_TAB%IPARTFRICM,INTBUF_FRIC_TAB,IVIS2   ,GAPM_MX       , GAPS_MX               ,
-     K GAPM_L_MX  ,GAPS_L_MX        ,IPARTSM         ,DRAD          )
+     K GAPM_L_MX  ,GAPS_L_MX        ,IPARTSM         ,DRAD          ,IPARTT                 ,
+     J IPARTP     ,IPARTR   )
        IPARI(21) = IGAP
 C-----------------------------------------------------------
 C      ELEMENT NEIGHBROURS & FREE EDGES

--- a/starter/source/model/assembling/hm_read_part.F
+++ b/starter/source/model/assembling/hm_read_part.F
@@ -390,6 +390,13 @@ C----VIRTUAL THICKNESS OUTPUT  (For properties which are compatible with shell e
      .      (IGTYP == 19).OR.(IGTYP == 51).OR.(IGTYP == 52)) THEN      
           WRITE(IOUT,'(A,1PG20.13,2A)')'     VIRT. THICKN:       ',THK_PART(I)
         ENDIF
+C----VIRTUAL THICKNESS OUTPUT  (extended to /BEAM /TRUSS /SPRING) 
+        IF( THK_PART(I)>ZERO .AND. ((IGTYP == 3).OR.(IGTYP == 2).OR.
+     .      (IGTYP == 18).OR.(IGTYP == 4).OR.(IGTYP == 8).OR.
+     .      (IGTYP == 12).OR.(IGTYP == 13).OR.(IGTYP == 23).OR.
+     .      (IGTYP == 25).OR.(IGTYP == 26).OR.(IGTYP == 27))) THEN      
+          WRITE(IOUT,'(A,1PG20.13,2A)')'     VIRT. THICKN:       ',THK_PART(I)
+        ENDIF
 
 C----SPH SMOOTHING LENGTH OUTPUT ( /PROP/SPH (Type34) )   
         IF (IGEO(11,IPID) == 34) THEN


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
actual "thick" in /PART is available only for shell elements (gap compute for contact), now beam,truss&spring elements are also available.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
