### PR TITLE
/INTER/TYPE25 message print using MSTOP=2 in case of high velocities

### DIFF
--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -3517,16 +3517,12 @@ C
           DT2T = DT2TT
           NELTST = NELTSTT
           ITYPTST= ITYPTSTT
-          ENDIF
+        ENDIF
 #include "lockoff.inc"
 
 !$OMP END PARALLEL
         IF(INTER_ERRORS > 0) THEN
-          CALL SORTIE_ERROR(
-     1     V        ,NODGLOB    ,WEIGHT     ,ITAB       ,MS          ,
-     2     MS0      ,10         ,PARTSAV    ,IPART      ,PM          ,
-     3     IGEO     )
-           CALL ARRET(2)
+           MSTOP = 2
         ENDIF
 
 


### PR DESCRIPTION

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
use MSTOP=2 instead of SORTIE_ERROR to stop and exit the code when /INTER/TYPE25 is expected to hang due to high velocity of some nodes

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
