### PR TITLE
Coupling methods : Fixes

### DIFF
--- a/common_source/tools/input_output/write_routtines.c
+++ b/common_source/tools/input_output/write_routtines.c
@@ -228,7 +228,7 @@ void open_c(int *ifil,int *len,int *mod)
      }else{                                    // Not zipped file
 
        #ifdef _WIN64
-          fopen_s(&curfile,filnam,"r");
+          curfile=fopen(filnam,"r");
        #else
           curfile=fopen(filnam,"r");
        #endif
@@ -253,7 +253,7 @@ void open_c(int *ifil,int *len,int *mod)
                                                                                        // Several buffers can be opened at same time.
      }
      #ifdef _WIN64
-        fopen_s(&curfile,filnam,"w");
+        curfile=fopen(filnam,"w");
      #else
         curfile=fopen(filnam,"w");
      #endif
@@ -261,7 +261,7 @@ void open_c(int *ifil,int *len,int *mod)
 
   if (*mod==2) {                           // Open Read/Write : uncompressed
      #ifdef _WIN64
-        fopen_s(&curfile,filnam,"r+");
+        curfile=fopen(filnam,"r+");
      #else
         curfile=fopen(filnam,"r+");
      #endif
@@ -269,7 +269,7 @@ void open_c(int *ifil,int *len,int *mod)
 
   if (*mod==8) {                           // Open Append mode - unzipped
      #ifdef _WIN64
-        fopen_s(&curfile,filnam,"a");
+        curfile=fopen(filnam,"a");
      #else
         curfile=fopen(filnam,"a");
      #endif

--- a/engine/source/coupling/rad2rad/rad2rad_c.c
+++ b/engine/source/coupling/rad2rad/rad2rad_c.c
@@ -2253,7 +2253,7 @@ int *sd;
   
 #ifdef _WIN64 
 
-
+    gethostname(PUF,512);
     hp = gethostbyname(PUF);
     
     memcpy ( &(server.sin_addr.s_addr), hp->h_addr,  hp->h_length);


### PR DESCRIPTION
 1/ Some coupling method use a file read by 2 processes. fopen_s does not permit this under Windows.

2/ rad2rad coupling : use of gethostbyname without initializing the hostname

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
