### PR TITLE
correction to output /H3D/SOLID/TENS/IR=ALL/IS=ALL/IT=ALL for tet10

### DIFF
--- a/engine/source/output/h3d/h3d_build_fortran/lech3d.F
+++ b/engine/source/output/h3d/h3d_build_fortran/lech3d.F
@@ -1065,6 +1065,12 @@ C----special case for thick-shell Isolid=14  :
                 ENDDO
               END IF ! IF ((IS_IR_ALL + IS_IS_ALL+IS_IT_ALL)>0)
 
+!----special case for tet10  :
+              IF (NUMELS10G>0) THEN
+                 IF (IS_IR_ALL == 1) IR_MAX = MAX(IR_MAX,2)
+                 IF (IS_IS_ALL == 1) IS_MAX = MAX(IS_MAX,2)
+                 IF (IS_IT_ALL == 1) IT_MAX = MAX(IT_MAX,2)
+              END IF 
 c
               ID_MAX = 0
               IF (IS_ID_ALL == 1) THEN

--- a/engine/source/output/h3d/h3d_results/h3d_solid_tensor_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_solid_tensor_1.F
@@ -201,6 +201,11 @@ C-------- LAYER_INPUT not available yet fix in function of JHBE+IJK
              IS = 1
            END IF
           END IF
+! tet10 to hav 4 ipt		   
+          IF(ISOLNOD == 10.OR.(ISOLNOD == 4 .AND. ISROT == 1))THEN
+            NPTS = 2                 
+            NPTT = 2
+          END IF
 C-----------------------------------------------
           IF (KEYWORD == 'TENS/STRESS') THEN
 C-----------------------------------------------


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
only one or two integration point result are output of /H3D/SOLID/TENS/IR=ALL/IS=ALL/IT=ALL for tet10 element (or tet4+Itetra4=1).

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
correction to output rightly /H3D/SOLID/TENS/IR=ALL/IS=ALL/IT=ALL for tet10

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
