### PR TITLE
Add default binary names

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -139,6 +139,11 @@ if (NOT DEFINED arch)
    set (arch "linux64_gf")
 endif ()
 
+if (NOT DEFINED EXEC_NAME)
+   set (EXEC_NAME "openradioss_engine")
+endif ()
+
+
 if ( NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/CMake_Compilers${cdir}/cmake_${arch}.txt )
    message(STATUS "CMake_Compilers${cdir}/cmake_${arch}.txt  file not found ")
    set (arch "none")

--- a/starter/CMakeLists.txt
+++ b/starter/CMakeLists.txt
@@ -129,6 +129,11 @@ if (NOT DEFINED arch)
    set (arch "linux64_gf")
 endif ()
 
+if (NOT DEFINED EXEC_NAME)
+   set (EXEC_NAME "openradioss_starter")
+endif ()
+
+
 if ( NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/CMake_Compilers${cdir}/cmake_${arch}.txt )
    message(STATUS "CMake_Compilers/cmake_${arch}.txt  file not found ")
    set (arch "none")


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Having a generic default name for OpenRadioss binaries is useful for spack installation
(no need to define it in package.py)

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
The default names are "openradioss_starter" and "openradioss_engine"

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
