### PR TITLE
truss element groups : add PID/MID as group sorting criteria

### DIFF
--- a/starter/source/elements/truss/tgrhead.F
+++ b/starter/source/elements/truss/tgrhead.F
@@ -48,7 +48,7 @@ C     ISEL(NSELT)       TABLEAU DESPOUTRES CHOISIS POUR TH         E/S
 C     ITR1(NSELT)       TABLEAU DE TRAVAIL                         E/S
 C     EADD(NUMELT)      TABLEAU DES ADRESSES DANS IDAM CHGT DAMIER   S
 C     INDEX(NUMELT)     TABLEAU DE TRAVAIL                         E/S
-C     ITRI(4,NUMELT)    TABLEAU DE TRAVAIL                         E/S
+C     ITRI(5,NUMELT)    TABLEAU DE TRAVAIL                         E/S
 C     IPARTT(NUMELT)    TABLEAU PART                               E/S
 C     CEP(NUMELT)    TABLEAU PROC                               E/S
 C     XEP(NUMELT)    TABLEAU PROC                               E/S
@@ -68,7 +68,7 @@ C-----------------------------------------------
 C   D U M M Y   A R G U M E N T S
 C-----------------------------------------------
       INTEGER IXT(5,*),ISEL(*),INUM(7,*),IPARTT(*),
-     .        EADD(*),ITR1(*),INDEX(*),ITRI(4,*),
+     .        EADD(*),ITR1(*),INDEX(*),ITRI(5,*),
      .        ND, CEP(*), XEP(*),
      .        ITRUOFF(*), TAGPRT_SMS(*)
       INTEGER ,INTENT(INOUT), DIMENSION(NUMELT) ::ITAGPRLD_TRUSS
@@ -82,8 +82,8 @@ C-----------------------------------------------
 C   L O C A L   V A R I A B L E S
 C-----------------------------------------------
       INTEGER 
-     .        I, K,  MLN, NG, ISSN, NN, N, MID, PID ,
-     .        II, J, II2,JJ2,JJ,L,II3,JJ3,NGROU,
+     .        I,J,K,L,NG, ISSN, NN,N,MLN,MID,PID ,NGROU,
+     .        II,JJ,II2,JJ2,II3,JJ3,II4,JJ4,II5,JJ5,
      .        MSKMLN,MSKISN,MSKPID, MSKMID, MODE,
      .        WORK(70000),IPRLD
       EXTERNAL MY_SHIFTL,MY_SHIFTR,MY_AND
@@ -101,7 +101,6 @@ C----------------------------------------------------------
 C
       DO I=1,NUMELT
         EADD(I)=1
-        ITRI(4,I)=I
         INDEX(I)=I
         INUM(1,I)=IPARTT(I)
         INUM(2,I)=ITRUOFF(I)
@@ -146,6 +145,12 @@ C
 C       JSMS=MY_SHIFTL(JSMS,0)
         ITRI(3,I) = JSMS
 C       NEXT=MY_SHIFTL(NEXT,1)
+c
+C       key4
+        ITRI(4,I) = MID
+C       key5
+        ITRI(5,I) = PID
+
       ENDDO
 C
       MODE=0
@@ -211,12 +216,18 @@ C--------------------------------------------------------------
         JJ2=ITRI(2,INDEX(I-1))
         II3=ITRI(3,INDEX(I))
         JJ3=ITRI(3,INDEX(I-1))
-        IF(II/=JJ.OR.II2/=JJ2.OR.II3/=JJ3) THEN
+        II4=ITRI(4,INDEX(I))
+        JJ4=ITRI(4,INDEX(I-1))
+        II5=ITRI(5,INDEX(I))
+        JJ5=ITRI(5,INDEX(I-1))
+        
+        IF (II/=JJ   .OR. II2/=JJ2 .OR. II3/=JJ3  .OR.
+     .      II4/=JJ4 .OR. II5/=JJ5) THEN
           ND=ND+1
           EADD(ND)=I
         ENDIF
       ENDDO
       EADD(ND+1) = NUMELT+1
-C
+c-----------
       RETURN
       END

--- a/starter/source/starter/lectur.F
+++ b/starter/source/starter/lectur.F
@@ -5809,7 +5809,7 @@ C---------------------------
       NUMSPHK8     =    NUMSPH
 ! working int8 to avoid integer overflow for large models
       EMAX = MAX(23*NUMELCK8,24*NUMELTGK8+1,29*NUMELSK8+1,19*NUMELRK8,
-     .           18*NUMELPK8+1,16*NUMELTK8,19*NUMELQK8,
+     .           18*NUMELPK8+1,17*NUMELTK8,19*NUMELQK8,
      .           15*NUMELXK8+1,24*NUMELIG3DK8+1,NUMSPHK8) + 1
 
       ALLOCATE(IPARGTMP(NPARG,NUMEL)    ,STAT=stat)
@@ -6039,8 +6039,8 @@ C------
        K2 = 8*NUMELT
        K3 = 9*NUMELT+1
        K4 = 11*NUMELT+1
-       K5 = 15*NUMELT+1
-       K6 = 16*NUMELT+1
+       K5 = 16*NUMELT+1
+       K6 = 17*NUMELT+1
        !warning: please also update any index change
        !         for MODIF option (MODIF_SPMD.F)
        IWORK  = 0


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

no change for the user

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

modifed truss element group sorting criteria : force the same PID/MID for one group, same as other element types

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
