### PR TITLE
fix lsdyna format part_composite syntax

### DIFF
--- a/hm_cfg_files/config/CFG/Keyword971_R10.1/COMPONENT/part_composite_option.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R10.1/COMPONENT/part_composite_option.cfg
@@ -489,8 +489,8 @@ FORMAT(Keyword971_R10.1)
 
     if(PartComposite_ContactOption == 1 || PartComposite_ContactOption == 2 || PartComposite_ContactOption == 3)
     {
-      COMMENT("$      MID     THICK         B      TMID       MID     THICK         B      TMID");
-      FREE_CELL_LIST(Number_of_Plies,"%10d%10lg%10lg%10d",PartComposite_MID,PartComposite_Thick,PartComposite_B,PartComposite_TMID,80);
+      COMMENT("$     MID1    THICK1        B1     TMID1      MID2    THICK2        B2     TMID2");
+      FREE_CELL_LIST(Number_of_Plies,"%10d%10lg%10lg%10d%10d%10lg%10lg%10d",PartComposite_MID,PartComposite_Thick,PartComposite_B,PartComposite_TMID,PartComposite_MID,PartComposite_Thick,PartComposite_B,PartComposite_TMID);
     }
     else if(PartComposite_ContactOption == 4)
     {


### PR DESCRIPTION
#### Description of the feature or the bug
A dyna format k file containing *PART_COMPOSITE is not parsed correctly in Radioss. #1995 
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
I'll start with [LS-DYNA R10.0](https://www.dynasupport.com/manuals/ls-dyna-manuals/ls-dyna-manual-r10.0-vol-i)
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
