### PR TITLE
missing initializaiton in TH_SURF

### DIFF
--- a/common_source/modules/interfaces/th_surf_mod.F
+++ b/common_source/modules/interfaces/th_surf_mod.F
@@ -222,6 +222,13 @@ C-----------------------------------------------
             CALL READ_I_C(TH_SURF%LOADP_SEGS,TH_SURF%S_LOADP_SEGS)
           ENDIF
         ENDIF
+      ELSE ! initialization to 0
+        TH_SURF%NSURF = 0
+        TH_SURF%PLOAD_FLAG = 0
+        TH_SURF%LOADP_FLAG = 0
+        TH_SURF%NSEGLOADP = 0
+        TH_SURF%NSEGLOADPF = 0
+        TH_SURF%NSEGLOADPB = 0
 
       ENDIF
 


### PR DESCRIPTION

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
For instance, LOADP_FLAG is used in load_pressure.F even if TH_SURF%IOK == 0

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
