### PR TITLE
Fix an issue in the shooting node algo for interface 25 with eroded solid

### DIFF
--- a/engine/source/interfaces/interf/check_neighbours_surface_state.F
+++ b/engine/source/interfaces/interf/check_neighbours_surface_state.F
@@ -618,8 +618,7 @@ C---------------------------------------------------------
 
             NI25=0
             LSHIFT=0
-            DO NI =1,NBINTC
-                NIN = INTLIST(NI)
+             DO NIN=1,NINTER
                 NTY=IPARI(7,NIN)
                 NRTM = IPARI(4,NIN)
                 IF(NTY==25) THEN                   
@@ -669,11 +668,11 @@ C
                        P =  PROC_REM25(I)
                        ISOM(P) = ISOM(P) + 1
                     ENDDO
-                     SPMD_ARRAYS%IAD_FREDG((NSPMD+1)*(NI25-1)+1) = LSHIFT + 1
+                     SPMD_ARRAYS%IAD_FREDG(NI25) = LSHIFT + 1
 
                     DO P = 1, NSPMD
-                        SPMD_ARRAYS%IAD_FREDG((NSPMD+1)*(NI25-1)+P+1) = SPMD_ARRAYS%IAD_FREDG((NSPMD+1)*(NI25-1)+P) + ISOM(P)
-                    ENDDO           
+                        SPMD_ARRAYS%IAD_FREDG(P*NINTER25+NI25) = SPMD_ARRAYS%IAD_FREDG((P-1)*NINTER25+NI25) + ISOM(P)
+                    ENDDO 
                     LSHIFT=LSHIFT+NBDDEDG
                 ENDIF
             END DO


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
A issue related to the shooting node algo was found with a model with several interface 25: the neighbors are re-computed each time a element is deleted, this computation was buggy.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Fix the issue

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
