### PR TITLE
Correct H3D damage output for quads

### DIFF
--- a/engine/source/output/h3d/h3d_results/h3d_quad_tensor.F
+++ b/engine/source/output/h3d/h3d_results/h3d_quad_tensor.F
@@ -339,13 +339,15 @@ c
      .                IR <= NPTR .AND. IS >= 0 .AND. IS <= NPTS) THEN 
 c
                 LBUF =>  ELBUF_TAB(NG)%BUFLY(1)%LBUF(IR,IS,1)        
-                DO I=1,NEL
-                  N = I + NFT                                                     
-                  EVAR(1,I) = EVAR(1,I)+LBUF%DGLO(JJ(1) + I)
-                  EVAR(2,I) = EVAR(2,I)+LBUF%DGLO(JJ(2) + I)
-                  EVAR(4,I) = EVAR(4,I)+LBUF%DGLO(JJ(4) + I)
-                  IS_WRITTEN_TENSOR(I) = 1
-                ENDDO                                                      
+                IF (ELBUF_TAB(NG)%BUFLY(1)%L_DGLO > 0) THEN
+                  DO I=1,NEL
+                    N = I + NFT                                                   
+                    EVAR(1,I) = EVAR(1,I)+LBUF%DGLO(JJ(1) + I)
+                    EVAR(2,I) = EVAR(2,I)+LBUF%DGLO(JJ(2) + I)
+                    EVAR(4,I) = EVAR(4,I)+LBUF%DGLO(JJ(4) + I)
+                    IS_WRITTEN_TENSOR(I) = 1
+                  ENDDO                                                    
+                ENDIF
 c
               ENDIF
 C-----------------------------------------------


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Avoid potential problem of H3D output in quads when requested damage variable is not calculated

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Added check of damage variable allocation before h3d output in quads

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
