### PR TITLE
Fix missing flexion energy increment

### DIFF
--- a/engine/source/elements/beam/main_beam3.F
+++ b/engine/source/elements/beam/main_beam3.F
@@ -260,6 +260,7 @@ c
       DO I=1,NEL
         DEGMB(I) = DEGMB(I) + FOR(I,1)*EXX(I)
         DEGSH(I) = DEGSH(I) + FOR(I,2)*EXY(I) + FOR(I,3)*EXZ(I)
+        DEGFX(I) = DEGFX(I) + MOM(I,1)*KXX(I) + MOM(I,2)*KYY(I) + MOM(I,3)*KZZ(I)
         FACT = HALF*OFF(I)*AL(I)
         EINT(I,1) = EINT(I,1) + (DEGSH(I)+DEGMB(I))*FACT
         EINT(I,2) = EINT(I,2) +  FACT*DEGFX(I)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

A problem was found due to a recent PR. The flexion energy of TYPE3 BEAM is not anymore well computed. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Add the missing flexion energy increment. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
