### PR TITLE
/EBCS/MONVOL:argument removed

### DIFF
--- a/starter/source/boundary_conditions/ebcs/read_ebcs.F
+++ b/starter/source/boundary_conditions/ebcs/read_ebcs.F
@@ -226,7 +226,7 @@ C-----------------------------------------------
             allocate (t_ebcs_monvol :: EBCS_TAB%tab(ii)%poly)
             select type (twf => EBCS_TAB%tab(ii)%poly)
             type is (t_ebcs_monvol)
-              CALL HM_READ_EBCS_MONVOL(IGRSURF,MULTI_FVM,UNITAB, ID, TITR, TYP, UID, LSUBMODEL, twf)
+              CALL HM_READ_EBCS_MONVOL(IGRSURF,MULTI_FVM,UNITAB, ID, TITR, UID, LSUBMODEL, twf)
             end select
 
          CASE DEFAULT


### PR DESCRIPTION
#### /EBCS/MONVOL:argument removed

#### Description of the changes
The argument 'TYP' from the subroutine 'HM_READ_EBCS_MONVOL' has been removed. This argument should have been removed during the previous cleanup (commit: bdd2ce631c9974f31b75f503e3e8ab3755263e9a). It is now done.
