### PR TITLE
Fix several issues related to deactivation/activation segment algorithm

### DIFF
--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -2341,7 +2341,7 @@ C Init var parallel SMP
           IF(NSPMD>1) THEN 
             IF(ITSK==0) CALL SPMD_EXCH_DELETED_SURF_EDGE( IAD_ELEM,ITABM1,SHOOT_STRUCT,INTBUF_TAB,NEWFRONT,
      .                           IPARI,GEO,
-     .                           IXS,IXC,IXT,IXP,IXR,IXTG,
+     .                           IXS,IXC,IXT,IXP,IXR,IXTG,IXS(L1),
      .                           ADDCNEL,CNEL,WA(NWAFTSK),TAGEL )
             CALL MY_BARRIER()
           ENDIF
@@ -2353,7 +2353,7 @@ C Init var parallel SMP
           CALL CHECK_SURFACE_STATE( ITSK,SHOOT_STRUCT%SAVE_SURFACE_NB,SHOOT_STRUCT%SAVE_SURFACE,
      .                              SHOOT_STRUCT%SHIFT_INTERFACE,INTBUF_TAB,
      .                              IPARI,GEO,
-     .                              IXS,IXC,IXT,IXP,IXR,IXTG,
+     .                              IXS,IXC,IXT,IXP,IXR,IXTG,IXS(L1),
      .                              ADDCNEL,CNEL,WA(NWAFTSK),TAGEL,SHOOT_STRUCT )
 
           ! loop over the edge id and deactivate the edge
@@ -2361,7 +2361,7 @@ C Init var parallel SMP
           CALL CHECK_EDGE_STATE( ITSK,SHOOT_STRUCT%SAVE_M_EDGE_NB,SHOOT_STRUCT%SAVE_S_EDGE_NB,
      .                           SHOOT_STRUCT%SAVE_M_EDGE,SHOOT_STRUCT%SAVE_S_EDGE,
      .                           SHOOT_STRUCT%SHIFT_INTERFACE,INTBUF_TAB,NEWFRONT,IPARI,GEO,
-     .                           IXS,IXC,IXT,IXP,IXR,IXTG,
+     .                           IXS,IXC,IXT,IXP,IXR,IXTG,IXS(L1),
      .                           ADDCNEL,CNEL,WA(NWAFTSK),TAGEL,SHOOT_STRUCT )
           ! ---------------------
 
@@ -5371,7 +5371,7 @@ C WA local  : utilise de 1 a NUMNOD
           IF(NSPMD>1) THEN 
             IF(ITSK==0) CALL SPMD_EXCH_DELETED_SURF_EDGE( IAD_ELEM,ITABM1,SHOOT_STRUCT,INTBUF_TAB,NEWFRONT,
      .                           IPARI,GEO,
-     .                           IXS,IXC,IXT,IXP,IXR,IXTG,
+     .                           IXS,IXC,IXT,IXP,IXR,IXTG,IXS(L1),
      .                           ADDCNEL,CNEL,WA(NWAFTSK),TAGEL )
             CALL MY_BARRIER()
           ENDIF
@@ -5384,7 +5384,7 @@ C WA local  : utilise de 1 a NUMNOD
           CALL CHECK_SURFACE_STATE( ITSK,SHOOT_STRUCT%SAVE_SURFACE_NB,SHOOT_STRUCT%SAVE_SURFACE,
      .                              SHOOT_STRUCT%SHIFT_INTERFACE,INTBUF_TAB,
      .                              IPARI,GEO,
-     .                              IXS,IXC,IXT,IXP,IXR,IXTG,
+     .                              IXS,IXC,IXT,IXP,IXR,IXTG,IXS(L1),
      .                              ADDCNEL,CNEL,WA(NWAFTSK),TAGEL,SHOOT_STRUCT )
 
           ! loop over the edge id and deactivate the edge
@@ -5392,7 +5392,7 @@ C WA local  : utilise de 1 a NUMNOD
           CALL CHECK_EDGE_STATE( ITSK,SHOOT_STRUCT%SAVE_M_EDGE_NB,SHOOT_STRUCT%SAVE_S_EDGE_NB,
      .                           SHOOT_STRUCT%SAVE_M_EDGE,SHOOT_STRUCT%SAVE_S_EDGE,
      .                           SHOOT_STRUCT%SHIFT_INTERFACE,INTBUF_TAB,NEWFRONT,IPARI,GEO,
-     .                           IXS,IXC,IXT,IXP,IXR,IXTG,
+     .                           IXS,IXC,IXT,IXP,IXR,IXTG,IXS(L1),
      .                           ADDCNEL,CNEL,WA(NWAFTSK),TAGEL,SHOOT_STRUCT )
           ! ---------------------
 

--- a/engine/source/interfaces/interf/check_active_elem_edge.F
+++ b/engine/source/interfaces/interf/check_active_elem_edge.F
@@ -29,7 +29,7 @@ Chd|-- calls ---------------
 Chd|====================================================================
         SUBROUTINE CHECK_ACTIVE_ELEM_EDGE( NUMBER_NODE, N1,N2,N3,N4,
      .                                     DEACTIVATION,GEO,IXS,IXC,
-     .                                     IXT,IXP,IXR,IXTG,ADDCNEL,CNEL,
+     .                                     IXT,IXP,IXR,IXTG,IXS10,ADDCNEL,CNEL,
      .                                     TAG_NODE,TAG_ELEM )
 !$COMMENT
 !       CHECK_ACTIVE_ELEM_EDGE description
@@ -55,12 +55,13 @@ C-----------------------------------------------
         LOGICAL, INTENT(inout) :: DEACTIVATION
         INTEGER, INTENT(in) :: NUMBER_NODE ! number of node of the edge/surface
         INTEGER, INTENT(in) :: N1,N2,N3,N4 ! node id : for interface type11 -> N3&N4 are fake node id (ie. =0)
-        INTEGER, DIMENSION(NIXS,NUMELS),TARGET, INTENT(in) :: IXS   ! solid array
-        INTEGER, DIMENSION(NIXC,NUMELC),TARGET, INTENT(in) :: IXC   ! shell array
-        INTEGER, DIMENSION(NIXT,NUMELT),TARGET, INTENT(in) :: IXT! truss array
-        INTEGER, DIMENSION(NIXP,NUMELP),TARGET, INTENT(in) :: IXP! beam array
-        INTEGER, DIMENSION(NIXR,NUMELR),TARGET, INTENT(in) :: IXR! spring array
-        INTEGER, DIMENSION(NIXTG,NUMELTG),TARGET, INTENT(in) :: IXTG! triangle array
+        INTEGER, DIMENSION(NIXS,NUMELS), INTENT(in) :: IXS   ! solid array
+        INTEGER, DIMENSION(NIXC,NUMELC), INTENT(in) :: IXC   ! shell array
+        INTEGER, DIMENSION(NIXT,NUMELT), INTENT(in) :: IXT! truss array
+        INTEGER, DIMENSION(NIXP,NUMELP), INTENT(in) :: IXP! beam array
+        INTEGER, DIMENSION(NIXR,NUMELR), INTENT(in) :: IXR! spring array
+        INTEGER, DIMENSION(NIXTG,NUMELTG), INTENT(in) :: IXTG! triangle array
+        INTEGER, DIMENSION(6,NUMELS10), INTENT(in) :: IXS10!< tetra10 data
         INTEGER, DIMENSION(0:NUMNOD+1), INTENT(in) :: ADDCNEL ! address for the CNEL array
         my_real, DIMENSION(NPROPG,NUMGEO), INTENT(in) :: GEO
         INTEGER, DIMENSION(0:LCNEL), INTENT(in) :: CNEL ! connectivity node-->element
@@ -125,9 +126,15 @@ C-----------------------------------------------
                 ! solid element
                 IF(ELEM_ID<=OFFSET_SHELL) THEN
                     DO K=2,9
-                        NODE_ID = IXS(K,ELEM_ID)
-                        TAG_NODE(NODE_ID) = 1
+                      NODE_ID = IXS(K,ELEM_ID)
+                      TAG_NODE(NODE_ID) = 1
                     ENDDO
+                    IF(ELEM_ID>NUMELS8.AND.ELEM_ID<=NUMELS8+NUMELS10) THEN
+                      DO K=1,6
+                        NODE_ID = IXS10(K,ELEM_ID)
+                        TAG_NODE(NODE_ID) = 1
+                      ENDDO
+                    ENDIF
                 ELSEIF(ELEM_ID>OFFSET_SHELL.AND.ELEM_ID<=OFFSET_TRUSS) THEN
                 ! -----------------
                 ! shell element

--- a/engine/source/interfaces/interf/check_edge_state.F
+++ b/engine/source/interfaces/interf/check_edge_state.F
@@ -32,7 +32,7 @@ Chd|        SHOOTING_NODE_MOD             share/modules/shooting_node_mod.F
 Chd|====================================================================
         SUBROUTINE CHECK_EDGE_STATE( ITASK,M_EDGE_NB,S_EDGE_NB,M_EDGE_ID,S_EDGE_ID,
      .                               SHIFT_INTERFACE,INTBUF_TAB,NEWFRONT,IPARI,GEO,
-     .                               IXS,IXC,IXT,IXP,IXR,IXTG,
+     .                               IXS,IXC,IXT,IXP,IXR,IXTG,IXS10,
      .                               ADDCNEL,CNEL,TAG_NODE,TAG_ELEM,SHOOT_STRUCT )
 !$COMMENT
 !       CHECK_EDGE_STATE description
@@ -73,6 +73,7 @@ C-----------------------------------------------
         INTEGER, DIMENSION(NIXP,NUMELP), INTENT(in) :: IXP! beam array
         INTEGER, DIMENSION(NIXR,NUMELR), INTENT(in) :: IXR! spring array
         INTEGER, DIMENSION(NIXTG,NUMELTG), INTENT(in) :: IXTG! triangle array
+        INTEGER, DIMENSION(6,NUMELS10), INTENT(in) :: IXS10!< tetra10 data
         INTEGER, DIMENSION(0:NUMNOD+1), INTENT(in) :: ADDCNEL ! address for the CNEL array
         my_real, DIMENSION(NPROPG,NUMGEO), INTENT(in) :: GEO
         INTEGER, DIMENSION(0:LCNEL), INTENT(in) :: CNEL ! connectivity node-->element
@@ -128,7 +129,7 @@ C-----------------------------------------------
                     IF(SHOOT_STRUCT%INTER(NIN)%REMOTE_ELM_M(K)<1) THEN
                         CALL CHECK_ACTIVE_ELEM_EDGE( NUMBER_NODE, N1,N2,N3,N4,
      .                                               DEACTIVATION,GEO,IXS,IXC,
-     .                                               IXT,IXP,IXR,IXTG,ADDCNEL,CNEL,
+     .                                               IXT,IXP,IXR,IXTG,IXS10,ADDCNEL,CNEL,
      .                                               TAG_NODE,TAG_ELEM )
                     ELSE
                         DEACTIVATION = .FALSE.
@@ -177,7 +178,7 @@ C-----------------------------------------------
                     IF(SHOOT_STRUCT%INTER(NIN)%REMOTE_ELM_S(K)<1) THEN
                         CALL CHECK_ACTIVE_ELEM_EDGE( NUMBER_NODE, N1,N2,N3,N4,
      .                                               DEACTIVATION,GEO,IXS,IXC,
-     .                                               IXT,IXP,IXR,IXTG,ADDCNEL,CNEL,
+     .                                               IXT,IXP,IXR,IXTG,IXS10,ADDCNEL,CNEL,
      .                                               TAG_NODE,TAG_ELEM )
                     ELSE
                         DEACTIVATION = .FALSE.

--- a/engine/source/interfaces/interf/check_surface_state.F
+++ b/engine/source/interfaces/interf/check_surface_state.F
@@ -33,7 +33,7 @@ Chd|        SHOOTING_NODE_MOD             share/modules/shooting_node_mod.F
 Chd|====================================================================
         SUBROUTINE CHECK_SURFACE_STATE( ITASK,SURFARCE_NB,SURFACE_ID,SHIFT_INTERFACE,INTBUF_TAB,
      .                                  IPARI,GEO,
-     .                                  IXS,IXC,IXT,IXP,IXR,IXTG,
+     .                                  IXS,IXC,IXT,IXP,IXR,IXTG,IXS10,
      .                                  ADDCNEL,CNEL,TAG_NODE,TAG_ELEM,SHOOT_STRUCT )
 !$COMMENT
 !       CHECK_SURFACE_STATE description
@@ -74,6 +74,7 @@ C-----------------------------------------------
         INTEGER, DIMENSION(NIXP,NUMELP), INTENT(in) :: IXP! beam array
         INTEGER, DIMENSION(NIXR,NUMELR), INTENT(in) :: IXR! spring array
         INTEGER, DIMENSION(NIXTG,NUMELTG), INTENT(in) :: IXTG! triangle array
+        INTEGER, DIMENSION(6,NUMELS10), INTENT(in) :: IXS10!< tetra10 data
         INTEGER, DIMENSION(0:NUMNOD+1), INTENT(in) :: ADDCNEL ! address for the CNEL array
         my_real, DIMENSION(NPROPG,NUMGEO), INTENT(in) :: GEO
         INTEGER, DIMENSION(0:LCNEL), INTENT(in) :: CNEL ! connectivity node-->element
@@ -160,7 +161,7 @@ C-----------------------------------------------
             IF(SHOOT_STRUCT%INTER(NIN)%REMOTE_ELM_M(K)<1) THEN
               CALL CHECK_ACTIVE_ELEM_EDGE( NUMBER_NODE, N1,N2,N3,N4,
      .                                     DEACTIVATION,GEO,IXS,IXC,
-     .                                     IXT,IXP,IXR,IXTG,ADDCNEL,CNEL,
+     .                                     IXT,IXP,IXR,IXTG,IXS10,ADDCNEL,CNEL,
      .                                     TAG_NODE,TAG_ELEM)
             ELSE
               DEACTIVATION = .FALSE.

--- a/engine/source/interfaces/interf/find_edge_from_remote_proc.F
+++ b/engine/source/interfaces/interf/find_edge_from_remote_proc.F
@@ -32,7 +32,7 @@ Chd|        SHOOTING_NODE_MOD             share/modules/shooting_node_mod.F
 Chd|====================================================================
         SUBROUTINE FIND_EDGE_FROM_REMOTE_PROC(SHOOT_STRUCT,NB_EDGE,LIST_NODE,INTBUF_TAB,ITABM1,
      .                                        NEWFRONT,IPARI,GEO,
-     .                                        IXS,IXC,IXT,IXP,IXR,IXTG,
+     .                                        IXS,IXC,IXT,IXP,IXR,IXTG,IXS10,
      .                                        ADDCNEL,CNEL,TAG_NODE,TAG_ELEM )
 !$COMMENT
 !       FIND_EDGE_FROM_REMOTE_PROC description
@@ -71,6 +71,7 @@ C-----------------------------------------------
         INTEGER, DIMENSION(NIXP,NUMELP), INTENT(in) :: IXP! beam array
         INTEGER, DIMENSION(NIXR,NUMELR), INTENT(in) :: IXR! spring array
         INTEGER, DIMENSION(NIXTG,NUMELTG), INTENT(in) :: IXTG! triangle array
+        INTEGER, DIMENSION(6,NUMELS10), INTENT(in) :: IXS10!< tetra10 data
         INTEGER, DIMENSION(0:NUMNOD+1), INTENT(in) :: ADDCNEL ! address for the CNEL array
         INTEGER, DIMENSION(NPARI,NINTER), INTENT(in) :: IPARI
         my_real, DIMENSION(NPROPG,NUMGEO), INTENT(in) :: GEO
@@ -200,7 +201,7 @@ C-----------------------------------------------
         CALL CHECK_EDGE_STATE( -1,NB_EDGE_R_PROC_M,NB_EDGE_R_PROC_S,
      .                         LIST_EDGE_R_PROC(1),LIST_EDGE_R_PROC(1+NB_EDGE_R_PROC_M),
      .                         SHOOT_STRUCT%SHIFT_INTERFACE,INTBUF_TAB,NEWFRONT,IPARI,GEO,
-     .                         IXS,IXC,IXT,IXP,IXR,IXTG,
+     .                         IXS,IXC,IXT,IXP,IXR,IXTG,IXS10,
      .                         ADDCNEL,CNEL,TAG_NODE,TAG_ELEM,SHOOT_STRUCT )
 
         DEALLOCATE( LIST_EDGE_R_PROC )

--- a/engine/source/interfaces/interf/find_surface_from_remote_proc.F
+++ b/engine/source/interfaces/interf/find_surface_from_remote_proc.F
@@ -32,7 +32,7 @@ Chd|        SHOOTING_NODE_MOD             share/modules/shooting_node_mod.F
 Chd|====================================================================
         SUBROUTINE FIND_SURFACE_FROM_REMOTE_PROC(SHOOT_STRUCT,NB_SURFACE,LIST_NODE,INTBUF_TAB,ITABM1,
      .                                           IPARI,GEO,
-     .                                           IXS,IXC,IXT,IXP,IXR,IXTG,
+     .                                           IXS,IXC,IXT,IXP,IXR,IXTG,IXS10,
      .                                           ADDCNEL,CNEL,TAG_NODE,TAG_ELEM )
 !$COMMENT
 !       FIND_SURFACE_FROM_REMOTE_PROC description
@@ -70,6 +70,7 @@ C-----------------------------------------------
         INTEGER, DIMENSION(NIXP,NUMELP), INTENT(in) :: IXP! beam array
         INTEGER, DIMENSION(NIXR,NUMELR), INTENT(in) :: IXR! spring array
         INTEGER, DIMENSION(NIXTG,NUMELTG), INTENT(in) :: IXTG! triangle array
+        INTEGER, DIMENSION(6,NUMELS10), INTENT(in) :: IXS10!< tetra10 data
         INTEGER, DIMENSION(0:NUMNOD+1), INTENT(in) :: ADDCNEL ! address for the CNEL array
         INTEGER, DIMENSION(NPARI,NINTER), INTENT(in) :: IPARI
         my_real, DIMENSION(NPROPG,NUMGEO), INTENT(in) :: GEO
@@ -153,7 +154,7 @@ C-----------------------------------------------
 
         CALL CHECK_SURFACE_STATE( -1,NB_SURFACE_R_PROC,LIST_SURFACE_R_PROC,SHOOT_STRUCT%SHIFT_INTERFACE,INTBUF_TAB,
      .                            IPARI,GEO,
-     .                            IXS,IXC,IXT,IXP,IXR,IXTG,
+     .                            IXS,IXC,IXT,IXP,IXR,IXTG,IXS10,
      .                            ADDCNEL,CNEL,TAG_NODE,TAG_ELEM,SHOOT_STRUCT )
 
         DEALLOCATE( LIST_SURFACE_R_PROC )

--- a/engine/source/interfaces/interf/get_segment_normal.F90
+++ b/engine/source/interfaces/interf/get_segment_normal.F90
@@ -30,7 +30,7 @@
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   modules
 ! ----------------------------------------------------------------------------------------------------------------------
-          use constant_mod , only : zero,em20,fourth
+          use constant_mod , only : zero,em20,fourth,third
           use intbufdef_mod , only : intbuf_struct_
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   implicit none
@@ -55,10 +55,13 @@
 ! ----------------------------------------------------------------------------------------------------------------------
           integer :: i,j
           integer :: node_id,elem_id
+          integer :: node_id_3,node_id_4
+          integer :: node_number
           my_real :: xx13,yy13,zz13,xx24,yy24,zz24
           my_real :: nor1,nor2,nor3
           my_real :: area,dds
           my_real :: xc,yc,zc
+          my_real :: ratio
           my_real, dimension(4) :: xx1,xx2,xx3
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   external functions
@@ -74,16 +77,31 @@
           segment_position(1) = zero 
           segment_position(2) = zero 
           segment_position(3) = zero
-          do i=1,4
+          node_number = 4
+          node_id_3 = intbuf_tab%irectm(4*(segment_id-1)+3)
+          node_id_4 = intbuf_tab%irectm(4*(segment_id-1)+4)
+          ratio = fourth
+          if(node_id_3==node_id_4) then
+            node_number = 3
+            ratio = third
+          endif
+          do i=1,node_number
             node_id = intbuf_tab%irectm(4*(segment_id-1)+i) ! get the node id
             segment_node_id(i) = node_id
             xx1(i) = x(1,node_id)
             xx2(i) = x(2,node_id)
             xx3(i) = x(3,node_id)
-            segment_position(1) = segment_position(1)+fourth*x(1,node_id)
-            segment_position(2) = segment_position(2)+fourth*x(2,node_id)
-            segment_position(3) = segment_position(3)+fourth*x(3,node_id)   
+            segment_position(1) = segment_position(1)+ratio*x(1,node_id)
+            segment_position(2) = segment_position(2)+ratio*x(2,node_id)
+            segment_position(3) = segment_position(3)+ratio*x(3,node_id)   
           enddo    
+          if(node_id_3==node_id_4) then
+            node_id = intbuf_tab%irectm(4*(segment_id-1)+4) ! get the node id
+            segment_node_id(4) = node_id
+            xx1(4) = x(1,node_id)
+            xx2(4) = x(2,node_id)
+            xx3(4) = x(3,node_id)
+          endif
 
           xx13 =xx1(3)-xx1(1)
           yy13 =xx2(3)-xx2(1)

--- a/engine/source/interfaces/interf/init_nodal_state.F
+++ b/engine/source/interfaces/interf/init_nodal_state.F
@@ -435,7 +435,7 @@ C-----------------------------------------------
             NRTM = IPARI(4,NIN) ! number of main surfaces/edges
             NRTS = IPARI(3,NIN) ! number of secondary edges
             IDEL = IPARI(17,NIN)! idel option
-            TYPE_INTER = (ITY==7.OR.ITY==10.OR.ITY==22.OR.ITY==24) ! interface 7/10/11/22/24/25 with idel=1
+            TYPE_INTER = (ITY==7.OR.ITY==10.OR.ITY==11.OR.ITY==22.OR.ITY==24) ! interface 7/10/11/22/24/25 with idel=1
             TYPE_INTER = (TYPE_INTER.OR.(ITY==25.AND.IPARI(100,NIN)==0)) ! interface  7/10/11/22/24/25 with idel=1
             TYPE_INTER = (TYPE_INTER.AND.(IDEL==1)) ! interface  7/10/11/22/24/25 with idel=1
             ! ----------------------------------------

--- a/engine/source/mpi/interfaces/spmd_exch_deleted_surf_edge.F
+++ b/engine/source/mpi/interfaces/spmd_exch_deleted_surf_edge.F
@@ -35,7 +35,7 @@ Chd|        SHOOTING_NODE_MOD             share/modules/shooting_node_mod.F
 Chd|====================================================================
         SUBROUTINE SPMD_EXCH_DELETED_SURF_EDGE( IAD_ELEM,ITABM1,SHOOT_STRUCT,INTBUF_TAB,NEWFRONT,
      .                                          IPARI,GEO,
-     .                                          IXS,IXC,IXT,IXP,IXR,IXTG,
+     .                                          IXS,IXC,IXT,IXP,IXR,IXTG,IXS10,
      .                                          ADDCNEL,CNEL,TAG_NODE,TAG_ELEM )
 !$COMMENT
 !       SPMD_EXCH_DELETED_SURF_EDGE description
@@ -81,6 +81,7 @@ C-----------------------------------------------
         INTEGER, DIMENSION(NIXP,NUMELP),TARGET, INTENT(in) :: IXP! beam array
         INTEGER, DIMENSION(NIXR,NUMELR),TARGET, INTENT(in) :: IXR! spring array
         INTEGER, DIMENSION(NIXTG,NUMELTG),TARGET, INTENT(in) :: IXTG! triangle array
+        INTEGER, DIMENSION(6,NUMELS10), INTENT(in) :: IXS10!< tetra10 data
         INTEGER, DIMENSION(0:NUMNOD+1), INTENT(in) :: ADDCNEL ! address for the CNEL array
         INTEGER, DIMENSION(NPARI,NINTER), INTENT(in) :: IPARI
         my_real, DIMENSION(NPROPG,NUMGEO), INTENT(in) :: GEO
@@ -240,13 +241,13 @@ C-----------------------------------------------
 
             CALL FIND_SURFACE_FROM_REMOTE_PROC(SHOOT_STRUCT,NB_SURFACE,BUFFER_R(ADDRESS),INTBUF_TAB,ITABM1,
      .                                         IPARI,GEO,
-     .                                         IXS,IXC,IXT,IXP,IXR,IXTG,
+     .                                         IXS,IXC,IXT,IXP,IXR,IXTG,IXS10,
      .                                         ADDCNEL,CNEL,TAG_NODE,TAG_ELEM )
             NB_EDGE = REMOTE_SURF_PER_PROC_2(2,K)
             ADDRESS = INDEX_BUFFER_R_2(K)+4*NB_SURFACE  
             CALL FIND_EDGE_FROM_REMOTE_PROC( SHOOT_STRUCT,NB_EDGE,BUFFER_R(ADDRESS),INTBUF_TAB,ITABM1,
      .                                       NEWFRONT,IPARI,GEO,
-     .                                       IXS,IXC,IXT,IXP,IXR,IXTG,
+     .                                       IXS,IXC,IXT,IXP,IXR,IXTG,IXS10,
      .                                       ADDCNEL,CNEL,TAG_NODE,TAG_ELEM )
         ENDDO
         ! ----------------


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Several issues were fixed : 

- an array was not allocated for the interface 11 (introduced by c61b97b13f02d5e0ce8f07ce2ee897b104dff95c)
- there was an general issue with the tetra10 element
- the barycentre computation for the interface 25 + solid erosion was buggy for triangle segment (introduced by c61b97b13f02d5e0ce8f07ce2ee897b104dff95c)

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
