### PR TITLE
Correct /SENSOR/RESET output in engine, avoid multiple prints in spmd

### DIFF
--- a/engine/source/tools/sensor/sensor_init.F
+++ b/engine/source/tools/sensor/sensor_init.F
@@ -410,9 +410,7 @@ c----------------------------------------------------------------------
             SENSORS%SENSOR_TAB(I)%TCRIT  = 1.E20
             SENSORS%SENSOR_TAB(I)%VALUE  = ZERO     
             SENSORS%SENSOR_TAB(I)%VAR(:) = ZERO
-#include "lockon.inc"
-             WRITE (IOUT,100) SENSORS%SENSOR_TAB(I)%SENS_ID
-#include "lockoff.inc"
+            IF (ISPMD == 0) WRITE (IOUT,100) SENSORS%SENSOR_TAB(I)%SENS_ID
           ENDDO
         ELSE IF (SENSORS%NRESET > 0) THEN
           DO J=1,SENSORS%NRESET
@@ -423,9 +421,7 @@ c----------------------------------------------------------------------
                 SENSORS%SENSOR_TAB(I)%TCRIT  = 1.E20
                 SENSORS%SENSOR_TAB(I)%VALUE  = ZERO     
                 SENSORS%SENSOR_TAB(I)%VAR(:) = ZERO
-#include "lockon.inc"
-             WRITE (IOUT,100) SENSORS%SENSOR_TAB(I)%SENS_ID
-#include "lockoff.inc"
+                IF (ISPMD == 0) WRITE (IOUT,100) SENSORS%SENSOR_TAB(I)%SENS_ID
                 EXIT
               END IF
             ENDDO


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

information about sensor reset was printed multiple times in engine output, by each proc
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

restricted engine output to proc 0

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
