### PR TITLE
Correct dimension of FUNC_ID array in routine argument declarations

### DIFF
--- a/starter/source/materials/mat/mat036/law36_upd.F
+++ b/starter/source/materials/mat/mat036/law36_upd.F
@@ -33,7 +33,7 @@ Chd|        TABLE_MOD                     share/modules1/table_mod.F
 Chd|====================================================================
       SUBROUTINE LAW36_UPD(IOUT   ,TITR   ,MAT_ID ,NUPARAM,UPARAM ,
      .                     NFUNC  ,IFUNC  ,FUNC_ID,NPC    ,PLD    ,
-     .                     MTAG   )
+     .                     MTAG   ,NFUNCT )
 C----------------------------------------------- 
 C   M o d u l e s
 C-----------------------------------------------
@@ -51,8 +51,11 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER MAT_ID,IOUT,NUPARAM,NFUNC
-      INTEGER, DIMENSION(NFUNC) :: IFUNC, FUNC_ID
+      INTEGER ,INTENT(IN) :: MAT_ID,IOUT,NUPARAM
+      INTEGER ,INTENT(IN) :: NFUNC    ! number of functions defined in the law
+      INTEGER ,INTENT(IN) :: NFUNCT   ! total number of functions in the system
+      INTEGER, DIMENSION(NFUNC)  :: IFUNC
+      INTEGER, DIMENSION(NFUNCT) :: FUNC_ID
       INTEGER NPC(*)
       my_real UPARAM(NUPARAM),PLD(*)
       CHARACTER*nchartitle  :: TITR
@@ -114,10 +117,10 @@ c-----------------------------------------------------------------------
 c     Check if yield curves for different strain rates do not intersect
 c-----------------------------------------------------------------------
       DO I = 1,NRATE
+        FUNC1 = IFUNC(I)
+        FAC1  = UPARAM(NRATE + 6 + I)
         DO J = I+1,NRATE
-          FUNC1 = IFUNC(I)
           FUNC2 = IFUNC(J)
-          FAC1  = UPARAM(NRATE + 6 + I)
           FAC2  = UPARAM(NRATE + 6 + J)
           IF (FUNC1 > 0 .and. FUNC2 > 0 .and. FUNC1 /= FUNC2) THEN
             CALL FUNC_INTERS(TITR,MAT_ID,FUNC1 ,FUNC2 ,FAC1 ,FAC2 ,

--- a/starter/source/materials/mat/mat058/law58_upd.F
+++ b/starter/source/materials/mat/mat058/law58_upd.F
@@ -59,13 +59,13 @@ C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       CHARACTER*nchartitle  :: TITR
       INTEGER MAT_ID,IOUT,NFUNC,NFUNL,NUPARAM,NPTS
-      INTEGER NPC(SNPC), FUNC_ID(*),IFUNC(NFUNC+NFUNL)
+      INTEGER NPC(SNPC), FUNC_ID(NFUNCT),IFUNC(NFUNC+NFUNL)
       my_real UPARAM(NUPARAM),PLD(STF),PM(NPROPM)
       TYPE (SENSORS_) ,INTENT(IN) :: SENSORS
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I,K,FUNC,FUND,UNLOAD,PN,IOK,ISENS,SENS_ID,TEST
+      INTEGER I,K,FUNC,FUND,UNLOAD,PN,IOK,ISENS,SENS_ID
       my_real KC,KT,KCMAX,KTMAX,KFC,KFT,GMAX,DERI,STIFF,STIFFMIN,STIFFINI,
      .  STIFFMAX,STIFFAVG,XINT1,YINT1,XINT2,YINT2,FAC,FAC1,FAC2,GFROT,GSH
 C=======================================================================

--- a/starter/source/materials/mat/mat069/law69_upd.F
+++ b/starter/source/materials/mat/mat069/law69_upd.F
@@ -33,7 +33,7 @@ Chd|        LAW69_NLSQF_AUTO              source/materials/tools/law69_nlsqf_aut
 Chd|        MESSAGE_MOD                   share/message_module/message_mod.F
 Chd|        TABLE_MOD                     share/modules1/table_mod.F    
 Chd|====================================================================
-      SUBROUTINE LAW69_UPD(IOUT,TITR    ,MAT_ID,UPARAM,NFUNC,
+      SUBROUTINE LAW69_UPD(IOUT,TITR    ,MAT_ID,UPARAM,NFUNC,NFUNCT,
      .                      IFUNC, FUNC_ID,NPC   ,PLD   ,PM,IPM, GAMA_INF)
 C-----------------------------------------------
 C   M o d u l e s
@@ -53,8 +53,10 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       CHARACTER*nchartitle  :: TITR
-      INTEGER MAT_ID,IOUT, NFUNC
-      INTEGER NPC(*), FUNC_ID(*) ,IPM(NPROPMI)
+      INTEGER MAT_ID,IOUT
+      INTEGER ,INTENT(IN) :: NFUNC
+      INTEGER ,INTENT(IN) :: NFUNCT
+      INTEGER NPC(*), FUNC_ID(NFUNCT) ,IPM(NPROPMI)
       my_real 
      .         UPARAM(*),PLD(*),PM(NPROPM)
       my_real , INTENT(IN)    ::  GAMA_INF

--- a/starter/source/materials/mat/mat087/law87_upd.F
+++ b/starter/source/materials/mat/mat087/law87_upd.F
@@ -35,7 +35,7 @@ Chd|        FINTER                        source/tools/curve/finter.F
 Chd|        MESSAGE_MOD                   share/message_module/message_mod.F
 Chd|        TABLE_MOD                     share/modules1/table_mod.F    
 Chd|====================================================================
-      SUBROUTINE LAW87_UPD(IOUT, TITR,MAT_ID,UPARAM,NFUNC, 
+      SUBROUTINE LAW87_UPD(IOUT, TITR,MAT_ID,UPARAM,NFUNC,NFUNCT,
      .                        IFUNC, FUNC_ID , NPC   , PLD , PM)
 C-----------------------------------------------
 C   M o d u l e s
@@ -55,12 +55,14 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       CHARACTER*nchartitle  :: TITR
-      INTEGER MAT_ID,IOUT, NFUNC
-      INTEGER NPC(*), FUNC_ID(*) 
-      my_real 
-     .         FINTER,UPARAM(*),PLD(*),PM(NPROPM)
+      INTEGER MAT_ID,IOUT
+      INTEGER ,INTENT(IN) :: NFUNCT
+      INTEGER ,INTENT(INOUT) :: NFUNC
+      INTEGER, DIMENSION(NFUNC) :: IFUNC
+      INTEGER, DIMENSION(NFUNCT):: FUNC_ID
+      INTEGER NPC(*)
+      my_real :: FINTER,UPARAM(*),PLD(*),PM(NPROPM)
       EXTERNAL FINTER
-      INTEGER, DIMENSION(NFUNC):: IFUNC
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat088/law88_upd.F
+++ b/starter/source/materials/mat/mat088/law88_upd.F
@@ -34,7 +34,8 @@ Chd|        MESSAGE_MOD                   share/message_module/message_mod.F
 Chd|        TABLE_MOD                     share/modules1/table_mod.F    
 Chd|====================================================================
       SUBROUTINE LAW88_UPD(IOUT   ,TITR   ,UPARAM ,NPC    ,PLD    ,  
-     .                     NFUNC  ,IFUNC  ,MAT_ID ,FUNC_ID,PM   )
+     .                     NFUNC  ,IFUNC  ,MAT_ID ,FUNC_ID,PM     ,
+     .                     NFUNCT )
       USE MESSAGE_MOD
 C-----------------------------------------------
 C   M o d u l e s
@@ -54,8 +55,10 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       CHARACTER*nchartitle  :: TITR
-      INTEGER MAT_ID,IOUT,NFUNC
-      INTEGER NPC(*), FUNC_ID(*),IFUNC(NFUNC)
+      INTEGER MAT_ID,IOUT
+      INTEGER ,INTENT(IN) :: NFUNC
+      INTEGER ,INTENT(IN) :: NFUNCT
+      INTEGER NPC(*), FUNC_ID(NFUNCT),IFUNC(NFUNC)
       my_real UPARAM(*),PLD(*)
       my_real , DIMENSION(NPROPM), INTENT(INOUT) :: PM
 C-----------------------------------------------

--- a/starter/source/materials/mat/mat090/law90_upd.F
+++ b/starter/source/materials/mat/mat090/law90_upd.F
@@ -29,7 +29,8 @@ Chd|        FUNC_SLOPE                    source/tools/curve/func_slope.F
 Chd|        MESSAGE_MOD                   share/message_module/message_mod.F
 Chd|        TABLE_MOD                     share/modules1/table_mod.F    
 Chd|====================================================================
-      SUBROUTINE LAW90_UPD(IOUT,TITR,MAT_ID,UPARAM,IPM, FUNC_ID,NPC,PLD,PM)
+      SUBROUTINE LAW90_UPD(IOUT,TITR,MAT_ID,UPARAM,IPM, FUNC_ID,NPC,PLD,PM,
+     .                     NFUNCT)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -48,8 +49,9 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       CHARACTER*nchartitle  :: TITR
+      INTEGER ,INTENT(IN) :: NFUNCT
       INTEGER MAT_ID,IOUT,ID_F1,ID_F2
-      INTEGER NPC(*), FUNC_ID(*), IPM(NPROPMI)
+      INTEGER NPC(*), FUNC_ID(NFUNCT), IPM(NPROPMI)
       my_real 
      .         UPARAM(*),PLD(*),PM(NPROPM)
 !      TYPE(TTABLE) TABLE(*)

--- a/starter/source/materials/mat/mat092/law92_upd.F
+++ b/starter/source/materials/mat/mat092/law92_upd.F
@@ -30,7 +30,7 @@ Chd|        LAW92_NLSQF                   source/materials/mat/mat092/law92_nlsq
 Chd|        MESSAGE_MOD                   share/message_module/message_mod.F
 Chd|        TABLE_MOD                     share/modules1/table_mod.F    
 Chd|====================================================================
-      SUBROUTINE LAW92_UPD(IOUT,TITR    ,MAT_ID,UPARAM,NFUNC,
+      SUBROUTINE LAW92_UPD(IOUT,TITR    ,MAT_ID,UPARAM,NFUNC,NFUNCT,
      .                      IFUNC, FUNC_ID,NPC   ,PLD   ,PM,IPM)
 C-----------------------------------------------
 C   M o d u l e s
@@ -50,8 +50,10 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       CHARACTER*nchartitle  :: TITR
-      INTEGER MAT_ID,IOUT, NFUNC
-      INTEGER NPC(*), FUNC_ID(*), IPM(NPROPMI)
+      INTEGER MAT_ID,IOUT
+      INTEGER ,INTENT(IN) :: NFUNC
+      INTEGER ,INTENT(IN) :: NFUNCT
+      INTEGER NPC(*), FUNC_ID(NFUNCT), IPM(NPROPMI)
       my_real UPARAM(*),PLD(*),PM(NPROPM)
       INTEGER, DIMENSION(NFUNC):: IFUNC
 C-----------------------------------------------

--- a/starter/source/materials/updmat.F
+++ b/starter/source/materials/updmat.F
@@ -92,7 +92,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER NPC(SNPC), FUNC_ID(*)
+      INTEGER NPC(SNPC), FUNC_ID(NFUNCT)
       INTEGER, DIMENSION(NPROPMI,NUMMAT) ,INTENT(INOUT) :: IPM
       my_real PM(NPROPM,NUMMAT), PLD(STF),BUFMAT(SBUFMAT)
       TARGET IPM,BUFMAT
@@ -223,8 +223,8 @@ c-------------------------
 c------------------
            MTAG => MLAW_TAG(IMAT)
            CALL LAW36_UPD(IOUT   ,TITR   ,MAT_ID ,NPARAM,UPARAM ,
-     .                     NFUNC  ,IFUNC  ,FUNC_ID,NPC    ,PLD  ,
-     .                     MTAG  )        
+     .                    NFUNC  ,IFUNC  ,FUNC_ID,NPC    ,PLD  ,
+     .                    MTAG   ,NFUNCT )        
 c-------------------------
           CASE (42) 
 c------------------
@@ -245,7 +245,7 @@ c------------------
 c------------------
           CASE (69) 
 c------------------
-           CALL LAW69_UPD(IOUT, TITR    , MAT_ID, UPARAM, NFUNC, 
+           CALL LAW69_UPD(IOUT, TITR    , MAT_ID, UPARAM, NFUNC,NFUNCT, 
      .                    IFUNC, FUNC_ID , NPC   , PLD , 
      .                    PM(1,IMAT),IPM(1,IMAT),GAMA_INF)
 c          
@@ -277,7 +277,7 @@ c------------------
             NFUNC = UPARAM(25)
             FLAG_FIT = NINT ( UPARAM(25+2*NFUNC+9) )
             IF (FLAG_FIT == 1) THEN 
-              CALL LAW87_UPD(IOUT,TITR,MAT_ID   ,UPARAM,NFUNC  ,
+              CALL LAW87_UPD(IOUT,TITR,MAT_ID   ,UPARAM,NFUNC  ,NFUNCT,
      .                       IFUNC,FUNC_ID,NPC,PLD,PM(1,IMAT))
             ENDIF
 c-------------------------
@@ -285,13 +285,15 @@ c-------------------------
 c------------------
 c
             CALL LAW88_UPD(IOUT,TITR,UPARAM,NPC,PLD,
-     .                     NFUNC,IFUNC,MAT_ID,FUNC_ID,PM(1,IMAT))
+     .                     NFUNC,IFUNC,MAT_ID,FUNC_ID,PM(1,IMAT),
+     .                     NFUNCT )
 c------------------
           CASE (90) 
 c------------------
 c
             CALL LAW90_UPD(IOUT,TITR,MAT_ID   ,UPARAM,
-     .                     IPM(1,IMAT),FUNC_ID,NPC,PLD,PM(1,IMAT))
+     .                     IPM(1,IMAT),FUNC_ID,NPC,PLD,PM(1,IMAT),
+     .                     NFUNCT)
 c------------------
           CASE (92) ! Arruda-Boyce hyperelastic law
 c------------------
@@ -299,7 +301,7 @@ c
             UPARAM(13) = MULLINS(IMAT)
             IFC = IPM(11,IMAT)
             IF (IFC > 0) THEN
-              CALL LAW92_UPD(IOUT  ,TITR    ,MAT_ID ,UPARAM ,NFUNC     , 
+              CALL LAW92_UPD(IOUT  ,TITR    ,MAT_ID ,UPARAM ,NFUNC ,NFUNCT, 
      .                 IFUNC ,FUNC_ID ,NPC    ,PLD   ,PM(1,IMAT),IPM(1,IMAT))
             ENDIF
 c------------------


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

possible memory overflow in warning message in starter for law36 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

corrected FUNC_ID variable size in declaration of several material law update routines in starter

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
