### PR TITLE
H3D/ELEM/VECT/ACC : quad and tria compatibility for collocated scheme

### DIFF
--- a/engine/source/output/h3d/h3d_results/h3d_quad_vector.F
+++ b/engine/source/output/h3d/h3d_results/h3d_quad_vector.F
@@ -216,8 +216,20 @@ C--------------------------------------------------
 C                OUTPUT TENSOR STORED IN GLOBAL SYSTEM TO BE TRANSFERRED IN THE ELEMENT LOCAL ONE
                  CALL QROTA_VECT(X,IXQ(1,NFT+1),JCVT,EVAR,GBUF%GAMA,NEL)
                ENDIF
-c 
+C--------------------------------------------------
+            ELSEIF (KEYWORD == 'VECT/ACC') THEN
+C--------------------------------------------------
+               IF (MLW == 151 .AND. ALLOCATED(MULTI_FVM%ACC)) THEN
+                  DO I = 1, NEL
+                     EVAR(1,I) = MULTI_FVM%ACC(1, I + NFT)
+                     EVAR(2,I) = MULTI_FVM%ACC(2, I + NFT)
+                     EVAR(3,I) = MULTI_FVM%ACC(3, I + NFT)
+                     IS_WRITTEN_VECTOR(I) = 1
+                  ENDDO
+               ENDIF
+C--------------------------------------------------
             ENDIF  ! KEYWORD
+
           ENDIF  ! ITY 
 C-----------------------------------------------
           CALL H3D_WRITE_VECTORS(IOK_PART,IS_WRITTEN_QUAD,QUAD_VECTOR,NEL,0,NFT,

--- a/engine/source/output/h3d/h3d_results/h3d_shell_vector_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_shell_vector_1.F
@@ -195,14 +195,24 @@ C--------------------------------------------------
                         VALUE(1) = GBUF%MOM(JJ(1) + I) / GBUF%RHO(I) 
                         VALUE(2) = GBUF%MOM(JJ(2) + I) / GBUF%RHO(I)
                         VALUE(3) = GBUF%MOM(JJ(3) + I) / GBUF%RHO(I)
-                        CALL H3D_WRITE_VECTOR(IOK_PART,IS_WRITTEN_SHELL,SHELL_VECTOR,I,OFFSET,NFT,
-     .                       VALUE)
+                        CALL H3D_WRITE_VECTOR(IOK_PART,IS_WRITTEN_SHELL,SHELL_VECTOR,I,OFFSET,NFT,VALUE)
                      ENDIF
                   ENDDO
                ENDIF
-c 
+C--------------------------------------------------
+            ELSEIF (KEYWORD == 'VECT/ACC') THEN
+C--------------------------------------------------
+               IF (MLW == 151 .AND. ALLOCATED(MULTI_FVM%ACC)) THEN
+                  DO I = 1, NEL
+                     VALUE(1) = MULTI_FVM%ACC(1, I + NFT)
+                     VALUE(2) = MULTI_FVM%ACC(2, I + NFT)
+                     VALUE(3) = MULTI_FVM%ACC(3, I + NFT)
+                     CALL H3D_WRITE_VECTOR(IOK_PART,IS_WRITTEN_SHELL,SHELL_VECTOR,I,OFFSET,NFT,VALUE)
+                  ENDDO
+               ENDIF
+C--------------------------------------------------
             ENDIF  ! KEYWORD
-          ENDIF  ! ITY 
+         ENDIF  ! ITY
 c
 C-----------------------------------------------
        ENDIF     ! MLW /= 13  

--- a/engine/source/output/h3d/input_list/h3d_list_quad_vector.F
+++ b/engine/source/output/h3d/input_list/h3d_list_quad_vector.F
@@ -62,5 +62,10 @@ c-----------------------------------------------
       H3D_KEYWORD_QUAD_VECTOR(I)%TEXT1  = 'Element Velocity'
       H3D_KEYWORD_QUAD_VECTOR(I)%COMMENT  = 'Element velocity for FVM solver'
 c-----------------------------------------------
+      I = I + 1
+      H3D_KEYWORD_QUAD_VECTOR(I)%KEY3  = 'VECT/ACC'
+      H3D_KEYWORD_QUAD_VECTOR(I)%TEXT1  = 'Element Acceleration'
+      H3D_KEYWORD_QUAD_VECTOR(I)%COMMENT  = 'Element acceleration for FVM solver'
+c-----------------------------------------------
       NKEY=I
       END

--- a/engine/source/output/h3d/input_list/h3d_list_shell_vector.F
+++ b/engine/source/output/h3d/input_list/h3d_list_shell_vector.F
@@ -94,7 +94,10 @@ c-----------------------------------------------
       H3D_KEYWORD_SHELL_VECTOR(I)%TEXT1  = 'Pressure vector'
       H3D_KEYWORD_SHELL_VECTOR(I)%COMMENT  = 'External pressure vector on the Skin of shell'
 c-----------------------------------------------
-
+      I = I + 1
+      H3D_KEYWORD_SHELL_VECTOR(I)%KEY3  = 'VECT/ACC'
+      H3D_KEYWORD_SHELL_VECTOR(I)%TEXT1  = 'Element Acceleration'
+      H3D_KEYWORD_SHELL_VECTOR(I)%COMMENT  = 'Element acceleration for FVM solver'
 
 
 c-----------------------------------------------


### PR DESCRIPTION
#### H3D/ELEM/VECT/ACC : quad and tria compatibility for collocated scheme

#### Description of the changes
This output contour is now also working for following 2D solids : /QUAD & /TRIA
(Collocated scheme is enabled with /MAT/LAW151)