### PR TITLE
/MAT/LAW41 : parameters renamed

### DIFF
--- a/engine/source/materials/mat/mat041/sigeps41.F
+++ b/engine/source/materials/mat/mat041/sigeps41.F
@@ -57,14 +57,14 @@ C   IREAC FLAG
 C
 C   *** IREAC = 1 ***
 C   ORIGINAL 2-TERM-MODEL   --> dF/dT = IGNITION TERM + GROWTH TERM
-C     IGNITION TERM : ratei = rki * (1.-fc)**ex * (etar-1.)**ri     , if P>0
-C     GROWTH TERM   : rateg = rkg * (1.-fc)**ex * fc**yg * pres**zg , if P>0
+C     IGNITION TERM : ratei = I * (1.-F)**b * (etar-1.)**x     , if P>0
+C     GROWTH TERM   : rateg = G1 * (1.-F)**b * F**d * pres**y  , if P>0
 C
 C   *** IREAC = 2 ***
 C   EXTENDED 3-TERM-MODEL   --> dF/dT = IGNITION TERM + GROWTH TERM 1 + GROWTH TERM 2
-C        IGNITION TERM :  ratei = rki * (1.-fc+tol)**ex * abs(etar-1.-ccrit)**ri       , if 0<f<fmxig & P>0 & compression thresold (etar-1>=ccrit)
-C        GROWTH TERM 1 : rateg1 = grow1 * (1.-fc+tol)**ex1 * (fc+tol)**yg1 * pres**zg1 , if 0<f<fmxgr & P>0
-C        GROWTH TERM 2 : rateg2 = grow2 * (1.-fc+tol)**ex2 * (fc+tol)**yg2 * pres**zg2 , if 0<f<fmngr & P>0
+C        IGNITION TERM :  ratei = I * (1.-F+tol)**b * abs(etar-1.-ccrit)**x     , if 0<f<Figmax & P>0 & compression thresold (etar-1>=ccrit)
+C        GROWTH TERM 1 : rateg1 = G1 * (1.-F+tol)**c * (F+tol)**d * pres**y     , if 0<f<FG1max & P>0
+C        GROWTH TERM 2 : rateg2 = G2 * (1.-F+tol)**e * (F+tol)**g * pres**z     , if FG2min<f<1 & P>0
 C
 C   ________________________________
 C   NOTATION
@@ -163,11 +163,11 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       my_real ar,br,r1r,r2r,r3r,cvr,etar,
      .        ap,bp,r1p,r2p,r3p,cvp,etap,
-     .        epsil,check, tmp,
-     .        rki,ex,ri,rkg,yg,zg,grow2,
-     .        zg2,yg2,ex1,ex2,fmxig,fmxgr,fmngr,
+     .        epsil,ftol, tmp,
+     .        I_,B_,X_,G1,D_,Y_,G2,
+     .        Z_,G_,C_,E_,Figmax,FG1max,FG2min,
      .        cappa,chi,ccrit,tol,cv,dedv,
-     .        artvisc,dt,pres,fc,cburn,enq,shr,vol_rel,dvol_rel
+     .        artvisc,dt,pres,fc,cburn,enq,SHEAR,vol_rel,dvol_rel
       my_real oldfc,tem1,tem2,chydro,chydro2,dpdmu,dpde,heat
       my_real mt,pold,er,tfextt,wr,wp
       integer  itrmax,i_reac,i
@@ -207,26 +207,26 @@ C-----------------------------------------------
       cvp = uparam(15)
       enq = uparam(16)
       epsil = uparam(17)
-      check = uparam(19)
-      rki = uparam(20)
-      ex = uparam(21)
-      ri = uparam(22)
-      rkg = uparam(23)
-      yg = uparam(24)
-      zg = uparam(25)
+      ftol = uparam(19)
+      I_ = uparam(20)
+      B_ = uparam(21)
+      X_ = uparam(22)
+      G1 = uparam(23)
+      D_ = uparam(24)
+      Y_ = uparam(25)
       cappa = uparam(26)
       chi = uparam(27)
       tol = uparam(28)
       ccrit = uparam(29)
-      grow2 = uparam(30)
-      ex1 = uparam(31)
-      ex2 = uparam(32)
-      yg2 = uparam(33)
-      zg2 = uparam(34)
-      fmxig = uparam(35)
-      fmxgr = uparam(36)
-      fmngr = uparam(37)
-      shr = uparam(38)
+      G2 = uparam(30)
+      C_ = uparam(31)
+      E_ = uparam(32)
+      G_ = uparam(33)
+      Z_ = uparam(34)
+      Figmax = uparam(35)
+      FG1max = uparam(36)
+      FG2min = uparam(37)
+      SHEAR = uparam(38)
 c
       do i=1,nel
         vol_rel = RHO0(i) / RHO(i) !no unit
@@ -260,7 +260,7 @@ c  hydrodynamic state (pass 1)
         dpde=ZERO
         CALL MIXTURE_EQUILIBRIUM(ar ,br   ,r1r  ,r2r   ,r3r ,cvr  ,etar,
      .           ap ,bp   ,r1p  ,r2p   ,r3p ,cvp  ,etap,
-     .           dpdmu,dpde,epsil,check,itrmax,enq,
+     .           dpdmu,dpde,epsil,ftol,itrmax,enq,
      .           tmp,heat,vol_rel ,fc,cv,dedv,pres, beta)
 c
 c  hydrodynamic state (pass 2)
@@ -268,18 +268,18 @@ c  hydrodynamic state (pass 2)
         tmp = tmp - HALF*(tem2-tem1)*dvol_rel    ! (Cv  SI:J/m3/K = Pa/K)
         CALL MIXTURE_EQUILIBRIUM(ar ,br   ,r1r  ,r2r   ,r3r ,cvr  ,etar,
      .           ap ,bp   ,r1p  ,r2p   ,r3p ,cvp  ,etap,
-     .           dpdmu,dpde,epsil,check,itrmax,enq,
+     .           dpdmu,dpde,epsil,ftol,itrmax,enq,
      .           tmp,heat,vol_rel ,fc,cv,dedv,pres, beta)
 c
 c  dF/dt (F function)
         !ORIGINAL 2-TERM-MODEL
-        if (i_reac == 1) CALL BURN_FRACTION_IREAC1(rki,ex,ri,rkg,yg,zg,cappa,artvisc,dt,pres,etar,fc,cburn,oldfc)
+        if (i_reac == 1) CALL BURN_FRACTION_IREAC1(I_,B_,X_,G1,D_,Y_,cappa,artvisc,dt,pres,etar,fc,cburn,oldfc)
         !EXTENDED 3-TERM-MODEL
-        if (i_reac == 2) CALL BURN_FRACTION_IREAC2(rki,ex,ri,rkg,yg,zg,grow2,zg2,yg2,ex1,ex2,fmxig,fmxgr,fmngr,
+        if (i_reac == 2) CALL BURN_FRACTION_IREAC2(I_,B_,X_,G1,D_,Y_,G2,Z_,G_,C_,E_,Figmax,FG1max,FG2min,
      .                             cappa,chi,ccrit,tol,artvisc,dt,pres,etar,fc,cburn,oldfc)
         tmp = tmp + (fc - oldfc) * heat/cv
 c  sound speed (time step criteria)
-        chydro2 = dpdmu + abs(pres)*(vol_rel*vol_rel)*dpde + ONEP33*shr
+        chydro2 = dpdmu + abs(pres)*(vol_rel*vol_rel)*dpde + ONEP33*SHEAR
         chydro2=max(chydro2,max(wr+ONE,wp+ONE)*abs(pres)/max(em30,RHO(I)))
         chydro = sqrt(chydro2)
 c
@@ -328,13 +328,15 @@ C-----------------------------------------------
 C-----------------------------------------------
 
 C-----------------------------------------------
-      SUBROUTINE BURN_FRACTION_IREAC1(rki,ex,ri,rkg,yg,zg,cappa,artvisc,dt,pres,etar,fc,cburn,oldfc)
+      SUBROUTINE BURN_FRACTION_IREAC1(I_,B_,X_,G1,D_,Y_,cappa,artvisc,dt,pres,etar,fc,cburn,oldfc)
 C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
-c   LEE-TARVER ORIGINAL 2-TERM-MODEL
-c     IGNITION TERM :  ratei = rki * (1.-fc)**ex * (etar-1.)**ri       , P>0
-c     GROWTH TERM :    rateg = rkg * (1.-fc)**ex * fc**yg * pres**zg   , P>0
+
+C   *** IREAC = 1 ***
+C   ORIGINAL 2-TERM-MODEL   --> dF/dT = IGNITION TERM + GROWTH TERM
+C     IGNITION TERM : ratei = I * (1.-F)**b * (etar-1.)**x     , if P>0
+C     GROWTH TERM   : rateg = G1 * (1.-F)**b * F**d * pres**y  , if P>0
 c
 c    bounds :
 c    -dfc limited during 1 cycle (chi)
@@ -352,7 +354,7 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       my_real
-     .   rki,ex,ri,rkg,yg,zg,cappa,
+     .   I_,B_,X_,G1,D_,Y_,cappa,
      .   artvisc,dt,pres,etar,fc,cburn,oldfc
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
@@ -369,11 +371,11 @@ C   S o u r c e   L i n e s
 C-----------------------------------------------
       cburn = ZERO
 c     ignition term
-      ratei = rki * (ONE -fc)**ex * (etar-ONE)**ri
+      ratei = I_ * (ONE -fc)**B_ * (etar-ONE)**X_
       if ((etar - ONE) <= ZERO) ratei=ZERO
       dfci = ratei * dt
 c     growth term
-      rateg =  rkg * (ONE - fc)**ex * fc**yg * pres**zg
+      rateg =  G1 * (ONE - fc)**B_ * fc**D_ * pres**Y_
       dfcg = rateg * dt
 c     F function  (0. < F < 1.)
       fc = oldfc + max(dfci,zero) + max(dfcg,zero)
@@ -385,15 +387,16 @@ C-----------------------------------------------
 
 
 C-----------------------------------------------
-      SUBROUTINE BURN_FRACTION_IREAC2(rki,ex,ri,rkg,yg,zg,grow2,zg2,yg2,ex1,ex2,fmxig,fmxgr,fmngr,cappa,chi,ccrit,tol,
+      SUBROUTINE BURN_FRACTION_IREAC2(I_,B_,X_,G1,D_,Y_,G2,Z_,G_,C_,E_,Figmax,FG1max,FG2min,cappa,chi,ccrit,tol,
      .                 artvisc,dt,pres,etar,fc,cburn,oldfc)
 C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
-c   LEE TARVER EXTENDED 3-TERM-MODEL
-c        IGNITION TERM :     ratei = rki * (1.-fc+tol)**ex * abs(etar-1.-ccrit)**ri        , 0<f<fmxig & P>0 & compression thresold (etar-1>=ccrit)
-c        GROWTH TERM 1 :    rateg1 = grow1 * (1.-fc+tol)**ex1 * (fc+tol)**yg1 * pres**zg1  , 0<f<fmxgr & P>0
-c        GROWTH TERM 2 :    rateg2 = grow2 * (1.-fc+tol)**ex2 * (fc+tol)**yg2 * pres**zg2  , 0<f<fmngr & P>0
+C   *** IREAC = 2 ***
+C   EXTENDED 3-TERM-MODEL   --> dF/dT = IGNITION TERM + GROWTH TERM 1 + GROWTH TERM 2
+C        IGNITION TERM :  ratei = I * (1.-F+tol)**b * abs(etar-1.-ccrit)**x     , if 0<f<Figmax & P>0 & compression thresold (etar-1>=ccrit)
+C        GROWTH TERM 1 : rateg1 = G1 * (1.-F+tol)**c * (F+tol)**d * pres**y , if 0<f<FG1max & P>0
+C        GROWTH TERM 2 : rateg2 = G2 * (1.-F+tol)**e * (F+tol)**g * pres**z     , if FG2min<f<1 & P>0
 c
 c    bounds :
 c    - dfc limited during 1 cycle (chi)
@@ -410,39 +413,36 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      my_real rki,ex,ri,rkg,yg,zg,grow2,zg2,yg2,ex1,ex2,
-     .        fmxig,fmxgr,fmngr,cappa,chi,ccrit,tol,
+      my_real I_,B_,X_,G1,D_,Y_,G2,Z_,G_,C_,E_,
+     .        Figmax,FG1max,FG2min,cappa,chi,ccrit,tol,
      .        artvisc,dt,pres,etar,fc,cburn,oldfc
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      my_real ratei,rateg,rateg1,rateg2,dfci,dfcg,grow1,yg1,zg1
+      my_real ratei,rateg,rateg1,rateg2,dfci,dfcg,grow1
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
 c   initi.
       cburn = ZERO
-      grow1 = rkg
-      yg1 = yg
-      zg1 = zg
       if (pres <= ZERO) return
       if (fc == ONE) return
       if (artvisc >= (cappa*pres)) return
-      if (fc <= fmxig) then
+      if (fc <= Figmax) then
        ! ignition term
-        ratei = rki * (ONE-fc+tol)**ex * abs(etar-ONE-ccrit)**ri
+        ratei = I_ * (ONE-fc+tol)**B_ * abs(etar-ONE-ccrit)**X_
         if ((etar- ONE -ccrit)<=ZERO) ratei = ZERO
         dfci = ratei * dt
         fc = oldfc + max(dfci,zero)
-        if (fc > fmxig) fc = fmxig
+        if (fc > Figmax) fc = Figmax
       endif
 
       ! growth term 1
-      rateg1 = grow1 * (ONE -fc+tol)**ex1 * (fc+tol)**yg1 * pres**zg1
-      if (fc > fmxgr) rateg1 = ZERO
+      rateg1 = G1 * (ONE -fc+tol)**C_ * (fc+tol)**D_ * pres**Y_
+      if (fc > FG1max) rateg1 = ZERO
       ! growth term 2
-      rateg2 = grow2 * (ONE -fc+tol)**ex2 * (fc+tol)**yg2 * pres**zg2
-      if (fc < fmngr) rateg2 = ZERO
+      rateg2 = G2 * (ONE -fc+tol)**E_ * (fc+tol)**G_ * pres**Z_
+      if (fc < FG2min) rateg2 = ZERO
       ! F function  (0. < F < 1.)
       rateg = rateg1 + rateg2
       dfcg = rateg * dt
@@ -459,7 +459,7 @@ C-----------------------------------------------
       SUBROUTINE MIXTURE_EQUILIBRIUM(
      .               ar   ,br   ,r1r    ,r2r  ,r3r   ,cvr ,etar,
      .               ap   ,bp   ,r1p    ,r2p  ,r3p   ,cvp ,etap,
-     .               dpdmu,dpde ,epsil  ,check,itrmax,enq ,
+     .               dpdmu,dpde ,epsil  ,ftol,itrmax,enq ,
      .               tmp  ,heat ,vol_rel,fc,cv,dedv  ,pres, beta)
 C-----------------------------------------------
 C   D e s c r i p t i o n
@@ -482,7 +482,7 @@ C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       my_real ar ,br   ,r1r  ,r2r   ,r3r ,cvr  ,etar,
      .        ap ,bp   ,r1p  ,r2p   ,r3p ,cvp  ,etap,
-     .        epsil,check,heat,dpdmu,dpde,enq, tmp,
+     .        epsil,ftol,heat,dpdmu,dpde,enq, tmp,
      .        vol_rel ,fc,cv,dedv,pres, beta
       integer  itrmax
 C-----------------------------------------------
@@ -501,7 +501,7 @@ C-----------------------------------------------
 c   initi.
       etac = ONE/vol_rel
       fc1 = ONE -fc
-      if (fc < check) then
+      if (fc < ftol) then
 c       reaction has not started : F=0., beta=Vfrac(reagent)=1.
         etar = fc1 * etac
         CALL JWL_EOS_STATE(ar,br,r1r,r2r,r3r,cvr,etar,tmp,dedvr,pres,bthr,dpdtr,enr)
@@ -515,7 +515,7 @@ c       reaction has not started : F=0., beta=Vfrac(reagent)=1.
         heat = enq-enp+enr
         return
 c
-      elseif (fc > (ONE -check)) then
+      elseif (fc > (ONE -ftol)) then
 c       reaction has finished : F=1., beta=Vfrac(reagent)=0.
         etap = fc * etac
         CALL JWL_EOS_STATE(ap,bp,r1p,r2p,r3p,cvp,etap,tmp,dedvp,pres,bthp,dpdtp,enp )

--- a/hm_cfg_files/config/CFG/radioss2023/MAT/matl41_lee_t.cfg
+++ b/hm_cfg_files/config/CFG/radioss2023/MAT/matl41_lee_t.cfg
@@ -1,0 +1,585 @@
+//Copyright>    CFG Files and Library ("CFG")
+//Copyright>    Copyright (C) 1986-2023 Altair Engineering Inc.
+//Copyright>
+//Copyright>    Altair Engineering Inc. grants to third parties limited permission to
+//Copyright>    use and modify CFG solely in connection with OpenRadioss software, provided
+//Copyright>    that any modification to CFG by a third party must be provided back to
+//Copyright>    Altair Engineering Inc. and shall be deemed a Contribution under and therefore
+//Copyright>    subject to the CONTRIBUTOR LICENSE AGREEMENT for OpenRadioss software.
+//Copyright>
+//Copyright>    CFG IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//Copyright>    INCLUDING, BUT NOT LIMITED TO, THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+//Copyright>    A PARTICULAR PURPOSE, AND NONINFRINGEMENT.  IN NO EVENT SHALL ALTAIR ENGINEERING
+//Copyright>    INC. OR ITS AFFILIATES BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY,
+//Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
+//Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
+//
+// Material law 41 (LEE_T) Setup File
+// 
+//This law describes the Lee-Tarver material.
+//Enhanced to generic page support, venkatk, RFE11336, 03-03-2009
+
+ATTRIBUTES(COMMON) {
+    // Support
+    // NB_PARTS                     = SIZE("Number of Connected Parts"); 
+    //COMPONENT                     = ARRAY[NB_PARTS](COMPONENT,"Connected Parts");
+    KEYWORD_STR                     = VALUE(STRING, "Solver Keyword");
+    NUM_COMMENTS                    = SIZE("NUM_COMMENTS");
+    CommentEnumField                = VALUE(INT,"User Comments");
+    COMMENTS                        = ARRAY[NUM_COMMENTS](STRING,"Entity Comments");
+    // Initial and reference densities
+    MAT_RHO                         = VALUE(FLOAT,"Initial Density");
+    Refer_Rho                       = VALUE(FLOAT,"Reference Density (for lower than 14.0 version)");
+    DUMMY                           = VALUE(STRING,"Dummy variable for Ref_Rho flag");
+    MAT_REFRHO_Option               = VALUE(INT, "RefRho_Option");
+    // Other values
+    Ireac                           = VALUE(INT,"Ignition and Growth");
+    a_r                             = VALUE(FLOAT,"ar Reagents Coefficient (JWL Equation of State)");
+    b_r                             = VALUE(FLOAT,"br Reagents Coefficient (JWL Equation of State)");
+    r_1r                            = VALUE(FLOAT,"r1r Reagents Coefficient (JWL Equation of State)");
+    r_2r                            = VALUE(FLOAT,"r2r Reagents Coefficient (JWL Equation of State)");
+    r_3r                            = VALUE(FLOAT,"r3r Reagents Coefficient (JWL Equation of State)");
+    //
+    a_p                             = VALUE(FLOAT,"ap Product Coefficient (JWL Equation of State)");
+    b_p                             = VALUE(FLOAT,"bp Product Coefficient (JWL Equation of State)");
+    r_1p                            = VALUE(FLOAT,"r1p Product Coefficient (JWL Equation of State)");
+    r_2p                            = VALUE(FLOAT,"r2p Product Coefficient (JWL Equation of State)");
+    r_3p                            = VALUE(FLOAT,"r3p Product Coefficient (JWL Equation of State)");
+    //
+    C_vr                            = VALUE(FLOAT,"Heat Capacity Reagent");
+    C_vp                            = VALUE(FLOAT,"Heat Capacity Product");
+    enq                             = VALUE(FLOAT,"Heat Reaction");
+    //
+    NITRS                           = VALUE(INT,"Maximum Number of Iterations for the Mixing Law");
+    //NITRS                         = SIZE("Max Number of iter. for the mixing law");
+    Epsilon_0                       = VALUE(FLOAT,"Precision on Hydrodynamic Balance");
+    ftol                            = VALUE(FLOAT,"Limiter of the Massic Fraction of Products");
+    //
+    I_                              = VALUE(FLOAT,"I Chemical Kinetic Coefficient of the Starting Phase (Lee-Tarver & Dyna-2D)");
+    b_                              = VALUE(FLOAT,"b Chemical Kinetic Coefficient of the Starting Phase (Lee-Tarver & Dyna-2D)");
+    x_                              = VALUE(FLOAT,"x Chemical Kinetic Coefficient of the Starting Phase (Lee-Tarver & Dyna-2D)");
+    //
+    g1                              = VALUE(FLOAT,"G1 Chemical Kinetic Coefficient of the Growing Phase (Lee-Tarver & Dyna-2D)");
+    d_                              = VALUE(FLOAT,"d Chemical Kinetic Coefficient of the Growing Phase (Lee-Tarver & Dyna-2D)");
+    y_                              = VALUE(FLOAT,"y Chemical Kinetic Coefficient of the Growing Phase (Lee-Tarver & Dyna-2D)");
+    c_                              = VALUE(FLOAT,"c Chemical Kinetic Coefficient of the Growing Phase (Dyna-2D)");
+    //
+    Kn                              = VALUE(FLOAT,"Numerical Limiters Coefficient (Lee-Tarver & Dyna-2D)");
+    chi                             = VALUE(FLOAT,"Numerical Limiters Coefficient (Dyna-2D)");
+    MAT_Tol                         = VALUE(FLOAT,"Numerical Limiters Coefficient (Dyna-2D)");
+    //
+    g2                              = VALUE(FLOAT,"G2 Growing Phase 2 Coefficient (Dyna-2D)");
+    e_                              = VALUE(FLOAT,"e Growing Phase 2 Coefficient (Dyna-2D)");
+    g_                              = VALUE(FLOAT,"g Growing Phase 2 Coefficient (Dyna-2D)");
+    z_                              = VALUE(FLOAT,"z Growing Phase 2 Coefficient (Dyna-2D)");
+    //
+    ccrit                           = VALUE(FLOAT,"Starting Threshold (for compression) (Dyna-2D)");
+    figmax                          = VALUE(FLOAT,"Starting Threshold (massic fraction) (Dyna-2D)");
+    fg1max                          = VALUE(FLOAT,"Coefficient (Dyna-2D)");
+    fg2min                          = VALUE(FLOAT,"Coefficient (Dyna-2D)");
+    //
+    MAT_G0                          = VALUE(FLOAT,"Shear Modulus");
+    T_Initial                       = VALUE(FLOAT,"Initial Temperature (K)");
+    // HEAT
+    Heat_Inp_opt                    = VALUE(INT,   "Heat");  
+    SUBGRP_HEAT_MAT                 = VALUE(SUBOBJECT, "");
+    // THERM_STRESS
+    THERM_STRESS                    = VALUE(INT,"Therm Stress");
+    SUBGRP_THERM_STRESS             = VALUE(SUBOBJECT, "");
+    ALE_Form                        = VALUE(INT, "Flag for Heat Transfer Formulation");
+    SUBGRP_ALE_MAT                  = VALUE(SUBOBJECT, "");
+    SUBGRP_EULER_MAT                = VALUE(SUBOBJECT, "");
+    //
+    IO_FLAG                         = VALUE(INT, "");
+    LAW_NO                          = VALUE(STRING, "");
+    Mat_Name_OR_LawNo               = VALUE(INT,  "RADIOSS_COMMENT_FLAG");
+    TITLE                           = VALUE(STRING,"");
+}
+
+
+SKEYWORDS_IDENTIFIER(COMMON)
+{
+    KEYWORD_STR                     = 9000;
+    COMMENTS                        = 5109;
+    CommentEnumField                = 7951;
+    MAT_REFRHO_Option               = 4285;
+    MAT_RHO                         = 118;
+    Refer_Rho                       = 4229;
+    DUMMY                           = -1;
+    C_vp                            = 4401;
+    C_vr                            = 4400;
+    Epsilon_0                       = 4198;
+    Ireac                           = 4389;
+    Kn                              = 843;
+    MAT_G0                          = 304;
+    MAT_Tol                         = 4102;
+    NITRS                           = 7250;
+    T_Initial                       = 4113;
+    a_p                             = 4395;
+    a_r                             = 4390;
+    b_p                             = 4396;
+    b_r                             = 4391;
+    ccrit                           = 4416;
+    ftol                            = 4403;
+    chi                             = 4411;
+    enq                             = 4402;
+    b_                              = 4405;
+    c_                              = 4410;
+    e_                              = 4413;
+    fg2min                          = 4419;
+    fg1max                          = 4418;
+    figmax                          = 4417;
+    g2                              = 4412;
+    r_1p                            = 4397;
+    r_1r                            = 4392;
+    r_2p                            = 4398;
+    r_2r                            = 4393;
+    r_3p                            = 4399;
+    r_3r                            = 4394;
+    x_                              = 4406;
+    g1                              = 4407;
+    I_                              = 4404;
+    d_                              = 4408;
+    g_                              = 4414;
+    y_                              = 4409;
+    z_                              = 4415;
+    NUM_COMMENTS                           = 5110;
+    //HEAT
+    Heat_Inp_opt                    = 4346;
+    SUBGRP_HEAT_MAT                        = -1;
+    // THERM_STRESS
+    THERM_STRESS                    = 4555;
+    SUBGRP_THERM_STRESS                    = -1;
+    ALE_Form                               = 4336;
+    SUBGRP_ALE_MAT                         = -1;
+    SUBGRP_EULER_MAT                       = -1;
+    LAW_NO                                 = -1;
+    Mat_Name_OR_LawNo                      = 4538;
+    IO_FLAG                                = -1;
+    TITLE                                  = -1;
+}
+
+DRAWABLES(COMMON) {
+public:
+    INITIAL_DENSITY                         = SCALAR(MAT_RHO);
+}
+
+CHECK(COMMON)
+{
+    MAT_RHO                         > 0.0;
+}
+
+DEFAULTS(COMMON) {
+    Ireac                           = 1;
+    c_                              = 0.0;
+    MAT_Tol                         = 0.0;
+    g2                              = 0.0;
+    e_                              = 0.0;
+    g_                              = 0.0;
+    z_                              = 0.0;
+    ccrit                           = 0.0;
+    figmax                          = 0.0;
+    Heat_Inp_opt                    = 0;
+    Epsilon_0                       = 1e-03;
+    Kn                              = 99.0;
+    NITRS                           = 80;
+    ftol                            = 1e-05;
+    chi                             = 99.0;
+}
+
+GUI(COMMON) {
+    RADIO(CommentEnumField)
+    {
+        ENUM_VALUE_FLAG=TRUE;
+        ADD(1, "Hide in Menu/Export");
+        ADD(2, "Show in Menu/Export");
+        ADD(3, "Do not export");
+    }
+    if(CommentEnumField == 2)
+    {  
+        SIZE(NUM_COMMENTS);
+        ARRAY(NUM_COMMENTS,"")
+        {
+            SCALAR(COMMENTS);
+        }   
+    }
+    if(Mat_Name_OR_LawNo == 2)
+    {
+        ASSIGN(KEYWORD_STR, "/MAT");
+        ASSIGN(KEYWORD_STR, "/LAW41/");
+    }
+    else 
+    {
+        ASSIGN(KEYWORD_STR, "/MAT");
+        ASSIGN(KEYWORD_STR, "/LEE_TARVER/");
+    }
+    FLAG(MAT_REFRHO_Option);
+    if(MAT_REFRHO_Option!=FALSE)
+    {
+        SCALAR(Refer_Rho)      { DIMENSION="density";       }
+    }
+    mandatory:
+    SCALAR(MAT_RHO)      { DIMENSION="density";            }
+
+    optional:
+    RADIO(Ireac) {
+            ADD(1, "1: For Lee-Tarver");
+            ADD(2, "2: For Dyna");
+        }
+
+        SEPARATOR("Reagents coefficients (JWL equation of state)");
+    SCALAR(a_r)         { DIMENSION="pressure"; }
+    SCALAR(b_r)         { DIMENSION="pressure"; }
+    SCALAR(r_1r)        { DIMENSION="DIMENSIONLESS"; }
+    SCALAR(r_2r)        { DIMENSION="DIMENSIONLESS"; }
+    SCALAR(r_3r)        { DIMENSION="specificheat"; }
+        SEPARATOR();
+    //
+        SEPARATOR("Product coefficients (JWL equation of state)");
+    SCALAR(a_p)         { DIMENSION="pressure"; }
+    SCALAR(b_p)         { DIMENSION="pressure"; }
+    SCALAR(r_1p)        { DIMENSION="DIMENSIONLESS"; }
+    SCALAR(r_2p)        { DIMENSION="DIMENSIONLESS"; }
+    SCALAR(r_3p)        { DIMENSION="specificheat"; }
+    SEPARATOR();
+    //
+    SCALAR(C_vr)        { DIMENSION="specificheat"; }
+    SCALAR(C_vp)        { DIMENSION="specificheat"; }
+    SCALAR(enq)         { DIMENSION="pressure"; }
+    //
+    SCALAR(NITRS)       { DIMENSION="DIMENSIONLESS"; }
+    //SIZE(NITRS);
+    SCALAR(Epsilon_0)   { DIMENSION="DIMENSIONLESS"; }
+    SCALAR(ftol)        { DIMENSION="DIMENSIONLESS"; }
+    //
+        SEPARATOR("Chemical kinetic coeff. of the starting phase (Lee-T and Dyna-2D)");
+    SCALAR(I_)      { DIMENSION="f"; }
+    SCALAR(b_)      { DIMENSION="DIMENSIONLESS"; }
+    SCALAR(x_)      { DIMENSION="DIMENSIONLESS"; }
+        SEPARATOR();
+    //
+        SEPARATOR("Chemical kinetic coeff. of the growing phase (Lee-T and Dyna-2D)");
+    SCALAR(g1)      { DIMENSION="CUSTOM_DIM_3<y_>"; }
+    SCALAR(d_)      { DIMENSION="DIMENSIONLESS"; }
+    SCALAR(y_)      { DIMENSION="DIMENSIONLESS"; }
+        SEPARATOR();
+    SCALAR(c_)     { DIMENSION="DIMENSIONLESS"; }
+    //
+    SCALAR(Kn)      { DIMENSION="DIMENSIONLESS"; }
+    SCALAR(chi)     { DIMENSION="DIMENSIONLESS"; }
+    SCALAR(MAT_Tol) { DIMENSION="DIMENSIONLESS"; }
+    //
+        SEPARATOR("Growing phase 2 coefficients (Dyna-2D)");
+    SCALAR(g2)     { DIMENSION="CUSTOM_DIM_2<z_>"; }
+    SCALAR(e_)     { DIMENSION="DIMENSIONLESS"; }
+    SCALAR(g_)    { DIMENSION="DIMENSIONLESS"; }
+    SCALAR(z_)    { DIMENSION="DIMENSIONLESS"; }
+        SEPARATOR();
+    //
+    SCALAR(ccrit)    { DIMENSION="DIMENSIONLESS"; }
+    SCALAR(figmax)   { DIMENSION="DIMENSIONLESS"; }
+    SCALAR(fg1max)   { DIMENSION="DIMENSIONLESS"; }
+    SCALAR(fg2min)   { DIMENSION="DIMENSIONLESS"; }
+
+    //
+    SCALAR(MAT_G0)    { DIMENSION="pressure"; }
+    SCALAR(T_Initial) { DIMENSION="k"; }
+        // HEAT data
+    graphical FLAG(Heat_Inp_opt);
+    if (Heat_Inp_opt!= 0) {
+            SUBOBJECT(SUBGRP_HEAT_MAT) {SUBTYPES = (/SUBOBJECT/HEAT);}  
+        }
+
+    graphical FLAG(THERM_STRESS);
+    if (THERM_STRESS!= 0) {
+            SUBOBJECT(SUBGRP_THERM_STRESS) {SUBTYPES = (/SUBOBJECT/THERM_STRESS);}  
+        }
+    /*
+    graphical SUPPORT("Support") {
+    OBJECTS=(/PART/QUAD,/PART/BRICK,/PART/TETRA4);
+    ADD(PART,"Parts");
+    }
+    */
+}
+
+GUI(ALE) {
+optional:
+    graphical RADIO(ALE_Form) 
+    {
+        ADD(1,"NONE") ;
+        ADD(2,"ALE") ;
+        ADD(3,"EULER");
+    }
+    if(ALE_Form == 2)
+    {
+        SUBOBJECT(SUBGRP_ALE_MAT) {SUBTYPES = (/SUBOBJECT/ALE_MAT);}
+    }
+    else if(ALE_Form == 3)
+    {
+        SUBOBJECT(SUBGRP_EULER_MAT) {SUBTYPES = (/SUBOBJECT/EULER);}
+    }
+}
+
+
+
+// File format
+FORMAT(radioss2023) {
+    ASSIGN(IO_FLAG, 0, EXPORT);
+    ASSIGN(IO_FLAG, 1,IMPORT);
+    if(IO_FLAG == 1)
+    {
+        HEADER("/MAT/%3s",LAW_NO);
+        if(LAW_NO == "LAW" )
+        {
+            ASSIGN(Mat_Name_OR_LawNo,2);
+        }
+    }
+    else if(IO_FLAG == 0 && Mat_Name_OR_LawNo == 2)
+    {
+        HEADER("/MAT/LAW41/%d",_ID_);
+        CARD("%-100s", TITLE);
+    }
+    else
+    {
+        HEADER("/MAT/LEE_TARVER/%d",_ID_);
+        CARD("%-100s", TITLE);
+    }
+    CARD_PREREAD("                    %20s",DUMMY);
+    if(DUMMY!="")
+    {
+        ASSIGN(MAT_REFRHO_Option,1,IMPORT);
+    }
+    else
+    {
+        ASSIGN(MAT_REFRHO_Option,0,IMPORT);
+    }
+    if(MAT_REFRHO_Option!=FALSE)
+    {
+        COMMENT("#              RHO_I               RHO_O");
+        CARD("%20lg%20lg",MAT_RHO,Refer_Rho);
+    }
+    else{
+        COMMENT("#              RHO_I");
+        CARD("%20lg",MAT_RHO);
+    }
+    //
+    COMMENT("#    Ireac");
+    CARD("%10d",Ireac);
+    //
+    COMMENT("#                 Ar                  Br                 R1r                 R2r                 R3r");
+    CARD("%20lg%20lg%20lg%20lg%20lg", a_r, b_r, r_1r, r_2r, r_3r);
+    //
+    COMMENT("#                 Ap                  Bp                 R1p                 R2p                 R3p");
+    CARD("%20lg%20lg%20lg%20lg%20lg", a_p, b_p, r_1p, r_2p, r_3p);
+    //
+    COMMENT("#                Cvr                 Cvp                 enq");
+    CARD("%20lg%20lg%20lg", C_vr, C_vp, enq);
+    //
+    COMMENT("#     iter                           eps                Ftol");
+    CARD("%10d          %20lg%20lg", NITRS, Epsilon_0, ftol);
+    //
+    COMMENT("#                  I                   b                   x");
+    CARD("%20lg%20lg%20lg", I_, b_, x_);
+    //
+    COMMENT("#                 G1                   d                   y                   c");
+    CARD("%20lg%20lg%20lg%20lg", g1, d_, y_, c_);
+    //
+    COMMENT("#                  k                   x                 tol");
+    CARD("%20lg%20lg%20lg", Kn, chi, MAT_Tol);
+    //
+    COMMENT("#                 G2                   e                   g                   z");
+    CARD("%20lg%20lg%20lg%20lg", g2, e_, g_, z_);
+    //
+    COMMENT("#                  a              Figmax              FG1max              FG2min");
+    CARD("%20lg%20lg%20lg%20lg", ccrit, figmax, fg1max, fg2min);
+    //
+    COMMENT("#                  G                  Ti");
+    CARD("%20lg%20lg", MAT_G0, T_Initial);
+    //
+    if(Heat_Inp_opt!=0)
+    {
+        SUBOBJECTS(SUBGRP_HEAT_MAT,/SUBOBJECT/HEAT);
+    } 
+    if(Heat_Inp_opt!=0 && THERM_STRESS !=0)
+    {
+        SUBOBJECTS(SUBGRP_THERM_STRESS,/SUBOBJECT/THERM_STRESS);
+    }
+    if(ALE_Form == 2)
+    {
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT);
+    }
+    else if(ALE_Form == 3)
+    {
+        SUBOBJECTS(SUBGRP_EULER_MAT,/SUBOBJECT/EULER);
+    }
+}
+FORMAT(radioss100) {
+    ASSIGN(IO_FLAG, 0, EXPORT);
+    ASSIGN(IO_FLAG, 1,IMPORT);
+    if(IO_FLAG == 1)
+    {
+        HEADER("/MAT/%3s",LAW_NO);
+        if(LAW_NO == "LAW" )
+        {
+            ASSIGN(Mat_Name_OR_LawNo,2);
+        }
+    }
+    else if(IO_FLAG == 0 && Mat_Name_OR_LawNo == 2)
+    {
+        HEADER("/MAT/LAW41/%d",_ID_);
+        CARD("%-100s", TITLE);
+    }
+    else
+    {
+        HEADER("/MAT/LEE_TARVER/%d",_ID_);
+        CARD("%-100s", TITLE);
+    }
+    CARD_PREREAD("                    %20s",DUMMY);
+    if(DUMMY!="")
+    {
+        ASSIGN(MAT_REFRHO_Option,1,IMPORT);
+    }
+    else
+    {
+        ASSIGN(MAT_REFRHO_Option,0,IMPORT);
+    }
+    if(MAT_REFRHO_Option!=FALSE)
+    {
+        COMMENT("#              RHO_I               RHO_O");
+        CARD("%20lg%20lg",MAT_RHO,Refer_Rho);
+    }
+    else{
+        COMMENT("#              RHO_I");
+        CARD("%20lg",MAT_RHO);
+    }
+    //
+    COMMENT("#    Ireac");
+    CARD("%10d",Ireac);
+    //
+    COMMENT("#                 Ar                  Br                 r1r                 r2r                 r3r");
+    CARD("%20lg%20lg%20lg%20lg%20lg", a_r, b_r, r_1r, r_2r, r_3r);
+    //
+    COMMENT("#                 Ap                  bp                 r1p                 r2p                 r3p");
+    CARD("%20lg%20lg%20lg%20lg%20lg", a_p, b_p, r_1p, r_2p, r_3p);
+    //
+    COMMENT("#                Cvr                 Cvp                 enq");
+    CARD("%20lg%20lg%20lg", C_vr, C_vp, enq);
+    //
+    COMMENT("#     iter                           EPS               check");
+    CARD("%10d          %20lg%20lg", NITRS, Epsilon_0, ftol);
+    //
+    COMMENT("#                rki                  ex                  ri");
+    CARD("%20lg%20lg%20lg", I_, b_, x_);
+    //
+    COMMENT("#                rkg                  yg                  zg                 ex1");
+    CARD("%20lg%20lg%20lg%20lg", g1, d_, y_, c_);
+    //
+    COMMENT("#                  k                   x                 tol");
+    CARD("%20lg%20lg%20lg", Kn, chi, MAT_Tol);
+    //
+    COMMENT("#              grow2                 ex2                 yg2                 zg2");
+    CARD("%20lg%20lg%20lg%20lg", g2, e_, g_, z_);
+    //
+    COMMENT("#              ccrit               fmxig               fmxgr               fmngr");
+    CARD("%20lg%20lg%20lg%20lg", ccrit, figmax, fg1max, fg2min);
+    //
+    COMMENT("#                  G                  Ti");
+    CARD("%20lg%20lg", MAT_G0, T_Initial);
+    //
+    if(Heat_Inp_opt!=0)
+    {
+        SUBOBJECTS(SUBGRP_HEAT_MAT,/SUBOBJECT/HEAT);
+    } 
+    if(Heat_Inp_opt!=0 && THERM_STRESS !=0)
+    {
+        SUBOBJECTS(SUBGRP_THERM_STRESS,/SUBOBJECT/THERM_STRESS);
+    }
+    if(ALE_Form == 2)
+    {
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT);
+    }
+    else if(ALE_Form == 3)
+    {
+        SUBOBJECTS(SUBGRP_EULER_MAT,/SUBOBJECT/EULER);
+    }
+}
+
+FORMAT(radioss51) {
+    ASSIGN(IO_FLAG, 0, EXPORT);
+    ASSIGN(IO_FLAG, 1,IMPORT);
+    if(IO_FLAG == 1)
+    {
+        HEADER("/MAT/%3s",LAW_NO);
+        if(LAW_NO == "LAW" )
+        {
+            ASSIGN(Mat_Name_OR_LawNo,2);
+        }
+    }
+    CARD_PREREAD("                    %20s",DUMMY);
+    if(DUMMY!="")
+    {
+        ASSIGN(MAT_REFRHO_Option,1,IMPORT);
+    }
+    else
+    {
+        ASSIGN(MAT_REFRHO_Option,0,IMPORT);
+    }
+    if(MAT_REFRHO_Option!=FALSE)
+    {
+        COMMENT("#        Init. dens.          Ref. dens.");
+        CARD("%20lg%20lg",MAT_RHO,Refer_Rho);
+    }
+    else{
+        COMMENT("#        Init. dens.");
+        CARD("%20lg",MAT_RHO);
+    }
+    COMMENT("#    IREAC");
+    CARD("%10d",Ireac);
+    //
+    COMMENT("#                 AR                  BR                 R1R                 R2R                 R3R");
+    CARD("%20lg%20lg%20lg%20lg%20lg", a_r, b_r, r_1r, r_2r, r_3r);
+    //
+    COMMENT("#                 AP                  BP                 R1P                 R2P                 R3P");
+    CARD("%20lg%20lg%20lg%20lg%20lg", a_p, b_p, r_1p, r_2p, r_3p);
+    //
+    COMMENT("#                CVR                 CVP                 ENQ");
+    CARD("%20lg%20lg%20lg", C_vr, C_vp, enq);
+    //
+    COMMENT("#     ITER                           EPS               CHECK");
+    CARD("%10d          %20lg%20lg", NITRS, Epsilon_0, ftol);
+    //
+    COMMENT("#                RKI                  EX                  RI");
+    CARD("%20lg%20lg%20lg", I_, b_, x_);
+    //
+    COMMENT("#                RKG                  YG                  ZG                 EX1");
+    CARD("%20lg%20lg%20lg%20lg", g1, d_, y_, c_);
+    //
+    COMMENT("#                  K                  XI                 TOL");
+    CARD("%20lg%20lg%20lg", Kn, chi, MAT_Tol);
+    //
+    COMMENT("#              GROW2                 EX2                 YG2                 ZG2");
+    CARD("%20lg%20lg%20lg%20lg", g2, e_, g_, z_);
+    //
+    COMMENT("#              CCRIT               FMXIG               FMXGR               FMNGR");
+    CARD("%20lg%20lg%20lg%20lg", ccrit, figmax, fg1max, fg2min);
+    //
+    COMMENT("#                  G                  TI");
+    CARD("%20lg%20lg", MAT_G0, T_Initial);
+    //
+    if(Heat_Inp_opt!=0)
+    {
+        SUBOBJECTS(SUBGRP_HEAT_MAT,/SUBOBJECT/HEAT);
+    } 
+    if(Heat_Inp_opt!=0 && THERM_STRESS !=0)
+    {
+        SUBOBJECTS(SUBGRP_THERM_STRESS,/SUBOBJECT/THERM_STRESS);
+    }
+    if(ALE_Form == 2)
+    {
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT);
+    }
+    else if(ALE_Form == 3)
+    {
+        SUBOBJECTS(SUBGRP_EULER_MAT,/SUBOBJECT/EULER);
+    }
+}

--- a/starter/source/materials/mat/mat041/hm_read_mat41.F
+++ b/starter/source/materials/mat/mat041/hm_read_mat41.F
@@ -68,14 +68,14 @@ C   IREAC FLAG
 C
 C   *** IREAC = 1 ***
 C   ORIGINAL 2-TERM-MODEL   --> dF/dT = IGNITION TERM + GROWTH TERM
-C     IGNITION TERM : ratei = rki * (1.-fc)**ex * (etar-1.)**ri     , if P>0
-C     GROWTH TERM   : rateg = rkg * (1.-fc)**ex * fc**yg * pres**zg , if P>0
+C     IGNITION TERM : ratei = I * (1.-F)**b * (etar-1.)**x     , if P>0
+C     GROWTH TERM   : rateg = G1 * (1.-F)**b * F**d * pres**y  , if P>0
 C
 C   *** IREAC = 2 ***
 C   EXTENDED 3-TERM-MODEL   --> dF/dT = IGNITION TERM + GROWTH TERM 1 + GROWTH TERM 2
-C        IGNITION TERM :  ratei = rki * (1.-fc+tol)**ex * abs(etar-1.-ccrit)**ri       , if 0<f<fmxig & P>0 & compression thresold (etar-1>=ccrit)
-C        GROWTH TERM 1 : rateg1 = grow1 * (1.-fc+tol)**ex1 * (fc+tol)**yg1 * pres**zg1 , if 0<f<fmxgr & P>0
-C        GROWTH TERM 2 : rateg2 = grow2 * (1.-fc+tol)**ex2 * (fc+tol)**yg2 * pres**zg2 , if 0<f<fmngr & P>0
+C        IGNITION TERM :  ratei = I * (1.-F+tol)**b * abs(etar-1.-ccrit)**x     , if 0<F<Figmax & P>0 & compression thresold (etar-1>=ccrit)
+C        GROWTH TERM 1 : rateg1 = G1 * (1.-F+tol)**c * (F+tol)**d * pres**y     , if 0<F<FG1max & P>0
+C        GROWTH TERM 2 : rateg2 = G2 * (1.-F+tol)**e * (F+tol)**g * pres**z     , if FG2min<F<1 & P>0
 C
 C-----------------------------------------------
 C   M o d u l e s
@@ -114,15 +114,14 @@ C-----------------------------------------------
       my_real AR, BR, R1R, R2R, R3R, WR,
      .        AP, BP, R1P, R2P, R3P, WP,
      .        CVR, CVP,
-     .        ENQ, EPSILON, FC, RKI, EX, RI, RKG, YG, ZG, CAPPA, CHI, TOL,
-     .        CCRIT, GROW2, EX1, EX2, YG2, ZG2, FMXIG, FMXGR, FMNGR, SHR, T,
+     .        ENQ, EPSILON, FTOL, I_, B_, X_, G1, D_, Y_, CAPPA, CHI, TOL,
+     .        CCRIT, G2, C_, E_, G_, Z_, Figmax, FG1max, FG2min, SHR, T,
      .        RHO0, RHOR
       LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
       IS_ENCRYPTED = .FALSE.
-!     Check input encryption
       CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
       NUPARAM = 40
 
@@ -160,30 +159,30 @@ C-----------------------------------------------
     
       CALL HM_GET_INTV('NITRS', ITER, IS_AVAILABLE, LSUBMODEL)
       CALL HM_GET_FLOATV('Epsilon_0', EPSILON, IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('check', FC, IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('ftol', FTOL, IS_AVAILABLE, LSUBMODEL, UNITAB)
                                   
-      CALL HM_GET_FLOATV('rki', RKI, IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('ex', EX, IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('ri', RI, IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('I_', I_, IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('b_', B_, IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('x_', X_, IS_AVAILABLE, LSUBMODEL, UNITAB)
       
-      CALL HM_GET_FLOATV('rkg', RKG, IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('yg', YG, IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('zg', ZG, IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('ex1', EX1, IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('g1', G1, IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('d_', D_, IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('y_', Y_, IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('c_', C_, IS_AVAILABLE, LSUBMODEL, UNITAB)
                                      
       CALL HM_GET_FLOATV('Kn', CAPPA, IS_AVAILABLE, LSUBMODEL, UNITAB)
       CALL HM_GET_FLOATV('chi', CHI, IS_AVAILABLE, LSUBMODEL, UNITAB)
       CALL HM_GET_FLOATV('MAT_Tol', TOL, IS_AVAILABLE, LSUBMODEL, UNITAB)
 
-      CALL HM_GET_FLOATV('grow2', GROW2, IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('ex2', EX2, IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('yg2', YG2, IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('zg2', ZG2, IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('g2', G2, IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('e_', E_, IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('g_', G_, IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('z_', Z_, IS_AVAILABLE, LSUBMODEL, UNITAB)
                                    
       CALL HM_GET_FLOATV('ccrit', CCRIT, IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('fmxig', FMXIG, IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('fmxgr', FMXGR, IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('fmngr', FMNGR, IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('figmax', Figmax, IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('fg1max', FG1max, IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('fg2min', FG2min, IS_AVAILABLE, LSUBMODEL, UNITAB)
 
       CALL HM_GET_FLOATV('MAT_G0', SHR, IS_AVAILABLE, LSUBMODEL, UNITAB)
       CALL HM_GET_FLOATV('T_Initial', T, IS_AVAILABLE, LSUBMODEL, UNITAB) 
@@ -199,7 +198,7 @@ C-----------------------------------------------
       WP = R3P/CVP   !SI : both units are J/m3/K (=Pa/K) ; WR is dimensionless (JWL EoS param)
       IF (EPSILON==ZERO) EPSILON = EM3
       IF (ITER==0) ITER = 80
-      IF (FC==ZERO) FC = EM5
+      IF (FTOL==ZERO) FTOL = EM5
       IF (CAPPA==ZERO) CAPPA = EIGHTY19                               
       IF (CHI==ZERO) CHI = EIGHTY19                                   
       NFUNC = 0                                                              
@@ -227,25 +226,25 @@ C-----------------------------------------------
       UPARAM(16) = ENQ                                                       
       UPARAM(17) = EPSILON                                                   
       UPARAM(18) = ITER                                                      
-      UPARAM(19) = FC           
-      UPARAM(20) = rki                                                       
-      UPARAM(21) = ex                                                        
-      UPARAM(22) = ri                                                        
-      UPARAM(23) = RKG                                                       
-      UPARAM(24) = YG                                                        
-      UPARAM(25) = ZG                                                        
-      UPARAM(31) = EX1                                                       
+      UPARAM(19) = FTOL
+      UPARAM(20) = I_                                                       
+      UPARAM(21) = B_                                                        
+      UPARAM(22) = X_                                                        
+      UPARAM(23) = G1                                                       
+      UPARAM(24) = D_                                                        
+      UPARAM(25) = Y_                                                        
+      UPARAM(31) = C_                                                       
       UPARAM(26) = CAPPA                                                     
       UPARAM(27) = CHI                                                       
       UPARAM(28) = TOL
-      UPARAM(32) = EX2                                                       
-      UPARAM(33) = YG2                                                       
-      UPARAM(34) = ZG2                                                       
-      UPARAM(30) = GROW2
+      UPARAM(32) = E_                                                       
+      UPARAM(33) = G_                                                       
+      UPARAM(34) = Z_                                                       
+      UPARAM(30) = G2
       UPARAM(29) = CCRIT                                                     
-      UPARAM(35) = FMXIG                                                     
-      UPARAM(36) = FMXGR                                                     
-      UPARAM(37) = FMNGR 
+      UPARAM(35) = Figmax                                                     
+      UPARAM(36) = FG1max                                                     
+      UPARAM(37) = FG2min 
       UPARAM(38) = SHR                                                       
       UPARAM(39) = T                                                         
       UPARAM(40) = ZERO                                                            
@@ -278,7 +277,9 @@ c-----------------
  1000 FORMAT(
      & 5X,'  LEE TARVER REACTIVE EXPLOSIVE         ',/,
      & 5X,'  -----------------------------         ',/,
-     & 5X,'REAC(1: LEE-TARVER 2:DYNA). . . . . . . =',1PG20.13/,
+     & 5X,'IREAC FLAG. . . . . . . . . . . . . . . =',1PG20.13/,
+     & 5X, '   1:ORIGINAL 2-TERM-MODEL (1980)      ',/,     
+     & 5X, '   2:EXTENDED 3-TERM-MODEL (1985)      ',/,     
      & 5X,'  REACTIVES JWL EQUATION OF STATES :    ',/,
      & 5X,'AR COEFFICIENT. . . . . . . . . . . . . =',1PG20.13/,
      & 5X,'BR COEFFICIENT. . . . . . . . . . . . . =',1PG20.13/,
@@ -300,31 +301,31 @@ c-----------------
      & /,
      & 5X,'EPSILON . . . . . . . . . . . . . . . . =',1PG20.13/,
      & 5X,'MAXIMUM NUMBER OF ITERATIONS. . . . . . =',1PG20.13/,
-     & 5X,'FC CHECK. . . . . . . . . . . . . . . . =',1PG20.13/,
+     & 5X,'FTOL  . . . . . . . . . . . . . . . . . =',1PG20.13/,
      & 5X,'  KINETICAL PARAMETERS                   :    ',/,
-     & 5X,'  IGNITION PHASE :                        ',/,
-     & 5X,'RKI COEFFICIENT . . . . . . . . . . . . =',1PG20.13/,
-     & 5X,'EX COEFFICIENT. . . . . . . . . . . . . =',1PG20.13/,
-     & 5X,'RI COEFFICIENT. . . . . . . . . . . . . =',1PG20.13/,
-     & 5X,'  GROWTH PHASE (LEE-TARVER):             ',/,
-     & 5X,'RKG COEFFICIENT . . . . . . . . . . . . =',1PG20.13/,
-     & 5X,'YG COEFFICIENT. . . . . . . . . . . . . =',1PG20.13/,
-     & 5X,'ZG COEFFICIENT. . . . . . . . . . . . . =',1PG20.13/,
+     & 5X,'  IGNITION TERM :                        ',/,
+     & 5X,'I COEFFICIENT . . . . . . . . . . . . . =',1PG20.13/,
+     & 5X,'b COEFFICIENT . . . . . . . . . . . . . =',1PG20.13/,
+     & 5X,'x COEFFICIENT . . . . . . . . . . . . . =',1PG20.13/,
+     & 5X,'  GROWTH TERM 1 :                        ',/,
+     & 5X,'G1 COEFFICIENT  . . . . . . . . . . . . =',1PG20.13/,
+     & 5X,'d COEFFICIENT . . . . . . . . . . . . . =',1PG20.13/,
+     & 5X,'y COEFFICIENT . . . . . . . . . . . . . =',1PG20.13/,
      & 5X,'  NUMERICAL LIMITORS                       ',/,
      & 5X,'CAPPA . . . . . . . . . . . . . . . . . =',1PG20.13/,
      & 5X,'CHI . . . . . . . . . . . . . . . . . . =',1PG20.13/,
      & 5X,'TOL . . . . . . . . . . . . . . . . . . =',1PG20.13/,
-     & 5X,'CCRIT . . . . . . . . . . . . . . . . . =',1PG20.13/,
-     & 5X,'  GROWTH PHASE  (DYNA-2D MODEL) :        ',/,
-     & 5X,'EX1 COEFFICIENT . . . . . . . . . . . . =',1PG20.13/,
-     & 5X,'GROW2 . . . . . . . . . . . . . . . . . =',1PG20.13/,
-     & 5X,'EX2 COEFFICIENT . . . . . . . . . . . . =',1PG20.13/,
-     & 5X,'YG2 COEFFICIENT . . . . . . . . . . . . =',1PG20.13/,
-     & 5X,'ZG2 COEFFICIENT . . . . . . . . . . . . =',1PG20.13/,
+     & 5X,'a COEFFICIENT . . . . . . . . . . . . . =',1PG20.13/,
+     & 5X,'  GROWTH TERM 2                          ',/,
+     & 5X,'c COEFFICIENT . . . . . . . . . . . . . =',1PG20.13/,
+     & 5X,'G2 COEFFICIENT. . . . . . . . . . . . . =',1PG20.13/,
+     & 5X,'e COEFFICIENT . . . . . . . . . . . . . =',1PG20.13/,
+     & 5X,'g COEFFICIENT . . . . . . . . . . . . . =',1PG20.13/,
+     & 5X,'z COEFFICIENT . . . . . . . . . . . . . =',1PG20.13/,
      & /,
-     & 5X,'FMXIG . . . . . . . . . . . . . . . . . =',1PG20.13/,
-     & 5X,'FMXGR . . . . . . . . . . . . . . . . . =',1PG20.13/,
-     & 5X,'FMNGR . . . . . . . . . . . . . . . . . =',1PG20.13/,
+     & 5X,'Figmax (LIMITER FOR IGNITIONT TERM) . . =',1PG20.13/,
+     & 5X,'FG1max (LIMITER FOR GROWTH TERM 1). . . =',1PG20.13/,
+     & 5X,'FG2min (LIMITER FOR GROWTH TERM 2). . . =',1PG20.13/,
      & /,
      & 5X,'SHEAR MODULUS . . . . . . . . . . . . . =',1PG20.13/,
      & 5X,'INITIAL TEMPERATURE (K) . . . . . . . . =',1PG20.13//)


### PR DESCRIPTION
#### /MAT/LAW41 : parameters renamed

#### Description of the changes
Parameters from LEE-TARVER material model are renamed to be consistent with bibliography from scientific community.
Following notation is now used : dF/dt = **I**(1-F)^**b**.(eta-1-**a**)^x  +  **G1**(1-F)^**c**.F^**d**.P^**y**  +  **G2**(1-F)^**e**.F^**g**.P^**z**

Following files were updated consequently :
- CFG file : ./radioss2023/MAT/matl41_lee_t.cfg  (new format 2023 introduced with new labels)
- Starter Reader : hm_read_mat41.F
- Engine file : sigeps41.F

**List of updated variables :**
_rki -> I
ex   -> b
ri   -> x
rkg -> G1
yg  -> g
zg  -> y
ex1 -> c
grow2 -> G2
ex2 -> e
yg2 -> g
zg2 -> z
ccrit -> a
fmxig -> Figmax
fmxgr -> FG1max
fmngr -> FG2min
check -> Ftol_

Manual Page is going to be updated consequently.