### PR TITLE
Airbag Defaults for Type 8 Airbags:

### DIFF
--- a/starter/source/airbag/hm_read_monvol_type8.F
+++ b/starter/source/airbag/hm_read_monvol_type8.F
@@ -584,6 +584,8 @@ C     ==============
 
       IF(TSWITCH == ZERO) TSWITCH=EP20
       IF (KMESH == 0) KMESH=14
+      IF (KMESH == 2) KMESH=12  ! KMESH=2 is deprecated, set to 12.
+      IF (KMESH == 4) KMESH=14  ! KMESH=4 is deprecated, set to 14.
       IF (IBRIC /= 0) THEN      !IF IBRIC is not 0 and KMESH has been set to 2, KMESH is ignored
          KMESH = 1
       ENDIF

--- a/starter/source/airbag/init_monvol.F
+++ b/starter/source/airbag/init_monvol.F
@@ -38,9 +38,7 @@ Chd|        FVELSURF                      source/airbag/fvelsurf.F
 Chd|        FVINJECT                      source/airbag/fvinject.F      
 Chd|        FVNODI                        source/airbag/fvmbag1.F       
 Chd|        FVVENTHOLE                    source/airbag/fvventhole.F    
-Chd|        HYPERMESH_TETRA               stub/fvmbags_stub.F           
-Chd|        LOAD_MESHGEMS_LIBRARY         stub/fvmbags_stub.F           
-Chd|        MESHGEMS_TETRA                stub/fvmbags_stub.F           
+Chd|        HYPERMESH_TETRA               stub/fvmbags_stub.F                    
 Chd|        MONVOL_CHECK_DELETE_DUPLICATEDsource/airbag/monvol_check_delete_duplicated.F
 Chd|        MONVOL_TRIANGULATE_SURFACE    source/airbag/monvol_triangulate_surface.F
 Chd|        WRITEMESH                     source/airbag/writeMesh.F     
@@ -160,7 +158,7 @@ C
       CHARACTER*20 VENTTITLE
       INTEGER :: NB_TETRA, NB_VERTICES, NB_EXTRA_VERTICES
       INTEGER :: EXT_SURFID, INT_SURFID
-      LOGICAL :: FOUND, MGM_USED
+      LOGICAL :: FOUND
       INTEGER :: SIZE1, SIZE2,LENGTH
       INTEGER :: COMM_TAG(NVOLU), NCOMMU
       INTEGER, DIMENSION(:, :), ALLOCATABLE :: IBAGJET_SAVE
@@ -238,21 +236,6 @@ C     FVMABG2 are in fact FVMBAG1 with simplified input
          ENDIF
          IF (KMESH(N) >= 2) TETRAMESHER_USED = .TRUE.
       ENDDO
-      MGM_USED = .FALSE.
-      DO N = 1, NVOLU
-         IF (KMESH(N) == 2 .OR. KMESH(N) == 4) THEN
-            MGM_USED = .TRUE.
-         ENDIF
-      ENDDO
-C------------------------------------------
-C     If meshgems is to be used, then
-C     replace bufalei by bufalei_mgm
-C------------------------------------------
-      IF (MGM_USED) THEN
-C     MESHGEMS TETRAMESHER
-         RET_VAL=0
-         CALL LOAD_MESHGEMS_LIBRARY(RET_VAL)
-      ENDIF
 
       DO N=1,NVOLU
          ITYPE = T_MONVOL(N)%TYPE
@@ -362,10 +345,6 @@ C
             IF (KMESH(N) >= 2) THEN
 !     Automatic tetrameshing
                SELECT CASE (KMESH(N))
-               CASE (2, 4)
-!     Meshgems (2), Meshgems + writing of mesh as an include file (4)
-                  CALL MESHGEMS_TETRA(T_MONVOL(N), NIXS, N, KMESH(N),
-     .                 NB_EXTRA_VERTICES, NB_TETRA, NB_VERTICES)
                CASE (12, 14) 
 !     Hypermesh (12), Hypermesh + writing of mesh as an include file (14)
                   CALL HYPERMESH_TETRA(T_MONVOL(N), NIXS, N, KMESH(N),

--- a/starter/stub/fvmbags_stub.F
+++ b/starter/stub/fvmbags_stub.F
@@ -82,37 +82,6 @@ C-----------------------------------------------
         CALL ARRET(5)
       END SUBROUTINE
 Chd|====================================================================
-Chd|  MESHGEMS_TETRA                stub/fvmbags_stub.F           
-Chd|-- called by -----------
-Chd|        INIT_MONVOL                   source/airbag/init_monvol.F   
-Chd|-- calls ---------------
-Chd|        FVMBAG_MESHCONTROL_MOD        ../common_source/modules/airbag/fvmbag_meshcontrol_mod.F
-Chd|        MESSAGE_MOD                   share/message_module/message_mod.F
-Chd|        MONVOL_STRUCT_MOD             share/modules1/monvol_struct_mod.F
-Chd|====================================================================
-      SUBROUTINE MESHGEMS_TETRA(T_MONVOLN, NIXSL, N, KM, 
-     .     NB_EXTRA_VERTICES, NB_TETRA, NB_VERTICES)
-C-----------------------------------------------
-C     M o d u l e s
-C-----------------------------------------------
-      USE FVMBAG_MESHCONTROL_MOD
-      USE MESSAGE_MOD
-      USE MONVOL_STRUCT_MOD
-C-----------------------------------------------
-C     I m p l i c i t   T y p e s
-C-----------------------------------------------
-#include      "implicit_f.inc"
-C-----------------------------------------------
-C     D u m m y   A r g u m e n t s
-C-----------------------------------------------
-      INTEGER, INTENT(IN) :: NIXSL
-      INTEGER, INTENT(IN) :: N, KM
-      INTEGER, INTENT(INOUT) :: NB_EXTRA_VERTICES, NB_TETRA, NB_VERTICES
-      TYPE(MONVOL_STRUCT_), INTENT(INOUT) :: T_MONVOLN
-        WRITE(6,*) "FVMBAGS require a mesher"
-        STOP
-      END SUBROUTINE
-Chd|====================================================================
 Chd|  HYPERMESH_TETRA               stub/fvmbags_stub.F           
 Chd|-- called by -----------
 Chd|        INIT_MONVOL                   source/airbag/init_monvol.F   
@@ -140,18 +109,6 @@ C-----------------------------------------------
       INTEGER, INTENT(IN) :: N, KM
       INTEGER, INTENT(INOUT) :: NB_EXTRA_VERTICES, NB_TETRA, NB_VERTICES
       TYPE(MONVOL_STRUCT_), INTENT(IN) :: T_MONVOLN
-        WRITE(6,*) "FVMBAGS require a mesher"
-        STOP
-      END SUBROUTINE
-Chd|====================================================================
-Chd|  LOAD_MESHGEMS_LIBRARY         stub/fvmbags_stub.F           
-Chd|-- called by -----------
-Chd|        INIT_MONVOL                   source/airbag/init_monvol.F   
-Chd|-- calls ---------------
-Chd|====================================================================
-      SUBROUTINE LOAD_MESHGEMS_LIBRARY(N)
-        IMPLICIT NONE
-        INTEGER :: N
         WRITE(6,*) "FVMBAGS require a mesher"
         STOP
       END SUBROUTINE


### PR DESCRIPTION
Kmesh=2 & 4 are deprecated. 
Change to Resp. KMesh=12 or 14 Remove code related to KMESH=2 or 4.

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
