### PR TITLE
Revert "Revert "Option State, INISHEL, INISH3 and drape & fix issue r…

### DIFF
--- a/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
@@ -1388,7 +1388,7 @@ c
                     IF (ITY == 3) THEN
                      IF (IGTYP == 17 .OR. IGTYP == 51 .OR. IGTYP == 52 ) THEN
                       IF (MLW /= 0 .AND. MLW /= 13) THEN
-                       IF(IDRAPE > 0 . AND. (IGTYP == 51 .OR. IGTYP == 52)) THEN
+                       IF(IDRAPE > 0 .AND. (IGTYP == 51 .OR. IGTYP == 52)) THEN
                          IF(IPT <= BUFLY%NPTT ) THEN
                             LBUF_DIR => ELBUF_TAB(NG)%BUFLY(J)%LBUF_DIR(IPT) 
                          ELSE
@@ -1624,11 +1624,11 @@ c
                     ELSEIF (ITY == 7) THEN
                      IF (IGTYP == 17 .OR. IGTYP == 51 .OR. IGTYP == 52 ) THEN
                       IF (MLW /= 0 .AND. MLW /= 13) THEN
-                       IF(IDRAPE > 0 .AND. IGTYP == 17) THEN 
+                       IF(IDRAPE > 0 .AND. (IGTYP == 51 .OR. IGTYP == 52)) THEN 
                         IF(IPT <= BUFLY%NPTT ) THEN
                             LBUF_DIR => ELBUF_TAB(NG)%BUFLY(J)%LBUF_DIR(IPT) 
                         ELSE
-                           LBUF_DIR => ELBUF_TAB(NG)%BUFLY(J)%LBUF_DIR(1)   
+                            LBUF_DIR => ELBUF_TAB(NG)%BUFLY(J)%LBUF_DIR(1)  
                         ENDIF      
                 	DO I=1,NEL						
                 	  N = I + NFT						  

--- a/engine/source/output/sta/stat_c_orth_loc.F
+++ b/engine/source/output/sta/stat_c_orth_loc.F
@@ -68,7 +68,7 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,J,K,N,II,JJ,LEN, IOFF, IREP,NG, NEL, NFT, ITY, LFT, NPT,
-     .        LLT, MLW,NDIR,NLAY,IHBE,ISH3N,IDRAPE,
+     .        LLT, MLW,NDIR,NLAY,IHBE,ISH3N,IDRAPE,NPTT, NPLY_MAX,IPT,
      .        IGTYP, ID, IPRT0, IPRT,NPG,IPG,IE, FLAGDEG,IDEL,ILAY,ILAW
       INTEGER PTWA_P0(0:MAX(1,STAT_NUMELC_G,STAT_NUMELTG_G)),
      .        PTWA(MAX(STAT_NUMELC ,STAT_NUMELTG)),IFRAM_OLD
@@ -111,6 +111,14 @@ C
          IREP = IPARG(35,NG)
          NLAY = ELBUF_TAB(NG)%NLAY
          IDRAPE = ELBUF_TAB(NG)%IDRAPE
+         NPLY_MAX = 0
+         IF(IDRAPE > 0 . AND. (IGTYP == 51 .OR. IGTYP == 52)) THEN
+          NPLY_MAX = 0
+          DO J = 1,NLAY
+           NPLY_MAX  = NPLY_MAX + ELBUF_TAB(NG)%BUFLY(J)%NPTT
+          ENDDO  
+         ENDIF
+         NPT = MAX (NPLY_MAX, NPT)
          NDIR = 1
          IF (IREP > 1) NDIR = 2                  
          LFT=1
@@ -231,141 +239,144 @@ C
           JJ = JJ + 1
           WA(JJ) = IREP
           IF(IDRAPE > 0 .AND. (IGTYP == 51 .OR. IGTYP == 52)) THEN
-            DO J=1,NLAY  
-              LBUF_DIR => ELBUF_TAB(NG)%BUFLY(J)%LBUF_DIR(1)                                
-              DIR1_1 = LBUF_DIR%DIRA(I)
-              DIR1_2 = LBUF_DIR%DIRA(I+NEL)
-              ILAW = ELBUF_TAB(NG)%BUFLY(J)%ILAW
-              IF (IREP == 1) THEN
-                AA = DIR1_1
-                BB = DIR1_2
-                V1 = AA*RX + BB*SX         
-                V2 = AA*RY + BB*SY         
-                V3 = AA*RZ + BB*SZ         
-                VR = V1*E1X+ V2*E1Y + V3*E1Z
-                VS = V1*E2X+ V2*E2Y + V3*E2Z
-                SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)                
-                DIR1_1 = VR/SUMA                                                   
-                DIR1_2 = VS/SUMA
-              ELSEIF (IREP == 2) THEN
+            DO J=1,NLAY 
+              NPTT = ELBUF_TAB(NG)%BUFLY(J)%NPTT
+              DO IPT = 1, NPTT
+                 LBUF_DIR => ELBUF_TAB(NG)%BUFLY(J)%LBUF_DIR(IPT)                             
+                 DIR1_1 = LBUF_DIR%DIRA(I)
+                 DIR1_2 = LBUF_DIR%DIRA(I+NEL)
+                 ILAW = ELBUF_TAB(NG)%BUFLY(J)%ILAW
+                 IF (IREP == 1) THEN
+                   AA = DIR1_1
+                   BB = DIR1_2
+                   V1 = AA*RX + BB*SX         
+                   V2 = AA*RY + BB*SY         
+                   V3 = AA*RZ + BB*SZ         
+                   VR = V1*E1X+ V2*E1Y + V3*E1Z
+                   VS = V1*E2X+ V2*E2Y + V3*E2Z
+                   SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)              
+                   DIR1_1 = VR/SUMA                                                
+                   DIR1_2 = VS/SUMA
+                 ELSEIF (IREP == 2) THEN
 C---        Axe I
-                AA = DIR1_1
-                BB = DIR1_2
-                V1 = AA*RX + BB*SX         
-                V2 = AA*RY + BB*SY         
-                V3 = AA*RZ + BB*SZ         
-                VR = V1*E1X+ V2*E1Y + V3*E1Z
-                VS = V1*E2X+ V2*E2Y + V3*E2Z
-                SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)                
-                DIR1_1 = VR/SUMA                                                   
-                DIR1_2 = VS/SUMA
+                   AA = DIR1_1
+                   BB = DIR1_2
+                   V1 = AA*RX + BB*SX         
+                   V2 = AA*RY + BB*SY         
+                   V3 = AA*RZ + BB*SZ         
+                   VR = V1*E1X+ V2*E1Y + V3*E1Z
+                   VS = V1*E2X+ V2*E2Y + V3*E2Z
+                   SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)              
+                   DIR1_1 = VR/SUMA                                                
+                   DIR1_2 = VS/SUMA
 C---        Axe II
-                AA = LBUF_DIR%DIRB(I)	 			    
-                BB = LBUF_DIR%DIRB(I + NEL)			   
-                V1 = AA*RX + BB*SX                                               
-                V2 = AA*RY + BB*SY                                               
-                V3 = AA*RZ + BB*SZ                                               
-                VR = V1*E1X+ V2*E1Y + V3*E1Z                                     
-                VS = V1*E2X+ V2*E2Y + V3*E2Z                                     
-                SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)                
-                DIR2_1 = VR/SUMA                                                 
-                DIR2_2 = VS/SUMA
-              ELSEIF (IREP == 3) THEN
-C   mixing law58 with other user laws with IREP = 0 within PID51
-                IF (ILAW == 58) THEN
+                   AA = LBUF_DIR%DIRB(I)                             
+                   BB = LBUF_DIR%DIRB(I + NEL)                       
+                   V1 = AA*RX + BB*SX                                            
+                   V2 = AA*RY + BB*SY                                            
+                   V3 = AA*RZ + BB*SZ                                            
+                   VR = V1*E1X+ V2*E1Y + V3*E1Z                                  
+                   VS = V1*E2X+ V2*E2Y + V3*E2Z                                  
+                   SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)              
+                   DIR2_1 = VR/SUMA                                              
+                   DIR2_2 = VS/SUMA
+                 ELSEIF (IREP == 3) THEN
+C   mixing law   58 with other user laws with IREP = 0 within PID51
+                   IF (ILAW == 58) THEN
 C---        Axe I
-                  AA = DIR1_1
-                  BB = DIR1_2
-                  V1 = AA*RX + BB*SX         
-                  V2 = AA*RY + BB*SY         
-                  V3 = AA*RZ + BB*SZ         
-                  VR = V1*E1X+ V2*E1Y + V3*E1Z
-                  VS = V1*E2X+ V2*E2Y + V3*E2Z
-                  SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)                
-                  DIR1_1 = VR/SUMA                                                   
-                  DIR1_2 = VS/SUMA
+                     AA = DIR1_1
+                     BB = DIR1_2
+                     V1 = AA*RX + BB*SX         
+                     V2 = AA*RY + BB*SY         
+                     V3 = AA*RZ + BB*SZ         
+                     VR = V1*E1X+ V2*E1Y + V3*E1Z
+                     VS = V1*E2X+ V2*E2Y + V3*E2Z
+                     SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)             
+                     DIR1_1 = VR/SUMA                                                
+                     DIR1_2 = VS/SUMA
 C---        Axe II
-                  AA = LBUF_DIR%DIRB(I)	   			       
-                  BB = LBUF_DIR%DIRB(I + NEL)			      
-                  V1 = AA*RX + BB*SX                                               
-                  V2 = AA*RY + BB*SY                                               
-                  V3 = AA*RZ + BB*SZ                                               
-                  VR = V1*E1X+ V2*E1Y + V3*E1Z                                     
-                  VS = V1*E2X+ V2*E2Y + V3*E2Z                                     
-                  SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)                
-                  DIR2_1 = VR/SUMA                                                 
-                  DIR2_2 = VS/SUMA
-                ELSE  ! IREP = 0 within PID51
+                     AA = LBUF_DIR%DIRB(I)                             
+                     BB = LBUF_DIR%DIRB(I + NEL)                      
+                     V1 = AA*RX + BB*SX                                            
+                     V2 = AA*RY + BB*SY                                            
+                     V3 = AA*RZ + BB*SZ                                            
+                     VR = V1*E1X+ V2*E1Y + V3*E1Z                                  
+                     VS = V1*E2X+ V2*E2Y + V3*E2Z                                  
+                     SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)             
+                     DIR2_1 = VR/SUMA                                              
+                     DIR2_2 = VS/SUMA
+                   ELSE  ! IREP = 0 within PID51
 C     DIR1_1 and DIT1_2 already got
-                ENDIF
-              ELSEIF (IREP == 4) THEN
-C   mixing law58 with other user laws with IREP = 1 within PID51
-                IF (ILAW == 58) THEN
+                   ENDIF
+                 ELSEIF (IREP == 4) THEN
+C   mixing law   58 with other user laws with IREP = 1 within PID51
+                   IF (ILAW == 58) THEN
 C---        Axe I
-                  AA = DIR1_1
-                  BB = DIR1_2
-                  V1 = AA*RX + BB*SX         
-                  V2 = AA*RY + BB*SY         
-                  V3 = AA*RZ + BB*SZ         
-                  VR = V1*E1X+ V2*E1Y + V3*E1Z
-                  VS = V1*E2X+ V2*E2Y + V3*E2Z
-                  SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)                
-                  DIR1_1 = VR/SUMA                                                   
-                  DIR1_2 = VS/SUMA
+                     AA = DIR1_1
+                     BB = DIR1_2
+                     V1 = AA*RX + BB*SX         
+                     V2 = AA*RY + BB*SY         
+                     V3 = AA*RZ + BB*SZ         
+                     VR = V1*E1X+ V2*E1Y + V3*E1Z
+                     VS = V1*E2X+ V2*E2Y + V3*E2Z
+                     SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)             
+                     DIR1_1 = VR/SUMA                                                
+                     DIR1_2 = VS/SUMA
 C---        Axe II
-                  AA = LBUF_DIR%DIRB(I)	   			       
-                  BB = LBUF_DIR%DIRB(I + NEL)			      
-                  V1 = AA*RX + BB*SX                                               
-                  V2 = AA*RY + BB*SY                                               
-                  V3 = AA*RZ + BB*SZ                                               
-                  VR = V1*E1X+ V2*E1Y + V3*E1Z                                     
-                  VS = V1*E2X+ V2*E2Y + V3*E2Z                                     
-                  SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)                
-                  DIR2_1 = VR/SUMA                                                 
-                  DIR2_2 = VS/SUMA
-                ELSE  ! IREP = 1 within PID51
-                  AA = DIR1_1
-                  BB = DIR1_2
-                  V1 = AA*RX + BB*SX         
-                  V2 = AA*RY + BB*SY         
-                  V3 = AA*RZ + BB*SZ         
-                  VR = V1*E1X+ V2*E1Y + V3*E1Z
-                  VS = V1*E2X+ V2*E2Y + V3*E2Z
-                  SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)                
-                  DIR1_1 = VR/SUMA                                                   
-                  DIR1_2 = VS/SUMA
-                ENDIF
-              ENDIF
+                     AA = LBUF_DIR%DIRB(I)                             
+                     BB = LBUF_DIR%DIRB(I + NEL)                      
+                     V1 = AA*RX + BB*SX                                            
+                     V2 = AA*RY + BB*SY                                            
+                     V3 = AA*RZ + BB*SZ                                            
+                     VR = V1*E1X+ V2*E1Y + V3*E1Z                                  
+                     VS = V1*E2X+ V2*E2Y + V3*E2Z                                  
+                     SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)             
+                     DIR2_1 = VR/SUMA                                              
+                     DIR2_2 = VS/SUMA
+                   ELSE  ! IREP = 1 within PID51
+                     AA = DIR1_1
+                     BB = DIR1_2
+                     V1 = AA*RX + BB*SX         
+                     V2 = AA*RY + BB*SY         
+                     V3 = AA*RZ + BB*SZ         
+                     VR = V1*E1X+ V2*E1Y + V3*E1Z
+                     VS = V1*E2X+ V2*E2Y + V3*E2Z
+                     SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)             
+                     DIR1_1 = VR/SUMA                                                
+                     DIR1_2 = VS/SUMA
+                   ENDIF
+                 ENDIF
 C
-              JJ = JJ + 1
-              WA(JJ) = ILAW
+                 JJ = JJ + 1
+                 WA(JJ) = ILAW
 C  charging all directions
-              JJ = JJ + 1                                                          
-              IF (MLW /= 0 .AND. MLW /= 13) THEN                               
-                WA(JJ) = DIR1_1                                                    
-              ELSE                                                                 
-                WA(JJ) = ZERO                                                      
-              ENDIF                                                                
-              JJ = JJ + 1                                                          
-              IF (MLW /= 0 .AND. MLW /= 13) THEN                               
-                WA(JJ) = DIR1_2                                                    
-              ELSE                                                                 
-                WA(JJ) = ZERO                                                      
-              ENDIF
-              IF (IREP > 1 .AND. ILAW == 58) THEN
-                JJ = JJ + 1                                                        
-                IF (MLW /= 0 .AND. MLW /= 13) THEN                             
-                  WA(JJ) = DIR2_1                                                  
-                ELSE                                                               
-                  WA(JJ) = ZERO                                                    
-                ENDIF                                                              
-                JJ = JJ + 1                                                        
-                IF (MLW /= 0 .AND. MLW /= 13) THEN                             
-                  WA(JJ) = DIR2_2                                                  
-                ELSE                                                               
-                  WA(JJ) = ZERO                                                    
-                ENDIF
-              ENDIF !  IF (IREP > 1) THEN
+                 JJ = JJ + 1                                                       
+                 IF (MLW /= 0 .AND. MLW /= 13) THEN                            
+                   WA(JJ) = DIR1_1                                                 
+                 ELSE                                                              
+                   WA(JJ) = ZERO                                                   
+                 ENDIF                                                             
+                 JJ = JJ + 1                                                       
+                 IF (MLW /= 0 .AND. MLW /= 13) THEN                            
+                   WA(JJ) = DIR1_2                                                 
+                 ELSE                                                              
+                   WA(JJ) = ZERO                                                   
+                 ENDIF
+                 IF (IREP > 1 .AND. ILAW == 58) THEN
+                   JJ = JJ + 1                                                     
+                   IF (MLW /= 0 .AND. MLW /= 13) THEN                          
+                     WA(JJ) = DIR2_1                                               
+                   ELSE                                                            
+                     WA(JJ) = ZERO                                                 
+                   ENDIF                                                           
+                   JJ = JJ + 1                                                     
+                   IF (MLW /= 0 .AND. MLW /= 13) THEN                          
+                     WA(JJ) = DIR2_2                                               
+                   ELSE                                                            
+                     WA(JJ) = ZERO                                                 
+                   ENDIF
+                 ENDIF !  IF (IREP > 1) THEN
+               ENDDO ! NPTT
             ENDDO  !  DO J=1,NLAY   
           ELSEIF (IGTYP == 9  .OR. IGTYP == 10 .OR. IGTYP == 11 .OR.
      .        IGTYP == 16 .OR. IGTYP == 17 .OR. IGTYP == 51 .OR.
@@ -664,6 +675,15 @@ C
          NPG  = ELBUF_TAB(NG)%NPTR*ELBUF_TAB(NG)%NPTS
          IREP = IPARG(35,NG)
          NLAY = ELBUF_TAB(NG)%NLAY
+         IDRAPE = ELBUF_TAB(NG)%IDRAPE
+         NPLY_MAX = 0
+         IF(IDRAPE > 0 . AND. (IGTYP == 51 .OR. IGTYP == 52)) THEN
+          NPLY_MAX = 0
+          DO J = 1,NLAY
+           NPLY_MAX  = NPLY_MAX + ELBUF_TAB(NG)%BUFLY(J)%NPTT
+          ENDDO  
+         ENDIF
+         NPT = MAX (NPLY_MAX, NPT)
          NDIR = 1
          IF (ISH3N==3.AND.ISH3NFRAM==0) THEN
           IFRAM_OLD =0
@@ -673,6 +693,7 @@ C
          IF (IREP > 1) NDIR = 2
          LFT=1
          LLT=NEL
+
 c------------------------------------------
          DO I=LFT,LLT
           N  = I + NFT
@@ -760,6 +781,147 @@ C
           IF (IGTYP == 9  .OR. IGTYP == 10 .OR. IGTYP == 11 .OR.
      .        IGTYP == 16 .OR. IGTYP == 17 .OR. IGTYP == 51 .OR.
      .        IGTYP == 52 ) THEN
+           IF(IDRAPE > 0 .AND. (IGTYP == 51 .OR. IGTYP == 52)) THEN
+            DO J=1,NLAY 
+              NPTT = ELBUF_TAB(NG)%BUFLY(J)%NPTT
+              DO IPT = 1, NPTT
+                LBUF_DIR => ELBUF_TAB(NG)%BUFLY(J)%LBUF_DIR(IPT)                                                          
+                DIR1_1 = LBUF_DIR%DIRA(I)
+                DIR1_2 = LBUF_DIR%DIRA(I + NEL)
+                ILAW = ELBUF_TAB(NG)%BUFLY(J)%ILAW
+                IF (IREP == 1) THEN
+                  AA = DIR1_1
+                  BB = DIR1_2
+                  V1 = AA*RX + BB*SX         
+                  V2 = AA*RY + BB*SY         
+                  V3 = AA*RZ + BB*SZ         
+                  VR = V1*E1X+ V2*E1Y + V3*E1Z
+                  VS = V1*E2X+ V2*E2Y + V3*E2Z
+                  SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)                
+                  DIR1_1 = VR/SUMA                                                   
+                  DIR1_2 = VS/SUMA
+                ELSEIF (IREP == 2) THEN
+C---        Axe I
+                  AA = DIR1_1
+                  BB = DIR1_2
+                  V1 = AA*RX + BB*SX         
+                  V2 = AA*RY + BB*SY         
+                  V3 = AA*RZ + BB*SZ         
+                  VR = V1*E1X+ V2*E1Y + V3*E1Z
+                  VS = V1*E2X+ V2*E2Y + V3*E2Z
+                  SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)                
+                  DIR1_1 = VR/SUMA                                                   
+                  DIR1_2 = VS/SUMA
+C---        Axe II
+                  AA = LBUF_DIR%DIRB(I)                                 
+                  BB = LBUF_DIR%DIRB(I + NEL)                          
+                  V1 = AA*RX + BB*SX                                               
+                  V2 = AA*RY + BB*SY                                               
+                  V3 = AA*RZ + BB*SZ                                               
+                  VR = V1*E1X+ V2*E1Y + V3*E1Z                                     
+                  VS = V1*E2X+ V2*E2Y + V3*E2Z                                     
+                  SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)                
+                  DIR2_1 = VR/SUMA                                                 
+                  DIR2_2 = VS/SUMA
+                ELSEIF (IREP == 3) THEN
+C   mixing law  58 with other user laws with IREP = 0 within PID51
+                  IF (ILAW == 58) THEN
+C---        Axe I
+                    AA = DIR1_1
+                    BB = DIR1_2
+                    V1 = AA*RX + BB*SX         
+                    V2 = AA*RY + BB*SY         
+                    V3 = AA*RZ + BB*SZ         
+                    VR = V1*E1X+ V2*E1Y + V3*E1Z
+                    VS = V1*E2X+ V2*E2Y + V3*E2Z
+                    SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)                
+                    DIR1_1 = VR/SUMA                                                   
+                    DIR1_2 = VS/SUMA
+C---        Ax  e II
+                    AA = LBUF_DIR%DIRB(I)                                
+                    BB = LBUF_DIR%DIRB(I + NEL)                         
+                    V1 = AA*RX + BB*SX                                               
+                    V2 = AA*RY + BB*SY                                               
+                    V3 = AA*RZ + BB*SZ                                               
+                    VR = V1*E1X+ V2*E1Y + V3*E1Z                                     
+                    VS = V1*E2X+ V2*E2Y + V3*E2Z                                     
+                    SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)                
+                    DIR2_1 = VR/SUMA                                                 
+                    DIR2_2 = VS/SUMA
+                  ELSE  ! IREP = 0 within PID51
+C     DIR1_1 and DIT1_2 already got
+                  ENDIF
+                ELSEIF (IREP == 4) THEN
+C   mixing law  58 with other user laws with IREP = 1 within PID51
+                  IF (ILAW == 58) THEN
+C---        Axe I
+                    AA = DIR1_1
+                    BB = DIR1_2
+                    V1 = AA*RX + BB*SX         
+                    V2 = AA*RY + BB*SY         
+                    V3 = AA*RZ + BB*SZ         
+                    VR = V1*E1X+ V2*E1Y + V3*E1Z
+                    VS = V1*E2X+ V2*E2Y + V3*E2Z
+                    SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)                
+                    DIR1_1 = VR/SUMA                                                   
+                    DIR1_2 = VS/SUMA
+C---        Axe II
+                    AA = LBUF_DIR%DIRB(I)                                 
+                    BB = LBUF_DIR%DIRB(I + NEL)                          
+                    V1 = AA*RX + BB*SX                                               
+                    V2 = AA*RY + BB*SY                                               
+                    V3 = AA*RZ + BB*SZ                                               
+                    VR = V1*E1X+ V2*E1Y + V3*E1Z                                     
+                    VS = V1*E2X+ V2*E2Y + V3*E2Z                                     
+                    SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)                
+                    DIR2_1 = VR/SUMA                                                 
+                    DIR2_2 = VS/SUMA
+                  ELSE  ! IREP = 1 within PID51
+                    AA = DIR1_1
+                    BB = DIR1_2
+                    V1 = AA*RX + BB*SX         
+                    V2 = AA*RY + BB*SY         
+                    V3 = AA*RZ + BB*SZ         
+                    VR = V1*E1X+ V2*E1Y + V3*E1Z
+                    VS = V1*E2X+ V2*E2Y + V3*E2Z
+                    SUMA=MAX(SQRT(VR*VR + VS*VS) , EM20)                
+                    DIR1_1 = VR/SUMA                                                   
+                    DIR1_2 = VS/SUMA
+                  ENDIF
+                ENDIF
+C
+                JJ = JJ + 1
+                WA(JJ) = ILAW
+C  charging all directions
+                JJ = JJ + 1                                                          
+                IF (MLW /= 0 .AND. MLW /= 13) THEN                               
+                  WA(JJ) = DIR1_1                                                    
+                ELSE                                                                 
+                  WA(JJ) = ZERO                                                      
+                ENDIF                                                                
+                JJ = JJ + 1                                                          
+                IF (MLW /= 0 .AND. MLW /= 13) THEN                               
+                  WA(JJ) = DIR1_2                                                    
+                ELSE                                                                 
+                  WA(JJ) = ZERO                                                      
+                ENDIF
+                IF (IREP > 1 .AND. ILAW == 58) THEN
+                  JJ = JJ + 1                                                        
+                  IF (MLW /= 0 .AND. MLW /= 13) THEN                             
+                    WA(JJ) = DIR2_1                                                  
+                  ELSE                                                               
+                    WA(JJ) = ZERO                                                    
+                  ENDIF                                                              
+                  JJ = JJ + 1                                                        
+                  IF (MLW /= 0 .AND. MLW /= 13) THEN                             
+                    WA(JJ) = DIR2_2                                                  
+                  ELSE                                                               
+                    WA(JJ) = ZERO                                                    
+                  ENDIF
+                ENDIF !  IF (IREP > 1) THEN
+              ENDDO ! NPTT
+            ENDDO  !  DO J=1,NLAY        
+           ELSE ! Idrape == 0
             DO J=1,NLAY                                                            
               DIR1_1 = ELBUF_TAB(NG)%BUFLY(J)%DIRA(I)
               DIR1_2 = ELBUF_TAB(NG)%BUFLY(J)%DIRA(I + NEL)
@@ -895,6 +1057,7 @@ C  charging all directions
                 ENDIF
               ENDIF !  IF (IREP > 1) THEN
             ENDDO  !  DO J=1,NLAY
+           ENDIF ! IDRAPE 
           ENDIF  !  IF ( IGTYP )
 c
           IE=IE+1

--- a/starter/source/elements/initia/hm_read_inistate_d00.F
+++ b/starter/source/elements/initia/hm_read_inistate_d00.F
@@ -2669,27 +2669,6 @@ C---------
                   ID_SIGSH(I) = ID_ELEM
                   SIGSH(2,I) = 0
                   SIGSH(3,I) = THK
-!
-c---
-C  check for incompatibility with /DRAPE option
-c---
-                  IF (NDRAPE > 0) THEN
-                    NIP = IGEO(4,IG)
-                    DO JJ=1,NIP
-                      JDRP_ID = IDRAPE(JJ,IE)
-                      IF (JDRP_ID > 0) THEN
-                        CALL ANCMSG(MSGID=1156,
-     .                              MSGTYPE=MSGERROR,
-     .                              ANMODE=ANINFO,
-     .                              C1='/INISHE/THICK',
-     .                              C2='SHELL',
-     .                              I1=ID_ELEM,
-     .                              C3='/INISHE/THICK',
-     .                              I2=JDRP_ID)
-                          EXIT
-                      ENDIF ! IF (JDRP_ID > 0)
-                    ENDDO ! DO JJ=1,NIP
-                  ENDIF ! IF (NDRAPE > 0)
                 ENDIF ! IF (IE == 0)
               ENDDO ! DO J=1,NB_ELEMENTS
 C---------
@@ -2749,25 +2728,6 @@ C---------
      .                                     C1='/INISHE/ORTHO',
      .                                     C2='SHELL')
                   ELSE
-c---
-C  check for incompatibility with /DRAPE option
-c---
-                    IF (NDRAPE > 0) THEN
-                      DO JJ=1,NIP
-                        JDRP_ID = IDRAPE(JJ,IE)
-                        IF (JDRP_ID > 0) THEN
-                          CALL ANCMSG(MSGID=1156,
-     .                                MSGTYPE=MSGERROR,
-     .                                ANMODE=ANINFO,
-     .                                C1='/INISHE/ORTHO',
-     .                                C2='SHELL',
-     .                                I1=ID_ELEM,
-     .                                C3='/INISHE/ORTHO',
-     .                                I2=JDRP_ID)
-                          EXIT
-                        ENDIF ! IF (JDRP_ID > 0)
-                      ENDDO ! DO JJ=1,NIP
-                    ENDIF ! IF (NDRAPE > 0)
 !
                     IG   = IXC(6,IE)
                     IHBE = IGEO(10,IG)
@@ -2839,25 +2799,6 @@ c---
      .                                     C1='/INISHE/ORTH_LOC',
      .                                     C2='SHELL')
                   ELSE
-c---
-C  check for incompatibility with /DRAPE option
-c---
-                    IF (NDRAPE > 0) THEN
-                      DO JJ=1,NIP
-                        JDRP_ID = IDRAPE(JJ,IE)
-                        IF (JDRP_ID > 0) THEN
-                          CALL ANCMSG(MSGID=1156,
-     .                                MSGTYPE=MSGERROR,
-     .                                ANMODE=ANINFO,
-     .                                C1='/INISHE/ORTH_LOC',
-     .                                C2='SHELL',
-     .                                I1=ID_ELEM,
-     .                                C3='/INISHE/ORTH_LOC',
-     .                                I2=JDRP_ID)
-                          EXIT
-                        ENDIF ! IF (JDRP_ID > 0)
-                      ENDDO ! DO JJ=1,NIP
-                    ENDIF ! IF (NDRAPE > 0)
 !
                     IG    = IXC(6,IE)
                     IHBE  = IGEO(10,IG)
@@ -3854,27 +3795,6 @@ C---------
                   ID_SIGSH(I) = ID_ELEM
                   SIGSH(2,I) = 0
                   SIGSH(3,I) = THK
-!
-c---
-C  check for incompatibility with /DRAPE option
-c---
-                  IF (NDRAPE > 0) THEN
-                    NIP = IGEO(4,IG)
-                    DO JJ=1,NIP
-                      JDRP_ID = IDRAPE(JJ,IE)
-                      IF (JDRP_ID > 0) THEN
-                        CALL ANCMSG(MSGID=1156,
-     .                              MSGTYPE=MSGERROR,
-     .                              ANMODE=ANINFO,
-     .                              C1='/INISH3/THICK',
-     .                              C2='SH3N',
-     .                              I1=ID_ELEM,
-     .                              C3='/INISH3/THICK',
-     .                              I2=JDRP_ID)
-                          EXIT
-                      ENDIF ! IF (JDRP_ID > 0)
-                    ENDDO ! DO JJ=1,NIP
-                  ENDIF ! IF (NDRAPE > 0)
                 ENDIF ! IF (IE == 0)
               ENDDO ! DO J=1,NB_ELEMENTS
 C---------
@@ -3933,25 +3853,6 @@ C---------
      .                                     C1='/INISH3/ORTHO',
      .                                     C2='SH3N')
                   ELSE
-c---
-C  check for incompatibility with /DRAPE option
-c---
-                    IF (NDRAPE > 0) THEN
-                      DO JJ=1,NIP
-                        JDRP_ID = IDRAPE(JJ,IE)
-                        IF (JDRP_ID > 0) THEN
-                          CALL ANCMSG(MSGID=1156,
-     .                                MSGTYPE=MSGERROR,
-     .                                ANMODE=ANINFO,
-     .                                C1='/INISH3/ORTHO',
-     .                                C2='SHELL',
-     .                                I1=ID_ELEM,
-     .                                C3='/INISH3/ORTHO',
-     .                                I2=JDRP_ID)
-                          EXIT
-                        ENDIF ! IF (JDRP_ID > 0)
-                      ENDDO ! DO JJ=1,NIP
-                    ENDIF ! IF (NDRAPE > 0)
 !
                     IG   = IXTG(5,IE)
                     ISH3N = IGEO(18,IG)
@@ -4023,25 +3924,6 @@ c---
      .                                     C1='/INISH3/ORTH_LOC',
      .                                     C2='SH3N')
                   ELSE
-c---
-C  check for incompatibility with /DRAPE option
-c---
-                    IF (NDRAPE > 0) THEN
-                      DO JJ=1,NIP
-                        JDRP_ID = IDRAPE(JJ,IE)
-                        IF (JDRP_ID > 0) THEN
-                          CALL ANCMSG(MSGID=1156,
-     .                                MSGTYPE=MSGERROR,
-     .                                ANMODE=ANINFO,
-     .                                C1='/INISH3/ORTH_LOC',
-     .                                C2='SH3N',
-     .                                I1=ID_ELEM,
-     .                                C3='/INISH3/ORTH_LOC',
-     .                                I2=JDRP_ID)
-                          EXIT
-                        ENDIF ! IF (JDRP_ID > 0)
-                      ENDDO ! DO JJ=1,NIP
-                    ENDIF ! IF (NDRAPE > 0)
 !
                     IG    = IXTG(5,IE)
                     ISH3N = IGEO(18,IG)

--- a/starter/source/elements/initia/lec_inistate_tri.F
+++ b/starter/source/elements/initia/lec_inistate_tri.F
@@ -84,6 +84,7 @@ C
         NUMSHEL0=NUMSHEL
         IF(NUMSHEL>0)THEN
 C        tri des elts du Y000 par ID croissant
+          
           DO ISYS = 1, NUMSHEL
             ITRI(ISYS) =ID_SIGSH(ISYS)
           END DO

--- a/starter/source/elements/sh3n/coque3n/c3init3.F
+++ b/starter/source/elements/sh3n/coque3n/c3init3.F
@@ -142,9 +142,7 @@ C-----------------------------------------------
       INTEGER IORTHLOC(MVSIZ),MAT(MVSIZ),PID(MVSIZ),NGL(MVSIZ),JJ(6),
      .   IX1(MVSIZ),IX2(MVSIZ),IX3(MVSIZ)
       my_real
-     .   VX(MVSIZ),VY(MVSIZ),VZ(MVSIZ),PHI1(NPT,MVSIZ),PHI2(NPT,MVSIZ),
-     .   COOR1(NPT,MVSIZ),COOR2(NPT,MVSIZ),COOR3(NPT,MVSIZ),
-     .   COOR4(NPT,MVSIZ),ALDT(MVSIZ),AREA(MVSIZ)
+     .   VX(MVSIZ),VY(MVSIZ),VZ(MVSIZ),ALDT(MVSIZ),AREA(MVSIZ)
       my_real,
      .   DIMENSION(MVSIZ) :: PX1G,PY1G,PY2G,X2S,X3S,Y3S,DT
       my_real X1(MVSIZ), X2(MVSIZ), X3(MVSIZ) ,X4(MVSIZ),
@@ -159,7 +157,8 @@ C-----------------------------------------------
       CHARACTER*nchartitle,
      .   TITR
       my_real, 
-     .    ALLOCATABLE, DIMENSION(:) :: DIR_A,DIR_B
+     .    ALLOCATABLE, DIMENSION(:) :: DIR_A,DIR_B,PHI1,PHI2,
+     .                                 COOR1,COOR2,COOR3,COOR4
       INTEGER, ALLOCATABLE, DIMENSION(:) :: INDX     
       PARAMETER (LAYNPT_MAX = 10)
       PARAMETER (LAY_MAX = 100)
@@ -196,12 +195,6 @@ C
       VX   = ZERO
       VY   = ZERO
       VZ   = ZERO
-      PHI1 = ZERO
-      PHI2 = ZERO
-      COOR1 = ZERO
-      COOR2 = ZERO
-      COOR3 = ZERO
-      COOR4 = ZERO
       IORTHLOC = 0
       ITG = 1+NUMELC
 C---
@@ -213,22 +206,48 @@ C---
 C      
       NPT_ALL = 0
       DO IL=1,NLAY
-        NPT_ALL = NPT_ALL + ELBUF_STR%BUFLY(IL)%NPTT
-      ENDDO
+          NPT_ALL = NPT_ALL + ELBUF_STR%BUFLY(IL)%NPTT
+      ENDDO  
       MPT  = MAX(1,NPT_ALL)
+      IF(NPT_ALL == 0) NPT_ALL = NLAY
       IF (IPARG(6) == 0.OR.NPT==0) MPT=0
       IF((IGTYP == 51 .OR. IGTYP == 52) .AND. IDRAPE > 0) THEN
          ALLOCATE(DIR_A(NPT_ALL*NEL*2))
          ALLOCATE(DIR_B(NPT_ALL*NEL*2))
          DIR_A = ZERO
-         DIR_B = ZERO
+         DIR_B = ZERO 
+         ALLOCATE(PHI1(MVSIZ*NPT_ALL))
+         ALLOCATE(PHI2(NVSIZ*NPT_ALL))
+         PHI1  = ZERO
+         PHI2  = ZERO
+         ALLOCATE(COOR1(NPT_ALL*MVSIZ))
+         ALLOCATE(COOR2(NPT_ALL*MVSIZ))
+         ALLOCATE(COOR3(NPT_ALL*MVSIZ))
+         ALLOCATE(COOR4(NPT_ALL*MVSIZ))
+         COOR1 = ZERO
+         COOR2 = ZERO
+         COOR3 = ZERO
+         COOR4 = ZERO
       ELSE
          ALLOCATE(DIR_A(NLAY*NEL*2))
          ALLOCATE(DIR_B(NLAY*NEL*2))
          DIR_A = ZERO
-         DIR_B = ZERO
+         DIR_B = ZERO  
+         ALLOCATE(PHI1(NLAY*MVSIZ))
+         ALLOCATE(PHI2(NLAY*MVSIZ))
+         PHI1  = ZERO
+         PHI2  = ZERO
+         ALLOCATE(COOR1(NLAY*MVSIZ))
+         ALLOCATE(COOR2(NLAY*MVSIZ))
+         ALLOCATE(COOR3(NLAY*MVSIZ))
+         ALLOCATE(COOR4(NLAY*MVSIZ))
+         COOR1 = ZERO
+         COOR2 = ZERO
+         COOR3 = ZERO
+         COOR4 = ZERO
          NPT_ALL = NLAY
-      ENDIF
+      ENDIF 
+      !
 C
       DO J=1,6
         JJ(J) = NEL*(J-1)

--- a/starter/source/elements/sh3n/coquedk/cdkinit3.F
+++ b/starter/source/elements/sh3n/coquedk/cdkinit3.F
@@ -203,9 +203,10 @@ C-----------------------------------------------
       IF (MTN == 1 .OR. MTN == 3 .OR. MTN == 23) NPT = 0
       NPT_ALL = 0
       DO IL=1,NLAY
-        NPT_ALL = NPT_ALL + ELBUF_STR%BUFLY(IL)%NPTT
+          NPT_ALL = NPT_ALL + ELBUF_STR%BUFLY(IL)%NPTT
       ENDDO
       MPT  = MAX(1,NPT_ALL)
+      IF(NPT_ALL == 0 ) NPT_ALL = NLAY
       IF (IPARG(6) == 0.OR.NPT==0) MPT=0
 C
       IF((IGTYP == 51 .OR. IGTYP == 52) .AND. IDRAPE > 0) THEN

--- a/starter/source/elements/sh3n/coquedk/cmaini3.F
+++ b/starter/source/elements/sh3n/coquedk/cmaini3.F
@@ -91,8 +91,8 @@ C-----------------------------------------------
       my_real
      .   VX(MVSIZ),VY(MVSIZ),VZ(MVSIZ),PHI1(NPT_ALL,MVSIZ),PHI2(NPT_ALL,MVSIZ)
       my_real
-     .   COOR1(NLAY,MVSIZ),COOR2(NLAY,MVSIZ),COOR3(NLAY,MVSIZ),
-     .   COOR4(NLAY,MVSIZ)
+     .   COOR1(NPT_ALL,MVSIZ),COOR2(NPT_ALL,MVSIZ),COOR3(NPT_ALL,MVSIZ),
+     .   COOR4(NPT_ALL,MVSIZ)
       CHARACTER*nchartitle,
      .   TITR,TITR1
       my_real,

--- a/starter/source/elements/shell/coque/cinit3.F
+++ b/starter/source/elements/shell/coque/cinit3.F
@@ -157,8 +157,6 @@ C-----------------------------------------------
       TYPE(L_BUFEL_DIR_), POINTER :: LBUF_DIR
 C=======================================================================
       GBUF  => ELBUF_STR%GBUF
-      
-     
 c
       IMAT  = IXC(1,1+NFT)         ! mat N
       IPROP = IXC(NIXC-1,1+NFT)    ! property N
@@ -184,10 +182,10 @@ C
       IDRAPE = ELBUF_STR%IDRAPE
       NPT_ALL = 0
       DO IL=1,NLAY
-        NPT_ALL = NPT_ALL + ELBUF_STR%BUFLY(IL)%NPTT
+         NPT_ALL = NPT_ALL + ELBUF_STR%BUFLY(IL)%NPTT
       ENDDO
       MPT  = MAX(1,NPT_ALL)
-      IF(NPT_ALL == 0) NPT_ALL = NLAY
+      IF(NPT_ALL == 0 ) NPT_ALL = NLAY
 C----- NPT=0 for some cases      
       IF((IGTYP == 51 .OR. IGTYP == 52) .AND. IDRAPE > 0) THEN
          ALLOCATE(PHI1(MVSIZ*NPT_ALL))
@@ -198,6 +196,14 @@ C----- NPT=0 for some cases
          PHI2  = ZERO
          DIR_A = ZERO
          DIR_B = ZERO
+         ALLOCATE(COOR1(NPT_ALL*MVSIZ))
+         ALLOCATE(COOR2(NPT_ALL*MVSIZ))
+         ALLOCATE(COOR3(NPT_ALL*MVSIZ))
+         ALLOCATE(COOR4(NPT_ALL*MVSIZ))
+         COOR1 = ZERO
+         COOR2 = ZERO
+         COOR3 = ZERO
+         COOR4 = ZERO
       ELSE
          ALLOCATE(PHI1(NLAY*MVSIZ))
          ALLOCATE(PHI2(NLAY*MVSIZ))
@@ -207,16 +213,16 @@ C----- NPT=0 for some cases
          PHI2  = ZERO
          DIR_A = ZERO
          DIR_B = ZERO
+         ALLOCATE(COOR1(NLAY*MVSIZ))
+         ALLOCATE(COOR2(NLAY*MVSIZ))
+         ALLOCATE(COOR3(NLAY*MVSIZ))
+         ALLOCATE(COOR4(NLAY*MVSIZ))
+         COOR1 = ZERO
+         COOR2 = ZERO
+         COOR3 = ZERO
+         COOR4 = ZERO
          NPT_ALL = NLAY
       ENDIF
-      ALLOCATE(COOR1(NLAY*MVSIZ))
-      COOR1 = ZERO
-      ALLOCATE(COOR2(NLAY*MVSIZ))
-      COOR2 = ZERO
-      ALLOCATE(COOR3(NLAY*MVSIZ))
-      COOR3 = ZERO
-      ALLOCATE(COOR4(NLAY*MVSIZ))
-      COOR4 = ZERO
 C      
       IF (IPARG(6) == 0.OR.NPT==0) MPT=0
 C
@@ -300,6 +306,7 @@ C-----------------------------------------------
       ENDIF
 C-----------------------------------------------------------------------
 c     PHI, COOR used only with dimension(NLAY,MVSIZ); !! now corrected
+       print*, 'nbre of int pt defoNE',NLAY, MPT
       CALL CORTHINI(
      .   LFT        ,LLT       ,NFT       ,NLAY       ,NUMELC     ,
      .   NSIGSH     ,NIXC      ,IXC(1,NFT+1),IGEO     ,GEO        ,
@@ -462,6 +469,7 @@ C to be checked for IGTYP = 51 : ok
      .             E1X ,E2X ,E3X ,E1Y ,E2Y ,E3Y ,E1Z ,E2Z ,E3Z , 
      .             IDRAPE, IGTYP )
         END IF
+         
         CALL CSIGINI(ELBUF_STR ,
      1       LFT     ,LLT      ,NFT      ,MPT       ,ISTRAIN   ,
      2       GBUF%THK,GBUF%EINT,GBUF%STRA,GBUF%HOURG,GBUF%PLA  ,

--- a/starter/source/elements/shell/coque/corthdir.F
+++ b/starter/source/elements/shell/coque/corthdir.F
@@ -70,8 +70,8 @@ C-----------------------------------------------
      .                                         X1,X2,X3,X4,Y1,Y2,Y3,Y4,Z1,Z2,Z3,Z4
       my_real
      .   GEO(NPROPG,*),VX(*),VY(*),VZ(*),PHI1(NPT_ALL,*),PHI2(NPT_ALL,*),
-     .   COOR1(NLAY,MVSIZ),COOR2(NLAY,MVSIZ),
-     .   COOR3(NLAY,MVSIZ),COOR4(NLAY,MVSIZ),
+     .   COOR1(NPT_ALL,MVSIZ),COOR2(NPT_ALL,MVSIZ),
+     .   COOR3(NPT_ALL,MVSIZ),COOR4(NPT_ALL,MVSIZ),
      .   GEO_STACK(NPROPG,*)
       TYPE(ELBUF_STRUCT_), TARGET :: ELBUF_STR
       TYPE (STACK_PLY):: STACK
@@ -261,14 +261,14 @@ C-------
                        DIR1(I+NEL) = VS(I)*CSP+VR(I)*SNP                     
                    ENDIF                                           
                    IF (IORTHLOC(I) /= 0) THEN                                
-                     DIR1(I)     = COOR1(IL,I)                               
-                     DIR1(I+NEL) = COOR2(IL,I)                               
+                     DIR1(I)     = COOR1(IPT,I)                               
+                     DIR1(I+NEL) = COOR2(IPT,I)                               
                    ENDIF                                                     
                  ENDDO    
                ENDDO ! NPPT
              ELSE
                DO IT = 1, NPTT  
-                  LBUF_DIR => ELBUF_STR%BUFLY(I)%LBUF_DIR(IT)    
+                  LBUF_DIR => ELBUF_STR%BUFLY(IL)%LBUF_DIR(IT)    
                   DIR1 => LBUF_DIR%DIRA
                   IPT = IPT_ALL + IT 
                   DO I=LFT,LLT                                               
@@ -277,15 +277,15 @@ C-------
                     DIR1(I)     = VR(I)*CSP-VS(I)*SNP                        
                     DIR1(I+NEL) = VS(I)*CSP+VR(I)*SNP                 
                     IF (IORTHLOC(I) /= 0) THEN                                
-                     DIR1(I)     = COOR1(IL,I)                               
-                     DIR1(I+NEL) = COOR2(IL,I)                               
+                     DIR1(I)     = COOR1(IPT,I)                               
+                     DIR1(I+NEL) = COOR2(IPT,I)                               
                     ENDIF                                                     
                  ENDDO    
                ENDDO ! NPPT
              ENDIF !
              IPT_ALL = IPT_ALL + NPTT                                                    
-            ENDDO
-          IF (IREP == 1) THEN
+            ENDDO ! NLAY
+          IF(IREP == 1) THEN
             DO I=LFT,LLT
               U1X = E11(I)*E1X(I)+E12(I)*E1Y(I)+E13(I)*E1Z(I)
               U1Y = E11(I)*E2X(I)+E12(I)*E2Y(I)+E13(I)*E2Z(I)
@@ -296,14 +296,16 @@ C-------
               W2Y = U1X/DET
               W1Y = -U1Y/DET
               W2X = -U2X/DET
+              IPT_ALL = 0
               DO IL=1,NLAY
-               DIR1 => ELBUF_STR%BUFLY(IL)%DIRA 
-               NPTT = ELBUF_STR%BUFLY(IL)%NPTT
-               DIR1 => ELBUF_STR%BUFLY(IL)%DIRA   
+                LBUF_DIR => ELBUF_STR%BUFLY(IL)%LBUF_DIR(IT)    
+                DIR1 => LBUF_DIR%DIRA
+                NPTT = ELBUF_STR%BUFLY(IL)%NPTT
                DO IT = 1,NPTT
+                IPT = IPT_ALL + IT 
                 IF (IORTHLOC(I) /= 0) THEN
-                  DIR1(I)     = COOR1(IL,I) ! il --> It 
-                  DIR1(I+NEL) = COOR2(IL,I) 
+                  DIR1(I)     = COOR1(IPT,I) ! il --> It 
+                  DIR1(I+NEL) = COOR2(IPT,I) 
                 ENDIF
                 D1 = DIR1(I)
                 D2 = DIR1(I+NEL)
@@ -320,7 +322,7 @@ C---      Axe I d'anisotropie
             DO IL=1,NLAY
               NPTT =  ELBUF_STR%BUFLY(IL)%NPTT
               DO IT = 1, NPTT  
-                 LBUF_DIR => ELBUF_STR%BUFLY(I)%LBUF_DIR(IT)    
+                  LBUF_DIR => ELBUF_STR%BUFLY(IL)%LBUF_DIR(IT)    
                   DIR1 => LBUF_DIR%DIRA
                   DIR2 => LBUF_DIR%DIRB
                  IPT = IPT_ALL + IT
@@ -348,16 +350,16 @@ C---
             DO IL=1,NLAY
               NPTT =  ELBUF_STR%BUFLY(IL)%NPTT
               DO IT = 1, NPTT  
-                 LBUF_DIR => ELBUF_STR%BUFLY(I)%LBUF_DIR(IT)    
+                 LBUF_DIR => ELBUF_STR%BUFLY(IL)%LBUF_DIR(IT)    
                  DIR1 => LBUF_DIR%DIRA
                  DIR2 => LBUF_DIR%DIRB
                  IPT = IPT_ALL + IT
                  DO I=LFT,LLT  
                    IF (IORTHLOC(I) /= 0) THEN                               
-                     DIR1(I)     =  COOR1(IL,I) !! IL ou ipt
-                     DIR1(I+NEL) =  COOR2(IL,I)
-                     DIR2(I)     =  COOR3(IL,I)
-                     DIR2(I+NEL) =  COOR4(IL,I)
+                     DIR1(I)     =  COOR1(IPT,I) !! IL ou ipt
+                     DIR1(I+NEL) =  COOR2(IPT,I)
+                     DIR2(I)     =  COOR3(IPT,I)
+                     DIR2(I+NEL) =  COOR4(IPT,I)
                    ENDIF  
                  ENDDO  
               ENDDO ! NPTT
@@ -378,7 +380,7 @@ C---
               DO IL=1,NLAY  
                NPTT =  ELBUF_STR%BUFLY(IL)%NPTT
                DO IT = 1, NPTT  
-                 LBUF_DIR => ELBUF_STR%BUFLY(I)%LBUF_DIR(IT)    
+                 LBUF_DIR => ELBUF_STR%BUFLY(IL)%LBUF_DIR(IT)    
                  DIR1 => LBUF_DIR%DIRA
                  DIR2 => LBUF_DIR%DIRB
                  IPT = IPT_ALL + IT
@@ -409,7 +411,7 @@ C   mixing law58 with other user laws with IREP = 0 within PID51
               NPTT =  ELBUF_STR%BUFLY(IL)%NPTT
              IF (ILAW == 58) THEN         
                DO IT = 1, NPTT  
-                 LBUF_DIR => ELBUF_STR%BUFLY(I)%LBUF_DIR(IT)    
+                 LBUF_DIR => ELBUF_STR%BUFLY(IL)%LBUF_DIR(IT)    
                  DIR1 => LBUF_DIR%DIRA
                  DIR2 => LBUF_DIR%DIRB
                  IPT = IPT_ALL + IT
@@ -432,10 +434,10 @@ C---      Axe II d'anisotropie
 C---
                   DO I=LFT,LLT  
                     IF (IORTHLOC(I) /= 0) THEN                                
-                      DIR1(I)     =  COOR1(IL,I)  ! to check
-                      DIR1(I+NEL) =  COOR2(IL,I)
-                      DIR2(I)     =  COOR3(IL,I) 
-                      DIR2(I+NEL) =  COOR4(IL,I) 
+                      DIR1(I)     =  COOR1(IPT,I)  ! to check
+                      DIR1(I+NEL) =  COOR2(IPT,I)
+                      DIR2(I)     =  COOR3(IPT,I) 
+                      DIR2(I+NEL) =  COOR4(IPT,I) 
                     ENDIF  
                   ENDDO
 C---
@@ -470,7 +472,7 @@ C---          dir II
                  IPT_ALL  = IPT_ALL + NPTT 
               ELSE  ! IREP = 0 within PID51
                  DO IT = 1, NPTT  
-                  LBUF_DIR => ELBUF_STR%BUFLY(I)%LBUF_DIR(IT)    
+                  LBUF_DIR => ELBUF_STR%BUFLY(IL)%LBUF_DIR(IT)    
                   DIR1 => LBUF_DIR%DIRA
                   DIR2 => LBUF_DIR%DIRB
                   IPT = IPT_ALL + IT
@@ -480,8 +482,8 @@ C---          dir II
                     DIR1(I)     = VR(I)*CSP-VS(I)*SNP
                     DIR1(I+NEL) = VS(I)*CSP+VR(I)*SNP
                     IF (IORTHLOC(I) /= 0) THEN
-                      DIR1(I)     = COOR1(IL,I) 
-                      DIR1(I+NEL) = COOR2(IL,I) 
+                      DIR1(I)     = COOR1(IPT,I) 
+                      DIR1(I+NEL) = COOR2(IPT,I) 
                     ENDIF
                   ENDDO
                 ENDDO
@@ -495,7 +497,7 @@ C   mixing law58 with other user laws with IREP = 1 within PID51
               ILAW = ELBUF_STR%BUFLY(IL)%ILAW
               IF (ILAW == 58) THEN
                DO IT = 1, NPTT  
-                 LBUF_DIR => ELBUF_STR%BUFLY(I)%LBUF_DIR(IT)    
+                 LBUF_DIR => ELBUF_STR%BUFLY(IL)%LBUF_DIR(IT)    
                  DIR1 => LBUF_DIR%DIRA
                  DIR2 => LBUF_DIR%DIRB
                  IPT = IPT_ALL + IT
@@ -518,10 +520,10 @@ C---      Axe II d'anisotropie
 C---
                 DO I=LFT,LLT  
                   IF (IORTHLOC(I) /= 0) THEN                                  
-                    DIR1(I)     =  COOR1(IL,I) 
-                    DIR1(I+NEL) =  COOR2(IL,I)
-                    DIR2(I)     =  COOR3(IL,I) 
-                    DIR2(I+NEL) =  COOR4(IL,I) 
+                    DIR1(I)     =  COOR1(IPT,I) 
+                    DIR1(I+NEL) =  COOR2(IPT,I)
+                    DIR2(I)     =  COOR3(IPT,I) 
+                    DIR2(I+NEL) =  COOR4(IPT,I) 
                   ENDIF  
                 ENDDO
 C---
@@ -556,7 +558,7 @@ C---          dir II
                IPT_ALL = IPT_ALL + NPTT
               ELSE  ! Ilaw
                DO IT = 1, NPTT  
-                 LBUF_DIR => ELBUF_STR%BUFLY(I)%LBUF_DIR(IT)    
+                 LBUF_DIR => ELBUF_STR%BUFLY(IL)%LBUF_DIR(IT)    
                  DIR1 => LBUF_DIR%DIRA
                  DIR2 => LBUF_DIR%DIRB
                  IPT = IPT_ALL + IT
@@ -571,8 +573,8 @@ C---          dir II
                     W1Y = -U1Y/DET
                     W2X = -U2X/DET
                     IF (IORTHLOC(I) /= 0) THEN
-                      DIR1(I)     = COOR1(IL,I) 
-                      DIR1(I+NEL) = COOR2(IL,I) 
+                      DIR1(I)     = COOR1(IPT,I) 
+                      DIR1(I+NEL) = COOR2(IPT,I) 
                     ENDIF
                     D1 = DIR1(I)
                     D2 = DIR1(I+NEL)

--- a/starter/source/elements/shell/coque/corthini.F
+++ b/starter/source/elements/shell/coque/corthini.F
@@ -79,8 +79,8 @@ C-----------------------------------------------
       INTEGER, DIMENSION(*)  :: INDX  
       my_real
      . GEO(NPROPG,*),SKEW(LSKEW,*),SIGSH(NSIGSH,*),VX(*),VY(*),VZ(*),
-     . PHI1(NPT_ALL,*),PHI2(NPT_ALL,*),COOR1(NLAY,MVSIZ),COOR2(NLAY,MVSIZ),
-     . COOR3(NLAY,MVSIZ),COOR4(NLAY,MVSIZ),
+     . PHI1(NPT_ALL,*),PHI2(NPT_ALL,*),COOR1(NPT_ALL,MVSIZ),COOR2(NPT_ALL,MVSIZ),
+     . COOR3(NPT_ALL,MVSIZ),COOR4(NPT_ALL,MVSIZ),
      . ANGLE(*),GEO_STACK(NPROPG,*),X(3,*),BETAORTH(*)
       my_real, DIMENSION(MVSIZ), INTENT(IN) :: E3X,E3Y,E3Z,X1,X2,Y1,Y2,Z1,Z2
 C------------------------------------------------------     
@@ -203,7 +203,7 @@ C---    read property data
                  IF(STACK%IGEO(2+J,ISUBSTACK) /= 0) THEN        
                    IF(IGEO(49,STACK%IGEO(2+J,ISUBSTACK)) == 1)THEN                                 
                         PHI1(J,I)   = GEO_STACK(2,STACK%IGEO(2+J,ISUBSTACK)) + ANGLE(I)                    
-                        DEF_ORTH(I) = DEF_ORTH(I) - 1                                                                                               
+                        DEF_ORTH(I) = DEF_ORTH(I) - 1
                    ENDIF 
                  ENDIF                              
                  IF (IREP >= 2) PHI2(J,I)= STACK%GEO(IPDIR+J,ISUBSTACK) !!! ???
@@ -564,7 +564,11 @@ C---    Overwrite with optional element data__ ORTH_LOC
             END IF
 C
             NPT  = NINT(GEO(6,IX(NIX-1,I)))
-            IF (IGTYP == 16 .OR. IGTYP == 17 .OR. IGTYP == 51 .OR. IGTYP == 52) NPT = NLAY
+            IF(IDRAPE > 0 .AND. (IGTYP == 51 .OR. IGTYP==52)) THEN
+              NPT = NPT_ALL
+            ELSEIF (IGTYP == 16 .OR. IGTYP == 17 .OR. IGTYP == 51 .OR. IGTYP == 52) THEN
+              NPT = NLAY
+            ENDIF  
             NPTI = NINT(SIGSH(2,II))
             IF (NPT /= NPTI) THEN
               IPID   = IX(NIX-1,I)

--- a/starter/source/elements/shell/coqueba/cbainit3.F
+++ b/starter/source/elements/shell/coqueba/cbainit3.F
@@ -202,9 +202,10 @@ C
     
       NPT_ALL = 0
       DO IL=1,NLAY
-        NPT_ALL = NPT_ALL + ELBUF_STR%BUFLY(IL)%NPTT
+           NPT_ALL = NPT_ALL + ELBUF_STR%BUFLY(IL)%NPTT
       ENDDO   
       MPT  = MAX(1,NPT_ALL)
+      IF(NPT_ALL == 0 ) NPT_ALL = NLAY
       IF (IPARG(6) == 0.OR.NPT==0) MPT=0
       IF((IGTYP == 51 .OR. IGTYP == 52) .AND. IDRAPE > 0) THEN
          ALLOCATE(DIR_A(NPT_ALL*NEL*2))
@@ -330,6 +331,7 @@ c---------------------------
           PTM = (IPG-1)*LENM
           PTS = (IPG-1)*LENS
 c
+
           CALL CMAINI3(ELBUF_STR,PM       ,GEO      ,NEL       ,NLAY     ,
      .                 SKEW     ,IGEO     ,IXC(1,NFT+1),NIXC   ,NUMELC   ,
      .                 NSIGSH   ,SIGSH    ,PTSHEL   ,IGTYP     ,IORTHLOC ,
@@ -350,7 +352,6 @@ c
      .             Y3  ,Y4  ,Z1  ,Z2  ,Z3  ,Z4  ,
      .             E1X ,E2X ,E3X ,E1Y ,E2Y ,E3Y ,E1Z ,E2Z ,E3Z ,
      .             IDRAPE, IGTYP)
-           IF(MPT < 3) stop
            CALL CSIGINI4(ELBUF_STR,IHBE     ,
      1          LFT      ,LLT      ,NFT      ,MPT      ,ISTRAIN,
      2          GBUF%THK ,GBUF%EINT,GBUF%STRPG(PTS+1),GBUF%HOURG,

--- a/starter/source/elements/shell/coqueba/layini1.F
+++ b/starter/source/elements/shell/coqueba/layini1.F
@@ -65,7 +65,7 @@ C-----------------------------------------------
       my_real GEO(NPROPG,*),POSLY(MVSIZ,*),THK(*)
       TYPE(ELBUF_STRUCT_), TARGET :: ELBUF_STR
       TYPE (STACK_PLY) :: STACK
-      TYPE (DRAPE_), DIMENSION(:), TARGET  :: DRAPE
+      TYPE (DRAPE_), DIMENSION(NUMELC_DRAPE + NUMELTG_DRAPE), TARGET  :: DRAPE
       INTEGER , DIMENSION(NUMEL_DRAPE) :: INDX
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/starter/source/properties/composite_options/drape/hm_read_drape.F
+++ b/starter/source/properties/composite_options/drape/hm_read_drape.F
@@ -946,7 +946,7 @@ C---
             IGR    = IGRSH3N_DRP(J,1)
             IDRP   = IGRSH3N_DRP(J,2)
             NSLICE = IGRSH3N_DRP(J,3)
-            DO JJ=1,NGRSHEL
+            DO JJ=1, NGRSH3N
               OFFC = NGRNOD + NGRBRIC + NGRQUAD + NGRSHEL + NGRTRUS + 
      .               NGRBEAM + NGRSPRI + JJ
               JGR = IGRSH3N(JJ)%ID

--- a/starter/source/stack/hm_read_stack.F
+++ b/starter/source/stack/hm_read_stack.F
@@ -84,7 +84,8 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER :: I,J,K,KK,M1,ISHELL,ISH3N,ISMSTR,ISROT,ISTRAIN,IINT,ITHK,
      .   IORTH,IPOS,IGMAT,ISHEAR,IPLAST,NPLY,NP,NSUB,NISUB,IGTYP,IMID,
-     .   ISK,IDSK,PLY_ID,IPID0,IDSUB,INTER,IS,LAMIN,IPID1,IPID2,NPT_SUB,IRP
+     .   ISK,IDSK,PLY_ID,IPID0,IDSUB,INTER,IS,LAMIN,IPID1,IPID2,NPT_SUB,IRP,
+     .   NPLY_MAX
       my_real :: PTHK,ZSHIFT,HM,HF,HR,DM,DN,ASHEAR,VX,VY,VZ,FAILEXP,CVIS,
      .           NORM,ANG,POS,PTHKLY,WEIGHT
       LOGICAL :: IS_AVAILABLE, IS_ENCRYPTED, LFOUND
@@ -155,19 +156,21 @@ c
           STACK_INFO%SUB(2*(IS-1) + 2) = NPT_SUB  
 c
           DO I = 1,NPT_SUB
-            NPLY = NPLY + 1
             CALL HM_GET_INT_ARRAY_2INDEXES('plyidlist',PLY_ID,IS,I,IS_AVAILABLE,LSUBMODEL)
             CALL HM_GET_FLOAT_ARRAY_2INDEXES('LAM_Stack_phi',ANG,IS,I,IS_AVAILABLE,LSUBMODEL,UNITAB)
             CALL HM_GET_FLOAT_ARRAY_2INDEXES('LAM_Stack_Zi',POS,IS,I,IS_AVAILABLE,LSUBMODEL,UNITAB)
             CALL HM_GET_FLOAT_ARRAY_2INDEXES('P_thick_fail_lam',PTHKLY,IS,I,IS_AVAILABLE,LSUBMODEL,UNITAB)
             CALL HM_GET_FLOAT_ARRAY_2INDEXES('F_weight_i',WEIGHT,IS,I,IS_AVAILABLE,LSUBMODEL,UNITAB)
-            IF (PTHKLY == ZERO) PTHKLY = EM03
-            IF (WEIGHT == ZERO) WEIGHT = ONE
-            STACK_INFO%PID(NPLY) = PLY_ID
-            STACK_INFO%ANG(NPLY) = ANG
-            STACK_INFO%POS(NPLY) = POS
-            STACK_INFO%THKLY(NPLY)  = PTHKLY
-            STACK_INFO%WEIGHT(NPLY) = WEIGHT
+            IF(PLY_ID > 0) THEN
+                NPLY = NPLY + 1
+               IF (PTHKLY == ZERO) PTHKLY = EM03
+               IF (WEIGHT == ZERO) WEIGHT = ONE
+               STACK_INFO%PID(NPLY) = PLY_ID
+               STACK_INFO%ANG(NPLY) = ANG
+               STACK_INFO%POS(NPLY) = POS
+               STACK_INFO%THKLY(NPLY)  = PTHKLY
+               STACK_INFO%WEIGHT(NPLY) = WEIGHT
+           ENDIF    
           END DO
         END DO
 c
@@ -180,22 +183,25 @@ c
           END DO
         END IF  
       ELSE  ! property defined by a list of plies
-        CALL HM_GET_INTV('plyidlistmax' ,NPLY ,IS_AVAILABLE ,LSUBMODEL)
-        DO I=1,NPLY
+        CALL HM_GET_INTV('plyidlistmax' ,NPLY_MAX ,IS_AVAILABLE ,LSUBMODEL)
+        NPLY =  0
+        DO I=1,NPLY_MAX
           CALL HM_GET_INT_ARRAY_INDEX  ('plyidlist' ,PLY_ID,I,IS_AVAILABLE,LSUBMODEL)
           CALL HM_GET_FLOAT_ARRAY_INDEX('LAM_Stack_phi',ANG,I,IS_AVAILABLE,LSUBMODEL,UNITAB)   
           CALL HM_GET_FLOAT_ARRAY_INDEX('LAM_Stack_Zi' ,POS,I,IS_AVAILABLE,LSUBMODEL,UNITAB)   
           CALL HM_GET_FLOAT_ARRAY_INDEX('P_thick_fail_lam' ,PTHKLY,I,IS_AVAILABLE,LSUBMODEL,UNITAB)   
           CALL HM_GET_FLOAT_ARRAY_INDEX('F_weight_i' ,WEIGHT,I,IS_AVAILABLE,LSUBMODEL,UNITAB)   
-c
-          IF (PTHKLY == ZERO) PTHKLY = EM03
-          IF (WEIGHT == ZERO) WEIGHT = ONE
-          STACK_INFO%PID(I) = PLY_ID
-          STACK_INFO%ANG(I) = ANG
-          STACK_INFO%POS(I) = POS
-          STACK_INFO%THKLY(I)  = PTHKLY
-          STACK_INFO%WEIGHT(I) = WEIGHT
-          ! old format of interply not supported
+c       
+          IF(PLY_ID > 0) THEN
+             NPLY = NPLY + 1
+             IF (PTHKLY == ZERO) PTHKLY = EM03
+             IF (WEIGHT == ZERO) WEIGHT = ONE
+             STACK_INFO%PID(NPLY) = PLY_ID
+             STACK_INFO%ANG(NPLY) = ANG
+             STACK_INFO%POS(NPLY) = POS
+             STACK_INFO%THKLY(NPLY)  = PTHKLY
+             STACK_INFO%WEIGHT(NPLY) = WEIGHT
+          ENDIF
         END DO
       END IF
 c--------------------------------------------

--- a/starter/source/stack/pres_stackgroup.F
+++ b/starter/source/stack/pres_stackgroup.F
@@ -94,7 +94,7 @@ C-----------------------------------------------
       INTEGER :: NBFI,IPPID, NGL,IPID_1,NUMS,IPWEIGHT,IPTHKLY,NSHQ4,NSHT3
      
       INTEGER, DIMENSION(:,:), ALLOCATABLE :: ITRI
-      INTEGER, DIMENSION (:) ,ALLOCATABLE ::ICSH,INDX,ICSH_STACK
+      INTEGER, DIMENSION (:) ,ALLOCATABLE ::ICSH,INDX
       CHARACTER*nchartitle,
      .   TITR,TITR1
 C----------------------------f-------------------    
@@ -381,10 +381,7 @@ C !GR  T3
                 ENDIF  
               ENDDO
              ENDIF  ! ID > 0           
-11      CONTINUE 
-C tag of ply element        
-          ALLOCATE(ICSH_STACK(NUMELC + NUMELTG) )
-          IF(NUMELC + NUMELTG > 0)ICSH_STACK = 0       
+11      CONTINUE        
 C   compteur by element               
             DO I= 1,NPLY
               J   = IDGR4N(I)
@@ -404,8 +401,7 @@ C element type Q4
                      IF(IWORK_T(IDSHEL)%IDSTACK == 0) THEN 
                           IWORKSH (1,IDSHEL) = IWORKSH(1,IDSHEL) + 1
                           IWORK_T(IDSHEL)%IDSTACK = IDS
-                          ICSH_STACK(IDSHEL) = IDS
-                      ELSEIF(ICSH_STACK(IDSHEL) == IDS) THEN
+                      ELSEIF(IWORK_T(IDSHEL)%IDSTACK == IDS) THEN
                           IWORKSH (1,IDSHEL) = IWORKSH(1,IDSHEL) + 1
                       ELSE
 C  message d'erreur      
@@ -429,8 +425,7 @@ C  message d'erreur
 C element type T3 
                 ITY = IGRSH3N(J)%GRTYPE
                  DO 222 II = 1,NEL
-! c a verifier l'id du triangle
-
+! 
                    ISH3N = IGRSH3N(J)%ENTITY(II)
                    PID = IXTG(5,ISH3N)
                    IGTYP = IGEO(11,PID)
@@ -443,7 +438,7 @@ C element type T3
                           IWORKSH(1,IDSHEL) =   IWORKSH(1,IDSHEL ) + 1
                       ELSE
 C  message d'erreur
-                        IPID_1=IGEO_STACK(1,ICSH_STACK(IDSHEL))
+                        IPID_1=IGEO_STACK(1,IWORK_T(IDSHEL)%IDSTACK)
                         NGL =IXTG(NIXTG,IDSHEL)
                         CALL ANCMSG(MSGID=1152,
      .                    MSGTYPE=MSGERROR,
@@ -463,6 +458,7 @@ C
              NPT = IWORKSH(1,I)
              ALLOCATE(IWORK_T(I)%PLYID(NPT) )
              IWORK_T(I)%PLYID = 0
+             IWORK_T(I)%IDSTACK = 0
              IWORKSH(1,I) = 0
            ENDDO
 C
@@ -492,7 +488,7 @@ C element type Q4
                           IWORK_T(IDSHEL)%PLYID(NPT) = IDPLY
                       ELSE
 C  message d'erreur      
-                        IPID_1=IGEO_STACK(1,ICSH_STACK(IDSHEL))
+                        IPID_1=IGEO_STACK(1,IWORK_T(IDSHEL)%IDSTACK)
                         NGL =IXC(NIXC,IDSHEL)
                         CALL ANCMSG(MSGID=1152,
      .                    MSGTYPE=MSGERROR,
@@ -500,7 +496,7 @@ C  message d'erreur
      .                    I1=NGL,
 !!     .                    C2='SHELL',
      .                    I2= IGEO_STACK(1,IDS),
-     .                    I3=  IGEO_STACK(1,IPID_1) )                 
+     .                    I3=  IGEO_STACK(1,IPID_1) )
                       ENDIF
                     ENDIF 
                 ENDDO
@@ -524,13 +520,13 @@ C element type T3
                           NPT = IWORKSH(1,IDSHEL)
                           IWORK_T(IDSHEL)%PLYID(NPT) = IDPLY
                           IWORK_T(IDSHEL)%IDSTACK= IDS
-                      ELSEIF(ICSH_STACK(IDSHEL) == IDS) THEN
+                      ELSEIF(IWORK_T(IDSHEL)%IDSTACK == IDS) THEN
                            IWORKSH(1,IDSHEL) =   IWORKSH(1,IDSHEL ) + 1
                            NPT = IWORKSH(1,IDSHEL)
                            IWORK_T(IDSHEL)%PLYID(NPT) = IDPLY
                       ELSE
 C  message d'erreur
-                        IPID_1=IGEO_STACK(1,ICSH_STACK(IDSHEL))
+                        IPID_1=IGEO_STACK(1,IWORK_T(IDSHEL)%IDSTACK)
                         NGL =IXTG(NIXTG,IDSHEL)
                         CALL ANCMSG(MSGID=1152,
      .                    MSGTYPE=MSGERROR,


### PR DESCRIPTION
…elated to drape""

This reverts commit e213c3342844b3c389c0cc42ae650fc641a3529b.

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Drape option is not compatible with /STATE
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

- Adding the possibilityto get orthotropic direction by slice.
- Correct the right integration point in the thikness of shell with properties different to type51 and type52. The files modified compared to the first Pr 

1. -cinit3.F
2. cbainit3.F
3. c3init3.F
4. cdkinit3.F
The part of the code modified for ex (cinit3.F)
     NPT_ALL = 0
      DO IL=1,NLAY
         NPT_ALL = NPT_ALL + ELBUF_STR%BUFLY(IL)%NPTT
      ENDDO
      MPT  = MAX(1,NPT_ALL)
      IF(NPT_ALL == 0 ) NPT_ALL = NLAY**

- Fix the issue of /DRAPE and Sh3n groupe wich not considered. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
