### PR TITLE
Add last interpolation position for strain rate in law70 table interpolation

### DIFF
--- a/engine/source/materials/mat/mat070/sigeps70.F
+++ b/engine/source/materials/mat/mat070/sigeps70.F
@@ -230,7 +230,7 @@ c=======================================================================
 #include "vectorize.inc"
         DO I=1,NEL
           IPOS(I,1) = VARTMP(I,2)
-          IPOS(I,2) = 1
+          IPOS(I,2) = VARTMP(I,5)
           XVEC(I,1) = MIN(EPST(I), EPSSMAX)
           XVEC(I,2) = EPSP(I)
 c          XVEC(I,2) = MIN(EPSP(I), EPSPMAX)
@@ -242,6 +242,7 @@ c
       ELSE IF (NLOAD == 1) THEN  ! static only
 c
         IPOS(:,1) = VARTMP(:,2)
+        IPOS(:,2) = VARTMP(:,5)
         DO I=1,NEL
           XVEC(I,1)  = MIN(EPST(I), EPSSMAX)
         ENDDO
@@ -271,7 +272,7 @@ c=======================================================================
 #include "vectorize.inc"
           DO I=1,NEL
             IPOS(I,1) = VARTMP(I,3)
-            IPOS(I,2) = 1
+            IPOS(I,2) = VARTMP(I,6)
             XVEC(I,1) = MIN(EPST(I), EPSSMAX)
             XVEC(I,2) = EPSP(I) ! MAX(MIN(EPSP(I), EPSPMAX), EPSP0)
           ENDDO
@@ -280,6 +281,7 @@ c
 c
         ELSE IF (NUNLOAD == 1) THEN
           IPOS(:,1) = VARTMP(:,3)
+          IPOS(:,2) = VARTMP(:,6)
           DO I=1,NEL
             XVEC(I,1) = EPST(I) !  MAX(MIN(EPST(I), EPSSMAX),EPSP0) 
           ENDDO


### PR DESCRIPTION


#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

fix the performance problem of law70 using multi-dimansional function tables

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

store and retrieve last interpolation position of strain rate before valling interpolation routines

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
