### PR TITLE
add new Press-fit option Inacti=-2 of int24 with high stiffness

### DIFF
--- a/engine/source/interfaces/int24/i24cor3.F
+++ b/engine/source/interfaces/int24/i24cor3.F
@@ -995,6 +995,7 @@ C--- fixing min(stif) with Inacti=-1
           END IF
 c      STIF_R(I) = MIN(STIF_S,STF(L))/MAX(EM20,STIF(I))
           STIF(I) = MIN(STIF_S,STF(L))
+          IF(IGSTI==2) STIF(I) = HALF*(STIF_S+STF(L))
          ENDDO
       ELSEIF (IGSTI==-1)THEN
          DO I=1,JLT
@@ -1016,8 +1017,8 @@ c      STIF_R(I) = MIN(STIF_S,STF(L))/MAX(EM20,STIF(I))
          FB = MAX(ZERO,THREE*TNCY-TWO)
          F_PFIT = EM04*(FA+FAB)+FB
          STIF(1:JLT)=F_PFIT*STIF(1:JLT)
-         IF (FB >ZERO) IKNON(1:JLT) = 1 ! -> nonlinear stiff
-      ELSEIF (INACTI==-1)THEN
+         IF (FB >ZERO.AND.IGSTI/=2) IKNON(1:JLT) = 1 ! -> nonlinear stiff
+      ELSEIF (INACTI==-1.AND.IGSTI/=2)THEN
          IKNON(1:JLT) = 1 
       ELSEIF (IGSTI ==-1)THEN
          DO I=1,JLT

--- a/starter/source/interfaces/int24/hm_read_inter_type24.F
+++ b/starter/source/interfaces/int24/hm_read_inter_type24.F
@@ -456,8 +456,13 @@ C-------tempo: Isurf <- ILEV=IPARI(20) -----
 
 C------ consisting w/ manuel         
         IF (IREM24I2==0) IREM24I2 = 3
-
-        IF (INACTI==-1.AND.(IGSTI==0.OR.IGSTI==1000)) IGSTI = 4
+C--------auto stif w/ Press-fit
+        IF (INACTI==-1) THEN
+          IGSTI = 4
+        ELSEIF (INACTI==-2) THEN ! using high stif
+         IGSTI = 2
+         INACTI=-1
+        END IF
         IPARI(20)=ILEV
         IPARI(34)=IGSTI
         IPARI(47) = INTTH
@@ -811,6 +816,7 @@ C
 
 C........* PRINT INTERFACES INPUT *.....................
 
+       IF (INACTI==-1.AND.IGSTI==2) INACTI=-2 ! just for printing
        IDUM =IEDGE
        IF (IEDGE/=1000.AND.IEDGE>0)IDUM =MIN(1,IEDGE)
 


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Some issues observed of Press-fit simulation using interface type24 (Inacti=-1), in these cases, high stiffness should be used to get correct result.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Add new option of Preff-fit Inacti=-2 which uses high stiffness to get better result for some cases.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
