### PR TITLE
/INIVOL option with single precision : due to the single precision, a cell id exceeds the maximal number of cell

### DIFF
--- a/starter/source/initial_conditions/inivol/ale_box_coloration.F
+++ b/starter/source/initial_conditions/inivol/ale_box_coloration.F
@@ -176,6 +176,12 @@ C-----------------------------------------------
             CELL_POSITION(1,I) =MAX(1,1+INT(NB_CELL_X*(X(1,I)-XMIN)/(XMAX-XMIN)))
             CELL_POSITION(2,I) =MAX(1,1+INT(NB_CELL_Y*(X(2,I)-YMIN)/(YMAX-YMIN)))
             CELL_POSITION(3,I) =MAX(1,1+INT(NB_CELL_Z*(X(3,I)-ZMIN)/(ZMAX-ZMIN)))
+
+            ! ensure that cell_position does not exceed the number of
+            ! cell (single precision issue)
+            CELL_POSITION(1,I) =MIN(CELL_POSITION(1,I),NB_CELL_X)
+            CELL_POSITION(2,I) =MIN(CELL_POSITION(2,I),NB_CELL_Y)
+            CELL_POSITION(3,I) =MIN(CELL_POSITION(3,I),NB_CELL_Z)
         ENDDO   
         !   ------------------
 


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
In the /INIVOL algorithm, a cell id (integer value) is computed thanks to the position X. Due to the limitation of the single precision, the cell id can exceed the maximal number of cell.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Check if the cell id exceed the maximal number of cell
If yes, limit the cell id to the maximal number of cell

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
