### PR TITLE
Correct deviatoric stress calculation in law109 (eos compatibility)

### DIFF
--- a/engine/source/materials/mat/mat109/sigeps109.F
+++ b/engine/source/materials/mat/mat109/sigeps109.F
@@ -321,9 +321,16 @@ c
          ENDDO              
 c            
         END DO   !  ITER = 1,NITER
-!
+c        
         DO II = 1, NINDX 
           I = INDEX(II)
+          SIGNXX(I) = SXX(I) + SIGM(I)
+          SIGNYY(I) = SYY(I) + SIGM(I)
+          SIGNZZ(I) = SZZ(I) + SIGM(I)
+          SIGNXY(I) = SXY(I)
+          SIGNYZ(I) = SYZ(I)
+          SIGNZX(I) = SZX(I)
+c
           PLA(I) = PLA(I) + MAX(DPLA(I), ZERO)
           ET(I)  = HARDP(I) / (HARDP(I) + YOUNG)
         ENDDO                      
@@ -335,27 +342,18 @@ c
             TEMP(I) = TEMP(I) + FTHERM(I)*YLD(I)*DPLA(I)
           ENDDO                      
         ENDIF
-c            
+c
       END IF     !  NINDX > 0  (plasticity)
-!
-      ! update total stress tensor       
-      IF (IEOS == 0) THEN 
+!-----------------------------------------------------------------------------
+      ! if EOS is used, material law calculates only deviatoric stress tensor
+      IF (IEOS > 0) THEN
         DO I = 1, NEL
-          SIGNXX(I) = SXX(I) + SIGM(I)
-          SIGNYY(I) = SYY(I) + SIGM(I)
-          SIGNZZ(I) = SZZ(I) + SIGM(I)
-          SIGNXY(I) = SXY(I)
-          SIGNYZ(I) = SYZ(I)
-          SIGNZX(I) = SZX(I)
-        ENDDO
-      ELSE      ! EOS is used => law calculates deviatoric stress only
-        DO I = 1, NEL
-          SIGNXX(I) = SXX(I)
-          SIGNYY(I) = SYY(I)
-          SIGNZZ(I) = SZZ(I)
-          SIGNXY(I) = SXY(I)
-          SIGNYZ(I) = SYZ(I)
-          SIGNZX(I) = SZX(I)
+          SIGNXX(I) = SIGNXX(I) - SIGM(I)
+          SIGNYY(I) = SIGNYY(I) - SIGM(I)
+          SIGNZZ(I) = SIGNZZ(I) - SIGM(I)
+          SIGNXY(I) = SIGNXY(I)
+          SIGNYZ(I) = SIGNYZ(I)
+          SIGNZX(I) = SIGNZX(I)
         ENDDO
       END IF                
 c


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

material law109 was broken  by previous modification for eos comaptibility

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

calculation of deviatoric stress as output of material law 109 was corrected

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
