### PR TITLE
Build on CentOs 8 + upgrade actions download/upload/checkout to version 4 to be compatible with node.js 20

### DIFF
--- a/.github/workflows/developer_ci.yml
+++ b/.github/workflows/developer_ci.yml
@@ -25,7 +25,7 @@ jobs:
     # DEV ONLY # runs-on: ["build","dev_devci"]
     runs-on: ["build","developer_ci"]
     container: 
-      image: fr-qafactorydev.europe.altair.com/build-linux64_gf:ompi411-devts11
+      image: fr-qafactorydev.europe.altair.com/build-linux64_gf:cos8-ompi411-devts11
       credentials: 
         username: ${{secrets.DOCKER_REGISTRY_USER}}
         password: ${{secrets.DOCKER_REGISTRY_PASSWD}}
@@ -80,7 +80,7 @@ jobs:
           md5sum exec/* || echo "Nothing in exec/" 
 
       # Get last git modifications, WS is not persistent here
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: 'true'
           ref: refs/pull/${{ github.event.number }}/merge
@@ -116,11 +116,11 @@ jobs:
           cd ..
           md5sum exec/* || exit 1
 
-      # Upload artifact 
+      # Upload artifact (since V4 we can't upload artifact using the same name, each one must be unique) 
       - name: Upload built artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: bins-${{ matrix.os }}-${{ matrix.precision }}
+          name: bins-${{ matrix.os }}-${{ matrix.precision }}-${{ matrix.build }}
           path: exec
 
   qa:
@@ -128,7 +128,7 @@ jobs:
     # DEV ONLY # runs-on: ["qa_${{ matrix.os }}","dev"]
     runs-on: ["qa_${{ matrix.os }}","developer_ci"]
     container: 
-      image: fr-qafactorydev.europe.altair.com/qa-linux64_gf:ompi411
+      image: fr-qafactorydev.europe.altair.com/qa-linux64_gf:cos8-ompi411
       credentials: 
         username: ${{secrets.DOCKER_REGISTRY_USER}}
         password: ${{secrets.DOCKER_REGISTRY_PASSWD}}
@@ -155,7 +155,7 @@ jobs:
     steps:
 
       # Get git related to the commit
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: 'true'
           ref: refs/pull/${{ github.event.number }}/merge
@@ -164,11 +164,26 @@ jobs:
         run: |
           rm -rf exec
 
-      # Download artifacts
-      - uses: actions/download-artifact@v3
+      # Download artifacts (since V4 we must download all needed artifacts, we could do it using wildcard but it doesn't work ... see https://github.com/actions/download-artifact/issues/337)
+      # Using hard name waiting for this issue to be fixed
+      # - name: Download artifacts
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: bins-${{ matrix.os }}-${{ matrix.precision }}-*
+      #     path: exec
+      #     merge-multiple: true
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
         with:
-          name: bins-${{ matrix.os }}-${{ matrix.precision }}
+          name: bins-${{ matrix.os }}-${{ matrix.precision }}-starter_linux64_gf
           path: exec
+          merge-multiple: true
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: bins-${{ matrix.os }}-${{ matrix.precision }}-engine_linux64_gf_ompi
+          path: exec
+          merge-multiple: true
 
       - name: Running qa
         run: |

--- a/.github/workflows/prmerge_ci_main.yml
+++ b/.github/workflows/prmerge_ci_main.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ["linux64","prmerge_ci"]
     continue-on-error: true
     container: 
-      image: fr-qafactorydev.europe.altair.com/build-linux64_gf:ompi411-devts11
+      image: fr-qafactorydev.europe.altair.com/build-linux64_gf:cos8-ompi411-devts11
       credentials: 
         username: ${{secrets.DOCKER_REGISTRY_USER}}
         password: ${{secrets.DOCKER_REGISTRY_PASSWD}}
@@ -58,7 +58,7 @@ jobs:
 
       # Get last git modifications, don't clean before (way to keep persistent obj files)
       - name: Checkout git sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ${{ env.WORKDIR }}
           clean: 'false'
@@ -120,7 +120,7 @@ jobs:
 
       # Upload artifact
       - name: Upload built artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tools-${{ env.os }}
           path: ${{ env.WORKDIR }}/exec
@@ -167,7 +167,7 @@ jobs:
 
       # Get last git modifications, don't clean before (way to keep persistent obj files)
       - name: Checkout git sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ${{ env.WORKDIR }}
           clean: 'false'
@@ -219,7 +219,7 @@ jobs:
 
       # Upload artifact
       - name: Upload built artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tools-${{ env.os }}
           path: ${{ env.WORKDIR }}/exec
@@ -229,7 +229,7 @@ jobs:
     # DEV ONLY # runs-on: ["${{ matrix.build }}","dev_pmci"]
     runs-on: ["${{ matrix.build }}","prmerge_ci"]
     container: 
-      image: fr-qafactorydev.europe.altair.com/build-linux64_gf:ompi411-devts11
+      image: fr-qafactorydev.europe.altair.com/build-linux64_gf:cos8-ompi411-devts11
       credentials: 
         username: ${{secrets.DOCKER_REGISTRY_USER}}
         password: ${{secrets.DOCKER_REGISTRY_PASSWD}}
@@ -302,7 +302,7 @@ jobs:
 
       # Get last git modifications, don't clean before (way to keep persistent obj files)
       - name: Checkout git sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ${{ env.WORKDIR }}
           clean: 'false'
@@ -373,11 +373,11 @@ jobs:
             echo -e "Status\t[ \033[32;2;1mOK\033[0m ]"
           fi
 
-      # Upload artifact
+      # Upload artifact (since V4 we can't upload artifact using the same name, each one must be unique)
       - name: Upload built artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: bins-${{ matrix.os }}-${{ matrix.precision }}
+          name: bins-${{ matrix.os }}-${{ matrix.precision }}-${{ matrix.build }}
           path: ${{ env.WORKDIR }}/exec
         if: ${{ env.CLOSE_BRANCH == 0 }} 
 
@@ -421,7 +421,7 @@ jobs:
     # DEV ONLY # runs-on: ["qa_${{ matrix.os }}","dev"]
     runs-on: ["qa_${{ matrix.os }}","prmerge_ci"]
     container: 
-      image: fr-qafactorydev.europe.altair.com/qa-linux64_gf:ompi411
+      image: fr-qafactorydev.europe.altair.com/qa-linux64_gf:cos8-ompi411
       credentials: 
         username: ${{secrets.DOCKER_REGISTRY_USER}}
         password: ${{secrets.DOCKER_REGISTRY_PASSWD}}
@@ -451,7 +451,7 @@ jobs:
 
       # Get git related to the commit
       - name: Checkout git sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: 'true'
 
@@ -459,11 +459,28 @@ jobs:
         run: |
           rm -rf exec
 
-      # Download artifacts
-      - uses: actions/download-artifact@v3
+      # Download artifacts (since V4 we must download all needed artifacts, we could do it using wildcard but it doesn't work ... see https://github.com/actions/download-artifact/issues/337)
+      # Using hard name waiting for this issue to be fixed
+      # - name: Download artifacts
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: bins-${{ matrix.os }}-${{ matrix.precision }}-*
+      #     path: exec
+      #     merge-multiple: true
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
         with:
-          name: bins-${{ matrix.os }}-${{ matrix.precision }}
+          # name: "bins-${{ matrix.os }}-${{ matrix.precision }}-*"
+          name: bins-${{ matrix.os }}-${{ matrix.precision }}-starter_linux64_gf
           path: exec
+          merge-multiple: true
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # name: "bins-${{ matrix.os }}-${{ matrix.precision }}-*"
+          name: bins-${{ matrix.os }}-${{ matrix.precision }}-engine_linux64_gf_ompi
+          path: exec
+          merge-multiple: true
 
       - name: Running qa
         run: |
@@ -654,7 +671,7 @@ jobs:
           
       # Get last git modifications, don't clean before (way to keep persistent obj files)
       - name: Checkout git sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ${{ env.WORKDIR }}
           clean: 'false'
@@ -706,11 +723,12 @@ jobs:
           echo -e \"Status\t[ \033[32;2;1mOK\033[0m ]\";
           fi;   
           "
-      # Upload artifact
+
+      # Upload artifact (since V4 we can't upload artifact using the same name, each one must be unique)
       - name: Upload built artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: bins-${{ matrix.os }}-${{ matrix.precision }}
+          name: bins-${{ matrix.os }}-${{ matrix.precision }}-${{ matrix.build }}
           path: ${{ env.WORKDIR }}/exec
         if: ${{ env.CLOSE_BRANCH == 0 }}           
 
@@ -771,13 +789,13 @@ jobs:
 
       # Get git related to the commit
       - name: Checkout git sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: 'true'
 
       # Get OpenRadioss extras from dedicated repository
       - name: Checkout git EXTRA sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: 'true'
           clean: 'false'
@@ -793,11 +811,28 @@ jobs:
           rm -rf exec;
           "
 
-      # Download artifacts
-      - uses: actions/download-artifact@v3
+      # Download artifacts (since V4 we must download all needed artifacts, we could do it using wildcard but it doesn't work ... see https://github.com/actions/download-artifact/issues/337)
+      # Using hard name waiting for this issue to be fixed
+      # - name: Download artifacts
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: bins-${{ matrix.os }}-${{ matrix.precision }}-*
+      #     path: exec
+      #     merge-multiple: true
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
         with:
-          name: bins-${{ matrix.os }}-${{ matrix.precision }}
+          # name: "bins-${{ matrix.os }}-${{ matrix.precision }}-*"
+          name: bins-${{ matrix.os }}-${{ matrix.precision }}-starter_win64
           path: exec
+          merge-multiple: true
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # name: "bins-${{ matrix.os }}-${{ matrix.precision }}-*"
+          name: bins-${{ matrix.os }}-${{ matrix.precision }}-engine_win64_impi
+          path: exec
+          merge-multiple: true
 
       - name: Running qa
         # Running cygwin from powershell or cmd => neither identation nor comment !
@@ -927,14 +962,14 @@ jobs:
 
       # Get last git modifications, don't clean before (way to go faster)
       - name: Checkout git sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           clean: 'false'
           lfs: 'true'
 
       # Get OpenRadioss extras from dedicated repository
       - name: Checkout git EXTRA sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: 'true'
           clean: 'false'
@@ -943,7 +978,8 @@ jobs:
           token: '${{ secrets.EXTRA_REPOSITORY_PAT }}'
 
       # Download ALL artifacts
-      - uses: actions/download-artifact@v3
+      - name: Download ALL artifacts for packaging
+        uses: actions/download-artifact@v4
         with:
           path: exec_tmp
 

--- a/.github/workflows/upd_headers_ci.yml
+++ b/.github/workflows/upd_headers_ci.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
 
       # Get last git modifications, WS is not persistent here
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: 'true'
           # Use a PAT else the push won't trigger the next workflow


### PR DESCRIPTION
#### Description of the feature or the bug
Upgrade some github actions to last version to be compatible with node.js 20 (node.js 16 will be deprecated in June 2024)


#### Description of the changes
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Node 16 has reached its [end of life](https://github.com/nodejs/Release/#end-of-life-releases), prompting us to initiate its deprecation process for GitHub Actions. Our plan is to transition all actions to run on Node 20 by Spring 2024. We will actively monitor the migration's progress and gather community feedback before finalizing the transition date. Starting October 23rd, workflows containing actions running on Node 16 will display a warning to alert users about the upcoming migration.
