### PR TITLE
bug fixing to avoid infinite loop of int11+Iremgap

### DIFF
--- a/starter/source/interfaces/inter3d1/i11remlin.F
+++ b/starter/source/interfaces/inter3d1/i11remlin.F
@@ -329,6 +329,8 @@ C
 CC END DO NRTM
         DEALLOCATE(DIST1,TAGNOD,ORIGIN)
 C
+      ELSE
+        I_START = NRTM  ! avoid infinite loop later
       ENDIF
 C
       RETURN


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Starter might hang up due to infinite loop when interface type11 defined Iremgap w/ asymmetry edges

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
correction to avoid infinite loop.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
