### PR TITLE
Correction of strain rate effect in law83

### DIFF
--- a/engine/source/elements/solid/sconnect/suser43.F
+++ b/engine/source/elements/solid/sconnect/suser43.F
@@ -83,7 +83,7 @@ C NUVAR    |  1      | I | R | NUMBER OF USER ELEMENT VARIABLES
 C IOUT     |  1      | I | R | OUTPUT FILE UNIT (L01 file)
 C IPROP    |  1      | I | R | PROPERTY NUMBER
 C IMAT     |  1      | I | R | MATERIAL NUMBER
-C NGL |  NEL    | I | R | SOLID ELEMENT ID
+C NGL      |  NEL    | I | R | SOLID ELEMENT ID
 C----------+---------+---+---+--------------------------------------------
 C TIME     |  1      | F | R | CURRENT TIME 
 C TIMESTEP |  1      | F | R | CURRENT TIME STEP
@@ -182,7 +182,7 @@ C-----------------------------------------------
      .  NPAR,NPARF,NVARF,NFUNC,NFUNCR,NFAILS,ISMSTR,ILAW_USER,IPTR,IPTS,IPTT,
      .  IADBUF,IFAIL,NUVAR,MTN,NDAMF,ISOLID,ISOLIDF,NUMTABL,NVARTMP
       INTEGER IFUNC(MAXFUNC),IFUNCR(MAXFUNC)
-      my_real :: A,B,C,ALPHA,EPSP,ASRATE,TTHICK,OFF_EL
+      my_real :: A,B,C,EPSP,ASRATE,ALPHA,TTHICK,OFF_EL
       my_real 
      .   HH(NPG,NPG),AREAP(MVSIZ,NPG),AREAT(MVSIZ),
      .   UXLOC(MVSIZ,8),UYLOC(MVSIZ,8),UZLOC(MVSIZ,8),
@@ -234,7 +234,8 @@ C=======================================================================
       ITABLE => IPM(226+1:226+NUMTABL,IMAT)
                      
       ISRATE = IPM(3,IMAT)
-      ALPHA  = PM(9,IMAT)
+      ASRATE = PM(9,IMAT)   ! 2*PI*FCUT
+      ALPHA  = MIN(ONE,ASRATE*TIMESTEP)
       
       ISMSTR = IGEO(5,IPROP)
       TTHICK = GEO(41,IPROP)
@@ -312,8 +313,8 @@ c-----------------------------------------------------------------------
 C-------------------
 C     MEAN STRAIN RATE
 C-------------------
-      IF (MTN == 116) THEN
-        CONTINUE
+      IF (MTN == 116 .or. MTN == 83 .or. MTN == 120) THEN
+        GBUF%EPSD(1:NEL) = ZERO                                   
       ELSE
         DO IPG=1,NPG                                          
           DO I=1,NEL                                          
@@ -326,13 +327,11 @@ C-------------------
           EP1(I) = EP1(I)*FOURTH                               
           EP2(I) = EP2(I)*FOURTH                               
           EP3(I) = EP3(I)*FOURTH                               
-          EPSP   = SQRT(EP1(I)**2 + EP2(I)**2 + EP3(I)**2)    
-                                                              
+          EPSP   = SQRT(EP1(I)**2 + EP2(I)**2 + EP3(I)**2)                                                                  
           IF (ISRATE > 0) THEN                                
-            ASRATE = MIN(ONE,ALPHA*TIMESTEP)                    
-            EPSP = ASRATE*EPSP + (ONE - ASRATE)*GBUF%EPSD(I)    
-          ENDIF                                               
-          GBUF%EPSD(I)=EPSP                                   
+            EPSP  = ALPHA*EPSP + (ONE - ALPHA)*GBUF%EPSD(I)
+          ENDIF 
+          GBUF%EPSD(I) = EPSP                                   
         ENDDO
       END IF                                            
 C--------------------------------------------------
@@ -409,7 +408,7 @@ c
      3         AREA     ,DEPSZZ   ,DEPSYZ   ,DEPSZX   ,NPAR     ,EPSZZ   ,  
      4         SIG0ZZ   ,SIG0YZ   ,SIG0ZX   ,SIGNZZ   ,SIGNYZ   ,SIGNZX  ,  
      5         LBUF%PLA ,JSMS     ,DMELS    ,SYM      ,UVAR     ,NUVAR   ,  
-     6         LBUF%DMG ,ASRATE   ,ISRATE   )                                                      
+     6         LBUF%DMG ,ALPHA    )                                                      
 c           mean Gauss point values for element output                                                     
             DO IEL=1,NEL
               GBUF%PLA(IEL)  = GBUF%PLA(IEL)  + FOURTH*LBUF%PLA(IEL)

--- a/engine/source/materials/mat/mat083/sigeps83.F
+++ b/engine/source/materials/mat/mat083/sigeps83.F
@@ -33,7 +33,7 @@ Chd|====================================================================
      3     AREA    ,DEPSZZ  ,DEPSYZ  ,DEPSZX  ,NUPARAM ,EPSZZ   ,
      4     SIGOZZ  ,SIGOYZ  ,SIGOZX  ,SIGNZZ  ,SIGNYZ  ,SIGNZX  ,
      5     PLA     ,JSMS    ,DMELS   ,SYM,     UVAR    ,NUVAR   ,
-     6     DMG     ,ASRATE  ,ISRATE  )    
+     6     DMG     ,ASRATE  )    
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -74,7 +74,7 @@ C---------+---------+---+---+--------------------------------------------
 C----------------------------------------------------------
 C   D u m m y   A r g u m e n t s  
 C----------------------------------------------------------
-      INTEGER NEL,NUPARAM,NUVAR,MAXFUNC, JSMS,ISRATE
+      INTEGER NEL,NUPARAM,NUVAR,MAXFUNC,JSMS
       INTEGER IFUNC(*),NPF(*)
       my_real
      .   TIME,TIMESTEP,ASRATE
@@ -88,13 +88,12 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER :: II,IEL,ITER,IRATE,NRATE,IDYIELD,IPLAS,IFUNN,IFUNT,
-     .           ICOMP,NTRAC,NCOMP
+     .           ICOMP,NTRAC,NCOMP,VP
       INTEGER ,DIMENSION(NEL) :: ELTRAC,ELCOMP
-      my_real :: YOUNGT,YOUNGC,SHEAR,DYDX1,DYDX2,Y1,Y2,FAC,R,DSIG,
-     .   SVMN,SVMT,DTB,ALPHA, BETA, SVM,TTA,TS,TN,XSCALE,RNC,RSC,FAIL,
-     .   XFAC,YFAC,YFACT ,YFACN ,AN,AS,SVMA,SVMP,SFP,NORMEF,NZZ,NYZ,NZX,
-     .   AA,FPX,FPY,FPN,FPS,DTN,DTS,FPRIM,DEPL,NORM,SIGN,SIGT,
-     .   PUI_1,PUI_2,PUI_3,MAX_SVMT,MAX_SVMN
+      my_real :: YOUNGT,YOUNGC,SHEAR,DYDX,
+     .   SVMN,SVMT,DTB,ALPHA,BETA,SVM,TS,TN,XSCALE,RNC,RSC,XFAC,YFAC,
+     .   AA,AN,AS,NORMEF,NZZ,NYZ,NZX,FACN,FACT,SZZ,SYZ,SZX,
+     .   FPX,FPY,FPRIM,SIGN,SIGT,SIG_EFF,PHI,DTINV,DSZZ,DSYZ,DSZX,DYLD,YLD0
       my_real ,DIMENSION(NEL) :: DSIGX,DSIGY,DSIGZ,DEP,DEPST,STF,EPSP,HT, 
      .   FYIELD,HYIELD, RN,HN,RS,SIGTRZZ,SIGTRYZ,SIGTRZX,YOUNG
 C----------------------------------------------------------
@@ -102,9 +101,7 @@ C   E x t e r n a l  F u n c t i o n
 C----------------------------------------------------------
        my_real :: FINTER
 c-----------------------------------------------------
-c     UVAR(1)  = DEPLA
-c     UVAR(2)  = Sigma equiv
-c     UVAR(3)  = Plastic strain rate
+c     UVAR(1) = strain rate
 C=======================================================================
 C     INPUT PARAMETERS INITIALIZATION
 C-----------------------------------------------
@@ -123,13 +120,16 @@ C-----------------------------------------------
       SHEAR   = UPARAM(11)
       ICOMP   = NINT(UPARAM(12))
       YOUNGC  = UPARAM(13)
+      VP      = NINT(UPARAM(14))
+      DTINV   = ONE / MAX(EM20,TIMESTEP)
 c
-      IF (ISRATE > 0) THEN
-        EPSP(:NEL) = UVAR(:NEL,3)
-      ELSE
-        EPSP(:NEL) = EPSD(:NEL)
+      IF (VP == 0) THEN              ! total displacement rate
+        EPSP(1:NEL)   = SQRT(DEPSZZ(1:NEL)**2 + DEPSYZ(1:NEL)**2 + DEPSZX(1:NEL)**2) *DTINV                                                      
+        UVAR(1:NEL,1) = ASRATE*EPSP(1:NEL) + (ONE - ASRATE)*UVAR(:NEL,1)
+        EPSD(1:NEL)   = UVAR(1:NEL,1)
       ENDIF
-      DEP(:NEL) = ZERO   ! UVAR(1)    
+      EPSP(:NEL) = UVAR(:NEL,1)
+      DEP(:NEL)  = ZERO
 c----------------------------------
       NTRAC = 0
       NCOMP = 0
@@ -140,7 +140,7 @@ c----------------------------------
           DO IEL=1,NEL
             IF (SIGOZZ(IEL) > ZERO) THEN   ! element in tension
               YOUNG(IEL)  = YOUNGT
-            ELSE                          ! element in compression
+            ELSE                           ! element in compression
               YOUNG(IEL)  = YOUNGC
             ENDIF
           ENDDO
@@ -165,13 +165,13 @@ c
       DSIGZ(1:NEL)   = YOUNG(1:NEL) * DEPSZZ(1:NEL)
       DSIGY(1:NEL)   = SHEAR*DEPSYZ(1:NEL)                              
       DSIGX(1:NEL)   = SHEAR*DEPSZX(1:NEL)                              
-      SIGNZZ(1:NEL)  = SIGOZZ(1:NEL) + DSIGZ(1:NEL)                  
-      SIGNYZ(1:NEL)  = SIGOYZ(1:NEL) + DSIGY(1:NEL)                  
-      SIGNZX(1:NEL)  = SIGOZX(1:NEL) + DSIGX(1:NEL)                  
-      STIFM(1:NEL)   = STIFM(1:NEL)  + STF(1:NEL)*OFF(1:NEL)                                              
+      SIGNZZ(1:NEL)  = SIGOZZ(1:NEL) + DSIGZ(1:NEL) * OFF(1:NEL)             
+      SIGNYZ(1:NEL)  = SIGOYZ(1:NEL) + DSIGY(1:NEL) * OFF(1:NEL)              
+      SIGNZX(1:NEL)  = SIGOZX(1:NEL) + DSIGX(1:NEL) * OFF(1:NEL)              
+      STIFM(1:NEL)   = STIFM(1:NEL)  + STF(1:NEL)*OFF(1:NEL)                                           
       SIGTRZZ(1:NEL) = SIGNZZ(1:NEL)                   
       SIGTRYZ(1:NEL) = SIGNYZ(1:NEL)                     
-      SIGTRZX(1:NEL) = SIGNZX(1:NEL)           
+      SIGTRZX(1:NEL) = SIGNZX(1:NEL)            
 c-----------------------------------------------------      
 c omega = sqrt(2k/2*dmels), dt=2/omega, 2*dmels=dt**2 * 2k / 4
       IF (IDTMINS==2 .AND. JSMS/=0) THEN
@@ -185,7 +185,7 @@ c----------------------Interpolation
 c
       IF (IFUNN /= 0) THEN
         DO IEL=1,NEL               
-          RN(IEL) = FINTER(IFUNN,EPSP(IEL)*XSCALE,NPF,TF,DYDX1) * RNC  !/ AREA(IEL)
+          RN(IEL) = FINTER(IFUNN,EPSP(IEL)*XSCALE,NPF,TF,DYDX) * RNC  !/ AREA(IEL)
         ENDDO
       ELSE
         DO IEL=1,NEL               
@@ -195,7 +195,7 @@ c
  
       IF (IFUNT /=0)THEN
         DO IEL=1,NEL       
-          RS(IEL) = FINTER(IFUNT,EPSP(IEL)*XSCALE,NPF,TF,DYDX1) * RSC  !/ AREA(IEL)
+          RS(IEL) = FINTER(IFUNT,EPSP(IEL)*XSCALE,NPF,TF,DYDX) * RSC  !/ AREA(IEL)
         ENDDO
       ELSE
         DO IEL=1,NEL               
@@ -203,9 +203,9 @@ c
         ENDDO
       ENDIF
       DO IEL=1,NEL          
-        FYIELD(IEL) = MAX(ZERO, FINTER(IDYIELD,PLA(IEL)*XFAC,NPF,TF,DYDX1))
+        FYIELD(IEL) = MAX(ZERO, FINTER(IDYIELD,PLA(IEL)*XFAC,NPF,TF,DYDX))
         FYIELD(IEL) = FYIELD(IEL)*(ONE-DMG(IEL))*YFAC
-        HYIELD(IEL) = DYDX1*YFAC
+        HYIELD(IEL) = DYDX*YFAC
       ENDDO
 c-----------------------------------------------------------------------------
 c     Plasticity projection (radial return from sigma trial) 
@@ -214,66 +214,41 @@ c-----------------------------------------------------------------------------
         IF (ICOMP == 0) THEN    ! elasto-plastic in tension and compression
           DO IEL = 1,NEL
             AA = RN(IEL)*(ONE-ALPHA*SIN(SYM(IEL)))
-            AN = ONE/MAX(EM20,AA)
-            AS = ONE/MAX(EM20,RS(IEL))
-            SVMN  = ABS(SIGTRZZ(IEL))                        ! normal stress    
-            SVMT  = SQRT(SIGTRYZ(IEL)**2 + SIGTRZX(IEL)**2)  ! shear stress      
-            
-            TN  = SVMN * AN
-            TS  = SVMT * AS
-            SVM = TN ** 2 + TS ** 2  ! effective stress svm
-            IF (FYIELD(IEL) > ZERO) THEN
-             PUI_1 = FYIELD(IEL)**2
-            ELSE
-             PUI_1 = ZERO
-            ENDIF
-            IF (AN/=ZERO) THEN
-              PUI_2 = AN**2
-            ELSE
-              PUI_2 = ZERO
-            ENDIF
-            IF (AS/=ZERO) THEN
-             PUI_3 = AS**2
-            ELSE
-             PUI_3 = ZERO
-            ENDIF
-            DSIG = SVM - PUI_1 ! FYIELD(IEL)**2
-            IF (SVM > ZERO .and. DSIG > ZERO) THEN ! plastic
+            AN = ONE/MAX(EM20,AA)**2
+            AS = ONE/MAX(EM20,RS(IEL))**2
+            SIG_EFF = AN * SIGTRZZ(IEL)** 2 + AS * (SIGTRYZ(IEL)**2 + SIGTRZX(IEL)**2)
+            YLD0 = FYIELD(IEL)
+            PHI  = SIG_EFF - YLD0**2
+            IF (SIG_EFF > ZERO .and. PHI > ZERO) THEN ! plastic
               NORMEF = SQRT (SIGTRZZ(IEL)**2 + SIGTRYZ(IEL)**2 + SIGTRZX(IEL)**2)
               NZZ  = SIGTRZZ(IEL) / NORMEF
               NYZ  = SIGTRYZ(IEL) / NORMEF
               NZX  = SIGTRZX(IEL) / NORMEF
-              FAC = - BETA * YOUNG(IEL) / MAX(EM20,NORMEF)
+              FACN = TWO*AN*YOUNG(IEL)
+              FACT = TWO*AS*SHEAR
               DO ITER= 1,3
-                DTN  = ZERO
-                DTS  = ZERO
-                IF (SIGNZZ(IEL)/= ZERO)
-     .          DTN  = SIGTRZZ(IEL) * SIGNZZ(IEL)/ ABS(SIGNZZ(IEL))
-                IF (SVMT  /= ZERO)
-     .          DTS  = (SIGNZX(IEL)*SIGTRZX(IEL)+SIGNYZ(IEL)*SIGTRYZ(IEL))/SVMT     
-                FPN  = PUI_2 *MAX(EM20,SVMN)
-                FPS  = PUI_3 *MAX(EM20,SVMT)
-                FPRIM = FAC * (FPN * DTN + FPS * DTS)
+                FPRIM = -FACN*SIGNZZ(IEL)*NZZ - FACT*(SIGNYZ(IEL)*NYZ + SIGNZX(IEL)*NZX)
+                FPRIM = FPRIM -TWO*FYIELD(IEL)
+                              
+                DSZZ = -FACN*SIGNZZ(IEL)*NZZ
+                DSYZ = -FACT*SIGNYZ(IEL)*NYZ
+                DSZX = -FACT*SIGNZX(IEL)*NZX
+                DYLD = -TWO*FYIELD(IEL)*HYIELD(IEL)
+                FPRIM = DSZZ + DSYZ + DSZX + DYLD
 
-                DEP(IEL) = DEP(IEL) - DSIG/FPRIM
-                DEP(IEL) = MAX(ZERO, DEP(IEL))
+                DEP(IEL) = DEP(IEL) - PHI / FPRIM
 
                 SIGNZZ(IEL) = SIGTRZZ(IEL) - YOUNG(IEL)*DEP(IEL) * NZZ
                 SIGNYZ(IEL) = SIGTRYZ(IEL) - SHEAR*DEP(IEL) * NYZ
                 SIGNZX(IEL) = SIGTRZX(IEL) - SHEAR*DEP(IEL) * NZX
 
-                SVMN  = ABS(SIGNZZ(IEL))                       ! normal stress
-                SVMT  = SQRT(SIGNYZ(IEL)**2 + SIGNZX(IEL)**2)  ! shear stress 
-                TN  = SVMN * AN
-                TS  = SVMT * AS
-                SVM = TN**2 + TS**2   ! effective stress svm
-                DSIG = SVM - PUI_1    ! yield criterion function
+                FYIELD(IEL) = YLD0 + HYIELD(IEL)*DEP(IEL)
+                SIG_EFF = AN * SIGNZZ(IEL)** 2 + AS * (SIGNYZ(IEL)**2 + SIGNZX(IEL)**2)
+                PHI     = SIG_EFF - FYIELD(IEL)**2    ! yield criterion function
               ENDDO  
-              DEP(IEL) = DEP(IEL)*OFF(IEL)
-              UVAR(IEL,1) = DEP(IEL)
+              DEP(IEL) = MAX(ZERO, DEP(IEL))*OFF(IEL)
               PLA(IEL) = PLA(IEL) + DEP(IEL)
             ENDIF 
-            UVAR(IEL,2) = SQRT(SVM)  ! equivalent stress for output
           ENDDO
 c--------------
         ELSE  !  ICOMP = 1 (linear in compression, elasto-plastic in tension)
@@ -281,105 +256,68 @@ c--------------
           DO II = 1,NTRAC                                                    
             IEL= ELTRAC(II)                                                   
             AA = RN(IEL)*(ONE-ALPHA*SIN(SYM(IEL)))
-            AN = ONE/MAX(EM20,AA)
-            AS = ONE/MAX(EM20,RS(IEL))
-            SVMN  = ABS(SIGTRZZ(IEL))                        ! normal stress    
-            SVMT  = SQRT(SIGTRYZ(IEL)**2 + SIGTRZX(IEL)**2)  ! shear stress      
-            
-            TN  = SVMN * AN
-            TS  = SVMT * AS
-            SVM = TN ** 2 + TS ** 2  !effective stress svm
-            IF (FYIELD(IEL) > ZERO) THEN
-             PUI_1 = FYIELD(IEL)**2
-            ELSE
-             PUI_1 = ZERO
-            ENDIF
-            IF (AN/=ZERO) THEN
-              PUI_2 = AN**2
-            ELSE
-              PUI_2 = ZERO
-            ENDIF
-            IF (AS/=ZERO) THEN
-             PUI_3 = AS**2
-            ELSE
-             PUI_3 = ZERO
-            ENDIF
-            DSIG = SVM - PUI_1 ! FYIELD(IEL)**2
-            IF (SVM > ZERO .and. DSIG > ZERO) THEN ! plastic
+            AN = ONE/MAX(EM20,AA)**2
+            AS = ONE/MAX(EM20,RS(IEL))**2
+            SIG_EFF = AN * SIGTRZZ(IEL)** 2 + AS * (SIGTRYZ(IEL)**2 + SIGTRZX(IEL)**2)
+            YLD0 = FYIELD(IEL)
+            PHI  = SIG_EFF - YLD0**2
+            IF (SIG_EFF > ZERO .and. PHI > ZERO) THEN ! plastic
               NORMEF = SQRT (SIGTRZZ(IEL)**2 + SIGTRYZ(IEL)**2 + SIGTRZX(IEL)**2)
               NZZ  = SIGTRZZ(IEL) / NORMEF
               NYZ  = SIGTRYZ(IEL) / NORMEF
               NZX  = SIGTRZX(IEL) / NORMEF
-              FAC = - BETA * YOUNG(IEL) / MAX(EM20,NORMEF)
+              FACN = TWO*AN*YOUNG(IEL)
+              FACT = TWO*AS*SHEAR
               DO ITER= 1,3
-                DTN  = ZERO
-                DTS  = ZERO
-                IF (SIGNZZ(IEL)/= ZERO)
-     .          DTN  = SIGTRZZ(IEL) * SIGNZZ(IEL)/ ABS(SIGNZZ(IEL))
-                IF (SVMT  /= ZERO)
-     .          DTS  = (SIGNZX(IEL)*SIGTRZX(IEL)+SIGNYZ(IEL)*SIGTRYZ(IEL))/SVMT     
-                FPN  = PUI_2 *MAX(EM20,SVMN)
-                FPS  = PUI_3 *MAX(EM20,SVMT)
-                FPRIM = FAC * (FPN * DTN + FPS * DTS)
+                DSZZ = -FACN*SIGNZZ(IEL)*NZZ
+                DSYZ = -FACT*SIGNYZ(IEL)*NYZ
+                DSZX = -FACT*SIGNZX(IEL)*NZX
+                DYLD = -TWO*FYIELD(IEL)*HYIELD(IEL)
+                FPRIM = DSZZ + DSYZ + DSZX + DYLD
 
-                DEP(IEL) = DEP(IEL) - DSIG/FPRIM
-                DEP(IEL) = MAX(ZERO, DEP(IEL))
+                DEP(IEL) = DEP(IEL) - PHI / FPRIM
 
                 SIGNZZ(IEL) = SIGTRZZ(IEL) - YOUNG(IEL)*DEP(IEL) * NZZ
                 SIGNYZ(IEL) = SIGTRYZ(IEL) - SHEAR*DEP(IEL) * NYZ
                 SIGNZX(IEL) = SIGTRZX(IEL) - SHEAR*DEP(IEL) * NZX
 
-                SVMN  = ABS(SIGNZZ(IEL))                       ! normal stress
-                SVMT  = SQRT(SIGNYZ(IEL)**2 + SIGNZX(IEL)**2)  ! shear stress 
-                TN  = SVMN * AN
-                TS  = SVMT * AS
-                SVM = TN**2 + TS**2   ! effective stress svm
-                DSIG = SVM - PUI_1    ! yield criterion function
+                FYIELD(IEL) = YLD0 + HYIELD(IEL)*DEP(IEL)
+                SIG_EFF = AN * SIGNZZ(IEL)** 2 + AS * (SIGNYZ(IEL)**2 + SIGNZX(IEL)**2)
+                PHI     = SIG_EFF - FYIELD(IEL)**2    ! yield criterion function
               ENDDO  
-               DEP(IEL) = DEP(IEL)*OFF(IEL)
-               UVAR(IEL,1) = DEP(IEL)
-               PLA(IEL) = PLA(IEL) + DEP(IEL)
+              DEP(IEL) = MAX(ZERO, DEP(IEL))*OFF(IEL)
+              PLA(IEL) = PLA(IEL) + DEP(IEL)
             ENDIF 
-            UVAR(IEL,2) = SQRT(SVM)  ! equivalent stress for output
           ENDDO
 c
           DO II = 1,NCOMP                                                  
             IEL= ELCOMP(II)                                                   
-            SVMT = SQRT(SIGTRYZ(IEL)**2 + SIGTRZX(IEL)**2)  ! trial shear stress
-            AA = RN(IEL)*(ONE-ALPHA*SIN(SYM(IEL)))
-            AN = ONE/MAX(EM20,AA)
-            AS   = ONE /  MAX(EM20,RS(IEL))
-            TN   = SIGTRZZ(IEL) * AN
-            TS   = SVMT * AS
-            DSIG = TS - FYIELD(IEL)
-            DEPL = ZERO
-c
-            IF (SVMT > ZERO .and. DSIG > ZERO) THEN ! plastic
-              NYZ  = SIGTRYZ(IEL) / SVMT
-              NZX  = SIGTRZX(IEL) / SVMT
-              FAC  = -SHEAR / (RS(IEL)*SVMT)
-              SIGT = SVMT
-              
+            AS = ONE/MAX(EM20,RS(IEL))**2
+            SIG_EFF = AS * (SIGTRYZ(IEL)**2 + SIGTRZX(IEL)**2)
+            YLD0 = FYIELD(IEL)
+            PHI  = SIG_EFF - YLD0**2
+            IF (SIG_EFF > ZERO .and. PHI > ZERO) THEN ! plastic
+              NORMEF = SQRT (SIGTRYZ(IEL)**2 + SIGTRZX(IEL)**2)
+              NYZ  = SIGTRYZ(IEL) / NORMEF
+              NZX  = SIGTRZX(IEL) / NORMEF
+              FACT = TWO*AS*SHEAR
               DO ITER= 1,3
-                DTS  = (SIGNZX(IEL)*SIGTRZX(IEL)+SIGNYZ(IEL)*SIGTRYZ(IEL)) / SIGT     
-                FPRIM = FAC * DTS - HYIELD(IEL)
+                DSYZ = -FACT*SIGNYZ(IEL)*NYZ
+                DSZX = -FACT*SIGNZX(IEL)*NZX
+                DYLD = -TWO*FYIELD(IEL)*HYIELD(IEL)
+                FPRIM = DSYZ + DSZX + DYLD
 
-                DEPL = DEPL - DSIG/FPRIM
-                DEP(IEL) = MAX(ZERO, DEP(IEL) + DEPL)
+                DEP(IEL) = DEP(IEL) - PHI / FPRIM
+                SIGNYZ(IEL) = SIGTRYZ(IEL) - SHEAR*DEP(IEL) * NYZ
+                SIGNZX(IEL) = SIGTRZX(IEL) - SHEAR*DEP(IEL) * NZX
 
-                SIGNYZ(IEL) = SIGTRYZ(IEL) - SHEAR*DEP(IEL)*NYZ
-                SIGNZX(IEL) = SIGTRZX(IEL) - SHEAR*DEP(IEL)*NZX
-
-                SIGT = SQRT(SIGNYZ(IEL)**2 + SIGNZX(IEL)**2)  ! shear stress 
-                TS   = SIGT * AS
-                DSIG = TS -  FYIELD(IEL)   ! yield criterion function
+                FYIELD(IEL) = YLD0 + HYIELD(IEL)*DEP(IEL)
+                SIG_EFF = AS * (SIGNYZ(IEL)**2 + SIGNZX(IEL)**2)
+                PHI     = SIG_EFF - FYIELD(IEL)**2    ! yield criterion function
               ENDDO  
-              DEP(IEL) = DEP(IEL)*OFF(IEL)
-              UVAR(IEL,1) = DEP(IEL)
+              DEP(IEL) = MAX(ZERO, DEP(IEL))*OFF(IEL)
               PLA(IEL) = PLA(IEL) + DEP(IEL)
             ENDIF 
-            SVM = TN**2 + TS**2   ! effective stress svm
-            UVAR(IEL,2) = SQRT(SVM)  ! equivalent stress for output
           ENDDO
 c
         END IF
@@ -389,66 +327,46 @@ c------------------------
         IF (ICOMP == 0) THEN    ! elasto-plastic in tension and compression
           DO IEL=1,NEL                                                      
             AA = RN(IEL)*(ONE-ALPHA*SIN(SYM(IEL)))
-            AN = ONE/MAX(EM20,AA)
-            AS = ONE/MAX(EM20,RS(IEL))
-            SVMN  = ABS(SIGTRZZ(IEL))                        ! normal stress    
-            SVMT  = SQRT(SIGTRYZ(IEL)**2 + SIGTRZX(IEL)**2)  ! shear stress      
-            
-            TN  = SVMN * AN
-            TS  = SVMT * AS
-            SVM = TN ** BETA + TS ** BETA  !effective stress svm
-            IF (FYIELD(IEL) > ZERO) THEN
-             PUI_1 = FYIELD(IEL)**BETA
-            ELSE
-             PUI_1 = ZERO
-            ENDIF
-            IF (AN/=ZERO) THEN
-              PUI_2 = AN**BETA
-            ELSE
-              PUI_2 = ZERO
-            ENDIF
-            IF (AS/=ZERO) THEN
-             PUI_3 = AS**BETA
-            ELSE
-             PUI_3 = ZERO
-            ENDIF
-            DSIG = SVM - PUI_1 ! FYIELD(IEL)**BETA
-            IF (SVM > ZERO .and. DSIG > ZERO) THEN ! plastic
-              DEP(IEL) = ZERO !UVAR(IEL,1)    
+            AN = ONE/MAX(EM20,AA)**BETA
+            AS = ONE/MAX(EM20,RS(IEL))**BETA
+            SVMN = ABS(SIGNZZ(IEL))                      ! plast - normal stress
+            SVMT = SQRT(SIGNYZ(IEL)**2 + SIGNZX(IEL)**2) ! plast - shear stress 
+            SIG_EFF = AN * SVMN**BETA + AS * SVMT**BETA 
+            YLD0 = FYIELD(IEL)
+            PHI  = SIG_EFF - YLD0**BETA
+            IF (SIG_EFF > ZERO .and. PHI > ZERO) THEN ! plastic
               NORMEF = SQRT (SIGTRZZ(IEL)**2+SIGTRYZ(IEL)**2 + SIGTRZX(IEL)**2)
               NZZ  = SIGTRZZ(IEL) / NORMEF
               NYZ  = SIGTRYZ(IEL) / NORMEF
               NZX  = SIGTRZX(IEL) / NORMEF
-              FAC = -BETA * YOUNG(IEL) / MAX(EM20,NORMEF)
-              DO ITER=1,5
-                DTN  = ZERO
-                DTS  = ZERO
-                IF (SIGNZZ(IEL)/= ZERO)
-     .          DTN  = SIGTRZZ(IEL) * SIGNZZ(IEL)/ ABS(SIGNZZ(IEL))
-                IF (SVMT  /= ZERO)
-     .          DTS  = (SIGNZX(IEL)*SIGTRZX(IEL)+SIGNYZ(IEL)*SIGTRYZ(IEL))/SVMT     
-                FPN  = PUI_2 *MAX(EM20,SVMN)**(BETA-ONE)
-                FPS  = PUI_3 *MAX(EM20,SVMT)**(BETA-ONE)
-                FPRIM = FAC * (FPN * DTN + FPS * DTS)
 
-                DEP(IEL) = DEP(IEL) - DSIG/FPRIM
+              FACN = BETA*AN*YOUNG(IEL)
+              FACT = BETA*AS*SHEAR
 
-                SIGNZZ(IEL) = SIGOZZ(IEL) + YOUNG(IEL)*(DEPSZZ(IEL)- DEP(IEL)*NZZ)
-                SIGNYZ(IEL) = SIGOYZ(IEL) + SHEAR*(DEPSYZ(IEL)- DEP(IEL)*NYZ)           
-                SIGNZX(IEL) = SIGOZX(IEL) + SHEAR*(DEPSZX(IEL)- DEP(IEL)*NZX)            
+              DO ITER=1,3
+                SZZ = ABS(SIGNZZ(IEL))
+                SYZ = ABS(SIGNYZ(IEL))
+                SZX = ABS(SIGNZX(IEL))
+                DSZZ = -FACN*NZZ*SZZ**(BETA-ONE)
+                DSYZ = -FACT*NYZ*SYZ*SVMT**(BETA-TWO)
+                DSZX = -FACT*NZX*SZX*SVMT**(BETA-TWO)
+                DYLD = -BETA*HYIELD(IEL)*FYIELD(IEL)**(BETA-ONE)
+                FPRIM = DSZZ + DSYZ + DSZX + DYLD
 
-                SVMN  = ABS(SIGNZZ(IEL))                      ! plast - normal stress
-                SVMT  = SQRT(SIGNYZ(IEL)**2 + SIGNZX(IEL)**2) ! plast - shear stress 
-                TN  = SVMN * AN
-                TS  = SVMT * AS
-                SVM= TN ** BETA + TS ** BETA!effective stress svm
-                DSIG = SVM - PUI_1 ! FYIELD(IEL)**BETA    
+                DEP(IEL) = DEP(IEL) - PHI / FPRIM
+
+                SIGNZZ(IEL) = SIGTRZZ(IEL) - YOUNG(IEL)*DEP(IEL) * NZZ
+                SIGNYZ(IEL) = SIGTRYZ(IEL) - SHEAR*DEP(IEL) * NYZ
+                SIGNZX(IEL) = SIGTRZX(IEL) - SHEAR*DEP(IEL) * NZX
+                FYIELD(IEL) = YLD0 + HYIELD(IEL)*DEP(IEL)
+
+                SVMT = SQRT(SIGNYZ(IEL)**2 + SIGNZX(IEL)**2)
+                SIG_EFF = AN * SZZ**BETA + AS * SVMT**BETA 
+                PHI     = SIG_EFF - FYIELD(IEL)**BETA
               ENDDO  
-              DEP(IEL) = MAX(ZERO, DEP(IEL)*OFF(IEL) )
-              UVAR(IEL,1) = DEP(IEL)
+              DEP(IEL) = MAX(ZERO, DEP(IEL))*OFF(IEL)
               PLA(IEL) = PLA(IEL) + DEP(IEL)
             ENDIF 
-            UVAR(IEL,2) = SVM**(ONE / BETA)  ! equivalent stress for output
           ENDDO
 c
         ELSE   ! ICOMP = 1   ! elastic in compression
@@ -456,105 +374,82 @@ c
           DO II = 1,NTRAC                                                    
             IEL= ELTRAC(II)                                                   
             AA = RN(IEL)*(ONE-ALPHA*SIN(SYM(IEL)))
-            AN = ONE/MAX(EM20,AA)
-            AS = ONE/MAX(EM20,RS(IEL))
-            SVMN  = ABS(SIGTRZZ(IEL))                        ! normal stress    
-            SVMT  = SQRT(SIGTRYZ(IEL)**2 + SIGTRZX(IEL)**2)  ! shear stress      
-            
-            TN  = SVMN * AN
-            TS  = SVMT * AS
-            SVM = TN ** BETA + TS ** BETA  !effective stress svm
-            IF (FYIELD(IEL) > ZERO) THEN
-             PUI_1 = FYIELD(IEL)**BETA
-            ELSE
-             PUI_1 = ZERO
-            ENDIF
-            IF (AN/=ZERO) THEN
-              PUI_2 = AN**BETA
-            ELSE
-              PUI_2 = ZERO
-            ENDIF
-            IF (AS/=ZERO) THEN
-             PUI_3 = AS**BETA
-            ELSE
-             PUI_3 = ZERO
-            ENDIF
-            DSIG = SVM - PUI_1 ! FYIELD(IEL)**BETA
-            IF (SVM > ZERO .and. DSIG > ZERO) THEN ! plastic
-              DEP(IEL) = ZERO !UVAR(IEL,1)    
+            AN = ONE/MAX(EM20,AA)**BETA
+            AS = ONE/MAX(EM20,RS(IEL))**BETA
+            SVMN = ABS(SIGNZZ(IEL))                      ! plast - normal stress
+            SVMT = SQRT(SIGNYZ(IEL)**2 + SIGNZX(IEL)**2) ! plast - shear stress 
+            SIG_EFF = AN * SVMN**BETA + AS * SVMT**BETA 
+            YLD0 = FYIELD(IEL)
+            PHI  = SIG_EFF - YLD0**BETA
+            IF (SIG_EFF > ZERO .and. PHI > ZERO) THEN ! plastic
               NORMEF = SQRT (SIGTRZZ(IEL)**2+SIGTRYZ(IEL)**2 + SIGTRZX(IEL)**2)
               NZZ  = SIGTRZZ(IEL) / NORMEF
               NYZ  = SIGTRYZ(IEL) / NORMEF
               NZX  = SIGTRZX(IEL) / NORMEF
-              FAC = - BETA * YOUNG(IEL) / MAX(EM20,NORMEF)
-              DO ITER=1,5
-                DTN  = ZERO
-                DTS  = ZERO
-                IF (SIGNZZ(IEL)/= ZERO)
-     .          DTN  = SIGTRZZ(IEL) * SIGNZZ(IEL)/ ABS(SIGNZZ(IEL))
-                IF (SVMT  /= ZERO)
-     .          DTS  = (SIGNZX(IEL)*SIGTRZX(IEL)+SIGNYZ(IEL)*SIGTRYZ(IEL))/SVMT     
-                FPN  = PUI_2 *MAX(EM20,SVMN)**(BETA-ONE)
-                FPS  = PUI_3 *MAX(EM20,SVMT)**(BETA-ONE)
-                FPRIM = FAC * (FPN * DTN + FPS * DTS)
 
-                DEP(IEL) = DEP(IEL) - DSIG/FPRIM
+              FACN = BETA*AN*YOUNG(IEL)
+              FACT = BETA*AS*SHEAR
 
-                SIGNZZ(IEL) = SIGOZZ(IEL) + YOUNG(IEL)*(DEPSZZ(IEL)- DEP(IEL)*NZZ)
-                SIGNYZ(IEL) = SIGOYZ(IEL) + SHEAR*(DEPSYZ(IEL)- DEP(IEL)*NYZ)           
-                SIGNZX(IEL) = SIGOZX(IEL) + SHEAR*(DEPSZX(IEL)- DEP(IEL)*NZX)            
+              DO ITER=1,3
+                SZZ = ABS(SIGNZZ(IEL))
+                SYZ = ABS(SIGNYZ(IEL))
+                SZX = ABS(SIGNZX(IEL))
+                DSZZ = -FACN*NZZ*SZZ**(BETA-ONE)
+                DSYZ = -FACT*NYZ*SYZ*SVMT**(BETA-TWO)
+                DSZX = -FACT*NZX*SZX*SVMT**(BETA-TWO)
+                DYLD = -BETA*HYIELD(IEL)*FYIELD(IEL)**(BETA-ONE)
+                FPRIM = DSZZ + DSYZ + DSZX + DYLD
 
-                SVMN  = ABS(SIGNZZ(IEL))                     ! plast - normal stress 
-                SVMT  = SQRT(SIGNYZ(IEL)**2 + SIGNZX(IEL)**2)! plast - shear stress 
-                TN  = SVMN * AN
-                TS  = SVMT * AS
-                SVM= TN ** BETA + TS ** BETA!effective stress svm
-                DSIG = SVM - PUI_1 ! FYIELD(IEL)**BETA    
+                DEP(IEL) = DEP(IEL) - PHI / FPRIM
+
+                SIGNZZ(IEL) = SIGTRZZ(IEL) - YOUNG(IEL)*DEP(IEL) * NZZ
+                SIGNYZ(IEL) = SIGTRYZ(IEL) - SHEAR*DEP(IEL) * NYZ
+                SIGNZX(IEL) = SIGTRZX(IEL) - SHEAR*DEP(IEL) * NZX
+                FYIELD(IEL) = YLD0 + HYIELD(IEL)*DEP(IEL)
+
+                SVMT = SQRT(SIGNYZ(IEL)**2 + SIGNZX(IEL)**2)
+                SIG_EFF = AN * SZZ**BETA + AS * SVMT**BETA 
+                PHI     = SIG_EFF - FYIELD(IEL)**BETA
               ENDDO  
-              DEP(IEL) = MAX(ZERO, DEP(IEL)*OFF(IEL) )
-              UVAR(IEL,1) = DEP(IEL)
+              DEP(IEL) = MAX(ZERO, DEP(IEL))*OFF(IEL)
               PLA(IEL) = PLA(IEL) + DEP(IEL)
             ENDIF 
-            UVAR(IEL,2) = SVM**(ONE / BETA)  ! equivalent stress for output
           ENDDO
 c
           DO II = 1,NCOMP                                                  
             IEL= ELCOMP(II)                                                   
-            SVMT = SQRT(SIGTRYZ(IEL)**2 + SIGTRZX(IEL)**2)  ! trial shear stress
-            AA = RN(IEL)*(ONE-ALPHA*SIN(SYM(IEL)))
-            AN = ONE/MAX(EM20,AA)
-            AS   = ONE /  MAX(EM20,RS(IEL))
-            TN   = SIGTRZZ(IEL) * AN
-            TS   = SVMT * AS
-            DSIG = TS - FYIELD(IEL)
-            DEPL = ZERO
-c
-            IF (SVMT > ZERO .and. DSIG > ZERO) THEN ! plastic
-              NYZ  = SIGTRYZ(IEL) / SVMT
-              NZX  = SIGTRZX(IEL) / SVMT
-              FAC  = -SHEAR / (RS(IEL)*SVMT)
-              SIGT = SVMT
-              
-              DO ITER= 1,3
-                DTS  = (SIGNZX(IEL)*SIGTRZX(IEL)+SIGNYZ(IEL)*SIGTRYZ(IEL)) / SIGT     
-                FPRIM = FAC * DTS - HYIELD(IEL)
+            AS = ONE/MAX(EM20,RS(IEL))**BETA
+            SVMT = SQRT(SIGNYZ(IEL)**2 + SIGNZX(IEL)**2) ! plast - shear stress 
+            SIG_EFF = AS * SVMT**BETA 
+            YLD0 = FYIELD(IEL)
+            PHI  = SIG_EFF - YLD0**BETA
+            IF (SIG_EFF > ZERO .and. PHI > ZERO) THEN ! plastic
+              NORMEF = SVMT
+              NYZ  = SIGTRYZ(IEL) / NORMEF
+              NZX  = SIGTRZX(IEL) / NORMEF
+              FACT = BETA*AS*SHEAR
 
-                DEPL = DEPL - DSIG/FPRIM
-                DEP(IEL) = MAX(ZERO, DEP(IEL) + DEPL)
+              DO ITER=1,3
+                SYZ = ABS(SIGNYZ(IEL))
+                SZX = ABS(SIGNZX(IEL))
+                DSYZ = -FACT*NYZ*SYZ*SVMT**(BETA-TWO)
+                DSZX = -FACT*NZX*SZX*SVMT**(BETA-TWO)
+                DYLD = -BETA*HYIELD(IEL)*FYIELD(IEL)**(BETA-ONE)
+                FPRIM = DSYZ + DSZX + DYLD
 
-                SIGNYZ(IEL) = SIGTRYZ(IEL) - SHEAR*DEP(IEL)*NYZ
-                SIGNZX(IEL) = SIGTRZX(IEL) - SHEAR*DEP(IEL)*NZX
+                DEP(IEL) = DEP(IEL) - PHI / FPRIM
 
-                SIGT = SQRT(SIGNYZ(IEL)**2 + SIGNZX(IEL)**2)  ! shear stress 
-                TS   = SIGT * AS
-                DSIG = TS -  FYIELD(IEL)   ! yield criterion function
+                SIGNYZ(IEL) = SIGTRYZ(IEL) - SHEAR*DEP(IEL) * NYZ
+                SIGNZX(IEL) = SIGTRZX(IEL) - SHEAR*DEP(IEL) * NZX
+                FYIELD(IEL) = YLD0 + HYIELD(IEL)*DEP(IEL)
+
+                SVMT = SQRT(SIGNYZ(IEL)**2 + SIGNZX(IEL)**2)
+                SIG_EFF = AS * SVMT**BETA 
+                PHI     = SIG_EFF - FYIELD(IEL)**BETA
               ENDDO  
-              DEP(IEL) = DEP(IEL)*OFF(IEL)
-              UVAR(IEL,1) = DEP(IEL)
+              DEP(IEL) = MAX(ZERO, DEP(IEL))*OFF(IEL)
               PLA(IEL) = PLA(IEL) + DEP(IEL)
             ENDIF 
-            SVM = TN**BETA + TS**BETA       ! effective stress svm
-            UVAR(IEL,2) = SVM**(ONE / BETA)  ! equivalent stress for output
           ENDDO
 c
         END IF    ! ICOMP
@@ -563,10 +458,11 @@ c
 c----------------------------end iplas 2--------------------------------------
 c     normal projection option (hidden: iplas = 1) deleted in august 2021
 c------------------
-      IF (ISRATE > 0) THEN
+      IF (VP == 1) THEN
         DO IEL=1,NEL
-          EPSP(IEL)   = DEP(IEL) / MAX(EM20,TIMESTEP)  ! plastic strain rate
-          UVAR(IEL,3) = ASRATE*EPSP(IEL) + (ONE - ASRATE)*UVAR(IEL,3)
+          EPSP(IEL)   = DEP(IEL) * DTINV  ! plastic strain rate
+          UVAR(IEL,1) = ASRATE*EPSP(IEL) + (ONE - ASRATE)*UVAR(IEL,1)
+          EPSD(IEL)   = UVAR(IEL,1)
         ENDDO
       ENDIF
 C-----------

--- a/starter/source/materials/mat/mat083/hm_read_mat83.F
+++ b/starter/source/materials/mat/mat083/hm_read_mat83.F
@@ -89,15 +89,15 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER :: I,J,NRATE,IFILTR,IDYIELD,IFUNN,IFUNT,
-     .           RHOFLAG,ICOMP,IPLAS,ILAW
+     .           RHOFLAG,ICOMP,IPLAS,VP,ILAW
       my_real :: YOUNGT,YOUNGC,G,YOUNG,FCUT,XFAC,YFAC,XSCALE,RN,RS,BETA,ALPHA,
-     .           ASRATE,A1,A2,AA,E0,EMAX,EPSMAX,RHO0,RHOR,YFAC_UNIT,
+     .           A1,A2,AA,E0,EMAX,EPSMAX,RHO0,RHOR,YFAC_UNIT,
      .           XFAC_UNIT,XSCALE_UNIT,RN_UNIT,RS_UNIT
       LOGICAL :: IS_AVAILABLE,IS_ENCRYPTED
-C-----------------------------------------------
+!======================================================================= 
       ILAW = 83
 !
-      IS_ENCRYPTED   = .FALSE.
+      IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
 !
       CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
@@ -120,7 +120,7 @@ card4
       CALL HM_GET_FLOATV('MAT_R00'      ,RN          ,IS_AVAILABLE, LSUBMODEL, UNITAB)
       CALL HM_GET_FLOATV('MAT_R45'      ,RS          ,IS_AVAILABLE, LSUBMODEL, UNITAB)
       CALL HM_GET_INTV  ('Fsmooth'      ,ISRATE      ,IS_AVAILABLE ,LSUBMODEL)
-      CALL HM_GET_FLOATV('Fcut'         ,ASRATE      ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('Fcut'         ,FCUT      ,IS_AVAILABLE, LSUBMODEL, UNITAB)
 card5
       CALL HM_GET_INTV  ('FUN_A2'       ,IFUNN       ,IS_AVAILABLE ,LSUBMODEL)
       CALL HM_GET_INTV  ('FUN_A3'       ,IFUNT       ,IS_AVAILABLE ,LSUBMODEL)
@@ -131,18 +131,24 @@ c-------------------------------------------------------------------------------
       CALL HM_GET_FLOATV_DIM('FScale33' ,XSCALE_UNIT ,IS_AVAILABLE, LSUBMODEL, UNITAB)
       CALL HM_GET_FLOATV_DIM('MAT_R00'  ,RN_UNIT     ,IS_AVAILABLE, LSUBMODEL, UNITAB)
       CALL HM_GET_FLOATV_DIM('MAT_R45'  ,RS_UNIT     ,IS_AVAILABLE, LSUBMODEL, UNITAB)
-C---
+c-------------------------------------------------------------------------------------
       IF (RHOR == ZERO) RHOR=RHO0
       PM(1) = RHOR
       PM(89)= RHO0
 !
-      IF (ASRATE  == ZERO) ASRATE = INFINITY
       IF (XFAC == ZERO) XFAC = ONE*XFAC_UNIT
       IF (BETA  == ZERO) BETA = TWO
       IF (RN  == ZERO) RN = ONE*RN_UNIT
       IF (RS  == ZERO) RS = ONE*RS_UNIT
       IPLAS = 0 ! hidden
       IF (IPLAS == 0)  IPLAS = 2
+      IF (ISRATE == 0) THEN
+        VP = 0
+      ELSE
+        VP = 1
+        ISRATE = 1
+      END IF
+      IF (FCUT  == ZERO) FCUT = 10000.0D0*UNITAB%FAC_T_WORK
 C---
       NFUNC = 3 
       IFUNC(1) = IFUNN
@@ -176,13 +182,14 @@ C----------------
       UPARAM(11) = G
       UPARAM(12) = ICOMP
       UPARAM(13) = YOUNGC
+      UPARAM(14) = VP      ! total or plastic strain rate flag
 C----------------
-      NUPARAM = 13
-      NUVAR   = 3
+      NUPARAM = 14
+      NUVAR   = 1
 C----------------
       PARMAT(1) = YOUNG/THREE
       PARMAT(2) = YOUNG
-      PARMAT(5) = ASRATE
+      PARMAT(5) = FCUT
 C     Formulation for solid elements time step computation.
       PARMAT(16) = 2
       PARMAT(17) =  ONE ! (ONE - TWO*NU)/(ONE - NU), NU=0      
@@ -207,7 +214,12 @@ C----------------
       ELSE                                                     
         WRITE(IOUT,1200) RHO0
         WRITE(IOUT,1300) YOUNGT,YOUNGC,G,ICOMP,RHOFLAG,IDYIELD,YFAC,XFAC,ALPHA,BETA
-        WRITE(IOUT,1400)IFUNN,IFUNT,XSCALE,RN,RS,ISRATE,ASRATE
+        WRITE(IOUT,1400)IFUNN,IFUNT,XSCALE,RN,RS,ISRATE,FCUT
+        IF (VP ==0) THEN
+          WRITE(IOUT,1500)
+        ELSE
+          WRITE(IOUT,1600)
+        END IF
       ENDIF
 C-----------
       RETURN
@@ -243,6 +255,8 @@ C-----------
      & 5X,'RN VARIABLE . . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'RS VARIABLE . . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'STRAIN RATE FILTERING FLAG  . . . . . . . . . . . .=',I10/,
-     & 5X,'CUT FREQ FOR STRAIN RATE FILTERING  . . . . . . . .=',1PG20.13/)
+     & 5X,'CUT FREQ FOR STRAIN RATE FILTERING  . . . . . . . .=',1PG20.13)
+ 1500 FORMAT(5X,'USING TOTAL STRAIN RATE',/)
+ 1600 FORMAT(5X,'USING PLASTIC STRAIN RATE',/)
 C--------
       END


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

strain rate was not calculated except when plastic strain rate was chosen (ISRATE=1)

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

corrected strain rate calculation including filtering by default

corrected plasticity projection algorithm 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
