### PR TITLE
Interface Type11 initialization: in Starter

### DIFF
--- a/starter/source/interfaces/inter3d1/i11sti3.F
+++ b/starter/source/interfaces/inter3d1/i11sti3.F
@@ -374,7 +374,7 @@ C------------------------------------
         ELSEIF(NELP /= 0) THEN
           MT=IXP(1,NELP)
           MG=IXP(5,NELP)
-          IP = IPARTT(NELP)
+          IP = IPARTP(NELP)
           IF (THK_PART(IP) > ZERO ) THEN
             DX1=THK_PART(IP)
           ELSE
@@ -422,7 +422,7 @@ C------------------------------------
         ELSEIF(NELR /= 0) THEN
           MG=IXR(1,NELR)
           MT = IXR(5,NELR)
-          IP = IPARTT(NELR)
+          IP = IPARTR(NELR)
           IF(IP > 0)THEN
             IF (THK_PART(IP) > ZERO ) THEN
               DX1=THK_PART(IP)


### PR DESCRIPTION
Part thickness value is wrong for Beam and Spring elements, as PARTID from Truss are used.

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
