### PR TITLE
Wrong Executable name for win64_impi Executable + typo in one routine

### DIFF
--- a/engine/CMake_Compilers/cmake_win64.txt
+++ b/engine/CMake_Compilers/cmake_win64.txt
@@ -32,7 +32,7 @@ set ( mpiver "${MPI}" )
     # Intel MPI version
     ####################
 
-    set (cpprel  "-DCPP_rel=00" )
+    set (cpprel  "-DCPP_rel=20" )
     set (mpi_suf "_${mpiver}" )
 
     #MPI     

--- a/engine/source/output/anim/generate/anim_nodal_contour_fvmbags.F
+++ b/engine/source/output/anim/generate/anim_nodal_contour_fvmbags.F
@@ -51,7 +51,7 @@ C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE FVBAG_MOD , only:FVBAG_DATA !data structure definition
-      USEGROUPDEF_MOD , only:GROUP_
+      USE GROUPDEF_MOD , only:GROUP_
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------


### PR DESCRIPTION
Fixed some errors...

Wrong Executable name for win64_impi Executable
Typo error in output routine.

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
