### PR TITLE
/FVMBAG use of uninitialized variable (injectors)

### DIFF
--- a/engine/source/airbag/fvbag1.F
+++ b/engine/source/airbag/fvbag1.F
@@ -589,12 +589,12 @@ C---------------------------------------------------
       ENDIF
 
       PEXT =RVOLU(3)
+      DATAINJ(1:6,1:NJET)=ZERO
       IF(IVOLU(39) == 0) GO TO 250
 
 C---------------------------------------------------
 C Injecteurs
 C---------------------------------------------------
-      DATAINJ(1:6,1:NJET)=ZERO
       DO IEL=1,NELT
         IF (ITAGEL(IEL) > 0) THEN
           IINJ=ITAGEL(IEL)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
When TTF > 0, DATAINJ(1:6,1:NJET) was used without being initialized


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
