### PR TITLE
correction on distortion control of Hexa solid using single precision (argument type mismatch)

### DIFF
--- a/engine/source/elements/solid/solide/s8get_x3.F
+++ b/engine/source/elements/solid/solide/s8get_x3.F
@@ -59,7 +59,7 @@ C-----------------------------------------------
 !     
       my_real, DIMENSION(3,NUMNOD), INTENT(IN) :: X
       DOUBLE PRECISION, DIMENSION(3,NUMNOD), INTENT(IN) ::XDP
-      DOUBLE PRECISION, DIMENSION(MVSIZ), INTENT(INOUT) ::
+      my_real, DIMENSION(MVSIZ), INTENT(INOUT) ::
      .    X1,       X2,       X3,       X4,      
      .    X5,       X6,       X7,       X8,      
      .    Y1,       Y2,       Y3,       Y4,      

--- a/engine/source/elements/solid/solide/ssort_n4.F
+++ b/engine/source/elements/solid/solide/ssort_n4.F
@@ -45,8 +45,7 @@ C-----------------------------------------------
       INTEGER, INTENT (IN)  :: NEL
       INTEGER, DIMENSION(MVSIZ),INTENT (INOUT) :: IFC1
       my_real, DIMENSION(MVSIZ), INTENT (IN) :: MARGE,
-     .                        XI,     YI,     ZI,STIF 
-      DOUBLE PRECISION, DIMENSION(MVSIZ), INTENT (IN) ::
+     .                        XI,     YI,     ZI,STIF, 
      .                        X1,     X2,      X3,      X4,
      .                        Y1,     Y2,      Y3,      Y4,
      .                        Z1,     Z2,      Z3,      Z4


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Bug fix: my_real coordinates (in sforc3.F,szforc3.F,s8eforc3.F) were passed to DOUBLE PRECISION (s8get_x3). 

Get Nan or segfault in single precision for distortion control w/ Hexa solid elements

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
correction to fix the single precision issue of distortion control w/ Hexa solid elements

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
