### PR TITLE
Change name of law 126 in element deletion message

### DIFF
--- a/engine/source/materials/mat/mat126/sigeps126.F90
+++ b/engine/source/materials/mat/mat126/sigeps126.F90
@@ -372,7 +372,7 @@
               write(istdo,1000) ngl(indx(j)),tt
             enddo
           endif
- 1000 format(1x,'-- RUPTURE (JH-1) OF SOLID ELEMENT :',I10,' AT TIME :',1PE12.4)     
+ 1000 format(1x,'-- RUPTURE (JHC) OF SOLID ELEMENT :',I10,' AT TIME :',1PE12.4)     
 
         end subroutine sigeps126
       end module sigeps126_mod  


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

The name of element deletion message for /MAT/LAW126 was not consistent. Needed to change it. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

JH1 -> JHC for Johnson-Holmquist Concrete. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
