### PR TITLE
/LOAD/PBLAST : new default values

### DIFF
--- a/common_source/modules/loads/pblast_mod.F
+++ b/common_source/modules/loads/pblast_mod.F
@@ -3431,7 +3431,7 @@ C-----------------------------------------------
               ENDIF
               RES = ABS(FUNCT)   !g(x_new)
             ENDDO
-            DECAY_inci=MAX(ONE,ZETA)   ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
+            DECAY_inci=MAX(ZERO,ZETA)   ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
 
             ITER=0
             ZETA=ONE
@@ -3457,7 +3457,7 @@ C-----------------------------------------------
               ENDIF
               RES = ABS(FUNCT)   !g(x_new)
             ENDDO
-            DECAY_refl=MAX(ONE,ZETA)   ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
+            DECAY_refl=MAX(ZERO,ZETA)   ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
           ENDIF
 
           !CONVERSION UNITS !
@@ -3641,7 +3641,7 @@ C-----------------------------------------------
               ENDIF
               RES = ABS(FUNCT)   !g(x_new)
             ENDDO
-            DECAY_inci=MAX(ONE,ZETA)    ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
+            DECAY_inci=MAX(ZERO,ZETA)    ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
 
             ITER=0
             ZETA=ONE
@@ -3667,7 +3667,7 @@ C-----------------------------------------------
               ENDIF
               RES = ABS(FUNCT)   !g(x_new)
             ENDDO
-            DECAY_refl=MAX(ONE,ZETA)    ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
+            DECAY_refl=MAX(ZERO,ZETA)    ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
 
           ENDIF! IS_DECAY_TO_BE_COMPUTED
 
@@ -4115,7 +4115,7 @@ C-----------------------------------------------
               ENDIF
               RES = ABS(FUNCT)   !g(x_new)
             ENDDO
-            DECAY_inci=MAX(ONE,ZETA)    ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
+            DECAY_inci=MAX(ZERO,ZETA)    ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
 
             ITER=0
             ZETA=ONE
@@ -4141,7 +4141,7 @@ C-----------------------------------------------
               ENDIF
               RES = ABS(FUNCT)   !g(x_new)
             ENDDO
-            DECAY_refl=MAX(ONE,ZETA)    ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
+            DECAY_refl=MAX(ZERO,ZETA)    ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
 
           ENDIF! IS_DECAY_TO_BE_COMPUTED
 

--- a/starter/source/loads/pblast/hm_read_pblast.F
+++ b/starter/source/loads/pblast/hm_read_pblast.F
@@ -297,8 +297,15 @@ C-----------------------------------------------
         !--------------------------------------------------------------
 
         IF(TSTOP == ZERO)TSTOP=EP20
-        IF(PMIN == ZERO)PMIN=-EP20
         IF(NDT == 0) NDT=100
+
+        IF(PMIN < ZERO)THEN
+           MSGOUT1=''
+           MSGOUT1='PMIN PARAMETER IS NEGATIVE. PLEASE CHECK THE LOAD HISTORY FOR NEGATIVE PRESSURE,'
+           MSGOUT2=''
+           MSGOUT2='AS THE PBLAST MODEL IS FITTED ONLY FOR THE POSITIVE PHASE'
+           CALL ANCMSG(MSGID=1907, MSGTYPE=MSGWARNING, ANMODE=ANINFO,C1=TRIM(TITR), I1=ID, C2=MSGOUT1, C3=MSGOUT2)
+        ENDIF
 
         IF(WTNT == ZERO)THEN
            MSGOUT1=''
@@ -369,7 +376,7 @@ C-----------------------------------------------
         !ITA_SHIFT : BLAST ARRIVAL
         !---1:no shift (default)
         !---2:shift    loading starts from the first cycle T=0 is shift to time on which first targeted segment is reached (within all pblast options)
-        IF(ITA_SHIFT==0) ITA_SHIFT = 1
+        IF(ITA_SHIFT==0) ITA_SHIFT = 2
         IF(ITA_SHIFT < 0 .OR. ITA_SHIFT >= 3)ITA_SHIFT = 1
         IF(ITA_SHIFT == 2)IS_ITA_SHIFT=.TRUE.
 


### PR DESCRIPTION
#### /LOAD/PBLAST : new default values


#### Description of the changes
The PBLAT option represents a surface loading where the applied time history follows a Friedlander blast wave model. Parameters of the blast history are derived from empirical tables.

New defaults have been established:
- i_Tshift is set to 2 (the first cycle starts on the first arrival time).
- Pmin is set to 0.0.
- The decay parameter is bounded to [0.0, infinity[, instead of [1.0, infinity[.
- Finally a warning message is introduced when Pmin is negative. Users are advised to verify the blast history for negative pressure, as the empirical model is calibrated for the positive phase only.
