### PR TITLE
using the same membrane rigidity us Ipos=0

### DIFF
--- a/starter/source/materials/globmat.F
+++ b/starter/source/materials/globmat.F
@@ -127,8 +127,7 @@ C
           RHO0 = RHOG0/MAX(EM20,THICKT)
           RHOCP = RHOCPG/MAX(EM20,THICKT)
           E = E/MAX(EM20,THICKT)
-          A11 = A11/MAX(EM20,THICKT) 
-          IF(IPOS > 0)A11 = TWO*A11
+          A11 = A11/MAX(EM20,THICKT)
           A12 = A12/MAX(EM20,THICKT)
           IZ = ONE_OVER_12*THICKT**3
           A11R =A11R/MAX(EM20, IZ)
@@ -215,7 +214,6 @@ C
               RHOCP = RHOCPG/MAX(EM20,THICKT)
               E = E/MAX(EM20,THICKT)
               A11 = A11/MAX(EM20,THICKT) 
-              IF(IPOS > 0)A11 = TWO*A11
               A12 = A12/MAX(EM20,THICKT)
               IZ = ONE_OVER_12*THICKT**3
               A11R =A11R/MAX(EM20, IZ)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
For /PROP/TYPE51, 17, 11 and TYPE52 when Ipos > 0 we don't have the same timestep. 
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

In order to get the same element timestep we should use the same membrane rigidiy

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
