### PR TITLE
/INTER/TYPE25 + iedge spmd bug fix

### DIFF
--- a/engine/source/mpi/interfaces/spmd_tri25vox.F
+++ b/engine/source/mpi/interfaces/spmd_tri25vox.F
@@ -191,8 +191,15 @@ C
 C
 C   boite minmax pour le tri provenant de i7buce BMINMA
 C
+      NEDGE_REMOTE = 0
+      DO P = 1, NSPMD
+        NSNFI(NIN)%P(P) = 0
+        IF(IEDGE /= 0) NSNFIE(NIN)%P(P) = 0
+      ENDDO
+
       IF(IRCVFROM(NIN,LOC_PROC)==0.AND.
      .   ISENDTO(NIN,LOC_PROC)==0) RETURN
+
       IF (IMONM > 0) CALL STARTIME(25,1)
       BMINMA(1,LOC_PROC) = BMINMAL(1)
       BMINMA(2,LOC_PROC) = BMINMAL(2)


### PR DESCRIPTION


#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Missing initialization of NEDGE_REMOTE when the domain do not participate to the spmd communication of type25