### PR TITLE
/INIVEL/FVM : Adding Starter Printout

### DIFF
--- a/starter/source/initial_conditions/general/inivel/hm_read_inivel.F
+++ b/starter/source/initial_conditions/general/inivel/hm_read_inivel.F
@@ -44,11 +44,23 @@ Chd|        MESSAGE_MOD                   share/message_module/message_mod.F
 Chd|        MULTI_FVM_MOD                 ../common_source/modules/ale/multi_fvm_mod.F
 Chd|        SUBMODEL_MOD                  share/modules1/submodel_mod.F 
 Chd|====================================================================
-      SUBROUTINE HM_READ_INIVEL(V         ,W      ,ITAB     ,ITABM1 ,VR       ,
-     .                  IGRNOD    ,IGRBRIC,ISKN     ,SKEW   ,INIVIDS  ,
-     .                  X         ,UNITAB ,LSUBMODEL,RTRANS ,XFRAME   ,
-     .                  IFRAME    ,VFLOW  ,WFLOW    ,KXSP   ,MULTI_FVM,
-     .                  FVM_INIVEL,IGRQUAD,IGRSH3N  ,RBY_MSN,RBY_INIAXIS)
+      SUBROUTINE HM_READ_INIVEL(V         , W      , ITAB     , ITABM1 , VR         ,
+     .                          IGRNOD    , IGRBRIC, ISKN     , SKEW   , INIVIDS    ,
+     .                          X         , UNITAB , LSUBMODEL, RTRANS , XFRAME     ,
+     .                          IFRAME    , VFLOW  , WFLOW    , KXSP   , MULTI_FVM  ,
+     .                          FVM_INIVEL, IGRQUAD, IGRSH3N  , RBY_MSN, RBY_INIAXIS)
+C-----------------------------------------------
+C   D e s c r i p t i o n
+C-----------------------------------------------
+C INITIAL VELOCITY READER (OPTIONS : /INIVEL/...)
+C
+C  /INIVEL/TRA       ITYPE=0
+C  /INIVEL/ROT       ITYPE=1
+C  /INIVEL/T+G       ITYPE=2
+C  /INIVEL/GRID      ITYPE=3
+C  /INIVEL/AXIS      ITYPE=4
+C  /INIVEL/FVM       ITYPE=5
+C  /INIVEL/NODE      ITYPE=6
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -75,12 +87,12 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      TYPE (UNIT_TYPE_),INTENT(IN) ::UNITAB 
+      TYPE (UNIT_TYPE_),INTENT(IN) ::UNITAB
       INTEGER ITAB(*), ITABM1(*),ISKN(LISKN,*),
      .        INIVIDS(*),IFRAME(LISKN,*),KXSP(NISP,*),RBY_MSN(2,*)
       TYPE(SUBMODEL_DATA) LSUBMODEL(*)
       my_real
-     .   V(3,*),W(3,*),VR(3,*),SKEW(LSKEW,*),BID,X(3,*),
+     .   V(3,*),W(3,*),VR(3,*),SKEW(LSKEW,*),X(3,*),
      .   RTRANS(NTRANSF,*),XFRAME(NXFRAME,*),VFLOW(3,*) ,WFLOW(3,*),
      .   RBY_INIAXIS(7,*)
       TYPE(MULTI_FVM_STRUCT) :: MULTI_FVM
@@ -93,81 +105,68 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I,J,K,N,NRB,KPRI,KROT,NNOD,NOSYS,ITYPE,ID,ISK,IGR,IGRS,NBVEL,
-     .        UID,IFLAGUNIT,NODID,NODID1,SUB_INDEX,IDIR,
-     .        IDGRBRICK, IDGRQUAD, IDGRSH3N, IDGRBRICK_LOC, IDGRQUAD_LOC, IDGRSH3N_LOC,
-     .        IAD1, IAD2,NODE,NL,JREC,NOD_COUNT,IAD,NODINIVEL,CPT,XYZSIZE,SUB_ID
-      INTEGER FLAG_FMT,FLAG_FMT_TMP,IFIX_TMP,IFRA,IFM,IUN,JJ,K1,K2,K3,INOD,NB_NODES,
-     .        ID_NODE,IOK
+      INTEGER :: I,J,K,N,NRB,KPRI,KROT,NNOD,NOSYS,ITYPE,ID,ISK,IGR,IGRS,NBVEL
+      INTEGER :: USER_UNIT_ID,NODID,NODID1,SUB_INDEX,IDIR
+      INTEGER :: IDGRBRICK, IDGRQUAD, IDGRTRIA, IDGRBRICK_LOC, IDGRQUAD_LOC, IDGRTRIA_LOC
+      INTEGER :: IAD1, IAD2,NODE,NL,JREC,NOD_COUNT,IAD,NODINIVEL,CPT,SUB_ID
+      INTEGER :: FLAG_FMT,FLAG_FMT_TMP,IFIX_TMP,IFRA,IFM,IUN,JJ,K1,K2,K3,INOD,NB_NODES, ID_NODE,IOK
+      INTEGER :: NINIVEL_FVM,NINIVEL_TOTAL
+      INTEGER :: FVM_GRBRIC_USER_ID(NINVEL), FVM_GRQUAD_USER_ID(NINVEL), FVM_GRTRIA_USER_ID(NINVEL) ! printout only
       INTEGER, DIMENSION(:), ALLOCATABLE :: TAGNO_RBY
-      my_real
-     .   V1, V2, V3, V4, V5, V6, VL1, VL2, VL3,VRA, OX, OY, OZ,
-     .   NIXJ(6),VR1,VR2,VR3,VRL1,VRL2,VRL3
+      my_real :: V1, V2, V3, V4, V5, V6, VL1, VL2, VL3,VRA, OX, OY, OZ, NIXJ(6),VR1,VR2,VR3,VRL1,VRL2,VRL3,BID
+      CHARACTER MESS*40,LLINE*ncharline,TITR*nchartitle,KEY*ncharkey,XYZ*ncharfield
       LOGICAL LV,LVR
-      CHARACTER MESS*40,LLINE*ncharline,TITR*nchartitle,KEY*ncharkey,
-     .          XYZ*ncharfield
-      LOGICAL IS_AVAILABLE
+      LOGICAL IS_AVAILABLE, IS_FOUND_UNIT_ID, IS_FOUND
 C-----------------------------------------------
 C   E x t e r n a l   F u n c t i o n s
 C-----------------------------------------------
-      INTEGER USR2SYS, USRTOS, KFRAME
+      INTEGER,EXTERNAL :: USR2SYS
       DATA MESS/'INITIAL VELOCITIES DEFINITION           '/
       DATA IUN/1/
-C=======================================================================
+C-----------------------------------------------
+C   S o u r c e   L i n e s
+C-----------------------------------------------
       IS_AVAILABLE = .FALSE.
       FLAG_FMT = 0
       NBVEL = 0
-      ISK   = 0
-      IFRA  = 0
-      IFM   = 0
-      K1    = 0
-      K2    = 0
-      K3    = 0
-      IDIR  = 0
-C--------------------------------------------------
-C     V INI DANS FICHIER D00 ou 0.RAD
-C--------------------------------------------------
-!---
-!     KEY = 'NODE', temporary velocity table allocation
-!
-!  start count
-      NOD_COUNT = 0
+      ISK = 0
+      IFRA = 0
+      IFM = 0
+      K1 = 0
+      K2 = 0
+      K3 = 0
+      IDIR = 0
       KROT = 0
+      NOD_COUNT = 0
+      CALL HM_OPTION_COUNT('/INIVEL'    , NINIVEL_TOTAL)
+      CALL HM_OPTION_COUNT('/INIVEL/FVM', NINIVEL_FVM)
 C--------------------------------------------------
-C START BROWSING MODEL PROPERTIES
+C LOOP OVER /INIVEL/... OPTIONS IN INPUT FILE
 C--------------------------------------------------
       CALL HM_OPTION_START('/INIVEL')
       I = 0 
 
       DO CPT=1,HM_NINVEL
         I = I + 1
-C--------------------------------------------------
-C EXTRACT DATAS OF /INIVEL/... LINE
-C--------------------------------------------------
-        CALL HM_OPTION_READ_KEY(LSUBMODEL,
-     .                       OPTION_ID = ID,
-     .                       UNIT_ID = UID,
-     .                       SUBMODEL_INDEX = SUB_INDEX,
-     .                       SUBMODEL_ID = SUB_ID,
-     .                       OPTION_TITR = TITR,
-     .                       KEYWORD2 = KEY)
-C
-        IFLAGUNIT = 0
+        !---SET CURSOR ON NEXT INIVEL OPTION
+        CALL HM_OPTION_READ_KEY(LSUBMODEL,OPTION_ID = ID,UNIT_ID = USER_UNIT_ID,SUBMODEL_INDEX = SUB_INDEX,
+     .                          SUBMODEL_ID = SUB_ID,OPTION_TITR = TITR,KEYWORD2 = KEY)
+
+        !---CHECK EXISTING UNIT ID IF PROVIDED
+        IS_FOUND_UNIT_ID = .FALSE.
         DO J=1,UNITAB%NUNITS
-          IF (UNITAB%UNIT_ID(J) == UID) THEN
-            IFLAGUNIT = 1
+          IF (UNITAB%UNIT_ID(J) == USER_UNIT_ID) THEN
+            IS_FOUND_UNIT_ID = .TRUE.
             EXIT
           ENDIF
         ENDDO
-        IF (UID/=0.AND.IFLAGUNIT==0) THEN
+        IF (USER_UNIT_ID /= 0 .AND. .NOT.IS_FOUND_UNIT_ID) THEN
           CALL ANCMSG(MSGID=659,ANMODE=ANINFO,MSGTYPE=MSGERROR,
-     .                I2=UID,I1=ID,C1='INITIAL VELOCITY',
-     .                 C2='INITIAL VELOCITY',
-     .                 C3=TITR) 
+     .                 I2=USER_UNIT_ID,I1=ID,C1='INITIAL VELOCITY',C2='INITIAL VELOCITY',C3=TITR) 
         ENDIF
 
+        !---SET ITYPE DEPENDING ON USER KEYWORD
         FVM_INIVEL(I)%FLAG = .FALSE.
-C
         IF(KEY(1:3)=='TRA')THEN
           ITYPE=0
         ELSEIF(KEY(1:3)=='ROT')THEN
@@ -177,85 +176,70 @@ C
         ELSEIF(KEY(1:3)=='GRI')THEN
           ITYPE=3
         ELSEIF(KEY(1:4)=='AXIS')THEN
-          IF(INVERS < 120) CALL ANCMSG(MSGID=2046,
-     .                                 ANMODE=ANINFO,
-     .                                 MSGTYPE=MSGERROR,
-     .                                 C1='/INIVEL/AXIS',
-     .                                 I1=INVERS)
+          IF(INVERS < 120) THEN
+            CALL ANCMSG(MSGID=2046,ANMODE=ANINFO,MSGTYPE=MSGERROR,C1='/INIVEL/AXIS',I1=INVERS)
+          ENDIF
           ITYPE=4
         ELSEIF(KEY(1:3) == 'FVM') THEN
-          ITYPE = 5
+          ITYPE=5
           FVM_INIVEL(I)%FLAG = .TRUE.
         ELSEIF(KEY(1:4)=='NODE')THEN
           ITYPE=6
         ELSE
-          GOTO 999
+          CALL FREERR(1)
+          RETURN
         ENDIF
 
         NBVEL = NBVEL+1
         INIVIDS(NBVEL)=ID
-!
-        IF(ITYPE > 6) THEN
+
+       IF(ITYPE > 6) THEN
+          !invalid type
           CYCLE
+
+        !---READER /INIVEL/TRA,ROT,T+G,GRID  (0,1,2,3)
         ELSEIF (ITYPE <= 3) THEN
           IFRA  = 0
-C--------------------------------------------------
-C EXTRACT DATAS (INTEGER VALUES)
-C--------------------------------------------------
           CALL HM_GET_INTV('entityid',IGR,IS_AVAILABLE,LSUBMODEL)
           CALL HM_GET_INTV('inputsystem',ISK,IS_AVAILABLE,LSUBMODEL)
           IF(ISK == 0 .AND. SUB_INDEX /= 0 ) ISK = LSUBMODEL(SUB_INDEX)%SKEW
-C--------------------------------------------------
-C EXTRACT DATAS (REAL VALUES)
-C--------------------------------------------------
           CALL HM_GET_FLOATV('vector_X',VL1,IS_AVAILABLE,LSUBMODEL,UNITAB)
           CALL HM_GET_FLOATV('vector_Y',VL2,IS_AVAILABLE,LSUBMODEL,UNITAB)
           CALL HM_GET_FLOATV('vector_Z',VL3,IS_AVAILABLE,LSUBMODEL,UNITAB)
 
+        !---READER /INIVEL/AXIS (4)
         ELSEIF (ITYPE == 4) THEN
-C--------------------------------------------------
-C EXTRACT DATAS (STRING)
-C--------------------------------------------------
           CALL HM_GET_STRING('rad_dir',XYZ,ncharfield,IS_AVAILABLE)
-C--------------------------------------------------
-C EXTRACT DATAS (INTEGER VALUES)
-C--------------------------------------------------
           CALL HM_GET_INTV('inputsystem',IFRA,IS_AVAILABLE,LSUBMODEL)
           CALL HM_GET_INTV('entityid',IGR,IS_AVAILABLE,LSUBMODEL)
-C--------------------------------------------------
-C EXTRACT DATAS (REAL VALUES)
-C--------------------------------------------------
+
           CALL HM_GET_FLOATV('vector_X',VL1,IS_AVAILABLE,LSUBMODEL,UNITAB)
           CALL HM_GET_FLOATV('vector_Y',VL2,IS_AVAILABLE,LSUBMODEL,UNITAB)
           CALL HM_GET_FLOATV('vector_Z',VL3,IS_AVAILABLE,LSUBMODEL,UNITAB)
           CALL HM_GET_FLOATV('rad_rotational_velocity',VRA,IS_AVAILABLE,LSUBMODEL,UNITAB)                                                 
-          IF(IFRA == 0 .AND. SUB_INDEX  /=  0) CALL SUBROTVECT(VL1,VL2,VL3,RTRANS,SUB_ID,LSUBMODEL)    
-C
-C  UTILISER LEN_TRIM A LA PLACE DE XYZSIZE : XYZ(1:LEN_TRIM(XYZ))
-C
-          XYZSIZE=1
-          IF(XYZ(1:XYZSIZE)=='X') THEN
+          IF(IFRA == 0 .AND. SUB_INDEX  /=  0) CALL SUBROTVECT(VL1,VL2,VL3,RTRANS,SUB_ID,LSUBMODEL)
+          IF(XYZ(1:1)=='X') THEN
             IDIR=1
-          ELSEIF(XYZ(1:XYZSIZE)=='Y') THEN
+          ELSEIF(XYZ(1:1)=='Y') THEN
             IDIR=2
-          ELSEIF(XYZ(1:XYZSIZE)=='Z') THEN
+          ELSEIF(XYZ(1:1)=='Z') THEN
             IDIR=3
           ELSE
-            CALL ANCMSG(MSGID=933,
-     .                  MSGTYPE=MSGERROR,
-     .                  ANMODE=ANINFO,
-     .                  I1=ID,
-     .                  C1=TITR)
+            CALL ANCMSG(MSGID=933,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=ID,C1=TITR)
           ENDIF
           ISK = 0
+
+         !---READER /INIVEL/FVM (5)
         ELSEIF (ITYPE == 5) THEN
           CALL HM_GET_FLOATV('Vx', VL1, IS_AVAILABLE, LSUBMODEL, UNITAB)
           CALL HM_GET_FLOATV('Vy', VL2, IS_AVAILABLE, LSUBMODEL, UNITAB)
           CALL HM_GET_FLOATV('Vz', VL3, IS_AVAILABLE, LSUBMODEL, UNITAB)
           CALL HM_GET_INTV('grbric_ID', IDGRBRICK, IS_AVAILABLE, LSUBMODEL)
           CALL HM_GET_INTV('grqd_ID', IDGRQUAD, IS_AVAILABLE, LSUBMODEL)
-          CALL HM_GET_INTV('grtria_ID', IDGRSH3N, IS_AVAILABLE, LSUBMODEL)
+          CALL HM_GET_INTV('grtria_ID', IDGRTRIA, IS_AVAILABLE, LSUBMODEL)
           CALL HM_GET_INTV('skew_ID', ISK, IS_AVAILABLE, LSUBMODEL)
+
+         !---READER /INIVEL/NODE (6)
         ELSEIF (ITYPE == 6) THEN
           CALL HM_GET_INTV('NB_NODES', NB_NODES, IS_AVAILABLE, LSUBMODEL)
           DO N=1,NB_NODES
@@ -267,7 +251,6 @@ C
             CALL HM_GET_FLOAT_ARRAY_INDEX('VXRA', VR1, N, IS_AVAILABLE, LSUBMODEL, UNITAB)
             CALL HM_GET_FLOAT_ARRAY_INDEX('VYRA', VR2, N, IS_AVAILABLE, LSUBMODEL, UNITAB)
             CALL HM_GET_FLOAT_ARRAY_INDEX('VZRA', VR3, N, IS_AVAILABLE, LSUBMODEL, UNITAB)
-
             IOK = 0
             KROT = 1
             IF (ID_NODE > 0) THEN
@@ -284,15 +267,8 @@ C
                     IOK = 1
                   ENDIF
                 ENDDO
-                IF (IOK == 0)CALL ANCMSG(MSGID=184,
-     .                      MSGTYPE=MSGERROR,
-     .                      ANMODE=ANINFO,
-     .                      C1='INITIAL VELOCITY',
-     .                      I1=ID,
-     .                      C2='INITIAL VELOCITY',
-     .                      C3=TITR,
-     .                      I2=ISK)
-
+                IF (IOK == 0)CALL ANCMSG(MSGID=184,MSGTYPE=MSGERROR,ANMODE=ANINFO,
+     .                                   I1=ID,I2=ISK,C1='INITIAL VELOCITY',C2='INITIAL VELOCITY',C3=TITR)
                  NOSYS = USR2SYS(ID_NODE,ITABM1,MESS,ID)
                  V(1,NOSYS)  = V1
                  V(2,NOSYS)  = V2
@@ -310,49 +286,45 @@ C
                  VR(3,NOSYS) = VR3
               ENDIF
             ENDIF
-          ENDDO 
+          ENDDO !N=1,NB_NODES
           ISK = 0
-        ENDIF
+
+        ENDIF !ITYPE TEST
 C
         IF (ITYPE /= 6) THEN
           IF (ISK > 0) THEN
+              IS_FOUND = .FALSE.
               DO J=0,NUMSKW+MIN(IUN,NSPCOND)*NUMSPH+NSUBMOD
                 IF (ISK == ISKN(4,J+1)) THEN
                   ISK=J+1
                   V1 = SKEW(1,ISK)*VL1+SKEW(4,ISK)*VL2+SKEW(7,ISK)*VL3
                   V2 = SKEW(2,ISK)*VL1+SKEW(5,ISK)*VL2+SKEW(8,ISK)*VL3
                   V3 = SKEW(3,ISK)*VL1+SKEW(6,ISK)*VL2+SKEW(9,ISK)*VL3
-                  GO TO 200
+                  IS_FOUND = .TRUE.
+                  EXIT
                 ENDIF
               ENDDO
-              CALL ANCMSG(MSGID=184,
-     .                    MSGTYPE=MSGERROR,
-     .                    ANMODE=ANINFO,
-     .                    C1='INITIAL VELOCITY',
-     .                    I1=ID,
-     .                    C2='INITIAL VELOCITY',
-     .                    C3=TITR,
-     .                    I2=ISK)
-200           CONTINUE
+              IF(.NOT. IS_FOUND)THEN
+                CALL ANCMSG(MSGID=184,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=ID,I2=ISK,
+     .                      C1='INITIAL VELOCITY', C2='INITIAL VELOCITY', C3=TITR)
+              ENDIF
+
           ELSEIF (IFRA > 0) THEN
+            IS_FOUND = .FALSE.
             DO K=1,NUMFRAM
               J=K+1
               IF(IFRA==IFRAME(4,J)) THEN
                 V1 = XFRAME(1,J)*VL1+XFRAME(4,J)*VL2+XFRAME(7,J)*VL3
                 V2 = XFRAME(2,J)*VL1+XFRAME(5,J)*VL2+XFRAME(8,J)*VL3
                 V3 = XFRAME(3,J)*VL1+XFRAME(6,J)*VL2+XFRAME(9,J)*VL3
-                GO TO 110
+                IS_FOUND = .TRUE.
+                EXIT
               ENDIF
             ENDDO
-            CALL ANCMSG(MSGID=490,
-     .                  MSGTYPE=MSGERROR,
-     .                  ANMODE=ANINFO,
-     .                  C1='INITIAL VELOCITY',
-     .                  I1=ID,
-     .                  C2='INITIAL VELOCITY',
-     .                  C3=TITR,
-     .                  I2=IFRA)
-110         CONTINUE
+            IF(.NOT. IS_FOUND)THEN
+              CALL ANCMSG(MSGID=490,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=ID,I2=IFRA,
+     .                    C1='INITIAL VELOCITY',C2='INITIAL VELOCITY',C3=TITR)
+            ENDIF
             IFM = J
           ELSEIF (ISK == 0 .AND. IFRA == 0) THEN
             V1 = VL1
@@ -360,30 +332,23 @@ C
             V3 = VL3
           ENDIF 
         ENDIF
+
         IF (ITYPE == 5) THEN
            IF (.NOT. MULTI_FVM%IS_USED) THEN
-              CALL ANCMSG(MSGID=1554,
-     .             MSGTYPE=MSGERROR,
-     .             ANMODE=ANINFO,
-     .             C1='IN /INIVEL OPTION')
+              CALL ANCMSG(MSGID=1554,MSGTYPE=MSGERROR,ANMODE=ANINFO,C1='IN /INIVEL OPTION')
            ELSE
               IDGRBRICK_LOC = -1
               IDGRQUAD_LOC  = -1
-              IDGRSH3N_LOC  = -1
-              IF (IDGRBRICK + IDGRQUAD + IDGRSH3N == 0) THEN
-                 CALL ANCMSG(MSGID=1553, MSGTYPE=MSGWARNING, ANMODE=ANINFO,
-     .                C1='IN /INIVEL OPTION')
+              IDGRTRIA_LOC  = -1
+              IF (IDGRBRICK + IDGRQUAD + IDGRTRIA == 0) THEN
+                 CALL ANCMSG(MSGID=1553, MSGTYPE=MSGWARNING, ANMODE=ANINFO,C1='IN /INIVEL OPTION')
               ELSE
                  IF (IDGRBRICK /= 0) THEN
                     DO J = 1,NGRBRIC
                        IF (IDGRBRICK == IGRBRIC(J)%ID) IDGRBRICK_LOC = J
                     ENDDO
                     IF (IDGRBRICK_LOC == -1) THEN
-                       CALL ANCMSG(MSGID=1554,
-     .                      MSGTYPE=MSGERROR,
-     .                      ANMODE=ANINFO,
-     .                      C1='IN /INIVEL OPTION',
-     .                      I1=IDGRBRICK)
+                       CALL ANCMSG(MSGID=1554, MSGTYPE=MSGERROR,ANMODE=ANINFO,C1='IN /INIVEL OPTION',I1=IDGRBRICK)
                     ENDIF
                  ENDIF
                  IF (IDGRQUAD /= 0) THEN
@@ -391,48 +356,37 @@ C
                        IF (IDGRQUAD == IGRQUAD(J)%ID) IDGRQUAD_LOC = J
                     ENDDO    
                     IF (IDGRQUAD_LOC == -1) THEN
-                       CALL ANCMSG(MSGID=1554,
-     .                      MSGTYPE=MSGERROR,
-     .                      ANMODE=ANINFO,
-     .                      C1='IN /INIVEL OPTION',
-     .                      I1=IDGRQUAD)
+                       CALL ANCMSG(MSGID=1554,MSGTYPE=MSGERROR,ANMODE=ANINFO,C1='IN /INIVEL OPTION',I1=IDGRQUAD)
                     ENDIF
                  ENDIF
-                 IF (IDGRSH3N /= 0) THEN
+                 IF (IDGRTRIA /= 0) THEN
                     DO J = 1,NGRSH3N
-                       IF (IDGRSH3N == IGRSH3N(J)%ID) IDGRSH3N_LOC = J
+                       IF (IDGRTRIA == IGRSH3N(J)%ID) IDGRTRIA_LOC = J
                     ENDDO      
-                    IF (IDGRSH3N_LOC == -1) THEN
-                       CALL ANCMSG(MSGID=1554,
-     .                      MSGTYPE=MSGERROR,
-     .                      ANMODE=ANINFO,
-     .                      C1='IN /INIVEL OPTION',
-     .                      I1=IDGRSH3N)                   
+                    IF (IDGRTRIA_LOC == -1) THEN
+                       CALL ANCMSG(MSGID=1554,MSGTYPE=MSGERROR,ANMODE=ANINFO,C1='IN /INIVEL OPTION',I1=IDGRTRIA)
                     ENDIF
                  ENDIF
               ENDIF
-C     Going on
-C     Brick groups
+              !     Going on
+              !     Brick groups
               FVM_INIVEL(I)%FLAG = .TRUE.
               FVM_INIVEL(I)%GRBRICID = IDGRBRICK_LOC
               FVM_INIVEL(I)%GRQUADID = IDGRQUAD_LOC
-              FVM_INIVEL(I)%GRSH3NID = IDGRSH3N_LOC
+              FVM_INIVEL(I)%GRSH3NID = IDGRTRIA_LOC
               FVM_INIVEL(I)%VX = V1
               FVM_INIVEL(I)%VY = V2
               FVM_INIVEL(I)%VZ = V3
+              FVM_GRBRIC_USER_ID(I) = IDGRBRICK
+              FVM_GRQUAD_USER_ID(I) = IDGRQUAD
+              FVM_GRTRIA_USER_ID(I) = IDGRTRIA
            ENDIF 
         ENDIF 
 C
         IF (ITYPE /= 5 .AND. ITYPE /= 6) THEN
            IGRS=0
            IF (IGR == 0) THEN
-              CALL ANCMSG(MSGID=668,
-     .             MSGTYPE=MSGERROR,
-     .             ANMODE=ANINFO,
-     .             C1='/INIVEL',
-     .             C2='/INIVEL',
-     .             C3=TITR,
-     .             I1=ID)
+              CALL ANCMSG(MSGID=668,MSGTYPE=MSGERROR,ANMODE=ANINFO,C1='/INIVEL',C2='/INIVEL',C3=TITR,I1=ID)
            ENDIF
            DO J=1,NGRNOD
               IF(IGR == IGRNOD(J)%ID) IGRS=J
@@ -448,7 +402,6 @@ C
                        VFLOW(1,NOSYS) = V1
                        VFLOW(2,NOSYS) = V2
                        VFLOW(3,NOSYS) = V3
-C     
                        WFLOW(1,NOSYS) = V1
                        WFLOW(2,NOSYS) = V2
                        WFLOW(3,NOSYS) = V3
@@ -473,7 +426,6 @@ C
                        VFLOW(1,NOSYS) = V1
                        VFLOW(2,NOSYS) = V2
                        VFLOW(3,NOSYS) = V3
-C     
                        WFLOW(1,NOSYS) = V1
                        WFLOW(2,NOSYS) = V2
                        WFLOW(3,NOSYS) = V3
@@ -486,7 +438,6 @@ C
                        VFLOW(1,NOSYS) = V1
                        VFLOW(2,NOSYS) = V2
                        VFLOW(3,NOSYS) = V3
-C     
                        WFLOW(1,NOSYS) = V1
                        WFLOW(2,NOSYS) = V2
                        WFLOW(3,NOSYS) = V3
@@ -500,7 +451,6 @@ C--                 /INIVEL/AXIS -> tag of main nodes of rbody
                         TAGNO_RBY(RBY_MSN(2,NRB)) = NRB
                       ENDDO
                     ENDIF
-C
                     NIXJ = ZERO
                     IF (IFRA > 0) THEN
                        K1=3*IDIR-2
@@ -547,12 +497,11 @@ C
                        VFLOW(1,NOSYS) = V(1,NOSYS)
                        VFLOW(2,NOSYS) = V(2,NOSYS)
                        VFLOW(3,NOSYS) = V(3,NOSYS)
-C     
                        WFLOW(1,NOSYS) = V(1,NOSYS)
                        WFLOW(2,NOSYS) = V(2,NOSYS)
                        WFLOW(3,NOSYS) = V(3,NOSYS)
                     ENDIF
-C
+
 C--                 /INIVEL/AXIS -> data must be stored to update initial velocity when RBODY main node is moved (inirby.F)
                     IF (NRBODY > 0) THEN
                       IF (TAGNO_RBY(NOSYS) > 0) THEN
@@ -567,25 +516,20 @@ C--                 /INIVEL/AXIS -> data must be stored to update initial veloci
                         ENDIF                   
                       ENDIF
                     ENDIF
-C
                  ENDIF
               ENDDO
               NNOD=IGRNOD(IGRS)%NENTITY
            ELSE
-              CALL ANCMSG(MSGID=53,
-     .             MSGTYPE=MSGERROR,
-     .             ANMODE=ANINFO,
-     .             C1='IN /INIVEL OPTION',
-     .             I1=IGR)
+              CALL ANCMSG(MSGID=53,MSGTYPE=MSGERROR,ANMODE=ANINFO,C1='IN /INIVEL OPTION',I1=IGR)
            ENDIF
         ENDIF ! IF (ITYPE /= 5 .AND. ITYPE /= 6)
       ENDDO
-C
+
       IF (ALLOCATED(TAGNO_RBY)) DEALLOCATE(TAGNO_RBY)
-C---
+
       CALL UDOUBLE(INIVIDS,1,NBVEL,MESS,0,BID)
-C
-C--- RAZ vitesses for SPH Reserve particles
+
+      !--- Reset velocities for the dormant SPH particles in the reservoir
       IF (NSPHRES>0) THEN
         DO N=1,NSPHRES
           INOD = KXSP(3,FIRST_SPHRES+N-1)
@@ -599,162 +543,136 @@ C--- RAZ vitesses for SPH Reserve particles
           ENDIF
         END DO   
       ENDIF
-C--------------------------------------------------
-C     PRINT
-C--------------------------------------------------
+
+
+      !--------------------------------------------------
+      !     STARTER LISTING FILE (INITIAL VELOCITY PRINTED IF IPRI >= 2)
+      !            IPRI : SEE /IOFLAG OPTION
+      !--------------------------------------------------
       IF (HM_NINVEL > 0) THEN
+        J=0
+        NODINIVEL=0
 
-      J=0
-      NODINIVEL=0
-      IF(IPRI>=2)THEN
-       IF(IALE/=0) THEN
-         WRITE(IOUT,2100)
-       ELSEIF(KROT==0) THEN
-         WRITE(IOUT,2000)
-       ELSE
-         WRITE(IOUT,2200)
-       ENDIF
-       KPRI=0
-       DO 340 N=1,NUMNOD,50
-       J=J+50
-       J=MIN(J,NUMNOD)
-       IF(IALE==0) THEN
-        DO 330 I=N,J
-          IF(KPRI>=50) THEN
-            IF(KROT==0) THEN
-              WRITE(IOUT,2000)
-            ELSE
-              WRITE(IOUT,2200)
-            ENDIF
-            KPRI=0
-          ENDIF
-          IF(IRODDL/=0) THEN
-            IF (V(1,I)/=ZERO.OR.V(2,I)/=ZERO.OR.V(3,I)/=ZERO.OR.
-     .        VR(1,I)/=ZERO.OR.VR(2,I)/=ZERO.OR.VR(3,I)/=ZERO)THEN
-              NODINIVEL=NODINIVEL+1
-              IF (VR(1,I)/=ZERO.OR.VR(2,I)/=ZERO.OR.
-     .            VR(3,I)/=ZERO) THEN
-                WRITE(IOUT,'(3X,I10,8X,1P6G20.13)')
-     .              ITAB(I),V(1,I),V(2,I),V(3,I),VR(1,I),VR(2,I),VR(3,I)
-              ELSE
-                WRITE(IOUT,'(3X,I10,8X,1P6G20.13)')
-     .               ITAB(I),V(1,I),V(2,I),V(3,I)
-              ENDIF
-              KPRI=KPRI+1
-            ENDIF
-         ELSEIF(V(1,I)/=ZERO.OR.V(2,I)/=ZERO.OR.V(3,I)/=ZERO) THEN
-           NODINIVEL=NODINIVEL+1
-           WRITE(IOUT,'(3X,I10,8X,1P6G20.13)')
-     .           ITAB(I),V(1,I),V(2,I),V(3,I)
-           KPRI=KPRI+1
-         ENDIF
- 330    CONTINUE
-       ELSE
-        DO 335 I=N,J
-          IF(KPRI==50) THEN
+        ! INITIAL VELOCIIES FOR STAGGERED SCHEME
+        IF(IPRI >= 2 .AND. NINIVEL_TOTAL-NINIVEL_FVM > 0 )THEN
+
+          !---TITLE OUTPUT
+          !     STAGGERED SCHEME (VELOCITIES AT NODES)
+          IF(IALE /= 0) THEN
             WRITE(IOUT,2100)
-            KPRI=0
+          ELSEIF(KROT == 0) THEN
+            WRITE(IOUT,2000)
+          ELSE
+            WRITE(IOUT,2200)
           ENDIF
-        IF(V(1,I)/=ZERO.OR.V(2,I)/=ZERO.OR.V(3,I)/=ZERO.OR.
-     .     W(1,I)/=ZERO.OR.W(2,I)/=ZERO.OR.W(3,I)/=ZERO) THEN
-          NODINIVEL=NODINIVEL+1
-          WRITE(IOUT,'(5X,I10,8X,1P6G20.13)') ITAB(I),
-     +                        V(1,I),V(2,I),V(3,I),W(1,I),W(2,I),W(3,I)
-          KPRI=KPRI+1
-        ENDIF
- 335    CONTINUE
-       ENDIF
- 340  CONTINUE
-      WRITE(IOUT,'(/,A,I10,//)')
-     +           ' NUMBER OF NODES WITH INITIAL VELOCITY:',NODINIVEL
-      ENDIF
 
-      ENDIF
+          !---DETAILS OUTPUT--------------------------
+          !     STAGGERED SCHEME (VELOCITIES AT NODES)
+            KPRI=0
+            DO N=1,NUMNOD,50
+              J=J+50
+              J=MIN(J,NUMNOD)
+              IF(IALE == 0)THEN
+                DO I=N,J
+                  IF(KPRI >= 50) THEN
+                    IF(KROT == 0) THEN
+                      WRITE(IOUT,2000)
+                    ELSE
+                      WRITE(IOUT,2200)
+                    ENDIF
+                    KPRI=0
+                  ENDIF
+                  IF(IRODDL /= 0) THEN
+                    IF (V(1,I)/=ZERO.OR.V(2,I)/=ZERO.OR.V(3,I)/=ZERO.OR.VR(1,I)/=ZERO.OR.VR(2,I)/=ZERO.OR.VR(3,I)/=ZERO)THEN
+                      NODINIVEL=NODINIVEL+1
+                      IF (VR(1,I) /= ZERO .OR. VR(2,I) /= ZERO .OR. VR(3,I) /= ZERO) THEN
+                        WRITE(IOUT,'(3X,I10,8X,1P6G20.13)') ITAB(I),V(1,I),V(2,I),V(3,I),VR(1,I),VR(2,I),VR(3,I)
+                      ELSE
+                        WRITE(IOUT,'(3X,I10,8X,1P6G20.13)')ITAB(I),V(1,I),V(2,I),V(3,I)
+                      ENDIF
+                      KPRI=KPRI+1
+                    ENDIF
+                  ELSEIF(V(1,I) /= ZERO .OR. V(2,I) /= ZERO .OR. V(3,I) /= ZERO) THEN
+                    NODINIVEL=NODINIVEL+1
+                    WRITE(IOUT,'(3X,I10,8X,1P6G20.13)')ITAB(I),V(1,I),V(2,I),V(3,I)
+                    KPRI=KPRI+1
+                  ENDIF
+                ENDDO!next I
+
+              ELSEIF(IALE /= 0)THEN
+                DO I=N,J
+                  IF(KPRI==50) THEN
+                    WRITE(IOUT,2100)
+                    KPRI=0
+                  ENDIF
+                  IF(V(1,I)/=ZERO.OR.V(2,I)/=ZERO.OR.V(3,I)/=ZERO.OR.W(1,I)/=ZERO.OR.W(2,I)/=ZERO.OR.W(3,I)/=ZERO) THEN
+                    NODINIVEL=NODINIVEL+1
+                    WRITE(IOUT,'(5X,I10,8X,1P6G20.13)') ITAB(I),V(1,I),V(2,I),V(3,I),W(1,I),W(2,I),W(3,I)
+                    KPRI=KPRI+1
+                  ENDIF
+                ENDDO! NEXT I
+              ENDIF
+
+            ENDDO!NEXT N
+            WRITE(IOUT,'(/,A,I10,//)') ' NUMBER OF NODES WITH INITIAL VELOCITY:',NODINIVEL
+
+        ENDIF
+
+        ! INITIAL VELOCIIES FOR COLLOCATED SCHEME
+        IF(IPRI >= 2 .AND. NINIVEL_FVM > 0 )THEN
+          WRITE(IOUT,3000)
+          !---DETAILS OUTPUT-----------------------------------
+          !     COLOCATED SCHEME (VELOCITIES AT CELL CENTROIDS)
+            DO CPT=1,HM_NINVEL
+              IF(.NOT. FVM_INIVEL(I)%FLAG)CYCLE
+              V1=FVM_INIVEL(I)%VX
+              V2=FVM_INIVEL(I)%VY
+              V3=FVM_INIVEL(I)%VZ
+              IF(IDGRBRICK_LOC >0)THEN
+                WRITE(IOUT,3001)
+                WRITE(IOUT,'(5X,I10,8X,1P6G20.13)') FVM_GRBRIC_USER_ID(I),V1,V2,V3
+              ENDIF
+              IF(IDGRQUAD_LOC >0)THEN
+                WRITE(IOUT,3002)
+                WRITE(IOUT,'(5X,I10,8X,1P6G20.13)') FVM_GRQUAD_USER_ID(I),V1,V2,V3
+              ENDIF
+              IF(IDGRTRIA_LOC >0)THEN
+                WRITE(IOUT,3003)
+                WRITE(IOUT,'(5X,I10,8X,1P6G20.13)') FVM_GRTRIA_USER_ID(I),V1,V2,V3
+              ENDIF
+            ENDDO!next CPT
+             WRITE(IOUT,'(//)')
+        ENDIF!IF(IPRI >= 2)
+
+      ENDIF!(HM_NINVEL > 0)
 !-----------
       RETURN
 !-----------
 2000  FORMAT(//
      .'     INITIAL VELOCITIES    '/
-     .'     -------------------    '/
+     .'     -------------------   '/
      + 9X,'NODE',22X,'VX   ',15X,'VY   ',15X,'VZ   '/)
 2100  FORMAT(//
      .'     INITIAL VELOCITIES    '/
-     .'     -------------------    '/
+     .'     -------------------   '/
      + 9X,'NODE',22X,'VX   ',15X,'VY   ',15X,'VZ   ',
      +           14X,'WX   ',15X,'WY   ',15X,'WZ   '/)
 2200  FORMAT(//
      .'     INITIAL VELOCITIES    '/
-     .'     -------------------    '/
+     .'     -------------------   '/
      + 9X,'NODE',22X,'VX   ',15X,'VY   ',15X,'VZ   ',
      +           14X,'VRX  ',15X,'VRY  ',15X,'VRZ'/)
- 999  CALL FREERR(1)
-      RETURN
-      END
-Chd|====================================================================
-Chd|  HM_PREREAD_INIVEL             source/initial_conditions/general/inivel/hm_read_inivel.F
-Chd|-- called by -----------
-Chd|        CONTRL                        source/starter/contrl.F       
-Chd|-- calls ---------------
-Chd|        HM_OPTION_READ_KEY            source/devtools/hm_reader/hm_option_read_key.F
-Chd|        HM_OPTION_START               source/devtools/hm_reader/hm_option_start.F
-Chd|        HM_OPTION_READ_MOD            share/modules1/hm_option_read_mod.F
-Chd|        STACK_VAR_MOD                 share/modules1/stack_var_mod.F
-Chd|        SUBMODEL_MOD                  share/modules1/submodel_mod.F 
-Chd|====================================================================
-      SUBROUTINE HM_PREREAD_INIVEL(KROT,LSUBMODEL)
-C============================================================================
-C-----------------------------------------------
-C   A n a l y s e   M o d u l e
-C-----------------------------------------------
-      USE STACK_VAR_MOD
-      USE SUBMODEL_MOD
-      USE HM_OPTION_READ_MOD
-C-----------------------------------------------
-C   I m p l i c i t   T y p e s
-C-----------------------------------------------
-#include      "implicit_f.inc"
-C-----------------------------------------------
-C   C o m m o n   B l o c k s
-C-----------------------------------------------
-#include      "com04_c.inc"
-C-----------------------------------------------
-C   D u m m y   A r g u m e n t s
-C-----------------------------------------------
-      INTEGER KROT
-      TYPE(SUBMODEL_DATA) LSUBMODEL(*)
-C-----------------------------------------------
-C   L o c a l   V a r i a b l e s
-C-----------------------------------------------
-      INTEGER I,IG,CPT
-      CHARACTER IDTITL*nchartitle,KEY*ncharkey, 
-     .          SOLVERKEYWORD*ncharline
-      LOGICAL IS_AVAILABLE
-C=======================================================================
-C--------------------------------------------------
-      IS_AVAILABLE = .FALSE.
-C--------------------------------------------------
-C START BROWSING INIVEL OPTIONS
-C--------------------------------------------------
-      CALL HM_OPTION_START('/INIVEL')
-      I = 0
-C--------------------------------------------------
-C BROWSING INIVEL OPTIONS 1->HM_NINVEL
-C--------------------------------------------------
-! rotational inivel at nodes
-      DO CPT=1,HM_NINVEL
-        I = I + 1
-        KEY = ''
-        SOLVERKEYWORD = ''
-        IDTITL = ''
-C--------------------------------------------------
-C EXTRACT DATAS OF /INIVEL/... LINE
-C--------------------------------------------------
-        CALL HM_OPTION_READ_KEY(LSUBMODEL,
-     .                       OPTION_ID = IG,
-     .                       KEYWORD2 = KEY)
-C
-        IF (KEY(1:4) == 'NODE') KROT = 1
-      ENDDO
-C      
-      RETURN
-      END
+3000  FORMAT(//
+     .'     INITIAL VELOCITIES (FVM)   '/
+     .'     ------------------------   ')
+3001  FORMAT(
+     + 9X,'GRBRIC',22X,'VX   ',15X,'VY   ',15X,'VZ   ')
+3002  FORMAT(
+     + 9X,'GRQUAD',22X,'VX   ',15X,'VY   ',15X,'VZ   ')
+3003  FORMAT(
+     + 9X,'GRTRIA',22X,'VX   ',15X,'VY   ',15X,'VZ   ')
+
+!-----------
+      END SUBROUTINE HM_READ_INIVEL
+
+

--- a/starter/source/starter/contrl.F
+++ b/starter/source/starter/contrl.F
@@ -1059,7 +1059,8 @@ C----------------------------------------------------------
 C     solids with rotation
 C----------------------------------------------------------
       KROT = 0
-      CALL HM_PREREAD_INIVEL(KROT,LSUBMODEL)
+      CALL HM_OPTION_COUNT('/INIVEL/NODE',I)
+      IF(I > 0)KROT=1
       IRODDL=MIN(1,NUMELC+NUMELP+NRBODY+NUMELR+NUMELTG+NGJOINT+NUMMPC+NFXBODY+NUMELX+KROT)
       IRODDL0 = 0
       IISROT = 0

--- a/starter/source/starter/lectur.F
+++ b/starter/source/starter/lectur.F
@@ -4748,12 +4748,12 @@ C
           FVM_INIVEL(I)%FLAG = .FALSE.
        ENDDO
 C
-        CALL HM_READ_INIVEL(V       ,W       ,ITAB   ,ITABM1  ,VR      ,
-     .              IGRNOD    ,IGRBRIC ,ISKWN    ,SKEW    ,IWORK    ,
-     .              X       ,UNITAB  ,LSUBMODEL,RTRANS,XFRAME  ,
-     .              IFRAME    ,VFLOW   ,WFLOW    ,KXSP    ,MULTI_FVM,
-     .              FVM_INIVEL,IGRQUAD ,IGRSH3N  ,RBY_MSN ,RBY_INIAXIS)
-        CALL INIVEL(V       ,VR      ,SVR_1 ,ITABM1     )
+        CALL HM_READ_INIVEL(V         , W      , ITAB     , ITABM1 , VR         ,
+     .                      IGRNOD    , IGRBRIC, ISKWN    , SKEW   , IWORK      ,
+     .                      X         , UNITAB , LSUBMODEL, RTRANS , XFRAME     ,
+     .                      IFRAME    , VFLOW  , WFLOW    , KXSP   , MULTI_FVM  ,
+     .                      FVM_INIVEL, IGRQUAD, IGRSH3N  , RBY_MSN, RBY_INIAXIS)
+        CALL INIVEL(V, VR, SVR_1, ITABM1)
 C
         IF(ALLOCATED(IWORK)) DEALLOCATE(IWORK)
         NINVEL  = SIWORK


### PR DESCRIPTION
#### /INIVEL/FVM : Adding Starter Printout

#### Description of the changes
The /INIVEL/FVM option, which defines the initial velocity conditions at element centroids for the collocated scheme (FVM with law151), now includes its printout in the Starter listing file. This enhancement enables users to verify whether their specified options in the input file are accurately considered.