### PR TITLE
Fix GENE1 DTMIN criterion for Tria elements

### DIFF
--- a/starter/source/materials/fail/gene1/hm_read_fail_gene1.F
+++ b/starter/source/materials/fail/gene1/hm_read_fail_gene1.F
@@ -264,7 +264,7 @@ C===============================================================================
       IF (MAXPRES == ZERO) MAXPRES = INFINITY
       IF (SIGP1   == ZERO) SIGP1   = INFINITY
       IF (TMAX    == ZERO) TMAX    = INFINITY
-      IF (DTMIN   == ZERO) DTMIN   = EM20
+      IF (DTMIN   == ZERO) DTMIN   = -INFINITY
       ! Card 2 
       IF (fct_IDsm > 0) THEN
         IF (EPSDOT_SM == ZERO) THEN


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

DTMIN failure in /FAIL/GENE1 was not compatible with tria elements when used with /DT/NODA

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

The default value of DTMIN was changed to -INFINITY to fix the problem. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
