### PR TITLE
Fix uninitialized NFUNC parameters for beams failure

### DIFF
--- a/engine/source/elements/beam/fail_beam18.F
+++ b/engine/source/elements/beam/fail_beam18.F
@@ -117,6 +117,7 @@ C--------------------------------------
       ENDDO
       COUNT(1:NEL) = 0
       NPARAM  = FAIL%NUPARAM
+      NFUNC   = FAIL%NFUNC
 C---------------------------------------
 C     START LOOP OVER INTEGRATION POINTS
 C---------------------------------------

--- a/engine/source/elements/beam/fail_beam3.F
+++ b/engine/source/elements/beam/fail_beam3.F
@@ -104,6 +104,7 @@ c-----------------------------------------------------
       IFL  = 1              ! only one failure model for beams      
 C--------------------------------------   
       NPARAM  = FAIL%NUPARAM
+      NFUNC   = FAIL%NFUNC
 c-------------------------------------
 c     progressive element erosion      
 c


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

There was an uninitialized integer parameter for /PROP/TYPE18 and /PROP/TYPE3 beams failure.  

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Add the correct initialization for NFUNC.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
