### PR TITLE
Fix missing argument in inigrav_load routine

### DIFF
--- a/starter/source/initial_conditions/inigrav/inigrav_load.F
+++ b/starter/source/initial_conditions/inigrav/inigrav_load.F
@@ -479,7 +479,7 @@ C-----------------------------------------------
                 MATID  = IPM(20 + IMAT, IX(1, 1))  
                 MATLAW = IPM(2, MATID)            
                 CALL INIGRAV_EOS(NEL,   NEL2 , NG   , MATID, IPM, GRAV0, RHO0, DEPTH, PM, BUFMAT(IADBUF), ELBUF_TAB, 
-     .                           PSURF, LIST , PGRAV, IMAT , MLW, NPF, TF,MAT_PARAM)
+     .                           PSURF, LIST , PGRAV, IMAT , MLW, NPF,TF,NUMMAT,MAT_PARAM)
               ENDDO
               ! GLOBAL STATE
               DO KK=1,NEL2


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Inigrav_load calls inigrav_eos without the NUMMAT argument

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Add NUMMAT to the list of arguments

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
