### PR TITLE
revert 2D table declaration lenghts in table2d_vinterp_log.F

### DIFF
--- a/engine/source/tools/curve/table2d_vinterp_log.F
+++ b/engine/source/tools/curve/table2d_vinterp_log.F
@@ -72,8 +72,8 @@ C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       TYPE(TTABLE)            :: TABLE
       INTEGER ,INTENT(IN)                 :: ISMOOTH,NEL
-      INTEGER ,DIMENSION(NEL,TABLE%NDIM)  :: IPOS
-      my_real ,DIMENSION(NEL,TABLE%NDIM)  :: XX
+      INTEGER ,DIMENSION(:,:)  :: IPOS
+      my_real ,DIMENSION(:,:)  :: XX
       my_real ,DIMENSION(NEL) :: YY, DYDX1, DYDX2
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

correct problem material law109  with logarythmic table interpolation

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

reverted 2D table declaration to previous form without explicit length to avoid misaligned access in law109

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
