### PR TITLE
m51init:uparam(31) set to 1 when iform=12

### DIFF
--- a/starter/source/materials/mat/mat051/m51init.F
+++ b/starter/source/materials/mat/mat051/m51init.F
@@ -88,6 +88,8 @@ C-----------------------------------------------
       !need to initialize element buffer with initial density for this specific case.
       IS_IFORM12 = .FALSE.
       IF(IFORM == 12)THEN
+        UPARAM(31) = 1
+        UPARAM(55) = 1
         IFORM = 1
         IFLG = 1
         IS_IFORM12 = .TRUE.


### PR DESCRIPTION
#### m51init:uparam(31) set to 1


#### Description of the changes
In response to the update introduced in commit 93c5e1eb0e1ab9056043f1866722eba0280bc12b, where uparam(31) was configured to 12 in fill_buffer51.F to facilitate the detection of input format when invoking m51init.F. Subsequently, it is imperative to reset uparam(31) to its original value of 1.

Although not classified as a bug currently, resetting this parameter to its expected value is essential to preempt any potential complications with future development reliant on upram(31) and material law51.