### PR TITLE
INIMAP issue with file reading

### DIFF
--- a/starter/source/output/tools/write_routines.c
+++ b/starter/source/output/tools/write_routines.c
@@ -583,7 +583,7 @@ FILE *UCompressedFOpen (char   *fileName, char *type, int suffix)
 /* ---------------------------------------------- */
 /* restart writing */
 /* ---------------------------------------------- */
-FILE *outfile[3],*curfile;
+FILE *outfile[100],*curfile;
 int cur_nf;
 
 /*in parallel each restart on one thread writes on one specific file*/


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
At the engine, we had 100 file descriptors in sortie_c.c, but at the starter, there was only 3. INIMAP was using id 21

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
The number file descriptors is set to 100 in the starter, to be consistent with the engine

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
