### PR TITLE
/LOAD/PFLUID:update for parallel arithmetic OFF

### DIFF
--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -3305,10 +3305,10 @@ C-------------------------------------------------------------------
         IF (IMON>0) CALL STARTIME(4,1)
         IF (IMONM > 0) CALL STARTIME(41,1)
 !$OMP PARALLEL
-          CALL PFLUID(ILOADP  ,LOADP   ,NPC        ,TF        ,A         ,
-     2                V       ,X       ,XFRAME     ,MS        ,
-     3                NSENSOR,SENSORS%SENSOR_TAB,TFEXC,IADS(I87M) ,
-     4                FSKY    ,FSKY    ,LLOADP     ,FEXT     ,H3D_DATA   ,
+          CALL PFLUID(ILOADP  ,LOADP             ,NPC        ,TF         ,A         ,
+     2                V       ,X                 ,XFRAME     ,MS         ,
+     3                NSENSOR ,SENSORS%SENSOR_TAB,TFEXC      ,IADS(I87M) ,
+     4                FSKY    ,FSKY              ,LLOADP     ,FEXT       ,H3D_DATA  ,
      5                OUTPUT%TH%TH_SURF)
 !$OMP END PARALLEL
         IF (IMONM > 0) CALL STOPTIME(41,1)

--- a/engine/source/loads/general/pfluid/pfluid.F
+++ b/engine/source/loads/general/pfluid/pfluid.F
@@ -392,7 +392,7 @@ C
      +                          +FZ*(V(3,N1)+V(3,N2)+V(3,N3)))  
      
 
-#include "lockoff.inc"
+#include "lockon.inc"
               !/PARITH/OFF: force is direcctly added in A array. It will be dividedby nodal mass later
               !-node_1
               A(1,N1)=A(1,N1)+FX                                                                    


### PR DESCRIPTION
#### /LOAD/PFLUID:update for parallel arithmetic OFF


#### Description of the changes
A bug has been fixed when using PFLUID with the /PARITH/OFF option (parallel arithmetic). The previous behavior could lead to an unexpected termination of the Engine program.