### PR TITLE
Add lower value for plastic strain at failure for /FAIL/JOHNSON

### DIFF
--- a/engine/source/materials/fail/johnson_cook/fail_johnson.F
+++ b/engine/source/materials/fail/johnson_cook/fail_johnson.F
@@ -77,7 +77,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,J,JJ,IDEL,IDEV,IFLAG,NINDX,IR,IFAIL,ISOLID
       INTEGER ,DIMENSION(NEL) :: INDX
-      my_real :: D1,D2,D3,D4,D5,EPSP0,P,EPSF,SVM,SCALE,SXX,SYY,SZZ
+      my_real :: D1,D2,D3,D4,D5,EPSP0,P,EPSF,SVM,SCALE,SXX,SYY,SZZ,EPSF_MIN
 C--------------------------------------------------------------
       D1 = UPARAM(1)
       D2 = UPARAM(2)
@@ -86,6 +86,7 @@ C--------------------------------------------------------------
       D5 = UPARAM(5)
       EPSP0 = UPARAM(6)
       ISOLID = INT(UPARAM(8)) 
+      EPSF_MIN = UPARAM(12)
 
 C-----------------------------------------------
       IDEL=0
@@ -120,6 +121,7 @@ C
            EPSF = D1 + D2*EXP(EPSF)
            IF(D4/=ZERO) EPSF = EPSF * (ONE + D4*LOG(MAX(ONE,EPSP(I)/EPSP0))) ! if d4=0, epsp is not correctly defined
            IF(D5/=ZERO) EPSF = EPSF * (ONE + D5*TSTAR(I)) ! if d5=0, tsart is not correctly defined
+           EPSF = MAX(EPSF,EPSF_MIN)
            IF(EPSF>ZERO) DFMAX(I) = DFMAX(I) + DPLA(I)/EPSF
          ENDIF
          IF(DFMAX(I)>=ONE.AND.OFF(I)==ONE) THEN
@@ -158,6 +160,7 @@ Cc deviatoric will be vanished
      .           D2*EXP(EPSF))*(ONE 
      .                  + D4*LOG(MAX(ONE,EPSP(I)/EPSP0)))
      .                    *(ONE + D5*TSTAR(I))
+          EPSF = MAX(EPSF,EPSF_MIN)
           IF(EPSF>ZERO) DFMAX(I) = DFMAX(I) + DPLA(I)/EPSF
           IF(DFMAX(I)>=ONE.AND.OFF(I)==ONE) THEN
            NINDX=NINDX+1

--- a/engine/source/materials/fail/johnson_cook/fail_johnson_b.F
+++ b/engine/source/materials/fail/johnson_cook/fail_johnson_b.F
@@ -64,7 +64,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER :: I,J,NINDX
       INTEGER ,DIMENSION(NEL) :: INDX
-      my_real :: D1,D2,D3,D4,D5,EPSD0,EPSF
+      my_real :: D1,D2,D3,D4,D5,EPSD0,EPSF,EPSF_MIN
 C=======================================================================
       NINDX = 0  
       D1    = UPARAM(1)
@@ -73,13 +73,15 @@ C=======================================================================
       D4    = UPARAM(4)
       D5    = UPARAM(5)
       EPSD0 = UPARAM(6)
+      EPSF_MIN = UPARAM(12)
 c-----------------------------
       DO I=1,NEL
         IF (OFF(I) == ONE .and. DPLA(I) > ZERO) THEN
           EPSF = D3 * PRESSURE(I) / MAX(EM20, SVM(I))
           EPSF = D1 + D2 * EXP(EPSF)
           IF (D4 /= ZERO)  EPSF = EPSF * (ONE + D4*LOG(MAX(ONE,EPSD(I)/EPSD0)))
-          IF (D5 /= ZERO)  EPSF = EPSF * (ONE + D5*TSTAR(I))                  
+          IF (D5 /= ZERO)  EPSF = EPSF * (ONE + D5*TSTAR(I))        
+          EPSF = MAX(EPSF,EPSF_MIN)   
           IF (EPSF > ZERO) DFMAX(I) = DFMAX(I) + DPLA(I) / EPSF  
           IF (DFMAX(I) >= ONE) THEN ! total damage in integration point
             NINDX = NINDX + 1

--- a/engine/source/materials/fail/johnson_cook/fail_johnson_c.F
+++ b/engine/source/materials/fail/johnson_cook/fail_johnson_c.F
@@ -96,7 +96,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER :: I,J,NINDX
       INTEGER ,DIMENSION(NEL) :: INDX
-      my_real :: D1,D2,D3,D4,D5,EPSP0,P,EPSF,SVM
+      my_real :: D1,D2,D3,D4,D5,EPSP0,P,EPSF,SVM,EPSF_MIN
 C=======================================================================
       NINDX   = 0  
       D1      = UPARAM(1)
@@ -105,6 +105,7 @@ C=======================================================================
       D4      = UPARAM(4)
       D5      = UPARAM(5)
       EPSP0   = UPARAM(6)
+      EPSF_MIN = UPARAM(12)
 c-----------------------------
       DO I=1,NEL
         IF (OFF(I) == ONE .and. FOFF(I) == 1 .and. DPLA(I) > ZERO) THEN
@@ -115,6 +116,7 @@ c-----------------------------
           EPSF = (D1 + D2*EXP(EPSF))
           IF(D4/=ZERO) EPSF = EPSF * (ONE + D4*LOG(MAX(ONE,EPSP(I)/EPSP0))) ! if d4=0, epsp is not correctly defined
           IF(D5/=ZERO) EPSF = EPSF * (ONE + D5*TSTAR(I)) ! if d5=0, tstart is not correctly defined
+          EPSF = MAX(EPSF,EPSF_MIN)
           IF (EPSF > ZERO) DFMAX(I) = DFMAX(I) + DPLA(I)/EPSF  
           IF (DFMAX(I) >= ONE) THEN
             NINDX = NINDX + 1

--- a/engine/source/materials/fail/johnson_cook/fail_johnson_ib.F
+++ b/engine/source/materials/fail/johnson_cook/fail_johnson_ib.F
@@ -67,7 +67,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER :: I,J,NINDX
       INTEGER ,DIMENSION(NEL) :: INDX
-      my_real :: D1,D2,D3,D4,D5,EPSD0,P,EPSF,SVM
+      my_real :: D1,D2,D3,D4,D5,EPSD0,P,EPSF,SVM,EPSF_MIN
 C=======================================================================
       NINDX = 0  
       D1    = UPARAM(1)
@@ -76,6 +76,7 @@ C=======================================================================
       D4    = UPARAM(4)
       D5    = UPARAM(5)
       EPSD0 = UPARAM(6)
+      EPSF_MIN = UPARAM(12)
 c-----------------------------
       DO I=1,NEL
         IF (OFF(I) == ONE .and. FOFF(I) == 1 .and. DPLA(I) > ZERO) THEN
@@ -85,7 +86,8 @@ c-----------------------------
           EPSF = D3 * P / MAX(EM20, SVM)
           EPSF = D1 + D2 * EXP(EPSF)
           IF (D4 /= ZERO)  EPSF = EPSF * (ONE + D4*LOG(MAX(ONE,EPSD(I)/EPSD0)))
-          IF (D5 /= ZERO)  EPSF = EPSF * (ONE + D5*TSTAR(I))                  
+          IF (D5 /= ZERO)  EPSF = EPSF * (ONE + D5*TSTAR(I))         
+          EPSF = MAX(EPSF,EPSF_MIN)  
           IF (EPSF > ZERO) DFMAX(I) = DFMAX(I) + DPLA(I) / EPSF
           IF (DFMAX(I) >= ONE) THEN ! total damage in integration point
             NINDX = NINDX + 1

--- a/engine/source/materials/fail/johnson_cook/fail_johnson_xfem.F
+++ b/engine/source/materials/fail/johnson_cook/fail_johnson_xfem.F
@@ -99,7 +99,7 @@ C-----------------------------------------------
       INTEGER I,J,K,L,JJ,ISHELL,NINDX,NINDXP,IADR,LAYXFEM
       INTEGER INDX(NEL),INDXP(NEL),RFLAG(NEL),RFLAGP(NEL)
       my_real D1,D2,D3,D4,D5,EPSP0,P,EPSF,SVM,THK_TMP,
-     .    DADV,CC,BB,CR,ORM,SS1,SS2
+     .    DADV,CC,BB,CR,ORM,SS1,SS2,EPSF_MIN
       CHARACTER (LEN=3) :: XCHAR
 C=======================================================================
       IADR = (IPT-1)*NEL
@@ -112,6 +112,7 @@ c
       D5      = UPARAM(5)
       EPSP0   = UPARAM(6)
       DADV    = UPARAM(10)
+      EPSF_MIN = UPARAM(12)
       ISHELL  = INT(UPARAM(7))
 c-----------------------------
       LAYXFEM = IXFEM
@@ -159,7 +160,8 @@ C---------------
                 EPSF = D3*P/MAX(EM20,SVM)                                       
                 EPSF = (D1 + D2*EXP(EPSF))*(ONE                                       
      .                     + D4*LOG(MAX(ONE,EPSP(I)/EPSP0)))                   
-     .                     * (ONE + D5*TSTAR(I))                                
+     .                     * (ONE + D5*TSTAR(I))     
+                EPSF = MAX(EPSF,EPSF_MIN)  
                 IF (EPSF > ZERO) DFMAX(I) = DFMAX(I) + DPLA(I)/EPSF              
 c                                                                               
                 IF (IXEL == 0) THEN                                             
@@ -268,7 +270,8 @@ c
                 EPSF = D3*P/MAX(EM20,SVM)                            
                 EPSF = (D1 + D2*EXP(EPSF))*(ONE                       
      .                     + D4*LOG(MAX(ONE,EPSP(I)/EPSP0)))       
-     .                     * (ONE + D5*TSTAR(I))                    
+     .                     * (ONE + D5*TSTAR(I))     
+                EPSF = MAX(EPSF,EPSF_MIN)
                 IF (EPSF > ZERO) DFMAX(I) = DFMAX(I) + DPLA(I)/EPSF  
 c
                 IF (IXEL == 0) THEN                                  
@@ -329,7 +332,8 @@ c
                   EPSF = D3*P/MAX(EM20,SVM)                                       
                   EPSF = (D1 + D2*EXP(EPSF))*(ONE                                       
      .                       + D4*LOG(MAX(ONE,EPSP(I)/EPSP0)))                   
-     .                       * (ONE + D5*TSTAR(I))                                
+     .                       * (ONE + D5*TSTAR(I))    
+                  EPSF = MAX(EPSF,EPSF_MIN)          
                   IF (EPSF > ZERO) DFMAX(I) = DFMAX(I) + DPLA(I)/EPSF
 c                                                                                 
                   IF (IXEL == 0) THEN                                             

--- a/hm_cfg_files/config/CFG/radioss2024/FAIL/fail_johnson.cfg
+++ b/hm_cfg_files/config/CFG/radioss2024/FAIL/fail_johnson.cfg
@@ -1,0 +1,155 @@
+//Copyright>    CFG Files and Library ("CFG")
+//Copyright>    Copyright (C) 1986-2024 Altair Engineering Inc.
+//Copyright>
+//Copyright>    Altair Engineering Inc. grants to third parties limited permission to
+//Copyright>    use and modify CFG solely in connection with OpenRadioss software, provided
+//Copyright>    that any modification to CFG by a third party must be provided back to
+//Copyright>    Altair Engineering Inc. and shall be deemed a Contribution under and therefore
+//Copyright>    subject to the CONTRIBUTOR LICENSE AGREEMENT for OpenRadioss software.
+//Copyright>
+//Copyright>    CFG IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//Copyright>    INCLUDING, BUT NOT LIMITED TO, THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+//Copyright>    A PARTICULAR PURPOSE, AND NONINFRINGEMENT.  IN NO EVENT SHALL ALTAIR ENGINEERING
+//Copyright>    INC. OR ITS AFFILIATES BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY,
+//Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
+//Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
+//
+// Failure model, Johnson (JOHNSON) Setup File
+// 
+
+ATTRIBUTES(COMMON){ 
+
+	_HMCOMMENTSFLAG  	= VALUE(INT, "Write HM Comments");
+	mat_id           	= VALUE(MAT,  "Material");
+		
+	D1					= VALUE(FLOAT,"1st parameter");
+	D2					= VALUE(FLOAT,"2nd parameter");
+	D3					= VALUE(FLOAT,"3rd parameter");
+	D4					= VALUE(FLOAT,"4th parameter");
+	D5					= VALUE(FLOAT,"5th parameter");
+
+	Epsilon_Dot_0		= VALUE(FLOAT,"Reference strain rate");
+	Ifail_sh  			= VALUE(INT,  "Shell failure flag");
+	Ifail_so  			= VALUE(INT,  "Flag for solid failure model");
+    EPSF_MIN            = VALUE(FLOAT,"Lower value for plastic strain at failure");
+	Dadv				= VALUE(FLOAT,"Criterion for the crack advancement");
+	Ixfem				= VALUE(INT,  "XFEM flag ");
+    // HM INTERNAL
+    KEYWORD_STR                                 = VALUE(STRING,"Solver Keyword");
+	ID_CARD_EXIST		= VALUE(BOOL, "Give an Id");
+}
+
+
+SKEYWORDS_IDENTIFIER(COMMON)
+{
+        // HM INTERNAL
+    KEYWORD_STR                                 = 9000;
+	_HMCOMMENTSFLAG=-1;
+}
+/*
+
+
+DEFINITIONS(COMMON) {
+  SUPPORTING=(MAT);
+}
+*/
+CHECK(COMMON)
+{
+  Dadv<=1 ;
+}
+
+GUI(COMMON) {
+
+  ASSIGN(KEYWORD_STR, "/FAIL/JOHNSON/");
+mandatory:
+  DATA(mat_id);
+optional:
+  SCALAR(D1)         { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(D2)         { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(D3)         { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(D4)         { DIMENSION = "DIMENSIONLESS"; }
+  SCALAR(D5)         { DIMENSION = "DIMENSIONLESS"; }  
+  //
+  SCALAR(Epsilon_Dot_0) { DIMENSION="strain_rate";     }  
+  //
+  RADIO(Ifail_sh) {
+    ADD(0,"0: Default");
+    ADD(1,"1: Shell is deleted if cond. reached for 1 integration point or layer");
+    ADD(2,"2: For each integration point, the stress tensor is set to 0 if cond. reached,and deleted if cond. reached for all integration points or layers");
+  }
+  RADIO(Ifail_so) {
+    ADD(0,"0: Default");
+    ADD(1,"1: Solid element is deleted if cond. reached for 1 integration point");
+    ADD(2,"2: For each integration point, deviatoric stress tensor is vanished if cond. reached for 1 integration point");
+  }
+  SCALAR(EPSF_MIN)   { DIMENSION = "DIMENSIONLESS"; }  
+  SCALAR(Dadv);
+  RADIO(Ixfem) {
+    ADD(0,"0: Without XFEM");
+    ADD(1,"1: XFEM formulation ");
+  }
+optional:
+  FLAG(ID_CARD_EXIST);
+}
+
+FORMAT(radioss2024) { 
+	HEADER("/FAIL/JOHNSON/%d",mat_id);
+	COMMENT("#                 D1                  D2                  D3                  D4                  D5");
+	CARD("%20lg%20lg%20lg%20lg%20lg",D1,D2,D3,D4,D5);
+	COMMENT("#      EPSILON_DOT_0  IFAIL_SH  IFAIL_SO            EPSF_MIN                DADV               IXFEM");
+	CARD("%20lg%10d%10d%20lg%20lg%10s%10d",Epsilon_Dot_0,Ifail_sh,Ifail_so,EPSF_MIN,Dadv,_BLANK_,Ixfem); 
+	
+	if (ID_CARD_EXIST==TRUE)
+	{
+	 COMMENT("#  FAIL_ID") ;
+	}
+	FREE_CARD(ID_CARD_EXIST,"%10d", _ID_);
+}
+
+FORMAT(radioss2017) { 
+	HEADER("/FAIL/JOHNSON/%d",mat_id);
+
+	COMMENT("#                 D1                  D2                  D3                  D4                  D5");
+	CARD("%20lg%20lg%20lg%20lg%20lg",D1,D2,D3,D4,D5);
+	COMMENT("#      EPSILON_DOT_0  IFAIL_SH  IFAIL_SO                                    DADV               IXFEM");
+	CARD("%20lg%10d%10d                    %20lg          %10d",Epsilon_Dot_0,Ifail_sh,Ifail_so,Dadv,Ixfem); 
+	
+	if (ID_CARD_EXIST==TRUE)
+	{
+	 COMMENT("#  FAIL_ID") ;
+	}
+	FREE_CARD(ID_CARD_EXIST,"%10d", _ID_);
+}
+
+FORMAT(radioss130) {
+	HEADER("/FAIL/JOHNSON/%d",mat_id);
+
+	COMMENT("#                 D1                  D2                  D3                  D4                  D5");
+	CARD("%20lg%20lg%20lg%20lg%20lg",D1,D2,D3,D4,D5);
+	COMMENT("#      EPSILON_DOT_0  IFAIL_SH  IFAIL_SO                                    DADV               IXFEM");
+	CARD("%20lg%10d%10d                    %20lg          %10d",Epsilon_Dot_0,Ifail_sh,Ifail_so,Dadv,Ixfem); 
+	
+	if (ID_CARD_EXIST==TRUE)
+	{
+	 COMMENT("#  FAIL_ID") ;
+	}
+	FREE_CARD(ID_CARD_EXIST,"%10d", _ID_);
+}
+
+FORMAT(radioss120) {
+	HEADER("/FAIL/JOHNSON/%d",mat_id);
+
+	COMMENT("#                 D1                  D2                  D3                  D4                  D5");
+	CARD("%20lg%20lg%20lg%20lg%20lg",D1,D2,D3,D4,D5);
+	COMMENT("#      EPSILON_DOT_0  IFAIL_SH  IFAIL_SO                                                       IXFEM");
+	CARD("%20lg%10d%10d                                                  %10d",Epsilon_Dot_0,Ifail_sh,Ifail_so,Ixfem); 
+}
+
+FORMAT(radioss51) {
+	HEADER("/FAIL/JOHNSON/%d",mat_id);
+		
+	COMMENT("#                 D1                  D2                  D3                  D4                  D5");
+	CARD("%20lg%20lg%20lg%20lg%20lg",D1,D2,D3,D4,D5);
+	COMMENT("#      EPSILON_DOT_0    ISHELL    ISOLID");
+	CARD("%20lg%10d%10d",Epsilon_Dot_0,Ifail_sh,Ifail_so);
+}

--- a/starter/source/elements/elbuf_init/elbuf_ini.F
+++ b/starter/source/elements/elbuf_init/elbuf_ini.F
@@ -1961,7 +1961,8 @@ C---
               BUFLY%NPTT = NPTT
               ALLOCATE(BUFLY%LBUF(NPTR,NPTS,NPTT))  
               ALLOCATE(BUFLY%MAT (NPTR,NPTS,NPTT))
-              ALLOCATE(BUFLY%EOS (NPTR,NPTS,NPTT))       
+              ALLOCATE(BUFLY%EOS (NPTR,NPTS,NPTT))
+              ALLOCATE(BUFLY%FAIL(NPTR,NPTS,NPTT))         
             ENDDO
 C---
 c
@@ -1993,8 +1994,8 @@ c
               NVARTMP = ELBUF_TAB(NG)%BUFLY(IL)%NVARTMP
               NUVAREOS= ELBUF_TAB(NG)%BUFLY(IL)%NVAR_EOS
               NPTT    = ELBUF_TAB(NG)%BUFLY(IL)%NPTT
-              NFAIL   = ELBUF_TAB(NG)%BUFLY(IL)%NFAIL
-              IF (NFAIL == 1) ALLOCATE(BUFLY%FAIL(NPTR,NPTS,NPTT))                
+              NFAIL   = ELBUF_TAB(NG)%BUFLY(IL)%NFAIL                                                
+              IRUPT   = MAT_PARAM(IMAT(IL))%FAIL(1)%IRUPT   ! Failure model type    
               
               DO IR = 1,NPTR                                       
                 DO IS = 1,NPTS                                      
@@ -2213,7 +2214,7 @@ c
           IF (IGTYP == 3 .and. IFAIL > 0) THEN
              ALLOCATE(ELBUF_TAB(NG)%GBUF%FAIL(1))
 c
-             ELBUF_TAB(NG)%GBUF%FAIL(1)%ILAWF = MAT_PARAM(IMID)%FAIL(J)%IRUPT                                           
+             ELBUF_TAB(NG)%GBUF%FAIL(1)%ILAWF = MAT_PARAM(IMID)%FAIL(1)%IRUPT                                           
              GFAIL = GFAIL + 1 
 c
              ELBUF_TAB(NG)%GBUF%FAIL(1)%IDFAIL = MAT_PARAM(IMID)%FAIL(1)%FAIL_ID

--- a/starter/source/materials/fail/johnson_cook/hm_read_fail_johnson.F
+++ b/starter/source/materials/fail/johnson_cook/hm_read_fail_johnson.F
@@ -71,7 +71,7 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER IFAIL_SH,ISOLID
-      my_real D1,D2,D3,D4,D5,EPSP0,UNIT_T,DADV,PTHKF
+      my_real D1,D2,D3,D4,D5,EPSP0,UNIT_T,DADV,PTHKF,EPSF_MIN
       LOGICAL :: IS_AVAILABLE,IS_ENCRYPTED
 C=======================================================================
       IS_ENCRYPTED = .FALSE.
@@ -89,9 +89,10 @@ C--------------------------------------------------
       CALL HM_GET_FLOATV         ('D4'           ,D4      ,IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV         ('D5'           ,D5      ,IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV         ('Epsilon_Dot_0',EPSP0   ,IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_INTV           ('Ifail_sh'     ,IFAIL_SH  ,IS_AVAILABLE,LSUBMODEL)
+      CALL HM_GET_INTV           ('Ifail_sh'     ,IFAIL_SH,IS_AVAILABLE,LSUBMODEL)
       CALL HM_GET_INTV           ('Ifail_so'     ,ISOLID  ,IS_AVAILABLE,LSUBMODEL)
-      CALL HM_GET_FLOATV         ('Dadv         ',DADV    ,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV         ('EPSF_MIN'     ,EPSF_MIN,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV         ('Dadv'         ,DADV    ,IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_INTV           ('Ixfem'        ,IXFEM   ,IS_AVAILABLE,LSUBMODEL)
 !
       ! CHECK COMPATIBILITY WITH MATERIAL LAW
@@ -117,7 +118,7 @@ c----------------------------------
       FAIL%KEYWORD = 'JOHNSON-COOK' 
       FAIL%IRUPT   = IRUPT 
       FAIL%FAIL_ID = FAIL_ID 
-      FAIL%NUPARAM = 11
+      FAIL%NUPARAM = 12
       FAIL%NIPARAM = 0
       FAIL%NUVAR   = 0
       FAIL%NFUNC   = 0
@@ -141,6 +142,7 @@ c
       FAIL%UPARAM(9) = 0 ! not used
       FAIL%UPARAM(10)= DADV
       FAIL%UPARAM(11)= IXFEM
+      FAIL%UPARAM(12)= EPSF_MIN
 c---------------------------
 c     OUTPUT
 c---------------------------
@@ -154,14 +156,14 @@ C---
 C for shell      
 C---
         IF (IXFEM == 0)THEN
-          WRITE(IOUT, 1000)D1,D2,D3,D4,D5
+          WRITE(IOUT, 1000)D1,D2,D3,D4,D5,EPSF_MIN
           IF (IFAIL_SH == 1)THEN
             WRITE(IOUT, 1100)
           ELSEIF(IFAIL_SH == 2)THEN
             WRITE(IOUT, 1200)
           ENDIF
         ELSE
-          WRITE(IOUT, 1010)D1,D2,D3,D4,D5,IXFEM,DADV
+          WRITE(IOUT, 1010)D1,D2,D3,D4,D5,IXFEM,DADV,EPSF_MIN
           WRITE(IOUT, 1400)
         END IF
 C---
@@ -186,13 +188,15 @@ c-----------------------------------------------------------
      & 5X,'FAILURE MODEL. . . . . . . . . . . .=',I10/
      & 5X,'FAIL_ID. . . . . . . . . . . . . . .=',I10/)
  1000 FORMAT(
-     & 5X,'     XFEM JOHNSON COOK DAMAGE MODEL     ',/,
-     & 5X,'     ------------------------------     ',/,
-     & 5X,'FIRST FAILURE PARAMETER (D1).. . . . . =',E12.4/
-     & 5X,'SECOND FAILURE PARAMETER(D2). . . . . .=',E12.4/
-     & 5X,'THIRD FAILURE PARAMETER (D3). . . . . .=',E12.4/
-     & 5X,'FORTH FAILURE PARAMETER (D4). . . . . .=',E12.4/
-     & 5X,'FIFTH FAILURE PARAMETER (D5).   . . . .=',E12.4//)
+     & 5X,'  ----------------------------------------------------   ',/
+     & 5X,'           FAILURE CRITERION : JOHNSON-COOK              ',/,
+     & 5X,'  ----------------------------------------------------   ',/
+     & 5X,'FIRST  FAILURE PARAMETER (D1). . . . . . . . . . . . . .=',1PG20.13/
+     & 5X,'SECOND FAILURE PARAMETER (D2). . . . . . . . . . . . . .=',1PG20.13/
+     & 5X,'THIRD  FAILURE PARAMETER (D3). . . . . . . . . . . . . .=',1PG20.13/
+     & 5X,'FORTH  FAILURE PARAMETER (D4). . . . . . . . . . . . . .=',1PG20.13/
+     & 5X,'FIFTH  FAILURE PARAMETER (D5). . . . . . . . . . . . . .=',1PG20.13/
+     & 5X,'LOWER PLASTIC STRAIN AT FAILURE (EPSF_MIN). . . . . . . =',1PG20.13//)
  1100 FORMAT(
      & 5X,'   SHELL ELEMENT DELETION AFTER FAILURE') 
  2100 FORMAT(
@@ -206,15 +210,17 @@ c-----------------------------------------------------------
      & 5X,'   DEVIATORIC STRESS IN SOLID WILL VANISH AFTER FAILURE')    
 C
  1010 FORMAT(
-     & 5X,'     XFEM JOHNSON COOK DAMAGE MODEL     ',/,
-     & 5X,'     ------------------------------     ',/,
-     & 5X,'FIRST  FAILURE PARAMETER(D1). . . . . .=',E12.4/
-     & 5X,'SECOND FAILURE PARAMETER(D2). . . . . .=',E12.4/
-     & 5X,'THIRD  FAILURE PARAMETER(D3). . . . . .=',E12.4/
-     & 5X,'FORTH  FAILURE PARAMETER(D4). . . . . .=',E12.4/
-     & 5X,'FIFTH  FAILURE PARAMETER(D5). . . . . .=',E12.4/
-     & 5X,'FLAG XFEM . . . . . . . . . . . . . . .=',I10/,
-     & 5X,'CRITICAL ADVANCEMENT VALUE. . . . . . .=',E12.4//)
+     & 5X,'  ----------------------------------------------------   ',/
+     & 5X,'         FAILURE CRITERION : X-FEM JOHNSON-COOK          ',/,
+     & 5X,'  ----------------------------------------------------   ',/
+     & 5X,'FIRST  FAILURE PARAMETER (D1). . . . . . . . . . . . . .=',1PG20.13/
+     & 5X,'SECOND FAILURE PARAMETER (D2). . . . . . . . . . . . . .=',1PG20.13/
+     & 5X,'THIRD  FAILURE PARAMETER (D3). . . . . . . . . . . . . .=',1PG20.13/
+     & 5X,'FORTH  FAILURE PARAMETER (D4). . . . . . . . . . . . . .=',1PG20.13/
+     & 5X,'FIFTH  FAILURE PARAMETER (D5). . . . . . . . . . . . . .=',1PG20.13/
+     & 5X,'FLAG XFEM. . . . . . . . . . . . . . . . . . . . . . . .=',I10/
+     & 5X,'CRITICAL ADVANCEMENT VALUE . . . . . . . . . . . . . . .=',1PG20.13/
+     & 5X,'LOWER PLASTIC STRAIN AT FAILURE (EPSF_MIN). . . . . . . =',1PG20.13//)
 C-----------
       RETURN
       END


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Add a lower value for plastic strain at failure for /FAIL/JOHNSON and fix a major memory issue in element buffer for beam failure (leading to segfault).

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Add EPSF_MIN parameter and fix the element buffer problem in elbuf_ini. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
