### PR TITLE
correct /fail/johnson rupture criterion for integrated beams

### DIFF
--- a/engine/source/elements/beam/main_beam18.F
+++ b/engine/source/elements/beam/main_beam18.F
@@ -113,10 +113,9 @@ C     STRAIN RATE
 C-------------------
       ISRATE = IPM(3,IMAT)                      
       ASRATE = MIN(ONE, PM(9,IMAT)*DTIME)
-c
+c     calculate total strain rate on neutral fiber position
       DO I = 1,NEL                                              
-        EPSDI  = HALF*(EXX(I)**2) + (HALF*EXY(I))**2 + (HALF*EXZ(I))**2
-        EPSDI  = AL(I)*SQRT(THREE*EPSDI)/THREE_HALF                         
+        EPSDI  = SQRT(EXX(I)**2 + HALF*(EXY(I)**2 + EXZ(I)**2))                       
         IF (ISRATE > 0) THEN                                    
           EPSD(I)= ASRATE*EPSDI + (ONE - ASRATE)*EPSD(I)
         ELSE       

--- a/engine/source/materials/fail/johnson_cook/fail_johnson.F
+++ b/engine/source/materials/fail/johnson_cook/fail_johnson.F
@@ -88,7 +88,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I,J,IDEL,IDEV,IFLAG,INDX(MVSIZ),IADBUF,NINDX,
+      INTEGER I,J,IDEL,IDEV,ISOLID,INDX(MVSIZ),IADBUF,NINDX,
      .        NINDEX,INDEX(MVSIZ),IR,IFAIL,JJ
       my_real 
      .        D1,D2,D3,D4,D5,
@@ -100,15 +100,15 @@ C--------------------------------------------------------------
       D4 = UPARAM(4)
       D5 = UPARAM(5)
       EPSP0 = UPARAM(6)
-      IFLAG = INT(UPARAM(8)) 
+      ISOLID = INT(UPARAM(8)) 
 
 C-----------------------------------------------
       IDEL=0
       IDEV=0
       SCALE = ZERO
-      IF(IFLAG==1)THEN
+      IF(ISOLID==1)THEN
         IDEL=1
-      ELSEIF(IFLAG==2)THEN
+      ELSEIF(ISOLID==2)THEN
        IDEV =1
       END IF
 C...
@@ -122,7 +122,7 @@ C
       IF(IDEL==1)THEN
        NINDX=0  
        DO I=1,NEL
-        IF(IFLAG==1.AND.OFF(I)==ONE)THEN
+        IF(ISOLID==1.AND.OFF(I)==ONE)THEN
          IF(DPLA(I)/=ZERO)THEN
            P = THIRD*(SIGNXX(I) + SIGNYY(I) + SIGNZZ(I))
            SXX = SIGNXX(I) - P
@@ -132,7 +132,7 @@ C
      .            +SIGNXY(I)**2 + SIGNZX(I)**2 + SIGNYZ(I)**2
            SVM=SQRT(THREE*SVM)
            EPSF = D3*P/MAX(EM20,SVM)
-           EPSF = (D1 + D2*EXP(EPSF))
+           EPSF = D1 + D2*EXP(EPSF)
            IF(D4/=ZERO) EPSF = EPSF * (ONE + D4*LOG(MAX(ONE,EPSP(I)/EPSP0))) ! if d4=0, epsp is not correctly defined
            IF(D5/=ZERO) EPSF = EPSF * (ONE + D5*TSTAR(I)) ! if d5=0, tsart is not correctly defined
            IF(EPSF>ZERO) DFMAX(I) = DFMAX(I) + DPLA(I)/EPSF
@@ -160,7 +160,7 @@ Cc deviatoric will be vanished
        NINDX=0 
        NINDEX = 0 
        DO I=1,NEL 
-        IF(IFLAG==2.AND.OFF(I)==ONE)THEN 
+        IF(ISOLID==2.AND.OFF(I)==ONE)THEN 
          IF(DFMAX(I)<ONE.AND.DPLA(I)/=ZERO)THEN
           P = THIRD*(SIGNXX(I) + SIGNYY(I) + SIGNZZ(I))
           SXX = SIGNXX(I) - P

--- a/engine/source/materials/fail/johnson_cook/fail_johnson_ib.F
+++ b/engine/source/materials/fail/johnson_cook/fail_johnson_ib.F
@@ -79,13 +79,14 @@ C=======================================================================
 c-----------------------------
       DO I=1,NEL
         IF (OFF(I) == ONE .and. FOFF(I) == 1 .and. DPLA(I) > ZERO) THEN
-          P    = THIRD*SIGNXX(I)
-          SVM  = SQRT(THREE*(HALF*SIGNXX(I)**2 + SIGNXY(I)**2 + SIGNZX(I)**2))
+          P   = THIRD*SIGNXX(I)
+          SVM = SIGNXX(I)**2 + THREE*(SIGNXY(I)**2 + SIGNZX(I)**2)
+          SVM = SQRT(SVM)
           EPSF = D3 * P / MAX(EM20, SVM)
           EPSF = D1 + D2 * EXP(EPSF)
           IF (D4 /= ZERO)  EPSF = EPSF * (ONE + D4*LOG(MAX(ONE,EPSD(I)/EPSD0)))
           IF (D5 /= ZERO)  EPSF = EPSF * (ONE + D5*TSTAR(I))                  
-          IF (EPSF > ZERO) DFMAX(I) = DFMAX(I) + DPLA(I) / EPSF  
+          IF (EPSF > ZERO) DFMAX(I) = DFMAX(I) + DPLA(I) / EPSF
           IF (DFMAX(I) >= ONE) THEN ! total damage in integration point
             NINDX = NINDX + 1
             INDX(NINDX) = I  


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

correct Johnson-Cook failure model for integrated beams. The results are identical to solid element reference 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

modified strain rate definition in beams to be the same as in solid elements

corrected wrong definition of SVM in Johnson-Cook failure model for beams

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
