### PR TITLE
Correct sensor reference in material law 58

### DIFF
--- a/starter/source/materials/mat/mat058/law58_upd.F
+++ b/starter/source/materials/mat/mat058/law58_upd.F
@@ -85,13 +85,14 @@ C----------------------------
         DO I=1,SENSORS%NSENSOR
           IF (SENS_ID == SENSORS%SENSOR_TAB(I)%SENS_ID) THEN
             ISENS = I
-            UPARAM(25) = ISENS
             EXIT
           END IF
         ENDDO
-        IF (ISENS == 0)  
-     .    CALL ANCMSG(MSGID=1240,ANMODE=ANINFO,MSGTYPE=MSGWARNING,
+        IF (ISENS == 0) THEN 
+          CALL ANCMSG(MSGID=1240,ANMODE=ANINFO,MSGTYPE=MSGWARNING,
      .          I1=MAT_ID,C1=TITR,I2=ISENS) 
+        END IF
+        UPARAM(25) = ISENS
       ENDIF
 c---------------------------------------------------------------
       KC   = ZERO


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Avoid potential problem when material law58 definition contains non existing sensor 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Sensor number was not set to 0 in material parameter table when sensor is defined in material cards but does not exist 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
