### PR TITLE
Correct H3D and ANIM output of total strain in law58

### DIFF
--- a/engine/source/materials/mat/mat058/sigeps58c.F
+++ b/engine/source/materials/mat/mat058/sigeps58c.F
@@ -194,11 +194,11 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   S t a t e    V a r i a b l e s  (U V A R)
 C-----------------------------------------------
-c     UVAR(1)  = SIGNXX + SIGVXX  ! total stress in 1st direction (elastic + viscous)
-c     UVAR(2)  = SIGNYY + SIGVYY  ! total stress in 2nd direction (elastic + viscous)
+c     UVAR(1)  = SIGNXX + SIGVXX  ! total engineering stress in 1st direction (elastic + viscous)
+c     UVAR(2)  = SIGNYY + SIGVYY  ! total engineering stress in 2nd direction (elastic + viscous)
 c     UVAR(3)  = SIGNXY + SIGVXY  ! total shear stress (elastic + friction)
-c     UVAR(4)  = EC               ! total element elongation in 1st direction
-c     UVAR(5)  = ET               ! total element elongation in 2nd direction
+c     UVAR(4)  = EC               ! total true element strain in 1st fiber direction
+c     UVAR(5)  = ET               ! total true element strain in 2nd fiber direction
 c     UVAR(6)  = DEPSXY           ! tan(alpha) of shear angle
 c     UVAR(7)  = YC               ! total flex element elongation in 1st direction
 c     UVAR(8)  = YT               ! total flex element elongation in 2nd direction

--- a/engine/source/output/anim/generate/dfuncc.F
+++ b/engine/source/output/anim/generate/dfuncc.F
@@ -1278,7 +1278,7 @@ c
                     DO IR = 1, NPTR                                                        
                       DO IS = 1, NPTS                                                      
                         UVAR=>ELBUF_TAB(NG)%BUFLY(IL)%MAT(IR,IS,IPT)%VAR                   
-                        IF (IUS==3 .OR. IUS==4) THEN  ! convert true to eng strain                                           
+                        IF (IUS==4 .OR. IUS==5) THEN  ! convert true to eng strain                                           
                           EVAR(I) = EVAR(I) + EXP(UVAR(I1+I) - ONE) / NPG                     
                         ELSE                                                               
                           EVAR(I) = EVAR(I) + UVAR(I1 + I) / NPG                             

--- a/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
@@ -1130,7 +1130,7 @@ c
                         DO IR = 1, NPTR
                           DO IS = 1, NPTS
                             UVAR=>ELBUF_TAB(NG)%BUFLY(IL)%MAT(IR,IS,IPT)%VAR
-                            IF(IUVAR==3.OR.IUVAR==4)THEN
+                            IF(IUVAR==4.OR.IUVAR==5)THEN
                               DO I=1,NEL
                                 VALUE(I) = VALUE(I) + LOG(UVAR(I1 + I)+ONE)/NPG
                                 IS_WRITTEN_VALUE(I) = 1


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

UVAR4 and UVAR5 variable output was wrong according to actual documentation

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

changed index of UVAR in H3D and ANIM output in law 58.
updated UVAR description in engine code of the material law (in comments)

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
