### PR TITLE
fix an issue in mulaw8 : sigxxx arrays were not correctly defined

### DIFF
--- a/engine/source/materials/mat_share/mulaw8.F
+++ b/engine/source/materials/mat_share/mulaw8.F
@@ -561,7 +561,7 @@ C-------------------
           SIGBXY => LBUF%SIGB(3*NEL+1:4*NEL)
           SIGBYZ => LBUF%SIGB(4*NEL+1:5*NEL)
           SIGBZX => LBUF%SIGB(5*NEL+1:6*NEL)
-        ELSEIF(IMPL_S>0) THEN
+        ELSE
           VECNUL(1:NEL) = ZERO
           SIGBXX => VECNUL(1:NEL)
           SIGBYY => VECNUL(1:NEL)
@@ -570,6 +570,7 @@ C-------------------
           SIGBYZ => VECNUL(1:NEL)
           SIGBZX => VECNUL(1:NEL)
         ENDIF
+
         CALL SIGEPS36(
      2    LLT      ,NUVAR    ,NFUNC    ,IFUNC    ,NPF ,
      3    TF       ,TT       ,DT1      ,UPARAM   ,RHO0,


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
An issue was introduced in b323d7acbe61339e681d4fa3fa344b272ae5bb6e : SIGxxx arrays used by law36 routine were not correctly defined.
The issue is in mulaw8 routine

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
SIGxxx arrays point to fake arrays VECNUL if FISOKIN=0

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
