### PR TITLE
Auto set number of build threads for Apptainer images

### DIFF
--- a/Apptainer/arm/openradioss_arm.def
+++ b/Apptainer/arm/openradioss_arm.def
@@ -11,6 +11,7 @@ export CC=armclang
 export CXX=armclang++
 export Fortran_COMPILER=armflang
 export FC=armflang
+export NCPU=$(nproc)
 
 #echo "Checking if compiler is in PATH"
 #echo `which $CC`
@@ -29,10 +30,10 @@ cd /opt
 git lfs install
 git clone --depth 1 --branch main https://github.com/OpenRadioss/OpenRadioss.git
 cd /opt/OpenRadioss/starter
-./build_script.sh -arch=linuxa64 -nt=80 -static-link
+./build_script.sh -arch=linuxa64 -nt=$NCPU -static-link
 cd /opt/OpenRadioss/engine
-./build_script.sh -arch=linuxa64 -nt=80 -static-link
-./build_script.sh -arch=linuxa64 -mpi=ompi -nt=80 -static-link
+./build_script.sh -arch=linuxa64 -nt=$NCPU -static-link
+./build_script.sh -arch=linuxa64 -mpi=ompi -nt=$NCPU -static-link
 cd /opt/OpenRadioss/tools/anim_to_vtk/linux64
 ./build.bash
 cd /opt/OpenRadioss/tools/th_to_csv/linux64

--- a/Apptainer/openradioss.def
+++ b/Apptainer/openradioss.def
@@ -8,6 +8,8 @@ gcc gcc-gfortran gcc-c++ make cmake perl git-lfs \
 wget git patch diffutils libxcrypt-compat \
 which python
 
+export NCPU=$(nproc)
+
 cd /tmp
 wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.2.tar.gz
 tar xzvf openmpi-4.1.2.tar.gz
@@ -20,10 +22,10 @@ cd /opt
 git lfs install
 git clone --depth 1 --branch main https://github.com/OpenRadioss/OpenRadioss.git
 cd /opt/OpenRadioss/starter
-./build_script.sh -arch=linux64_gf
+./build_script.sh -arch=linux64_gf -nt=$NCPU
 cd /opt/OpenRadioss/engine
-./build_script.sh -arch=linux64_gf
-./build_script.sh -arch=linux64_gf -mpi=ompi
+./build_script.sh -arch=linux64_gf -nt=$NCPU
+./build_script.sh -arch=linux64_gf -mpi=ompi -nt=$NCPU
 cd /opt/OpenRadioss/tools/anim_to_vtk/linux64
 ./build.bash
 cd /opt/OpenRadioss/tools/th_to_csv/linux64

--- a/Apptainer/openradioss_intel.def
+++ b/Apptainer/openradioss_intel.def
@@ -27,16 +27,17 @@ export CPP=icpx
 export Fortran_COMPILER=ifx
 export MKLROOT=/opt/intel/oneapi/mkl/2022.1.0
 export I_MPI_ROOT=/opt/intel/oneapi/mpi/2021.6.0
+export NCPU=$(nproc)
 
 cd /opt
 git lfs install
 git clone https://github.com/OpenRadioss/OpenRadioss.git
 cd OpenRadioss
 cd /opt/OpenRadioss/starter
-./build_script.sh -arch=linux64_intel -nt=8
+./build_script.sh -arch=linux64_intel -nt=$NCPU
 cd /opt/OpenRadioss/engine
-./build_script.sh -arch=linux64_intel -nt=8
-./build_script.sh -arch=linux64_intel -mpi=impi -nt=8
+./build_script.sh -arch=linux64_intel -nt=$NCPU
+./build_script.sh -arch=linux64_intel -mpi=impi -nt=$NCPU
 cd /opt/OpenRadioss/tools/anim_to_vtk/linux64
 ./build.bash
 cd /opt/OpenRadioss/tools/th_to_csv/linux64


### PR DESCRIPTION
#### Description of the feature or the bug
Apptainer definition files have hardcoded values for number of build threads, varying from 1 to 80


#### Description of the changes
Definition files query number of cores on host system and save to new environment variable. Calls to build_script.sh now reference -nt=$NCPU 


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
