### PR TITLE
Inertia was not initialized correctly for solids with IRODDL >0

### DIFF
--- a/starter/source/elements/elbuf_init/suinit3.F
+++ b/starter/source/elements/elbuf_init/suinit3.F
@@ -345,7 +345,7 @@ C----------------------------------------
       CALL SUMASS3(MS,PARTSAV,X,V,IPARTS(NF1),MSS(1,NF1),
      2             MAS,INN,GBUF%VOL,VOLU,MASS,IN,
      3             NC1, NC2, NC3, NC4, NC5, NC6, NC7, NC8,
-     4             INS,GBUF%FILL)
+     4             INS(1,NF1),GBUF%FILL)
 C----------------------------------------
 c Failure model initialisation
 C----------------------------------------


### PR DESCRIPTION
#### Description of the feature or the bug
inertia was wrong, due to wrong offset.
This caused a bug for tetras solids with  `/PROP/CONNECT`

#### Description of the changes
Fix the offset


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
