### PR TITLE
BEM: progression bar fix

### DIFF
--- a/engine/source/system/progcond_c.c
+++ b/engine/source/system/progcond_c.c
@@ -60,7 +60,7 @@ void progcond_c__(int *icur, int *imax, int *iproc, int *ilvl, int *id, int *ist
 
 void progcondp_c(int *icur, int *imax, int *iproc, int *id)
 {
-     char outline[10];
+     char outline[11];
      double percent ;
      char ctab[80] ;
      int i,j ;


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Bug fix in progression bar for BEM/DAA.
Depending on the value of Iprint, a progression bar may be written in stdout. The dimension of the array outline was too small.