### PR TITLE
Fix EPSDOT output for H3D files

### DIFF
--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_quad_tensor_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_quad_tensor_datatype.cpp
@@ -96,6 +96,7 @@ void c_h3d_create_quad_tensor_datatype_(int *cpt_data, char *name1, int *size1, 
     ccomment[*s_comment]='\0';  
 
     if( strncmp(cname,"Strain",6)  == 0 ) tensor_type = H3D_DS_STRAIN; 
+    if( strncmp(cname,"Strn rate",9)  == 0 ) tensor_type = H3D_DS_STRAIN;
 
     char * LAYERPOOL = new char [100];
     LAYERPOOL[0] ='\0'; 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_shell_tensor_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_shell_tensor_datatype.cpp
@@ -116,7 +116,7 @@ void c_h3d_create_shell_tensor_datatype_(int *cpt_data, char *name1, int *size1,
 
     if( strncmp(cname,"Strain",6)  == 0 ) tensor_type = H3D_DS_STRAIN_2D;
     if( strncmp(cname,"Stress",6)  == 0 ) tensor_type = H3D_DS_STRESS_2D;
-
+    if( strncmp(cname,"Strn rate",9)  == 0 ) tensor_type = H3D_DS_STRAIN_2D;
 
     H3D_ID layer_pool_id = H3D_NULL_ID;
 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_skin_tensor_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_skin_tensor_datatype.cpp
@@ -113,6 +113,7 @@ void c_h3d_create_skin_tensor_datatype_(int *cpt_data, char *name1, int *size1, 
 /*    if( strncmp(cname,"Strain",6)  == 0 ) tensor_type = H3D_DS_STRAIN; */
     if( strncmp(cname,"Strain",6)  == 0 ) tensor_type = H3D_DS_STRAIN_2D;
     if( strncmp(cname,"Stress",6)  == 0 ) tensor_type = H3D_DS_STRESS_2D;
+    if( strncmp(cname,"Strn rate",9)  == 0 ) tensor_type = H3D_DS_STRAIN_2D;
 
     H3D_ID layer_pool_id = H3D_NULL_ID;
     if(*layer > 0 ||  *nuvar > 0 || *ir > 0 || *is > 0 || *it > 0 )

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_solid_tensor_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_solid_tensor_datatype.cpp
@@ -119,6 +119,7 @@ void c_h3d_create_solid_tensor_datatype_(int *cpt_data, char *name1, int *size1,
 
     if( strncmp(cname,"Strain",6)  == 0 ) tensor_type = H3D_DS_STRAIN;
     if( strncmp(cname,"Stress",6)  == 0 ) tensor_type = H3D_DS_STRESS;
+    if( strncmp(cname,"Strn rate",9)  == 0 ) tensor_type = H3D_DS_STRAIN;
     if( strncmp(cname,"CornerStrain",12)  == 0 ) tensor_type = H3D_DS_STRAIN;
     if( strncmp(cname,"CornerStress",12)  == 0 ) tensor_type = H3D_DS_STRESS;
 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_sph_tensor_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_sph_tensor_datatype.cpp
@@ -112,6 +112,7 @@ void c_h3d_create_sph_tensor_datatype_(int *cpt_data, char *name1, int *size1, i
     H3D_ID layer_pool_id = H3D_NULL_ID;
 
     if( strncmp(cname,"Strain",6)  == 0 ) tensor_type = H3D_DS_STRAIN;
+    if( strncmp(cname,"Strn rate",9)  == 0 ) tensor_type = H3D_DS_STRAIN;
 
     char edata_type[50];
 


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

EPSDOT output for H3D files was giving bad Von Mises equivalent values. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Fix EPSDOT output by setting the strain rate tensor type to H3D_DS_STRAIN

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
