### PR TITLE
Avoid integer overflow in case of big node IDs in hm_read_inimap.F

### DIFF
--- a/starter/source/initial_conditions/inimap/hm_read_inimap2d.F
+++ b/starter/source/initial_conditions/inimap/hm_read_inimap2d.F
@@ -329,7 +329,7 @@ C     ==============
             INIMAP2D(KK)%NODEID3 = LNODID3
          ENDIF
 
-         IF (LNODID1 * LNODID2 * LNODID3 == 0) THEN
+         IF (LNODID1==0 .or. LNODID2==0 .or. LNODID3==0) THEN
 C       Error here, we need 3 nodes to define a plane
          ELSE
             X0(1:3) = XGRID(1:3, LNODID1)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

no influence for the user

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

changed test of null node identifiers to avoid integer overflow

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
