### PR TITLE
Code refactoring + output /H3D/ELEM/VECT/CONT (law151)

### DIFF
--- a/engine/share/modules/aleanim_mod.F
+++ b/engine/share/modules/aleanim_mod.F
@@ -35,7 +35,18 @@ Chd|====================================================================
       
 #include "my_real.inc"
 
-        my_real , 
-     .    DIMENSION(:), ALLOCATABLE ::  FANI_CELL
+        TYPE FANI_CELL_
+          LOGICAL IS_F18_FVM_REQUESTED
+          LOGICAL IS_VORT_X_REQUESTED
+          LOGICAL IS_VORT_Y_REQUESTED
+          LOGICAL IS_VORT_Z_REQUESTED
+          my_real,DIMENSION(:,:), ALLOCATABLE :: F18
+          my_real,DIMENSION(:), ALLOCATABLE :: VORT_X
+          my_real,DIMENSION(:), ALLOCATABLE :: VORT_Y
+          my_real,DIMENSION(:), ALLOCATABLE :: VORT_Z
+        END TYPE
+
+        TYPE(FANI_CELL_) :: FANI_CELL
+
 
       END MODULE ALEANIM_MOD

--- a/engine/source/elements/solid/solide/sdefo3.F
+++ b/engine/source/elements/solid/solide/sdefo3.F
@@ -58,7 +58,7 @@ C   W = 1/2 * (E - t(E))
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
-      USE ALEANIM_MOD , ONLY : FANI_CELL
+      USE ALEANIM_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -288,21 +288,19 @@ C-----------------------------------------------
       !VORTICITY OUTPUT /ANIM/ELEM/VORTX,VORTY,VORTZ
       IF(DT1/=ZERO)THEN
         FAC = FOUR/DT1
-        IF(ANIM_SE(10)==1)THEN
+        IF(FANI_CELL%IS_VORT_X_REQUESTED)THEN
           DO I=1,NEL
-            FANI_CELL(I+NFT) = FAC*WXX(I)
+            FANI_CELL%VORT_X(I+NFT) = FAC*WXX(I)
           ENDDO
         ENDIF
-        IF(ANIM_SE(4960)==1)THEN
-          IDX=(NUMELS)*ANIM_SE(10)
+        IF(FANI_CELL%IS_VORT_Y_REQUESTED)THEN
           DO I=1,NEL
-            FANI_CELL(IDX+I+NFT) = FAC*WYY(I)
+            FANI_CELL%VORT_Y(I+NFT) = FAC*WYY(I)
           ENDDO
         ENDIF
-        IF(ANIM_SE(4961)==1)THEN
-          IDX = (NUMELS)*(ANIM_SE(10)+ANIM_SE(4960))
+        IF(FANI_CELL%IS_VORT_Z_REQUESTED)THEN
           DO I=1,NEL
-            FANI_CELL(IDX+I+NFT) = FAC*WZZ(I)
+            FANI_CELL%VORT_Z(I+NFT) = FAC*WZZ(I)
           ENDDO
         ENDIF
       ENDIF

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -8282,7 +8282,7 @@ C Regular animation
      r   FANI(1,NFNCA2+1),FANI(1,NFTCA2+1),IBCL        ,ILOADP         ,LLOADP        ,
      s   LOADP         ,TAGNCONT       ,LOADP_HYD_INTER,FORC           ,DRAPEG        ,
      t   USER_WINDOWS  ,OUTPUT         ,DT             ,FSAVSURF       ,NSEG_LOADP    ,
-     u   TABLE         ,LOADS          ) 
+     u   TABLE         ,LOADS          ,SFANI)
 C
         IF((MSTOP == 1 .AND. ICTLSTOP == 0) .OR. MSTOP == 2 .OR. DT2<=ZERO)THEN
           CALL SORTIE_ERROR(

--- a/engine/source/interfaces/int18/i18for3.F
+++ b/engine/source/interfaces/int18/i18for3.F
@@ -176,9 +176,8 @@ C-----------------------------------------------
      .   CS(MVSIZ),C1(MVSIZ),C2(MVSIZ),C3(MVSIZ),C4(MVSIZ),
      .   CX,CY,CFI,AUX,PHI1(MVSIZ), PHI2(MVSIZ), PHI3(MVSIZ),
      .   PHI4(MVSIZ),DX, DTI
-      INTEGER JSUB,KSUB,JJ,KK,IN,NSUB,IBID,IDX,ILEN,IPOS,ITASK,NELFT,NELLT
-      my_real
-     .   FSAVSUB1(15,NISUB),IMPX,IMPY,IMPZ,PP1,PP2,PP3,PP4,BID
+      INTEGER JSUB,KSUB,JJ,KK,IN,NSUB,IBID,ITASK,NELFT,NELLT
+      my_real FSAVSUB1(15,NISUB),IMPX,IMPY,IMPZ,PP1,PP2,PP3,PP4,BID
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
@@ -771,16 +770,12 @@ C---------------------------------
            !   /H3D/ELEM/VECT/CONT WITH LAW151 (COLOCATED SCHEME)                       
            IF (MULTI_FVM%IS_USED) THEN 
              IF(H3D_DATA%N_VECT_CONT  > 0)THEN                                                 
-               IDX=NUMELS*(ANIM_SE(10)+ANIM_SE(4960)+ANIM_SE(4961)) !skip vorticity data  
-               ILEN=NUMELS+NUMELQ                                                         
-               DO I=1,JLT                                                                 
-                 IPOS=NSVG(I)
-                 IF(IPOS>0) THEN ! local cell
-                      IPOS=IPOS-NUMNOD                                                         
-                      IPOS = IDX+3*(IPOS-1)                                                    
-                      FANI_CELL(IPOS+1)=FANI_CELL(IPOS+1)-FXI(I)                               
-                      FANI_CELL(IPOS+2)=FANI_CELL(IPOS+2)-FYI(I)                               
-                      FANI_CELL(IPOS+3)=FANI_CELL(IPOS+3)-FZI(I)                               
+               DO I=1,JLT
+                 JG=NSVG(I)-NUMNOD
+                 IF(JG>0) THEN ! local cell
+                    FANI_CELL%F18(1,JG)=FANI_CELL%F18(1,JG)-FXI(I)
+                    FANI_CELL%F18(2,JG)=FANI_CELL%F18(2,JG)-FYI(I)
+                    FANI_CELL%F18(3,JG)=FANI_CELL%F18(3,JG)-FZI(I)
                   ENDIF
                ENDDO     
              ENDIF                                                                 

--- a/engine/source/interfaces/int18/int18_law151_update.F
+++ b/engine/source/interfaces/int18/int18_law151_update.F
@@ -99,7 +99,7 @@ C-----------------------------------------------
         NODL = (1 + ITASK) * NUMNOD / NTHREAD 
 
         !   1:NUMNOD --> classical x/v/mass
-        IF(IALE/=0) X_APPEND(1:3,NODF:NODL) = X(1:3,NODF:NODL)
+        X_APPEND(1:3,NODF:NODL) = X(1:3,NODF:NODL) !strcture nodes must also be updated
         V_APPEND(1:3,NODF:NODL) = V(1:3,NODF:NODL)
         MASS_APPEND(NODF:NODL) = MS(NODF:NODL)
         KINET_APPEND(NODF:NODL) = KINET(NODF:NODL)
@@ -218,7 +218,7 @@ C-----------------------------------------------
                 MASS = ELBUF_TAB(GROUP_ID)%GBUF%RHO(ILOC) * ELBUF_TAB(GROUP_ID)%GBUF%VOL(ILOC)
                 MASS_APPEND(NUMNOD + IBRIC) = ZERO!MASS
                 !   position
-                IF(IALE/=0) THEN
+                IF(IALE /= 0) THEN
                     X_APPEND(1, NUMNOD + IBRIC) = ZERO
                     X_APPEND(2, NUMNOD + IBRIC) = ZERO
                     X_APPEND(3, NUMNOD + IBRIC) = ZERO

--- a/engine/source/output/anim/generate/dfunc6.F
+++ b/engine/source/output/anim/generate/dfunc6.F
@@ -56,6 +56,7 @@ C-----------------------------------------------
       USE ALEFVM_MOD  
       USE MULTI_FVM_MOD   
       USE ALE_CONNECTIVITY_MOD
+      USE ALEANIM_MOD , ONLY : FANI_CELL_
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -82,7 +83,7 @@ C-----------------------------------------------
       my_real
      .   FUNC(*), MASS(*) ,PM(NPROPM,NUMMAT), GEO(NPROPG,NUMGEO),
      .   EHOUR(*),ANIM(*), SPBUF(*),X(3,NUMNOD),V(3,NUMNOD), W(3,NUMNOD),BUFMAT(*)
-      my_real, INTENT(IN) :: FANI_CELL(SFANI_CELL)
+      TYPE(FANI_CELL_), INTENT(IN) :: FANI_CELL
       INTEGER IPARG(NPARG,*),EL2FA(*),IXS(NIXS,NUMELS),IFUNC,NBF,ISPH3D,
      .        NBPART,IADG(NSPMD,*),IPM(NPROPMI,NUMMAT),
      .        IPART(LIPART1,*),IPARTSP(*),BUF,IGEO(NPROPGI,NUMGEO)
@@ -302,14 +303,13 @@ C               VISCOSITE TURBULENTE
                 ENDDO                                               
 c-----------
               ELSEIF(IFUNC == 10)THEN
-C               VORTICITE-X
+C               VORTICITY-X
                 DO I=LFT,LLT     
-                  EVAR(I) = FANI_CELL(I+NFT)                 
+                  EVAR(I) = FANI_CELL%VORT_X(I+NFT)                 
                 ENDDO
 C
 c-----------
-              ELSEIF((IFUNC == 11.OR.IFUNC == 12.OR.IFUNC == 13)
-     .                                      .AND.MLW == 24)THEN
+              ELSEIF((IFUNC == 11.OR.IFUNC == 12.OR.IFUNC == 13) .AND.MLW == 24)THEN
 C                dam 1 2 3
                  DO I=LFT,LLT
                    EVAR(I) = LBUF%DAM(JJ(IFUNC-10) + I)
@@ -1327,17 +1327,15 @@ c-----------
                 ENDIF  
 c-----------
               ELSEIF(IFUNC == 4960)THEN
-                !VORTICITE-Y
-                IDX = ANIM_SE(10)*NUMELS 
+                !VORTICITY-Y
                 DO I=LFT,LLT
-                  EVAR(I) = FANI_CELL(IDX+I+NFT)                 
+                  EVAR(I) = FANI_CELL%VORT_Y(I+NFT)                 
                 ENDDO     
 c-----------
               ELSEIF(IFUNC == 4961)THEN
-                !VORTICITE-Z
-                IDX = (ANIM_SE(10)+ANIM_SE(4960))*NUMELS 
+                !VORTICITY-Z
                 DO I=LFT,LLT
-                  EVAR(I) = FANI_CELL(IDX+I+NFT)                 
+                  EVAR(I) = FANI_CELL%VORT_Z(I+NFT)                 
                 ENDDO   
 c-----------
               ELSEIF(IFUNC == 4962)THEN

--- a/engine/source/output/h3d/h3d_build_fortran/create_h3d_input.F
+++ b/engine/source/output/h3d/h3d_build_fortran/create_h3d_input.F
@@ -32,6 +32,16 @@ Chd|        H3D_MOD                       share/modules/h3d_mod.F
 Chd|====================================================================
       SUBROUTINE CREATE_H3D_INPUT(H3D_DATA,IKAD,IKEY,IREC,NBC,KEY0,KEY2,KEY3,KEY4,KEY5,KEY6,KEY7,KEY8)
 C-----------------------------------------------
+C   D e s c r i p t i o n
+C-----------------------------------------------
+C This subroutine is activating flags which are used by Engine
+C to make allocation or specific calculatations.
+C Example :
+C   H3D_DATA%N_VECT_CONT  = 1
+C   means /H3D/ELEM/VECT/CONT is defined and
+C   specific calculation & storage are requested
+C   to output this result
+C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE H3D_MOD
@@ -223,7 +233,15 @@ c vector
       IF(KEY2 == "ELEM" .OR. KEY2 == 'SOLID' .OR. KEY2 == 'QUAD')THEN
         IF (KEY3_GLOB == 'VECT/CONT') H3D_DATA%N_VECT_CONT  = 1
         IF (KEY3_GLOB == 'VECT/ACC') H3D_DATA%N_VECT_ACC  = 1
-        IF (KEY3_GLOB == 'TENS/EPSDOT') IEPSDOT = 1   
+        IF (KEY3_GLOB == 'TENS/EPSDOT') IEPSDOT = 1
+        IF (KEY3_GLOB == 'VORTX') H3D_DATA%SOL_SCAL_VORTX  = 1
+        IF (KEY3_GLOB == 'VORTY') H3D_DATA%SOL_SCAL_VORTY  = 1
+        IF (KEY3_GLOB == 'VORTZ') H3D_DATA%SOL_SCAL_VORTZ  = 1
+        IF (KEY3_GLOB == 'VORT') THEN
+          H3D_DATA%SOL_SCAL_VORTX  = 1
+          H3D_DATA%SOL_SCAL_VORTY  = 1
+          H3D_DATA%SOL_SCAL_VORTZ  = 1
+        ENDIF
       ENDIF
 c
       IF(KEY2 == 'SHELL') THEN

--- a/engine/source/output/h3d/h3d_results/genh3d.F
+++ b/engine/source/output/h3d/h3d_results/genh3d.F
@@ -2710,7 +2710,7 @@ c          IF(ISPMD == 0)  print *,'solid scalar',N_OUTP_DATA,'IFUNC',IFUNC,'INF
      .                    NV46      ,NERCVOIS  ,NESDVOIS      ,LERCVOIS     ,LESDVOIS   ,
      .                    STACK     ,SOLID_ID  ,SOLID_ITY     ,IPARTS       ,LAYER      ,
      .                    IR        ,IS        ,IT            ,IUVAR        ,H3D_DATA%OUTPUT_LIST(I)%PART,
-     .                    IS_WRITEN_SOLID,INFO1,KEYWORD       ,FANI_CELL    ,SFANI_CELL ,
+     .                    IS_WRITEN_SOLID,INFO1,KEYWORD       ,FANI_CELL    ,
      .                    MULTI_FVM, H3D_DATA  ,IDMDS         ,IMDSVAR      ,MDS_MATID  ,
      .                    OBJECT_ID)
 c
@@ -2761,7 +2761,7 @@ c          IF(ISPMD == 0)  print *,'solid scalar',N_OUTP_DATA,'IFUNC',IFUNC,'INF
      .                    NV46      ,NERCVOIS  ,NESDVOIS      ,LERCVOIS     ,LESDVOIS   ,
      .                    STACK     ,SOLID_ID  ,SOLID_ITY     ,IPARTS       ,LAYER      ,
      .                    IR        ,IS        ,IT            ,IUVAR        ,H3D_DATA%OUTPUT_LIST(I)%PART,
-     .                    IS_WRITEN_SOLID,INFO1,KEYWORD       ,FANI_CELL    ,SFANI_CELL ,
+     .                    IS_WRITEN_SOLID,INFO1,KEYWORD       ,FANI_CELL    ,
      .                    H3D_DATA, MULTI_FVM)
 c
           IF (NSPMD > 1 ) THEN

--- a/engine/source/output/h3d/h3d_results/h3d_solid_scalar.F
+++ b/engine/source/output/h3d/h3d_results/h3d_solid_scalar.F
@@ -44,7 +44,7 @@ Chd|====================================================================
      .                  NV46            ,NERCVOIS     ,NESDVOIS  ,LERCVOIS    ,LESDVOIS,
      .                  STACK           ,ID_ELEM      ,ITY_ELEM  ,IPARTS      ,LAYER_INPUT ,
      .                  IR_INPUT        ,IS_INPUT     ,IT_INPUT  ,IUVAR_INPUT ,H3D_PART    ,
-     .                  IS_WRITTEN_SOLID,INFO1        ,KEYWORD   ,FANI_CELL   ,SFANI_CELL  ,
+     .                  IS_WRITTEN_SOLID,INFO1        ,KEYWORD   ,FANI_CELL   ,
      .                  MULTI_FVM       , H3D_DATA    ,IDMDS     ,IMDSVAR     ,MDS_MATID   ,
      .                  ID              )
 C-----------------------------------------------
@@ -57,6 +57,7 @@ C-----------------------------------------------
       USE H3D_MOD        
       USE MULTI_FVM_MOD
       USE ALE_CONNECTIVITY_MOD
+      USE ALEANIM_MOD , ONLY : FANI_CELL_
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -81,11 +82,11 @@ C-----------------------------------------------
      .   IADP(*),NBF_L, NBPART,IADG(NSPMD,*),IPM(NPROPMI,*),
      .   IGEO(NPROPGI,*),INVERT(*), NV46,ID_ELEM(*),ITY_ELEM(*),IPARTS(*),ID,
      .   H3D_PART(*),IS_WRITTEN_SOLID(*),INFO1,LAYER_INPUT,IR_INPUT,IS_INPUT,IT_INPUT,
-     .   IUVAR_INPUT,SFANI_CELL,IDMDS,IMDSVAR,MDS_MATID(*)
+     .   IUVAR_INPUT,IDMDS,IMDSVAR,MDS_MATID(*)
       TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP), TARGET :: ELBUF_TAB
       TYPE (STACK_PLY) :: STACK
       CHARACTER*ncharline KEYWORD
-      my_real, INTENT(IN) :: FANI_CELL(SFANI_CELL)
+      TYPE(FANI_CELL_),INTENT(IN) :: FANI_CELL
       TYPE (H3D_DATABASE) :: H3D_DATA
       TYPE(MULTI_FVM_STRUCT), INTENT(IN) :: MULTI_FVM
       TYPE(t_ale_connectivity), INTENT(IN) :: ALE_CONNECT
@@ -156,7 +157,7 @@ c
      .                  NV46            ,NERCVOIS     ,NESDVOIS  ,LERCVOIS    ,LESDVOIS,
      .                  STACK           ,ID_ELEM      ,ITY_ELEM  ,IPARTS      ,LAYER_INPUT ,
      .                  IR_INPUT        ,IS_INPUT     ,IT_INPUT  ,IUVAR_INPUT ,H3D_PART    ,
-     .                  IS_WRITTEN_SOLID,INFO1        ,KEYWORD   ,FANI_CELL   ,SFANI_CELL  ,
+     .                  IS_WRITTEN_SOLID,INFO1        ,KEYWORD   ,FANI_CELL   ,
      .                  MULTI_FVM       , H3D_DATA    ,NG        ,IDMDS       ,IMDSVAR     ,
      .                  MDS_MATID       ,ID           )
 

--- a/engine/source/output/h3d/h3d_results/h3d_solid_scalar_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_solid_scalar_1.F
@@ -50,7 +50,7 @@ Chd|====================================================================
      .                  NV46            ,NERCVOIS     ,NESDVOIS  ,LERCVOIS    ,LESDVOIS,
      .                  STACK           ,ID_ELEM      ,ITY_ELEM  ,IPARTS      ,LAYER_INPUT ,
      .                  IR_INPUT        ,IS_INPUT     ,IT_INPUT  ,IUVAR_INPUT ,H3D_PART    ,
-     .                  IS_WRITTEN_SOLID,INFO1        ,KEYWORD   ,FANI_CELL   ,SFANI_CELL  ,
+     .                  IS_WRITTEN_SOLID,INFO1        ,KEYWORD   ,FANI_CELL   ,
      .                  MULTI_FVM       , H3D_DATA    ,NG        ,IDMDS       ,IMDSVAR     ,
      .                  MDS_MATID       ,ID           )
 C-----------------------------------------------
@@ -64,6 +64,7 @@ C-----------------------------------------------
       USE MULTI_FVM_MOD
       USE ALE_CONNECTIVITY_MOD
       USE ALEFVM_MOD , only:ALEFVM_Param
+      USE ALEANIM_MOD , ONLY : FANI_CELL_
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -92,11 +93,11 @@ C-----------------------------------------------
      .   IADP(*),NBF_L, NBPART,IADG(NSPMD,*),IPM(NPROPMI,*),
      .   IGEO(NPROPGI,*),INVERT(*), NV46,ID_ELEM(*),ITY_ELEM(*),IPARTS(*),ID,
      .   H3D_PART(*),IS_WRITTEN_SOLID(*),INFO1,LAYER_INPUT,IR_INPUT,IS_INPUT,IT_INPUT,
-     .   IUVAR_INPUT,SFANI_CELL,NG,IDMDS,IMDSVAR,MDS_MATID(*)
+     .   IUVAR_INPUT,NG,IDMDS,IMDSVAR,MDS_MATID(*)
       TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP), TARGET :: ELBUF_TAB
       TYPE (STACK_PLY) :: STACK
       CHARACTER*ncharline KEYWORD
-      my_real, INTENT(IN) :: FANI_CELL(SFANI_CELL)
+      TYPE(FANI_CELL_), INTENT(IN) :: FANI_CELL
       TYPE (H3D_DATABASE) :: H3D_DATA
       TYPE(MULTI_FVM_STRUCT), INTENT(IN) :: MULTI_FVM
       TYPE(t_ale_connectivity), INTENT(IN) :: ALE_CONNECT
@@ -483,10 +484,10 @@ C               VISCOSITE TURBULENTE
 C--------------------------------------------------
               ELSEIF(KEYWORD == 'VORTX')THEN
 C--------------------------------------------------
-C               VORTICITE-X
+C               VORTICITY-X
                 IF(MLW /= 151)THEN
                   DO I=1,NEL    
-                    VALUE(I) = FANI_CELL(I+NFT)  
+                    VALUE(I) = FANI_CELL%VORT_X(I+NFT)  
                     IS_WRITTEN_VALUE(I) = 1  
                   ENDDO
                 ELSEIF(MLW == 151)THEN
@@ -523,11 +524,10 @@ C               VORTICITE-X
 C--------------------------------------------------
               ELSEIF(KEYWORD == 'VORTY')THEN
 C--------------------------------------------------
-C               VORTICITE-Y
+C               VORTICITY-Y
                 IF(MLW /= 151)THEN
-                  IDX = MIN(1,ANIM_SE(10)+H3D_DATA%SOL_SCAL_VORTX)*NUMELS 
                   DO I=1,NEL    
-                    VALUE(I) = FANI_CELL(IDX+I+NFT)  
+                    VALUE(I) = FANI_CELL%VORT_Y(I+NFT)  
                     IS_WRITTEN_VALUE(I) = 1  
                   ENDDO
                 ELSEIF(MLW == 151)THEN
@@ -565,11 +565,10 @@ C               VORTICITE-Y
 C--------------------------------------------------
               ELSEIF(KEYWORD == 'VORTZ')THEN
 C--------------------------------------------------
-C               VORTICITE-Z
+C               VORTICITY-Z
                 IF(MLW /= 151)THEN
-                  IDX = (MIN(1,ANIM_SE(10)+H3D_DATA%SOL_SCAL_VORTX)+ MIN(1,ANIM_SE(4960)+H3D_DATA%SOL_SCAL_VORTY) )*NUMELS 
                   DO I=1,NEL    
-                    VALUE(I) = FANI_CELL(IDX+I+NFT)  
+                    VALUE(I) = FANI_CELL%VORT_Z(I+NFT)  
                     IS_WRITTEN_VALUE(I) = 1  
                   ENDDO
                 ELSEIF(MLW == 151)THEN

--- a/engine/source/output/h3d/h3d_results/h3d_solid_vector.F
+++ b/engine/source/output/h3d/h3d_results/h3d_solid_vector.F
@@ -44,7 +44,7 @@ Chd|====================================================================
      .                  NV46            ,NERCVOIS     ,NESDVOIS  ,LERCVOIS    ,LESDVOIS    ,
      .                  STACK           ,ID_ELEM      ,ITY_ELEM  ,IPARTS      ,LAYER_INPUT ,
      .                  IR_INPUT        ,IS_INPUT     ,IT_INPUT  ,IUVAR_INPUT ,H3D_PART    ,
-     .                  IS_WRITTEN_SOLID,INFO1        ,KEYWORD   ,FANI_CELL   ,SFANI_CELL  ,
+     .                  IS_WRITTEN_SOLID,INFO1        ,KEYWORD   ,FANI_CELL   ,
      .                  H3D_DATA        ,MULTI_FVM)
 C-----------------------------------------------
 C   M o d u l e s
@@ -55,6 +55,7 @@ C-----------------------------------------------
       USE STACK_MOD       
       USE H3D_MOD  
       USE MULTI_FVM_MOD
+      USE ALEANIM_MOD , ONLY : FANI_CELL_
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -80,11 +81,11 @@ C-----------------------------------------------
      .   IADP(*),NBF_L, NBPART,IADG(NSPMD,*),IPM(NPROPMI,NUMMAT),
      .   IGEO(NPROPGI,NUMGEO),INVERT(*), NV46,ID_ELEM(*),ITY_ELEM(*),IPARTS(*),
      .   H3D_PART(*),IS_WRITTEN_SOLID(*),INFO1,LAYER_INPUT,IR_INPUT,IS_INPUT,IT_INPUT,
-     .   IUVAR_INPUT,SFANI_CELL
+     .   IUVAR_INPUT
       TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP), TARGET :: ELBUF_TAB
       TYPE (STACK_PLY) :: STACK
       CHARACTER*ncharline KEYWORD
-      my_real, INTENT(IN) :: FANI_CELL(SFANI_CELL)
+      TYPE(FANI_CELL_), INTENT(IN) :: FANI_CELL
       TYPE (H3D_DATABASE) :: H3D_DATA
       TYPE (MULTI_FVM_STRUCT), INTENT(IN) :: MULTI_FVM
 C-----------------------------------------------
@@ -186,14 +187,11 @@ C--------------------------------------------------
 C--------------------------------------------------
             IF (KEYWORD == 'VECT/CONT') THEN
 C--------------------------------------------------
-               IF (MLW == 151) THEN
-                  IDX=NUMELS*(ANIM_SE(10)+ANIM_SE(4960)+ANIM_SE(4961)) !skip vorticity data
-                  ILEN=NUMELS+NUMELQ           
+               IF (MLW == 151) THEN         
                   DO I = 1, NEL
-                     IPOS = IDX+3*(NFT+I-1)
-                     VALUE(1) = FANI_CELL(IPOS+1)
-                     VALUE(2) = FANI_CELL(IPOS+2)
-                     VALUE(3) = FANI_CELL(IPOS+3)
+                     VALUE(1) = FANI_CELL%F18(1,I+NFT)
+                     VALUE(2) = FANI_CELL%F18(2,I+NFT)
+                     VALUE(3) = FANI_CELL%F18(3,I+NFT)
                      CALL H3D_WRITE_VECTOR(IOK_PART,IS_WRITTEN_SOLID,SOLID_VECTOR,I,OFFSET,NFT,VALUE)
                   ENDDO
                ENDIF

--- a/engine/source/output/restart/arralloc.F
+++ b/engine/source/output/restart/arralloc.F
@@ -133,7 +133,7 @@ C-----------------------------------------------
 C----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER IERR0,IERROR, NBMAT,I,NPT
+      INTEGER IERR0,IERROR, NBMAT,I,NPT,ISIZ1,ISIZ2
 C-----------------------------------------------
       IERROR = 0
 C pour eviter conflit avec IERR dans commun
@@ -1332,10 +1332,35 @@ C
         IF (IERR/=0) GOTO 1000
         FANI = 0  
 
-        ALLOCATE (FANI_CELL(SFANI_CELL),STAT=IERR)
-        IF (IERR/=0) GOTO 1000
-        FANI_CELL = 0 
-        
+        ISIZ1=2
+        ISIZ2=NUMELQ+NUMELTG
+        IF(N2D == 0)THEN
+          ISIZ1=3
+          ISIZ2=NUMELS
+        ENDIF
+        !
+        IF(FANI_CELL%IS_VORT_X_REQUESTED)THEN
+          ALLOCATE (FANI_CELL%VORT_X(ISIZ2),STAT=IERR)
+          IF (IERR/=0) GOTO 1000
+          FANI_CELL%VORT_X(:) = ZERO
+        ENDIF
+        IF(FANI_CELL%IS_VORT_Y_REQUESTED)THEN
+          ALLOCATE (FANI_CELL%VORT_Y(ISIZ2),STAT=IERR)
+          IF (IERR/=0) GOTO 1000
+          FANI_CELL%VORT_Y(:) = ZERO
+        ENDIF
+        IF(FANI_CELL%IS_VORT_Z_REQUESTED)THEN
+          ALLOCATE (FANI_CELL%VORT_Z(ISIZ2),STAT=IERR)
+          IF (IERR/=0) GOTO 1000
+          FANI_CELL%VORT_Z(:) = ZERO
+        ENDIF
+        !
+        IF(FANI_CELL%IS_F18_FVM_REQUESTED)THEN
+          ALLOCATE (FANI_CELL%F18(ISIZ1,ISIZ2),STAT=IERR)
+          IF (IERR/=0) GOTO 1000
+          FANI_CELL%F18(:,:) = ZERO
+        ENDIF
+
         ALLOCATE (XCUT(SXCUT),STAT=IERR)
         IF (IERR/=0) GOTO 1000
         XCUT = 0  

--- a/engine/source/output/restart/rdresa.F
+++ b/engine/source/output/restart/rdresa.F
@@ -202,6 +202,7 @@ C-----------------------------------------------
       USE H3D_MOD
       USE PINCHTYPE_MOD
       USE ALE_MOD
+      USE ALEANIM_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -518,8 +519,6 @@ C---------------------------------------------------------
      .          + 6*NUMNOD*MIN(1,ANIM_V(12)+OUTP_V(12)+H3D_DATA%N_VECT_PCONT)  
      .          + 3*NUMNOD*MIN(1,ANIM_V(13)+H3D_DATA%N_VECT_CONT2)
      .          + 6*NUMNOD*MIN(1,ANIM_V(27)+H3D_DATA%N_VECT_PCONT2)  
-      SFANI_CELL = (NUMELS)*(ANIM_SE(10)+ANIM_SE(4960)+ANIM_SE(4961)) !ALE : 3D-Vorticity        
-      SFANI_CELL = SFANI_CELL+(NUMELS+NUMELQ)*3*(H3D_DATA%N_VECT_CONT) !ALE : FSI reaction force  /H3D/ELEM/VECT/CONT
 
       SXCUT = 7*NCUTS
       SANIN = NUMNOD*( 
@@ -533,6 +532,19 @@ C
 C     Work Array private to sph : WAPSH(LWASPH)
       SWASPH = LWASPH
 C
+      !/H3D/ELEM/VORT,X,Y,Z
+      FANI_CELL%IS_VORT_X_REQUESTED = .FALSE.
+      FANI_CELL%IS_VORT_Y_REQUESTED = .FALSE.
+      FANI_CELL%IS_VORT_Z_REQUESTED = .FALSE.
+      IF(ANIM_SE(10) == 1   .OR. H3D_DATA%SOL_SCAL_VORTX == 1)FANI_CELL%IS_VORT_X_REQUESTED=.TRUE.
+      IF(ANIM_SE(4960) == 1 .OR. H3D_DATA%SOL_SCAL_VORTY == 1)FANI_CELL%IS_VORT_Y_REQUESTED=.TRUE.
+      IF(ANIM_SE(4961) == 1 .OR. H3D_DATA%SOL_SCAL_VORTZ == 1)FANI_CELL%IS_VORT_Z_REQUESTED=.TRUE.
+
+      ! /H3D/ELEM/VECT/CONT
+      ! INTER18 REACTION FORCES ON CELL CENTROIDS
+      FANI_CELL%IS_F18_FVM_REQUESTED = .FALSE.
+      IF(H3D_DATA%N_VECT_CONT == 1)FANI_CELL%IS_F18_FVM_REQUESTED = .TRUE.
+
       M16STAK = 0
       IF(NUMELS16/=0)THEN
         NPE = 16

--- a/engine/source/output/sortie_main.F
+++ b/engine/source/output/sortie_main.F
@@ -125,7 +125,7 @@ Chd|====================================================================
      r            FNCONTP2  ,FTCONTP2    ,IBCL        ,ILOADP   ,LLOADP   ,
      s            LOADP     ,TAGNCONT    ,LOADP_HYD_INTER,FORC  ,DRAPEG,USER_WINDOWS,
      t            OUTPUT    ,DT          ,FSAVSURF    ,NSEG_LOADP,TABLE   ,
-     u            LOADS     )  
+     u            LOADS     ,SFANI)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -196,6 +196,7 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       LOGICAL LOUT
+      INTEGER, INTENT(IN) :: SFANI
       INTEGER IPARG(*), IXS(*), IXQ(*), IXC(*), IXT(*), IXP(*),
      .   IXS10(6,*) ,IXS16(8,*)  ,IXS20(12,*) ,INDX_CRK(*),
      .   IXR(*), IXTG(*), ITAB(*),ICUT(*),NSTRF(*),LPBY(*),
@@ -942,9 +943,9 @@ C----------------------
           TABFWR0(10) = TABFWR(10)
         ENDIF
         IF(NINTER+NEXMAD/=0.AND.ANIM_V(4)+OUTP_V(4)+H3D_DATA%N_VECT_CONT > 0)THEN
-            CALL ANICON0(CONT,NUMNOD)
+            IF(SFANI >0)CALL ANICON0(CONT,NUMNOD)
             !law151 reaction forces can be output only with H3D (not ANIM files since vectores are at element centroids)
-            IF (MULTI_FVM%IS_USED .AND. H3D_DATA%N_VECT_CONT > 0)CALL ANICON0(FANI_CELL,NUMELS+NUMELQ) !/H3D/ELEM/VECT/CONT
+            IF (MULTI_FVM%IS_USED .AND. H3D_DATA%N_VECT_CONT > 0)CALL ANICON0(FANI_CELL%F18,NUMELS+NUMELQ) !/H3D/ELEM/VECT/CONT
         ENDIF
         IF(NINTSTAMP/=0.AND.ANIM_V(4)+OUTP_V(4)+H3D_DATA%N_VECT_CONT >0)THEN
             CALL ANICON2(FCONTG,NCONT,INDEXCONT)     


### PR DESCRIPTION
####  /H3D/ELEM/VECT/CONT : data structure update & output fix for law151 & inter18

#### Description of the changes
- Data strucutre FANI_CELL is updated to simplify source code and improve readability. Developer now quickly understands when it is used/allocated, and how to use it.
- Potential memory corruption fixed when calling subroutine from anincon0.F (allocation is now checked before initializating the array)
- /H3D/ELEM/VECT/CONT is now working with /INTER18 + /MAT/LAW151 (reaction force at cell centroids can be post-treated)
- Bug fix in case of EULER (instead of ALE), re-sorting criteria (voxel) is now fixed for /INTER/TYPE18
