### PR TITLE
Remove FAILIP from /MAT/LAW124 which can cause segfault issue

### DIFF
--- a/engine/source/materials/mat/mat124/sigeps124.F
+++ b/engine/source/materials/mat/mat124/sigeps124.F
@@ -30,7 +30,7 @@ Chd|        VALPVEC_V                     source/materials/mat/mat033/sigeps33.F
 Chd|====================================================================
       SUBROUTINE SIGEPS124(
      1     NEL     ,NGL     ,NUPARAM ,NUVAR   ,TIMESTEP,TIME    ,
-     2     UPARAM  ,UVAR    ,RHO     ,PLA     ,DPLA    ,UELR    ,
+     2     UPARAM  ,UVAR    ,RHO     ,PLA     ,DPLA    ,
      3     SOUNDSP ,EPSD    ,OFF     ,LOFF    ,IPG     ,NPG     ,
      4     DEPSXX  ,DEPSYY  ,DEPSZZ  ,DEPSXY  ,DEPSYZ  ,DEPSZX  ,
      5     EPSXX   ,EPSYY   ,EPSZZ   ,EPSXY   ,EPSYZ   ,EPSZX   ,
@@ -64,14 +64,14 @@ Chd|====================================================================
       my_real,DIMENSION(NEL) ::
      .   SIGY,ET
       my_real ,DIMENSION(NEL), INTENT(INOUT)       :: 
-     .   PLA,DPLA,EPSD,LOFF,OFF,DMG,UELR
+     .   PLA,DPLA,EPSD,LOFF,OFF,DMG
       my_real ,DIMENSION(NEL,NUVAR), INTENT(INOUT) :: 
      .   UVAR
       !=======================================================================
       !      Local Variables
       !=======================================================================
       INTEGER I,J,II,ITER,NITER,NINDX,INDX(NEL),NINDX2,INDX2(NEL),
-     .        IRATE,DTYPE,DFLAG,IREG,INDX3(NEL),NINDX3,FAILIP
+     .        IRATE,DTYPE,DFLAG,IREG,INDX3(NEL),NINDX3
       my_real 
      .   YOUNG,BULK,G,NU,LAM,G2,AFILTR,AH,BH,CH,DH,HP,AS,QH0,
      .   M0,ECC,DF,BS,EPSI,EPST0,EPSTMAX,DELTAS,BETAS,EPSC0,
@@ -140,10 +140,7 @@ c
       EPSC0      = UPARAM(32)       ! Reference tensile strain rate
       EPSCMAX    = UPARAM(33)       ! Maximum compressive strain rate threshold
       ALPHAS     = UPARAM(34)       ! Compressive strain rate effect parameter 1
-      GAMMAS     = UPARAM(35)       ! Compressive strain rate effect parameter 2           
-      !  -> Flag for element deletion
-      FAILIP     = NINT(UPARAM(36)) ! Number of failed integration points
-      FAILIP     = MIN(FAILIP,NPG)
+      GAMMAS     = UPARAM(35)       ! Compressive strain rate effect parameter 2
 c
       !--------------------------------------------------------------------
       ! Recovering internal variables
@@ -907,15 +904,12 @@ c
             SIGNXY(I) = ZERO
             SIGNYZ(I) = ZERO
             SIGNZX(I) = ZERO  
-            DMG(I)  = ONE
-            LOFF(I) = FOUR_OVER_5       
-            UELR(I) = UELR(I) + ONE
-            IF (NINT(UELR(I)) == FAILIP)THEN 
-              NINDX3 = NINDX3 + 1
-              INDX3(NINDX3) = I
-              IDEL7NOK = 1
-              OFF(I) = ZERO   
-            ENDIF
+            DMG(I)    = ONE
+            LOFF(I)   = FOUR_OVER_5
+            NINDX3    = NINDX3 + 1
+            INDX3(NINDX3) = I
+            IDEL7NOK  = 1
+            OFF(I)    = ZERO   
           ENDIF
 c
         ENDDO

--- a/engine/source/materials/mat_share/mulaw.F
+++ b/engine/source/materials/mat_share/mulaw.F
@@ -1762,7 +1762,7 @@ c
         CALL MSTRAIN_RATE(NEL    ,ISRATE ,ASRATE ,EPSD   ,IDEV   ,
      .                    EP1    ,EP2    ,EP3    ,EP4    ,EP5    ,EP6)
         CALL SIGEPS124(NEL    ,NGL    ,NPAR   ,NUVAR  ,DT1    ,TT     ,
-     .                 UPARAM ,UVAR   ,RHO    ,DEFP   ,DPLA   ,GBUF%UELR,
+     .                 UPARAM ,UVAR   ,RHO    ,DEFP   ,DPLA   ,
      .                 SSP    ,EPSD   ,OFF    ,LBUF%OFF,IPG   ,NPG    ,
      .                 DE1    ,DE2    ,DE3    ,DE4    ,DE5    ,DE6    ,
      .                 ES1    ,ES2    ,ES3    ,ES4    ,ES5    ,ES6    ,

--- a/hm_cfg_files/config/CFG/radioss2022/MAT/matl124_cdpm2.cfg
+++ b/hm_cfg_files/config/CFG/radioss2022/MAT/matl124_cdpm2.cfg
@@ -25,7 +25,6 @@ ATTRIBUTES(COMMON)
     //
     MAT_E                      = VALUE(FLOAT, "Young's Modulus");
     MAT_NU                     = VALUE(FLOAT, "Poisson's Ratio");
-    FAILIP                     = VALUE(INT,   "Number of failed intg. point. prior to solid deletion");
     IRATE                      = VALUE(INT,   "Strain rate effect flag");
     FCUT                       = VALUE(FLOAT, "Strain rate filtering cutoff frequency");
     //
@@ -73,7 +72,6 @@ SKEYWORDS_IDENTIFIER(COMMON)
     //
     MAT_E                      = 119;
     MAT_NU                     = 120;  
-    FAILIP                     = -1;
     IRATE                      = -1;
     FCUT                       = -1;
     //
@@ -240,8 +238,8 @@ FORMAT(radioss2022) {
     }
     COMMENT("#              RHO_I");
     CARD("%20lg",MAT_RHO);
-    COMMENT("#                  E                  NU              FAILIP               IRATE                FCUT");
-    CARD("%20lg%20lg%10s%10d%10s%10d%20lg",MAT_E,MAT_NU,_BLANK_,FAILIP,_BLANK_,IRATE,FCUT); 
+    COMMENT("#                  E                  NU                                   IRATE                FCUT");
+    CARD("%20lg%20lg%30s%10d%20lg",MAT_E,MAT_NU,_BLANK_,IRATE,FCUT); 
     COMMENT("#                ECC                 QH0                  FT                  FC                  HP");
     CARD("%20lg%20lg%20lg%20lg%20lg",MAT_ECC,MAT_QH0,MAT_FT,MAT_FC,MAT_HP);
     COMMENT("#                 AH                  BH                  CH                  DH");

--- a/starter/source/materials/mat/mat124/hm_read_mat124.F
+++ b/starter/source/materials/mat/mat124/hm_read_mat124.F
@@ -76,7 +76,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I,J,K,ILAW,IRATE,DTYPE,DFLAG,IREG,FAILIP
+      INTEGER I,J,K,ILAW,IRATE,DTYPE,DFLAG,IREG
 C     REAL ou REAL*8
       my_real
      .   RHO0,YOUNG,NU,A,G,G2,LAM,BULK,FCUT,FC,FT,GFT,
@@ -99,7 +99,6 @@ card1 - Density
 card2 - Elasticity, flags, strain-rate effect and filtering  
       CALL HM_GET_FLOATV('MAT_E'      ,YOUNG      ,IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('MAT_NU'     ,NU         ,IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_INTV  ('FAILIP'     ,FAILIP     ,IS_AVAILABLE,LSUBMODEL)
       CALL HM_GET_INTV  ('IRATE'      ,IRATE      ,IS_AVAILABLE,LSUBMODEL)
       CALL HM_GET_FLOATV('FCUT'       ,ASRATE     ,IS_AVAILABLE,LSUBMODEL,UNITAB)
 card3 - Eccentricity, strength limits and hardening
@@ -190,8 +189,6 @@ c-----------------------------
       ENDIF
       ! Friction parameter
       M0 = THREE*(((FC**2)-(FT**2))/(FC*FT))*(ECC/(ECC + ONE))
-      ! Failure flag check
-      FAILIP = MAX(FAILIP,0)
       ! Dflag check 
       IF (DFLAG == 0) DFLAG = 1
       DFLAG = MIN(MAX(1,DFLAG),4)
@@ -226,7 +223,7 @@ c--------------------------
 c     Filling buffer tables
 c-------------------------- 
       ! Number of material parameters
-      NUPARAM = 36
+      NUPARAM = 35
       ! Number of user variables 
       NUVAR = 18
 c      
@@ -270,8 +267,6 @@ c
       UPARAM(33) = EPSCMAX  ! Maximum compressive strain rate threshold
       UPARAM(34) = ALPHAS   ! Compressive strain rate effect parameter 1
       UPARAM(35) = GAMMAS   ! Compressive strain rate effect parameter 2
-      !  -> Failure flag
-      UPARAM(36) = FAILIP   ! Number of failed integration point
 c      
       ! PARMAT table
       PARMAT(1) = BULK
@@ -318,7 +313,6 @@ c--------------------------
         WRITE(IOUT,2000) DTYPE
         WRITE(IOUT,2100) IREG
         WRITE(IOUT,2200) WF,WF1,FT1,EFC
-        WRITE(IOUT,2300) FAILIP
       ENDIF     
 c-----------------------------------------------------------------------
  1000 FORMAT(/
@@ -375,7 +369,5 @@ c-----------------------------------------------------------------------
      & 5X,'WF1 (DAMAGE DISPLACEMENT THRESHOLD 1) . . . . . . . . . . . .=',1PG20.13/
      & 5X,'FT1 (UNIAXIAL STRESS THRESHOLD 1) . . . . . . . . . . . . . .=',1PG20.13/
      & 5X,'EFC (STRAIN THRESHOLD IN COMPRESSION) . . . . . . . . . . . .=',1PG20.13/)
- 2300 FORMAT(    
-     & 5X,'NUMBER OF FAILED INTG. POINTS PRIOR TO ELEMENT DELETION . . .=',I10/)
 c-----------------------------------------------------------------------
       END


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

FAILIP parameter in /MAT/LAW124 was used to trigger element deletion using UELR table. However, this table is only allocated when using a failure criterion and not a material law alone. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Remove FAILIP parameter and UELR table from /MAT/LAW124 to avoid checkbounds issue. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
