### PR TITLE
Correction of MAT_PARAM structure dimension in calling routines arguments

### DIFF
--- a/starter/source/elements/initia/initia.F
+++ b/starter/source/elements/initia/initia.F
@@ -333,7 +333,7 @@ C
       TYPE (FVM_INIVEL_STRUCT), INTENT(IN) :: FVM_INIVEL(*)
       TYPE (NLOCAL_STR_)   :: NLOC_DMG 
       TYPE (GROUP_PARAM_), DIMENSION(NGROUP)  :: GROUP_PARAM_TAB
-      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
+      TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(INOUT) :: MATPARAM
 C-----------------------------------------------
       TYPE (GROUP_)  , DIMENSION(NGRNOD)  :: IGRNOD
       TYPE (GROUP_)  , DIMENSION(NGRBRIC) :: IGRBRIC
@@ -1031,8 +1031,8 @@ C Element types
                   CALL S4REFSTA3(
      1                 ELBUF_TAB(NG),IXS        ,PM         ,GEO      ,IPARG(1,NG),
      2                 IPM        ,IGEO       ,SKEW       ,X        ,XREFS      ,
-     3                 NEL          ,IPART(I15A),IPART    ,BUFMAT   ,MATPARAM  ,
-     4                 NPC          ,PLD        )
+     3                 NEL        ,IPART(I15A),IPART    ,BUFMAT   ,NUMMAT     ,
+     4                 MATPARAM   ,NPC          ,PLD        )
 C Case total strain
                   IF (ISTOT == 1) THEN
                      CALL SGSAVREF(ISOLNOD,XREFS(1,1,NFT+1),GBUF%SMSTR,NEL)
@@ -1237,10 +1237,10 @@ C Case total strain
             ENDIF
            
             CALL SREFSTA3(
-     1        ELBUF_TAB(NG),IXS        ,PM         ,GEO      ,IPARG(1,NG),  
-     2        IPM        ,IGEO       ,SKEW       ,X        ,XREFS     ,
-     3        NEL          ,IPART(I15A),IPART      ,BUFMAT   ,MATPARAM,              
-     6        NPC          ,PLD        )
+     1        ELBUF_TAB(NG),IXS      ,PM         ,GEO      ,IPARG(1,NG),  
+     2        IPM        ,IGEO       ,SKEW       ,X        ,XREFS      ,
+     3        NEL        ,IPART(I15A),IPART      ,BUFMAT   ,NUMMAT     ,              
+     6        MATPARAM   ,NPC        ,PLD        )
 C
 C Case total strain: conf_ref <- XREF
             IF (NXREF > 0 .AND. (NPT == 1 .AND. ISTOT == 1) ) THEN

--- a/starter/source/elements/solid/solide/srefsta3.F
+++ b/starter/source/elements/solid/solide/srefsta3.F
@@ -42,10 +42,10 @@ Chd|        SZREFDERI3                    source/elements/solid/solide/srefsta3.
 Chd|        MAT_ELEM_MOD                  ../common_source/modules/mat_elem/mat_elem_mod.F
 Chd|        MESSAGE_MOD                   share/message_module/message_mod.F
 Chd|====================================================================
-      SUBROUTINE SREFSTA3(ELBUF_STR,IXS     ,PM     ,GEO     ,IPARG  ,
-     .                    IPM      ,IGEO    ,SKEW   ,X       ,XREFS  ,
-     .                    NEL      ,IPARTS  ,IPART  ,BUFMAT  ,MATPARAM,
-     .                    NPF      ,TF      )
+      SUBROUTINE SREFSTA3(ELBUF_STR,IXS     ,PM     ,GEO     ,IPARG    ,
+     .                    IPM      ,IGEO    ,SKEW   ,X       ,XREFS    ,
+     .                    NEL      ,IPARTS  ,IPART  ,BUFMAT  ,NUMMAT   ,
+     .                    MATPARAM,NPF     ,TF     )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -69,6 +69,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+      INTEGER ,INTENT(IN) :: NUMMAT
       INTEGER IXS(NIXS,*), IPARG(*),IPARTS(*), IGEO(*),
      .    IPM(NPROPMI,*),IPART(LIPART1,*), NEL, NPF(*)
 C     REAL
@@ -76,7 +77,7 @@ C     REAL
      .   PM(NPROPM,*), X(3,*), XREFS(8,3,*), GEO(NPROPG,*),
      .   SKEW(LSKEW,*), BUFMAT(*), TF(*)
       TYPE (ELBUF_STRUCT_), TARGET :: ELBUF_STR
-      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
+      TYPE(MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(INOUT) :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -628,7 +629,7 @@ C-----------
 C-----------
           CALL MMAIN(PM   ,ELBUF_STR,IXS    ,NIXS    ,X      ,
      2             GEO    ,IPARG    ,NEL    ,SKEW    ,BUFMAT ,
-     3             IPART  ,IPARTS   ,MATPARAM,
+     3             IPART  ,IPARTS   ,NUMMAT ,MATPARAM,
      4             MAT    ,IPM      ,NGL    ,PID     ,NPF    ,
      5             TF     ,MFXX     ,MFXY   ,MFXZ    ,MFYX   ,
      6             MFYY   ,MFYZ     ,MFZX   ,MFZY    ,MFZZ   ,

--- a/starter/source/elements/solid/solide4/s4refsta3.F
+++ b/starter/source/elements/solid/solide4/s4refsta3.F
@@ -44,8 +44,8 @@ Chd|        MESSAGE_MOD                   share/message_module/message_mod.F
 Chd|====================================================================
       SUBROUTINE S4REFSTA3(ELBUF_STR,IXS     ,PM     ,GEO     ,IPARG   ,
      .                     IPM    ,IGEO    ,SKEW   ,X      ,XREFS   ,
-     .                     NEL      ,IPARTS  ,IPART  ,BUFMAT  ,MATPARAM,
-     .                     NPF      ,TF      )
+     .                     NEL      ,IPARTS  ,IPART  ,BUFMAT  ,NUMMAT  ,
+     .                     MATPARAM,NPF      ,TF      )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -69,6 +69,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+      INTEGER ,INTENT(IN) :: NUMMAT
       INTEGER IXS(NIXS,*), IPARG(*),IPARTS(*),IGEO(NPROPGI,*),
      .    IPM(NPROPMI,*),IPART(LIPART1,*), NPF(*)
       INTEGER NEL
@@ -76,7 +77,7 @@ C-----------------------------------------------
      .   PM(NPROPM,*), X(3,*), XREFS(8,3,*), GEO(NPROPG,*),
      .   SKEW(LSKEW,*), BUFMAT(*), TF(*)
       TYPE (ELBUF_STRUCT_), TARGET :: ELBUF_STR
-      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
+      TYPE(MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(INOUT) :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -464,7 +465,7 @@ C-----------
 C-----------
           CALL MMAIN(PM     ,ELBUF_STR,IXS     ,NIXS   ,X      ,
      2               GEO    ,IPARG  ,NEL     ,SKEW   ,BUFMAT ,
-     3               IPART  ,IPARTS ,MATPARAM,
+     3               IPART  ,IPARTS ,NUMMAT  ,MATPARAM,
      4               MAT    ,IPM    ,NGL     ,PID    ,NPF    ,
      5               TF     ,MFXX   ,MFXY   ,MFXZ    ,MFYX   ,
      6               MFYY   ,MFYZ   ,MFZX   ,MFZY    ,MFZZ   ,

--- a/starter/source/materials/mat_share/mmain.F
+++ b/starter/source/materials/mat_share/mmain.F
@@ -31,7 +31,7 @@ Chd|        MAT_ELEM_MOD                  ../common_source/modules/mat_elem/mat_
 Chd|====================================================================
       SUBROUTINE MMAIN(PM      ,ELBUF_STR,IX   ,NIX    ,X       ,
      2                  GEO    ,IPARG  ,NEL    ,SKEW   ,BUFMAT  ,
-     3                  IPART  ,IPARTEL,MATPARAM,
+     3                  IPART  ,IPARTEL,NUMMAT ,MATPARAM,
      4                  MAT    ,IPM    ,NGL    ,PID    ,NPF     ,
      5                  TF     ,MFXX   ,MFXY   ,MFXZ   ,MFYX    ,
      6                  MFYY   ,MFYZ   ,MFZX   ,MFZY   ,MFZZ    ,
@@ -61,6 +61,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+      INTEGER ,INTENT(IN) :: NUMMAT
       INTEGER NIX,NEL
       INTEGER IX(NIX,*), IPARG(*),
      .        IPART(LIPART1,*),IPARTEL(*),MAT(*),IPM(NPROPMI,*),
@@ -79,7 +80,7 @@ C-----------------------------------------------
      .   S1(*)    ,S2(*)    ,S3(*) ,
      .   S4(*)    ,S5(*)    ,S6(*)
       TYPE (ELBUF_STRUCT_), TARGET :: ELBUF_STR
-      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
+      TYPE(MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(INOUT) :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/materials/mat_share/mulaw.F
+++ b/starter/source/materials/mat_share/mulaw.F
@@ -91,11 +91,12 @@ C
      .   TX(MVSIZ)    ,TY(MVSIZ)    ,TZ(MVSIZ)   ,
      .   MFXX(*)  ,MFXY(*)  ,MFXZ(*)  ,MFYX(*) ,MFYY(*)   ,MFYZ(*)   ,
      .   MFZX(*)  ,MFZY(*)  ,MFZZ(*)
-      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
+      TYPE(MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(INOUT) :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I, J,NVPHAS, N0PHAS, NPH, IFLG,NPAR, IADBUF, NFUNC, IFUNC(100) 
+      INTEGER I,J,IMAT,NVPHAS, N0PHAS, NPH, IFLG,NPAR, 
+     .   IADBUF, NFUNC, IFUNC(100) 
       my_real
      . EP1(MVSIZ), EP2(MVSIZ), EP3(MVSIZ),E7(MVSIZ),
      . EP4(2*MVSIZ),EP5(2*MVSIZ),EP6(2*MVSIZ),
@@ -115,16 +116,17 @@ C=======================================================================
       TIME    =ZERO
       TIMESTEP=ONE/FLOAT(NITRS)
 C---------------------------
-      NPAR   = IPM(9,MAT(1))
-      IADBUF = IPM(7,MAT(1))
-      NFUNC  = IPM(10,MAT(1))
+      IMAT   = MAT(1)
+      NPAR   = IPM(9,IMAT)
+      IADBUF = IPM(7,IMAT)
+      NFUNC  = IPM(10,IMAT)
       DO I=1,NFUNC
-        IFUNC(I) = IPM(10+I,MAT(1))
+        IFUNC(I) = IPM(10+I,IMAT)
       ENDDO
 C---------------------------
       VIS = ZERO
       DO I=LFT,LLT
-        RHO0(I)= PM( 1,MAT(I))
+        RHO0(I)= PM(1,IMAT)
       END DO
 C---------------------------
       EP1 = ZERO
@@ -272,7 +274,7 @@ C ====================================================================
      7                  S1  ,S2  ,S3  ,S4   ,S5   ,S6  ,
      8                  SV1 ,SV2 ,SV3 ,SV4  ,SV5  ,SV6 ,
      9                  SSP ,VIS ,UVAR,OFF  ,NGL  ,
-     A                  PM  ,IPM ,MAT ,MATPARAM)
+     A                  PM  ,IPM ,MAT ,MATPARAM(IMAT))
       ELSEIF(MTN==90)THEN
         CALL SIGEPS90(LLT ,NPAR,NUVAR,NFUNC,IFUNC,
      2                  NPF ,TF  ,TIME,TIMESTEP,BUFMAT,


### PR DESCRIPTION

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

correct bug with reference metrics with material law70 for solids

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

correctly defined argument declaration of MAT_PARAM structure, passing as scalar instead of vector

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
