### PR TITLE
Fix LAW110 automatic parameter computing formula

### DIFF
--- a/starter/source/materials/mat/mat110/hm_read_mat110.F
+++ b/starter/source/materials/mat/mat110/hm_read_mat110.F
@@ -292,9 +292,9 @@ c
         ENDIF
 c        
         ! Computation of plane strain reference point first coordinate
-        fPS_MIN   = 0.97D0
-        fPS_MAX   = 1.14D0
-        fPS_TRANS = 1.22D0
+        fPS_MIN   = 0.827D0
+        fPS_MAX   = 1.315D0
+        fPS_TRANS = 0.5D0
         ADIRAC    = 1.2D0
         DO J = 1,NANGLE
           FDIRAC    = EXP(ADIRAC*(rLank(J)-fPS_TRANS))


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Automatic computation of parameters when using /MAT/LAW110 with Icrit = 3 was too severe. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Change the constant of Abspoel formulas. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
