### PR TITLE
Fixed and reorganized Apptainer arm def files

### DIFF
--- a/Apptainer/arm/arm_buildEnv.def
+++ b/Apptainer/arm/arm_buildEnv.def
@@ -1,0 +1,29 @@
+Bootstrap: docker
+From: arm64v8/rockylinux:9
+
+%post
+dnf group install -y "Development Tools"
+dnf install -y \
+gcc gcc-gfortran gcc-c++ make cmake perl git-lfs \
+wget git patch diffutils libxcrypt-compat \
+procps environment-modules which nano python3
+
+ln -s /usr/bin/python3 /usr/bin/python
+
+echo "Downlaoding Arm compiler and performance libraries"
+cd /opt
+wget -q -c --read-timeout=15 --show-progress -O arm-compiler-for-linux_22.1_RHEL-8_aarch64.tar "https://developer.arm.com/-/media/Files/downloads/hpc/arm-compiler-for-linux/22-1/arm-compiler-for-linux_22.1_RHEL-8_aarch64.tar?rev=d7be1f977ef848c2873e1f2a1fb8482f&revision=d7be1f97-7ef8-48c2-873e-1f2a1fb8482f"
+tar -xvf arm-compiler-for-linux_22.1_RHEL-8_aarch64.tar
+cd arm-compiler-for-linux_22.1_RHEL-8
+./arm-compiler-for-linux_22.1_RHEL-8.sh -a
+
+cd /opt
+wget -q -c --read-timeout=15 --show-progress -O arm-performance-libraries_22.1_RHEL-8_gcc-11.2.tar "https://developer.arm.com/-/media/Files/downloads/hpc/arm-performance-libraries/22-1/rhel-8/arm-performance-libraries_22.1_RHEL-8_gcc-11.2.tar?rev=2efd010a9c974ebc99b7481a398e55d5&revision=2efd010a-9c97-4ebc-99b7-481a398e55d5"
+tar -xvf arm-performance-libraries_22.1_RHEL-8_gcc-11.2.tar
+cd arm-performance-libraries_22.1_RHEL-8
+./arm-performance-libraries_22.1_RHEL-8.sh -a
+
+echo "Cleaning up intermediate files"
+rm /opt/arm-compiler-for-linux_22.1_RHEL-8_aarch64.tar
+rm /opt/arm-performance-libraries_22.1_RHEL-8_gcc-11.2.tar
+rm -rf /opt/arm-*

--- a/Apptainer/arm/build_arm.sh
+++ b/Apptainer/arm/build_arm.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+function build_OpenRadioss(){
+  apptainer build openradioss_arm.sif openradioss_arm.def
+}
+
+function build_dev_environment(){
+  apptainer build arm_buildEnv.sif arm_buildEnv.def
+}
+
+# Check if file filename.sif exists
+if [ -f "arm_buildEnv.sif" ]; then
+    # Run command 2
+    echo "Build environment exists. Building OpenRadioss image..."
+    build_OpenRadioss
+
+else
+    # Build development environment image first
+    echo "Build environment image not found. Building first..."
+    build_dev_environment
+    
+    if [[ $? -ne 0 ]]; then
+      # Build failed, exit with an error
+      echo "Error creating image. Review console output."
+      exit 1
+    fi
+    build_OpenRadioss
+fi

--- a/Apptainer/arm/openradioss_arm.def
+++ b/Apptainer/arm/openradioss_arm.def
@@ -1,34 +1,20 @@
-Bootstrap: docker
-From: arm64v8/rockylinux:9
+Bootstrap: localimage
+From: arm_buildEnv.sif
 
 %post
-dnf group install -y "Development Tools"
-dnf install -y \
-gcc gcc-gfortran gcc-c++ make cmake perl git-lfs \
-wget git patch diffutils libxcrypt-compat \
-procps environment-modules
-
-cd /opt
-wget -q -O arm-compiler-for-linux_22.1_RHEL-8_aarch64.tar "https://developer.arm.com/-/media/Files/downloads/hpc/arm-compiler-for-linux/22-1/arm-compiler-for-linux_22.1_RHEL-8_aarch64.tar?rev=d7be1f977ef848c2873e1f2a1fb8482f&revision=d7be1f97-7ef8-48c2-873e-1f2a1fb8482f"
-tar xvf arm-compiler-for-linux_22.1_RHEL-8_aarch64.tar
-cd arm-compiler-for-linux_22.1_RHEL-8
-./arm-compiler-for-linux_22.1_RHEL-8.sh -a
-
-cd /opt
-wget -q -O arm-performance-libraries_22.1_RHEL-8_gcc-11.2.tar "https://developer.arm.com/-/media/Files/downloads/hpc/arm-performance-libraries/22-1/rhel-8/arm-performance-libraries_22.1_RHEL-8_gcc-11.2.tar?rev=2efd010a9c974ebc99b7481a398e55d5&revision=2efd010a-9c97-4ebc-99b7-481a398e55d5"
-tar xvf arm-performance-libraries_22.1_RHEL-8_gcc-11.2.tar
-cd arm-performance-libraries_22.1_RHEL-8
-./arm-performance-libraries_22.1_RHEL-8.sh -a
 
 source /etc/profile.d/modules.sh
 export MODULEPATH=/opt/arm/modulefiles:$MODULEPATH
 module load acfl
 
-
 export CC=armclang
 export CXX=armclang++
 export Fortran_COMPILER=armflang
 export FC=armflang
+
+#echo "Checking if compiler is in PATH"
+#echo `which $CC`
+
 cd /opt
 wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.4.tar.gz
 tar xzvf openmpi-4.1.4.tar.gz
@@ -43,10 +29,10 @@ cd /opt
 git lfs install
 git clone --depth 1 --branch main https://github.com/OpenRadioss/OpenRadioss.git
 cd /opt/OpenRadioss/starter
-./build_script.sh -arch=linuxa64 -nt=80
+./build_script.sh -arch=linuxa64 -nt=80 -static-link
 cd /opt/OpenRadioss/engine
-./build_script.sh -arch=linuxa64 -nt=80
-./build_script.sh -arch=linuxa64 -mpi=ompi -nt=80
+./build_script.sh -arch=linuxa64 -nt=80 -static-link
+./build_script.sh -arch=linuxa64 -mpi=ompi -nt=80 -static-link
 cd /opt/OpenRadioss/tools/anim_to_vtk/linux64
 ./build.bash
 cd /opt/OpenRadioss/tools/th_to_csv/linux64


### PR DESCRIPTION
#### Description of the feature or the bug
Fixes #2120 


#### Description of the changes
1. Fix dependency and build issues
- `which` and `python3` added to list of packages installed via final `dnf` command.
- A symlink pointing `/usr/local/bin/python` --> `/usr/local/bin/python3` is added.

2. Clean up definition files
- A separate definition file arm_buildEnv.def is provided to download and install all prerequisites into a base image. This will only occur once.
- The following options are added to the `wget` command:
  - `--show-progress` so user doesn't think progress has stalled when downloading the Arm compiler suite.
  - `-c --read-timeout=15` to restart download after 15 seconds of inactivity and continue from the partially-downloaded file.
- `rm ...` commands are added to clean up the Arm compiler and performance library intermediate files (`*.tar` downloads and unpacked `*.sh` installers) left behind after installation is complete.
- `openradioss_arm.def` definition file is now bootstrapped from the local build environment image (`arm_buildEnv.sif`) and ONLY downloads the OpenRadioss source. Libraries are static-linked so binaries can be copied to an archive and distributed externally.
- A build script `build_arm.sh` is provided that will first check if the build environment image exists and create it if necessary.
- Definition files are moved to `Apptainer\arm\` directory.
