### PR TITLE
Fix NUVAR wrong value for failure criteria

### DIFF
--- a/engine/source/materials/mat_share/mulawc.F
+++ b/engine/source/materials/mat_share/mulawc.F
@@ -1798,7 +1798,7 @@ c---
             DO IFL = 1, NFAIL      ! loop over fail models in current layer                                      
               IP   = (IFL - 1)*15                                             
               UVARF  => FBUF%FLOC(IFL)%VAR
-              NVARF  =  FBUF%FLOC(IFL)%NVAR                                 
+              NVARF  =  IPM(113 + IP ,IMAT)     
               IRUPT  =  FBUF%FLOC(IFL)%ILAWF                                
               DAM    => FBUF%FLOC(IFL)%DAM
               DFMAX  => FBUF%FLOC(IFL)%DAMMX 


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

NVARF for failure criteria should not be recovered from FBUF as it can create some conflict. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Get NVARF from IPM instead. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
