### PR TITLE
ignore MUMPS and dependencies in engine/extlib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,9 @@ qa-tests/scripts/Screen_Output
 qa-tests/scripts/*.tmp
 qa-tests/scripts/my_results
 qa-tests/ctest_*
+engine/extlib/MUMPS*
+engine/extlib/lapack*
+engine/extlib/scalap*
+engine/extlib/v2*
+engine/extlib/v3*
 .vscode/settings.json


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Update the .gitignore to remove MUMPS and its dependencies when installed by `engine/extlib/git_and_build_mumps.sh`