### PR TITLE
Wrong Path/file name for Temporary file to parse input file

### DIFF
--- a/engine/source/engine/lf_convert_c.c
+++ b/engine/source/engine/lf_convert_c.c
@@ -567,8 +567,8 @@ void lf_convert_c_flat(got_input, rootname, rootlen, filename, namelen, outname,
                   strcpy_s(outname_local,sz_lenpath,cwd);                                              
                   strcat_s(outname_local,sz_lenpath,"\\");                                                     
 #else
-                  strcat(outname_local, "/");  
                   strcpy(outname_local,cwd);                                              
+                  strcat(outname_local, "/");
 #endif
                   free(cwd);
                 }


### PR DESCRIPTION
Input file is copied in tempo file  on for any MPI process. 
The Path is found wrong ad a '/' is missing.


#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
