### PR TITLE
correct the order of logical terms when evaluating "if" condition

### DIFF
--- a/starter/source/materials/fail/fractal/random_walk_dmg.F90
+++ b/starter/source/materials/fail/fractal/random_walk_dmg.F90
@@ -169,7 +169,7 @@
 !
           end if      ! random start
           !------------------------------
-          if (debug == 1 .and. random_start .eqv. .false.) then
+          if ((debug == 1) .and. (random_start .eqv. .false.)) then
             print*,'starting element list'
             do i = 1,nstart
               iel = start_group(i)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

correct bug introduced when adding a conditional output prints in /fail/fractal_dmg

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

modified an "if then" condition, forcing a correct order of term evaluation

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
