### PR TITLE
correction to avoid Starter stop due to division by 0 in case of interface type 25 w/o edge

### DIFF
--- a/starter/source/interfaces/inter3d1/i7remnode.F
+++ b/starter/source/interfaces/inter3d1/i7remnode.F
@@ -1479,7 +1479,9 @@ C       IremI2 for edge to edge contact type 25
 C-----------------------------------------------
 
                     IF(NTY==25.AND.IF25>0.AND.IEDGE>0)THEN
-                      CALL REMN_I2OP_EDG25(N          ,FLAGREMNODE_SAV ,IPARI   ,INTBUF_TAB   ,I2NODE,
+                      NEDGE = IPARI(68,N)
+                      IF (NEDGE >0) 
+     .                CALL REMN_I2OP_EDG25(N          ,FLAGREMNODE_SAV ,IPARI   ,INTBUF_TAB   ,I2NODE,
      .                                     POINTS_I2N ,I2NODE_SIZE     ,NOM_OPT  ,ITAB,IDDLEVEL)
                     ENDIF      
         END DO 


### PR DESCRIPTION


#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Starter might crash in case of solid model using interface type25 + Iedge=1 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
correction to fix Starter crash due to division by 0.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
