### PR TITLE
/EBCS/INLET : compatibility with SUBMODELING (//SUBMODEL)

### DIFF
--- a/starter/source/boundary_conditions/ebcs/hm_read_ebcs_inlet.F
+++ b/starter/source/boundary_conditions/ebcs/hm_read_ebcs_inlet.F
@@ -38,7 +38,7 @@ Chd|        MESSAGE_MOD                   share/message_module/message_mod.F
 Chd|        MULTI_FVM_MOD                 ../common_source/modules/ale/multi_fvm_mod.F
 Chd|        SUBMODEL_MOD                  share/modules1/submodel_mod.F 
 Chd|====================================================================
-      SUBROUTINE HM_READ_EBCS_INLET(IGRSURF,NPC, MULTI_FVM, UNITAB, ID, TITR, UID, LSUBMODEL, KEY2, EBCS)
+      SUBROUTINE HM_READ_EBCS_INLET(IGRSURF,NPC, MULTI_FVM, UNITAB, ID, TITR, UID, LSUBMODEL, KEY2, SUB_INDEX, EBCS)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -64,6 +64,7 @@ C-----------------------------------------------
       TYPE (UNIT_TYPE_),INTENT(IN) ::UNITAB 
       INTEGER  NPC(*)
       INTEGER ID,UID
+      INTEGER,INTENT(IN) :: SUB_INDEX !< submodel index used to shift function identifiers if defined
       TYPE (MULTI_FVM_STRUCT), INTENT(INOUT) :: MULTI_FVM
       TYPE (SURF_)   ,TARGET,  DIMENSION(NSURF)   :: IGRSURF
       CHARACTER, INTENT(IN) :: TITR*nchartitle
@@ -75,7 +76,7 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER ISU,SURF,NGR2USR,IPRES,IRHO,J,NSEG,IENER,IVX,IVY,IVZ,IALPHA
-      INTEGER IMAT,IVEL_TYP,U_IALPHA,U_IRHO,U_IPRES,IFLAGUNIT
+      INTEGER IMAT,IVEL_TYP,U_IALPHA,U_IRHO,U_IPRES,IFLAGUNIT,OFF_DEF
       my_real :: CHECK_CUMUL_VF(2)
       my_real C,PRES,RHO,LCAR,R1,R2,ENER,VX,VY,VZ, ALPHA
       CHARACTER chain*9, chain1*64
@@ -171,6 +172,13 @@ C-----------------------------------------------
       CALL HM_GET_INTV('fct_IDvx',  IVX  ,IS_AVAILABLE,LSUBMODEL)
       CALL HM_GET_INTV('fct_IDvy',  IVY  ,IS_AVAILABLE,LSUBMODEL)
       CALL HM_GET_INTV('fct_IDvz',  IVZ  ,IS_AVAILABLE,LSUBMODEL)
+      IF(SUB_INDEX /= 0 ) THEN
+        OFF_DEF = LSUBMODEL(SUB_INDEX)%OFF_DEF
+        !since IVX, IVY, and IVZ may be -1, these values are shifted only if they are defined Spositive
+        IF(IVX > 0) IVX = IVX + OFF_DEF
+        IF(IVY > 0) IVY = IVY + OFF_DEF
+        IF(IVZ > 0) IVZ = IVZ + OFF_DEF
+      ENDIF
 
       IF(IVEL_TYP==0)THEN
         !NORMAL VELOCITY
@@ -289,6 +297,12 @@ C-----------------------------------------------
          CALL HM_GET_INT_ARRAY_INDEX('fct_IDvf_n',   IALPHA,IMAT,IS_AVAILABLE,LSUBMODEL)
          CALL HM_GET_INT_ARRAY_INDEX('fct_IDrho_n',  IRHO  ,IMAT,IS_AVAILABLE,LSUBMODEL)
          CALL HM_GET_INT_ARRAY_INDEX('fct_IDp_e_n',  IPRES ,IMAT,IS_AVAILABLE,LSUBMODEL)
+      IF(SUB_INDEX /= 0 ) THEN
+        OFF_DEF = LSUBMODEL(SUB_INDEX)%OFF_DEF
+        IF(IALPHA > 0) IALPHA = IALPHA + OFF_DEF
+        IF(IRHO > 0) IRHO = IRHO + OFF_DEF
+        IF(IPRES > 0) IPRES = IPRES + OFF_DEF
+      ENDIF
          CHECK_CUMUL_VF(1)=CHECK_CUMUL_VF(1)+ABS(IALPHA)
          CHECK_CUMUL_VF(2)=CHECK_CUMUL_VF(2)+ABS(ALPHA)
          !user ids backup

--- a/starter/source/boundary_conditions/ebcs/read_ebcs.F
+++ b/starter/source/boundary_conditions/ebcs/read_ebcs.F
@@ -93,7 +93,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER :: LOCAL_ID
       INTEGER :: ID,TYP,UID
-      INTEGER :: II, SURF_ID, JJ
+      INTEGER :: II, SURF_ID, JJ, SUB_INDEX
       CHARACTER*nchartitle :: TITR    
       CHARACTER*ncharkey :: KEY, KEY2
       LOGICAL :: IS_AVAILABLE
@@ -113,7 +113,7 @@ C-----------------------------------------------
          DO II = 1, NEBCS
             LOCAL_ID = II
             CALL HM_OPTION_READ_KEY(LSUBMODEL, OPTION_ID = ID, UNIT_ID = UID, OPTION_TITR = TITR, 
-     .           KEYWORD2 = KEY, KEYWORD3 = KEY2)
+     .           KEYWORD2 = KEY, KEYWORD3 = KEY2, SUBMODEL_INDEX = SUB_INDEX)
 !     Allocate type
        SELECT CASE(KEY)
          CASE ('GRADP0')  
@@ -199,7 +199,7 @@ C-----------------------------------------------
             select type (twf => EBCS_TAB%tab(ii)%poly)
             type is (t_ebcs_inlet)
 
-              CALL HM_READ_EBCS_INLET(IGRSURF, NPC1, MULTI_FVM, UNITAB, ID, TITR, UID, LSUBMODEL, KEY2, twf)
+              CALL HM_READ_EBCS_INLET(IGRSURF, NPC1, MULTI_FVM, UNITAB, ID, TITR, UID, LSUBMODEL, KEY2, SUB_INDEX, twf)
            end select
 
          CASE ('FLUXOUT') 


### PR DESCRIPTION
#### /EBCS/INLET : compatibility with SUBMODELING (//SUBMODEL)


#### Description of the changes
The //SUBMODEL option allows the definition of submodeling methods. In the case of /EBCS/INLET, function identifiers may be set to "-1" to define continuity. However, if the function is user-defined, then the identifiers must be offset by the submodel default offset ( _OFF_DEF = LSUBMODEL(SUB_INDEX)%OFF_DEF_ ). This update ensures that /EBCS/INLET is now compatible with the //SUBMODEL option.
