### PR TITLE
LAW151:global detonation time

### DIFF
--- a/engine/source/output/h3d/h3d_results/h3d_quad_scalar.F
+++ b/engine/source/output/h3d/h3d_results/h3d_quad_scalar.F
@@ -109,7 +109,7 @@ C-----------------------------------------------
      .   X41,Y21,Y32,Y34,Y41,Z21,Z32,Z34,Z41,SUMA,VR,VS,X31,Y31,
      .   Z31,E11,E12,E13,E21,E22,E23,AREA,X2L,VAR,
      .   E1X,E1Y,E1Z,E2X,E2Y,E2Z,E3X,E3Y,E3Z,RX,RY,RZ,SX,SY,SZ,
-     .   VG(5),VLY(5),VE(5),BUFMAT(*),VFRAC(MVSIZ,1:21),
+     .   VG(5),VLY(5),VE(5),BUFMAT(*),VFRAC(MVSIZ,1:21),VOLFRAC,BFRAC,
      .   S11,S22,S33,S4,S5,S6,CRIT,VALUE1,VALUE2,VEL(0:3),TMP(3,4),
      .   NX,NY,NZ,CUMUL(3),SURF,VX,VY,VZ,VOL,MASS0
       INTEGER I,I1,II,J,NG,NEL,NPTR,NPTS,NPTT,NLAY,L,IFAIL,ILAY,
@@ -124,7 +124,7 @@ C-----------------------------------------------
      .        PTE(4),PTP(4),PTMAT(4),PTVAR(4),NPT_ALL,IPLY,
      .        ID_ELEM_TMP(MVSIZ),NIX,IOK_PART(MVSIZ),JJ(6),NPGT,IUVAR,
      .        IS_WRITTEN_VALUE(MVSIZ),NFRAC,KFACE,NB_FACE,IV,ISUBMAT,IS_EULER,IS_ALE,IAD2,NVAREOS,
-     .        NTILLOTSON,IMAT_TILLOTSON
+     .        NTILLOTSON,IMAT_TILLOTSON,SUBMATLAW
       CHARACTER*5 BUFF
       REAL R4
       TYPE(G_BUFEL_)  ,POINTER :: GBUF     
@@ -137,6 +137,7 @@ C-----------------------------------------------
       TYPE(L_BUFEL_) ,POINTER  :: LBUF1,LBUF2,LBUF3,LBUF4
       TYPE(BUF_MAT_)  ,POINTER :: MBUF 
       my_real, DIMENSION(:) ,POINTER  :: UPARAM
+      LOGICAL DETECTED
       TARGET :: BUFMAT
       my_real PI_
       DATA PI_/3.141592653589793238462643/
@@ -806,7 +807,7 @@ C--------------------------------------------------
 C-------------------------------------------------- 
               ELSEIF (KEYWORD == 'TDET') THEN  !  /ANIM/ELEM/TDET
 C-------------------------------------------------- 
-                 IF (MLW  /= 51 .AND. GBUF%G_TB > 0) THEN
+                 IF (MLW  /= 51 .AND. MLW /= 151 .AND. GBUF%G_TB > 0) THEN
                    DO I=1,NEL
                      VALUE(I) = -GBUF%TB(I)
                      IS_WRITTEN_VALUE(I) = 1
@@ -819,7 +820,26 @@ C--------------------------------------------------
                    DO I=1,IPARG(2,NG)
                      VALUE(I) = -MBUF%VAR(K+I)
                      IS_WRITTEN_VALUE(I) = 1
-                   ENDDO 
+                   ENDDO
+                 ELSEIF(MLW == 151 .AND. GBUF%G_TB > 0)THEN
+                   DO I=1,NEL
+                     DETECTED = .FALSE.
+                     VALUE(I) = ZERO
+                     DO ILAY=1,NLAY
+                       SUBMATLAW = ELBUF_TAB(NG)%BUFLY(ILAY)%ILAW
+                       IF(SUBMATLAW == 5 )THEN
+                         VOLFRAC = ELBUF_TAB(NG)%BUFLY(ILAY)%LBUF(1,1,1)%VOL(I)/GBUF%VOL(I)
+                         BFRAC = MULTI_FVM%BFRAC(ILAY,I+NFT)
+                         IF(VOLFRAC > ZERO .OR. BFRAC > ZERO)THEN
+                           DETECTED = .TRUE.
+                         ENDIF
+                       ENDIF
+                     ENDDO
+                     IF(DETECTED)THEN
+                       VALUE(I) = -GBUF%TB(I)
+                     ENDIF
+                     IS_WRITTEN_VALUE(I) = 1
+                   ENDDO
                  ENDIF   
 C--------------------------------------------------
             ELSEIF(KEYWORD == 'LAW20/DENS1')THEN
@@ -841,7 +861,7 @@ C--------------------------------------------------
                   LBUF  => ELBUF_TAB(NG)%BUFLY(2)%LBUF(1,1,1)
                   VALUE(I) = LBUF%RHO(I)
             IS_WRITTEN_VALUE(I) = 1
-                ENDDO  
+                ENDDO
               ENDIF 
 C--------------------------------------------------
             ELSEIF(KEYWORD == 'LAW20/ENER1')THEN

--- a/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
@@ -107,18 +107,20 @@ C-----------------------------------------------
      .          NINTY,VONM2,S1,S2,S12,DMGMX,A1,A2,A3,A4,DIR1_1,DIR1_2,AA,BB,V1,V2,V3,X21,X32,X34,
      .          X41,Y21,Y32,Y34,Y41,Z21,Z32,Z34,Z41,SUMA,VR,VS,X31,Y31,Z31,E11,E12,E13,E21,E22,E23,SUM_,AREA,X2L,
      .          E1X,E1Y,E1Z,E2X,E2Y,E2Z,E3X,E3Y,E3Z,RX,RY,RZ,S_X,S_Y,S_Z,RHO0(MVSIZ),THK0,XX1,XX2,XX3,YY1,YY2,YY3,ZZ1,ZZ2,ZZ3,A0,
-     .          RINDX,VFRAC(MVSIZ,1:21),TMP(3,3),CUMUL(3),VX,VY,VZ,SURF,NX,NY,NZ,PHI,ERR,PRES(MVSIZ),VEL(0:3),MAXDAMINI
+     .          RINDX,VFRAC(MVSIZ,1:21),TMP(3,3),CUMUL(3),VX,VY,VZ,SURF,NX,NY,NZ,PHI,ERR,PRES(MVSIZ),VEL(0:3),MAXDAMINI,
+     .          VOLFRAC,BFRAC
         INTEGER I,I1,II,J,NEL,NPTR,NPTS,NPTT,NLAY,L,IFAIL,ILAY,
      .          IR,IS,IT,IL,MLW, NUVAR,NFAIL,
      .          N,K,K1,K2,JTURB,
      .          OFFSET,IHBE,NPG, MPT,IPT,IADR,IPMAT,
      .          ISUBSTACK,ITHK,ID_PLY,IOK,N1,N2,N3,N4,
-     .          IMAT,IU(4),NFRAC,IPOS,ITRIMAT,NS,IAD2,IDRAPE,NLAY_FAIL,ILAY0
+     .          IMAT,IU(4),NFRAC,IPOS,ITRIMAT,NS,IAD2,IDRAPE,NLAY_FAIL,ILAY0,SUBMATLAW
         INTEGER PID(MVSIZ),MAT(MVSIZ),MATLY(MVSIZ*100),FAILG(100,MVSIZ),
      .          IPLY,
      .          IOK_PART(MVSIZ),JJ(5),NPGT,IUVAR,
      .          IS_WRITTEN_VALUE(MVSIZ),IV,KFACE,NB_FACE,IADBUF,NUPARAM,ISUBMAT,IS_EULER,IS_ALE,
      .          IPINCH,IPG,USER_OK,IALEL,IMODE,NMOD,MAT_ID
+        LOGICAL DETECTED
         CHARACTER*5 BUFF
         TYPE(G_BUFEL_)  ,POINTER :: GBUF
         TYPE(L_BUFEL_)  ,POINTER :: LBUF
@@ -4976,7 +4978,7 @@ C--------------------------------------------------
 C--------------------------------------------------
             ELSEIF(KEYWORD == 'TDET' )THEN
 C--------------------------------------------------
-              IF (MLW  /= 51 .AND. GBUF%G_TB > 0) THEN
+              IF (MLW  /= 51 .AND. MLW /=151 .AND. GBUF%G_TB > 0) THEN
                 DO I=1,NEL
                   VALUE(I) = -GBUF%TB(I)
                   IS_WRITTEN_VALUE(I) = 1
@@ -4990,6 +4992,25 @@ C--------------------------------------------------
                   VALUE(I) = -MBUF%VAR(K+I)
                   IS_WRITTEN_VALUE(I) = 1
                 ENDDO
+                ELSEIF(MLW == 151 .AND. GBUF%G_TB > 0)THEN
+                   DO I=1,NEL
+                     DETECTED = .FALSE.
+                     VALUE(I) = ZERO
+                     DO ILAY=1,NLAY
+                       SUBMATLAW = ELBUF_TAB(NG)%BUFLY(ILAY)%ILAW
+                       IF(SUBMATLAW == 5 )THEN
+                         VOLFRAC = ELBUF_TAB(NG)%BUFLY(ILAY)%LBUF(1,1,1)%VOL(I)/GBUF%VOL(I)
+                         BFRAC = MULTI_FVM%BFRAC(ILAY,I+NFT)
+                         IF(VOLFRAC > ZERO .OR. BFRAC > ZERO)THEN
+                           DETECTED = .TRUE.
+                         ENDIF
+                       ENDIF
+                     ENDDO
+                     IF(DETECTED)THEN
+                       VALUE(I) = -GBUF%TB(I)
+                     ENDIF
+                     IS_WRITTEN_VALUE(I) = 1
+                   ENDDO
               ENDIF
 C--------------------------------------------------
             ELSEIF(KEYWORD == 'BFRAC' )THEN

--- a/engine/source/output/h3d/h3d_results/h3d_solid_scalar_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_solid_scalar_1.F
@@ -121,7 +121,8 @@ C-----------------------------------------------
      .     VG(5),VLY(5),VE(5),S11,S22,S33,S4,S5,S6,VONM,GAMA(6),
      .     T11,T21,T31,T12,T22,T32,T13,T23,T33,
      .     PHI,THETA,PSI,DAMMAX,EVAR_TMP,VEL(0:3),VFRAC(MVSIZ,1:21),TMP(3,8),
-     .     CUMUL(3),VX,VY,VZ,NX,NY,NZ,SURF,TMP_2(MVSIZ,3)
+     .     CUMUL(3),VX,VY,VZ,NX,NY,NZ,SURF,TMP_2(MVSIZ,3),
+     .     VOLFRAC,BFRAC
         my_real
      .     G1(MVSIZ,3),G2(MVSIZ,3),G3(MVSIZ,3),VOLN(MVSIZ),AREAM(MVSIZ),
      .     RHO0,DET(MVSIZ),EZZ(MVSIZ),MAXDAMINI,E33
@@ -137,7 +138,9 @@ C-----------------------------------------------
      .          PTE(4),PTP(4),PTMAT(4),PTVAR(4),NPT_ALL,IPLY,
      .          ID_ELEM_TMP(MVSIZ),NIX,ISOLNOD,IVISC,NPTG,TSHELL,TSH_ORT,
      .          IOK_PART(MVSIZ),JJ(6),IRUPT,IOK,NPG_PLANE,NUMLAY,IJK,IIR,
-     .          IS_WRITTEN_VALUE(MVSIZ),NFRAC,IU(4),IV,NB_FACE,KFACE,IS_EULER,IS_ALE,IAD2,KK,IMODE
+     .          IS_WRITTEN_VALUE(MVSIZ),NFRAC,IU(4),IV,NB_FACE,KFACE,IS_EULER,IS_ALE,IAD2,KK,IMODE,
+     .          SUBMATLAW
+        LOGICAL DETECTED
         CHARACTER*5 BUFF
         REAL R4
         TYPE(G_BUFEL_)  ,POINTER :: GBUF
@@ -2004,7 +2007,7 @@ C--------------------------------------------------
 C--------------------------------------------------
               ELSEIF (KEYWORD == 'TDET') THEN  !  /ANIM/ELEM/TDET
 C--------------------------------------------------
-                IF (MLW  /= 51 .AND. GBUF%G_TB > 0) THEN
+                IF (MLW  /= 51 .AND. MLW /= 151 .AND. GBUF%G_TB > 0) THEN
                   DO I=1,NEL
                     VALUE(I) = -GBUF%TB(I)
                     IS_WRITTEN_VALUE(I) = 1
@@ -2018,6 +2021,25 @@ C--------------------------------------------------
                     VALUE(I) = -MBUF%VAR(K+I)
                     IS_WRITTEN_VALUE(I) = 1
                   ENDDO
+                ELSEIF(MLW == 151 .AND. GBUF%G_TB > 0)THEN
+                   DO I=1,NEL
+                     DETECTED = .FALSE.
+                     VALUE(I) = ZERO
+                     DO ILAY=1,NLAY
+                       SUBMATLAW = ELBUF_TAB(NG)%BUFLY(ILAY)%ILAW
+                       IF(SUBMATLAW == 5 )THEN
+                         VOLFRAC = ELBUF_TAB(NG)%BUFLY(ILAY)%LBUF(1,1,1)%VOL(I)/GBUF%VOL(I)
+                         BFRAC = MULTI_FVM%BFRAC(ILAY,I+NFT)
+                         IF(VOLFRAC > ZERO .OR. BFRAC > ZERO)THEN
+                           DETECTED = .TRUE.
+                         ENDIF
+                       ENDIF
+                     ENDDO
+                     IF(DETECTED)THEN
+                       VALUE(I) = -GBUF%TB(I)
+                     ENDIF
+                     IS_WRITTEN_VALUE(I) = 1
+                   ENDDO
                 ENDIF
 C--------------------------------------------------
               ELSEIF (KEYWORD == 'MOMX') THEN

--- a/starter/source/multifluid/multifluid_global_tdet.F
+++ b/starter/source/multifluid/multifluid_global_tdet.F
@@ -109,9 +109,9 @@ C-----------------------------------------------
                           IF (SUBMATLAW == 5) THEN
                              LBUF => ELBUF_TAB(NG)%BUFLY(ILAY)%LBUF(1,1,1)
                              DO II = LFT, LLT
-                                VFRAC = LBUF%VOL(II)/GBUF%VOL(II) 
-                                IF(VFRAC > ZERO)THEN
-                                  GBUF%TB(II) = MAX(GBUF%TB(II), LBUF%TB(II))  !must be done only in case of initial volume fraction
+                                VFRAC = LBUF%VOL(II)/GBUF%VOL(II)
+                                IF(VFRAC >= ZERO)THEN
+                                  GBUF%TB(II) = MAX(GBUF%TB(II), LBUF%TB(II))
                                 ENDIF
                              ENDDO
                              IS_JWL = .TRUE.


### PR DESCRIPTION
#### Calculation of Global detonation time

#### Description of the changes
Detination Times are calculated for time controlled explosive material law.
The detonation time is calculated for the entire region associated with the material law, even if the volume fraction is not yet present. This prevents unexpected detonations when a small volume fraction of explosive moves into a cell without explosive, where the detonation time was previously 0.0.
For post-processing purposes, the detonation time is displayed only where it is relevant.