### PR TITLE
/LOAD/PBLAST:fixed typo error in output message

### DIFF
--- a/common_source/modules/loads/pblast_mod.F
+++ b/common_source/modules/loads/pblast_mod.F
@@ -54,6 +54,7 @@ Chd|====================================================================
         my_real, ALLOCATABLE,DIMENSION(:)    :: P_inci,P_refl,ta,t0,decay_inci,decay_refl ! Friedlander parameters
         my_real, DIMENSION(:)  , ALLOCATABLE :: FX,FY,FZ,NPt                              !working arrays (forces)
         INTEGER, DIMENSION(:,:), ALLOCATABLE :: N                                         !working array (normal vectors)
+        INTEGER, ALLOCATABLE,DIMENSION(:)    :: TAGMSG
       END TYPE PBLAST_STRUCT_
 
       TYPE FRIEDLANDER_PARAMS_
@@ -199,8 +200,9 @@ C-----------------------------------------------
         ALLOCATE ( PBLAST_TAB(I)%FZ(SIZ),STAT=IERR1); IF (IERR1/=0) GOTO 1000
         ALLOCATE ( PBLAST_TAB(I)%N(4,SIZ),STAT=IERR1); IF (IERR1/=0) GOTO 1000
         ALLOCATE ( PBLAST_TAB(I)%NPt(SIZ),STAT=IERR1); IF (IERR1/=0) GOTO 1000
-        ALLOCATE(RTMP(7*SIZ))
-        CALL READ_DB(RTMP,7*SIZ)
+        ALLOCATE ( PBLAST_TAB(I)%TAGMSG(SIZ),STAT=IERR1); IF (IERR1/=0) GOTO 1000
+        ALLOCATE(RTMP(8*SIZ))
+        CALL READ_DB(RTMP,8*SIZ)
         IAD = 0
         DO KK=1,SIZ
           PBLAST_TAB(I)%cos_theta(KK) = RTMP(IAD+1)
@@ -210,7 +212,8 @@ C-----------------------------------------------
           PBLAST_TAB(I)%t0(KK) = RTMP(IAD+5)
           PBLAST_TAB(I)%decay_inci(KK) = RTMP(IAD+6)
           PBLAST_TAB(I)%decay_refl(KK) = RTMP(IAD+7)
-          IAD = IAD+7
+          PBLAST_TAB(I)%TAGMSG(KK) = NINT(RTMP(IAD+8))
+          IAD = IAD+8
         ENDDO
         DEALLOCATE(RTMP)
       ENDDO
@@ -328,7 +331,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   P r e - C o n d i t i o n
 C-----------------------------------------------
-      IF(NLOADP_B<=0)RETURN
+      IF(NLOADP_B <= 0)RETURN
 C-----------------------------------------------
 C   S o u r c e   C o d e
 C-----------------------------------------------
@@ -366,7 +369,7 @@ C-----------------------------------------------
       OFF = NUMELC+NUMELTG+NUMELS+NUMELQ+NUMELT+NUMELP+NUMELR+NUMELX+NCONLD+NUMCONV+NUMRADIA+NFXFLUX
       DO I=1,NLOADP_B
         SIZ = NSEGL(I)
-        ALLOCATE(RTMP(7*NSEGL(I)))
+        ALLOCATE(RTMP(8*NSEGL(I)))
         IAD=0
         DO JJ=1,PBLAST_TAB(I)%SIZ
           IF(CEP(JJ+OFF)==PROC)THEN !write buffer if segment is on local domain
@@ -377,10 +380,11 @@ C-----------------------------------------------
             RTMP(IAD+5) = PBLAST_TAB(I)%t0(JJ)
             RTMP(IAD+6) = PBLAST_TAB(I)%decay_inci(JJ)
             RTMP(IAD+7) = PBLAST_TAB(I)%decay_refl(JJ)
-            IAD = IAD + 7
+            RTMP(IAD+8) = PBLAST_TAB(I)%TAGMSG(JJ)
+            IAD = IAD + 8
           ENDIF
         ENDDO
-        CALL WRITE_DB(RTMP,7*NSEGL(I))
+        CALL WRITE_DB(RTMP,8*NSEGL(I))
         DEALLOCATE(RTMP)
         OFF = OFF + PBLAST_TAB(I)%SIZ
       ENDDO
@@ -455,7 +459,7 @@ C-----------------------------------------------
       DO I=1,NLOADP_B
         SIZ = PBLAST_TAB(I)%SIZ
         IAD=0
-        ALLOCATE(RTMP(7*SIZ))
+        ALLOCATE(RTMP(8*SIZ))
         DO JJ=1,PBLAST_TAB(I)%SIZ
             RTMP(IAD+1) = PBLAST_TAB(I)%cos_theta(JJ)
             RTMP(IAD+2) = PBLAST_TAB(I)%P_inci(JJ)
@@ -464,9 +468,10 @@ C-----------------------------------------------
             RTMP(IAD+5) = PBLAST_TAB(I)%t0(JJ)
             RTMP(IAD+6) = PBLAST_TAB(I)%decay_inci(JJ)
             RTMP(IAD+7) = PBLAST_TAB(I)%decay_refl(JJ)
-            IAD = IAD + 7
+            RTMP(IAD+8) = PBLAST_TAB(I)%TAGMSG(JJ)
+            IAD = IAD + 8
         ENDDO
-        CALL WRITE_DB(RTMP,7*SIZ)
+        CALL WRITE_DB(RTMP,8*SIZ)
         DEALLOCATE(RTMP)
       ENDDO
 C-----------------------------------------------

--- a/engine/source/loads/pblast/pblast_1.F
+++ b/engine/source/loads/pblast/pblast_1.F
@@ -265,22 +265,32 @@ C-----------------------------------------------
           Z  = DNORM / W13    !in abac unit ID  g,cm,mus
           !display warning message if out of bounds
           ! precondition for SUBROUTINE PBLAST_PARAMETERS__FREE_AIR
-          IF(Z <= 0.5)THEN
-            if (N4==0)then
-              write(*,FMT='(A,3I11)')
-     .         "Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   mus/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3)
+          IF(Z <= 0.5 .AND. PBLAST_TAB(IL)%TAGMSG(I) == 0 )THEN
+            if (N4 == 0)then
+              write(IOUT,FMT='(A,3I11)')
+     .         "Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   cm/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3)
+              write(ISTDO,FMT='(A,3I11)')
+     .         "Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   cm/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3)
             else
-              write(*,FMT='(A,4I11)')
-     .         "Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   mus/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
+              write(IOUT,FMT='(A,4I11)')
+     .         "Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   cm/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
+              write(ISTDO,FMT='(A,4I11)')
+     .         "Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   cm/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
             endif
-          ELSEIF(Z > 400.)THEN
-              if (N4==0)then
-              write(*,FMT='(A,3I11)')
-     .         "Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 mus/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3)
+            PBLAST_TAB(IL)%TAGMSG(I) = .TRUE.
+          ELSEIF(Z > 400. AND. PBLAST_TAB(IL)%TAGMSG(I) == 0)THEN
+              if (N4 == 0)then
+              write(IOUT,FMT='(A,3I11)')
+     .         "Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 cm/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3)
+              write(ISTDO,FMT='(A,3I11)')
+     .         "Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 cm/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3)
               else
-              write(*,FMT='(A,4I11)')
-     .         "Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 mus/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
+              write(IOUT,FMT='(A,4I11)')
+     .         "Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 cm/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
+              write(ISTDO,FMT='(A,4I11)')
+     .         "Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 cm/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
               endif
+              PBLAST_TAB(IL)%TAGMSG(I) = 1
           ENDIF
 
           !------------------------------------------------------------------!
@@ -405,7 +415,10 @@ C----- /TH/SURF -------
 #include "lockoff.inc"
         CALL MY_BARRIER()
 !$OMP SINGLE
-        write(*,FMT='(A,I10,A,E16.8,A,E16.8)') "Updated parameters for /LOAD/PBLAST id=",
+        write(IOUT,FMT='(A,I10,A,E16.8,A,E16.8)') "Updated parameters for /LOAD/PBLAST id=",
+     .                                         ID,' previous first arrival time :',ZETA,
+     .                                         ' is now updated to :',FAC(07,NL)
+        write(ISTDO,FMT='(A,I10,A,E16.8,A,E16.8)') "Updated parameters for /LOAD/PBLAST id=",
      .                                         ID,' previous first arrival time :',ZETA,
      .                                         ' is now updated to :',FAC(07,NL)
 !$OMP END SINGLE

--- a/engine/source/loads/pblast/pblast_2.F
+++ b/engine/source/loads/pblast/pblast_2.F
@@ -288,23 +288,29 @@ C-----------------------------------------------
 
            !checking bounds
             IF(Z > 0.5 .AND. Z < 400.) then
-            elseif(Z <= 0.5)then
+              !inside interpolation tables
+            elseif(Z <= 0.5 .AND. PBLAST_TAB(IL)%TAGMSG(I) == 0)then
               if (N4==0)then
                 write(*,FMT='(A,3I11)')
-     .           "Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   mus/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3)
+     .           "Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   cm/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3)
               else
                 write(*,FMT='(A,4I11)')
-     .           "Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   mus/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
+     .           "Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   cm/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
               endif
-
-            elseif(Z > 400.)then
-              if (N4==0)then
-                write(*,FMT='(A,3I11)')
-     .           "Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 mus/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3)
+              PBLAST_TAB(IL)%TAGMSG(I) = .TRUE.
+            elseif(Z > 400. .AND. PBLAST_TAB(IL)%TAGMSG(I) == 0)then
+              if (N4 == 0)then
+                write(IOUT,FMT='(A,3I11)')
+     .           "Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 cm/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3)
+                write(ISTDO,FMT='(A,3I11)')
+     .           "Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 cm/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3)
               else
-                write(*,FMT='(A,4I11)')
-     .           "Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 mus/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
+                write(IOUT,FMT='(A,4I11)')
+     .           "Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 cm/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
+                write(ISTDO,FMT='(A,4I11)')
+     .           "Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 cm/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
               endif
+              PBLAST_TAB(IL)%TAGMSG(I) = 1
             ENDIF
 
             !------------------------------------------------------------------!

--- a/engine/source/loads/pblast/pblast_3.F
+++ b/engine/source/loads/pblast/pblast_3.F
@@ -359,13 +359,14 @@ C-----------------------------------------------
             ANGLE_g = min(ONE,max(-ONE,ANGLE_g)) ! bound it to expected range (epsilon)
             ANGLE_g = acos(ANGLE_g)
             ANGLE_g = cst_180/PI_*ANGLE_g !debug purpose
-            IF(ANGLE_g < ZERO)THEN
+            IF(ANGLE_g < ZERO .AND. PBLAST_TAB(IL)%TAGMSG(I) == 0 )THEN
               WRITE(IOUT,*) ' ** WARNING : /LOAD/PBLAST id=',ID,' NEGATIVE ANGLE,',ANGLE_g,
      .         ' FACE:',ITAB((/N1,N2,N3,N4/)),' SEEMS TO BE BELOW THE GROUND'
               WRITE(ISTDO,*)' ** WARNING : /LOAD/PBLAST id=',ID,' NEGATIVE ANGLE,',ANGLE_g,
      .          ' FACE:',ITAB((/N1,N2,N3,N4/)),' SEEMS TO BE BELOW THE GROUND'
               ANGLE_g = ZERO
-            ELSEIF(ANGLE_g > 85.00000)THEN
+              PBLAST_TAB(IL)%TAGMSG(I) = 1
+            ELSEIF(ANGLE_g > 85.00000 .AND. PBLAST_TAB(IL)%TAGMSG(I) == 0)THEN
               WRITE(IOUT,FMT='(A,I0,A,E10.4,A,4I11)')
      .        ' ** WARNING : /LOAD/PBLAST id=',ID,' ANGLE IS OVER THE UPPER BOUND,',ANGLE_g,
      .          '. ANGLE SET TO 85.00 FOR FACE:',ITAB((/N1,N2,N3,N4/))
@@ -373,6 +374,7 @@ C-----------------------------------------------
      .        ' ** WARNING : /LOAD/PBLAST id=',ID,' ANGLE IS OVER THE UPPER BOUND,',ANGLE_g,
      .          '. ANGLE SET TO 85.00 FOR FACE:',ITAB((/N1,N2,N3,N4/))
               ANGLE_g = 85.00000
+              PBLAST_TAB(IL)%TAGMSG(I) = 1
             ENDIF
 
 
@@ -494,9 +496,12 @@ C----- /TH/SURF -------
 #include "lockoff.inc"
         CALL MY_BARRIER()
 !$OMP SINGLE
-        write(*,FMT='(A,I10,A,E16.8,A,E16.8)') "Updated parameters for /LOAD/PBLAST id=",
-     .                                         ID,' previous first arrival time :',ZETA,
-     .                                         ' is now updated to :',FAC(07,NL)
+        write(IOUT ,FMT='(A,I10,A,E16.8,A,E16.8)') "Updated parameters for /LOAD/PBLAST id=",
+     .                                             ID,' previous first arrival time :',ZETA,
+     .                                             ' is now updated to :',FAC(07,NL)
+        write(ISTDO,FMT='(A,I10,A,E16.8,A,E16.8)') "Updated parameters for /LOAD/PBLAST id=",
+     .                                             ID,' previous first arrival time :',ZETA,
+     .                                             ' is now updated to :',FAC(07,NL)
 !$OMP END SINGLE
       ENDIF
 

--- a/starter/source/loads/pblast/hm_read_pblast.F
+++ b/starter/source/loads/pblast/hm_read_pblast.F
@@ -127,7 +127,7 @@ C-----------------------------------------------
       INTEGER IAD,ID,SURF_ID,internal_SURF_ID
       INTEGER IABAC,IADPL,itmp,IS,SUB_ID
       INTEGER ITA_SHIFT
-      INTEGER N1,N2,N3,N4,IERR1,ISIZ_SEG,NDT,ILD_PBLAST,IZ_UPDATE,IMODEL,NODE_ID
+      INTEGER N1,N2,N3,N4,IERR1,NDT,ILD_PBLAST,IZ_UPDATE,IMODEL,NODE_ID
       INTEGER SURF_ID_ground,internal_SURF_ID_GROUND
       INTEGER curve_id1,curve_id2,SEG_UNDERGROUND
       INTEGER, DIMENSION(:), POINTER :: INGR2USR
@@ -686,17 +686,17 @@ C-----------------------------------------------
         !--------------------------------------------------------------
         IF(internal_SURF_ID /= 0 .AND. .NOT.BOOL_SKIP_CALC)THEN
           NUMSEG = IGRSURF(internal_SURF_ID)%NSEG
-          ISIZ_SEG = NUMSEG
           IAD = ILOADP(4,K)
           ILD_PBLAST = ILD_PBLAST + 1
-          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%cos_theta(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
-          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%P_inci(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
-          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%P_refl(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
-          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%ta(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
-          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%t0(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
-          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%decay_inci(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
-          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%decay_refl(ISIZ_SEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
-          PBLAST_TAB(ILD_PBLAST)%SIZ=ISIZ_SEG
+          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%cos_theta(NUMSEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
+          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%P_inci(NUMSEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
+          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%P_refl(NUMSEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
+          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%ta(NUMSEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
+          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%t0(NUMSEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
+          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%decay_inci(NUMSEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
+          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%decay_refl(NUMSEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
+          ALLOCATE (PBLAST_TAB(ILD_PBLAST)%TAGMSG(NUMSEG) ,STAT=IERR1); IF (IERR1 /= 0) GOTO 1000
+          PBLAST_TAB(ILD_PBLAST)%SIZ=NUMSEG
 
           !  Coordinates of detonation point projection = DETPOINT + HC*n     !N_SURF is here -HC*n  where n is normal unitary vector of the plane
           IF(IABAC == 3)THEN
@@ -783,7 +783,7 @@ C-----------------------------------------------
               !--------------------------------------------------------
               !   Free Air
               !--------------------------------------------------------
-              IF(  IABAC == 1 ) THEN
+              IF( IABAC == 1 ) THEN
               !=== SPHERICAL CHARGE IN FREE FIELD ===!
 
                 ! scaled distance
@@ -794,19 +794,21 @@ C-----------------------------------------------
                 ELSEIF(Z <= 0.5)THEN
                   IF (N4 == 0)THEN
                     WRITE(IOUT,FMT='(A,3I11)')
-     .               "Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   mus/g**(1/3)    .Segment nodes : ", ITAB(N1),ITAB(N2),ITAB(N3)
+     .               "Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   cm/g**(1/3)    .Segment nodes : ", ITAB(N1),ITAB(N2),ITAB(N3)
                   ELSE
-                    WRITE(ISTDO,FMT='(A,4I11)')"Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   mus/g**(1/3)    .Segment nodes : ",
+                    WRITE(ISTDO,FMT='(A,4I11)')"Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   cm/g**(1/3)    .Segment nodes : ",
      .               ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
                   ENDIF
+                  PBLAST_TAB(ILD_PBLAST)%TAGMSG(I) = 1
                 ELSEIF(Z > 400.)THEN
                   IF (N4==0)THEN
                     WRITE(IOUT,FMT='(A,3I11)')
-     .               "Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 mus/g**(1/3)    .Segment nodes : ", ITAB(N1),ITAB(N2),ITAB(N3)
+     .               "Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 cm/g**(1/3)    .Segment nodes : ", ITAB(N1),ITAB(N2),ITAB(N3)
                   ELSE
-                    WRITE(ISTDO,FMT='(A,4I11)')"Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 mus/g**(1/3)    .Segment nodes : ",
+                    WRITE(ISTDO,FMT='(A,4I11)')"Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 cm/g**(1/3)    .Segment nodes : ",
      .               ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
                   ENDIF
+                  PBLAST_TAB(ILD_PBLAST)%TAGMSG(I) = 1
                 ENDIF
 
                 !Angle from detonation point
@@ -884,19 +886,31 @@ C-----------------------------------------------
                   ELSEIF(Z <= 0.5)THEN
                     IF (N4 == 0)THEN
                       WRITE(IOUT,FMT='(A,3I11)')
-     .                 "Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   mus/g**(1/3)    .Segment nodes : ", ITAB(N1),ITAB(N2),ITAB(N3)
+     .                 "Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   cm/g**(1/3)    .Segment nodes : ", ITAB(N1),ITAB(N2),ITAB(N3)
+                      WRITE(ISTDO,FMT='(A,3I11)')
+     .                 "Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   cm/g**(1/3)    .Segment nodes : ", ITAB(N1),ITAB(N2),ITAB(N3)
                     ELSE
-                      WRITE(ISTDO,FMT='(A,4I11)')"Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   mus/g**(1/3)    .Segment nodes : ",
-     .                 ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
+                      WRITE(IOUT,FMT='(A,4I11)')
+     .                 "Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   cm/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
+                      WRITE(ISTDO,FMT='(A,4I11)')
+     .                 "Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   cm/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
                     ENDIF
+                    PBLAST_TAB(ILD_PBLAST)%TAGMSG(I) = 1
                   ELSEIF(Z > 400.)THEN
                     IF (N4==0)THEN
                       WRITE(IOUT,FMT='(A,3I11)')
-     .                 "Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 mus/g**(1/3)    .Segment nodes : ", ITAB(N1),ITAB(N2),ITAB(N3)
+     .                 "Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 cm/g**(1/3)    .Segment nodes : ", ITAB(N1),ITAB(N2),ITAB(N3)
+                      WRITE(ISTDO,FMT='(A,3I11)')
+     .                 "Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 cm/g**(1/3)    .Segment nodes : ", ITAB(N1),ITAB(N2),ITAB(N3)
                     ELSE
-                      WRITE(ISTDO,FMT='(A,4I11)')"Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 mus/g**(1/3)    .Segment nodes : ",
+                      WRITE(IOUT,FMT='(A,4I11)')
+     .                 "Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 cm/g**(1/3)    .Segment nodes : ",
+     .                 ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
+                      WRITE(ISTDO,FMT='(A,4I11)')
+     .                 "Warning : /LOAD/PBLAST, R/W**(1/3) > 400.0 cm/g**(1/3)    .Segment nodes : ",
      .                 ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
                     ENDIF
+                    PBLAST_TAB(ILD_PBLAST)%TAGMSG(I) = 1
                   ENDIF
                   !------------------------------------------------------------!
                   CALL PBLAST_PARAMETERS__SURFACE_BURST( Z, W13, TDET,
@@ -977,6 +991,7 @@ C-----------------------------------------------
                     WRITE(ISTDO,*)' ** WARNING : /LOAD/PBLAST id=',ID,' NEGATIVE ANGLE,',ANGLE_g,' FACE:',ITAB((/N1,N2,N3,N4/)),
      .                            ' SEEMS TO BE BELOW THE GROUND'
                     ANGLE_g = ZERO
+                    PBLAST_TAB(ILD_PBLAST)%TAGMSG(I) = 1
                   ELSEIF(ANGLE_g > 85.00000)THEN
                     WRITE(IOUT,FMT='(A,I0,A,E10.4,A,4I11)')
      .              ' ** WARNING : /LOAD/PBLAST id=',ID,' ANGLE IS OVER THE UPPER BOUND,',ANGLE_g,
@@ -985,6 +1000,7 @@ C-----------------------------------------------
      .              ' ** WARNING : /LOAD/PBLAST id=',ID,' ANGLE IS OVER THE UPPER BOUND,',ANGLE_g,
      .                                            '. ANGLE SET TO 85.00 FOR FACE:',ITAB((/N1,N2,N3,N4/))
                     ANGLE_g = 85.00000
+                    PBLAST_TAB(ILD_PBLAST)%TAGMSG(I) = 1
                   ENDIF
 
                  !------------------------------------------------------------!
@@ -1021,6 +1037,7 @@ C-----------------------------------------------
               PBLAST_TAB(ILD_PBLAST)%t0(I) = DT_0
               PBLAST_TAB(ILD_PBLAST)%decay_inci(I) = decay_inci
               PBLAST_TAB(ILD_PBLAST)%decay_refl(I) = decay_refl
+              PBLAST_TAB(ILD_PBLAST)%TAGMSG(I) = 0
 
               b_min = MIN(b_min, decay_inci)
               b_min = MIN(b_min, decay_refl)


### PR DESCRIPTION
#### /LOAD/PBLAST:fixed typo error in output message


#### Description of the changes

1. A typo error in a warning message had been reporting an incorrect unit : µs/g^0.333. This unit is now replaced with the expected one : cm/g^0.333. Related files are in Starter and Engine when scaled distances are initilized (Started) or updated (Engine)
2. Limiter introduced for output messages. Once a warning message was printed for a related segment (shell face or solid face) then it is no longer output in the following Engine cycles. This prevent Engine computation from being slowed down.

This update has no effect on the numerical solution.