### PR TITLE
Add new failure parameter in /FAIL/FABRIC

### DIFF
--- a/engine/source/materials/fail/fabric/fail_fabric_c.F
+++ b/engine/source/materials/fail/fabric/fail_fabric_c.F
@@ -100,7 +100,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER :: I,J,NINDX1,NINDX2
+      INTEGER :: I,J,NINDX1,NINDX2,NDIR
       my_real :: XFAC,RF1,RR1,RF2,RR2,DYDX,EPSR1,EPSR2,EPSF1,EPSF2,DMG1,DMG2
       INTEGER ,DIMENSION(NEL) :: INDX1,INDX2
       my_real ,DIMENSION(NEL) :: RFAC1,RFAC2,EPSP1,EPSP2
@@ -115,6 +115,7 @@ C=======================================================================
       EPSF2 = UPARAM(3)
       EPSR2 = UPARAM(4)
       XFAC  = UPARAM(5)
+      NDIR  = NINT(UPARAM(6))
 C-------------------
 C     STRAIN 
 C-------------------
@@ -154,9 +155,16 @@ c
         UVAR(I,2) = MAX(UVAR(I,2), DMG2)
         IF (UVAR(I,1)>ZERO .and. SIG1(I)>ZERO) SIG1(I) = SIG1(I)*(ONE-UVAR(I,1))
         IF (UVAR(I,2)>ZERO .and. SIG2(I)>ZERO) SIG2(I) = SIG2(I)*(ONE-UVAR(I,2))
-        IF (UVAR(I,1) == ONE .and. UVAR(I,2) == ONE) THEN
-          FOFF(I) = 0
-          TDEL(I) = TIME                      
+        IF (NDIR == 2) THEN 
+          IF (UVAR(I,1) == ONE .AND. UVAR(I,2) == ONE) THEN
+            FOFF(I) = 0
+            TDEL(I) = TIME                      
+          ENDIF
+        ELSE
+          IF (UVAR(I,1) == ONE .OR. UVAR(I,2) == ONE) THEN
+            FOFF(I) = 0
+            TDEL(I) = TIME                      
+          ENDIF
         ENDIF
       ENDDO
 c

--- a/hm_cfg_files/config/CFG/radioss2023/FAIL/fail_fabric.cfg
+++ b/hm_cfg_files/config/CFG/radioss2023/FAIL/fail_fabric.cfg
@@ -1,0 +1,76 @@
+//Copyright>    CFG Files and Library ("CFG")
+//Copyright>    Copyright (C) 1986-2023 Altair Engineering Inc.
+//Copyright>
+//Copyright>    Altair Engineering Inc. grants to third parties limited permission to
+//Copyright>    use and modify CFG solely in connection with OpenRadioss software, provided
+//Copyright>    that any modification to CFG by a third party must be provided back to
+//Copyright>    Altair Engineering Inc. and shall be deemed a Contribution under and therefore
+//Copyright>    subject to the CONTRIBUTOR LICENSE AGREEMENT for OpenRadioss software.
+//Copyright>
+//Copyright>    CFG IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//Copyright>    INCLUDING, BUT NOT LIMITED TO, THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+//Copyright>    A PARTICULAR PURPOSE, AND NONINFRINGEMENT.  IN NO EVENT SHALL ALTAIR ENGINEERING
+//Copyright>    INC. OR ITS AFFILIATES BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY,
+//Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
+//Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
+//
+//FAIL : ENERGY for HC 2.7
+//
+
+
+
+ATTRIBUTES(COMMON){ 
+
+	_HMCOMMENTSFLAG  		= VALUE(INT, "Write HM Comments");
+	mat_id           		= VALUE(MAT,  "Material");
+   
+
+	Epsilon_f1   			= VALUE( FLOAT, "Failure tensile strain in direction 1") ;
+	Epsilon_r1   			= VALUE( FLOAT, "Rupture tensile strain in direction 1") ;
+	Epsilon_f2				= VALUE( FLOAT, "Failure tensile strain in direction 2") ;
+	Epsilon_r2				= VALUE( FLOAT, "Rupture tensile strain in direction 2") ;
+        NDIR                            = VALUE(INT, "Number of broken directions prior to element deletion");
+	
+	fct_ID 					= VALUE( FUNCT, "Function identifier for tensile strain limits in both direction vs. corresponding strain rates") ;
+	
+	ID_CARD_EXIST			= VALUE(BOOL, "ID_CARD_EXIST or not");
+}
+
+SKEYWORDS_IDENTIFIER(COMMON)
+{
+	_HMCOMMENTSFLAG=-1;
+}
+
+FORMAT(radioss2023) {
+	HEADER("/FAIL/FABRIC/%d",mat_id);
+
+	COMMENT("#         EPSILON_F1          EPSILON_R1          EPSILON_F2          EPSILON_R2                NDIR");
+	CARD("%20lg%20lg%20lg%20lg%10s%10d",Epsilon_f1 ,Epsilon_r1 ,Epsilon_f2 ,Epsilon_r2,_BLANK_,NDIR);
+	
+	COMMENT("#             FCT_ID");
+	CARD("%20lg",fct_ID);
+
+	if (ID_CARD_EXIST==TRUE)
+	{
+		COMMENT("#  FAIL_ID") ;
+	}  
+	FREE_CARD(ID_CARD_EXIST,"%10d", _ID_);    
+	
+}
+
+FORMAT(radioss2018) {
+	HEADER("/FAIL/FABRIC/%d",mat_id);
+
+	COMMENT("#         EPSILON_F1          EPSILON_R1          EPSILON_F2          EPSILON_R2");
+	CARD("%20lg%20lg%20lg%20lg",Epsilon_f1 ,Epsilon_r1 ,Epsilon_f2 ,Epsilon_r2);
+	
+	COMMENT("#             FCT_ID");
+	CARD("%20lg",fct_ID);
+
+	if (ID_CARD_EXIST==TRUE)
+	{
+		COMMENT("#  FAIL_ID") ;
+	}  
+	FREE_CARD(ID_CARD_EXIST,"%10d", _ID_);    
+	
+}

--- a/starter/source/materials/fail/fabric/hm_read_fail_fabric.F
+++ b/starter/source/materials/fail/fabric/hm_read_fail_fabric.F
@@ -70,7 +70,7 @@ C MODIFIED ARGUMENT
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER  :: IRFUN
+      INTEGER  :: IRFUN,NDIR
       my_real  :: EPSF1,EPSR1,EPSF2,EPSR2,FAC_T
       LOGICAL  :: IS_AVAILABLE,IS_ENCRYPTED
 C=======================================================================
@@ -95,6 +95,7 @@ C--------------------------------------------------
       CALL HM_GET_FLOATV ('Epsilon_r1'  ,EPSR1     ,IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV ('Epsilon_f2'  ,EPSF2     ,IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV ('Epsilon_r2'  ,EPSR2     ,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_INTV   ('NDIR'        ,NDIR      ,IS_AVAILABLE,LSUBMODEL)
 c
       CALL HM_GET_INTV   ('fct_ID'      ,IRFUN     ,IS_AVAILABLE,LSUBMODEL)
 c--------------------------------------------------
@@ -104,6 +105,9 @@ c--------------------------------------------------
       IF (EPSR1 <= ZERO) EPSR1 = EP20*TWO
       IF (EPSF2 <= ZERO) EPSF2 = EP20
       IF (EPSR2 <= ZERO) EPSR2 = EP20*TWO
+      IF (NDIR == 0) NDIR = 2
+      NDIR = MIN(NDIR,2)
+      NDIR = MAX(NDIR,1)
 c          
       IF (EPSF1 > EPSR1 .or. EPSF2 > EPSR2) THEN
         CALL ANCMSG(MSGID=617,
@@ -117,17 +121,18 @@ c--------------------------------------------------
       UPARAM(3) = EPSF2
       UPARAM(4) = EPSR2
       UPARAM(5) = FAC_T   ! abscissa unit scaling factor (strain rate)
+      UPARAM(6) = NDIR
 c-----------------------------------------------------
       IFUNC(1) = IRFUN
 c-----------------------------------------------------
-      NUPARAM = 5
+      NUPARAM = 6
       NUVAR   = 2
       NFUNC   = 1
 c-----------------------------------------------------
       IF (IS_ENCRYPTED)THEN
         WRITE(IOUT, 1000)
       ELSE
-        WRITE(IOUT, 1100) EPSF1,EPSR1,EPSF2,EPSR2,IRFUN
+        WRITE(IOUT, 1100) EPSF1,EPSR1,EPSF2,EPSR2,NDIR,IRFUN
       ENDIF
 c-----------
       RETURN
@@ -142,6 +147,7 @@ c--------------------------------------------------
      & 5X,'RUPTURE TENSION STRAIN DIRECTION 1 . . =',E12.4/
      & 5X,'FAILURE TENSION STRAIN DIRECTION 2 . . =',E12.4/
      & 5X,'RUPTURE TENSION STRAIN DIRECTION 2 . . =',E12.4/
-     & 5X,'STRAIN RATE SCALING FUNCTION . . . . . =',I8)
+     & 5X,'NUMBER OF BROKEN DIR. FOR EL. DELETION =',I10/
+     & 5X,'STRAIN RATE SCALING FUNCTION . . . . . =',I10)
 c-------------------------------------------------- 
       END


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

/FAIL/FABRIC could only trigger the element deletion when the 2 directions of the shell had been broken. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Add an additional parameter NDIR that allows to control the number of directions (NDIR) to brake prior triggering the element deletion. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
