### PR TITLE
initialize minimal pressure as -inf for law109 and 44 in case of utilization with EOS

### DIFF
--- a/starter/source/materials/mat/hm_read_mat.F
+++ b/starter/source/materials/mat/hm_read_mat.F
@@ -1028,6 +1028,7 @@ c-------
      .           LSUBMODEL ) 
                  PM(1 ,I) = RHO               
                  PM(89,I) = RHO               
+                 PM(37,I) = -EP20               
 c-------     
           CASE ('LAW110','VEGTER')
             ILAW = 110

--- a/starter/source/materials/mat/mat044/hm_read_mat44.F
+++ b/starter/source/materials/mat/mat044/hm_read_mat44.F
@@ -262,6 +262,7 @@ c-----------------
       PM(89) = RHO0
       PM(27) = SQRT(A1/RHO0)  ! sound speed estimation
       PM(100)= BULK      
+      PM(37) = -EP20          ! PMIN in case of EOS           
 c-----------------
 c     Element buffer variable allocation
 c-----------------


### PR DESCRIPTION

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

It permits to avoid a pressure cut-off at zero in tension when /EOS is used with these laws
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Initialize a material parameter Pmin = -inf in starter. It is used in some EOS and usually initialized in hydrodynamic matarial laws but not in  standard materials for solids

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
