### PR TITLE
Add IOFF_DUCT for ductile failure in /MAT/LAW104

### DIFF
--- a/engine/source/materials/mat/mat104/mat104_ldam_nice.F
+++ b/engine/source/materials/mat/mat104/mat104_ldam_nice.F
@@ -682,11 +682,13 @@ c
           SIGNZX(I)  = ZERO
           SIGDR(I)   = ZERO
         ENDIF
-        ! USR Outputs
+        ! USR Outputs & coefficient for hourglass
         IF (DPLA(I) > ZERO) THEN 
           UVAR(I,1) = PHI(I)           ! Yield function value
+          ET(I)     = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)
         ELSE
           UVAR(I,1) = ZERO
+          ET(I)     = ONE
         ENDIF
         ! Standard outputs
         DMG(I,1)   = FT(I)/FR          ! Normalized total damage
@@ -699,8 +701,6 @@ c
         ! Plastic strain-rate (filtered)
         DPDT       = DPLA(I) / MAX(EM20,TIMESTEP)
         EPSD(I)    = AFILTR * DPDT + (ONE - AFILTR) * EPSD(I)
-        ! Coefficient for hourglass
-        ET(I)      = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)
         ! Computation of the sound speed
         SOUNDSP(I) = SQRT((BULK + FOUR_OVER_3*G)/RHO0(I))
         ! Storing the yield stress

--- a/engine/source/materials/mat/mat104/mat104_nldam_newton.F
+++ b/engine/source/materials/mat/mat104/mat104_nldam_newton.F
@@ -680,7 +680,11 @@ c
         DPDT       = DPLA(I) / MAX(EM20,TIMESTEP)
         EPSD(I)    = AFILTR * DPDT + (ONE - AFILTR) * EPSD(I)
         ! Coefficient for hourglass
-        ET(I)      = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)
+        IF (DPLA(I) > ZERO) THEN 
+          ET(I)     = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)
+        ELSE
+          ET(I)     = ONE
+        ENDIF
         ! Computation of the sound speed
         SOUNDSP(I) = SQRT((BULK + FOUR_OVER_3*G)/RHO0(I))
         ! Storing the yield stress

--- a/engine/source/materials/mat/mat104/mat104_nldam_nice.F
+++ b/engine/source/materials/mat/mat104/mat104_nldam_nice.F
@@ -620,11 +620,13 @@ c
           SIGNZX(I)  = ZERO
           SIGDR(I)   = ZERO
         ENDIF
-        ! USR Outputs
+        ! USR Outputs & coefficient for hourglass
         IF (DPLA(I) > ZERO) THEN 
-          UVAR(I,1) = PHI(I)           ! Yield function value
+          UVAR(I,1) = PHI(I)  ! Yield function value
+          ET(I)     = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)
         ELSE
           UVAR(I,1) = ZERO
+          ET(I)     = ONE
         ENDIF
         UVAR(I,2)  = YLD(I)            ! Yield stress
         ! Standard outputs
@@ -638,8 +640,6 @@ c
         ! Plastic strain-rate (filtered)
         DPDT       = DPLA(I) / MAX(EM20,TIMESTEP)
         EPSD(I)    = AFILTR * DPDT + (ONE - AFILTR) * EPSD(I)
-        ! Coefficient for hourglass
-        ET(I)      = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)
         ! Computation of the sound speed
         SOUNDSP(I) = SQRT((BULK + FOUR_OVER_3*G)/RHO0(I))
         ! Storing the yield stress

--- a/engine/source/materials/mat/mat104/mat104_nodam_newton.F
+++ b/engine/source/materials/mat/mat104/mat104_nodam_newton.F
@@ -450,7 +450,11 @@ c
         DPDT       = DPLA(I) / MAX(EM20,TIMESTEP)
         EPSD(I)    = AFILTR * DPDT + (ONE - AFILTR) * EPSD(I)
         ! Coefficient for hourglass
-        ET(I)      = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)
+        IF (DPLA(I) > ZERO) THEN 
+          ET(I)    = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)
+        ELSE
+          ET(I)    = ONE
+        ENDIF
         ! Computation of the sound speed
         SOUNDSP(I) = SQRT((BULK + FOUR_OVER_3*G)/RHO0(I))
         ! Storing the yield stress

--- a/engine/source/materials/mat/mat104/mat104_nodam_nice.F
+++ b/engine/source/materials/mat/mat104/mat104_nodam_nice.F
@@ -460,18 +460,18 @@ c
 c
       ! Storing new values
       DO I=1,NEL
-        ! USR Outputs
+        ! USR Outputs & coefficient for hourglass
         IF (DPLA(I) > ZERO) THEN 
           UVAR(I,1) = PHI(I)  ! Yield function value
+          ET(I)     = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)
         ELSE
           UVAR(I,1) = ZERO
+          ET(I)     = ONE
         ENDIF
         SEQ(I)     = SIGDR(I) ! SIGEQ
         DPDT       = DPLA(I) / MAX(EM20,TIMESTEP)
         ! Plastic strain-rate (filtered)
         EPSD(I)    = AFILTR * DPDT + (ONE - AFILTR) * EPSD(I)
-        ! Coefficient for hourglass
-        ET(I)      = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)
         ! Computation of the sound speed
         SOUNDSP(I) = SQRT((BULK + FOUR_OVER_3*G)/RHO0(I))
         ! Storing the yield stress

--- a/engine/source/materials/mat/mat104/mat104c_ldam_newton.F
+++ b/engine/source/materials/mat/mat104/mat104c_ldam_newton.F
@@ -637,7 +637,11 @@ c
         DPDT       = DPLA(I) / MAX(EM20,TIMESTEP)  
         EPSD(I)    = AFILTR * DPDT + (ONE - AFILTR) * EPSD(I)        
         ! Coefficient for hourglass
-        ET(I)      = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)
+        IF (DPLA(I) > ZERO) THEN 
+          ET(I) = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)  
+        ELSE
+          ET(I) = ONE
+        ENDIF
         ! Computation of the sound speed
         SOUNDSP(I) = SQRT((A11)/RHO(I))
         ! Storing the yield stress

--- a/engine/source/materials/mat/mat104/mat104c_ldam_nice.F
+++ b/engine/source/materials/mat/mat104/mat104c_ldam_nice.F
@@ -652,11 +652,13 @@ c
           SIGNZX(I)  = ZERO
           SIGDR(I)   = ZERO
         ENDIF
-        ! USR Outputs
+        ! USR Outputs & coefficient for hourglass
         IF (DPLA(I) > ZERO) THEN 
           UVAR(I,1) = PHI(I)           ! Yield function value
+          ET(I)     = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)  
         ELSE
           UVAR(I,1) = ZERO
+          ET(I)     = ONE
         ENDIF
         ! Standard outputs
         DMG(I,1)   = FT(I)/FR          ! Normalized total damage
@@ -669,8 +671,6 @@ c
         ! Plastic strain-rate (filtered)
         DPDT       = DPLA(I) / MAX(EM20,TIMESTEP)        
         EPSD(I)    = AFILTR * DPDT + (ONE - AFILTR) * EPSD(I)        
-        ! Coefficient for hourglass
-        ET(I)      = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)
         ! Computation of the sound speed
         SOUNDSP(I) = SQRT((A11)/RHO(I))
         ! Storing the yield stress

--- a/engine/source/materials/mat/mat104/mat104c_nldam_newton.F
+++ b/engine/source/materials/mat/mat104/mat104c_nldam_newton.F
@@ -650,8 +650,12 @@ c
         ! Plastic strain-rate (filtered)
         DPDT       = DPLA(I) / MAX(EM20,TIMESTEP)
         EPSD(I)    = AFILTR * DPDT + (ONE - AFILTR) * EPSD(I)
-        ! Coefficient for hourglass       
-        ET(I)      = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)
+        ! Coefficient for hourglass
+        IF (DPLA(I) > ZERO) THEN 
+          ET(I) = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)  
+        ELSE
+          ET(I) = ONE
+        ENDIF
         ! Computation of the sound speed
         SOUNDSP(I) = SQRT((A11)/RHO(I))
         ! Storing the yield stress

--- a/engine/source/materials/mat/mat104/mat104c_nldam_nice.F
+++ b/engine/source/materials/mat/mat104/mat104c_nldam_nice.F
@@ -599,11 +599,13 @@ c
           SIGNZX(I)  = ZERO
           SIGDR(I)   = ZERO
         ENDIF
-        ! USR Outputs
+        ! USR Outputs & coefficient for hourglass
         IF (DPLA(I) > ZERO) THEN 
           UVAR(I,1) = PHI(I)           ! Yield function value
+          ET(I)     = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)  
         ELSE
           UVAR(I,1) = ZERO
+          ET(I)     = ONE
         ENDIF
         UVAR(I,2)  = YLD(I)            ! Yield stress
         ! Standard outputs
@@ -617,8 +619,6 @@ c
         ! Plastic strain-rate (filtered)
         DPDT       = DPLA(I) / MAX(EM20,TIMESTEP)
         EPSD(I)    = AFILTR * DPDT + (ONE - AFILTR) * EPSD(I)
-        ! Coefficient for hourglass       
-        ET(I)      = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)
         ! Computation of the sound speed
         SOUNDSP(I) = SQRT((A11)/RHO(I))
         ! Storing the yield stress

--- a/engine/source/materials/mat/mat104/mat104c_nodam_newton.F
+++ b/engine/source/materials/mat/mat104/mat104c_nodam_newton.F
@@ -424,11 +424,15 @@ c
       DO I=1,NEL  
         ! USR Outputs
         SEQ(I)  = SIGDR(I)
+        ! Coefficient for hourglass
+        IF (DPLA(I) > ZERO) THEN 
+          ET(I) = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)  
+        ELSE
+          ET(I) = ONE
+        ENDIF
         ! Plastic strain-rate (filtered)
         DPDT    = DPLA(I) / MAX(EM20,TIMESTEP)
         EPSD(I) = AFILTR * DPDT + (ONE - AFILTR) * EPSD(I)
-        ! Coefficient for hourglass
-        ET(I)      = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG) 
         ! Computation of the sound speed   
         SOUNDSP(I) = SQRT(A11/RHO(I))
         ! Storing the yield stress

--- a/engine/source/materials/mat/mat104/mat104c_nodam_nice.F
+++ b/engine/source/materials/mat/mat104/mat104c_nodam_nice.F
@@ -432,18 +432,18 @@ c
 c      
       ! Storing new values
       DO I=1,NEL  
-        ! USR Outputs
+        ! USR Outputs & coefficient for hourglass
         IF (DPLA(I) > ZERO) THEN 
           UVAR(I,1) = PHI(I)  ! Yield function value
+          ET(I)     = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)  
         ELSE
           UVAR(I,1) = ZERO
+          ET(I)     = ONE
         ENDIF
         SEQ(I)     = SIGDR(I)
         ! Plastic strain-rate (filtered)
         DPDT       = DPLA(I) / MAX(EM20,TIMESTEP)
         EPSD(I)    = AFILTR * DPDT + (ONE - AFILTR) * EPSD(I)
-        ! Coefficient for hourglass
-        ET(I)      = HARDP(I)*FRATE(I) / (HARDP(I)*FRATE(I) + YOUNG)  
         ! Computation of the sound speed   
         SOUNDSP(I) = SQRT(A11/RHO(I))
         ! Storing the yield stress

--- a/engine/source/materials/mat/mat104/sigeps104c.F
+++ b/engine/source/materials/mat/mat104/sigeps104c.F
@@ -221,6 +221,11 @@ c--------------------------
 #include "lockoff.inc"
           ENDDO
         ENDIF
+      ELSE
+        DO I=1,NEL
+          IF (OFF(I) < EM01) OFF(I) = ZERO
+          IF (OFF(I) < ONE)  OFF(I) = OFF(I)*FOUR_OVER_5 
+        ENDDO 
       ENDIF
 c
  2000 FORMAT(1X,'FAILURE (GURSON) IN SHELL ELEMENT ',I10,1X,',GAUSS PT',I2,1X,',THICKNESS INTG. PT',I3)

--- a/engine/source/materials/mat_share/mulawc.F
+++ b/engine/source/materials/mat_share/mulawc.F
@@ -1576,7 +1576,7 @@ c
      7         LBUF%SIG(IJ1),LBUF%SIG(IJ2),LBUF%SIG(IJ3),LBUF%SIG(IJ4),LBUF%SIG(IJ5),
      8         SIGNXX , SIGNYY , SIGNXY  , SIGNYZ, SIGNZX,
      A         SSP    , VISCMX , THKN    , UVAR )          
-          ELSEIF (ILAW == 93) THEN     
+          ELSEIF (ILAW == 93) THEN  
             CALL SIGEPS93C(
      1         JLT      ,NUPARAM0  ,NUVAR    ,NFUNC    ,IFUNC    ,
      2         NPF      ,TF       ,TT       ,DT1C     ,UPARAM0   ,
@@ -1600,6 +1600,7 @@ c
      7         SIGNXX  ,SIGNYY  ,SIGNXY  ,SIGNYZ  ,SIGNZX  )
 c  
           ELSEIF (ILAW == 104 )THEN
+            IOFF_DUCT(JFT:JLT) = 1
             CALL SIGEPS104C(
      1         JLT     ,NGL     ,IPG     ,ILAYER  ,IT      ,NUPARAM0 ,NUVAR    ,
      2         DT1C    ,TT      ,UPARAM0 ,UVAR    ,JTHE    ,RHO      ,TEMPEL   ,
@@ -1680,7 +1681,7 @@ c
      A         IPG     ,IT      ,ELBUF_STR%NPTR,ELBUF_STR%NPTS,ELBUF_STR%NPTT,
      B         BUFLY   ,LBUF%OFF)
 c
-          ELSEIF (ILAW == 122) THEN     
+          ELSEIF (ILAW == 122) THEN 
             CALL SIGEPS122C(
      1         JLT      ,NUPARAM0 ,NUVAR    ,UPARAM0  ,UVAR     ,        
      2         EPSXX    ,EPSYY    ,RHO      ,LBUF%PLA ,DPLA     ,


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

For /MAT/LAW104, the IOFF_DUCT was not initialized to one, leading to a brutal element deletion when used when some specific criteria. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Add IOFF_DUCT initialization to 1 and update of the OFF flag in /MAT/LAW104. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
