### PR TITLE
/LOAD/PBLAST:remove implicit conversion

### DIFF
--- a/engine/source/loads/pblast/pblast_1.F
+++ b/engine/source/loads/pblast/pblast_1.F
@@ -277,7 +277,7 @@ C-----------------------------------------------
               write(ISTDO,FMT='(A,4I11)')
      .         "Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   cm/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
             endif
-            PBLAST_TAB(IL)%TAGMSG(I) = .TRUE.
+            PBLAST_TAB(IL)%TAGMSG(I) = 1
           ELSEIF(Z > 400. AND. PBLAST_TAB(IL)%TAGMSG(I) == 0)THEN
               if (N4 == 0)then
               write(IOUT,FMT='(A,3I11)')

--- a/engine/source/loads/pblast/pblast_2.F
+++ b/engine/source/loads/pblast/pblast_2.F
@@ -297,7 +297,7 @@ C-----------------------------------------------
                 write(*,FMT='(A,4I11)')
      .           "Warning : /LOAD/PBLAST, R/W**(1/3) < 0.5   cm/g**(1/3)    .Segment nodes : ",ITAB(N1),ITAB(N2),ITAB(N3),ITAB(N4)
               endif
-              PBLAST_TAB(IL)%TAGMSG(I) = .TRUE.
+              PBLAST_TAB(IL)%TAGMSG(I) = 1
             elseif(Z > 400. .AND. PBLAST_TAB(IL)%TAGMSG(I) == 0)then
               if (N4 == 0)then
                 write(IOUT,FMT='(A,3I11)')


### PR DESCRIPTION
#### /LOAD/PBLAST:remove implicit conversion

#### Description of the changes
An implicit conversion from LOGICAL to INTEGER is present in two source files. It is replaced by INTEGER instead of LOGICAL.
