### PR TITLE
Change radioss format of /FAIL/ORTHENERG from 2023 to 2024

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2023/data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/radioss2023/data_hierarchy.cfg
@@ -2565,14 +2565,6 @@ HIERARCHY {
         FILE    = "FAIL/fail_max_strain.cfg";
         USER_NAMES = (MAXSTRAIN);
     }
-    HIERARCHY {
-        KEYWORD = FAIL_ORTHENERG;
-        TITLE   = "FAIL_ORTHENERG";
-        SUBTYPE = USER;
-        USER_ID = 48;
-        FILE    = "FAIL/fail_orthenerg.cfg";
-        USER_NAMES = (ORTHENERG);
-    }
 
 }
 

--- a/hm_cfg_files/config/CFG/radioss2024/FAIL/fail_orthenerg.cfg
+++ b/hm_cfg_files/config/CFG/radioss2024/FAIL/fail_orthenerg.cfg
@@ -110,7 +110,7 @@ GUI(COMMON) {
     SCALAR(G_31C)         { DIMENSION = "stiffness"; }
 }
 
-FORMAT(radioss2023) {
+FORMAT(radioss2024) {
     HEADER("/FAIL/ORTHENERG/%d",mat_id);
     COMMENT("#         PTHICKFAIL                                                                  NMOD    FAILIP");
     CARD("%20lg%60s%10d%10d",PTHICKFAIL,_BLANK_,NMOD,FAILIP);


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Recently implemented /FAIL/ORTHENERG must be defined for radioss2024 format

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Change 2023 to 2024 format for /FAIL/ORTHENERG. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
