### PR TITLE
ale connectivity buffer: tria update

### DIFF
--- a/common_source/modules/ale/ale_connectivity_mod.F
+++ b/common_source/modules/ale/ale_connectivity_mod.F
@@ -787,31 +787,34 @@ C-----------------------------------------------
 
 !       2D elements
 !       /TRIA
-        DO II = 1, NUMELTG
-!       ale : jal = 1, euler : jal = 2
-         JAL_FROM_MAT = NINT(PM(72, IABS(IXTG(1, II)))) 
-         JAL_FROM_PROP = IGEO(62, IABS(IXTG(5, II)))
-         JAL = MAX(JAL_FROM_MAT, JAL_FROM_PROP)
-         JALT = JAL + NINT(PM(71, IABS(IXTG(1, II))) + PM(96, IABS(IXTG(1, II))))
-         IMID = IABS(IXTG(1, II))
-         IF (JALT == 0) CYCLE
-         MLW  = NINT(PM(19,IMID))
-         DO JJ = 1, 3
-            NODE_ID = IXTG(1 + JJ, II)
-            NE_NB_CONNECT(NODE_ID) = NE_NB_CONNECT(NODE_ID) + 1
-            IF (.NOT. THIS%NALE_ALREADY_COMPUTED) THEN
-               THIS%NALE(NODE_ID) = MAX(THIS%NALE(NODE_ID), JAL)
-               IF (MLW == 151) THEN
-                  IF (THIS%NALE(NODE_ID) == 1 .OR. THIS%NALE(NODE_ID) == 2) THIS%NALE(NODE_ID) = 150 + THIS%NALE(NODE_ID)
-               ENDIF
-            ENDIF
-         ENDDO
-        ENDDO
+        IF(N2D > 0)THEN
+          DO II = 1, NUMELTG
+!         ale : jal = 1, euler : jal = 2
+           JAL_FROM_MAT = NINT(PM(72, IABS(IXTG(1, II))))
+           JAL_FROM_PROP = IGEO(62, IABS(IXTG(5, II)))
+           JAL = MAX(JAL_FROM_MAT, JAL_FROM_PROP)
+           JALT = JAL + NINT(PM(71, IABS(IXTG(1, II))) + PM(96, IABS(IXTG(1, II))))
+           IMID = IABS(IXTG(1, II))
+           IF (JALT == 0) CYCLE
+           MLW  = NINT(PM(19,IMID))
+           DO JJ = 1, 3
+              NODE_ID = IXTG(1 + JJ, II)
+              NE_NB_CONNECT(NODE_ID) = NE_NB_CONNECT(NODE_ID) + 1
+              IF (.NOT. THIS%NALE_ALREADY_COMPUTED) THEN
+                 THIS%NALE(NODE_ID) = MAX(THIS%NALE(NODE_ID), JAL)
+                 IF (MLW == 151) THEN
+                    IF (THIS%NALE(NODE_ID) == 1 .OR. THIS%NALE(NODE_ID) == 2) THIS%NALE(NODE_ID) = 150 + THIS%NALE(NODE_ID)
+                 ENDIF
+              ENDIF
+           ENDDO
+          ENDDO
+        ENDIF
+
 !       /QUAD
         DO II = 1, NUMELQ
 !       ale : jal = 1, euler : jal = 2
          JAL_FROM_MAT = NINT(PM(72, IABS(IXQ(1, II))))
-         JAL_FROM_PROP = IGEO(62,IABS(IXQ(6, II))) 
+         JAL_FROM_PROP = IGEO(62,IABS(IXQ(6, II)))
          JAL = MAX(JAL_FROM_MAT, JAL_FROM_PROP)
          JALT = JAL + NINT(PM(71, IABS(IXQ(1, II))) + PM(96, IABS(IXQ(1, II))))
          IMID = IABS(IXQ(1, II))
@@ -828,7 +831,7 @@ C-----------------------------------------------
             ENDIF
          ENDDO
         ENDDO
-        
+
 !       3D elements
         DO II = 1, NUMELS
          JAL_FROM_MAT = NINT(PM(72, IABS(IXS(1, II))))
@@ -886,24 +889,27 @@ C-----------------------------------------------
         
 !       2D elements
 !       /TRIA
-        DO II = 1, NUMELTG
-         JAL_FROM_MAT = NINT(PM(72, IABS(IXTG(1, II)))) 
-         JAL_FROM_PROP = IGEO(62,IABS(IXTG(5, II)))
-         JAL = MAX(JAL_FROM_MAT, JAL_FROM_PROP)
-         JALT = JAL + NINT(PM(71, IABS(IXTG(1, II))) + PM(96, IABS(IXTG(1, II))))
-         IMID = IABS(IXTG(1, II))
-         IF (JALT == 0) CYCLE
-         DO JJ = 1, 3
-            NODE_ID = IXTG(1 + JJ, II)
-            CONNECTED(ADSKY(NODE_ID)) = II
-            TYPE(ADSKY(NODE_ID)) = 3
-            ADSKY(NODE_ID) = ADSKY(NODE_ID) + 1
-         ENDDO
-        ENDDO
+        IF(N2D > 0)THEN
+          DO II = 1, NUMELTG
+           JAL_FROM_MAT = NINT(PM(72, IABS(IXTG(1, II))))
+           JAL_FROM_PROP = IGEO(62,IABS(IXTG(5, II)))
+           JAL = MAX(JAL_FROM_MAT, JAL_FROM_PROP)
+           JALT = JAL + NINT(PM(71, IABS(IXTG(1, II))) + PM(96, IABS(IXTG(1, II))))
+           IMID = IABS(IXTG(1, II))
+           IF (JALT == 0) CYCLE
+           DO JJ = 1, 3
+              NODE_ID = IXTG(1 + JJ, II)
+              CONNECTED(ADSKY(NODE_ID)) = II
+              TYPE(ADSKY(NODE_ID)) = 3
+              ADSKY(NODE_ID) = ADSKY(NODE_ID) + 1
+           ENDDO
+          ENDDO
+        ENDIF
+
 !       /QUAD
         DO II = 1, NUMELQ
          JAL_FROM_MAT = NINT(PM(72, IABS(IXQ(1, II))))
-         JAL_FROM_PROP = IGEO(62, IABS(IXQ(6, II)) ) 
+         JAL_FROM_PROP = IGEO(62, IABS(IXQ(6, II)) )
          JAL = MAX(JAL_FROM_MAT, JAL_FROM_PROP)
          JALT = JAL + NINT(PM(71, IABS(IXQ(1, II))) + PM(96, IABS(IXQ(1, II))))
          IMID = IABS(IXQ(1, II))
@@ -914,7 +920,8 @@ C-----------------------------------------------
             TYPE(ADSKY(NODE_ID)) = 2
             ADSKY(NODE_ID) = ADSKY(NODE_ID) + 1
          ENDDO
-       ENDDO
+        ENDDO
+
 !      3D elements
         DO II = 1, NUMELS
          JAL_FROM_MAT = NINT(PM(72, IABS(IXS(1, II))))

--- a/starter/source/restart/ddsplit/c_ixfloc.F
+++ b/starter/source/restart/ddsplit/c_ixfloc.F
@@ -33,6 +33,9 @@ Chd|====================================================================
      +                    NQVOIS,NTGVOIS,PROC,IPARG,CEP,CEL,
      +                    ALE_CONNECTIVITY,ee_connect_l,IXS,IXQ,IXTG,NODLOCAL,NUMELS_L,NUMELQ_L,NUMELTG_L,MULTI_FVM,
      +                    ID_GLOBAL_VOIS,INDX_S,INDX_Q,INDX_TG,FACE_ELM_S,FACE_ELM_Q,FACE_ELM_TG,FACE_VOIS)
+C-----------------------------------------------
+C   M o d u l e s
+C-----------------------------------------------
       USE MULTI_FVM_MOD
       USE ALE_CONNECTIVITY_MOD
 C-----------------------------------------------
@@ -68,18 +71,21 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I, J, K, N, NG, IFS, IFQ, IFTG,IE_LOC, IV_LOC,
-     .        ISOLNOD,ILAW,JTUR,JTHE,ITY,IE,NFT,NEL,IV,PROC2,NFT_LOC,IAD1, LGTH, IAD2
-      INTEGER :: NUMEL_L, TMP, IALEUL
+      INTEGER I, J, K, N, NG, IFS, IFQ, IFTG,IE_LOC, IV_LOC
+      INTEGER ISOLNOD,ILAW,JTUR,JTHE,ITY,IE,NFT,NEL,IV,PROC2,NFT_LOC,IAD1, LGTH, IAD2
+      INTEGER NUMEL_L, TMP, IALEUL
       INTEGER, DIMENSION(:), ALLOCATABLE :: TAGE, nb_connect_l
-!
+      LOGICAL IS_HEXA,IS_QUAD,IS_TRIA
+C-----------------------------------------------
+C   S o u r c e   L i n e s
+C-----------------------------------------------
 !     Number of local elements
       NUMEL_L = 0 
       DO NG = 1, NGROUP
-         IF (IPARG(32, NG) == PROC) THEN
-            NEL = IPARG(2, NG)
-            NUMEL_L = NUMEL_L + NEL
-         ENDIF
+        IF (IPARG(32, NG) == PROC) THEN
+          NEL = IPARG(2, NG)
+          NUMEL_L = NUMEL_L + NEL
+        ENDIF
       ENDDO
       ALLOCATE(ee_connect_l%iad_connect(NUMEL_L + 1))
       ee_connect_l%iad_connect(1:NUMEL_L + 1) = 0
@@ -93,16 +99,25 @@ C-----------------------------------------------
             NEL = IPARG(2, NG)
             NFT = IPARG(3, NG)
             IALEUL = IPARG(7, NG) + IPARG(11, NG)
-            IF (IALEUL /= 0) THEN
-               DO I = 1, NEL
-!     Index of the element
+            ITY = IPARG(5,NG)
+            IS_HEXA=.FALSE.
+            IS_QUAD=.FALSE.
+            IS_TRIA=.FALSE.
+            IF(ITY == 1)IS_HEXA=.TRUE.
+            IF(ITY == 2)IS_QUAD=.TRUE.
+            IF(ITY == 7 .AND. N2D > 0)IS_TRIA=.TRUE.
+            IF(IS_HEXA .OR. IS_QUAD .OR. IS_TRIA)THEN !skip shell, sh3n, and other elem types
+              IF (IALEUL /= 0) THEN
+                DO I = 1, NEL
+                  ! Index of the element
                   IE = I + NFT
-!     Local index of the element
+                  ! Local index of the element
                   IE_LOC = I + NFT_LOC
-!     Number of neighbors
+                  ! Number of neighbors
                   LGTH = ALE_CONNECTIVITY%ee_connect%iad_connect(IE+1)-ALE_CONNECTIVITY%ee_connect%iad_connect(IE)
                   nb_connect_l(IE_LOC) = LGTH
-               ENDDO
+                ENDDO
+              ENDIF
             ENDIF
             NFT_LOC = NFT_LOC + NEL
          ENDIF
@@ -112,9 +127,9 @@ C-----------------------------------------------
          ee_connect_l%iad_connect(I) = ee_connect_l%iad_connect(I - 1) + nb_connect_l(I - 1)
       ENDDO
       TMP = ee_connect_l%iad_connect(NUMEL_L + 1) - 1
-      ALLOCATE(ee_connect_l%connected(TMP))
-      ALLOCATE(ee_connect_l%type(TMP))
-      ALLOCATE(ee_connect_l%iface2(TMP))
+      ALLOCATE(ee_connect_l%connected(TMP)) ; ee_connect_l%connected(1:TMP) = 0
+      ALLOCATE(ee_connect_l%type(TMP)) ; ee_connect_l%type(1:TMP) = 0
+      ALLOCATE(ee_connect_l%iface2(TMP)) ; ee_connect_l%iface2(1:TMP) = 0
 C
       ALLOCATE(TAGE(NUMEL))
       DO I = 1, NUMEL
@@ -134,6 +149,8 @@ C
          ITY = IPARG(5,NG)
 C   voir autres types solides
          ISOLNOD = IPARG(28,NG)
+         IALEUL = IPARG(7, NG) + IPARG(11, NG)
+         IF(IALEUL == 0)CYCLE
 C   3D
          IF(ITY==1) THEN
            DO I = 1, NEL
@@ -241,7 +258,7 @@ C   element interne
              ENDDO
            ENDDO
            NFT_LOC = NFT_LOC + NEL
-         ELSEIF(ITY==7 .AND. (N2D /= 0 .AND. MULTI_FVM%IS_USED)) THEN
+         ELSEIF(ITY == 7 .AND. (N2D /= 0 .AND. MULTI_FVM%IS_USED)) THEN
 C   2D
            DO I = 1, NEL
              IE = I+NFT

--- a/starter/source/restart/ddsplit/w_front.F
+++ b/starter/source/restart/ddsplit/w_front.F
@@ -1865,9 +1865,9 @@ C
         DO I=1,NUMELS
           DO J=1,8
              NS = IXS(j+1,I)         
-             IF ( (NODLOCAL(NS)/=0).AND.(NODLOCAL(NS)<=NUMNOD_L) ) THEN  
-                IAD1 = ALE_CONNECTIVITY%ee_connect%iad_connect(I)
-                LGTH = ALE_CONNECTIVITY%ee_connect%iad_connect(I+1)-ALE_CONNECTIVITY%ee_connect%iad_connect(I)
+             IF ( (NODLOCAL(NS)/=0) .AND. (NODLOCAL(NS)<=NUMNOD_L) ) THEN
+               IAD1 = ALE_CONNECTIVITY%ee_connect%iad_connect(I)
+               LGTH = ALE_CONNECTIVITY%ee_connect%iad_connect(I+1)-ALE_CONNECTIVITY%ee_connect%iad_connect(I)
                DO K=1,LGTH
                   IE = ALE_CONNECTIVITY%ee_connect%connected(IAD1 + K - 1)
                   IF (IE>0) THEN

--- a/starter/source/spmd/split_cfd_solide.F
+++ b/starter/source/spmd/split_cfd_solide.F
@@ -95,39 +95,39 @@ C ----------------------------------------
                 !       -----------------------------
                 ! check if a neighbouring element is used
                 BOOL(1:NSPMD)=.FALSE.
+                IAD1 = ALE_CONNECTIVITY%ee_connect%iad_connect(I)
+                LGTH = ALE_CONNECTIVITY%ee_connect%iad_connect(I+1)-ALE_CONNECTIVITY%ee_connect%iad_connect(I)
                 DO J=1,8
-                        NS = IXS(J+1,I)
-                        IAD1 = ALE_CONNECTIVITY%ee_connect%iad_connect(I)
-                        LGTH = ALE_CONNECTIVITY%ee_connect%iad_connect(I+1)-ALE_CONNECTIVITY%ee_connect%iad_connect(I)
-                        DO K=1,LGTH
-                                SOLV = ALE_CONNECTIVITY%ee_connect%connected(IAD1 + K - 1)
-                                IF (SOLV>0) THEN
-                                        DO L=1,8
-                                                N = IXS(L+1,SOLV)
-                                                CALL PLIST_IFRONT(ID_SPMD,N,NBR_PROC)
-                                                DO ISPMD=1,NBR_PROC
-                                                        BOOL(ID_SPMD(ISPMD)) = .TRUE.
-                                                ENDDO
-                                        ENDDO
-                                ENDIF
+                  NS = IXS(J+1,I)
+                  DO K=1,LGTH
+                    SOLV = ALE_CONNECTIVITY%ee_connect%connected(IAD1 + K - 1)
+                    IF (SOLV>0) THEN
+                      DO L=1,8
+                        N = IXS(L+1,SOLV)
+                        CALL PLIST_IFRONT(ID_SPMD,N,NBR_PROC)
+                        DO ISPMD=1,NBR_PROC
+                          BOOL(ID_SPMD(ISPMD)) = .TRUE.
                         ENDDO
+                      ENDDO
+                    ENDIF
+                  ENDDO
                 ENDDO
                 !       -----------------------------
                 !       fill the ALE_ELM array / increase the size
                 DO ISPMD=1,NSPMD
-                        IF( BOOL(ISPMD) ) THEN
-                                II(ISPMD) = II(ISPMD) + 1
-                                IF( II(ISPMD)>SIZE_ALE_ELM(ISPMD) ) THEN
-                                        !       need to check the size for small test, ie. when NUMELS < NSPMS
-                                        MIN_SIZE=MAX(1,5* NUMELS/ ( 4*NSPMD ))
-                                        NEW_SIZE_II = SIZE_ALE_ELM(ISPMD) + MIN_SIZE
-                                        ALLOCATE( TMP( NEW_SIZE_II ) )
-                                        TMP(1:SIZE_ALE_ELM(ISPMD)) = ALE_ELM(ISPMD)%SOL_ID( 1:SIZE_ALE_ELM(ISPMD) )
-                                        CALL MOVE_ALLOC(FROM=TMP,TO=ALE_ELM(ISPMD)%SOL_ID)
-                                        SIZE_ALE_ELM(ISPMD) = NEW_SIZE_II                                        
-                                ENDIF
-                                ALE_ELM(ISPMD)%SOL_ID(II(ISPMD)) = I   
-                        ENDIF
+                  IF( BOOL(ISPMD) ) THEN
+                    II(ISPMD) = II(ISPMD) + 1
+                    IF( II(ISPMD)>SIZE_ALE_ELM(ISPMD) ) THEN
+                      !       need to check the size for small test, ie. when NUMELS < NSPMS
+                      MIN_SIZE=MAX(1,5* NUMELS/ ( 4*NSPMD ))
+                      NEW_SIZE_II = SIZE_ALE_ELM(ISPMD) + MIN_SIZE
+                      ALLOCATE( TMP( NEW_SIZE_II ) )
+                      TMP(1:SIZE_ALE_ELM(ISPMD)) = ALE_ELM(ISPMD)%SOL_ID( 1:SIZE_ALE_ELM(ISPMD) )
+                      CALL MOVE_ALLOC(FROM=TMP,TO=ALE_ELM(ISPMD)%SOL_ID)
+                      SIZE_ALE_ELM(ISPMD) = NEW_SIZE_II
+                    ENDIF
+                    ALE_ELM(ISPMD)%SOL_ID(II(ISPMD)) = I
+                  ENDIF
                 ENDDO
                 !       -----------------------------
         ENDDO


### PR DESCRIPTION
#### ale connectivity buffer: tria update

#### Description of the changes
In the ALE framework, it is necessary to define connectivity between elements. Given an element, it is then possible to retrieve adjacent elements. This is facilitated by the ALE_CONNECTIVITY%%EE_CONNECT data structure ('ee' stands for element to element).

When dealing with triangles, the IXTG buffer is utilized. However, it is important to distinguish between 2D and 3D simulations. For 3D simulations, the IXTG array is used to store 3D 3-node-shell elements. For 2D simulations, IXTG stores triangle solids (for axial or planar analysis). This distinction is now correctly handled.

Prior to this update, there could have been a potential issue when the input file contained both 3D ALE elements (HEXA, TETRA) and 3-node-shell elements.
