### PR TITLE
/BCS/WALL: Eliminate implicit LOGICAL-INTEGER conversion

### DIFF
--- a/common_source/output/restart/write_bcs_wall.F90
+++ b/common_source/output/restart/write_bcs_wall.F90
@@ -51,11 +51,12 @@
 ! ----------------------------------------------------------------------------------------------------------------------                   
 
       ! /BCS/WALL
-      !   when starting from a restart file we need to read these values 
+      !   when starting from a restart file we need to read these values
 
-          itmp(1) = bcsw%is_enabled             !implicit conversion
-          itmp(2) = bcsw%is_depending_on_time   !implicit conversion
-          itmp(3) = bcsw%is_depending_on_sensor !implicit conversion
+          itmp(1:3) = 0
+          if(bcsw%is_enabled) itmp(1) = 1
+          if(bcsw%is_depending_on_time) itmp(2) = 1
+          if(bcsw%is_depending_on_sensor) itmp(3) = 1
           itmp(4) = bcsw%user_id
           itmp(5) = bcsw%grnod_id
           itmp(6) = bcsw%sensor_id

--- a/engine/source/boundary_conditions/bcs_wall_trigger.F90
+++ b/engine/source/boundary_conditions/bcs_wall_trigger.F90
@@ -65,13 +65,14 @@
 
       do ii=1,bcs%num_wall
 
-        if(bcs%wall(ii)%is_depending_on_time)then
-          tstart = bcs%wall(ii)%tstart
-          tstop = bcs%wall(ii)%tstop
-        elseif(bcs%wall(ii)%is_depending_on_sensor)then
+        if(bcs%wall(ii)%is_depending_on_sensor)then
           sensor_id = bcs%wall(ii)%sensor_id
           tstart =  sensor_tab(sensor_id)%tstart
           tstop = sensor_tab(sensor_id)%value
+        else
+          !depending_on_time
+          tstart = bcs%wall(ii)%tstart
+          tstop = bcs%wall(ii)%tstop          
         end if
 
         is_enabled = bcs%wall(ii)%is_enabled


### PR DESCRIPTION
/BCS/WALL: Eliminate implicit LOGICAL-INTEGER conversion

#### Description of the changes
The implicit conversion from LOGICAL to INTEGER may vary depending on the compiler used (intel, gfortran, ...). The source code in write_bcs_wall.F90 has been updated to use explicit assignments of 1 or 0 to address this.