### PR TITLE
/INISH3/STRS_F/GLOB doesn't work with ish3n=30 and law1 (npt=1)

### DIFF
--- a/starter/source/elements/sh3n/coquedk/cdkinit3.F
+++ b/starter/source/elements/sh3n/coquedk/cdkinit3.F
@@ -203,7 +203,6 @@ C-----------------------------------------------
      .             PERTURB,IX1   ,IX2      ,IX3    ,
      .             X2L    ,X3L    ,Y3L   ,IDRAPE , INDX)
 C-----------------------------------------------
-      IF (MTN == 1 .OR. MTN == 3 .OR. MTN == 23) NPT = 0
       NPT_ALL = 0
       DO IL=1,NLAY
           NPT_ALL = NPT_ALL + ELBUF_STR%BUFLY(IL)%NPTT


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
initial stress w/ INISH3/STRS_F/GLOB doen't work when dkt18 (Ish3n=30) +law1, npt=1

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
correction to fix the initial stress issue.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
