### PR TITLE
Improve equivalence between shells and solids for /FAIL/TENSSTRAIN

### DIFF
--- a/engine/source/materials/fail/tensstrain/fail_tensstrain_c.F
+++ b/engine/source/materials/fail/tensstrain/fail_tensstrain_c.F
@@ -205,13 +205,9 @@ c
           DO I=1,NEL          
             EPST_A = HALF*(EPSXX(I)+EPSYY(I))
             EPST_B = SQRT((HALF*(EPSXX(I)-EPSYY(I)))**2 + (HALF*EPSXY(I))**2)
-            EPST1(I)  = EPST_A + EPST_B
-            EPST2(I)  = EPST_A - EPST_B
-            IF (EPST1(I) > -EPST2(I)) THEN
-              EPS_MAX(I) = EPST1(I)
-            ELSE
-              EPS_MAX(I) = ZERO
-            END IF
+            EPST1(I)   = EPST_A + EPST_B
+            EPST2(I)   = EPST_A - EPST_B
+            EPS_MAX(I) = EPST1(I)
           ENDDO
       END SELECT
 c----------------------------------------------

--- a/engine/source/materials/fail/tensstrain/fail_tensstrain_s.F
+++ b/engine/source/materials/fail/tensstrain/fail_tensstrain_s.F
@@ -38,7 +38,7 @@ Chd|====================================================================
      5           SIGNXX ,SIGNYY ,SIGNZZ ,SIGNXY  ,SIGNYZ ,SIGNZX ,
      6           EPSP   ,UVAR   ,OFF    ,IP      ,DFMAX  ,TDELE  ,
      7           MFXX   ,MFXY   ,MFXZ   ,MFYX    ,MFYY   ,MFYZ   ,                 
-     8           MFZX   ,MFZY   ,MFZZ   )
+     8           MFZX   ,MFZY   ,MFZZ   ,DMG_SCALE)
 C-----------------------------------------------
 C   Tensile Strain failure criterion
 C-----------------------------------------------
@@ -85,6 +85,7 @@ C-----------------------------------------------
       my_real ,DIMENSION(NEL) :: SIGNXX,SIGNYY,SIGNZZ,SIGNXY,SIGNYZ,SIGNZX,
      .   EPSXX,EPSYY,EPSZZ,EPSXY,EPSYZ,EPSZX,EPSP,ALDT,TSTAR,
      .   MFXX,MFXY,MFXZ,MFYX,MFYY,MFYZ,MFZX,MFZY,MFZZ
+      my_real, DIMENSION(NEL), INTENT(INOUT) :: DMG_SCALE
 C-----------------------------------------------
 C   I N P U T   O U T P U T   A r g u m e n t s 
 C-----------------------------------------------
@@ -662,13 +663,8 @@ C ---
       DO I=1,NEL
         R1 = EPSF1
         R2 = EPSF2
-        IF (R1 < R2) THEN         
-          SIGNXX(I) = (ONE - DAMAGE(I))*SIGNXX(I)
-          SIGNYY(I) = (ONE - DAMAGE(I))*SIGNYY(I)
-          SIGNZZ(I) = (ONE - DAMAGE(I))*SIGNZZ(I)
-          SIGNXY(I) = (ONE - DAMAGE(I))*SIGNXY(I)
-          SIGNYZ(I) = (ONE - DAMAGE(I))*SIGNYZ(I)
-          SIGNZX(I) = (ONE - DAMAGE(I))*SIGNZX(I)
+        IF (R1 < R2) THEN    
+          DMG_SCALE(I) = ONE - DAMAGE(I)
         END IF
         DFMAX(I) = MAX(DFMAX(I),DAMAGE(I))  ! Maximum Damage storing for output : 0 < DFMAX < 1
        ENDDO            

--- a/engine/source/materials/mat_share/mmain.F
+++ b/engine/source/materials/mat_share/mmain.F
@@ -2171,7 +2171,7 @@ c---- strain tension
      5             SS1 ,SS2 ,SS3 ,SS4  ,SS5  ,SS6     ,
      6             EPSP,UVARF,OFF,IP   ,DFMAX,TDEL    ,
      7             MFXX   ,MFXY   ,MFXZ   ,MFYX    ,MFYY   ,MFYZ   ,                 
-     8             MFZX   ,MFZY   ,MFZZ   )
+     8             MFZX   ,MFZY   ,MFZZ   ,DMG_SCALE)
 c
           ELSEIF(IRUPT == 11)THEN                                                          
 c---- energy failure  

--- a/engine/source/materials/mat_share/mulaw.F
+++ b/engine/source/materials/mat_share/mulaw.F
@@ -1983,7 +1983,7 @@ C---- strain tension
      5             S1  ,S2  ,S3  ,S4   ,S5   ,S6      ,
      6             EPSP1,UVARF,OFF ,IP   ,DFMAX,TDEL  ,
      7             MFXX     ,MFXY     ,MFXZ     ,MFYX     ,MFYY     , MFYZ    ,                 
-     8             MFZX     ,MFZY     ,MFZZ     )
+     8             MFZX     ,MFZY     ,MFZZ     ,DMG_SCALE)
           ELSEIF (IRUPT == 11) THEN                                        
 C---- energy failure  
               CALL FAIL_ENERGY_S(NEL ,NPAR,NUVARR,NFUNC,IFUNC       ,

--- a/engine/source/materials/mat_share/mulaw8.F
+++ b/engine/source/materials/mat_share/mulaw8.F
@@ -144,7 +144,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER NPAR,IADBUF,NFUNC,I,J,II,IPT,JPT,IR,IP,ISRATE,
      .  IFUNC(MAXFUNC),IDUM1,IFAIL(MVSIZ),MATF(MVSIZ),IC,IFLAG,
-     .  NVARF,NVARF_MAX,MX, IEXPAN8,JJ(6),INLOC
+     .  NVARF,NVARF_MAX,MX, IEXPAN8,JJ(6),INLOC,DMG_FLAG
       my_real 
      .C1(MVSIZ),PNEW(MVSIZ),PP(MVSIZ),DEFP(MVSIZ),
      .EP1(MVSIZ),EP2(MVSIZ),EP3(MVSIZ),EP4(MVSIZ),EP5(MVSIZ),EP6(MVSIZ),
@@ -183,6 +183,7 @@ C=======================================================================
       NUVAR  = BUFLY%NVAR_MAT
       NVARTMP= BUFLY%NVARTMP
       UPARAM => BUFMAT(IADBUF:IADBUF+NPAR)
+      DMG_FLAG = BUFLY%L_DMGSCL
 C
       DO J=1,6
         JJ(J) = NEL*(J-1)
@@ -396,6 +397,20 @@ C------Compute of AMU as in mmain after thermal expansion computation ----------
         ENDDO 
       ENDIF
       IEXPAN8 = 0
+C
+C--------------------------------------------------------
+C     COMPUTE UNDAMAGED EFFECTIVE STRESSES
+C---------------------------------------------------------
+      IF (DMG_FLAG > 0) THEN 
+        DO I = LFT,LLT
+          SO1(I) = SO1(I)/MAX(LBUF%DMGSCL(I),EM20)
+          SO2(I) = SO2(I)/MAX(LBUF%DMGSCL(I),EM20)
+          SO3(I) = SO3(I)/MAX(LBUF%DMGSCL(I),EM20)
+          SO4(I) = SO4(I)/MAX(LBUF%DMGSCL(I),EM20)
+          SO5(I) = SO5(I)/MAX(LBUF%DMGSCL(I),EM20)
+          SO6(I) = SO6(I)/MAX(LBUF%DMGSCL(I),EM20)
+        ENDDO
+      ENDIF
 C---------------------------------------------------------------------------------
       IF(MTN == 28)THEN
         IDUM1 = 0
@@ -971,7 +986,7 @@ C----strain tension
      5              S1  ,S2  ,S3  ,S4   ,S5   ,S6      ,
      6              EPSP1,UVARF   ,OFF  ,IP   ,DFMAX   ,TDELE,
      7              BIDON   ,BIDON   ,BIDON   ,BIDON    ,BIDON   ,BIDON   ,                 
-     8              BIDON   ,BIDON   ,BIDON   )
+     8              BIDON   ,BIDON   ,BIDON   ,LBUF%DMGSCL)
 c
 C----        energy failure          
               ELSEIF(IFAIL(II) == 11)THEN
@@ -1054,6 +1069,21 @@ c---------
 c---------
          ENDDO
         ENDDO ! several failur model boucle ir  
+c---------
+c--------------------------------------------------------
+c     DAMAGED STRESSES
+c---------------------------------------------------------
+        IF (DMG_FLAG > 0) THEN 
+          DO I = LFT,LLT
+            S1(I) = S1(I)*LBUF%DMGSCL(I)
+            S2(I) = S2(I)*LBUF%DMGSCL(I)
+            S3(I) = S3(I)*LBUF%DMGSCL(I)
+            S4(I) = S4(I)*LBUF%DMGSCL(I)
+            S5(I) = S5(I)*LBUF%DMGSCL(I)
+            S6(I) = S6(I)*LBUF%DMGSCL(I)
+          ENDDO
+        ENDIF
+c---------------------------------------------------------
       IF ((ITASK==0).AND.(IMON_MAT==1))CALL STOPTIME(121,1)
 c----------
         IF (ISORTH /= 0) THEN

--- a/engine/source/materials/mat_share/usermat_solid.F
+++ b/engine/source/materials/mat_share/usermat_solid.F
@@ -1440,7 +1440,7 @@ C---- strain tension
      5             S1  ,S2  ,S3  ,S4   ,S5   ,S6      ,
      6             EPSP1,UVARF,OFF ,IP   ,DFMAX,TDEL  ,
      7             MFXX   ,MFXY   ,MFXZ   ,MFYX    ,MFYY   ,MFYZ   ,                 
-     8             MFZX   ,MFZY   ,MFZZ   )
+     8             MFZX   ,MFZY   ,MFZZ   ,DMG_SCALE)
           ELSEIF (IRUPT == 11)THEN                                        
 C---- energy failure  
               CALL FAIL_ENERGY_S(LLT ,NPAR,NUVARR,NFUNC,IFUNC       ,

--- a/starter/source/materials/updmat.F
+++ b/starter/source/materials/updmat.F
@@ -143,8 +143,9 @@ c-----------------------------------------------------------------------
               MTAG%G_DMG = 1
             ELSE IF (IRUP == 28) THEN  ! Alter
               MTAG%G_DMG = 2
-            ELSE IF (IRUP == 41 .OR. IRUP == 42 .OR. IRUP == 44 .OR. 
-     .               IRUP == 45 .OR. IRUP == 46 .OR. IRUP == 47) THEN 
+            ELSE IF (IRUP == 10 .OR. IRUP == 41 .OR. IRUP == 42 .OR.
+     .               IRUP == 44 .OR. IRUP == 45 .OR. IRUP == 46 .OR.
+     .               IRUP == 47) THEN 
               MTAG%L_DMGSCL = 1
             ENDIF
           ENDDO


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

/FAIL/TENSSTRAIN criterion does not give the same results with shell and solid elements in some specific cases: no stress softening for solids, additional check for compression with shells. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Add stress softening for solids and remove additional check for shells. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
