### PR TITLE
/ANIM/ELEM/VFRAC : fix

### DIFF
--- a/engine/source/output/anim/generate/dfuncc.F
+++ b/engine/source/output/anim/generate/dfuncc.F
@@ -395,12 +395,12 @@ c----           USER VARIABLES from 6 to 60
  
             !Burn Fraction      
             ELSEIF(IFUNC == 10252)THEN 
-              IF(ELBUF_TAB(NG)%GBUF%G_BFRAC>0)THEN
-                DO  I=LFT,LLT
+              IF(ELBUF_TAB(NG)%GBUF%G_BFRAC > 0 .AND. N2D > 0)THEN
+                DO I=LFT,LLT
                   FUNC(EL2FA(NN3+NFT+I)) =  ELBUF_TAB(NG)%GBUF%BFRAC(I)             
                 ENDDO  
               ELSE
-                DO  I=LFT,LLT
+                DO I=LFT,LLT
                   FUNC(EL2FA(NN3+NFT+I)) = ZERO
                 ENDDO
               ENDIF
@@ -427,12 +427,12 @@ c----           USER VARIABLES from 6 to 60
                     FUNC(EL2FA(NN3+NFT+I)) = ZERO                       
                   ENDDO 
                ELSE
-                 IF(ITY==2)THEN                                                                         
+                 IF(ITY == 2)THEN
                    CALL OUTPUT_SCHLIEREN(
      1                   EVAR    , IXQ    , X           ,
      2                   IPARG   , WA_L   , ELBUF_TAB   , ALE_CONNECTIVITY   , GBUF%VOL,
      3                   NG      , NIXQ   , ITY)
-                 ELSEIF(ITY==7.AND.N2D/=0)THEN
+                 ELSEIF(ITY == 7 .AND. N2D /= 0)THEN
                    CALL OUTPUT_SCHLIEREN(
      1                   EVAR    , IXTG   , X           ,
      2                   IPARG   , WA_L   , ELBUF_TAB   , ALE_CONNECTIVITY   , GBUF%VOL,

--- a/engine/source/output/anim/generate/genani.F
+++ b/engine/source/output/anim/generate/genani.F
@@ -3168,7 +3168,7 @@ C  en spmd localement NBF = 0 mais pas la somme sur pi !
        DO I = 1,MX_ANI
         IFUNC = I
         IF(ANIM_CE(I)==1)THEN
-          IF(I<=2142 .OR. I==2155 .OR. I==2156 .OR. (I>=2239.AND.I<=10251) .OR. 
+          IF(I<=2142 .OR. I==2155 .OR. I==2156 .OR. (I>=2239.AND.I<=10252) .OR.
      .      (I>=10253.AND.I<=10675) .OR. (I >= 10676 .AND. I <= 1000000)) THEN
             CALL DFUNCC(ELBUF_TAB ,WAFT        ,IFUNC         ,IPARG,GEO    ,
      .                  IXQ       ,IXC         ,IXTG          ,MAS          ,PM         ,


### PR DESCRIPTION
#### /ANIM/ELEM/VFRAC : fix

#### Description of the changes
An issue was reported when using /ANIM/ELEM/VFRAC instead of /ANIM/BRICK/VFRAC. The animation file was corrupted and unreadable by HyperView. This source update resolves the issue. The animation file is now correctly written and readable.