### PR TITLE
CMake dependancies issues : 

### DIFF
--- a/engine/source/output/anim/generate/anim_nodal_vector_fvmbags.F
+++ b/engine/source/output/anim/generate/anim_nodal_vector_fvmbags.F
@@ -42,7 +42,7 @@ C     none
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
-      USEGROUPDEF_MOD , only:GROUP_
+      USE GROUPDEF_MOD , only:GROUP_
       USE FVBAG_MOD , only:FVBAG_DATA !data structure definition
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s


### PR DESCRIPTION
Keyword USE and Modulename are attached. Dependency to GROUPDEF_MOD is missed

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
