### PR TITLE
subinterface: out-of-bound memory access

### DIFF
--- a/common_source/interf/intbuf_ini.F
+++ b/common_source/interf/intbuf_ini.F
@@ -702,9 +702,11 @@ C=======================================================================
         ENDIF
 
         SIZ = INTBUF_TAB(NI)%S_LISUBM
-        ALLOCATE(INTBUF_TAB(NI)%LISUBM(SIZ))
+        ALLOCATE(INTBUF_TAB(NI)%LISUBM(SIZ+1))
         IF(SIZ>0)THEN
           CALL READ_I_C(INTBUF_TAB(NI)%LISUBM,SIZ)
+          !sentinel value to avoid invalid read in i*for3.F
+          INTBUF_TAB(NI)%LISUBM(SIZ+1) = HUGE(SIZ)
         ENDIF
 
         SIZ = INTBUF_TAB(NI)%S_INFLG_SUBS


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Invalid memory read of LISUBM(K) in i*for3.F routines, because the value of K could be length(LISUBM) + 1

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

add sentinel value at `LISUBM(size+1)`

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
