### PR TITLE
Upgrade checkout upload and download action from v3 to v4

### DIFF
--- a/.github/workflows/developer_ci.yml
+++ b/.github/workflows/developer_ci.yml
@@ -80,7 +80,7 @@ jobs:
           md5sum exec/* || echo "Nothing in exec/" 
 
       # Get last git modifications, WS is not persistent here
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: 'true'
           ref: refs/pull/${{ github.event.number }}/merge
@@ -118,7 +118,7 @@ jobs:
 
       # Upload artifact 
       - name: Upload built artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bins-${{ matrix.os }}-${{ matrix.precision }}
           path: exec
@@ -155,7 +155,7 @@ jobs:
     steps:
 
       # Get git related to the commit
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: 'true'
           ref: refs/pull/${{ github.event.number }}/merge
@@ -165,7 +165,7 @@ jobs:
           rm -rf exec
 
       # Download artifacts
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: bins-${{ matrix.os }}-${{ matrix.precision }}
           path: exec

--- a/.github/workflows/prmerge_ci_main.yml
+++ b/.github/workflows/prmerge_ci_main.yml
@@ -58,7 +58,7 @@ jobs:
 
       # Get last git modifications, don't clean before (way to keep persistent obj files)
       - name: Checkout git sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ${{ env.WORKDIR }}
           clean: 'false'
@@ -120,7 +120,7 @@ jobs:
 
       # Upload artifact
       - name: Upload built artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tools-${{ env.os }}
           path: ${{ env.WORKDIR }}/exec
@@ -167,7 +167,7 @@ jobs:
 
       # Get last git modifications, don't clean before (way to keep persistent obj files)
       - name: Checkout git sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ${{ env.WORKDIR }}
           clean: 'false'
@@ -219,7 +219,7 @@ jobs:
 
       # Upload artifact
       - name: Upload built artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tools-${{ env.os }}
           path: ${{ env.WORKDIR }}/exec
@@ -302,7 +302,7 @@ jobs:
 
       # Get last git modifications, don't clean before (way to keep persistent obj files)
       - name: Checkout git sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ${{ env.WORKDIR }}
           clean: 'false'
@@ -375,7 +375,7 @@ jobs:
 
       # Upload artifact
       - name: Upload built artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bins-${{ matrix.os }}-${{ matrix.precision }}
           path: ${{ env.WORKDIR }}/exec
@@ -451,7 +451,7 @@ jobs:
 
       # Get git related to the commit
       - name: Checkout git sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: 'true'
 
@@ -460,7 +460,7 @@ jobs:
           rm -rf exec
 
       # Download artifacts
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: bins-${{ matrix.os }}-${{ matrix.precision }}
           path: exec
@@ -654,7 +654,7 @@ jobs:
           
       # Get last git modifications, don't clean before (way to keep persistent obj files)
       - name: Checkout git sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ${{ env.WORKDIR }}
           clean: 'false'
@@ -708,7 +708,7 @@ jobs:
           "
       # Upload artifact
       - name: Upload built artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bins-${{ matrix.os }}-${{ matrix.precision }}
           path: ${{ env.WORKDIR }}/exec
@@ -771,13 +771,13 @@ jobs:
 
       # Get git related to the commit
       - name: Checkout git sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: 'true'
 
       # Get OpenRadioss extras from dedicated repository
       - name: Checkout git EXTRA sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: 'true'
           clean: 'false'
@@ -794,7 +794,7 @@ jobs:
           "
 
       # Download artifacts
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: bins-${{ matrix.os }}-${{ matrix.precision }}
           path: exec
@@ -927,14 +927,14 @@ jobs:
 
       # Get last git modifications, don't clean before (way to go faster)
       - name: Checkout git sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           clean: 'false'
           lfs: 'true'
 
       # Get OpenRadioss extras from dedicated repository
       - name: Checkout git EXTRA sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: 'true'
           clean: 'false'
@@ -943,7 +943,7 @@ jobs:
           token: '${{ secrets.EXTRA_REPOSITORY_PAT }}'
 
       # Download ALL artifacts
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: exec_tmp
 

--- a/.github/workflows/upd_headers_ci.yml
+++ b/.github/workflows/upd_headers_ci.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
 
       # Get last git modifications, WS is not persistent here
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: 'true'
           # Use a PAT else the push won't trigger the next workflow


### PR DESCRIPTION
Upgrade checkout upload and download action from v3 to v4 to support node.js v20

#### Description of the feature or the bug
Node 16 has reached its [end of life](https://github.com/nodejs/Release/#end-of-life-releases), prompting us to initiate its deprecation process for GitHub Actions. Our plan is to transition all actions to run on Node 20 by Spring 2024. We will actively monitor the migration's progress and gather community feedback before finalizing the transition date. Starting October 23rd, workflows containing actions running on Node 16 will display a warning to alert users about the upcoming migration.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

#### Description of the changes
Upgrade checkout upload and download action from v3 to v4 to support node.js v20 in all CIs
