### PR TITLE
Update initia.F for TOTAL ADDED MASS output from starter

### DIFF
--- a/starter/source/elements/initia/initia.F
+++ b/starter/source/elements/initia/initia.F
@@ -2418,8 +2418,8 @@ c-----------
      .22X,'IXX',18X,'IYY',18X,'IZZ',18X,'IXY',18X,'IYZ',18X,'IZX')
  1300 FORMAT(
      .       5X,' ADDED NODAL NON-STRUCTURAL MASSES '   /
-     .       5X,'-----------------------------------'   //)
- 1400 FORMAT(//1X,' TOTAL ADDED MASS = ',1PG20.13//)
+     .       5X,'-----------------------------------'   /)
+ 1400 FORMAT(5X,' TOTAL ADDED MASS = ',1PG20.13//)
  1500 FORMAT(//
      . 5X,'KJOINT2 SPRING DEFINITION',/
      . 5X,'------------------------'/)


### PR DESCRIPTION
Tidying up format of output for Total Added Mass line (for non structural mass), removed 3 blank lines and align justification with header (indent 5 spaces instead of 1)

#### Description of the feature or the bug
User was confused by all the blank lines and misalignment of ADMAS total added mass report under the header


#### Description of the changes
Tidying up format of output for Total Added Mass line (for non structural mass), removed 3 blank lines, 1 at end of header and 2 at start of output and aligned justification with header (indent 5 spaces instead of 1)


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
