### PR TITLE
fix Nan issue when isotropic law used in Prop/type51 in the ply

### DIFF
--- a/engine/source/elements/sh3n/coquedk/cncoef3.F
+++ b/engine/source/elements/sh3n/coquedk/cncoef3.F
@@ -519,13 +519,14 @@ Chd|====================================================================
      2                     HC     ,HMFOR   ,IORTH     ,DIR     ,IGEO   ,
      3                     ISUBSTACK,STACK ,ELBUF_STR ,NLAY    ,THK    ,
      4                     DRAPE  ,NFT     ,NEL       ,INDX_DRAPE, THKE,
-     5                     SEDRAPE,   NUMEL_DRAPE)
+     5                     SEDRAPE,   NUMEL_DRAPE     ,MAT_ELEM)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE ELBUFDEF_MOD
       USE STACK_MOD
       USE DRAPE_MOD
+      USE MAT_ELEM_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -553,6 +554,7 @@ C     REAL
       TYPE (STACK_PLY) :: STACK
       TYPE(ELBUF_STRUCT_) :: ELBUF_STR
       TYPE (DRAPE_) :: DRAPE(NUMEL_DRAPE)
+      TYPE (MAT_ELEM_) ,INTENT(IN) :: MAT_ELEM
 C-----------------------------------------------
 c FUNCTION:   stiffness modulus matrix build For hourglass stress compute
 c
@@ -581,18 +583,19 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,MX,IPID,J,J1,J2,J3,JJ,L,IGTYP,
      .        ISUBSTACK,IGMAT,IPOS,IPT_ALL,ILAY,IPT,IT,NPTT,
-     .        LAYNPT_MAX, NLAY_MAX
+     .        LAYNPT_MAX, NLAY_MAX,ILAW_PLY
             INTEGER MAT_IPLY(MVSIZ,NPT)
       INTEGER, DIMENSION(:)   , ALLOCATABLE :: MATLY   !! 
       my_real, DIMENSION(:)   , ALLOCATABLE :: THKLY   !! 
       my_real, DIMENSION(:,:) , ALLOCATABLE :: POSLY,THK_LY
       my_real
-     .   WMC,FACG,COEF,WM
+     .   WMC,FACG,COEF,WM,A11,E11,NU,A12,G
       my_real
      .   HMOR(MVSIZ,2),HMLY(MVSIZ,4),HCLY(MVSIZ,2), 
      .   HMORLY(MVSIZ,2),SHF(MVSIZ),IZZ(MVSIZ),IZ(MVSIZ)
 C--------IORTH=2 -> HMFOR couplage non-null----------------
-      IF (MTN == 19.OR.MTN == 15.OR.MTN == 25.OR.MTN == 119) THEN
+      IF (IGTYP == 11 .OR. IGTYP == 17 .OR. IGTYP == 51 .OR. IGTYP == 52 .OR. 
+     .                   MTN == 19.OR.MTN == 15.OR.MTN == 25.OR.MTN == 119) THEN
         IORTH=1
       ELSE
         IORTH=0
@@ -641,7 +644,8 @@ C----------unify the factor ONE_OVER_12 after
             HF(I,5)=ONE_OVER_12*HMOR(I,1)
             HF(I,6)=ONE_OVER_12*HMOR(I,2)
           ENDDO
-        ELSEIF (MTN == 15.OR.MTN == 25) THEN
+        ELSEIF ((MTN == 15 .OR. MTN == 25 ) .AND. 
+     .           IGTYP == 9 .OR. IGTYP == 10 ) THEN
           SELECT CASE (IGTYP)
             CASE(9)
               CALL GEPM_LC(JFT,JLT,MAT,PM,SHF,HM,HC)
@@ -656,16 +660,15 @@ C----------unify the factor ONE_OVER_12 after
                 HF(I,5)=ONE_OVER_12*HMOR(I,1)
                 HF(I,6)=ONE_OVER_12*HMOR(I,2)
               ENDDO
-            CASE(10,11,16,17,51,52)
-              CALL LAYINI(ELBUF_STR,JFT      ,JLT      ,GEO      ,IGEO    , 
+            CASE(10)
+                CALL LAYINI(ELBUF_STR,JFT      ,JLT      ,GEO      ,IGEO    , 
      .                    MAT      ,PID      ,THKLY    ,MATLY    ,POSLY   , 
      .                    IGTYP    ,0        ,0        ,NLAY     ,NPT     , 
      .                    ISUBSTACK,STACK    ,DRAPE    ,NFT      ,THKE    ,
      .                    JLT      ,THK_LY   ,INDX_DRAPE, SEDRAPE,NUMEL_DRAPE)                              
-              HM(JFT:JLT,1:6)=ZERO
-              HF(JFT:JLT,1:6)=ZERO
-              HC(JFT:JLT,1:2)=ZERO
-              IF (IGTYP == 10) THEN
+                HM(JFT:JLT,1:6)=ZERO
+                HF(JFT:JLT,1:6)=ZERO
+                HC(JFT:JLT,1:2)=ZERO
                 DO J=1,NPT
                   J2=1+(J-1)*JLT
                   J3=1+(J-1)*JLT*2
@@ -690,10 +693,18 @@ C----------unify the factor ONE_OVER_12 after
                     HF(I,6)=HF(I,6)+WMC*HMORLY(I,2)
                   ENDDO
                 ENDDO 
-              ELSE
-                IORTH=2
-                IF ((IGTYP == 11 .OR. IGTYP == 17).AND. IGMAT > 0) THEN
-C                 
+             END SELECT ! IGTYP = 9, 10, 16  
+            ELSEIF(IGTYP == 11 .OR. IGTYP == 17 .OR. IGTYP == 51 .OR. IGTYP == 52) THEN
+              CALL LAYINI(ELBUF_STR,JFT      ,JLT      ,GEO      ,IGEO    , 
+     .                    MAT      ,PID      ,THKLY    ,MATLY    ,POSLY   , 
+     .                    IGTYP    ,0        ,0        ,NLAY     ,NPT     , 
+     .                    ISUBSTACK,STACK    ,DRAPE    ,NFT      ,THKE    ,
+     .                    JLT      ,THK_LY   ,INDX_DRAPE, SEDRAPE,NUMEL_DRAPE)                              
+              HM(JFT:JLT,1:6)=ZERO
+              HF(JFT:JLT,1:6)=ZERO
+              HC(JFT:JLT,1:2)=ZERO
+              IORTH=2
+              IF ((IGTYP == 11 .OR. IGTYP == 17).AND. IGMAT > 0) THEN         
                   DO I=JFT,JLT
                     IZZ(I) = ZERO
                     IZ(I) = ZERO
@@ -786,7 +797,25 @@ C
                     J2 = 1+(IPT-1)*JLT        ! THKLY
                     J3 = 1+(ILAY-1)*JLT*2     ! JDIR
                     J = IPT                   ! JPOS
-                    CALL GEPM_LC(JFT,JLT,MATLY(J1),PM,SHF,HMLY,HCLY)
+                    MX  = MATLY(J1)
+                    ILAW_PLY = MAT_ELEM%MAT_PARAM(MX)%ILAW 
+                    IF(ILAW_PLY == 15 .OR. ILAW_PLY == 25 ) THEN
+                      CALL GEPM_LC(JFT,JLT,MATLY(J1),PM,SHF,HMLY,HCLY)
+                    ELSE
+                        NU   =PM(21,MX)
+                       !! E    =PM(21,MX)
+                        G    =PM(22,MX)
+                        A11  =PM(24,MX) ! E/(one - nu*nu)
+                        A12  = NU*A11
+                        DO I=JFT,JLT
+                           HMLY(I,1)=A11
+                           HMLY(I,2)=A11
+                           HMLY(I,3)=A12
+                           HMLY(I,4)=G
+                           HCLY(I,1)=G*SHF(I)
+                           HCLY(I,2)=G*SHF(I)
+                        ENDDO
+                    ENDIF   
                     CALL CCTOGLOB(JFT,JLT,HMLY,HCLY,HMORLY,DIR(J3),NEL)
 C
                     DO I=JFT,JLT
@@ -831,7 +860,25 @@ C-----------
                     J2 = 1+(IPT-1)*JLT        ! THKY
                     J3 = 1+(ILAY-1)*JLT*2     ! JDIR
                     J = IPT                   ! POS
-                    CALL GEPM_LC(JFT,JLT,MATLY(J1),PM,SHF,HMLY,HCLY)
+                    MX  = MATLY(J1)
+                    ILAW_PLY = MAT_ELEM%MAT_PARAM(MX)%ILAW 
+                    IF(ILAW_PLY == 15 .OR. ILAW_PLY == 25 ) THEN
+                      CALL GEPM_LC(JFT,JLT,MATLY(J1),PM,SHF,HMLY,HCLY)
+                    ELSE
+                        NU   =PM(21,MX)
+                       !! E    =PM(21,MX)
+                        G    =PM(22,MX)
+                        A11  =PM(24,MX) ! E/(one - nu*nu)
+                        A12  = NU*A11
+                        DO I=JFT,JLT
+                           HMLY(I,1)=A11
+                           HMLY(I,2)=A11
+                           HMLY(I,3)=A12
+                           HMLY(I,4)=G
+                           HCLY(I,1)=G*SHF(I)
+                           HCLY(I,2)=G*SHF(I)
+                        ENDDO
+                    ENDIF   
                     CALL CCTOGLOB(JFT,JLT,HMLY,HCLY,HMORLY,DIR(J3),NEL)
 C
                     DO I=JFT,JLT
@@ -865,8 +912,6 @@ C-----------
                   IPT_ALL = IPT_ALL + NPTT
                 ENDDO  !  DO ILAY=1,NLAY
               ENDIF ! igmat + igtyp == 11
-            END IF !(IGTYP==10)
-          END SELECT
         ENDIF !IF (MTN==19)
       ENDIF    ! IF (IORTH==1) THEN
       DEALLOCATE(MATLY, THKLY, POSLY, THK_LY)

--- a/engine/source/elements/shell/coquez/czforc3.F
+++ b/engine/source/elements/shell/coquez/czforc3.F
@@ -432,7 +432,7 @@ C
      2               HC     ,HMFOR  ,IORTH     ,DIR_A   ,IGEO    ,
      3               ISUBSTACK,STACK,ELBUF_STR ,NLAY    ,GBUF%THK,
      4               DRAPE_SH4N  ,NFT  ,NEL    ,INDX_DRAPE , THKE,
-     5               SEDRAPE,NUMEL_DRAPE )
+     5               SEDRAPE,NUMEL_DRAPE       ,MAT_ELEM )
 C----------------------------------
 C     CALCUL VITESSE DE DEFORMATION 
 C----------------------------------

--- a/engine/source/elements/xfem/czforc3_crk.F
+++ b/engine/source/elements/xfem/czforc3_crk.F
@@ -408,7 +408,7 @@ C
      2                 HC     ,HMFOR  ,IORTH    ,DIR_A   ,IGEO   ,  
      3                 ISUBSTACK,STACK,XFEM_STR ,NXLAY   ,THKG   ,
      4                 DRAPE_SH4N ,NFT  ,NEL    ,INDX_DRAPE , THKE,
-     5                 SEDRAPE,NUMEL_DRAPE )           
+     5                 SEDRAPE,NUMEL_DRAPE , MAT_ELEM)           
 C----------------------------------
 C     CALCUL VITESSE DE DEFORMATION 
 C----------------------------------


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

NaN when define Law 25 in the part and Isotropic law in ply for property type51 with QEPH element

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
The issue is fixed 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
