### PR TITLE
mulaw.F:prevents UPARAMF pointer from unappropriate definition

### DIFF
--- a/engine/source/materials/mat_share/mulaw.F
+++ b/engine/source/materials/mat_share/mulaw.F
@@ -1858,7 +1858,8 @@ c----
           TDEL   => FBUF%FLOC(IR)%TDEL   
           NPAR   = IPM(112+IP, MX)   
           IADBUF = IPM(114+IP ,MX)
-          UPARAMF => BUFMAT(IADBUF:IADBUF+NPAR) 
+          NULLIFY(UPARAMF)
+          IF(IADBUF > 0)UPARAMF => BUFMAT(IADBUF:IADBUF+NPAR)
           NFUNC  = IPM(115+IP, MX)             
           FLD_IDX=> FBUF%FLOC(IR)%INDX
           FOFF   => FBUF%FLOC(IR)%OFF


### PR DESCRIPTION
#### mulaw.F:prevents UPARAMF pointer from unappropriate definition

#### Description of the changes
Debug tools may lead to an error when defining in mulaw.F :

-  UPARAMF=>BUFMAT(IADBUF: ) if IADBUF=0. 
         (In this specific situation it means there is no failure criterion /FAIL and then UPARAMF is not used.)

This is now updated to prevent debug tool to catch such usage of 0 index.