### PR TITLE
/EBCS/NRF:domain decomposition fix

### DIFF
--- a/starter/source/restart/ddsplit/ddsplit.F
+++ b/starter/source/restart/ddsplit/ddsplit.F
@@ -2166,9 +2166,9 @@ C--------------------------------------
         ! NRF ebcs
         IF(.NOT.EBCS_TAB%tab(ii)%poly%is_multifluid.AND.EBCS_TAB%tab(ii)%poly%type==10) THEN
             NEBCS_NRF = NEBCS_NRF + 1
-            DO JJ = 1, EBCS_TAB_LOC_2%tab(ii)%poly%nb_node
-                IF( NODLOCAL(EBCS_TAB_LOC_2%tab(ii)%poly%node_list(jj))>0.AND.
-     .              NODLOCAL(EBCS_TAB_LOC_2%tab(ii)%poly%node_list(jj))<=NUMNOD ) THEN
+            DO JJ = 1, EBCS_TAB_LOC_2%tab(NEBCS_NRF)%poly%nb_node
+                IF( NODLOCAL(EBCS_TAB_LOC_2%tab(NEBCS_NRF)%poly%node_list(jj)) > 0 .AND.
+     .              NODLOCAL(EBCS_TAB_LOC_2%tab(NEBCS_NRF)%poly%node_list(jj)) <= NUMNOD ) THEN
                     EBCS_TAB_LOC_2%tab(NEBCS_NRF)%poly%node_list(JJ) =
      .               NODLOCAL(EBCS_TAB_LOC_2%tab(NEBCS_NRF)%poly%node_list(JJ))                
                 ENDIF


### PR DESCRIPTION
#### /EBCS/NRF:domain decomposition fix

#### Description of the changes
array index is updated. EBCS_TAB_LOC_2 is allocated to the total number of /EBCS/NRF options. 
In ddsplit.F:2169 :
- 'ii' is index loop over all existing /EBCS options.
- NEBCS_NRF is index loop over /EBCS/NRF options only