### PR TITLE
/MAT/LAW70 : add missing last input function point after tranformation to table

### DIFF
--- a/starter/source/materials/mat/mat070/law70_upd.F
+++ b/starter/source/materials/mat/mat070/law70_upd.F
@@ -139,6 +139,9 @@ c     check and enforce passing through (0,0)
           XI(IPT,I) = S1
           YI(IPT,I) = T1
         END DO
+        IPT = IPT + 1
+        XI(IPT,I) = S2
+        YI(IPT,I) = T2
         LEN(I) = IPT
       END DO
 c------------------------------------------------------      
@@ -213,6 +216,9 @@ c
             XI(IPT,I) = S1
             YI(IPT,I) = T1
           END DO
+          IPT = IPT + 1
+          XI(IPT,I) = S2
+          YI(IPT,I) = T2
           LEN(I) = IPT
         END DO
 c------------------------------------------------------      


### PR DESCRIPTION

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

possible small difference in results with law70 when input functions contain big number of abscissa points

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

the last function points of original tabulated input was missing after smoothing, it is added now

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
