### PR TITLE
integer overflow in grid2mat weight computation

### DIFF
--- a/starter/source/spmd/domain_decomposition/grid2mat.F
+++ b/starter/source/spmd/domain_decomposition/grid2mat.F
@@ -2625,9 +2625,10 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER NEDGES, CC, N, N1, N2, NI, I, J, IW, ADDX,
+      INTEGER NEDGES, CC, N, N1, N2, NI, I, J,  ADDX,
      .        NUMSPHA, P, NCOND, NNODE, NEC, IERR1, MODE, NOD1, NOD2,
      .        IWFLG, NFLAG, NEWEDGE
+      INTEGER(kind=8) :: IW
       INTEGER IWD(NUMSPH), RESERVEP(NBPARTINLET),
      .        WORK(70000), OPTIONS(40), CEPSL(NUMSPH)
       INTEGER, DIMENSION(:),ALLOCATABLE :: IEND, XADJ, ADJNCY,
@@ -2855,7 +2856,7 @@ C
       DO I = 1, NSPMD
         IW = 0
         DO J = 1, NUMSPH
-          IF (CEPSP(J)+1==I) THEN
+          IF (CEPSP(J)+1==I .AND. IWD(J) > 0) THEN
             IW = IW + IWD(J)
           ENDIF
         ENDDO


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Integer overflow during the sum of weights to be printed in the statistics of domain decomposition

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Using integer(8)

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
