### PR TITLE
schlieren subroutine : arguments update

### DIFF
--- a/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
@@ -3705,9 +3705,9 @@ C--------------------------------------------------
                    LFT=1
                    LLT=NEL                                      
                    CALL OUTPUT_SCHLIEREN(
-     1                   EVAR  , IXTG , X         , V           , W       ,
+     1                   EVAR  , IXTG , X         ,
      2                   IPARG , WA_L , ELBUF_TAB , ALE_CONNECT , GBUF%VOL,
-     3                   PM    , NG   , NIXTG     , ITY) 
+     3                   NG    , NIXTG, ITY)
                    DO  I=1,NEL 
                      VALUE(I) = EVAR(I) 
                      IS_WRITTEN_VALUE(I) = 1


### PR DESCRIPTION
#### Argument cleaning for schlieren output (/H3D/ELEM/SCHLIEREN)

#### Description of the changes
argument were cleaned in subroutine OUTPUT_SCHLIEREN (v,w,pm arrays were removed) with commit 653b6326b72564a85393c40e22de56817f63942c. This cleaning was missing in h3d_shell_scalar1.F. This is now fixed. 