### PR TITLE
Fix soundspeed computation for /MAT/LAW66 in case of specific Young modulus in compression

### DIFF
--- a/engine/source/materials/mat/mat066/sigeps66.F
+++ b/engine/source/materials/mat/mat066/sigeps66.F
@@ -210,11 +210,12 @@ c------------------------------------------------
 c------------------------------------------------   
       E(1:NEL) = ET   
       G(1:NEL) = GT   
-      C1T  = ET/THREE/(ONE - TWO*NU)
+      C1T = ET/THREE/(ONE - TWO*NU)
       IF(EC > ZERO)THEN
         DO I=1,NEL  
 c         P(I) = C1 * (RHO(I)/RHO0(I)- ONE)
           P(I) = C1T * AMU(I)
+          C1T  = MAX(C1T,EC/THREE/(ONE - TWO*NU))
           IF(P(I) <=  - RPCT * PT) THEN
             E(I)   = ET
           ELSEIF(P(I) >= RPCT *PC) THEN


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

The Young modulus retained for soundspeed computation was not sufficient in case where Young modulus in compression is higher than Young modulus in tension. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Keep the maximum value of soundspeed between Young modulus in tension and Young modulus in compression. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
