### PR TITLE
Correct bug of initialization Prony viscosity model with material laws 25 and 66

### DIFF
--- a/engine/source/materials/mat/mat025/sigeps25c.F
+++ b/engine/source/materials/mat/mat025/sigeps25c.F
@@ -47,11 +47,11 @@ Chd|====================================================================
      E                    PLY_EXX  ,PLY_EYY ,PLY_EXY  ,PLY_EXZ ,PLY_EYZ ,
      F                    PLY_F    ,PLA     ,DAMT     ,CRAK    ,IERR    ,
      G                    IOFF_DUCT,IFAILURE,PLY_ID   ,IPG     ,TSAIWU  ,
-     H                    VISC     )
+     H                    MAT_PARAM)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
-      USE VISC_PARAM_MOD
+      USE MATPARAM_DEF_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -90,7 +90,7 @@ C     REAL
      .   SIGOXX(NEL),SIGOYY(NEL),SIGOXY(NEL),SIGOYZ(NEL),
      .   SIGOZX(NEL),PLA(NEL),DAMT(NEL,2),CRAK(NEL,2),SEQ_OUTP(NEL),
      .   OFFL(NEL),SIGV(NEL,5),DT_INV(MVSIZ),SIGPLY(NEL,3),TSAIWU(NEL)
-      TYPE(VISC_PARAM_) ,INTENT(IN) :: VISC
+      TYPE(MATPARAM_STRUCT_) ,INTENT(IN) :: MAT_PARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -115,13 +115,13 @@ C
 C  Check visco elastic model 
 C             
       NPMAX = 0
-      IF (VISC%ILAW == 1) THEN   ! PRONY model
-        NPRONY = VISC%IPARAM(1)
-        KV     = VISC%UPARAM(1)
+      IF (MAT_PARAM%IVISC == 1) THEN   ! PRONY model
+        NPRONY = MAT_PARAM%VISC%IPARAM(1)
+        KV     = MAT_PARAM%VISC%UPARAM(1)
         ALLOCATE(GV(NPRONY),BETA(NPRONY))
         DO I=1,NPRONY
-          GV(I)   = VISC%UPARAM(1 + I)         
-          BETA(I) = VISC%UPARAM(1 + NPRONY + I)
+          GV(I)   = MAT_PARAM%VISC%UPARAM(1 + I)         
+          BETA(I) = MAT_PARAM%VISC%UPARAM(1 + NPRONY + I)
         ENDDO 
       ELSE
         ALLOCATE(GV(0),BETA(0))
@@ -153,7 +153,7 @@ C
         ENDDO
       ENDIF
 C
-      IF (VISC%ILAW == 1) THEN 
+      IF (MAT_PARAM%IVISC == 1) THEN 
         DO I=JFT,JLT
           DTINV = DT_INV(I)
           EPSPXX(I) = EPS(I,1)*DTINV
@@ -208,7 +208,7 @@ C-----------------------
 C
 C  visco elastic model 
 C             
-      IF (VISC%ILAW == 1 ) THEN 
+      IF (MAT_PARAM%IVISC == 1 ) THEN 
         CALL PRONY25C(JLT      ,NPRONY ,BETA     ,KV      ,
      1                GV       ,DT1C   ,RHO0     ,OFF     ,DIR   ,   
      2                EPSPXX   ,EPSPYY ,EPSPXY   ,EPSPYZ  ,EPSPZX,

--- a/engine/source/materials/mat/mat066/sigeps66c.F
+++ b/engine/source/materials/mat/mat066/sigeps66c.F
@@ -31,24 +31,24 @@ Chd|        FINTER                        source/tools/curve/finter.F
 Chd|        VISC_PARAM_MOD                ../common_source/modules/mat_elem/visc_param_mod.F
 Chd|====================================================================
       SUBROUTINE SIGEPS66C(
-     1     NEL    ,NUPARAM,NUVAR   ,MFUNC   ,KFUNC  ,
-     2     NPF    ,NPT0   ,IPT     ,IFLAG   ,
-     2     TF     ,TIME   ,TIMESTEP,UPARAM  ,RHO0   ,
-     3     AREA   ,EINT   ,THKLY   ,
-     4     EPSPXX ,EPSPYY ,EPSPXY  ,EPSPYZ  ,EPSPZX ,
-     5     DEPSXX ,DEPSYY ,DEPSXY  ,DEPSYZ  ,DEPSZX ,
-     6     EPSXX  ,EPSYY  ,EPSXY   ,EPSYZ   ,EPSZX  ,
-     7     SIGOXX ,SIGOYY ,SIGOXY  ,SIGOYZ  ,SIGOZX ,
-     8     SIGNXX ,SIGNYY ,SIGNXY  ,SIGNYZ  ,SIGNZX ,
-     9     SIGVXX ,SIGVYY ,SIGVXY  ,SIGVYZ  ,SIGVZX ,
-     A     SOUNDSP,VISCMAX,THK     ,PLA     ,UVAR   ,
-     B     OFF    ,NGL    ,IPM     ,MAT     ,ETSE   ,
-     C     GS     ,YLD    ,EPSP    ,ISRATE  ,INLOC  ,
-     D     DPLANL ,VISC   ,NUVARV  ,UVARV   )
+     1     NEL    ,NUPARAM  ,NUVAR   ,MFUNC   ,KFUNC  ,
+     2     NPF    ,NPT0     ,IPT     ,IFLAG   ,
+     2     TF     ,TIME     ,TIMESTEP,UPARAM  ,RHO0   ,
+     3     AREA   ,EINT     ,THKLY   ,
+     4     EPSPXX ,EPSPYY   ,EPSPXY  ,EPSPYZ  ,EPSPZX ,
+     5     DEPSXX ,DEPSYY   ,DEPSXY  ,DEPSYZ  ,DEPSZX ,
+     6     EPSXX  ,EPSYY    ,EPSXY   ,EPSYZ   ,EPSZX  ,
+     7     SIGOXX ,SIGOYY   ,SIGOXY  ,SIGOYZ  ,SIGOZX ,
+     8     SIGNXX ,SIGNYY   ,SIGNXY  ,SIGNYZ  ,SIGNZX ,
+     9     SIGVXX ,SIGVYY   ,SIGVXY  ,SIGVYZ  ,SIGVZX ,
+     A     SOUNDSP,VISCMAX  ,THK     ,PLA     ,UVAR   ,
+     B     OFF    ,NGL      ,IPM     ,MAT     ,ETSE   ,
+     C     GS     ,YLD      ,EPSP    ,ISRATE  ,INLOC  ,
+     D     DPLANL ,MAT_PARAM,NUVARV  ,UVARV   )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
-      USE VISC_PARAM_MOD
+      USE MATPARAM_DEF_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -125,7 +125,7 @@ C-----------------------------------------------
      .   SIGOXX(NEL),SIGOYY(NEL),
      .   SIGOXY(NEL),SIGOYZ(NEL),SIGOZX(NEL),
      .   GS(*),EPSP(NEL),DPLANL(NEL)
-      TYPE(VISC_PARAM_) ,INTENT(IN) :: VISC
+      TYPE(MATPARAM_STRUCT_) ,INTENT(IN) :: MAT_PARAM
 C-----------------------------------------------
 C   O U T P U T   A r g u m e n t s
 C-----------------------------------------------
@@ -786,13 +786,13 @@ C
 C
 C  visco elastic model (prony)
 C             
-       IF (VISC%ILAW == 1) THEN   
-         NPRONY = VISC%IPARAM(1)
-         KV     = VISC%UPARAM(1)
+       IF (MAT_PARAM%IVISC == 1) THEN   
+         NPRONY = MAT_PARAM%VISC%IPARAM(1)
+         KV     = MAT_PARAM%VISC%UPARAM(1)
 c              
         DO I=1,NPRONY
-          GV(I)   = VISC%UPARAM(1 + I)         
-          BETA(I) = VISC%UPARAM(1 + NPRONY + I)
+          GV(I)   = MAT_PARAM%VISC%UPARAM(1 + I)         
+          BETA(I) = MAT_PARAM%VISC%UPARAM(1 + NPRONY + I)
         ENDDO 
 C
         CALL PRONY_MODELC( 

--- a/engine/source/materials/mat_share/mulawc.F
+++ b/engine/source/materials/mat_share/mulawc.F
@@ -1089,7 +1089,7 @@ C------------------------------------------
      E        PLY_EXX     ,PLY_EYY  ,PLY_EXY     ,PLY_EXZ  ,PLY_EYZ   ,
      F        PLY_F       ,LBUF%PLA ,LBUF%DAM    ,LBUF%CRAK,GBUF%IERR ,
      G        IOFF_DUCT   ,IFAILURE ,PLY_ID      ,IPG      ,LBUF%TSAIWU,
-     H        MATPARAM%VISC)
+     H        MATPARAM    )
           ELSEIF (IGTYP == 9) THEN
 !           INTEGRATION BY POINTS (through thickness)
             CALL SIGEPS25CP(
@@ -1415,7 +1415,7 @@ c
      A        SSP    ,VISCMX ,THKN    ,LBUF%PLA ,UVAR   ,
      B        OFF    ,NGL    ,IPM     ,MATLY(JMLY),ETSE ,
      C        GS     ,SIGY   ,EPSPL   ,ISRATE   ,INLOC  ,
-     D        VARNL(1,IT),MATPARAM%VISC,NUVARV  ,UVARV   )
+     D        VARNL(1,IT),MATPARAM    ,NUVARV  ,UVARV   )
           ELSEIF (ILAW == 69) THEN
            CALL SIGEPS69C(
      1         JLT    , NUPARAM0, NUVAR   , NFUNC , IFUNC , NPF   ,


### PR DESCRIPTION

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

avoid potential problems in material laws 25 and 66

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Corrected flag used for Prony model activation inside material laws for shells. When viscosity model was not used, the flag value was wrong or not initialized.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
