### PR TITLE
/ALE/GRID/DISP:source cleaning

### DIFF
--- a/engine/source/ale/grid/alew1.F
+++ b/engine/source/ale/grid/alew1.F
@@ -90,7 +90,6 @@ C  SPMD : COMM D
          LENCOM = NBRCVOIS(NSPMD+1)+NBSDVOIS(NSPMD+1)
          CALL SPMD_XVOIS(D,NBRCVOIS,NBSDVOIS,LNRCVOIS,LNSDVOIS,LENCOM)
 !$OMP END SINGLE
-
       END IF
       FAC=ONE/DT2/THREE
       DO I = NODFT, NODLT
@@ -115,10 +114,6 @@ C  SPMD : COMM D
             DX = FAC * (DX_MAX + DX_MIN - TWO * D(1, I))
             DY = FAC * (DY_MAX + DY_MIN - TWO * D(2, I))
             DZ = FAC * (DZ_MAX + DZ_MIN - TWO * D(3, I))
-
-            DX=ALE%GRID%VGX*DX
-            DY=ALE%GRID%VGY*DY
-            DZ=ALE%GRID%VGZ*DZ
             W(1,I)=SIGN(ONE,DX)*MIN(ABS(DX),ALE%GRID%ALPHA)
             W(2,I)=SIGN(ONE,DY)*MIN(ABS(DY),ALE%GRID%ALPHA)
             W(3,I)=SIGN(ONE,DZ)*MIN(ABS(DZ),ALE%GRID%ALPHA)

--- a/engine/source/input/freform.F
+++ b/engine/source/input/freform.F
@@ -1638,13 +1638,9 @@ C--------------------
        ELSEIF(StringALE(1:4)=='DISP'.OR.StringALE(1:1)=='1')THEN
         NUM_ALE_GRID = NUM_ALE_GRID + 1
         IALE_GRID_FORM=1
-        READ(IUSC2,*,ERR=1161,END=1161)ALP,A1,A2,A3,VM  !format kept for backward compatibility
-        IF(ALP/=ZERO.OR.VM/=ZERO.OR.A1/=ZERO.OR.A2/=ZERO.OR.A3/=ZERO)GOTO 1162
- 1161   REWIND(IUSC2)
-        A1=ZERO; A2=ZERO; A3=ZERO;
         READ(IUSC2,*,ERR=9990,END=9990)ALP,VM           !new format scale factor removed (hidden flags)
- 1162   CONTINUE
         GAM=ZERO
+        A1=ONE; A2=ONE; A3=ONE;
        !---------------------------------------!
        !    '/ALE/GRID/SPRING'                 !
        !---------------------------------------!

--- a/engine/source/input/lectur.F
+++ b/engine/source/input/lectur.F
@@ -1114,7 +1114,7 @@ C----------------------------------------
                WRITE(IOUT,1200) ALE%GRID%ALPHA,ALE%GRID%GAMMA,ALE%GRID%VGX,ALE%GRID%VGY,ALE%GRID%VGZ,VOLMIN
              CASE(1) !DISP
                WRITE(IOUT,1008)
-               WRITE(IOUT,1220) ALE%GRID%ALPHA,ALE%GRID%VGX,ALE%GRID%VGY,ALE%GRID%VGZ,VOLMIN
+               WRITE(IOUT,1220) ALE%GRID%ALPHA,VOLMIN
              CASE(2) !SPRING
                WRITE(IOUT,1008)
                WRITE(IOUT,1250) DT_INPUT,ALE%GRID%ALPHA,ALE%GRID%GAMMA,ALE%GRID%VGX,ALE%GRID%VGY,VOLMIN
@@ -2863,9 +2863,6 @@ C---------------------------------------------------------
      . 28X,' VOLMIN  : MINIMUM VOLUME FOR ELEMENT DELETION. . ',G14.7//)
  1220 FORMAT(
      . 28X,' UMAX  : MAXIMUM ABSOLUTE GRID VELOCITY . . . . . ',G14.7/
-     . 28X,' CWX   : X GRID VELOCITY SCALE FACTOR . . . . . . ',G14.7/
-     . 28X,' CWY   : Y GRID VELOCITY SCALE FACTOR . . . . . . ',G14.7/
-     . 28X,' CWZ   : Z GRID VELOCITY SCALE FACTOR . . . . . . ',G14.7/
      . 28X,' VMIN  : MINIMUM VOLUME FOR ELEMENT DELETION. . . ',G14.7//)
  1250 FORMAT(
      . 28X,' DT0   : TYPICAL TIME STEP. . . . . . . . . . . . ',G14.7/

--- a/hm_cfg_files/config/CFG/radioss140/CARDS/ale_grid_disp.cfg
+++ b/hm_cfg_files/config/CFG/radioss140/CARDS/ale_grid_disp.cfg
@@ -53,9 +53,6 @@ GUI(COMMON)
     SEPARATOR("ALE_GRID_DISP");
     SCALAR(MAT_EPS)     { DIMENSION="velocity";        }
     SCALAR(MAT_PC)      { DIMENSION="volume";        }
-    SCALAR(VEL_X)   { DIMENSION="DIMENSIONLESS"; }
-    SCALAR(VEL_Y)   { DIMENSION="DIMENSIONLESS"; }
-    SCALAR(VEL_Z)   { DIMENSION="DIMENSIONLESS"; }    SEPARATOR("");
 }
 
 FORMAT(radioss51)
@@ -67,8 +64,8 @@ FORMAT(radioss51)
     if(IO_FLAG == 0)
     {
         HEADER ("/ALE/GRID/DISP");
-        COMMENT("#              U_max                                Fscale_x            Fscale_y            Fscale_z");
-        CARD("%20lg%20s%20lg%20lg%20lg",MAT_EPS,_BLANK_,VEL_X,VEL_Y,VEL_Z);
+        COMMENT("#              U_max");
+        CARD("%20lg",MAT_EPS);
         COMMENT("#              Vmin");
         CARD("%20lg",MAT_PC);
     }

--- a/starter/source/general_controls/ale_grid/hm_read_ale_grid.F
+++ b/starter/source/general_controls/ale_grid/hm_read_ale_grid.F
@@ -117,14 +117,11 @@ C-----------------------------------------------
             IS_DEFINED_ALE_GRID = .TRUE.
             ALE%GRID%NWALE = 1
             CALL HM_GET_FLOATV('MAT_EPS', ALPHA, IS_AVAILABLE, LSUBMODEL, UNITAB)
-            CALL HM_GET_FLOATV('VEL_X', VGX, IS_AVAILABLE, LSUBMODEL, UNITAB)
-            CALL HM_GET_FLOATV('VEL_Y', VGY, IS_AVAILABLE, LSUBMODEL, UNITAB)
-            CALL HM_GET_FLOATV('VEL_Z', VGZ, IS_AVAILABLE, LSUBMODEL, UNITAB)
             CALL HM_GET_FLOATV('MAT_PC', VOLMIN, IS_AVAILABLE, LSUBMODEL, UNITAB)
             IF (ALPHA == ZERO) ALPHA = INFINITY
-            IF (VGX == ZERO) VGX = ONE
-            IF (VGY == ZERO) VGY = ONE
-            IF (VGZ == ZERO) VGZ = ONE
+            VGX = ONE
+            VGY = ONE
+            VGZ = ONE
          ELSEIF (KEY(1:6) == 'SPRING') THEN
             IS_DEFINED_ALE_GRID = .TRUE.
             IF (N2D /= 0) THEN

--- a/starter/source/starter/contrl.F
+++ b/starter/source/starter/contrl.F
@@ -1115,7 +1115,7 @@ C----------------------------------------------------------
       CALL HM_OPTION_COUNT('/USERWI',USER_WINDOWS%HAS_USER_WINDOW)
       NCPRI=1
       IF(DTINI==ZERO)DTINI=EP06
-      IF(VOLMIN==ZERO)VOLMIN=-EP30
+      IF(VOLMIN==ZERO)VOLMIN=-EP20
       DT2OLD=DTINI/ONEP1
       TT=ZERO
       DT1=ZERO
@@ -1372,7 +1372,7 @@ C
         WRITE (IOUT,5100)ALE%GRID%NWALE
         SELECT CASE (ALE%GRID%NWALE)
           CASE(0);WRITE (IOUT,5199) ALE%GRID%ALPHA,ALE%GRID%GAMMA,ALE%GRID%VGX,ALE%GRID%VGY,ALE%GRID%VGZ,VOLMIN
-          CASE(1);WRITE (IOUT,5200) ALE%GRID%ALPHA,ALE%GRID%VGX,ALE%GRID%VGY,ALE%GRID%VGZ,VOLMIN
+          CASE(1);WRITE (IOUT,5200) ALE%GRID%ALPHA,VOLMIN
           CASE(2);WRITE (IOUT,5300) DT_INPUT, ALE%GRID%ALPHA,ALE%GRID%GAMMA,ALE%GRID%VGX,ALE%GRID%VGY,VOLMIN
           CASE(3);WRITE (IOUT,5350) 
           CASE(4);WRITE (IOUT,5351) ALE%GRID%ALPHA,ALE%GRID%GAMMA,ALE%GRID%VGX,ALE%GRID%VGY 
@@ -1545,8 +1545,8 @@ c     & 4X,'MEMORY AVAILABLE FOR REALS. . . . . . . . . . . . . .',I10)
  5100 FORMAT(/
      & 4X,'NWALE : CHOICE OF ALE GRID VELOCITY FORMULATION . . .',I10)
  5199 FORMAT(//
-     & 4X,'ALE GRID FORMULATION                           '/
-     & 4X,'--------------------                           '/
+     & 4X,'ALE GRID SMOOTHING FORMULATION'/
+     & 4X,'------------------------------'/
      & 5X,'DONEA GRID VELOCITY COMPUTATION METHOD         '/
      & 5X,'ALPHA   : DONEA COEFFICIENT. . . . . . . . . . ',1PG20.13/
      & 5X,'GAMMA   : GRID VELOCITY LIMITATION FACTOR. . . ',1PG20.13/
@@ -1555,17 +1555,14 @@ c     & 4X,'MEMORY AVAILABLE FOR REALS. . . . . . . . . . . . . .',I10)
      & 5X,'FscaleZ : Z-GRID VELOCITY SCALE FACTOR . . . . ',1PG20.13/
      & 5X,'VOLMIN  : MINIMUM VOLUME FOR ELEMENT DELETION. ',1PG20.13)
  5200 FORMAT(//
-     & 4X,'ALE GRID FORMULATION                           '/
-     & 4X,'--------------------                           '/
+     & 4X,'ALE GRID SMOOTHING FORMULATION'/
+     & 4X,'------------------------------'/
      & 5X,'ALTAIR AVERAGE DISPLACEMENT GRID FORMULATION   '/
      & 5X,'UMAX  : MAXIMUM ABSOLUTE GRID VELOCITY . . . . ',1PG20.13/
-     & 5X,'CWX   : X GRID VELOCITY SCALE FACTOR . . . . . ',1PG20.13/
-     & 5X,'CWY   : Y GRID VELOCITY SCALE FACTOR . . . . . ',1PG20.13/
-     & 5X,'CWZ   : Z GRID VELOCITY SCALE FACTOR . . . . . ',1PG20.13/
      & 5X,'VMIN  : MINIMUM VOLUME FOR ELEMENT DELETION. . ',1PG20.13)
  5300 FORMAT(//
-     & 4X,'ALE GRID FORMULATION                           '/
-     & 4X,'--------------------                           '/
+     & 4X,'ALE GRID SMOOTHING FORMULATION'/
+     & 4X,'------------------------------'/
      &5X,'ALTAIR SPRING METHOD FOR GRID VELOCITY COMPUTATION    '/
      &5X,'DT0   : TYPICAL TIME STEP  . . . . . . . . . . . . ',1PG20.13/
      &5X,'DT0*  : EFFECTIVE TIME STEP. . . . . . . . . . . . ',1PG20.13/
@@ -1574,45 +1571,45 @@ c     & 4X,'MEMORY AVAILABLE FOR REALS. . . . . . . . . . . . . .',I10)
      &5X,'NU    : SHEAR FACTOR . . . . . . . . . . . . . . . ',1PG20.13/
      &5X,'VOLMIN: MINIMUM VOLUME FOR ELEMENT DELETION. . . . ',1PG20.13)
  5350 FORMAT(//
-     & 4X,'ALE GRID FORMULATION                           '/
-     & 4X,'--------------------                           '/
+     & 4X,'ALE GRID SMOOTHING FORMULATION'/
+     & 4X,'------------------------------'/
      & 5X,'GRID VELOCITY IS NOT COMPUTED (QUASI EULER) ')
  5351 FORMAT(//
-     & 4X,'ALE GRID FORMULATION                           '/
-     & 4X,'--------------------                           '/
+     & 4X,'ALE GRID SMOOTHING FORMULATION'/
+     & 4X,'------------------------------'/
      & 5X,'ALTAIR STANDARD METHOD FOR GRID VELOCITY COMPUTATION '/
      & 5X,'ALPHA : STABILITY FACTOR . . . . . . . . . . . . ',1PG20.13/
      & 5X,'GAMMA : NON LINEARITY FACTOR . . . . . . . . . . ',1PG20.13/
      & 5X,'BETA  : DAMPING COEFFICIENT. . . . . . . . . . . ',1PG20.13/
      & 5X,'LC    : CHARACTERISTIC LENGTH. . . . . . . . . . ',1PG20.13)
  5353 FORMAT(//
-     & 4X,'ALE GRID FORMULATION                           '/
-     & 4X,'--------------------                           '/
+     & 4X,'ALE GRID SMOOTHING FORMULATION'/
+     & 4X,'------------------------------'/
      & 5X,'LAPLACIAN SMOOTHING '/
      & 5X,'LAMBDA:. . . . . . . . . . . . . . . . . . . . . ',1PG20.13/
      & 5X,'NITER :. . . . . . . . . . . . . . . . . . . . . ',I10)
  5354 FORMAT(//
-     & 4X,'ALE GRID FORMULATION                           '/
-     & 4X,'--------------------                           '/
+     & 4X,'ALE GRID SMOOTHING FORMULATION'/
+     & 4X,'------------------------------'/
      & 5X,'VOLUME SMOOTHING ')
  5355 FORMAT(//
-     & 4X,'ALE GRID FORMULATION                           '/
-     & 4X,'--------------------                           '/
+     & 4X,'ALE GRID SMOOTHING FORMULATION'/
+     & 4X,'------------------------------'/
      & 5X,'AVERAGED MASSFLOW '/
      & 5X,'SCALE_DEF: . . . . . . . . . . . . . . . . . . . ',1PG20.13/
      & 5X,'SCALE_ROT: . . . . . . . . . . . . . . . . . . . ',1PG20.13/)
 
 
  5360 FORMAT(//
-     & 4X,'ALE UPWIND PARAMETERS                   '/
-     & 4X,'---------------------                   '/
+     & 4X,'ALE UPWIND PARAMETERS'/
+     & 4X,'---------------------'/
      & 5X,'UPWIND FOR MOMENTUM TRANSPORT . . . . .=',1PG20.13/,
      & 5X,'UPWIND FOR OTHER TRANSPORT. . . . . . .=',1PG20.13/)
  5380 FORMAT(/
-     & 4X,'CAA FLUID FORMULATION ACTIVATED         ')
+     & 4X,'CAA FLUID FORMULATION ACTIVATED')
  5400 FORMAT(
-     & 4X,'alpha M + beta K DAMPING                    '/,
-     & 4X,'------------------------                    '/,
+     & 4X,'alpha M + beta K DAMPING'/,
+     & 4X,'------------------------'/,
      . 4X,'NODE GROUP ID (=0 ALL NODES). . . . . . ',I5/,
      & 5X,'ALPHA . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'BETA. . . . . . . . . . . . . . . . . .=',1PG20.13)
@@ -1644,8 +1641,8 @@ c     & 4X,'MEMORY AVAILABLE FOR REALS. . . . . . . . . . . . . .',I10)
  5503 FORMAT(
      & 4X,'ISFINT : INTERNAL FORCES FORMULATION . . . . . . . . .',I10)  
  5504 FORMAT(//
-     & 4X,'ALEMUSCL                   '/
-     & 4X,'---------------------                   '/
+     & 4X,'MUSCL (MONOTONIC UPSTREAM-CENTERED SCHEME FOR CONSERVATION LAWS)'/
+     & 4X,'----------------------------------------------------------------'/
      & 5X,'COMPRESSION COEFFICIENT (BETA). . . . . . . . . . . : ',1PG20.13/  
      & 5X,'FORMULATION FLAG (IFLAG). . . . . . . . . . . . . . : ',I10)
  5700 FORMAT(//


### PR DESCRIPTION
#### /ALE/GRID/DISP:source cleaning

#### Description of the changes
With the ALE framework, employing a mesh smoothing technique becomes necessary due to the independence of mesh velocity from material velocity. The default formulation is 'DISP' (/ALE/GRID/DISP). Undocumented parameters (since version 51), namely vgxw, vgy, and vgz, have been present in source code. These scale factors have now been removed as they were never utilized in practice

- scale factors removed from source code
- removed from CFG file
- removed from Starter listing file & Reader
- removed from Engine Reader & its listing