### PR TITLE
/INIVOL : check bounds + clean

### DIFF
--- a/starter/source/initial_conditions/inivol/init_inivol.F90
+++ b/starter/source/initial_conditions/inivol/init_inivol.F90
@@ -406,10 +406,11 @@
             nuvar =  elbuf_tab(ng)%bufly(1)%nvar_mat
             nf1   =  nft+1
             nf1_2d = max(1,min(nf1,numeltg+numelq)) !kvol_2d_polyg  allocated to 1 when n2d=0
+            if (.not. required_2d_polygon_clipping) nf1_2d = 1
             call inivol_set( &
-                             mbuf%var  , nuvar, nel        , kvol(1,nf1) , mtn                         , &
-                             elbuf_tab , ng   , nbsubmat   , multi_fvm   , required_2d_polygon_clipping, &
-                             ixs       , idp  , ipart(i15_), nft         , kvol_2d_polyg(1,nf1_2d)     )
+                             mbuf%var  , nuvar      , nel        , kvol(1,nf1) , mtn                         , &
+                             elbuf_tab , ng         , nbsubmat   , multi_fvm   , required_2d_polygon_clipping, &
+                             idp       , ipart(i15_), nft        , kvol_2d_polyg(1,nf1_2d)     )
           enddo ! next ng=1,ngroup
 !-------------
 

--- a/starter/source/initial_conditions/inivol/inivol_set.F
+++ b/starter/source/initial_conditions/inivol/inivol_set.F
@@ -29,9 +29,9 @@ Chd|        ELBUFDEF_MOD                  ../common_source/modules/mat_elem/elbu
 Chd|        MESSAGE_MOD                   share/message_module/message_mod.F
 Chd|        MULTI_FVM_MOD                 ../common_source/modules/ale/multi_fvm_mod.F
 Chd|====================================================================
-      SUBROUTINE INIVOL_SET(UVAR     , NUVAR, NEL     , KVOL     , MLW                         ,
-     .                      ELBUF_TAB, NG   , NBSUBMAT, MULTI_FVM, REQUIRED_2D_POLYGON_CLIPPING,
-     .                      IXS      , IDP  , IPART   , NFT      , KVOL_2D_POLYG               )
+      SUBROUTINE INIVOL_SET(UVAR     , NUVAR , NEL     , KVOL         , MLW                         ,
+     .                      ELBUF_TAB, NG    , NBSUBMAT, MULTI_FVM    , REQUIRED_2D_POLYGON_CLIPPING,
+     .                      IDP      , IPART , NFT     , KVOL_2D_POLYG   )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -53,7 +53,6 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER,INTENT(IN)                 :: NEL, NUVAR, MLW, NG, NBSUBMAT,IDP,IPART(*),NFT
-      INTEGER,INTENT(INOUT)              :: IXS(NIXS,NUMELS)
       my_real,INTENT(INOUT)              :: KVOL(NBSUBMAT,NEL)
       my_real,INTENT(INOUT)              :: KVOL_2D_POLYG(NBSUBMAT,NEL)
       my_real,INTENT(INOUT)              :: UVAR(NEL,NUVAR)
@@ -67,7 +66,6 @@ C-----------------------------------------------
       TYPE(G_BUFEL_) ,POINTER :: GBUF   
       TYPE(L_BUFEL_) ,POINTER :: LBUF   
       my_real                 :: P, P1,P2,P3,P4,SUMVF,RATIO
-      LOGICAL                 :: PASSED
 C-----------------------------------------------
 C   S o u r c e  L i n e s
 C-----------------------------------------------
@@ -82,78 +80,69 @@ C-----------------------------------------------
       ENDIF
 
       !---CHECK UNOCCUPIPED SUBVOLUME AND FILL WITH PHASE 1. IF SUM(vfrac>1) display an error message.
-      PASSED = .TRUE.
       DO I=1,NEL
        IF(IPART(I+NFT) /= IDP)CYCLE
-        PASSED = .TRUE.
         SUMVF = SUM(KVOL(1:NBSUBMAT,I))
-        IF(SUMVF>ONE+EM06)THEN
+        IF(SUMVF > ONE+EM06)THEN
           !not expected, user input must be checked : error message
           SUMVF = SUM(KVOL(2:NBSUBMAT,I))
           IF(SUMVF <= ONE .AND. SUMVF > ZERO)THEN  ! sumvf is here calculated in range 2:nbsumat
             KVOL(1,I)=ONE-SUMVF
-            PASSED = .TRUE.
           ELSE
             SUMVF = SUM(KVOL(1:NBSUBMAT,I))
             RATIO=ONE/SUMVF
             KVOL(1:NBSUBMAT,I)=RATIO*KVOL(1:NBSUBMAT,I)
-            PASSED=.TRUE.
           ENDIF
-        ELSEIF(SUMVF<ONE-EM06)THEN
+        ELSEIF(SUMVF < ONE-EM06)THEN
           !fill unoccupied subvolume with phase-1
           KVOL(1,I) = KVOL(1,I) + ONE-SUMVF
-        ELSEIF(SUMVF>=ONE-EM06 .AND. SUMVF<=ONE+EM06)THEN
+        ELSEIF(SUMVF >= ONE-EM06 .AND. SUMVF <= ONE+EM06)THEN
           !get rid of precision issue so that sumvf is exactly 1.000000
           RATIO=ONE/SUMVF
           KVOL(1:NBSUBMAT,I)=RATIO*KVOL(1:NBSUBMAT,I)
         ENDIF
       ENDDO
 
-      IF(.NOT.PASSED)THEN
-         !display error message : sumvf must be <= 1.000000
-         CALL ANCMSG(MSGID=1597,MSGTYPE=MSGERROR,ANMODE=ANINFO,R1=SUMVF,I1=IXS(11,I+NFT))
-       ELSE 
-        !---set initial volumetric fraction using KVOL array    
-        IF(MLW==51)THEN
-          DO IMAT=1,4
-            KK = N0PHAS + (IMAT-1)*NVPHAS        
-            DO I=1,NEL
-              IF(IPART(I+NFT) /= IDP)CYCLE                          
-              UVAR(I,1+KK)   = KVOL(IMAT,I)  
-              UVAR(I,23+KK)  = KVOL(IMAT,I)  
-            ENDDO
-          ENDDO
+      !---set initial volumetric fraction using KVOL array
+      IF(MLW == 51)THEN
+        DO IMAT=1,4
+          KK = N0PHAS + (IMAT-1)*NVPHAS
           DO I=1,NEL
             IF(IPART(I+NFT) /= IDP)CYCLE
-            KK  = N0PHAS + (1-1)*NVPHAS
-            P1  = UVAR(I,18+KK) 
-            KK  = N0PHAS + (2-1)*NVPHAS
-            P2  = UVAR(I,18+KK)
-            KK  = N0PHAS + (3-1)*NVPHAS
-            P3  = UVAR(I,18+KK)
-            KK  = N0PHAS + (4-1)*NVPHAS
-            P4  = UVAR(I,18+KK)
-            SUMVF=SUM(KVOL(1:NBSUBMAT,I))
-            P   = KVOL(1,I)*P1 + KVOL(2,I)*P2 + KVOL(3,I)*P3 + KVOL(4,I)*P4
-            UVAR(I,4) = P
+            UVAR(I,1+KK)   = KVOL(IMAT,I)
+            UVAR(I,23+KK)  = KVOL(IMAT,I)
           ENDDO
-        ELSEIF(MLW==37)THEN    
-          DO I=1,NEL 
-            IF(IPART(I+NFT) /= IDP)CYCLE                         
-            UVAR(I,4)  = KVOL(1,I)  
-            UVAR(I,5)  = KVOL(2,I)  
+        ENDDO
+        DO I=1,NEL
+          IF(IPART(I+NFT) /= IDP)CYCLE
+          KK  = N0PHAS + (1-1)*NVPHAS
+          P1  = UVAR(I,18+KK)
+          KK  = N0PHAS + (2-1)*NVPHAS
+          P2  = UVAR(I,18+KK)
+          KK  = N0PHAS + (3-1)*NVPHAS
+          P3  = UVAR(I,18+KK)
+          KK  = N0PHAS + (4-1)*NVPHAS
+          P4  = UVAR(I,18+KK)
+          SUMVF=SUM(KVOL(1:NBSUBMAT,I))
+          P   = KVOL(1,I)*P1 + KVOL(2,I)*P2 + KVOL(3,I)*P3 + KVOL(4,I)*P4
+          UVAR(I,4) = P
+        ENDDO
+      ELSEIF(MLW == 37)THEN
+        DO I=1,NEL
+          IF(IPART(I+NFT) /= IDP)CYCLE
+          UVAR(I,4)  = KVOL(1,I)
+          UVAR(I,5)  = KVOL(2,I)
+        ENDDO
+      ELSEIF(MLW == 151)THEN
+        GBUF => ELBUF_TAB(NG)%GBUF
+        DO IMAT=1,MULTI_FVM%NBMAT
+          LBUF => ELBUF_TAB(NG)%BUFLY(IMAT)%LBUF(1,1,1)
+          DO I=1,NEL
+            IF(IPART(I+NFT) /= IDP)CYCLE
+            LBUF%VOL(I) = KVOL(IMAT,I) * GBUF%VOL(I)
           ENDDO
-        ELSEIF(MLW==151)THEN 
-          GBUF => ELBUF_TAB(NG)%GBUF
-          DO IMAT=1,MULTI_FVM%NBMAT   
-            LBUF => ELBUF_TAB(NG)%BUFLY(IMAT)%LBUF(1,1,1)   
-            DO I=1,NEL   
-              IF(IPART(I+NFT) /= IDP)CYCLE
-              LBUF%VOL(I) = KVOL(IMAT,I) * GBUF%VOL(I)                     
-            ENDDO
-          ENDDO
-        ENDIF
-      ENDIF !IF(.NOT.PASSED)
+        ENDDO
+      ENDIF
 
 
       RETURN


### PR DESCRIPTION
#### /INIVOL : check bounds + clean


#### Description of the changes
In a recent update, it was introduced an array index: nf1_2d (03b27e6efd0823662c54e15c7b8ee9e0e576f883). This index is now set to 1 when it is not in use (required_2d_polygon_clipping = .false.). This change prevents real-time debugging tools, such as "check bounds," from detecting an out-of-bounds index, even if the argument is not used in the called subroutine.

Additionally, some minor cleanup has been performed.