### PR TITLE
/LOAD/PBLAST : Improvements

### DIFF
--- a/common_source/modules/loads/pblast_mod.F
+++ b/common_source/modules/loads/pblast_mod.F
@@ -43,9 +43,12 @@ Chd|====================================================================
 
 #include "my_real.inc"
 
+      ! --- DATA STRUCTURE FOR BLAST PARAMETERS (EACH SEGMENT)
+      ! ------------------------------------------------------------
       TYPE PBLAST_STRUCT_
         INTEGER SIZ
         LOGICAL IS_RESET
+        my_real :: DTMIN
         my_real, ALLOCATABLE,DIMENSION(:)    :: PRES                                      ! pressure output(workarray)
         my_real, ALLOCATABLE,DIMENSION(:)    :: cos_theta                                 ! angle on structural face
         my_real, ALLOCATABLE,DIMENSION(:)    :: P_inci,P_refl,ta,t0,decay_inci,decay_refl ! Friedlander parameters
@@ -53,6 +56,8 @@ Chd|====================================================================
         INTEGER, DIMENSION(:,:), ALLOCATABLE :: N                                         !working array (normal vectors)
       END TYPE PBLAST_STRUCT_
 
+      ! --- HARDCODED TABLES {g,cm,µs,Mbar}
+      ! ------------------------------------------------------------
       TYPE PBLAST_DATA_
        !-----------------------------------------------------------!
        !            FREE AIR BURST                                 !
@@ -80,17 +85,19 @@ Chd|====================================================================
        my_real :: RW3_Surf(256),Ir_Surf(256),Iso_Surf(256),Pr_Surf(256),Pso_Surf(256),t0_Surf(256),ta_Surf(256)
       END TYPE PBLAST_DATA_
 
+      ! --- DATA STRUCTURE FOR PBLAST TIME STEP
+      ! ------------------------------------------------------------
+      TYPE PBLAST_DT_
+        INTEGER IDT
+        my_real TA_INF
+        my_real DT
+      END TYPE PBLAST_DT_
+
+      ! ------------------------------------------------------------
       TYPE(PBLAST_STRUCT_),ALLOCATABLE,DIMENSION(:) :: PBLAST_TAB
       TYPE(PBLAST_DATA_) :: PBLAST_DATA
-
-      INTEGER PBLAST_NDT
-      PARAMETER(PBLAST_NDT = 100)
-
-      COMMON /PBLAST_I/ IDT_PBLAST
-      INTEGER IDT_PBLAST
-
-      COMMON /PBLAST_J/ T0INF_PBLAST, TAINF_PBLAST, DT_PBLAST
-      my_real T0INF_PBLAST, TAINF_PBLAST, DT_PBLAST
+      TYPE(PBLAST_DT_) :: PBLAST_DT
+      ! ------------------------------------------------------------
 
 
        CONTAINS
@@ -132,6 +139,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER :: SIZ,IERR1,I
       my_real,DIMENSION(:),ALLOCATABLE :: RTMP
+      my_real :: TMP(1)
       INTEGER IAD,KK
 C-----------------------------------------------
 C   P r e - C o n d i t i o n
@@ -140,13 +148,22 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   S o u r c e   C o d e
 C-----------------------------------------------
-      ALLOCATE (   PBLAST_TAB(NLOADP_B),STAT=IERR1); IF (IERR1/=0) GOTO 1000
+      ALLOCATE (PBLAST_TAB(NLOADP_B),STAT=IERR1); IF (IERR1/=0) GOTO 1000
+      CALL READ_DB(TMP,1)
+      PBLAST_DT%TA_INF = TMP(1)
       !--------------------------------------
       !     READING NUMBER OF LOCAL SEGMENTS
       !--------------------------------------
       DO I=1,NLOADP_B
         CALL READ_I_C(PBLAST_TAB(I)%SIZ,1)
         PBLAST_TAB(I)%IS_RESET = .FALSE.
+      ENDDO
+      !--------------------------------------
+      !     READING MINIMUM TIME STEP
+      !--------------------------------------
+      DO I=1,NLOADP_B
+        CALL READ_DB(TMP,1)
+        PBLAST_TAB(I)%DTMIN = TMP(1)
       ENDDO
       !--------------------------------------
       !     READING REAL BUFFER (local segments only)
@@ -290,6 +307,7 @@ C-----------------------------------------------
       INTEGER :: SIZ,I,NSEG_LOC,IAD,OFF,JJ
       INTEGER, DIMENSION(:),ALLOCATABLE :: NSEGL
       my_real, DIMENSION(:),ALLOCATABLE :: RTMP
+      my_real :: TMP(1)
 C-----------------------------------------------
 C   P r e - C o n d i t i o n
 C-----------------------------------------------
@@ -297,6 +315,9 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   S o u r c e   C o d e
 C-----------------------------------------------
+      TMP(1) = PBLAST_DT%TA_INF
+      CALL WRITE_DB(TMP,1)
+      !--------------------------------------
       OFF = NUMELC+NUMELTG+NUMELS+NUMELQ+NUMELT+NUMELP+NUMELR+NUMELX+NCONLD+NUMCONV+NUMRADIA+NFXFLUX
       ALLOCATE(NSEGL(NLOADP_B))
       !--------------------------------------
@@ -312,6 +333,14 @@ C-----------------------------------------------
         NSEGL(I)=NSEG_LOC
         CALL WRITE_I_C(NSEG_LOC,1)
         OFF = OFF + PBLAST_TAB(I)%SIZ
+      ENDDO
+
+      !--------------------------------------
+      !     WRITING MINIMUM TIME STEP
+      !--------------------------------------
+      DO I=1,NLOADP_B
+        TMP(1) = PBLAST_TAB(I)%DTMIN
+        CALL WRITE_DB(TMP,1)
       ENDDO
 
       !--------------------------------------
@@ -381,6 +410,7 @@ C-----------------------------------------------
       INTEGER :: SIZ,I,IAD,JJ
       INTEGER, DIMENSION(:),ALLOCATABLE :: NSEGL
       my_real, DIMENSION(:),ALLOCATABLE :: RTMP
+      my_real :: TMP(1)
 C-----------------------------------------------
 C   P r e - C o n d i t i o n
 C-----------------------------------------------
@@ -388,11 +418,20 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   S o u r c e   C o d e
 C-----------------------------------------------
+      TMP(1)=PBLAST_DT%TA_INF
+      CALL WRITE_DB(TMP,1)
       !--------------------------------------
       !     WRITING LOCAL SIZE (number of local segments)
       !--------------------------------------
       DO I=1,NLOADP_B
         CALL WRITE_I_C(PBLAST_TAB(I)%SIZ,1)
+      ENDDO
+      !--------------------------------------
+      !     WRITING MINIMUM TIME STEP
+      !--------------------------------------
+      DO I=1,NLOADP_B
+        TMP(1) = PBLAST_TAB(I)%DTMIN
+        CALL WRITE_DB(TMP,1)
       ENDDO
       !--------------------------------------
       !     WRITING REAL BUFFER (for local segments only)

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -1300,8 +1300,7 @@ C
         LISENDP_CRK = 0
         LIRECVP_CRK = 0
 C
-        T0INF_PBLAST = EP20
-        IDT_PBLAST   = 0
+        PBLAST_DT%IDT   = 0
 C
         NUMSPH_GLO_R2R = 0
         FLG_SPHINOUT_R2R = 0  
@@ -3291,19 +3290,18 @@ C----------------------------------
           IF (IMONM > 0) CALL STARTIME(41,1)
           CALL PBLAST(ILOADP     ,LOADP      ,A          ,V       ,X      ,
      1                IADS(I87M) ,FSKY       ,FSKY       ,LLOADP  ,FEXT   ,
-     2                ITAB       ,H3D_DATA   ,OUTPUT%TH%TH_SURF,FSAVSURF,NSEG_LOADP) 
+     2                ITAB       ,H3D_DATA   ,OUTPUT%TH%TH_SURF,FSAVSURF,NSEG_LOADP)
           IF (IMONM > 0) CALL STOPTIME(41,1)
           IF (IMON>0) CALL STOPTIME(4,1)
           CALL TRACE_OUT(10)
-          IF(DT_PBLAST<DT2T)THEN
+          IF(PBLAST_DT%DT<DT2T)THEN
             !inter22 kinematic time step
-              DT2T         = DT_PBLAST  
-              ITYPTST      = 12
-              NELTST       = IDT_PBLAST
-              DT_PBLAST    = EP20
-              T0INF_PBLAST = EP20       
-         ENDIF    
-        ENDIF    
+            DT2T         = PBLAST_DT%DT
+            ITYPTST      = 12
+            NELTST       = PBLAST_DT%IDT
+            PBLAST_DT%DT = EP20
+         ENDIF
+        ENDIF
 C-------------------------------------------------------------------
 C       LOAD PCYL
 C----------------------------------

--- a/engine/source/loads/pblast/pblast.F
+++ b/engine/source/loads/pblast/pblast.F
@@ -74,9 +74,10 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-       INTEGER :: NL, ABAC_ID, NDT, NDT0, ID, II, IJK, NN(4), NNOD, IAD , IL, NSEGPL
-       my_real :: T0INF_LOC, TFEXT_LOC, T_STOP, TDET
+       INTEGER :: NL, ABAC_ID, ID, II, IJK, NN(4), NNOD, IAD , IL, NSEGPL
+       my_real :: DTMIN_LOC, TFEXT_LOC, T_STOP, TA_FIRST
        LOGICAL :: IS_RESET
+
 C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
@@ -90,9 +91,8 @@ C    AIR BURST     (ABAC_ID = 3)
 C-----------------------------------------------
 C   P r e - C o n d i t i o n
 C-----------------------------------------------
-       DT_PBLAST = EP20
-       T0INF_PBLAST = EP20       
-       IDT_PBLAST = 0      
+       PBLAST_DT%DT = EP20
+       PBLAST_DT%IDT = 0
 
        IF(NLOADP_B==0)THEN
          RETURN
@@ -103,37 +103,32 @@ C   S o u r c e   C o d e
 C-----------------------------------------------
 !$OMP PARALLEL
 !$OMP+ SHARED(FAC,A,V,X,TFEXT,IADC,FSKY,FSKYV,LLOADP,FEXT,ITAB,H3D_DATA,TT,ILOADP)
-!$OMP+ SHARED(T0INF_PBLAST,PBLAST_TAB,PBLAST_DATA)
-!$OMP+ PRIVATE(ABAC_ID,ID,NDT,NDT0,T0INF_LOC,NL,TFEXT_LOC)
-       
+!$OMP+ SHARED(PBLAST_DT,PBLAST_TAB,PBLAST_DATA)
+!$OMP+ PRIVATE(ABAC_ID,ID,DTMIN_LOC,NL,TFEXT_LOC,TA_FIRST,IJK)
+
        !-----------------------------------------------
        !   LOOP OVER all /LOAD/PBLAST options
-       !----------------------------------------------- 
+       !-----------------------------------------------
+
        DO NL=NLOADP_F+1, NLOADP_F+NLOADP_B
 
          ABAC_ID  = ILOADP(07,NL)
          ID       = ILOADP(08,NL) !user_id
-         NDT      = PBLAST_NDT
-         NDT0     = ILOADP(10,NL)
-         TDET     = FAC(01,NL)
+         TA_FIRST = FAC(07,NL)
          T_STOP   = FAC(13,NL)
-         
          IL       = NL-NLOADP_F
          IS_RESET = PBLAST_TAB(IL)%IS_RESET
-
-         IF(NDT0/=0) NDT = NDT0
-                  
          TFEXT_LOC = ZERO
-         T0INF_LOC = EP20
+         DTMIN_LOC = EP20
 
-         IF(TT >= TDET .AND. TT <= T_STOP)THEN
+         IF(TT <= T_STOP)THEN
            SELECT CASE(ABAC_ID)
              CASE(1)
                !--- LOADING MODEL : FREE AIR, SPHERICAL CHARGE
                CALL PBLAST_1(
      1                       ILOADP  ,FAC      ,A        ,V         ,X        ,
      2                       IADC    ,FSKY     ,LLOADP   ,FEXT      ,
-     3                       ITAB    ,H3D_DATA ,NL       ,T0INF_LOC ,TFEXT_LOC,
+     3                       ITAB    ,H3D_DATA ,NL       ,DTMIN_LOC ,TFEXT_LOC,
      4                       TH_SURF ,FSAVSURF ,NSEG_LOADP,NSEGPL   )
      
              CASE(2)
@@ -141,20 +136,20 @@ C-----------------------------------------------
                CALL PBLAST_2(
      1                       ILOADP  ,FAC      ,A        ,V         ,X        ,
      2                       IADC    ,FSKY     ,LLOADP   ,FEXT      ,
-     3                       ITAB    ,H3D_DATA ,NL       ,T0INF_LOC ,TFEXT_LOC,
+     3                       ITAB    ,H3D_DATA ,NL       ,DTMIN_LOC ,TFEXT_LOC,
      4                       TH_SURF ,FSAVSURF ,NSEG_LOADP,NSEGPL   )        
              CASE(3)
                !--- LOADING MODEL : SURFACE BURST, SPHERICAL CHARGE
                CALL PBLAST_3(
      1                       ILOADP  ,FAC      ,A        ,V         ,X        ,
      2                       IADC    ,FSKY     ,LLOADP   ,FEXT      ,
-     3                       ITAB    ,H3D_DATA ,NL       ,T0INF_LOC ,TFEXT_LOC,
+     3                       ITAB    ,H3D_DATA ,NL       ,DTMIN_LOC ,TFEXT_LOC,
      4                       TH_SURF ,FSAVSURF ,NSEG_LOADP,NSEGPL   )
      
              END SELECT 
              
          ELSEIF(TT > T_STOP)THEN         
-         
+           DTMIN_LOC = EP20
            IF(.NOT. IS_RESET)THEN
             ! FLUSH fsky array to 0.
 !$OMP DO SCHEDULE(GUIDED,MVSIZ)           
@@ -184,10 +179,14 @@ C-----------------------------------------------
 #include "lockon.inc"
          TFEXT = TFEXT + TFEXT_LOC
          ! Time Step (DT_PBLAST) and corresponding option id (IDT_PBLAST)
-         IF(T0INF_LOC/NDT<DT_PBLAST) THEN
-           IDT_PBLAST  = ID 
-           DT_PBLAST = T0INF_LOC/NDT
-         ENDIF      
+         ! if nothing was loaded : set time step to go on arrival time (no CPU time wasted in nothing happen elsewhere)
+         ! if load has started, use positive impulse to determine a time step for this current option
+
+           IF(DTMIN_LOC < PBLAST_DT%DT)THEN
+             PBLAST_DT%IDT  = ID
+             PBLAST_DT%DT = DTMIN_LOC
+           ENDIF
+
 #include  "lockoff.inc"
 
            CALL MY_BARRIER()

--- a/engine/source/loads/pblast/pblast_1.F
+++ b/engine/source/loads/pblast/pblast_1.F
@@ -35,7 +35,7 @@ Chd|        TH_SURF_MOD                   ../common_source/modules/interfaces/th
 Chd|====================================================================
       SUBROUTINE PBLAST_1(ILOADP  ,FAC      ,A       ,V         ,X       ,
      1                    IADC    ,FSKY     ,LLOADP  ,FEXT      ,
-     2                    ITAB    ,H3D_DATA ,NL      ,T0INF_LOC ,TFEXT_LOC,
+     2                    ITAB    ,H3D_DATA ,NL      ,DTMIN_LOC ,TFEXT_LOC,
      3                    TH_SURF ,FSAVSURF ,NSEG_LOADP,NSEGPL)
 C-----------------------------------------------
 C   M o d u l e s
@@ -67,11 +67,12 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER,INTENT(IN) :: LLOADP(SLLOADP)
-      INTEGER,INTENT(IN) :: ILOADP(SIZLOADP,NLOADP)
+      INTEGER,INTENT(INOUT) :: ILOADP(SIZLOADP,NLOADP)
       INTEGER,INTENT(IN) :: IADC(*)
       INTEGER, INTENT(IN) :: ITAB(NUMNOD),NL
-      my_real,INTENT(INOUT) :: T0INF_LOC,TFEXT_LOC
-      my_real,INTENT(IN) :: FAC(LFACLOAD,NLOADP),V(3,NUMNOD),X(3,NUMNOD)
+      my_real,INTENT(INOUT) :: DTMIN_LOC,TFEXT_LOC
+      my_real,INTENT(IN) :: V(3,NUMNOD),X(3,NUMNOD)
+      my_real,INTENT(INOUT) :: FAC(LFACLOAD,NLOADP)
       my_real,INTENT(INOUT) :: A(3,NUMNOD),FSKY(8,SFSKY/8),FEXT(3,NUMNOD)
       TYPE(H3D_DATABASE),INTENT(IN) :: H3D_DATA
       TYPE (TH_SURF_) , INTENT(IN) :: TH_SURF
@@ -81,23 +82,26 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER N1, N2, N3, N4,IL,IS,IAD,I,IANIM_OR_H3D,IZ_UPDATE,ABAC_ID,ISIZ_SEG,IERR1,
-     .        Phi_I, ID, ITA_SHIFT,NITER,ITER,IMODEL,NN(4),NS,KSURF
+     .        Phi_I, ID, ITA_SHIFT,NITER,ITER,IMODEL,NN(4),NS,KSURF,NDT
      
       my_real :: Zx,Zy,Zz,NORM,Nx,Ny,Nz,AREA
       
       my_real
      .   LAMBDA,cos_theta, alpha_inci, alpha_refl, P_inci, P_refl_,P_inci_, P_refl,Z,Phi_DB,bound1,bound2, 
      .   I_inci,I_refl,I_inci_,I_refl_, dt_0, t_a,dt_0_,
-     .   WAVE_refl,WAVE_inci, W13, P0
+     .   WAVE_refl,WAVE_inci, W13
       my_real DNORM,
      .        Xdet,Ydet,Zdet,Tdet,Wtnt,PMIN,T_STOP,Dx,Dy,Dz,P,
-     .        FAC_M_bb, FAC_L_bb, FAC_T_bb, FAC_P_bb, FAC_I_bb, TA_SHIFT, TT_STAR
+     .        FAC_M_bb, FAC_L_bb, FAC_T_bb, FAC_P_bb, FAC_I_bb, TA_FIRST, TT_STAR
       my_real Z1_
       my_real DECAY_inci,DECAY_refl,ZETA,TMP2,TMP3,FUNCT,DIFF,RES,TOL,kk
       my_real :: LogRes
       my_real :: cst_255_div_ln_Z1_on_ZN,  log10_, NPT, FF(3)
+      my_real :: TA_INF_LOC
       
       integer, external :: OMP_GET_THREAD_NUM
+
+      LOGICAL IS_UPDATED
       
       DATA cst_255_div_ln_Z1_on_ZN/-38.147316611455952998/
       DATA log10_ /2.30258509299405000000/
@@ -107,10 +111,38 @@ C   D e s c r i p t i o n
 C-----------------------------------------------
 C This subroutines is applying pressure load to a segment submitted to a blast wave (FREE AIR model).
 C Preussre time histories are built from "UFC 3-340-02, Dec. 5th 2008" tables which are hardcoded in unit system {g, cm, mus}
+C (table sampling : 256 points ; see pblast_mod.F)
+C
+C  T* = T + TA_INF (shift with first arrival time for all pblast option,  TA_INF=0. if ita_shift/=2)
+C  If request made to update blast profile (iz_update==2) then it is made once on T*=TDET
+C
 C-----------------------------------------------
 C   P r e - C o n d i t i o n
 C-----------------------------------------------
-      IF(NLOADP_B==0)GOTO 9000
+      !--- subroutine not relevant if no /LOAD/PBLAST option
+      IF(NLOADP_B==0)RETURN
+
+      !--- time step
+      TA_FIRST = FAC(07,NL) ! arrival time for first segment to be loaded
+      IL= NL-NLOADP_F
+      TT_STAR = TT + PBLAST_DT%TA_INF
+      IZ_UPDATE = ILOADP(06,NL)
+      TDET = FAC(01,NL)
+      TA_FIRST = FAC(07,NL) ! arrival time for first segment to be loaded
+      IF(IZ_UPDATE ==1)THEN
+        !if no update during engine
+        DTMIN_LOC = (ONE+EM06)*(TA_FIRST - TT)
+        DTMIN_LOC=MAX(PBLAST_TAB(IL)%DTMIN, DTMIN_LOC) !go directly to arrival time but avoid too
+        IF(TT_STAR<TA_FIRST)RETURN ! (nothing to load for now)
+      ELSE
+        IF(TDET > TT)THEN
+          DTMIN_LOC = (ONE+EM06)*(TDET - TT)
+          DTMIN_LOC=MAX(PBLAST_TAB(IL)%DTMIN, DTMIN_LOC)!go directly to arrival time but avoid too
+        ELSE
+          DTMIN_LOC = PBLAST_TAB(IL)%DTMIN
+        ENDIF
+        IF(TT_STAR<TDET)RETURN ! (nothing to update for now)
+      ENDIF
 C-----------------------------------------------,
 C   S o u r c e   C o d e
 C-----------------------------------------------
@@ -125,7 +157,9 @@ C-----------------------------------------------
       FAC_T_bb = FAC_TIME*EP06                                                                          
       FAC_P_bb = FAC_M_bb/FAC_L_bb/FAC_T_bb/FAC_T_bb                                                    
       FAC_I_bb = FAC_P_bb*FAC_T_bb                                                                      
-      FAC_I_bb = FAC_M_bb/FAC_L_bb/FAC_T_bb                                                             
+      FAC_I_bb = FAC_M_bb/FAC_L_bb/FAC_T_bb
+
+      IS_UPDATED=.FALSE.
 
       !-----------------------------------------------,                                                 
       !   FREE AIR BURST                                                                                
@@ -137,78 +171,76 @@ C-----------------------------------------------
       ZDET           = FAC(04,NL)                                                                       
       WTNT           = FAC(05,NL)                                                                       
       PMIN           = FAC(06,NL)                                                                       
-      TA_SHIFT       = FAC(07,NL)
-      T_STOP         = FAC(13,NL)      
-      P0             = ZERO                                                                             
+      TA_FIRST       = FAC(07,NL)
+      T_STOP         = FAC(13,NL)
       IS             = ILOADP(02,NL)                                                                    
       IZ_UPDATE      = ILOADP(06,NL)                                                                    
       ABAC_ID        = ILOADP(07,NL)                                                                    
       ID             = ILOADP(08,NL) !user_id                                                           
-      ITA_SHIFT      = ILOADP(09,NL)                                                                    
+      ITA_SHIFT      = ILOADP(09,NL)
+      NDT            = ILOADP(10,NL)
       IMODEL         = ILOADP(11,NL)                                                                    
       ISIZ_SEG       = ILOADP(01,NL)/4                                                                  
       IERR1          = 0                                                                                
       W13            = (WTNT*FAC_M_bb)**THIRD   ! '*FAC_M'  g->work unit    '/FAC_M' : WORK_UNIT -> g   
       Z              = ZERO                                                                             
-      TT_STAR = TT                                                                                      
-      IF(ITA_SHIFT==2)TT_STAR = TT + TA_SHIFT  !working unit  
-      IF(TT<TDET)RETURN  
-         
-      !---------------------------------------------                                                                                                                                                  
-      !   LOOP ON SEGMENTS (4N or 3N)                                                                                                                                                                 
-      !---------------------------------------------  
-                                                                                                                                                 
+      TA_INF_LOC     = EP20
+
+      !---------------------------------------------                                                                  
+      !   LOOP ON SEGMENTS (4N or 3N)                                                                  
+      !---------------------------------------------
+             
 !$OMP DO SCHEDULE(GUIDED,MVSIZ)
       DO I = 1,ISIZ_SEG   
-        N1=LLOADP(ILOADP(4,NL)+4*(I-1))                                                                                                                                                               
-        N2=LLOADP(ILOADP(4,NL)+4*(I-1)+1)                                                                                                                                                             
-        N3=LLOADP(ILOADP(4,NL)+4*(I-1)+2)                                                                                                                                                             
+        N1=LLOADP(ILOADP(4,NL)+4*(I-1))                                                                  
+        N2=LLOADP(ILOADP(4,NL)+4*(I-1)+1)                                                                  
+        N3=LLOADP(ILOADP(4,NL)+4*(I-1)+2)                                                                  
         N4=LLOADP(ILOADP(4,NL)+4*(I-1)+3)
         NN(1)=N1
         NN(2)=N2
         NN(3)=N3
-        NN(4)=N4                                                                                                                                                                       
-                                                                                                                                                                                                      
-        IF(N4==0 .OR. N3==N4 )THEN                                                                                                                                                                    
-          !3-NODE-SEGMENT                                                                                                                                                                            
-          PBLAST_TAB(IL)%NPt(I)   = THREE  
-          NPT = THREE                                                                                                                                                                          
-          !Segment Centroid                                                                                                                                                                            
-          Zx = X(1,N1)+X(1,N2)+X(1,N3)                                                                                                                                                                
-          Zy = X(2,N1)+X(2,N2)+X(2,N3)                                                                                                                                                                
-          Zz = X(3,N1)+X(3,N2)+X(3,N3)                                                                                                                                                                
-          Zx = Zx*THIRD                                                                                                                                                                               
-          Zy = Zy*THIRD                                                                                                                                                                               
-          Zz = Zz*THIRD  
-          !Normal vector : (NX,NY,NZ) = 2*S*n where |n|=1.0                                                                                                                                                                             
-          NX = (X(2,N3)-X(2,N1))*(X(3,N3)-X(3,N2)) - (X(3,N3)-X(3,N1))*(X(2,N3)-X(2,N2))                                                                                                              
-          NY = (X(3,N3)-X(3,N1))*(X(1,N3)-X(1,N2)) - (X(1,N3)-X(1,N1))*(X(3,N3)-X(3,N2))                                                                                                              
+        NN(4)=N4                                                   
+                                                                  
+        IF(N4==0 .OR. N3==N4 )THEN                                                                  
+          !3-NODE-SEGMENT                                                                 
+          PBLAST_TAB(IL)%NPt(I)   = THREE
+          NPT = THREE                                                           
+          !Segment Centroid                                                                   
+          Zx = X(1,N1)+X(1,N2)+X(1,N3)                                                                  
+          Zy = X(2,N1)+X(2,N2)+X(2,N3)                                                                  
+          Zz = X(3,N1)+X(3,N2)+X(3,N3)                                                                  
+          Zx = Zx*THIRD                                                                  
+          Zy = Zy*THIRD                                                                  
+          Zz = Zz*THIRD
+          !Normal vector : (NX,NY,NZ) = 2*S*n where |n|=1.0                           
+          NX = (X(2,N3)-X(2,N1))*(X(3,N3)-X(3,N2)) - (X(3,N3)-X(3,N1))*(X(2,N3)-X(2,N2))
+          NY = (X(3,N3)-X(3,N1))*(X(1,N3)-X(1,N2)) - (X(1,N3)-X(1,N1))*(X(3,N3)-X(3,N2))
           NZ = (X(1,N3)-X(1,N1))*(X(2,N3)-X(2,N2)) - (X(2,N3)-X(2,N1))*(X(1,N3)-X(1,N2))
-          !NORM = 2*S                                                                                                              
-          NORM = SQRT(NX*NX+NY*NY+NZ*NZ)                                                                                                                                                              
-        ELSE                                                                                                                                                                                          
-          !4-NODE-SEGMENT                                                                                                                                                                            
-          PBLAST_TAB(IL)%NPt(I)   = FOUR  
-          NPT = FOUR                                                                                                                                                                           
-          !Face Centroid                                                                                                                                                                           
-          Zx = X(1,N1)+X(1,N2)+X(1,N3)+X(1,N4)                                                                                                                                                        
-          Zy = X(2,N1)+X(2,N2)+X(2,N3)+X(2,N4)                                                                                                                                                        
-          Zz = X(3,N1)+X(3,N2)+X(3,N3)+X(3,N4)                                                                                                                                                        
-          Zx = Zx*FOURTH                                                                                                                                                                              
-          Zy = Zy*FOURTH                                                                                                                                                                              
-          Zz = Zz*FOURTH                                                                                                                                                                              
+          !NORM = 2*S 
+          NORM = SQRT(NX*NX+NY*NY+NZ*NZ)                                                                  
+        ELSE 
+          !4-NODE-SEGMENT 
+          PBLAST_TAB(IL)%NPt(I)   = FOUR
+          NPT = FOUR 
+          !Face Centroid 
+          Zx = X(1,N1)+X(1,N2)+X(1,N3)+X(1,N4)
+          Zy = X(2,N1)+X(2,N2)+X(2,N3)+X(2,N4)
+          Zz = X(3,N1)+X(3,N2)+X(3,N3)+X(3,N4)
+          Zx = Zx*FOURTH
+          Zy = Zy*FOURTH
+          Zz = Zz*FOURTH
           !Normal vector (NX,NY,NZ) = 2*S*n where |n|=1.0
-          NX = (X(2,N3)-X(2,N1))*(X(3,N4)-X(3,N2)) - (X(3,N3)-X(3,N1))*(X(2,N4)-X(2,N2))                                                                                                              
-          NY = (X(3,N3)-X(3,N1))*(X(1,N4)-X(1,N2)) - (X(1,N3)-X(1,N1))*(X(3,N4)-X(3,N2))                                                                                                              
-          NZ = (X(1,N3)-X(1,N1))*(X(2,N4)-X(2,N2)) - (X(2,N3)-X(2,N1))*(X(1,N4)-X(1,N2)) 
-          !NORM = 2*S                                                                                                             
-          NORM = SQRT(NX*NX+NY*NY+NZ*NZ)                                                                                                                                                              
-        ENDIF     
-                                                                                                                                                                                                          
-        PBLAST_TAB(IL)%N(1,I) = N1                                                                                                                                                                                   
-        PBLAST_TAB(IL)%N(2,I) = N2                                                                                                                                                                                   
-        PBLAST_TAB(IL)%N(3,I) = N3                                                                                                                                                                                   
-        PBLAST_TAB(IL)%N(4,I) = N4                                                                                                                                                                                   
+          NX = (X(2,N3)-X(2,N1))*(X(3,N4)-X(3,N2)) - (X(3,N3)-X(3,N1))*(X(2,N4)-X(2,N2))                      
+          NY = (X(3,N3)-X(3,N1))*(X(1,N4)-X(1,N2)) - (X(1,N3)-X(1,N1))*(X(3,N4)-X(3,N2))                      
+          NZ = (X(1,N3)-X(1,N1))*(X(2,N4)-X(2,N2)) - (X(2,N3)-X(2,N1))*(X(1,N4)-X(1,N2))
+          !NORM = 2*S 
+          NORM = SQRT(NX*NX+NY*NY+NZ*NZ)
+        ENDIF
+
+        PBLAST_TAB(IL)%N(1,I) = N1
+        PBLAST_TAB(IL)%N(2,I) = N2 
+        PBLAST_TAB(IL)%N(3,I) = N3
+        PBLAST_TAB(IL)%N(4,I) = N4 
 
         !--------------------------------------------!                                                                                                                                                
         !          Update Wave parameters            !                                                                                                                                                
@@ -216,8 +248,10 @@ C-----------------------------------------------
         ! If requested. Otherwise use Starter param. !                                                                                                                                                
         ! Default : do not update:use Starter param. !                                                                                                                                                
         !--------------------------------------------!                                                                                                                                                
-        IF(IZ_UPDATE==1)THEN                                                                                                                                                                          
-                                                                                                                                                                                                      
+        IF(IZ_UPDATE == 2)THEN
+
+          DTMIN_LOC = EP20
+
           !Dist                                                                                                                                                                                       
           Dx    = (Xdet - Zx)*FAC_L_bb  ! => working unit to cm                                                                                                                                       
           Dy    = (Ydet - Zy)*FAC_L_bb  ! => ... to cm                                                                                                                                                
@@ -331,80 +365,73 @@ C-----------------------------------------------
           DT_0_   = DT_0_  * W13
           T_A     = T_A    * W13
 
-          !---DECAY                                                                                                                                                                                   
-          IF(TT_STAR>=T_A)THEN                                                                                                                                                                        
-                                                                                                                                                                                                      
-            IF(IMODEL == 1)THEN                                                                                                                                                                       
-              !-Friedlander                                                                                                                                                                           
-              DECAY_inci = ONE                                                                                                                                                                        
-              DECAY_refl = ONE                                                                                                                                                                        
-                                                                                                                                                                                                      
-            ELSEIF(IMODEL == 2) THEN                                                                                                                                                                  
-              !SOLVE DECAY (b):    I_inci = P_inci*DT_0/b*(ONE-(1-exp(-b))/b)                                                                                                                         
-              !     g: b-> I_inci - P_inci*DT_0/b*(ONE-(1-exp(-b))/b)                                                                                                                                 
-              ! find b such as g(b)=0                                                                                                                                                                 
-              ! NEWTON ITERATIONS                                                                                                                                                                     
-              NITER=20                                                                                                                                                                                
-              TOL=EM06                                                                                                                                                                                
-              ITER=0                                                                                                                                                                                  
-              ZETA=ONE                                                                                                                                                                                
-              RES=EP20                                                                                                                                                                                
-              TMP2= P_inci*DT_0*EXP(-ZETA)/ZETA/ZETA                                                                                                                                                  
-              !--initialize first iteration                                                                                                                                                           
-              kk=P_inci*DT_0                                                                                                                                                                          
-              FUNCT = HALF*kk -I_inci !-ONE_OVER_6*kk*ZETA                                                                                                                                            
-              !--iterative solving                                                                                                                                                                    
-              DO WHILE (ITER<=NITER .AND. RES>TOL)                                                                                                                                                    
-                ITER=ITER+1                                                                                                                                                                           
-                IF(ABS(ZETA) < EM06)THEN                                                                                                                                                              
-                  !taylor expansion on 0. : g(b) = 1/2.k-1/6k.b +o(b )                                                                                                                                
-                  DIFF = kk*(-ONE_OVER_6 + ONE_OVER_12*ZETA)                                                                                                                                          
-                  ZETA = ZETA - FUNCT/DIFF                                                                                                                                                            
-                  FUNCT = HALF*kk-ONE_OVER_6*kk*ZETA - I_inci                                                                                                                                         
-                ELSE                                                                                                                                                                                  
-                  DIFF = ZETA*TMP2*EXP(ZETA) - (FUNCT+I_inci)*(ONE + TWO/ZETA)                                                                                                                        
-                  ZETA = ZETA - FUNCT/DIFF                                                                                                                                                            
-                  TMP2= P_inci*DT_0*EXP(-ZETA)/ZETA/ZETA                                                                                                                                              
-                  TMP3 = EXP(ZETA)*(ZETA-ONE)+ONE                                                                                                                                                     
-                  FUNCT = TMP2 * TMP3 -I_inci                                                                                                                                                         
-                ENDIF                                                                                                                                                                                 
-                RES = ABS(FUNCT)   !g(x_new)                                                                                                                                                          
-              ENDDO                                                                                                                                                                                   
-              DECAY_inci=MAX(EM06,ZETA)                                                                                                                                                               
+          !---DECAY  ('b' parameter in modified Friedlander model)
+          !    iterative solver : it can be solved in same unit system as hardcoded tables {g,cm,µs} since b has no dimension
+          IF(IMODEL == 1)THEN                                                                                                                                                                       
+            !-Friedlander                                                                                                                                                                           
+            DECAY_inci = ONE                                                                                                                                                                        
+            DECAY_refl = ONE                                                                                                                                                                        
+                                                                                                                                                                                                    
+          ELSEIF(IMODEL == 2) THEN                                                                                                                                                                  
+            !SOLVE DECAY (b):    I_inci = P_inci*DT_0/b*(ONE-(1-exp(-b))/b)                                                                                                                         
+            !     g: b-> I_inci - P_inci*DT_0/b*(ONE-(1-exp(-b))/b)                                                                                                                                 
+            ! find b such as g(b)=0                                                                                                                                                                 
+            ! NEWTON ITERATIONS                                                                                                                                                                     
+            NITER=20                                                                                                                                                                                
+            TOL=EM06                                                                                                                                                                                
+            ITER=0                                                                                                                                                                                  
+            ZETA=ONE                                                                                                                                                                                
+            RES=EP20                                                                                                                                                                                
+            TMP2= P_inci*DT_0*EXP(-ZETA)/ZETA/ZETA                                                                                                                                                  
+            !--initialize first iteration                                                                                                                                                           
+            kk=P_inci*DT_0                                                                                                                                                                          
+            FUNCT = HALF*kk -I_inci !-ONE_OVER_6*kk*ZETA                                                                                                                                            
+            !--iterative solving                                                                                                                                                                    
+            DO WHILE (ITER<=NITER .AND. RES>TOL)                                                                                                                                                    
+              ITER=ITER+1                                                                                                                                                                           
+              IF(ABS(ZETA) < EM06)THEN                                                                                                                                                              
+                !taylor expansion on 0. : g(b) = 1/2.k-1/6k.b +o(b )                                                                                                                                
+                DIFF = kk*(-ONE_OVER_6 + ONE_OVER_12*ZETA)                                                                                                                                          
+                ZETA = ZETA - FUNCT/DIFF                                                                                                                                                            
+                FUNCT = HALF*kk-ONE_OVER_6*kk*ZETA - I_inci                                                                                                                                         
+              ELSE                                                                                                                                                                                  
+                DIFF = ZETA*TMP2*EXP(ZETA) - (FUNCT+I_inci)*(ONE + TWO/ZETA)                                                                                                                        
+                ZETA = ZETA - FUNCT/DIFF                                                                                                                                                            
+                TMP2= P_inci*DT_0*EXP(-ZETA)/ZETA/ZETA                                                                                                                                              
+                TMP3 = EXP(ZETA)*(ZETA-ONE)+ONE                                                                                                                                                     
+                FUNCT = TMP2 * TMP3 -I_inci                                                                                                                                                         
+              ENDIF                                                                                                                                                                                 
+              RES = ABS(FUNCT)   !g(x_new)                                                                                                                                                          
+            ENDDO                                                                                                                                                                                   
+            DECAY_inci=MAX(ONE,ZETA)   ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
 
-              ITER=0                                                                                                                                                                                  
-              ZETA=ONE                                                                                                                                                                                
-              RES=EP20                                                                                                                                                                                
-              TMP2= P_refl*DT_0*EXP(-ZETA)/ZETA/ZETA                                                                                                                                                  
-              !--initialize first iteration                                                                                                                                                           
-              kk=P_refl*DT_0                                                                                                                                                                          
-              FUNCT = HALF*kk -I_refl !-ONE_OVER_6*kk*ZETA                                                                                                                                            
-              !--iterative solving                                                                                                                                                                    
-              DO WHILE (ITER<=NITER .AND. RES>TOL)                                                                                                                                                    
-                ITER=ITER+1                                                                                                                                                                           
-                IF(ABS(ZETA) < EM06)THEN                                                                                                                                                              
-                  !taylor expansion on 0. : g(b) = 1/2.k-1/6k.b +o(b )                                                                                                                                
-                  DIFF = kk*(-ONE_OVER_6 + ONE_OVER_12*ZETA)                                                                                                                                          
-                  ZETA = ZETA - FUNCT/DIFF                                                                                                                                                            
-                  FUNCT = HALF*kk-ONE_OVER_6*kk*ZETA - I_refl                                                                                                                                         
-                ELSE                                                                                                                                                                                  
-                  DIFF = ZETA*TMP2*EXP(ZETA) - (FUNCT+I_refl)*(ONE + TWO/ZETA)                                                                                                                        
-                  ZETA = ZETA - FUNCT/DIFF                                                                                                                                                            
-                  TMP2= P_refl*DT_0*EXP(-ZETA)/ZETA/ZETA                                                                                                                                              
-                  TMP3 = EXP(ZETA)*(ZETA-ONE)+ONE                                                                                                                                                     
-                  FUNCT = TMP2 * TMP3 -I_refl                                                                                                                                                         
-                ENDIF                                                                                                                                                                                 
-                RES = ABS(FUNCT)   !g(x_new)                                                                                                                                                          
-              ENDDO                                                                                                                                                                                   
-              DECAY_refl=MAX(EM06,ZETA)                                                                                                                                                               
-            ENDIF                                                                                                                                                                                     
-                                                                                                                                                                                                      
-          ELSE                                                                                                                                                                                        
-                                                                                                                                                                                                      
-            DECAY_inci = ONE                                                                                                                                                                          
-            DECAY_refl = ONE                                                                                                                                                                          
-                                                                                                                                                                                                      
-          ENDIF                                                                                                                                                                                       
+            ITER=0                                                                                                                                                                                  
+            ZETA=ONE                                                                                                                                                                                
+            RES=EP20                                                                                                                                                                                
+            TMP2= P_refl*DT_0*EXP(-ZETA)/ZETA/ZETA                                                                                                                                                  
+            !--initialize first iteration                                                                                                                                                           
+            kk=P_refl*DT_0                                                                                                                                                                          
+            FUNCT = HALF*kk -I_refl !-ONE_OVER_6*kk*ZETA                                                                                                                                            
+            !--iterative solving                                                                                                                                                                    
+            DO WHILE (ITER<=NITER .AND. RES>TOL)                                                                                                                                                    
+              ITER=ITER+1                                                                                                                                                                           
+              IF(ABS(ZETA) < EM06)THEN                                                                                                                                                              
+                !taylor expansion on 0. : g(b) = 1/2.k-1/6k.b +o(b )                                                                                                                                
+                DIFF = kk*(-ONE_OVER_6 + ONE_OVER_12*ZETA)                                                                                                                                          
+                ZETA = ZETA - FUNCT/DIFF                                                                                                                                                            
+                FUNCT = HALF*kk-ONE_OVER_6*kk*ZETA - I_refl                                                                                                                                         
+              ELSE                                                                                                                                                                                  
+                DIFF = ZETA*TMP2*EXP(ZETA) - (FUNCT+I_refl)*(ONE + TWO/ZETA)                                                                                                                        
+                ZETA = ZETA - FUNCT/DIFF                                                                                                                                                            
+                TMP2= P_refl*DT_0*EXP(-ZETA)/ZETA/ZETA                                                                                                                                              
+                TMP3 = EXP(ZETA)*(ZETA-ONE)+ONE                                                                                                                                                     
+                FUNCT = TMP2 * TMP3 -I_refl                                                                                                                                                         
+              ENDIF                                                                                                                                                                                 
+              RES = ABS(FUNCT)   !g(x_new)                                                                                                                                                          
+            ENDDO                                                                                                                                                                                   
+            DECAY_refl=MAX(ONE,ZETA)   ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
+          ENDIF                                                                                                                                                                                     
+                                                                                                                                                                                      
 
           !CONVERSION UNITS !                                                                                                                                                                         
           !g,cm,mus,Bar -> Working unit system                                                                                                                                                        
@@ -418,10 +445,10 @@ C-----------------------------------------------
           I_refl_ =  I_refl_ / FAC_I_bb                                                                                                                                                               
           DT_0    =  DT_0    / FAC_T_bb                                                                                                                                                               
           DT_0_   =  DT_0_   / FAC_T_bb                                                                                                                                                               
-          T_A     =  T_A     / FAC_T_bb                                                                                                                                                               
-
+          T_A     =  T_A     / FAC_T_bb
           T_A    = T_A + TDET                                                                                                                                                                         
-                                                                                                                                                                                                      
+          TA_INF_LOC = MIN(TA_INF_LOC, T_A)
+
           !update wave parameters                                                                                                                                                                     
           PBLAST_TAB(IL)%cos_theta(I) = cos_theta
           PBLAST_TAB(IL)%P_inci(I) = P_inci
@@ -430,8 +457,12 @@ C-----------------------------------------------
           PBLAST_TAB(IL)%t0(I) = DT_0
           PBLAST_TAB(IL)%decay_inci(I) = decay_inci
           PBLAST_TAB(IL)%decay_refl(I) = decay_refl
+
+          DTMIN_LOC = MIN(DTMIN_LOC,DT_0/NDT)
+          IS_UPDATED = .TRUE.
+
                                                                                                                                                                                                       
-        ELSE! => IZ_UPDATE=0                                                                                                                                                                                        
+        ELSE! => IZ_UPDATE=1
                                                                                                                                                                                                       
           !use wave parameters from Starter
           Z=ZERO                                                                                                                                                                                      
@@ -441,12 +472,11 @@ C-----------------------------------------------
           T_A  = PBLAST_TAB(IL)%ta(I)                                                                                                                                                                 
           DT_0 = PBLAST_TAB(IL)%t0(I)                                                                                                                                                                 
           decay_inci = PBLAST_TAB(IL)%decay_inci(I)                                                                                                                                                   
-          decay_refl = PBLAST_TAB(IL)%decay_refl(I)                                                                                                                                                   
+          decay_refl = PBLAST_TAB(IL)%decay_refl(I)
+          DTMIN_LOC = PBLAST_TAB(IL)%DTMIN
 
-        ENDIF !IF(IZ_UPDATE==1)
+        ENDIF !IF(IZ_UPDATE == 2)
 
-        T0INF_LOC = MIN(T0INF_LOC,DT_0)                                                                                                                                                             
-                                                                                                                                                                                                      
         !Coefficients for wave superimposition                                                                                                                                                        
         !PressureLoad = Reflected_Pressure * cos2X + IncidentPressure * (1 + cos2X -2 cosX)                                                                                                           
         IF(cos_theta<=ZERO)THEN                                                                                                                                                                       
@@ -468,7 +498,7 @@ C-----------------------------------------------
           WAVE_INCI = ZERO                                                                                                                                                                            
           WAVE_REFL = ZERO                                                                                                                                                                            
         ENDIF                                                                                                                                                                                         
-        P = P0 + alpha_refl * WAVE_REFL + alpha_inci * WAVE_INCI                                                                                                                                      
+        P = alpha_refl * WAVE_REFL + alpha_inci * WAVE_INCI
         P = MAX(P,PMIN)                                                                                                                                                                               
         IF (NUMSKINP > 0) PBLAST_TAB(IL)%PRES(I) = P                                                                                                                                                  
 
@@ -504,8 +534,26 @@ C----- /TH/SURF -------
       ENDDO!next I                                                                                                                                                                                    
 !$OMP END DO
          
-      CALL MY_BARRIER() 
-                 
+      IF(IS_UPDATED)THEN
+#include "lockon.inc"
+        !---arrival time
+        ZETA = FAC(07,NL)
+        FAC(07,NL) = MIN(TA_INF_LOC, FAC(07,NL)) !smp min value
+        !---time step
+        DTMIN_LOC = (ONE+EM06)*(FAC(07,NL) - TT) ! go directly to trigger time
+        DTMIN_LOC=MAX(PBLAST_TAB(IL)%DTMIN, DTMIN_LOC)
+        !---no update on next cycle
+        IZ_UPDATE = 1 !update done
+        ILOADP(06,NL) = IZ_UPDATE
+#include "lockoff.inc"
+        CALL MY_BARRIER()
+!$OMP SINGLE
+        write(*,FMT='(A,I10,A,E16.8,A,E16.8)') "Updated parameters for /LOAD/PBLAST id=",
+     .                                         ID,' previous first arrival time :',ZETA,
+     .                                         ' is now updated to :',FAC(07,NL)
+!$OMP END SINGLE
+      ENDIF
+
       !-------------------------------------------------------------------!
       !   FORCE ASSEMBLY                                                  !
       !     /PARITH/OFF : F directly added in A(1:3,1:NUMNOD).            !
@@ -590,7 +638,6 @@ C----- /TH/SURF -------
       ENDIF  
 !$OMP END SINGLE    
 
- 9000 CONTINUE 
       RETURN
       
 C-----------------------------------------------

--- a/engine/source/loads/pblast/pblast_2.F
+++ b/engine/source/loads/pblast/pblast_2.F
@@ -35,7 +35,7 @@ Chd|        TH_SURF_MOD                   ../common_source/modules/interfaces/th
 Chd|====================================================================
       SUBROUTINE PBLAST_2(ILOADP  ,FAC      ,A       ,V         ,X       ,
      1                    IADC    ,FSKY     ,LLOADP  ,FEXT      ,
-     2                    ITAB    ,H3D_DATA ,NL      ,T0INF_LOC ,TFEXT_LOC,
+     2                    ITAB    ,H3D_DATA ,NL      ,DTMIN_LOC ,TFEXT_LOC,
      3                    TH_SURF ,FSAVSURF ,NSEG_LOADP,NSEGPL)
 C-----------------------------------------------
 C   M o d u l e s
@@ -67,11 +67,12 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER,INTENT(IN) :: LLOADP(SLLOADP)
-      INTEGER,INTENT(IN) :: ILOADP(SIZLOADP,NLOADP)
+      INTEGER,INTENT(INOUT) :: ILOADP(SIZLOADP,NLOADP)
       INTEGER,INTENT(IN) :: IADC(*)
       INTEGER, INTENT(IN) :: ITAB(NUMNOD),NL
-      my_real,INTENT(INOUT) :: T0INF_LOC,TFEXT_LOC
-      my_real,INTENT(IN) :: FAC(LFACLOAD,NLOADP),V(3,NUMNOD),X(3,NUMNOD)
+      my_real,INTENT(INOUT) :: DTMIN_LOC,TFEXT_LOC
+      my_real,INTENT(IN) :: V(3,NUMNOD),X(3,NUMNOD)
+      my_real,INTENT(INOUT) :: FAC(LFACLOAD,NLOADP)
       my_real,INTENT(INOUT) :: A(3,NUMNOD),FSKY(8,SFSKY/8), FEXT(3,NUMNOD)
       TYPE(H3D_DATABASE),INTENT(IN) :: H3D_DATA
       TYPE (TH_SURF_) , INTENT(IN) :: TH_SURF
@@ -81,23 +82,24 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER N1, N2, N3, N4, IL, IS, IAD, I, IANIM_OR_H3D,IZ_UPDATE,ABAC_ID,ISIZ_SEG,IERR1,
-     .        Phi_I, ID, ITA_SHIFT,NS,KSURF,
+     .        Phi_I, ID, ITA_SHIFT,NS,KSURF,NDT,
      .        NITER,ITER,IMODEL,NN(4)
       my_real :: Zx,Zy,Zz,NORM,Nx,Ny,Nz,NNx,NNy,NNz,Hz,AREA
       my_real LAMBDA,cos_theta, alpha_inci, alpha_refl, P_inci,P_refl,Z,Phi_DB,bound1,bound2,
-     .        I_inci,I_refl,dt_0,t_a,WAVE_refl,WAVE_inci, W13, P0
-      my_real DNORM,
-     .        Xdet,Ydet,Zdet,Tdet,Wtnt,PMIN,T_STOP,
-     .        Dx,Dy,Dz,
+     .        I_inci,I_refl,dt_0,t_a,WAVE_refl,WAVE_inci, W13
+      my_real Xdet,Ydet,Zdet,Tdet,Wtnt,PMIN,T_STOP,
      .        P,
-     .        FAC_M_bb, FAC_L_bb, FAC_T_bb, FAC_P_bb, FAC_I_bb, TA_SHIFT, TT_STAR
+     .        FAC_M_bb, FAC_L_bb, FAC_T_bb, FAC_P_bb, FAC_I_bb, TA_FIRST, TT_STAR
       my_real Z1_
       my_real DECAY_inci,DECAY_refl,ZETA,TMP2,TMP3,FUNCT,DIFF,RES,TOL
       my_real kk
       my_real :: LogRes
       my_real :: cst_255_div_ln_Z1_on_ZN,  log10_, NPT, FF(3)
-      my_real :: PROJZ(3), tmp(3), LG, ZG, ProjDet(3), HC
+      my_real :: PROJZ(3), tmp(3), LG, ZG, HC
       my_real :: Base_x,Base_y,Base_z
+      my_real :: TA_INF_LOC
+
+      LOGICAL IS_UPDATED
 
       DATA cst_255_div_ln_Z1_on_ZN/-38.147316611455952998/
       DATA log10_ /2.30258509299405000000/
@@ -107,10 +109,38 @@ C   D e s c r i p t i o n
 C-----------------------------------------------
 C This subroutines is applying pressure load to a segment submitted to a blast wave (SURFACE BURST model).
 C Preussre time histories are built from "UFC 3-340-02, Dec. 5th 2008" tables which are hardcoded in unit system {g, cm, mus}
+C (table sampling : 256 points ; see pblast_mod.F)
+C
+C  T* = T + TA_INF (shift with first arrival time for all pblast option,  TA_INF=0. if ita_shift/=2)
+C  If request made to update blast profile (iz_update==2) then it is made once on T*=TDET
+C
 C-----------------------------------------------
 C   P r e - C o n d i t i o n
 C-----------------------------------------------
-      IF(NLOADP_B==0)GOTO 9000
+      !--- subroutine not relevant if no /LOAD/PBLAST option
+      IF(NLOADP_B==0)RETURN
+
+      !--- time step
+      TA_FIRST = FAC(07,NL) ! arrival time for first segment to be loaded
+      IL= NL-NLOADP_F
+      TT_STAR = TT + PBLAST_DT%TA_INF
+      IZ_UPDATE = ILOADP(06,NL)
+      TDET = FAC(01,NL)
+      TA_FIRST = FAC(07,NL) ! arrival time for first segment to be loaded
+      IF(IZ_UPDATE ==1)THEN
+        !if no update during engine
+        DTMIN_LOC = (ONE+EM06)*(TA_FIRST - TT)
+        DTMIN_LOC=MAX(PBLAST_TAB(IL)%DTMIN, DTMIN_LOC) !go directly to arrival time but avoid too
+        IF(TT_STAR<TA_FIRST)RETURN ! (nothing to load for now)
+      ELSE
+        IF(TDET > TT)THEN
+          DTMIN_LOC = (ONE+EM06)*(TDET - TT)
+          DTMIN_LOC=MAX(PBLAST_TAB(IL)%DTMIN, DTMIN_LOC)!go directly to arrival time but avoid too
+        ELSE
+          DTMIN_LOC = PBLAST_TAB(IL)%DTMIN
+        ENDIF
+        IF(TT_STAR<TDET)RETURN ! (nothing to update for now)
+      ENDIF
 C-----------------------------------------------,
 C   S o u r c e   C o d e
 C-----------------------------------------------
@@ -127,6 +157,8 @@ C-----------------------------------------------
       FAC_I_bb = FAC_P_bb*FAC_T_bb
       FAC_I_bb = FAC_M_bb/FAC_L_bb/FAC_T_bb
 
+      IS_UPDATED=.FALSE.
+
       !-----------------------------------------------,
       !   FREE AIR BURST
       !-----------------------------------------------
@@ -137,26 +169,24 @@ C-----------------------------------------------
       ZDET           = FAC(04,NL)
       WTNT           = FAC(05,NL)
       PMIN           = FAC(06,NL)
-      TA_SHIFT       = FAC(07,NL)
+      TA_FIRST       = FAC(07,NL)
       NNX            = FAC(08,NL)
       NNY            = FAC(09,NL)
       NNZ            = FAC(10,NL)
       HC             = FAC(11,NL)
       T_STOP         = FAC(13,NL)
-      P0             = ZERO
       IS             = ILOADP(02,NL)
       IZ_UPDATE      = ILOADP(06,NL)
       ABAC_ID        = ILOADP(07,NL)
       ID             = ILOADP(08,NL) !user_id
       ITA_SHIFT      = ILOADP(09,NL)
+      NDT            = ILOADP(10,NL)
       IMODEL         = ILOADP(11,NL)
       ISIZ_SEG       = ILOADP(01,NL)/4
       IERR1          = 0
       W13            = (WTNT*FAC_M_bb)**THIRD   ! '*FAC_M'  g->work unit    '/FAC_M' : WORK_UNIT -> g
       Z              = ZERO
-      TT_STAR = TT
-      IF(ITA_SHIFT==2)TT_STAR = TT + TA_SHIFT  !working unit
-      IF(TT<TDET)RETURN
+      TA_INF_LOC     = EP20
 
       !---------------------------------------------
       !   LOOP ON SEGMENTS (4N or 3N)
@@ -225,7 +255,9 @@ C-----------------------------------------------
         ! If requested. Otherwise use Starter param. !
         ! Default : do not update:use Starter param. !
         !--------------------------------------------!
-        IF(IZ_UPDATE==1)THEN
+        IF(IZ_UPDATE == 2)THEN
+
+          DTMIN_LOC = EP20
 
           IF(HZ > ZERO)THEN
 
@@ -326,80 +358,74 @@ C-----------------------------------------------
             DT_0    = DT_0   * W13
             T_A     = T_A    * W13
 
-            !---DECAY
-            IF(TT_STAR >= T_A)THEN
-
-              IF(IMODEL == 1)THEN
-                !-Friedlander
-                DECAY_inci = ONE
-                DECAY_refl = ONE
-
-              ELSEIF(IMODEL == 2) THEN
-                !SOLVE DECAY (b):    I_inci = P_inci*DT_0/b*(ONE-(1-exp(-b))/b)
-                !     g: b-> I_inci - P_inci*DT_0/b*(ONE-(1-exp(-b))/b)
-                ! find b such as g(b)=0
-                ! NEWTON ITERATIONS
-                NITER=20
-                TOL=EM06
-                ITER=0
-                ZETA=ONE
-                RES=EP20
-                TMP2= P_inci*DT_0*EXP(-ZETA)/ZETA/ZETA
-                !--initialize first iteration
-                kk=P_inci*DT_0
-                FUNCT = HALF*kk -I_inci !-ONE_OVER_6*kk*ZETA
-                !--iterative solving
-                DO WHILE (ITER<=NITER .AND. RES>TOL)
-                  ITER=ITER+1
-                  IF(ABS(ZETA) < EM06)THEN
-                    !taylor expansion on 0. : g(b) = 1/2.k-1/6k.b +o(b )
-                    DIFF = kk*(-ONE_OVER_6 + ONE_OVER_12*ZETA)
-                    ZETA = ZETA - FUNCT/DIFF
-                    FUNCT = HALF*kk-ONE_OVER_6*kk*ZETA - I_inci
-                  ELSE
-                    DIFF = ZETA*TMP2*EXP(ZETA) - (FUNCT+I_inci)*(ONE + TWO/ZETA)
-                    ZETA = ZETA - FUNCT/DIFF
-                    TMP2= P_inci*DT_0*EXP(-ZETA)/ZETA/ZETA
-                    TMP3 = EXP(ZETA)*(ZETA-ONE)+ONE
-                    FUNCT = TMP2 * TMP3 -I_inci
-                  ENDIF
-                  RES = ABS(FUNCT)   !g(x_new)
-                ENDDO
-                DECAY_inci=MAX(EM06,ZETA)
-
-                ITER=0
-                ZETA=ONE
-                RES=EP20
-                TMP2= P_refl*DT_0*EXP(-ZETA)/ZETA/ZETA
-                !--initialize first iteration
-                kk=P_refl*DT_0
-                FUNCT = HALF*kk -I_refl !-ONE_OVER_6*kk*ZETA
-                !--iterative solving
-                DO WHILE (ITER<=NITER .AND. RES>TOL)
-                  ITER=ITER+1
-                  IF(ABS(ZETA) < EM06)THEN
-                    !taylor expansion on 0. : g(b) = 1/2.k-1/6k.b +o(b )
-                    DIFF = kk*(-ONE_OVER_6 + ONE_OVER_12*ZETA)
-                    ZETA = ZETA - FUNCT/DIFF
-                    FUNCT = HALF*kk-ONE_OVER_6*kk*ZETA - I_refl
-                  ELSE
-                    DIFF = ZETA*TMP2*EXP(ZETA) - (FUNCT+I_refl)*(ONE + TWO/ZETA)
-                    ZETA = ZETA - FUNCT/DIFF
-                    TMP2= P_refl*DT_0*EXP(-ZETA)/ZETA/ZETA
-                    TMP3 = EXP(ZETA)*(ZETA-ONE)+ONE
-                    FUNCT = TMP2 * TMP3 -I_refl
-                  ENDIF
-                  RES = ABS(FUNCT)   !g(x_new)
-                ENDDO
-                DECAY_refl=MAX(EM06,ZETA)
-              ENDIF
-
-            ELSE
-
+            !---DECAY  ('b' parameter in modified Friedlander model)
+            !    iterative solver : it can be solved in same unit system as hardcoded tables {g,cm,µs} since b has no dimension
+            IF(IMODEL == 1)THEN
+              !-Friedlander
               DECAY_inci = ONE
               DECAY_refl = ONE
 
-            ENDIF
+            ELSEIF(IMODEL == 2) THEN
+              !SOLVE DECAY (b):    I_inci = P_inci*DT_0/b*(ONE-(1-exp(-b))/b)
+              !     g: b-> I_inci - P_inci*DT_0/b*(ONE-(1-exp(-b))/b)
+              ! find b such as g(b)=0
+              ! NEWTON ITERATIONS
+              NITER=20
+              TOL=EM06
+              ITER=0
+              ZETA=ONE
+              RES=EP20
+              TMP2= P_inci*DT_0*EXP(-ZETA)/ZETA/ZETA
+              !--initialize first iteration
+              kk=P_inci*DT_0
+              FUNCT = HALF*kk -I_inci !-ONE_OVER_6*kk*ZETA
+              !--iterative solving
+              DO WHILE (ITER<=NITER .AND. RES>TOL)
+                ITER=ITER+1
+                IF(ABS(ZETA) < EM06)THEN
+                  !taylor expansion on 0. : g(b) = 1/2.k-1/6k.b +o(b )
+                  DIFF = kk*(-ONE_OVER_6 + ONE_OVER_12*ZETA)
+                  ZETA = ZETA - FUNCT/DIFF
+                  FUNCT = HALF*kk-ONE_OVER_6*kk*ZETA - I_inci
+                ELSE
+                  DIFF = ZETA*TMP2*EXP(ZETA) - (FUNCT+I_inci)*(ONE + TWO/ZETA)
+                  ZETA = ZETA - FUNCT/DIFF
+                  TMP2= P_inci*DT_0*EXP(-ZETA)/ZETA/ZETA
+                  TMP3 = EXP(ZETA)*(ZETA-ONE)+ONE
+                  FUNCT = TMP2 * TMP3 -I_inci
+                ENDIF
+                RES = ABS(FUNCT)   !g(x_new)
+              ENDDO
+              DECAY_inci=MAX(ONE,ZETA)    ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
+
+              ITER=0
+              ZETA=ONE
+              RES=EP20
+              TMP2= P_refl*DT_0*EXP(-ZETA)/ZETA/ZETA
+              !--initialize first iteration
+              kk=P_refl*DT_0
+              FUNCT = HALF*kk -I_refl !-ONE_OVER_6*kk*ZETA
+              !--iterative solving
+              DO WHILE (ITER<=NITER .AND. RES>TOL)
+                ITER=ITER+1
+                IF(ABS(ZETA) < EM06)THEN
+                  !taylor expansion on 0. : g(b) = 1/2.k-1/6k.b +o(b )
+                  DIFF = kk*(-ONE_OVER_6 + ONE_OVER_12*ZETA)
+                  ZETA = ZETA - FUNCT/DIFF
+                  FUNCT = HALF*kk-ONE_OVER_6*kk*ZETA - I_refl
+                ELSE
+                  DIFF = ZETA*TMP2*EXP(ZETA) - (FUNCT+I_refl)*(ONE + TWO/ZETA)
+                  ZETA = ZETA - FUNCT/DIFF
+                  TMP2= P_refl*DT_0*EXP(-ZETA)/ZETA/ZETA
+                  TMP3 = EXP(ZETA)*(ZETA-ONE)+ONE
+                  FUNCT = TMP2 * TMP3 -I_refl
+                ENDIF
+                RES = ABS(FUNCT)   !g(x_new)
+              ENDDO
+              DECAY_refl=MAX(ONE,ZETA)    ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
+
+            ENDIF! IMODEL
+
 
             !CONVERSION UNITS !
             !g,cm,mus,Bar -> Working unit system
@@ -410,6 +436,7 @@ C-----------------------------------------------
             DT_0 = DT_0 / FAC_T_bb
             T_A = T_A / FAC_T_bb
             T_A = T_A + TDET
+            TA_INF_LOC = MIN(TA_INF_LOC, T_A)
 
             !update wave parameters
             PBLAST_TAB(IL)%cos_theta(I) = cos_theta
@@ -432,7 +459,12 @@ C-----------------------------------------------
             decay_refl = zero
           ENDIF
 
-        ELSE! => IZ_UPDATE=0
+          DTMIN_LOC = MIN(DTMIN_LOC,DT_0/NDT)
+          IZ_UPDATE = 1 !update done
+          ILOADP(06,NL) = IZ_UPDATE
+          IS_UPDATED=.TRUE.
+
+        ELSE! => IZ_UPDATE=1
 
           !use wave parameters from Starter
           Z = ZERO ! ZG not used here since all wave characteritics are stored.
@@ -443,10 +475,9 @@ C-----------------------------------------------
           DT_0 = PBLAST_TAB(IL)%t0(I)
           decay_inci = PBLAST_TAB(IL)%decay_inci(I)
           decay_refl = PBLAST_TAB(IL)%decay_refl(I)
+          DTMIN_LOC = PBLAST_TAB(IL)%DTMIN
 
-        ENDIF !IF(IZ_UPDATE==1)
-
-        T0INF_LOC = MIN(T0INF_LOC,DT_0)
+        ENDIF !IF(IZ_UPDATE == 2)
 
         !Coefficients for wave superimposition
         !PressureLoad = Reflected_Pressure * cos2X + IncidentPressure * (1 + cos2X -2 cosX)
@@ -469,7 +500,7 @@ C-----------------------------------------------
           WAVE_INCI = ZERO
           WAVE_REFL = ZERO
         ENDIF
-        P = P0 + alpha_refl * WAVE_REFL + alpha_inci * WAVE_INCI
+        P = alpha_refl * WAVE_REFL + alpha_inci * WAVE_INCI
         P = MAX(P,PMIN)
         IF (NUMSKINP > 0) PBLAST_TAB(IL)%PRES(I) = P
 
@@ -506,7 +537,25 @@ C----- /TH/SURF -------
       ENDDO!next I
 !$OMP END DO
 
-      CALL MY_BARRIER()
+      IF(IS_UPDATED)THEN
+#include "lockon.inc"
+        !---arrival time
+        ZETA = FAC(07,NL)
+        FAC(07,NL) = MIN(TA_INF_LOC, FAC(07,NL)) !smp min value
+        !---time step
+        DTMIN_LOC = (ONE+EM06)*(FAC(07,NL) - TT) ! go directly to trigger time
+        DTMIN_LOC=MAX(PBLAST_TAB(IL)%DTMIN, DTMIN_LOC)
+        !---no update on next cycle
+        IZ_UPDATE = 1 !update done
+        ILOADP(06,NL) = IZ_UPDATE
+#include "lockoff.inc"
+        CALL MY_BARRIER()
+!$OMP SINGLE
+        write(*,FMT='(A,I10,A,E16.8,A,E16.8)') "Updated parameters for /LOAD/PBLAST id=",
+     .                                         ID,' previous first arrival time :',ZETA,
+     .                                         ' is now updated to :',FAC(07,NL)
+!$OMP END SINGLE
+      ENDIF
 
       !-------------------------------------------------------------------!
       !   FORCE ASSEMBLY                                                  !
@@ -592,7 +641,6 @@ C----- /TH/SURF -------
       ENDIF
 !$OMP END SINGLE
 
- 9000 CONTINUE
       RETURN
 
 C-----------------------------------------------

--- a/engine/source/loads/pblast/pblast_3.F
+++ b/engine/source/loads/pblast/pblast_3.F
@@ -35,7 +35,7 @@ Chd|        TH_SURF_MOD                   ../common_source/modules/interfaces/th
 Chd|====================================================================
       SUBROUTINE PBLAST_3(ILOADP  ,FAC      ,A       ,V         ,X       ,
      1                    IADC    ,FSKY     ,LLOADP  ,FEXT      ,
-     2                    ITAB    ,H3D_DATA ,NL      ,T0INF_LOC ,TFEXT_LOC,
+     2                    ITAB    ,H3D_DATA ,NL      ,DTMIN_LOC ,TFEXT_LOC,
      4                    TH_SURF ,FSAVSURF ,NSEG_LOADP,NSEGPL)
 C-----------------------------------------------
 C   M o d u l e s
@@ -67,11 +67,12 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER,INTENT(IN) :: LLOADP(SLLOADP)
-      INTEGER,INTENT(IN) :: ILOADP(SIZLOADP,NLOADP)
+      INTEGER,INTENT(INOUT) :: ILOADP(SIZLOADP,NLOADP)
       INTEGER,INTENT(IN) :: IADC(*)
       INTEGER, INTENT(IN) :: ITAB(NUMNOD),NL
-      my_real,INTENT(INOUT) :: T0INF_LOC,TFEXT_LOC
-      my_real,INTENT(IN) :: FAC(LFACLOAD,NLOADP),V(3,NUMNOD),X(3,NUMNOD)
+      my_real,INTENT(INOUT) :: DTMIN_LOC,TFEXT_LOC
+      my_real,INTENT(IN) :: V(3,NUMNOD),X(3,NUMNOD)
+      my_real,INTENT(INOUT) :: FAC(LFACLOAD,NLOADP)
       my_real,INTENT(INOUT) :: A(3,NUMNOD),FSKY(8,SFSKY/8), FEXT(3,NUMNOD)
       TYPE(H3D_DATABASE),INTENT(IN) :: H3D_DATA
       TYPE (TH_SURF_) , INTENT(IN) :: TH_SURF
@@ -83,8 +84,8 @@ C-----------------------------------------------
       INTEGER N1, N2, N3, N4,IL,IS,IAD,I,IANIM_OR_H3D,IZ_UPDATE,ABAC_ID,ISIZ_SEG,IERR1
       INTEGER Phi_I, ID, ITA_SHIFT, NITER,ITER,IMODEL,ITMP
       INTEGER :: idx_zg1, idx_zg2, idx1_angle, idx2_angle, idx1, idx2,NS,KSURF, I_search
-      INTEGER :: curve_id1, curve_id2, NN(4)
-      LOGICAL :: calculate, BOOL_UNDERGROUND_CURRENT_SEG
+      INTEGER :: curve_id1, curve_id2, NN(4), NDT
+      LOGICAL :: calculate, BOOL_UNDERGROUND_CURRENT_SEG, IS_UPDATED
 
       my_real :: Zx,Zy,Zz,NORM,Nx,Ny,Nz ! target face centroid and normal vector
       my_real NNx,NNy,NNz,NORM_NN, NORM2_NN, tmp_var ! ground vector
@@ -102,14 +103,15 @@ C-----------------------------------------------
       my_real :: alpha_angle !inteprolation factor
 
       my_real LAMBDA, cos_theta, alpha_inci, alpha_refl,P_inci,P_refl,Z,Phi_DB,bound1,bound2,
-     .         I_inci,I_refl,dt_0,t_a,WAVE_refl,WAVE_inci, W13, P0
+     .         I_inci,I_refl,dt_0,t_a,WAVE_refl,WAVE_inci, W13
       my_real DNORM,Xdet,Ydet,Zdet,Tdet,Wtnt,PMIN,T_STOP,Dx,Dy,Dz,P,
-     .        FAC_M_bb, FAC_L_bb, FAC_T_bb, FAC_P_bb, FAC_I_bb, TA_SHIFT, TT_STAR
+     .        FAC_M_bb, FAC_L_bb, FAC_T_bb, FAC_P_bb, FAC_I_bb, TA_FIRST, TT_STAR
       my_real HC ! height of charge
       my_real logRes
       my_real Z1_
       my_real DECAY_inci,DECAY_refl,ZETA,TMP2,TMP3,FUNCT,DIFF,RES,TOL,AREA
       my_real kk ,NPT
+      my_real :: TA_INF_LOC
 
       my_real PI_
       DATA PI_/3.141592653589793238462643D0/
@@ -136,10 +138,38 @@ C   D e s c r i p t i o n
 C-----------------------------------------------
 C This subroutines is applying pressure load to a segment submitted to a blast wave (AIR BURST model).
 C Preussre time histories are built from "UFC 3-340-02, Dec. 5th 2008" tables which are hardcoded in unit system {g, cm, mus}
+C (table sampling : 256 points ; see pblast_mod.F)
+C
+C  T* = T + TA_INF (shift with first arrival time for all pblast option,  TA_INF=0. if ita_shift/=2)
+C  If request made to update blast profile (iz_update==2) then it is made once on T*=TDET
+C
 C-----------------------------------------------
 C   P r e - C o n d i t i o n
 C-----------------------------------------------
-      IF(NLOADP_B==0)GOTO 9000
+      !--- subroutine not relevant if no /LOAD/PBLAST option
+      IF(NLOADP_B==0)RETURN
+
+      !--- time step
+      TA_FIRST = FAC(07,NL) ! arrival time for first segment to be loaded
+      IL= NL-NLOADP_F
+      TT_STAR = TT + PBLAST_DT%TA_INF
+      IZ_UPDATE = ILOADP(06,NL)
+      TDET = FAC(01,NL)
+      TA_FIRST = FAC(07,NL) ! arrival time for first segment to be loaded
+      IF(IZ_UPDATE ==1)THEN
+        !if no update during engine
+        DTMIN_LOC = (ONE+EM06)*(TA_FIRST - TT)
+        DTMIN_LOC=MAX(PBLAST_TAB(IL)%DTMIN, DTMIN_LOC) !go directly to arrival time but avoid too
+        IF(TT_STAR<TA_FIRST)RETURN ! (nothing to load for now)
+      ELSE
+        IF(TDET > TT)THEN
+          DTMIN_LOC = (ONE+EM06)*(TDET - TT)
+          DTMIN_LOC=MAX(PBLAST_TAB(IL)%DTMIN, DTMIN_LOC)!go directly to arrival time but avoid too
+        ELSE
+          DTMIN_LOC = PBLAST_TAB(IL)%DTMIN
+        ENDIF
+        IF(TT_STAR<TDET)RETURN ! (nothing to update for now)
+      ENDIF
 C-----------------------------------------------,
 C   S o u r c e   C o d e
 C-----------------------------------------------
@@ -157,6 +187,8 @@ C-----------------------------------------------
       FAC_P_bb = FAC_M_bb/FAC_L_bb/FAC_T_bb/FAC_T_bb
       FAC_I_bb = FAC_P_bb*FAC_T_bb !/FAC_M_bb**THIRD
 
+      IS_UPDATED=.FALSE.
+
       !-----------------------------------------------,
       !    AIR BURST
       !-----------------------------------------------
@@ -167,21 +199,22 @@ C-----------------------------------------------
       ZDET           = FAC(04,NL)
       WTNT           = FAC(05,NL)
       PMIN           = FAC(06,NL)
-      TA_SHIFT       = FAC(07,NL)
+      TA_FIRST       = FAC(07,NL)
       NNX            = FAC(08,NL)
       NNY            = FAC(09,NL)
       NNZ            = FAC(10,NL)
       HC             = FAC(11,NL)
       alpha_zc       = FAC(12,NL)  !curve_id1+alpha_zc
       T_STOP         = FAC(13,NL)
-      P0             = ZERO
       ISIZ_SEG       = ILOADP(01,NL)/4
       IS             = ILOADP(02,NL)
       IZ_UPDATE      = ILOADP(06,NL)
       ABAC_ID        = ILOADP(07,NL)
       ID             = ILOADP(08,NL) !user_id
       ITA_SHIFT      = ILOADP(09,NL)
+      NDT            = ILOADP(10,NL)
       IMODEL         = ILOADP(11,NL)
+      TA_INF_LOC     = EP20
 
       !curve_id1+alpha_zc
       curve_id1=INT(alpha_zc)
@@ -193,9 +226,6 @@ C-----------------------------------------------
       Z = ZERO
       NORM2_NN=NNX*NNx+NNy*NNy+NNz*NNz
       NORM_NN =SQRT(NORM2_NN)
-      TT_STAR = TT
-      IF(ITA_SHIFT==2)TT_STAR = TT + TA_SHIFT  !working unit
-      IF(TT<TDET)RETURN
 
       !---------------------------------------------
       !   LOOP ON SEGMENTS (4N or 3N)
@@ -262,7 +292,10 @@ C-----------------------------------------------
         ! If requested. Otherwise use Starter param. !
         ! Default : do not update:use Starter param. !
         !--------------------------------------------!
-        IF(IZ_UPDATE==1)THEN
+        IF(IZ_UPDATE == 2)THEN
+
+          DTMIN_LOC = EP20
+
           !Dist
           Dx    = (Xdet - Zx)*FAC_L_bb  ! => working unit to cm
           Dy    = (Ydet - Zy)*FAC_L_bb  ! => ... to cm
@@ -651,80 +684,73 @@ C-----------------------------------------------
             DT_0    = DT_0   * W13
             T_A     = T_A    * W13
 
-            !---DECAY
-            IF (TT_STAR>=T_A)THEN
-
-              IF(IMODEL == 1)THEN
-                !-Friedlander
-                DECAY_inci = ONE
-                DECAY_refl = ONE
-
-              ELSEIF(IMODEL == 2 .AND. .NOT.BOOL_UNDERGROUND_CURRENT_SEG) THEN
-                !SOLVE DECAY (b):    I_inci = P_inci*DT_0/b*(ONE-(1-exp(-b))/b)
-                !     g: b-> I_inci - P_inci*DT_0/b*(ONE-(1-exp(-b))/b)
-                ! find b such as g(b)=0
-                ! NEWTON ITERATIONS
-                NITER=20
-                TOL=EM06
-                ITER=0
-                ZETA=ONE
-                RES=EP20
-                TMP2= P_inci*DT_0*EXP(-ZETA)/ZETA/ZETA
-                !--initialize first iteration
-                kk=P_inci*DT_0
-                FUNCT = HALF*kk -I_inci !-ONE_OVER_6*kk*ZETA
-                !--iterative solving
-                DO WHILE (ITER<=NITER .AND. RES>TOL)
-                  ITER=ITER+1
-                  IF(ABS(ZETA) < EM06)THEN
-                    !taylor expansion on 0. : g(b) = 1/2.k-1/6k.b +o(b )
-                    DIFF = kk*(-ONE_OVER_6 + ONE_OVER_12*ZETA)
-                    ZETA = ZETA - FUNCT/DIFF
-                    FUNCT = HALF*kk-ONE_OVER_6*kk*ZETA - I_inci
-                  ELSE
-                    DIFF = ZETA*TMP2*EXP(ZETA) - (FUNCT+I_inci)*(ONE + TWO/ZETA)
-                    ZETA = ZETA - FUNCT/DIFF
-                    TMP2= P_inci*DT_0*EXP(-ZETA)/ZETA/ZETA
-                    TMP3 = EXP(ZETA)*(ZETA-ONE)+ONE
-                    FUNCT = TMP2 * TMP3 -I_inci
-                  ENDIF
-                  RES = ABS(FUNCT)   !g(x_new)
-                ENDDO
-                DECAY_inci=MAX(EM06,ZETA)
-
-                ITER=0
-                ZETA=ONE
-                RES=EP20
-                TMP2= P_refl*DT_0*EXP(-ZETA)/ZETA/ZETA
-                !--initialize first iteration
-                kk=P_refl*DT_0
-                FUNCT = HALF*kk -I_refl !-ONE_OVER_6*kk*ZETA
-                !--iterative solving
-                DO WHILE (ITER<=NITER .AND. RES>TOL)
-                  ITER=ITER+1
-                  IF(ABS(ZETA) < EM06)THEN
-                    !taylor expansion on 0. : g(b) = 1/2.k-1/6k.b +o(b )
-                    DIFF = kk*(-ONE_OVER_6 + ONE_OVER_12*ZETA)
-                    ZETA = ZETA - FUNCT/DIFF
-                    FUNCT = HALF*kk-ONE_OVER_6*kk*ZETA - I_refl
-                  ELSE
-                    DIFF = ZETA*TMP2*EXP(ZETA) - (FUNCT+I_refl)*(ONE + TWO/ZETA)
-                    ZETA = ZETA - FUNCT/DIFF
-                    TMP2= P_refl*DT_0*EXP(-ZETA)/ZETA/ZETA
-                    TMP3 = EXP(ZETA)*(ZETA-ONE)+ONE
-                    FUNCT = TMP2 * TMP3 -I_refl
-                  ENDIF
-                  RES = ABS(FUNCT)   !g(x_new)
-                ENDDO
-                DECAY_refl=MAX(EM06,ZETA)
-              ENDIF
-
-            ELSE
-
+            !---DECAY  ('b' parameter in modified Friedlander model)
+            !    iterative solver : it can be solved in same unit system as hardcoded tables {g,cm,µs} since b has no dimension
+            IF(IMODEL == 1)THEN
+              !-Friedlander
               DECAY_inci = ONE
               DECAY_refl = ONE
 
-            ENDIF
+            ELSEIF(IMODEL == 2 .AND. .NOT.BOOL_UNDERGROUND_CURRENT_SEG) THEN
+              !SOLVE DECAY (b):    I_inci = P_inci*DT_0/b*(ONE-(1-exp(-b))/b)
+              !     g: b-> I_inci - P_inci*DT_0/b*(ONE-(1-exp(-b))/b)
+              ! find b such as g(b)=0
+              ! NEWTON ITERATIONS
+              NITER=20
+              TOL=EM06
+              ITER=0
+              ZETA=ONE
+              RES=EP20
+              TMP2= P_inci*DT_0*EXP(-ZETA)/ZETA/ZETA
+              !--initialize first iteration
+              kk=P_inci*DT_0
+              FUNCT = HALF*kk -I_inci !-ONE_OVER_6*kk*ZETA
+              !--iterative solving
+              DO WHILE (ITER<=NITER .AND. RES>TOL)
+                ITER=ITER+1
+                IF(ABS(ZETA) < EM06)THEN
+                  !taylor expansion on 0. : g(b) = 1/2.k-1/6k.b +o(b )
+                  DIFF = kk*(-ONE_OVER_6 + ONE_OVER_12*ZETA)
+                  ZETA = ZETA - FUNCT/DIFF
+                  FUNCT = HALF*kk-ONE_OVER_6*kk*ZETA - I_inci
+                ELSE
+                  DIFF = ZETA*TMP2*EXP(ZETA) - (FUNCT+I_inci)*(ONE + TWO/ZETA)
+                  ZETA = ZETA - FUNCT/DIFF
+                  TMP2= P_inci*DT_0*EXP(-ZETA)/ZETA/ZETA
+                  TMP3 = EXP(ZETA)*(ZETA-ONE)+ONE
+                  FUNCT = TMP2 * TMP3 -I_inci
+                ENDIF
+                RES = ABS(FUNCT)   !g(x_new)
+              ENDDO
+              DECAY_inci=MAX(ONE,ZETA)   ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
+
+              ITER=0
+              ZETA=ONE
+              RES=EP20
+              TMP2= P_refl*DT_0*EXP(-ZETA)/ZETA/ZETA
+              !--initialize first iteration
+              kk=P_refl*DT_0
+              FUNCT = HALF*kk -I_refl !-ONE_OVER_6*kk*ZETA
+              !--iterative solving
+              DO WHILE (ITER<=NITER .AND. RES>TOL)
+                ITER=ITER+1
+                IF(ABS(ZETA) < EM06)THEN
+                  !taylor expansion on 0. : g(b) = 1/2.k-1/6k.b +o(b )
+                  DIFF = kk*(-ONE_OVER_6 + ONE_OVER_12*ZETA)
+                  ZETA = ZETA - FUNCT/DIFF
+                  FUNCT = HALF*kk-ONE_OVER_6*kk*ZETA - I_refl
+                ELSE
+                  DIFF = ZETA*TMP2*EXP(ZETA) - (FUNCT+I_refl)*(ONE + TWO/ZETA)
+                  ZETA = ZETA - FUNCT/DIFF
+                  TMP2= P_refl*DT_0*EXP(-ZETA)/ZETA/ZETA
+                  TMP3 = EXP(ZETA)*(ZETA-ONE)+ONE
+                  FUNCT = TMP2 * TMP3 -I_refl
+                ENDIF
+                RES = ABS(FUNCT)   !g(x_new)
+              ENDDO
+              DECAY_refl=MAX(ONE,ZETA)   ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
+
+            ENDIF!IMODEL
 
 
             !CONVERSION UNITS !
@@ -735,8 +761,8 @@ C-----------------------------------------------
             I_refl  =  I_refl / FAC_I_bb
             DT_0    =  DT_0    / FAC_T_bb
             T_A     =  T_A     / FAC_T_bb
-
             T_A    = T_A + TDET
+            TA_INF_LOC = MIN(TA_INF_LOC, T_A)
 
             !update wave parameters
             PBLAST_TAB(IL)%cos_theta(I) = cos_theta
@@ -749,6 +775,11 @@ C-----------------------------------------------
 
           ENDIF !HZ
 
+          DTMIN_LOC = MIN(DTMIN_LOC,DT_0/NDT)
+          IZ_UPDATE = 1 !update done
+          ILOADP(06,NL) = IZ_UPDATE
+          IS_UPDATED=.TRUE.
+
         ELSE
 
           !Use wave parameters from Starter
@@ -759,12 +790,9 @@ C-----------------------------------------------
           DT_0 = PBLAST_TAB(IL)%t0(I)
           decay_inci = PBLAST_TAB(IL)%decay_inci(I)
           decay_refl = PBLAST_TAB(IL)%decay_refl(I)
+          DTMIN_LOC = PBLAST_TAB(IL)%DTMIN
 
         ENDIF ! IZ_UPDATE
-
-
-
-        T0INF_LOC = MIN(T0INF_LOC,DT_0)
 
 !-------------------------------                                                                                                                                                                  ---
 
@@ -782,14 +810,14 @@ C-----------------------------------------------
         !Building pressure waves from Friedlander model. (Modified model can bu introduced later if needed)
         WAVE_INCI = ZERO
         WAVE_REFL = ZERO
-        IF(TT_STAR>=T_A)THEN
+        IF(TT_STAR >= T_A)THEN
           WAVE_INCI =  P_inci*(ONE-(TT_STAR-T_A)/DT_0)*exp(-DECAY_inci*(TT_STAR-T_A)/DT_0)
           WAVE_REFL =  P_refl*(ONE-(TT_STAR-T_A)/DT_0)*exp(-DECAY_refl*(TT_STAR-T_A)/DT_0)
         ELSE
           WAVE_INCI = ZERO
           WAVE_REFL = ZERO
         ENDIF
-        P = P0 + alpha_refl * WAVE_REFL + alpha_inci * WAVE_INCI
+        P = alpha_refl * WAVE_REFL + alpha_inci * WAVE_INCI
         P = MAX(P,PMIN)
         IF (NUMSKINP > 0) PBLAST_TAB(IL)%PRES(I) = P
 
@@ -822,7 +850,25 @@ C----- /TH/SURF -------
       ENDDO!next I
 !$OMP END DO
 
-      CALL MY_BARRIER()
+      IF(IS_UPDATED)THEN
+#include "lockon.inc"
+        !---arrival time
+        ZETA = FAC(07,NL)
+        FAC(07,NL) = MIN(TA_INF_LOC, FAC(07,NL)) !smp min value
+        !---time step
+        DTMIN_LOC = (ONE+EM06)*(FAC(07,NL) - TT) ! go directly to trigger time
+        DTMIN_LOC=MAX(PBLAST_TAB(IL)%DTMIN, DTMIN_LOC)
+        !---no update on next cycle
+        IZ_UPDATE = 1 !update done
+        ILOADP(06,NL) = IZ_UPDATE
+#include "lockoff.inc"
+        CALL MY_BARRIER()
+!$OMP SINGLE
+        write(*,FMT='(A,I10,A,E16.8,A,E16.8)') "Updated parameters for /LOAD/PBLAST id=",
+     .                                         ID,' previous first arrival time :',ZETA,
+     .                                         ' is now updated to :',FAC(07,NL)
+!$OMP END SINGLE
+      ENDIF
 
       !-------------------------------------------------------------------!
       !   FORCE ASSEMBLY                                                  !
@@ -909,7 +955,6 @@ C----- /TH/SURF -------
        ENDIF
 !$OMP END SINGLE
 
- 9000 CONTINUE
       RETURN
 
 C-----------------------------------------------

--- a/starter/source/loads/pblast/hm_read_pblast.F
+++ b/starter/source/loads/pblast/hm_read_pblast.F
@@ -99,6 +99,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       LOGICAL :: IS_AVAILABLE,lFOUND, IS_AVAILABLE_TSTOP, calculate, BOOL_COORD, BOOL_SKIP_CALC
       LOGICAL :: BOOL_UNDERGROUND_CURRENT_LOAD, BOOL_UNDERGROUND_CURRENT_SEG
+      LOGICAL :: IS_ITA_SHIFT
 
       CHARACTER*ncharline :: MSGOUT1
       CHARACTER*ncharline :: MSGOUT2
@@ -115,9 +116,12 @@ C-----------------------------------------------
       my_real Lg,SHTP,Zg,tmp_var,Z_struct,Zx,Zy,Zz,Pra,Pra_refl,ProjZ(3),ProjDet(3)
       my_real kk,FUNCT ! lb/ft**1/3 -> mm/g**1/3
       my_real P_inci,P_refl,P_inci_,P_refl_,decay_inci,decay_refl,I_inci,I_refl,I_inci_,I_refl_
-      my_real DT_0,DT_0_,ZETA,TOL,TMP2,TMP3,DIFF,RES,TSTOP
+      my_real DT_0,DT_0_,ZETA,TOL,TMP2,TMP3,DIFF,RES,TSTOP,TA_PBLAST
+      my_real b_min, b_max
+      my_real DTMIN
+      my_real,ALLOCATABLE,DIMENSION(:,:) :: OUTPUT_USER_PARAMS
 
-      INTEGER I,J,K,NUMSEG
+      INTEGER I,J,K,NUMSEG,K_BLAST
       INTEGER IAD,ID,SURF_ID,internal_SURF_ID
       INTEGER IABAC,PHI_I,IADPL,itmp,IS,SUB_ID
       INTEGER ITA_SHIFT
@@ -215,16 +219,20 @@ C-----------------------------------------------
       CALL PBLAST_INIT_TABLES(PBLAST_DATA)
 
       !Init.
-      TAINF_PBLAST = EP20
+      PBLAST_DT%TA_INF = EP20
       NUMSEG = 0
       ILD_PBLAST = 0 !numbering
       alpha_zc = ZERO
       HC = ZERO
       BOOL_SKIP_CALC = .FALSE.
+      IS_ITA_SHIFT = .FALSE.
+
+      ALLOCATE( OUTPUT_USER_PARAMS(6,NLOADP_B))
 
       CALL HM_OPTION_START('/LOAD/PBLAST')
 
       DO K = 1+NLOADP_F, NLOADP_F+NLOADP_B
+        K_BLAST = K-NLOADP_F
         CALL HM_OPTION_READ_KEY(LSUBMODEL, OPTION_TITR = TITR, OPTION_ID = ID, SUBMODEL_ID = SUB_ID)
         IAD = NUMLOADP + 1
         SURF_ID = 0 !target surface id
@@ -239,6 +247,7 @@ C-----------------------------------------------
         TDET  = ZERO
         TSTOP = ZERO
         WTNT  = ZERO
+        TA_PBLAST = EP20 ! for current K, PBLAST_DT%TA_INF is global
 
         !--------------------------------------------------------------
         !   R e a d i n g   I n p u t   P a r a m e t e r s
@@ -264,6 +273,9 @@ C-----------------------------------------------
         !---line-4
         CALL HM_GET_INTV('surf_ground_ID', SURF_ID_GROUND, IS_AVAILABLE, LSUBMODEL)
 
+         OUTPUT_USER_PARAMS(1,K_BLAST)=SURF_ID
+         OUTPUT_USER_PARAMS(2,K_BLAST)=SURF_ID_GROUND
+
         BOOL_COORD=.FALSE.
         IF(XDET/=ZERO .OR. YDET/=ZERO .OR. ZDET/=ZERO)THEN
           BOOL_COORD=.TRUE.
@@ -285,6 +297,7 @@ C-----------------------------------------------
 
         IF(TSTOP == ZERO)TSTOP=EP20
         IF(PMIN == ZERO)PMIN=-EP20
+        IF(NDT == 0) NDT=100
 
         IF(WTNT == ZERO)THEN
            MSGOUT1=''
@@ -301,6 +314,7 @@ C-----------------------------------------------
             YDET = X(2,NODE_ID)
             ZDET = X(3,NODE_ID)
           ENDIF
+           OUTPUT_USER_PARAMS(5,K_BLAST)=NODE_ID
           IF(BOOL_COORD)THEN
             MSGOUT1=''
             MSGOUT1='NODE IDENTIFIER IS PROVIDED.'
@@ -351,20 +365,28 @@ C-----------------------------------------------
           ENDIF
         ENDIF
 
-
+        !ITA_SHIFT : BLAST ARRIVAL
+        !---1:no shift (default)
+        !---2:shift    loading starts from the first cycle T=0 is shift to time on which first targeted segment is reached (within all pblast options)
         IF(ITA_SHIFT==0) ITA_SHIFT = 1
         IF(ITA_SHIFT < 0 .OR. ITA_SHIFT >= 3)ITA_SHIFT = 1
+        IF(ITA_SHIFT == 2)IS_ITA_SHIFT=.TRUE.
 
         ! IMODEL : flag for blast model
         !---1:Friedlander
-        !---2:modified Friedlander
+        !---2:modified Friedlander (default)
         IF(IMODEL <= 0 .OR. IMODEL > 2)IMODEL=2
 
-        IF(IZ_UPDATE /= 1)IZ_UPDATE=0 !0:update scaled distance
+        ! IZ : Z update during Engine
+        !---1 : do not update (default)
+        !---2 : update blast characteristing during Engine (because target may have move)
+        IF(IZ_UPDATE == 0)IZ_UPDATE=1
+        IF(IZ_UPDATE >=3)IZ_UPDATE=1
 
-        !              1 : update scaled distance with time
-        ! otherwise => 0 : do not update
-
+        !IABAC flag : MODEL TYPE
+        !  1: FREE AIR (default)
+        !  2: SURFACE BURST
+        !  3: AIR BURST
         IF(IABAC <= 0)IABAC=1
         IF(IABAC >= 4)IABAC=1
 
@@ -644,7 +666,7 @@ C-----------------------------------------------
           FACLOADP( 4,K) = ZDET
           FACLOADP( 5,K) = WTNT
           FACLOADP( 6,K) = PMIN
-          FACLOADP( 7,K) = ZERO !TA_INT initialized below
+          FACLOADP( 7,K) = ZERO !TA_PBLAST initialized below
           FACLOADP( 8,K) = Nx_SURF
           FACLOADP( 9,K) = Ny_SURF
           FACLOADP(10,K) = Nz_SURF
@@ -662,13 +684,13 @@ C-----------------------------------------------
           ISIZ_SEG = NUMSEG
           IAD = ILOADP(4,K)
           ILD_PBLAST = ILD_PBLAST + 1
-          ALLOCATE (   PBLAST_TAB(ILD_PBLAST)%cos_theta(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
-          ALLOCATE (   PBLAST_TAB(ILD_PBLAST)%P_inci(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
-          ALLOCATE (   PBLAST_TAB(ILD_PBLAST)%P_refl(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
-          ALLOCATE (   PBLAST_TAB(ILD_PBLAST)%ta(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
-          ALLOCATE (   PBLAST_TAB(ILD_PBLAST)%t0(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
-          ALLOCATE (   PBLAST_TAB(ILD_PBLAST)%decay_inci(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
-          ALLOCATE (   PBLAST_TAB(ILD_PBLAST)%decay_refl(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
+          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%cos_theta(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
+          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%P_inci(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
+          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%P_refl(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
+          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%ta(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
+          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%t0(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
+          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%decay_inci(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
+          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%decay_refl(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
           PBLAST_TAB(ILD_PBLAST)%SIZ=ISIZ_SEG
 
           !  Coordinates of detonation point projection = DETPOINT + HC*n     !N_SURF is here -HC*n  where n is normal unitary vector of the plane
@@ -682,6 +704,9 @@ C-----------------------------------------------
             ProjDet(3) = Zdet
           ENDIF
 
+          b_min = EP20
+          b_max = -EP20
+          DTMIN = EP20
           DO I=1,NUMSEG
             N1=IGRSURF(internal_SURF_ID)%NODES(I,1)
             N2=IGRSURF(internal_SURF_ID)%NODES(I,2)
@@ -1367,12 +1392,9 @@ C-----------------------------------------------
               I_inci_ = I_inci_* W13
               I_refl  = I_refl * W13
               I_refl_ = I_refl_* W13
-              DT_0    = DT_0   * W13
-              DT_0_   = DT_0_  * W13
-              T_A     = T_A    * W13
-
-              TAINF_PBLAST = MIN(TAINF_PBLAST, T_A/FAC_T_bb) !from cm mus g TO  Working Unit System
-              !print *, Z,T_A/FAC_T_bb,TAINF_PBLAST
+              IF(DT_0 /= EP20) DT_0  = DT_0  * W13
+              IF(DT_0_ /= EP20)DT_0_ = DT_0_ * W13
+              IF(T_A /= EP20)  T_A   = T_A   * W13
 
               IF(IMODEL == 1)THEN
                 !-Friedlander
@@ -1410,7 +1432,7 @@ C-----------------------------------------------
                   ENDIF
                   RES = ABS(FUNCT)   !g(x_new)
                 ENDDO
-                DECAY_inci=MAX(EM06,ZETA)
+                DECAY_inci=MAX(ONE,ZETA)
                 ITER=0
                 ZETA=ONE
                 RES=EP20
@@ -1435,7 +1457,7 @@ C-----------------------------------------------
                   ENDIF
                   RES = ABS(FUNCT)   !g(x_new)
                 ENDDO
-                DECAY_refl=MAX(EM06,ZETA)
+                DECAY_refl=MAX(ONE,ZETA)
               ENDIF
 
               ! UNIT CONVERSION !
@@ -1448,11 +1470,13 @@ C-----------------------------------------------
               I_inci_ =  I_inci_ / FAC_I_bb
               P_refl_ =  P_refl_ / FAC_P_bb
               I_refl_ =  I_refl_ / FAC_I_bb
-              DT_0    =  DT_0    / FAC_T_bb
-              DT_0_   =  DT_0_   / FAC_T_bb
-              T_A     =  T_A     / FAC_T_bb
-
-              T_A    = T_A + TDET
+              IF(DT_0 /= EP20) DT_0  =  DT_0  / FAC_T_bb
+              IF(DT_0_ /= EP20)DT_0_ =  DT_0_ / FAC_T_bb
+              IF(T_A /= EP20)THEN
+                T_A = T_A / FAC_T_bb
+                T_A = T_A + TDET
+              ENDIF
+              TA_PBLAST = MIN(TA_PBLAST,  T_A)
 
               !--------------------------------------------------------
               !   Storage of Wave Parameters (transmitted to Engine)
@@ -1465,8 +1489,23 @@ C-----------------------------------------------
               PBLAST_TAB(ILD_PBLAST)%decay_inci(I) = decay_inci
               PBLAST_TAB(ILD_PBLAST)%decay_refl(I) = decay_refl
 
-           ENDDO
+              b_min = MIN(b_min, decay_inci)
+              b_min = MIN(b_min, decay_refl)
 
+              b_max = MAX(b_max, decay_inci)
+              b_max = MAX(b_max, decay_refl)
+
+              DTMIN = MIN(DTMIN, DT_0/NDT)
+
+           ENDDO! I=1,NUMSEG
+
+           PBLAST_TAB(ILD_PBLAST)%DTMIN = DTMIN
+
+           FACLOADP(7,K) = TA_PBLAST ! min(TDET+T_A, I=1..NUMSEG)
+           PBLAST_DT%TA_INF = MIN(PBLAST_DT%TA_INF, TA_PBLAST)!   min( [min(TDET+T_A, I=1..NUMSEG)] , K=1..'numpblast')
+           OUTPUT_USER_PARAMS(3,K_BLAST) = b_min
+           OUTPUT_USER_PARAMS(4,K_BLAST) = b_max
+           OUTPUT_USER_PARAMS(6,K_BLAST) = TA_PBLAST
            IF(BOOL_UNDERGROUND_CURRENT_LOAD)THEN
              MSGOUT1=''
              WRITE(MSGOUT1,FMT='(I0,A)') SEG_UNDERGROUND,' SEGMENT(S) ON TARGET SURFACE ARE BELOW THE GROUND'
@@ -1476,7 +1515,55 @@ C-----------------------------------------------
            ENDIF
 
         ENDIF
-!
+
+        NUMLOADP=NUMLOADP+4*NUMSEG ! /LOAD/PBLAST
+
+C-----------
+      ENDDO!next K (/LOAD/PBLAST)
+
+!Set (shifted arrival time) for all blast loading
+      IF(.NOT.IS_ITA_SHIFT)THEN
+        PBLAST_DT%TA_INF = ZERO
+      ELSE
+        DO K = 1+NLOADP_F, NLOADP_F+NLOADP_B
+          K_BLAST = K-NLOADP_F
+          ILOADP(9,K) = 2
+          TA_PBLAST = FACLOADP(7,K)
+          !shifting trigger time
+          ! arrival time for segments are not shifted, time will be translated
+          ! during engine using T* = T + T_shift
+          FACLOADP(7,K) = MAX(ZERO, TA_PBLAST-PBLAST_DT%TA_INF) !arrival time shifted if requested
+        ENDDO
+      ENDIF
+
+
+
+C-----------OUTPUT IN LISTING FILE
+C---------------------------------
+      !this output is made once all /LOAD/PBLAST options are read in order to display global parameters (min values)
+      DO K = 1+NLOADP_F, NLOADP_F+NLOADP_B
+        K_BLAST = K-NLOADP_F
+        IZ_UPDATE = ILOADP(6,K)
+        IABAC = ILOADP(7,K)
+        ID = ILOADP(8,K)
+        ITA_SHIFT = ILOADP(9,K)
+        NDT = ILOADP(10,K)
+        IMODEL = ILOADP(11,K)
+        TDET = FACLOADP(1,K)
+        XDET = FACLOADP(2,K)
+        YDET = FACLOADP(3,K)
+        ZDET = FACLOADP(4,K)
+        WTNT = FACLOADP(5,K)
+        PMIN = FACLOADP(6,K)
+        TA_PBLAST = FACLOADP(7,K)
+        HC = FACLOADP(11,K)
+        TSTOP = FACLOADP(13,K)
+        NODE_ID = INT(OUTPUT_USER_PARAMS(5,K_BLAST))
+        SURF_ID = INT(OUTPUT_USER_PARAMS(1,K_BLAST))
+        SURF_ID_GROUND = INT(OUTPUT_USER_PARAMS(2,K_BLAST))
+        DTMIN = PBLAST_TAB(ILD_PBLAST)%DTMIN
+        b_min =  OUTPUT_USER_PARAMS(3,K_BLAST)
+        b_max =  OUTPUT_USER_PARAMS(4,K_BLAST)
         WRITE (IOUT,2000)
         SELECT CASE (IABAC)
           CASE(1)
@@ -1487,63 +1574,107 @@ C-----------------------------------------------
             WRITE(IOUT,2003)
         END SELECT
         WRITE(IOUT,2010)
-        IF(IABAC == 3) WRITE(IOUT,2023) HC
-        WRITE (IOUT,2011)ID,SURF_ID,IABAC,IZ_UPDATE,IMODEL,ITA_SHIFT,XDET,YDET,ZDET,TDET,WTNT,PMIN
-        IF(IS_AVAILABLE_TSTOP)WRITE (IOUT,2024)TSTOP
-        IF(NODE_ID /= 0)WRITE (IOUT,2015)NODE_ID
-
-        IF(NDT /= 0)WRITE (IOUT,2014)NDT
-        IF(ITA_SHIFT == 2)THEN
-           WRITE (IOUT,2012)TAINF_PBLAST
+        IF(IABAC==1)THEN
+          WRITE (IOUT,2011)ID,SURF_ID,NUMSEG,IABAC,IZ_UPDATE,IMODEL,ITA_SHIFT,XDET,YDET,ZDET,TDET,WTNT,PMIN
         ELSE
-           WRITE (IOUT,2013)
+          WRITE (IOUT,2211)ID,SURF_ID,NUMSEG,SEG_UNDERGROUND, IABAC,IZ_UPDATE,IMODEL,ITA_SHIFT,
+     .                     XDET,YDET,ZDET,TDET,WTNT,PMIN
         ENDIF
 
-        NUMLOADP=NUMLOADP+4*NUMSEG ! /LOAD/PBLAST
+        WRITE (IOUT,2033)DTMIN
+        IF(IMODEL == 2)THEN
+          WRITE (IOUT,2031)b_min
+          WRITE (IOUT,2032)b_max
+        ENDIF
+        IF(IS_AVAILABLE_TSTOP)WRITE (IOUT,2024)TSTOP
+        IF(NODE_ID /= 0)WRITE (IOUT,2015)NODE_ID
+        IF(NDT /= 0)WRITE (IOUT,2014)NDT
+        IF(IABAC >=2)THEN
+          WRITE(IOUT,2034)NX_SURF,NY_SURF,NZ_SURF
+        ENDIF
+        IF(IABAC == 3) WRITE(IOUT,2023) HC
+        IF(ITA_SHIFT == 2)THEN
+           WRITE (IOUT,2013)OUTPUT_USER_PARAMS(6,K_BLAST)
+           WRITE (IOUT,2012)TA_PBLAST
+        ELSE
+           WRITE (IOUT,2013)TA_PBLAST
+        ENDIF
+        !DISPLAY MINIMUM VALUE WITHIN ALL PBLAST OPTIONS
+        IF(NLOADP_B>=2)THEN
+          WRITE(IOUT,2035)PBLAST_DT%TA_INF
+        ENDIF
 
-C-----------
-      ENDDO                     !next K (next /LOAD)
+      ENDDO!next K (/LOAD/PBLAST)
 
-!Set inf(T_arrival) for all blast loading
-      DO K = 1+NLOADC+NLOADP_F, NLOADC+NLOADP_F+NLOADP_B
-         FACLOADP( 7,K) = TAINF_PBLAST
-      ENDDO
+
+
 C--------------------------------------------------------------------------------C
+      DEALLOCATE( OUTPUT_USER_PARAMS)
       RETURN
 C--------------------------------------------------------------------------------C
  2000 FORMAT(
      .     //
      .     '      BLAST LOADING  '/,
      .     '     --------------  '/)
- 2001 FORMAT('     FREE AIR BURST'/)
- 2002 FORMAT('     SURFACE BURST'/)
- 2003 FORMAT('     AIR BURST'/)
+ 2001 FORMAT('     FREE AIR BURST')
+ 2002 FORMAT('     SURFACE BURST')
+ 2003 FORMAT('     AIR BURST')
  2010 FORMAT('     DEFAULT UNIT SYSTEM IS {g,cm,mus}'/)
  2011 FORMAT(
-     .     5X,'CARD IDENTIFIER. . . . . . . . . . . .=',I16/,
+     .     5X,'ID . . . . . . . . . . . . . . . . . .=',I16/,
      .     5X,'SURFACE IDENTIFIER . . . . . . . . . .=',I16/,
-     .     5X,'EXPERIMENTAL DATA IDENTIFIER. . . . . =',I16/,
-     .     5X,'IZ FLAG . . . . . . . . . . . . . . . =',I16/,
-     .     5X,'MODELING FLAG(FRIEDLANDER MODEL) . . .=',I16/,
-     .     5X,'FLAG FOR TIME SHIFTING . . . . . . . .=',I16/,
+     .     5X,'   > NUMBER OF SEGMENTS  . . . . . . .=',I16/,
+     .     5X,'EXP_DATA (ALGORITHM)  . . . . . . . . =',I16/,
+     .     5X,'IZ FLAG (ENGINE UPDATE) . . . . . . . =',I16/,
+     .     5X,'IFORM FLAG (FRIEDLANDER MODEL) . . . .=',I16/,
+     .     5X,'I_TSHIFT (FLAG FOR TIME SHIFTING)  . .=',I16/,
      .     5X,'X-DET. . . . . . . . . . . . . . . . .=',E12.4/,
      .     5X,'Y-DET . . . . . . . . . . . . . . . . =',E12.4/,
      .     5X,'Z-DET . . . . . . . . . . . . . . . . =',E12.4/,
-     .     5X,'DETONATION TIME. . . . . . . . . . . .=',E12.4/,
-     .     5X,'EXPLOSIVE MASS.  . . . . . . . . . . .=',E12.4/,
-     .     5X,'MINIMUM PRESSURE . . . . . . . . . . .=',E12.4/)
+     .     5X,'TDET . . . . . . . . . . . . . . . . .=',E12.4/,
+     .     5X,'WTNT  . . . . .  . . . . . . . . . . .=',E12.4/,
+     .     5X,'PMIN . . . . . . . . . . . . . . . . .=',E12.4)
+ 2211 FORMAT(
+     .     5X,'ID . . . . . . . . . . . . . . . . . .=',I16/,
+     .     5X,'SURFACE IDENTIFIER . . . . . . . . . .=',I16/,
+     .     5X,'   > NUMBER OF SEGMENTS  . . . . . . .=',I16/,
+     .     5X,'   > UNDERGROUND SEGMENTS. . . . . . .=',I16/,
+     .     5X,'EXP_DATA (ALGORITHM)  . . . . . . . . =',I16/,
+     .     5X,'IZ FLAG (ENGINE UPDATE) . . . . . . . =',I16/,
+     .     5X,'IFORM FLAG (FRIEDLANDER MODEL) . . . .=',I16/,
+     .     5X,'I_TSHIFT (FLAG FOR TIME SHIFTING)  . .=',I16/,
+     .     5X,'X-DET. . . . . . . . . . . . . . . . .=',E12.4/,
+     .     5X,'Y-DET . . . . . . . . . . . . . . . . =',E12.4/,
+     .     5X,'Z-DET . . . . . . . . . . . . . . . . =',E12.4/,
+     .     5X,'TDET . . . . . . . . . . . . . . . . .=',E12.4/,
+     .     5X,'WTNT  . . . . .  . . . . . . . . . . .=',E12.4/,
+     .     5X,'PMIN . . . . . . . . . . . . . . . . .=',E12.4)         
  2012 FORMAT(
-     .     5X,'COMPUTED TIME SHIFT. . . . . . . . . .=',E12.4//)
+     .     5X,'TIME OF ARRIVAL (SHIFTED). . . . . . .=',E12.4)
  2013 FORMAT(
-     .     5X,'NO TIME SHIFTING'//)
+     .     5X,'TIME OF ARRIVAL . . . . . . . . . . . =',E12.4)
  2014 FORMAT(
-     .     5X,'NUMBER OF TIME INTERVALS . . . . . . .=',I10)
+     .     5X,'NDT  . . . . . . . . . . . . . . . . .=',I10)
  2015 FORMAT(
      .     5X,'NODE IDENTIFIER. . . . . . . . . . . .=',I10)
  2023 FORMAT(
      .     5X,'CHARGE HEIGHT. . . . . . . . . . . . .=',E12.4)
  2024 FORMAT(
      .     5X,'STOP TIME . . . . .. . . . . . . . . .=',E12.4/)
+ 2031 FORMAT(
+     .     5X,'COMPUTED MINIMUM DECAY PARAMETER . . .=',E12.4)
+ 2032 FORMAT(
+     .     5X,'COMPUTED MAXIMUM DECAY PARAMETER . . .=',E12.4)
+ 2033 FORMAT(
+     .     5X,'COMPUTED MINIMUM TIME STEP . . . . . .=',E12.4)
+ 2034 FORMAT(
+     .     5X,'GROUND NX  . . . . . . . . . . . . . .=',E12.4/,
+     .     5X,'GROUND NY . . . . . . . . . . . . . . =',E12.4/,
+     .     5X,'GROUND NZ . . . . . . . . . . . . . . =',E12.4)
+ 2035 FORMAT(
+     .     5X,'TIME SHIFT VALUE',/,
+     .     5X,'  (MINIMUM AMONG ALL PBLAST OPTIONS). =',E12.4//)
+
 C-----------------------------------------------
  1000 CONTINUE
       IF (IERR1 /= 0) THEN


### PR DESCRIPTION
#### /LOAD/PBLAST : Improvements


#### Description of the changes
- **TIME STEP / COMPUTATION TIME :** Time step calculation improved. When arrival time of blast wave is not reached, then time step is set to trigger blast on next cycle (unless there is a lower time step elsewhere in the computation domain). This makes possible to gain CPU time (no calculation before arrival time, and output results are not time shifted)
- **ENGINE UPDATE** Blast wave parameters can be updated during Engine (target may have move or may be defomed due to previous loads). When IZ flag is 2 then a single calculation is made on TDET and time step set to trigger on next cycle
- **NUMERICAL RESULT** Decay parameter is limited to [1.00,infinity[ to prevent any unphysical blast wave profile. When b<1.0 correlating positive impulse (with Iform=2) may lead to unphysical negative impulse with almost no benefit in positive phase.
- **INPUT FIX** IZ flag values are now consistent with manual page. 1:no Engine update 2:Engine update
- **OUTPUT** Starter Listing file improved :  new output such as decay parameters, minimum time step, arrival time (before and after shift) , number of segments, number of underground segments, etc...
- **SOURCE CLEANING** : unused variables removed,  "T0INF_LOC" replaced by "DTMIN" for better readability