### PR TITLE
memory issue for outp plastic strain for Batoz shell and PID51 or 52

### DIFF
--- a/engine/source/output/anim/generate/dfuncc.F
+++ b/engine/source/output/anim/generate/dfuncc.F
@@ -1035,7 +1035,7 @@ c---
                          NPTT = BUFLY%NPTT
                          DO IS = 1,NPTS
                            DO IR = 1,NPTR
-                             DO IPT = 1, NPTT
+                             DO IT = 1, NPTT
                                DO  I=1,NEL  
                                  EVAR(I) = EVAR(I) + FOURTH*BUFLY%LBUF(IR,IS,IT)%PLA(I)/NPTT
                                ENDDO
@@ -3973,7 +3973,7 @@ C
                          NPTT = BUFLY%NPTT
                          DO IS = 1,NPTS
                            DO IR = 1,NPTR
-                             DO IPT = 1, NPTT
+                             DO IT = 1, NPTT
                                DO  I=1,NEL  
                                  EVAR(I) = EVAR(I) + FOURTH*BUFLY%LBUF(IR,IS,IT)%PLA(I)/NPTT
                                ENDDO

--- a/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
@@ -1802,7 +1802,7 @@ c ILAYER=NULL NPT=NULL
                          NPTT = BUFLY%NPTT
                          DO IS = 1,NPTS
                            DO IR = 1,NPTR
-                             DO IPT = 1, NPTT
+                             DO IT = 1, NPTT
                                DO  I=1,NEL  
                                  VALUE(I) = VALUE(I) + FOURTH*BUFLY%LBUF(IR,IS,IT)%PLA(I)/NPTT
                                  IS_WRITTEN_VALUE(I) = 1        
@@ -2066,7 +2066,7 @@ c ILAYER=NULL NPT=NULL
                          NPTT = BUFLY%NPTT
                          DO IS = 1,NPTS
                            DO IR = 1,NPTR
-                             DO IPT = 1, NPTT
+                             DO IT = 1, NPTT
                                DO  I=1,NEL  
                                  VALUE(I) = VALUE(I) + FOURTH*BUFLY%LBUF(IR,IS,IT)%PLA(I)/NPTT
                                  IS_WRITTEN_VALUE(I) = 1        


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Memory error for batoz shell element and PId51 or 52 if plastic output is requested in the animation

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Correct the  Parameters of the Loop.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
