### PR TITLE
Correct bug of element buffer allocation for beams

### DIFF
--- a/starter/source/elements/elbuf_init/elbuf_ini.F
+++ b/starter/source/elements/elbuf_init/elbuf_ini.F
@@ -2336,6 +2336,10 @@ c
             LLOC = LLOC + BUFLY%L_FAC_YLD 
             LLOC = LLOC + BUFLY%L_ABURN 
             LLOC = LLOC + BUFLY%L_MU
+            LLOC = LLOC + BUFLY%L_PLANL
+            LLOC = LLOC + BUFLY%L_EPSDNL
+            LLOC = LLOC + BUFLY%L_DMGSCL
+            LLOC = LLOC + BUFLY%L_TSAIWU
 c
             BUFLEN = BUFLEN + (LLOC * NEL + NPAR_LBUF) * NIP_LAY
           ENDDO


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

avoid starter core dump when some failure models are used with beam elements

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Corrected element buffer allocation in starter; several local variables used for failure models were not counted for beams.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
