### PR TITLE
Build script issue:

### DIFF
--- a/engine/build_script.sh
+++ b/engine/build_script.sh
@@ -376,6 +376,15 @@ then
 fi
 
 make -j ${threads} ${verbose}
+return_value=$?
+if [ $return_value -ne 0 ]
+then
+   echo " " 
+   echo " " 
+   echo "-- Errors in Build found"
+   cd ..
+   exit 1
+fi
 
 cd ..
 echo " "

--- a/starter/build_script.sh
+++ b/starter/build_script.sh
@@ -284,7 +284,15 @@ then
 fi
 
 make -j ${threads} ${verbose}
-
+return_value=$?
+if [ $return_value -ne 0 ]
+then
+   echo " " 
+   echo " " 
+   echo "-- Errors in Build found"
+   cd ..
+   exit 1
+fi
 
 cd ..
 echo " "


### PR DESCRIPTION
build_script should exit with error code when build is failing like cmake

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
