### PR TITLE
Add logarithmic scale to /FAIL/TAB2 strain rate dependency

### DIFF
--- a/engine/source/materials/fail/tabulated/fail_tab2_c.F
+++ b/engine/source/materials/fail/tabulated/fail_tab2_c.F
@@ -84,7 +84,8 @@ C-----------------------------------------------
       INTEGER I,J,INDX(NEL),NINDX,ITAB_EPSF,
      .        ITAB_INST,ITAB_SIZE,IREG,
      .        IPOS(NEL,3),NDIM,IPOS2(NEL),
-     .        IAD(NEL),ILEN(NEL)
+     .        IAD(NEL),ILEN(NEL),LOG_SCALE1,
+     .        LOG_SCALE2
       my_real 
      .        FCRIT  ,DN,DCRIT,ECRIT,EXP_REF,EXPO,EL_REF,
      .        SR_REF1,FSCALE_EL,SHRF,BIAXF  ,SR_REF2,
@@ -101,25 +102,26 @@ C!--------------------------------------------------------------
       ! - INITIALISATION OF COMPUTATION ON TIME STEP
       !=======================================================================
       ! Recovering failure criterion parameters
-      FCRIT         = UPARAM(2)
-      DN            = UPARAM(5)
-      DCRIT         = UPARAM(6) 
-      ECRIT         = UPARAM(8)
-      EXP_REF       = UPARAM(9)
-      EXPO          = UPARAM(10)
-      ITAB_SIZE     = NINT(UPARAM(11))
-      IREG          = NINT(UPARAM(12))
-      EL_REF        = UPARAM(13)
-      SR_REF1       = UPARAM(14)
-      FSCALE_EL     = UPARAM(15)
-      SHRF          = UPARAM(16)
-      BIAXF         = UPARAM(17)
-      SR_REF2       = UPARAM(18)
-      FSCALE_SR     = UPARAM(19)
-      CJC           = UPARAM(20)
-      FSCALE_DLIM   = UPARAM(21)
-      TEMP_REF      = UPARAM(22)
-      FSCALE_TEMP   = UPARAM(23)
+      FCRIT         = UPARAM(1)
+      DN            = UPARAM(4)
+      DCRIT         = UPARAM(5) 
+      ECRIT         = UPARAM(6)
+      EXP_REF       = UPARAM(7)
+      EXPO          = UPARAM(8)
+      IREG          = NINT(UPARAM(9))
+      EL_REF        = UPARAM(10)
+      SR_REF1       = UPARAM(11)
+      FSCALE_EL     = UPARAM(12)
+      SHRF          = UPARAM(13)
+      BIAXF         = UPARAM(14)
+      SR_REF2       = UPARAM(15)
+      FSCALE_SR     = UPARAM(16)
+      CJC           = UPARAM(17)
+      FSCALE_DLIM   = UPARAM(18)
+      TEMP_REF      = UPARAM(19)
+      FSCALE_TEMP   = UPARAM(20)
+      LOG_SCALE1    = NINT(UPARAM(21))
+      LOG_SCALE2    = NINT(UPARAM(22))
 c
       ITAB_EPSF = ITABLF(1)
       ITAB_INST = ITABLF(2)
@@ -209,7 +211,13 @@ c
             ! Scale factor vs element size vs strain rate
             CASE(2)
               XVEC(1:NEL,1)   = L0(1:NEL)/EL_REF
-              XVEC(1:NEL,2)   = EPSP(1:NEL)/SR_REF1
+              IF (LOG_SCALE1 > 0) THEN 
+                DO I = 1,NEL
+                  XVEC(I,2) = LOG(MAX(EPSP(I),EM20)/SR_REF1)
+                ENDDO 
+              ELSE
+                XVEC(1:NEL,2) = EPSP(1:NEL)/SR_REF1
+              ENDIF
               XVEC(1:NEL,3)   = ZERO
               IPOS(1:NEL,1:3) = 1
           END SELECT
@@ -251,11 +259,18 @@ c
 c
       ! Compute the strain rate dependency factor
       IF (IFUNC(2) > 0) THEN 
-        DO I=1,NEL   
-          LAMBDA     = EPSP(I)/SR_REF2
-          RATEFAC(I) = FINTER(IFUNC(2),LAMBDA,NPF,TF,DF) 
-          RATEFAC(I) = FSCALE_SR*RATEFAC(I)
-        ENDDO
+        IF (LOG_SCALE2 > 0) THEN
+          DO I = 1,NEL 
+            VAR(I) = LOG(MAX(EPSP(I),EM20)/SR_REF2)
+          ENDDO 
+        ELSE
+          VAR(1:NEL) = EPSP(1:NEL)/SR_REF2
+        ENDIF
+        IPOS2(1:NEL) = 1
+        IAD (1:NEL) = NPF(IFUNC(2)) / 2 + 1
+        ILEN(1:NEL) = NPF(IFUNC(2)+1) / 2 - IAD(1:NEL) - IPOS2(1:NEL)
+        CALL VINTER2(TF,IAD,IPOS2,ILEN,NEL,VAR,DFT,RATEFAC)
+        RATEFAC(1:NEL) = FSCALE_SR*RATEFAC(1:NEL)
       ELSEIF (CJC > ZERO) THEN 
         DO I=1,NEL
           IF (EPSP(I) > SR_REF2) THEN 

--- a/engine/source/materials/fail/tabulated/fail_tab2_s.F
+++ b/engine/source/materials/fail/tabulated/fail_tab2_s.F
@@ -83,7 +83,8 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,J,INDX(NEL),NINDX,ITAB_EPSF,FAILIP,
      .        ITAB_INST,ITAB_SIZE,IREG,IPOS(NEL,3),
-     .        NDIM,IPOS2(NEL),IAD(NEL),ILEN(NEL)
+     .        NDIM,IPOS2(NEL),IAD(NEL),ILEN(NEL),
+     .        LOG_SCALE1,LOG_SCALE2
       my_real 
      .        FCRIT  ,DN,DCRIT,ECRIT,EXP_REF,EXPO,EL_REF,
      .        SR_REF1,FSCALE_EL,SHRF,BIAXF  ,SR_REF2,
@@ -100,25 +101,27 @@ C!--------------------------------------------------------------
       ! - INITIALISATION OF COMPUTATION ON TIME STEP
       !=======================================================================
       ! Recovering failure criterion parameters
-      FCRIT         = UPARAM(2)
-      FAILIP        = MIN(NINT(UPARAM(3)),NPG)
-      DN            = UPARAM(5)
-      DCRIT         = UPARAM(6) 
-      ECRIT         = UPARAM(8)
-      EXP_REF       = UPARAM(9)
-      EXPO          = UPARAM(10)
-      IREG          = NINT(UPARAM(12))
-      EL_REF        = UPARAM(13)
-      SR_REF1       = UPARAM(14)
-      FSCALE_EL     = UPARAM(15)
-      SHRF          = UPARAM(16)
-      BIAXF         = UPARAM(17)
-      SR_REF2       = UPARAM(18)
-      FSCALE_SR     = UPARAM(19)
-      CJC           = UPARAM(20)
-      FSCALE_DLIM   = UPARAM(21)
-      TEMP_REF      = UPARAM(22)
-      FSCALE_TEMP   = UPARAM(23)
+      FCRIT         = UPARAM(1)
+      FAILIP        = MIN(NINT(UPARAM(2)),NPG)
+      DN            = UPARAM(4)
+      DCRIT         = UPARAM(5) 
+      ECRIT         = UPARAM(6)
+      EXP_REF       = UPARAM(7)
+      EXPO          = UPARAM(8)
+      IREG          = NINT(UPARAM(9))
+      EL_REF        = UPARAM(10)
+      SR_REF1       = UPARAM(11)
+      FSCALE_EL     = UPARAM(12)
+      SHRF          = UPARAM(13)
+      BIAXF         = UPARAM(14)
+      SR_REF2       = UPARAM(15)
+      FSCALE_SR     = UPARAM(16)
+      CJC           = UPARAM(17)
+      FSCALE_DLIM   = UPARAM(18)
+      TEMP_REF      = UPARAM(19)
+      FSCALE_TEMP   = UPARAM(20)
+      LOG_SCALE1    = NINT(UPARAM(21))
+      LOG_SCALE2    = NINT(UPARAM(22))
 c
       ITAB_EPSF = ITABLF(1)
       ITAB_INST = ITABLF(2)
@@ -209,7 +212,13 @@ c
             ! Scale factor vs element size vs strain rate
             CASE(2)
               XVEC(1:NEL,1)   = L0(1:NEL)/EL_REF
-              XVEC(1:NEL,2)   = EPSP(1:NEL)/SR_REF1
+              IF (LOG_SCALE1 > 0) THEN 
+                DO I = 1,NEL
+                  XVEC(I,2) = LOG(MAX(EPSP(I),EM20)/SR_REF1)
+                ENDDO 
+              ELSE
+                XVEC(1:NEL,2) = EPSP(1:NEL)/SR_REF1
+              ENDIF
               XVEC(1:NEL,3)   = ZERO
               IPOS(1:NEL,1:3) = 1
           END SELECT
@@ -251,11 +260,18 @@ c
 c
       ! Compute the strain rate dependency factor
       IF (IFUNC(2) > 0) THEN 
-        DO I=1,NEL   
-          LAMBDA     = EPSP(I)/SR_REF2
-          RATEFAC(I) = FINTER(IFUNC(2),LAMBDA,NPF,TF,DF) 
-          RATEFAC(I) = FSCALE_SR*RATEFAC(I)
-        ENDDO
+        IF (LOG_SCALE2 > 0) THEN
+          DO I = 1,NEL 
+            VAR(I) = LOG(MAX(EPSP(I),EM20)/SR_REF2)
+          ENDDO 
+        ELSE
+          VAR(1:NEL) = EPSP(1:NEL)/SR_REF2
+        ENDIF
+        IPOS2(1:NEL) = 1
+        IAD (1:NEL) = NPF(IFUNC(2)) / 2 + 1
+        ILEN(1:NEL) = NPF(IFUNC(2)+1) / 2 - IAD(1:NEL) - IPOS2(1:NEL)
+        CALL VINTER2(TF,IAD,IPOS2,ILEN,NEL,VAR,DFT,RATEFAC)
+        RATEFAC(1:NEL) = FSCALE_SR*RATEFAC(1:NEL)
       ELSEIF (CJC > ZERO) THEN 
         DO I=1,NEL
           IF (EPSP(I) > SR_REF2) THEN 

--- a/starter/source/materials/fail/tabulated/hm_read_fail_tab2.F
+++ b/starter/source/materials/fail/tabulated/hm_read_fail_tab2.F
@@ -171,7 +171,7 @@ C-------------------------------------------------------------------------------
       FAIL%KEYWORD = 'TAB2' 
       FAIL%IRUPT   = IRUPT 
       FAIL%FAIL_ID = FAIL_ID 
-      FAIL%NUPARAM = 23
+      FAIL%NUPARAM = 22
       FAIL%NIPARAM = 0
       FAIL%NUVAR   = 3
       FAIL%NFUNC   = 4
@@ -184,29 +184,28 @@ c
       ALLOCATE (FAIL%IFUNC (FAIL%NFUNC))
       ALLOCATE (FAIL%TABLE (FAIL%NTABLE))
 c
-      FAIL%UPARAM(1)  = 0              !   INT_ITAB_EPSF
-      FAIL%UPARAM(2)  = FCRIT
-      FAIL%UPARAM(3)  = FAILIP
-      FAIL%UPARAM(4)  = PTHKFAIL
-      FAIL%UPARAM(5)  = DN
-      FAIL%UPARAM(6)  = DCRIT
-      FAIL%UPARAM(7)  = 0              !   INT_ITAB_INST
-      FAIL%UPARAM(8)  = ECRIT
-      FAIL%UPARAM(9)  = EXP_REF
-      FAIL%UPARAM(10) = EXPO
-      FAIL%UPARAM(11) = 0              !   INT_ITAB_SIZE
-      FAIL%UPARAM(12) = IREG
-      FAIL%UPARAM(13) = EL_REF
-      FAIL%UPARAM(14) = SR_REF1
-      FAIL%UPARAM(15) = FSCALE_EL
-      FAIL%UPARAM(16) = SHRF
-      FAIL%UPARAM(17) = BIAXF
-      FAIL%UPARAM(18) = SR_REF2
-      FAIL%UPARAM(19) = FSCALE_SR
-      FAIL%UPARAM(20) = CJC
-      FAIL%UPARAM(21) = FSCALE_DLIM 
-      FAIL%UPARAM(22) = TEMP_REF
-      FAIL%UPARAM(23) = FSCALE_TEMP
+      FAIL%UPARAM(1)  = FCRIT
+      FAIL%UPARAM(2)  = FAILIP
+      FAIL%UPARAM(3)  = PTHKFAIL
+      FAIL%UPARAM(4)  = DN
+      FAIL%UPARAM(5)  = DCRIT
+      FAIL%UPARAM(6)  = ECRIT
+      FAIL%UPARAM(7)  = EXP_REF
+      FAIL%UPARAM(8)  = EXPO
+      FAIL%UPARAM(9)  = IREG
+      FAIL%UPARAM(10) = EL_REF
+      FAIL%UPARAM(11) = SR_REF1
+      FAIL%UPARAM(12) = FSCALE_EL
+      FAIL%UPARAM(13) = SHRF
+      FAIL%UPARAM(14) = BIAXF
+      FAIL%UPARAM(15) = SR_REF2
+      FAIL%UPARAM(16) = FSCALE_SR
+      FAIL%UPARAM(17) = CJC
+      FAIL%UPARAM(18) = FSCALE_DLIM 
+      FAIL%UPARAM(19) = TEMP_REF
+      FAIL%UPARAM(20) = FSCALE_TEMP
+      FAIL%UPARAM(21) = 0             ! Flag 1 for logarithmic scale in strain rate dependency
+      FAIL%UPARAM(22) = 0             ! Flag 2 for logarithmic scale in strain rate dependency
 c
       FAIL%IFUNC(1) = IFUN_EXP
       FAIL%IFUNC(2) = IFUN_RATE

--- a/starter/source/materials/updfail.F90
+++ b/starter/source/materials/updfail.F90
@@ -47,6 +47,7 @@
           use groupdef_mod
           use random_walk_def_mod
           use random_walk_dmg_mod
+          use constant_mod, only : zero
 ! ---------------------------------------------------------------------------------------------
           implicit none
 ! ---------------------------------------------------------------------------------------------
@@ -125,6 +126,19 @@
                         i1=mat_param(imat)%mat_id,                                          &
                         c1=mat_param(imat)%title)
                     endif
+                  endif
+                  ! check if strain rate dependency tables are in logarithmic scale
+                  if (nint(mat_param(imat)%fail(ir)%uparam(9)) == 1) then
+                    if (table(mat_param(imat)%fail(ir)%table(3))%ndim == 2) then
+                      if (table(mat_param(imat)%fail(ir)%table(3))%x(2)%values(1) < zero) then 
+                        mat_param(imat)%fail(ir)%uparam(21) = 1
+                      endif
+                    endif 
+                  endif
+                  if (mat_param(imat)%fail(ir)%ifunc(2) > 0) then
+                    if (table(mat_param(imat)%fail(ir)%ifunc(2))%x(1)%values(1) < zero) then 
+                      mat_param(imat)%fail(ir)%uparam(22) = 1
+                    endif 
                   endif
                 endif
 !           count number of /fail/fractal_dmg models


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

The switch to logarithmic scale for strain rate dependency in /FAIL/TAB2 was needed for DYN2RAD conversion. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Add the detection of negative values in strain rate dependency table to switch to logarithmic scale. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
