### PR TITLE
avoid strange density value for deleted solid element

### DIFF
--- a/engine/source/elements/solid/solide/srho3.F
+++ b/engine/source/elements/solid/solide/srho3.F
@@ -132,12 +132,14 @@ C--- due to /INIBRI/EREF
           ELSE
             IF (MTN /= 115) THEN 
               DO I=1,NEL
+                IF(OFFG(I)==ZERO.AND.VOLN(I)==ONE) VOLN(I)=VOLO(I)
                 DVOL(I) = VOLN(I)-(RHO0/RHON(I))*VOLO(I)
                 RHON(I) = RHO0*(VOLO(I)/VOLN(I))
                 EINT(I) = EINT(I)*VOLO(I)
               ENDDO
             ELSE
               DO I=1,NEL
+                IF(OFFG(I)==ZERO.AND.VOLN(I)==ONE) VOLN(I)=VOLO(I)
                 DVOL(I) = VOLN(I)-(RHON(I+NEL)/RHON(I))*VOLO(I)
                 RHON(I) = RHON(I+NEL)*(VOLO(I)/VOLN(I))
                 EINT(I) = EINT(I)*VOLO(I)
@@ -233,7 +235,7 @@ C------VOLDP doesn't change after switching to small strain,modifying VOL0DP to
           DVDP = DIVDE(I)*(VOLO(I)/VOLN(I))
           VOL0DP(I)=VOL0DP(I)-DVDP*VOLDP(I)
          ELSEIF(OFFG(I)==ZERO) THEN
-          VOLDP(I)=ONE
+          VOLDP(I)=VOLO(I)
          ELSE
           DVDP = VOLDP(I)-(RHO0/RHON_OLD(I))*VOL0DP(I)
           DVOL(I) = DVDP


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
might get strange value of density(output) of deleted solid element due to fixed value of volume.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
correction to avoid strange density value.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
