### PR TITLE
improve the performance of model With Batoz shell and PID51

### DIFF
--- a/engine/source/elements/sh3n/coquedk/cdkforc3.F
+++ b/engine/source/elements/sh3n/coquedk/cdkforc3.F
@@ -175,8 +175,6 @@ c  indx utilise localement contrairement aux coques 4n
      :    ALLOCATABLE, DIMENSION(:), TARGET :: DIRA,DIRB
       my_real,
      .  DIMENSION(:) ,POINTER  :: DIR_A,DIR_B,CRKDIR,DADV
-      my_real, 
-     .    ALLOCATABLE, DIMENSION(:,:,:) :: PLAPT_LAY,SIGPT_LAY
 C--- Variables pour le non-local
       INTEGER :: NDDL, INOD(3),NC1(MVSIZ), NC2(MVSIZ), NC3(MVSIZ), L_NLOC, IPOS(3),INLOC
       my_real, DIMENSION(:,:), ALLOCATABLE :: VAR_REG
@@ -298,15 +296,6 @@ c-------------------------------------
          DIR_B => DIRB(1:NLAY*NEL*L_DIRB)
       ENDIF ! IDRAPE
 C
-       IF (IGTYP == 51 .OR. IGTYP == 52) THEN
-         ALLOCATE(PLAPT_LAY(NLAY,NPG,MVSIZ))
-         ALLOCATE(SIGPT_LAY(NLAY,NPG,5*MVSIZ))
-         PLAPT_LAY = ZERO
-         SIGPT_LAY = ZERO
-       ELSE
-         ALLOCATE(PLAPT_LAY(0,0,0))
-         ALLOCATE(SIGPT_LAY(0,0,0))
-       ENDIF
 c-------------------------------------
       IGTYP = IGEO(11,IXTG(5,1))
       IGMAT = IGEO(98 ,IXTG(5,1))
@@ -462,35 +451,6 @@ c--------------------------
 c-------------------------------
       ENDDO  !  NG = 1,NPG
 C----
-C temporary storage for mean PLAPT, SIGPT
-C----
-      IF ((IGTYP == 51.OR. IGTYP == 52) .AND. NLAY > 1) THEN
-        DO ILAY=1,NLAY
-          BUFLY => ELBUF_STR%BUFLY(ILAY)
-          NPTT = BUFLY%NPTT
-          DO IT = 1,NPTT
-            DO NG =1,NPG
-              IR = NG
-              IS = 1
-              DO I=JFT,JLT
-                IF (BUFLY%L_PLA > 0) THEN
-                  PLAPT_LAY(ILAY,NG,I) = PLAPT_LAY(ILAY,NG,I) + 
-     .                                   BUFLY%LBUF(IR,IS,IT)%PLA(I)/NPTT
-                ELSE
-                  PLAPT_LAY(ILAY,NG,I) = ZERO
-                ENDIF
-                II = (I-1)*5
-                DO J=1,5
-                  JJ = II+J
-                  SIGPT_LAY(ILAY,NG,JJ) = SIGPT_LAY(ILAY,NG,JJ) + 
-     .                                    BUFLY%LBUF(IR,IS,IT)%SIG(KK(J)+I)/NPTT
-                ENDDO
-              ENDDO ! DO I=JFT,JLT
-            ENDDO ! DO NG =1,NPG
-          ENDDO ! DO IT = 1,NPTT
-        ENDDO ! DO ILAY=1,NLAY
-      ENDIF  ! IF (IGTYP == 51) THEN
-C----
 C----------------------------------------------------------------------------
 C     FIN DE BOUCLE DE 3 POINTS DE INTEGRATION------------
 C----------------------------------------------------------------------------
@@ -518,94 +478,6 @@ C---
      .                             + GBUF%MOMPG(PT3+KK(J)+I))	
          ENDDO
       ENDDO
-C---
-C    = PLAPT =
-C---
-      IF (NLAY > 1) THEN
-        IF (IGTYP == 51 .OR. IGTYP == 52) THEN
-          DO IPT = 1,NLAY
-            BUFLY => ELBUF_STR%BUFLY(IPT)
-            IF (BUFLY%L_PLA > 0) THEN
-              DO I=JFT,JLT  
-                BUFLY%PLAPT(I) = THIRD*(PLAPT_LAY(IPT,1,I) + PLAPT_LAY(IPT,2,I) +
-     .                                  PLAPT_LAY(IPT,3,I))
-              ENDDO
-            ENDIF
-          ENDDO
-        ELSE  ! (IGTYP /= 51)
-          DO IPT = 1,NLAY
-            BUFLY => ELBUF_STR%BUFLY(IPT)
-            IF (BUFLY%L_PLA > 0) THEN
-              LBUF1 => ELBUF_STR%BUFLY(IPT)%LBUF(1,1,1)
-              LBUF2 => ELBUF_STR%BUFLY(IPT)%LBUF(2,1,1)
-              LBUF3 => ELBUF_STR%BUFLY(IPT)%LBUF(3,1,1)
-              DO I=JFT,JLT  
-                BUFLY%PLAPT(I) = THIRD*(LBUF1%PLA(I) + LBUF2%PLA(I) +
-     .                                  LBUF3%PLA(I))
-              ENDDO
-            ENDIF
-          ENDDO
-        ENDIF  !  IF (IGTYP == 51) THEN
-      ELSE  !  (NLAY == 1)
-        BUFLY => ELBUF_STR%BUFLY(1)
-        DO IPT = 1,BUFLY%NPTT
-          IF (BUFLY%L_PLA > 0) THEN
-            LBUF1 => ELBUF_STR%BUFLY(1)%LBUF(1,1,IPT)
-            LBUF2 => ELBUF_STR%BUFLY(1)%LBUF(2,1,IPT)
-            LBUF3 => ELBUF_STR%BUFLY(1)%LBUF(3,1,IPT)
-            II = (IPT-1)*NEL
-            DO I=JFT,JLT                                                 
-              BUFLY%PLAPT(II+I) = THIRD*(LBUF1%PLA(I) + LBUF2%PLA(I) +
-     .                                   LBUF3%PLA(I))
-            ENDDO
-          ENDIF
-        ENDDO
-      ENDIF !  IF (NLAY > 1) THEN
-C---
-C    = SIGPT =
-C---
-      IF (NLAY > 1) THEN
-        IF (IGTYP == 51 .OR. IGTYP == 52) THEN
-          DO IPT = 1,NLAY
-            BUFLY => ELBUF_STR%BUFLY(IPT)
-            DO I=JFT,JLT*5  
-              BUFLY%SIGPT(I) = THIRD*(SIGPT_LAY(IPT,1,I) + SIGPT_LAY(IPT,2,I) +
-     .                                SIGPT_LAY(IPT,3,I))
-            ENDDO
-          ENDDO
-        ELSE  ! (IGTYP /= 51)
-          DO IPT = 1,NLAY
-            BUFLY => ELBUF_STR%BUFLY(IPT)
-            LBUF1 => ELBUF_STR%BUFLY(IPT)%LBUF(1,1,1)
-            LBUF2 => ELBUF_STR%BUFLY(IPT)%LBUF(2,1,1)
-            LBUF3 => ELBUF_STR%BUFLY(IPT)%LBUF(3,1,1)
-            DO I=JFT,JLT
-              II = (I-1)*5
-              DO J=1,5
-               JJ = II+J
-               BUFLY%SIGPT(JJ) = THIRD*(LBUF1%SIG(KK(J)+I) + LBUF2%SIG(KK(J)+I) +
-     .                                  LBUF3%SIG(KK(J)+I))
-              ENDDO
-            ENDDO
-          ENDDO
-        ENDIF  !  IF (IGTYP == 51) THEN
-      ELSE  !  (NLAY == 1)
-        BUFLY => ELBUF_STR%BUFLY(1)
-        DO IPT = 1,BUFLY%NPTT
-          LBUF1 => ELBUF_STR%BUFLY(1)%LBUF(1,1,IPT)
-          LBUF2 => ELBUF_STR%BUFLY(1)%LBUF(2,1,IPT)
-          LBUF3 => ELBUF_STR%BUFLY(1)%LBUF(3,1,IPT)
-          K = (IPT-1)*NEL*5
-          DO I=JFT,JLT
-            II = (I-1)*5
-            DO J=1,5
-              JJ = K+II+J
-              BUFLY%SIGPT(JJ) = THIRD*(LBUF1%SIG(KK(J)+I) + LBUF2%SIG(KK(J)+I)
-     .                               + LBUF3%SIG(KK(J)+I))
-            ENDDO
-          ENDDO
-        ENDDO
-      ENDIF !  IF (NLAY > 1) THEN
 C-------------------------
 C     ASSEMBLE
 C-------------------------
@@ -691,9 +563,7 @@ c
       ENDIF
 C------------
       IF (ALLOCATED(DIRB)) DEALLOCATE(DIRB)                                                          
-      IF (ALLOCATED(DIRA)) DEALLOCATE(DIRA)                                                          
-      IF (ALLOCATED(PLAPT_LAY)) DEALLOCATE(PLAPT_LAY)
-      IF (ALLOCATED(SIGPT_LAY)) DEALLOCATE(SIGPT_LAY)
+      IF (ALLOCATED(DIRA)) DEALLOCATE(DIRA)
       IF (ALLOCATED(VAR_REG))    DEALLOCATE(VAR_REG)
 C------------
       RETURN

--- a/engine/source/elements/shell/coqueba/cbaforc3.F
+++ b/engine/source/elements/shell/coqueba/cbaforc3.F
@@ -270,7 +270,6 @@ C-----------------------------------------------
       my_real, ALLOCATABLE, DIMENSION(:) :: DIR1_CRK,DIR2_CRK,DIRA,DIRB
       my_real
      .   EZZPG(MVSIZ,4)
-      my_real, ALLOCATABLE, DIMENSION(:,:,:) :: PLAPT_LAY,SIGPT_LAY
       TARGET :: DIRA,DIRB
       INTEGER :: NDDL, NC1(MVSIZ), NC2(MVSIZ), NC3(MVSIZ), NC4(MVSIZ),
      .           INLOC
@@ -421,16 +420,6 @@ C initiallisation pour la thermique ---
          THEM(I,4) = ZERO
          TEMPEL(I) = ZERO
        ENDDO
-C
-       IF (IGTYP == 51 .OR. IGTYP == 52) THEN
-         ALLOCATE(PLAPT_LAY(MVSIZ,NLAY,NPG))
-         ALLOCATE(SIGPT_LAY(5*MVSIZ,NLAY,NPG))
-         PLAPT_LAY = ZERO
-         SIGPT_LAY = ZERO
-       ELSE
-         ALLOCATE(PLAPT_LAY(0,0,0))
-         ALLOCATE(SIGPT_LAY(0,0,0))
-       ENDIF
 C
        IF(NPINCH > 0) THEN
          ALLOCATE(PINCH_LOCAL%EPINCHXZ(MVSIZ))
@@ -868,36 +857,6 @@ c--------------------------
 C---------------------------------------
 C-----FIN DE BOUCLE DE 4 POINTS DE GAUSS
 C---------------------------------------
-C----
-C temporary storage for mean PLAPT, SIGPT
-C----
-      IF ((IGTYP == 51 .OR. IGTYP == 52)  .AND. NLAY > 1) THEN
-        DO ILAY=1,NLAY
-          BUFLY => ELBUF_STR%BUFLY(ILAY)
-          NPTT = BUFLY%NPTT
-          DO IT = 1,NPTT
-            DO IS = 1,NPTS
-              DO IR = 1,NPTR
-                NG = NPTR*(IS-1) + IR
-                DO I=JFT,JLT
-                  IF (BUFLY%L_PLA > 0) THEN
-                    PLAPT_LAY(I,ILAY,NG) = PLAPT_LAY(I,ILAY,NG) + 
-     .                                     BUFLY%LBUF(IR,IS,IT)%PLA(I)/NPTT
-                  ELSE
-                    PLAPT_LAY(I,ILAY,NG) = ZERO
-                  ENDIF
-                  II = (I-1)*5
-                  DO J=1,5
-                    JJ = II+J
-                    SIGPT_LAY(JJ,ILAY,NG) = SIGPT_LAY(JJ,ILAY,NG) + 
-     .                                      BUFLY%LBUF(IR,IS,IT)%SIG(KK(J)+I)/NPTT
-                  ENDDO
-                ENDDO
-              ENDDO
-            ENDDO
-          ENDDO
-        ENDDO ! DO ILAY=1,NLAY
-      ENDIF  ! IF (IGTYP == 51) THEN
 C
       IF (NPINCH > 0) THEN
         CALL CBAPINCHTHK(
@@ -936,98 +895,6 @@ C---
      .                             + GBUF%MOMPG(PT4+KK(J)+I))
         ENDDO
       ENDDO
-C---
-C    = PLAPT =
-C---
-      IF (NLAY > 1) THEN
-        IF (IGTYP == 51 .OR. IGTYP == 52) THEN
-          DO IPT = 1,NLAY
-            BUFLY => ELBUF_STR%BUFLY(IPT)
-            IF (BUFLY%L_PLA > 0) THEN
-              DO I=JFT,JLT  
-                BUFLY%PLAPT(I) = FOURTH*(PLAPT_LAY(I,IPT,1) + PLAPT_LAY(I,IPT,2) +
-     .                                  PLAPT_LAY(I,IPT,3) + PLAPT_LAY(I,IPT,4))
-              ENDDO
-            ENDIF
-          ENDDO
-        ELSE  ! (IGTYP /= 51)
-          DO IPT = 1,NLAY
-            BUFLY => ELBUF_STR%BUFLY(IPT)
-            IF (BUFLY%L_PLA > 0) THEN
-              LBUF1 => ELBUF_STR%BUFLY(IPT)%LBUF(1,1,1)
-              LBUF2 => ELBUF_STR%BUFLY(IPT)%LBUF(2,1,1)
-              LBUF3 => ELBUF_STR%BUFLY(IPT)%LBUF(1,2,1)
-              LBUF4 => ELBUF_STR%BUFLY(IPT)%LBUF(2,2,1)
-              DO I=JFT,JLT  
-                BUFLY%PLAPT(I) = FOURTH*(LBUF1%PLA(I) + LBUF2%PLA(I) +
-     .                                  LBUF3%PLA(I) + LBUF4%PLA(I))
-              ENDDO
-            ENDIF
-          ENDDO
-        ENDIF  !  IF (IGTYP == 51) THEN
-      ELSE  !  (NLAY == 1)
-        BUFLY => ELBUF_STR%BUFLY(1)
-        DO IPT = 1,BUFLY%NPTT
-          IF (BUFLY%L_PLA > 0) THEN
-            LBUF1 => ELBUF_STR%BUFLY(1)%LBUF(1,1,IPT)
-            LBUF2 => ELBUF_STR%BUFLY(1)%LBUF(2,1,IPT)
-            LBUF3 => ELBUF_STR%BUFLY(1)%LBUF(1,2,IPT)
-            LBUF4 => ELBUF_STR%BUFLY(1)%LBUF(2,2,IPT)
-            II = (IPT-1)*NEL
-            DO I=JFT,JLT                                                 
-              BUFLY%PLAPT(II+I) = FOURTH*(LBUF1%PLA(I) + LBUF2%PLA(I) +
-     .                                   LBUF3%PLA(I) + LBUF4%PLA(I))
-            ENDDO
-          ENDIF
-        ENDDO
-      ENDIF !  IF (NLAY > 1) THEN
-C---
-C    = SIGPT =
-C---
-      IF (NLAY > 1) THEN
-        IF (IGTYP == 51 .OR. IGTYP == 52) THEN
-          DO IPT = 1,NLAY
-            BUFLY => ELBUF_STR%BUFLY(IPT)
-            DO I=JFT,JLT*5
-              BUFLY%SIGPT(I) = FOURTH*(SIGPT_LAY(I,IPT,1) + SIGPT_LAY(I,IPT,2) +
-     .                                SIGPT_LAY(I,IPT,3) + SIGPT_LAY(I,IPT,4))
-            ENDDO
-          ENDDO
-        ELSE  ! (IGTYP /= 51)
-          DO IPT = 1,NLAY
-            BUFLY => ELBUF_STR%BUFLY(IPT)
-            LBUF1 => ELBUF_STR%BUFLY(IPT)%LBUF(1,1,1)
-            LBUF2 => ELBUF_STR%BUFLY(IPT)%LBUF(2,1,1)
-            LBUF3 => ELBUF_STR%BUFLY(IPT)%LBUF(1,2,1)
-            LBUF4 => ELBUF_STR%BUFLY(IPT)%LBUF(2,2,1)
-            DO I=JFT,JLT
-              II = (I-1)*5
-              DO J=1,5
-               JJ = II+J
-               BUFLY%SIGPT(JJ) = FOURTH*(LBUF1%SIG(KK(J)+I) + LBUF2%SIG(KK(J)+I) +
-     .                                  LBUF3%SIG(KK(J)+I) + LBUF4%SIG(KK(J)+I))
-              ENDDO
-            ENDDO
-          ENDDO
-        ENDIF  !  IF (IGTYP == 51) THEN
-      ELSE  !  (NLAY == 1)
-        BUFLY => ELBUF_STR%BUFLY(1)
-        DO IPT = 1,BUFLY%NPTT
-          LBUF1 => ELBUF_STR%BUFLY(1)%LBUF(1,1,IPT)
-          LBUF2 => ELBUF_STR%BUFLY(1)%LBUF(2,1,IPT)
-          LBUF3 => ELBUF_STR%BUFLY(1)%LBUF(1,2,IPT)
-          LBUF4 => ELBUF_STR%BUFLY(1)%LBUF(2,2,IPT)
-          K = (IPT-1)*NEL*5
-          DO I=JFT,JLT
-            II = (I-1)*5
-            DO J=1,5
-              JJ = K+II+J
-              BUFLY%SIGPT(JJ) =FOURTH*(LBUF1%SIG(KK(J)+I) + LBUF2%SIG(KK(J)+I)
-     .                              + LBUF3%SIG(KK(J)+I) + LBUF4%SIG(KK(J)+I))
-            ENDDO
-          ENDDO
-        ENDDO
-      ENDIF !  IF (NLAY > 1) THEN
 c------------------------------      
 C     membrane shear traitement
       IF (IDRIL == 0) THEN
@@ -1206,10 +1073,8 @@ C
      8   STI_PLY,   MSZ2,      NFT,       NPT)
       ENDIF  
 C------------
-      IF (ALLOCATED(DIRB)) DEALLOCATE(DIRB)                                                          
-      IF (ALLOCATED(DIRA)) DEALLOCATE(DIRA)                                                          
-      IF (ALLOCATED(PLAPT_LAY)) DEALLOCATE(PLAPT_LAY)
-      IF (ALLOCATED(SIGPT_LAY)) DEALLOCATE(SIGPT_LAY)
+      IF (ALLOCATED(DIRB)) DEALLOCATE(DIRB) 
+      IF (ALLOCATED(DIRA)) DEALLOCATE(DIRA)
       IF (ALLOCATED(VAR_REG))   DEALLOCATE(VAR_REG)
 C
        IF(NPINCH > 0) THEN

--- a/engine/source/output/anim/generate/dfuncc.F
+++ b/engine/source/output/anim/generate/dfuncc.F
@@ -1025,46 +1025,56 @@ c---
             ELSEIF (IFUNC == 1 .AND. (MLW /= 15 .AND. MLW /= 25)) THEN   ! plastic strain (mid layer : npt/2 + 1) 
 ! law15 and law25 it's the plastic work instead plastic strain. it can be outp using /ANIM/ELEM/WPLA ( ifunc=4*MX_PLY_ANIM +13245)           
               IF (GBUF%G_PLA > 0) THEN
-                IF (NLAY > 1) THEN
-                  IPT = IABS(NLAY)/2 + 1
-                  BUFLY => ELBUF_TAB(NG)%BUFLY(IPT)
-                  IF (BUFLY%L_PLA > 0)THEN
+                ILAY = 1
+                IF (NLAY > 1) ILAY = IABS(NLAY)/2 + 1
+                 BUFLY => ELBUF_TAB(NG)%BUFLY(ILAY)
+                 IF (BUFLY%L_PLA > 0) THEN
                   IF (NPG > 1) THEN
-                    DO  I=LFT,LLT  
-                      EVAR(I) = ABS(BUFLY%PLAPT(I))
-                    ENDDO
+                    IF(ITY == 3) THEN
+                      IF(IGTYP == 51 .OR. IGTYP == 52) THEN
+                         NPTT = BUFLY%NPTT
+                         DO IS = 1,NPTS
+                           DO IR = 1,NPTR
+                             DO IPT = 1, NPTT
+                               DO  I=1,NEL  
+                                 EVAR(I) = EVAR(I) + FOURTH*BUFLY%LBUF(IR,IS,IT)%PLA(I)/NPTT
+                               ENDDO
+                             ENDDO
+                           ENDDO
+                         ENDDO     
+                      ELSE
+                         DO  I=1,NEL  
+                           EVAR(I) = FOURTH*(BUFLY%LBUF(1,1,1)%PLA(I) + BUFLY%LBUF(2,1,1)%PLA(I) + 
+     .                                        BUFLY%LBUF(1,2,1)%PLA(I) + BUFLY%LBUF(2,2,1)%PLA(I))
+                         ENDDO
+                      ENDIF ! igtyp
+                    ELSE ! ITY == 7
+                      IF(IGTYP == 51 .OR. IGTYP == 52) THEN
+                        NPTT = BUFLY%NPTT
+                        DO IT = 1,NPTT
+                          DO IR =1,NPG
+                            DO  I=1,NEL  
+                              EVAR(I) =  EVAR(I) + THIRD*BUFLY%LBUF(IR,1,IT)%PLA(I)/NPTT
+                            ENDDO
+                           ENDDO
+                         ENDDO   
+                       ELSE
+                         DO I=1,NEL  
+                           EVAR(I) = THIRD*(BUFLY%LBUF(1,1,1)%PLA(I) + BUFLY%LBUF(1,1,1)%PLA(I) +
+     .                                       BUFLY%LBUF(1,1,1)%PLA(I)) 
+                         ENDDO
+                       ENDIF ! igtyp 
+                     ENDIF  ! ity
                   ELSE
                     NPTT = BUFLY%NPTT  ! needed for PID51 (new shell prop)
-                    DO  I=LFT,LLT
-                      DO IT=1,NPTT
+                    DO IT=1,NPTT
+                      DO  I=1,NEL 
                         EVAR(I) = EVAR(I) + ABS(BUFLY%LBUF(1,1,IT)%PLA(I))/NPTT
-                      ENDDO
+                      ENDDO			
                     ENDDO
-                  ENDIF
-                 ENDIF
-                ELSEIF (NPG > 1) THEN   ! NLAY = 1
-                  BUFLY => ELBUF_TAB(NG)%BUFLY(1)
-                 IF (BUFLY%L_PLA > 0) THEN
-                  NPTT = BUFLY%NPTT  ! needed for PID51 (new shell prop)
-                  IPT = IABS(NPTT)/2 + 1
-cc                  IPT = IABS(NPT)/2 + 1
-                  II = (IPT-1)*NEL  
-                  DO  I=LFT,LLT
-                    EVAR(I) = ABS(BUFLY%PLAPT(II+I))
-                  ENDDO
-                 ENDIF
-                ELSE   !  NLAY=1, NPG=1
-                  BUFLY => ELBUF_TAB(NG)%BUFLY(1)
-                 IF (BUFLY%L_PLA > 0) THEN
-                  NPTT = BUFLY%NPTT  ! needed for PID51 (new shell prop)
-cc                  IPT = IABS(NPT)/2 + 1
-                  IPT = IABS(NPTT)/2 + 1
-                  DO  I=LFT,LLT
-                    EVAR(I) = ABS(BUFLY%LBUF(1,1,IPT)%PLA(I)) 
-                  ENDDO
-                 ENDIF
-                ENDIF
-              ENDIF  
+                  ENDIF ! npg
+                 ENDIF ! BUFLY%L_PLA 
+              ENDIF  ! GBUF
                           
 c---
             ELSEIF (IFUNC == 2) THEN
@@ -3953,46 +3963,56 @@ C
 ! it's the plastic work  /ANIM/ELEM/WPLA ( ifunc=4*MX_PLY_ANIM +13245)           
               IF (GBUF%G_PLA > 0) THEN
                 ! for law25, plastic work < 0 if the layer has reached failure-p !
-                IF (NLAY > 1) THEN
-                  IPT = IABS(NLAY)/2 + 1
-                  BUFLY => ELBUF_TAB(NG)%BUFLY(IPT)
-                  IF (BUFLY%L_PLA > 0)THEN
+                 ILAY = 1
+                IF (NLAY > 1) ILAY = IABS(NLAY)/2 + 1
+                 BUFLY => ELBUF_TAB(NG)%BUFLY(ILAY)
+                 IF (BUFLY%L_PLA > 0) THEN
                   IF (NPG > 1) THEN
-                    DO  I=LFT,LLT  
-                      EVAR(I) = ABS(BUFLY%PLAPT(I))
-                    ENDDO
+                    IF(ITY == 3) THEN
+                      IF(IGTYP == 51 .OR. IGTYP == 52) THEN
+                         NPTT = BUFLY%NPTT
+                         DO IS = 1,NPTS
+                           DO IR = 1,NPTR
+                             DO IPT = 1, NPTT
+                               DO  I=1,NEL  
+                                 EVAR(I) = EVAR(I) + FOURTH*BUFLY%LBUF(IR,IS,IT)%PLA(I)/NPTT
+                               ENDDO
+                             ENDDO
+                           ENDDO
+                         ENDDO     
+                      ELSE
+                         DO  I=1,NEL  
+                           EVAR(I) = FOURTH*(BUFLY%LBUF(1,1,1)%PLA(I) + BUFLY%LBUF(2,1,1)%PLA(I) + 
+     .                                        BUFLY%LBUF(1,2,1)%PLA(I) + BUFLY%LBUF(2,2,1)%PLA(I))
+                         ENDDO
+                      ENDIF ! igtyp
+                    ELSE ! ITY == 7
+                      IF(IGTYP == 51 .OR. IGTYP == 52) THEN
+                        NPTT = BUFLY%NPTT
+                        DO IT = 1,NPTT
+                          DO IR =1,NPG
+                            DO  I=1,NEL  
+                              EVAR(I) = EVAR(I)  + THIRD*BUFLY%LBUF(IR,1,IT)%PLA(I)/NPTT
+                            ENDDO
+                           ENDDO
+                         ENDDO   
+                       ELSE
+                         DO I=1,NEL 
+                           EVAR(I) = THIRD*(BUFLY%LBUF(1,1,1)%PLA(I) + BUFLY%LBUF(1,1,1)%PLA(I) +
+     .                                     BUFLY%LBUF(1,1,1)%PLA(I)) 
+                         ENDDO
+                       ENDIF ! igtyp 
+                     ENDIF  ! ity
                   ELSE
                     NPTT = BUFLY%NPTT  ! needed for PID51 (new shell prop)
-                    DO  I=LFT,LLT
-                      DO IT=1,NPTT
+                    DO IT=1,NPTT
+                      DO  I=1,NEL 
                         EVAR(I) = EVAR(I) + ABS(BUFLY%LBUF(1,1,IT)%PLA(I))/NPTT
-                      ENDDO
+                      ENDDO			
                     ENDDO
-                  ENDIF
-                 ENDIF
-                ELSEIF (NPG > 1) THEN   ! NLAY = 1
-                  BUFLY => ELBUF_TAB(NG)%BUFLY(1)
-                 IF (BUFLY%L_PLA > 0) THEN
-                  NPTT = BUFLY%NPTT  ! needed for PID51 (new shell prop)
-                  IPT = IABS(NPTT)/2 + 1
-cc                  IPT = IABS(NPT)/2 + 1
-                  II = (IPT-1)*NEL  
-                  DO  I=LFT,LLT
-                    EVAR(I) = ABS(BUFLY%PLAPT(II+I))
-                  ENDDO
-                 ENDIF
-                ELSE   !  NLAY=1, NPG=1
-                  BUFLY => ELBUF_TAB(NG)%BUFLY(1)
-                 IF (BUFLY%L_PLA > 0) THEN
-                  NPTT = BUFLY%NPTT  ! needed for PID51 (new shell prop)
-cc                  IPT = IABS(NPT)/2 + 1
-                  IPT = IABS(NPTT)/2 + 1
-                  DO  I=LFT,LLT
-                    EVAR(I) = ABS(BUFLY%LBUF(1,1,IPT)%PLA(I)) 
-                  ENDDO
-                 ENDIF
-                ENDIF
-              ENDIF  
+                  ENDIF ! npg
+                 ENDIF ! BUFLY%L_PLA 
+              ENDIF  ! gbuf
 c------------------------------------
             ELSEIF (IFUNC == 13246 + 4*MX_PLY_ANIM .AND. (MLW == 15 .OR. MLW == 25)) THEN  ! WPLA/UPPER
 c------------------------------------

--- a/engine/source/output/anim/generate/dfuncc_ply.F
+++ b/engine/source/output/anim/generate/dfuncc_ply.F
@@ -236,18 +236,26 @@ c---------
             ENDDO
 c---------
           ELSEIF(IFUNC == 7)THEN   ! Von Mises
-c---------
+c---------available only for Batoz shell and TYPE17 PID
             DO I=LFT,LLT
                N = I + NFT 
                II = (I-1)*5
-              ILAYER = PLYELEMS(N)
-               BUFLY => ELBUF_TAB(NG)%BUFLY(ILAYER)
+               ILAYER = PLYELEMS(N)
+                S1  = ZERO
+                S2  = ZERO
+                S12 = ZERO
                IF(ILAYER > 0) THEN
-                 S1 = BUFLY%SIGPT(II + 1)
-                 S2 = BUFLY%SIGPT(II + 2)
-                 S12= BUFLY%SIGPT(II + 3)
-                 VONM2= S1*S1 + S2*S2 - S1*S2 + THREE*S12*S12
-                 EVAR(I) = SQRT(VONM2)
+                 BUFLY => ELBUF_TAB(NG)%BUFLY(ILAYER)
+                 DO IR=1,NPTR                                                       
+                   DO IS=1,NPTS 
+                       LBUF => BUFLY%LBUF(IR,IS,1)
+                       S1 = S1  + LBUF%SIG(I        )/NPG
+                       S2 = S2  + LBUF%SIG(NEL   + I)/NPG
+                       S12= S12 + LBUF%SIG(2*NEL + I)/NPG
+                    ENDDO 
+                 ENDDO    
+                   VONM2= S1*S1 + S2*S2 - S1*S2 + THREE*S12*S12
+                   EVAR(I) =  SQRT(VONM2) 
                ENDIF  
             ENDDO
 c---------

--- a/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
@@ -109,7 +109,7 @@ C-----------------------------------------------
      .        N,K,K1,K2,JTURB,
      .        OFFSET,IHBE,NPG, MPT,IPT,IADR,IPMAT,
      .        ISUBSTACK,ITHK,ID_PLY,IOK,N1,N2,N3,N4,
-     .        IMAT,IU(4),NFRAC,IPOS,ITRIMAT,NS,IAD2,IDRAPE,NLAY_FAIL
+     .        IMAT,IU(4),NFRAC,IPOS,ITRIMAT,NS,IAD2,IDRAPE,NLAY_FAIL,ILAY0
       INTEGER PID(MVSIZ),MAT(MVSIZ),MATLY(MVSIZ*100),FAILG(100,MVSIZ),
      .        IPLY,
      .        IOK_PART(MVSIZ),JJ(5),NPGT,IUVAR,
@@ -1792,15 +1792,50 @@ c ILAYER=NULL NPT=NULL
                 ENDIF
               ELSEIF ( ILAY == -1 .AND. IPT == -1 .AND. IPLY == -1.and. GBUF%G_PLA > 0) THEN
                 ! for law25, plastic work < 0 if the layer has reached failure-p
-                IF (NLAY > 1) THEN
-                  IPT = IABS(NLAY)/2 + 1
-                  BUFLY => ELBUF_TAB(NG)%BUFLY(IPT)
+                ILAY0 = 1
+                IF (NLAY > 1) ILAY0 = IABS(NLAY)/2 + 1
+                 BUFLY => ELBUF_TAB(NG)%BUFLY(ILAY0)
                  IF (BUFLY%L_PLA > 0) THEN
                   IF (NPG > 1) THEN
-                    DO  I=1,NEL  
-                      VALUE(I) = ABS(BUFLY%PLAPT(I))
-                      IS_WRITTEN_VALUE(I) = 1				
-                    ENDDO
+                    IF(ITY == 3) THEN
+                      IF(IGTYP == 51 .OR. IGTYP == 52) THEN
+                         NPTT = BUFLY%NPTT
+                         DO IS = 1,NPTS
+                           DO IR = 1,NPTR
+                             DO IPT = 1, NPTT
+                               DO  I=1,NEL  
+                                 VALUE(I) = VALUE(I) + FOURTH*BUFLY%LBUF(IR,IS,IT)%PLA(I)/NPTT
+                                 IS_WRITTEN_VALUE(I) = 1        
+                               ENDDO
+                             ENDDO
+                           ENDDO
+                         ENDDO     
+                      ELSE
+                         DO  I=1,NEL  
+                           VALUE(I) = FOURTH*(BUFLY%LBUF(1,1,1)%PLA(I) + BUFLY%LBUF(2,1,1)%PLA(I) + 
+     .                                        BUFLY%LBUF(1,2,1)%PLA(I) + BUFLY%LBUF(2,2,1)%PLA(I))
+                           IS_WRITTEN_VALUE(I) = 1         
+                         ENDDO
+                      ENDIF ! igtyp
+                    ELSE ! ITY == 7
+                      IF(IGTYP == 51 .OR. IGTYP == 52) THEN
+                        NPTT = BUFLY%NPTT
+                        DO IT = 1,NPTT
+                          DO IR =1,NPG
+                            DO  I=1,NEL  
+                              VALUE(I) =  VALUE(I) + THIRD*BUFLY%LBUF(IR,1,IT)%PLA(I)/NPTT
+                              IS_WRITTEN_VALUE(I) = 1                   
+                            ENDDO
+                           ENDDO
+                         ENDDO   
+                       ELSE
+                         DO I=1,NEL  
+                           VALUE(I) = THIRD*(BUFLY%LBUF(1,1,1)%PLA(I) + BUFLY%LBUF(1,1,1)%PLA(I) +
+     .                                      BUFLY%LBUF(1,1,1)%PLA(I)) 
+                           IS_WRITTEN_VALUE(I) = 1 
+                         ENDDO
+                       ENDIF ! igtyp 
+                     ENDIF  ! ity
                   ELSE
                     NPTT = BUFLY%NPTT  ! needed for PID51 (new shell prop)
                     DO IT=1,NPTT
@@ -1809,32 +1844,8 @@ c ILAYER=NULL NPT=NULL
                         IS_WRITTEN_VALUE(I) = 1	
                       ENDDO			
                     ENDDO
-                  ENDIF
-                 ENDIF
-                ELSEIF (NPG > 1) THEN   ! NLAY = 1
-                  BUFLY => ELBUF_TAB(NG)%BUFLY(1)
-                 IF (BUFLY%L_PLA > 0) THEN
-                  NPTT = BUFLY%NPTT  ! needed for PID51 (new shell prop)
-                  IPT = IABS(NPTT)/2 + 1
-                  II = (IPT-1)*NEL
-                  DO  I=1,NEL
-                   VALUE(I) = ABS(BUFLY%PLAPT(II+I))
-                   IS_WRITTEN_VALUE(I) = 1				
-                  ENDDO
-                 ENDIF
-                ELSE   !  NLAY=1, NPG=1
-                  BUFLY => ELBUF_TAB(NG)%BUFLY(1)
-                 IF (BUFLY%L_PLA > 0) THEN
-                  NPTT = BUFLY%NPTT  ! needed for PID51 (new shell prop)
-cc                  IPT = IABS(NPT)/2 + 1
-                  IPT = IABS(NPTT)/2 + 1
-                  DO  I=1,NEL
-                    VALUE(I) = ABS(BUFLY%LBUF(1,1,IPT)%PLA(I)) 
-                    IS_WRITTEN_VALUE(I) = 1				
-                  ENDDO
-                 ENDIF
-                ENDIF
-
+                  ENDIF ! npg
+                 ENDIF ! BUFLY%L_PLA 
 c PLY=IPLY NPT=IPT
               ELSEIF ( IPLY > 0 .AND. (IPT <= MPT .AND. IPT > 0 ) .AND. GBUF%G_PLA > 0) THEN
 c
@@ -2045,15 +2056,50 @@ C--------------------------------------------------
 c ILAYER=NULL NPT=NULL
               IF ( ILAY == -1 .AND. IPT == -1 .AND. IPLY == -1.and. GBUF%G_PLA > 0) THEN
                 ! for law25, plastic work < 0 if the layer has reached failure-p
-                IF (NLAY > 1) THEN
-                  IPT = IABS(NLAY)/2 + 1
-                  BUFLY => ELBUF_TAB(NG)%BUFLY(IPT)
+                ILAY0 = 1
+                IF (NLAY > 1) ILAY0 = IABS(NLAY)/2 + 1
+                 BUFLY => ELBUF_TAB(NG)%BUFLY(ILAY0)
                  IF (BUFLY%L_PLA > 0) THEN
                   IF (NPG > 1) THEN
-                    DO  I=1,NEL  
-                      VALUE(I) = ABS(BUFLY%PLAPT(I))
-                      IS_WRITTEN_VALUE(I) = 1				
-                    ENDDO
+                    IF(ITY == 3) THEN
+                      IF(IGTYP == 51 .OR. IGTYP == 52) THEN
+                         NPTT = BUFLY%NPTT
+                         DO IS = 1,NPTS
+                           DO IR = 1,NPTR
+                             DO IPT = 1, NPTT
+                               DO  I=1,NEL  
+                                 VALUE(I) = VALUE(I) + FOURTH*BUFLY%LBUF(IR,IS,IT)%PLA(I)/NPTT
+                                 IS_WRITTEN_VALUE(I) = 1        
+                               ENDDO
+                             ENDDO
+                           ENDDO
+                         ENDDO     
+                      ELSE
+                         DO  I=1,NEL  
+                           VALUE(I) = FOURTH*(BUFLY%LBUF(1,1,1)%PLA(I) + BUFLY%LBUF(2,1,1)%PLA(I) + 
+     .                                        BUFLY%LBUF(1,2,1)%PLA(I) + BUFLY%LBUF(2,2,1)%PLA(I))
+                           IS_WRITTEN_VALUE(I) = 1         
+                         ENDDO
+                      ENDIF ! igtyp
+                    ELSE ! ITY == 7
+                      IF(IGTYP == 51 .OR. IGTYP == 52) THEN
+                        NPTT = BUFLY%NPTT
+                        DO IT = 1,NPTT
+                          DO IR =1,NPG
+                            DO  I=1,NEL  
+                              VALUE(I) =  VALUE(I) + THIRD*BUFLY%LBUF(IR,1,IT)%PLA(I)/NPTT
+                              IS_WRITTEN_VALUE(I) = 1                   
+                            ENDDO
+                           ENDDO
+                         ENDDO   
+                       ELSE
+                         DO I=1,NEL  
+                           VALUE(I) = THIRD*(BUFLY%LBUF(1,1,1)%PLA(I) + BUFLY%LBUF(1,1,1)%PLA(I) +
+     .                                        BUFLY%LBUF(1,1,1)%PLA(I)) 
+                           IS_WRITTEN_VALUE(I) = 1 
+                         ENDDO
+                       ENDIF ! igtyp 
+                     ENDIF  ! ity
                   ELSE
                     NPTT = BUFLY%NPTT  ! needed for PID51 (new shell prop)
                     DO IT=1,NPTT
@@ -2062,32 +2108,8 @@ c ILAYER=NULL NPT=NULL
                         IS_WRITTEN_VALUE(I) = 1	
                       ENDDO			
                     ENDDO
-                  ENDIF
-                 ENDIF
-                ELSEIF (NPG > 1) THEN   ! NLAY = 1
-                  BUFLY => ELBUF_TAB(NG)%BUFLY(1)
-                 IF (BUFLY%L_PLA > 0) THEN
-                  NPTT = BUFLY%NPTT  ! needed for PID51 (new shell prop)
-                  IPT = IABS(NPTT)/2 + 1
-                  II = (IPT-1)*NEL
-                  DO  I=1,NEL
-                   VALUE(I) = ABS(BUFLY%PLAPT(II+I))
-                   IS_WRITTEN_VALUE(I) = 1				
-                  ENDDO
-                 ENDIF
-                ELSE   !  NLAY=1, NPG=1
-                  BUFLY => ELBUF_TAB(NG)%BUFLY(1)
-                 IF (BUFLY%L_PLA > 0) THEN
-                  NPTT = BUFLY%NPTT  ! needed for PID51 (new shell prop)
-cc                  IPT = IABS(NPT)/2 + 1
-                  IPT = IABS(NPTT)/2 + 1
-                  DO  I=1,NEL
-                    VALUE(I) = ABS(BUFLY%LBUF(1,1,IPT)%PLA(I)) 
-                    IS_WRITTEN_VALUE(I) = 1				
-                  ENDDO
-                 ENDIF
-                ENDIF
-
+                  ENDIF ! npg
+                 ENDIF ! BUFLY%L_PLA 
 c PLY=IPLY NPT=IPT
               ELSEIF ( IPLY > 0 .AND. (IPT <= MPT .AND. IPT > 0 ) .AND. GBUF%G_PLA > 0) THEN
 c


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

The cpu time with TYPE51 is about 10% higher than model with PID11 used with  fully integrated shell element
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

All computing needed for outp (anim, h3D) did in the element are moved to the output subroutine and not did every cycle.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
