### PR TITLE
/MAT/LAW42 : allow new input with 10 Ogden model terms instead of 5

### DIFF
--- a/engine/source/materials/mat/mat042/sigeps42.F
+++ b/engine/source/materials/mat/mat042/sigeps42.F
@@ -41,7 +41,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      6      SIGNXX  ,SIGNYY  ,SIGNZZ  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
      7      MFXX    ,MFXY    ,MFXZ    ,MFYX    ,MFYY    ,MFYZ    ,  
      8      MFZX    ,MFZY    ,MFZZ    ,VISCMAX ,ISMSTR  ,ET      ,
-     9      IHET    ,EPSTH3  ,IEXPAN  )
+     9      IHET    ,EPSTH3  ,IEXPAN  ,NIPARAM ,IPARAM  )
 C-----------------------------------------------
 C   I M P L I C I T   T Y P E S
 C-----------------------------------------------
@@ -60,8 +60,11 @@ C-----------------------------------------------
 C----------------------------------------------------------------
 C  I N P U T   A R G U M E N T S
 C----------------------------------------------------------------
-      INTEGER, INTENT(IN) :: NEL,NUPARAM,NUVAR,ISMSTR,IHET,IEXPAN
+      INTEGER, INTENT(IN) :: NUPARAM
+      INTEGER, INTENT(IN) :: NIPARAM
+      INTEGER, INTENT(IN) :: NEL,NUVAR,ISMSTR,IHET,IEXPAN
       my_real, INTENT(IN) :: TIME, TIMESTEP
+      INTEGER, DIMENSION(NIPARAM), INTENT(IN) :: IPARAM(NIPARAM)
       my_real, DIMENSION(NUPARAM), INTENT(IN) :: UPARAM(NUPARAM)
       my_real, DIMENSION(NEL), INTENT(IN) ::RHO,RHO0,VOLUME,EINT,
      .  OFFG,EPSTH3,EPSP1,EPSP2,EPSP3,EPSP4,EPSP5,EPSP6,                  
@@ -86,11 +89,11 @@ C----------------------------------------------------------------
 C----------------------------------------------------------------
 C  L O C A L  V A R I A B L E S
 C----------------------------------------------------------------
-      INTEGER I,II,J,K,KFP,NPRONY,IFORM
+      INTEGER I,II,J,K,KFP,NPRONY,NORDER,IFORM
       my_real TENSIONCUT,AMAX,GVMAX,GMAX,FFAC,TRACE,RBULK,DPDMU,
      .  AA,CC,FAC,INVE,ETV,RV_PUI,AMIN,NU_1
-      my_real, DIMENSION(3) :: LAM_AL,FFT
-      my_real, DIMENSION(5) :: AL_TAB,MU_TAB
+      my_real, DIMENSION(3)   :: LAM_AL,FFT
+      my_real, DIMENSION(10)  :: AL,MU
       my_real, DIMENSION(100) :: GI,TAUX
       my_real, DIMENSION(NEL) :: SUMDWDL,RV,J2THIRD,P,DWDRV,ETI,GTMAX 
       my_real, DIMENSION(3,3) :: A
@@ -109,25 +112,27 @@ c
       ! - INITIALISATION OF COMPUTATION ON TIME STEP
       !=======================================================================
       ! Recovering model parameters
+!
+      NORDER = IPARAM(1)   ! Order of Ogden model
+      NPRONY = IPARAM(2)   ! Number of Prony Series
+      IFORM  = IPARAM(3)   ! Flag for strain energy density formulation
+      
+      
       GMAX = ZERO
-      DO I=1,5
+      DO I=1,10
         !  -> Shear hyperelastic modulus parameters
-        MU_TAB(I) = UPARAM(I)
+        MU(I) = UPARAM(I)
         !  -> Material exponents
-        AL_TAB(I) = UPARAM(5+I)
+        AL(I) = UPARAM(10+I)
         !  -> Shear modulus
-        GMAX = GMAX + MU_TAB(I)*AL_TAB(I)
+        GMAX = GMAX + MU(I)*AL(I)
       ENDDO
       ! Bulk modulus
-      RBULK = UPARAM(11)
+      RBULK = UPARAM(21)
       ! Cutoff stress in tension
-      TENSIONCUT = UPARAM(12)
+      TENSIONCUT = UPARAM(23)
       ! Bulk function scale factor
-      FFAC = UPARAM(15)
-      ! Number of Prony Series
-      NPRONY = UPARAM(16)
-      ! Flag for strain energy density formulation
-      IFORM  = UPARAM(17)
+      FFAC = UPARAM(24)
       ! Tabulated bulk function ID
       KFP   = IFUNC(1)
       ! Prony series parameters
@@ -135,8 +140,8 @@ c
       ETV   = ZERO
       IF (NPRONY > 0) THEN
         DO I=1,NPRONY
-          TAUX(I) = UPARAM(17 + NPRONY + I)
-          GI(I)   = UPARAM(17 + I)
+          TAUX(I) = UPARAM(24 + NPRONY + I)
+          GI(I)   = UPARAM(24 + I)
           GVMAX   = GVMAX + GI(I)
         ENDDO
         ETV = MIN(GVMAX,RBULK)/GMAX
@@ -177,7 +182,7 @@ c
             EV(I,1) = SQRT(EVV(I,1) + ONE)
             EV(I,2) = SQRT(EVV(I,2) + ONE)
             EV(I,3) = SQRT(EVV(I,3) + ONE)
-              ELSE
+          ELSE
             EV(I,1) = EVV(I,1) + ONE
             EV(I,2) = EVV(I,2) + ONE
             EV(I,3) = EVV(I,3) + ONE
@@ -195,20 +200,19 @@ c
       ! Implicit simulation - Hourglass for HEPH
       IF (IMPL_S > 0 .OR. IHET > 1) THEN
         DO J = 1,3
-          ! ETI = sum[MU(i)*AL(i)*AMAX**(AL(i)-1)] (i=1,5)
+          ! ETI = sum[MU(i)*AL(i)*AMAX**(AL(i)-1)] (i=1,norder)
           ! AMAX = 0 --> ETI = 0
-          ! else     --> ETI = sum[MU(i)*AL(i)*exp( (AL(i)-1)*ln(AMAX) ) ] ; (i=1,5)
+          ! else     --> ETI = sum[MU(i)*AL(i)*exp( (AL(i)-1)*ln(AMAX) ) ] ; (i=1,norder)
           ETI(1:NEL) = ZERO
-          DO II = 1,5
-           IF(MU_TAB(II)*AL_TAB(II)/=ZERO) THEN
+          DO II = 1,NORDER
+           IF(MU(II)*AL(II)/=ZERO) THEN
               DO I=1,NEL
                 AMAX = EV(I,J)                
                 IF(AMAX/=ZERO) THEN
-                  IF((AL_TAB(II)-ONE)/=ZERO) THEN
-                    ETI(I) = ETI(I) + MU_TAB(II)*AL_TAB(II) * 
-     .                    EXP((AL_TAB(II)-ONE)*LOG(AMAX))
+                  IF((AL(II)-ONE)/=ZERO) THEN
+                    ETI(I) = ETI(I) + MU(II)*AL(II) * EXP((AL(II)-ONE)*LOG(AMAX))
                   ELSE
-                    ETI(I) = ETI(I) + MU_TAB(II)*AL_TAB(II)
+                    ETI(I) = ETI(I) + MU(II)*AL(II)
                   ENDIF
                 ENDIF
               ENDDO
@@ -272,12 +276,12 @@ c
       GTMAX(1:NEL) = GMAX + GVMAX
       ETI(1:NEL) = ZERO
       CII(1:NEL,1:3) = ZERO
-      DO II = 1,5
-        IF (MU_TAB(II)*AL_TAB(II) /= ZERO) THEN
+      DO II = 1,NORDER
+        IF (MU(II)*AL(II) /= ZERO) THEN
           DO I=1,NEL
-            LAM_AL(1:3) = EXP(AL_TAB(II)*LOG(EVM(I,1:3)))
+            LAM_AL(1:3) = EXP(AL(II)*LOG(EVM(I,1:3)))
             AMAX = THIRD*(LAM_AL(1)+LAM_AL(2)+LAM_AL(3))
-            CII(I,1:3) = CII(I,1:3) + MU_TAB(II)*AL_TAB(II)*(LAM_AL(1:3)+AMAX)
+            CII(I,1:3) = CII(I,1:3) + MU(II)*AL(II)*(LAM_AL(1:3)+AMAX)
           ENDDO
         ENDIF
       ENDDO
@@ -298,19 +302,16 @@ c
       ! Note: here, the table DWDL(:,J) corresponds to the product EVM(J)*DWDEVM(:,J)
       DO J=1,3
         DWDL(1:NEL,J)=ZERO
-        DO II=1,5
-          IF(MU_TAB(II)/=ZERO) THEN
-            DO I=1,NEL
-              IF(EVM(I,J)/=ZERO) THEN
-                IF(AL_TAB(II)/=ZERO) THEN
-                  DWDL(I,J) = DWDL(I,J) + MU_TAB(II) *
-     .                        EXP(AL_TAB(II)*LOG(EVM(I,J)))
-                ELSE
-                  DWDL(I,J) = DWDL(I,J) + MU_TAB(II)
-                ENDIF
+        DO II=1,NORDER
+          DO I=1,NEL
+            IF (EVM(I,J)/=ZERO) THEN
+              IF (AL(II)/=ZERO) THEN
+                DWDL(I,J) = DWDL(I,J) + MU(II) * EXP(AL(II)*LOG(EVM(I,J)))
+              ELSE
+                DWDL(I,J) = DWDL(I,J) + MU(II)
               ENDIF
-            ENDDO
-          ENDIF
+            ENDIF
+          ENDDO
         ENDDO
       ENDDO
 c 

--- a/engine/source/materials/mat/mat042/sigeps42c.F
+++ b/engine/source/materials/mat/mat042/sigeps42c.F
@@ -20,6 +20,7 @@ Copyright>
 Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
 Copyright>        software under a commercial license.  Contact Altair to discuss further if the
 Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+
       !||====================================================================
       !||    sigeps42c   ../engine/source/materials/mat/mat042/sigeps42c.F
       !||--- called by ------------------------------------------------------
@@ -27,19 +28,16 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||--- calls      -----------------------------------------------------
       !||    finter      ../engine/source/tools/curve/finter.F
       !||====================================================================
-              SUBROUTINE SIGEPS42C(
-     1      NEL    , NUPARAM, NUVAR   , NFUNC , IFUNC , NPF   ,
-     2      NPT0   , ILAYER ,
-     2      TF     , TIME   , TIMESTEP, UPARAM, RHO0  ,
-     3      AREA   , EINT   , THKLYL,
-     4      EPSPXX , EPSPYY , EPSPXY, EPSPYZ, EPSPZX,
-     5      DEPSXX , DEPSYY , DEPSXY, DEPSYZ, DEPSZX,
-     6      EPSXX  , EPSYY  , EPSXY , EPSYZ , EPSZX ,
-     7      SIGOXX , SIGOYY , SIGOXY, SIGOYZ, SIGOZX,
-     8      SIGNXX , SIGNYY , SIGNXY, SIGNYZ, SIGNZX,
-     9      SIGVXX , SIGVYY , SIGVXY, SIGVYZ, SIGVZX,
-     A      SOUNDSP, VISCMAX, THKN  , UVAR  , OFF   ,
-     B      NGL    , ISMSTR , IPM   , GS    )
+      module sigeps42c_mod
+      contains
+      
+      SUBROUTINE SIGEPS42C(
+     1      NEL    , NUPARAM ,NIPARAM, NUVAR  , ISMSTR ,
+     2      TIME   , TIMESTEP,UPARAM , IPARAM , RHO0   ,  
+     3      DEPSXX , DEPSYY , DEPSXY , DEPSYZ , DEPSZX ,
+     4      EPSXX  , EPSYY  , EPSXY  , THKN   , THKLYL ,
+     5      SIGNXX , SIGNYY , SIGNXY , SIGNYZ , SIGNZX ,
+     6      SOUNDSP, GS     , UVAR   , OFF    )
 C-----------------------------------------------
 C   I M P L I C I T   T Y P E S
 C-----------------------------------------------
@@ -52,98 +50,82 @@ C-----------------------------------------------
 C----------------------------------------------------------------
 C  I N P U T   A R G U M E N T S
 C----------------------------------------------------------------
-      INTEGER NEL,NUPARAM,NUVAR,ISMSTR,NPT0,ILAYER
-      INTEGER IPM(NPROPMI,*),MAT(NEL),NGL(NEL)
-      my_real
-     .   TIME,TIMESTEP
-      my_real
-     .  UPARAM(NUPARAM),THKN(NEL),THKLYL(NEL),
-     .  RHO0(NEL),AREA(NEL),EINT(NEL,2),GS(NEL),
-     .  EPSPXX(NEL),EPSPYY(NEL),EPSPXY(NEL),EPSPYZ(NEL),EPSPZX(NEL),
-     .  DEPSXX(NEL),DEPSYY(NEL),DEPSXY(NEL),DEPSYZ(NEL),DEPSZX(NEL),
-     .  EPSXX (NEL),EPSYY (NEL),EPSXY (NEL),EPSYZ (NEL),EPSZX (NEL),
-     .  SIGOXX(NEL),SIGOYY(NEL),SIGOXY(NEL),SIGOYZ(NEL),SIGOZX(NEL)
+      INTEGER :: NEL
+      INTEGER :: NUPARAM
+      INTEGER :: NIPARAM
+      INTEGER :: NUVAR
+      INTEGER :: ISMSTR
+      INTEGER :: IPARAM(NIPARAM)
+      my_real :: UPARAM(NUPARAM)
+      my_real :: TIME,TIMESTEP
+      my_real ,DIMENSION(NEL) :: THKN,THKLYL,RHO0,GS,
+     .  DEPSXX,DEPSYY,DEPSXY,DEPSYZ,DEPSZX,EPSXX,EPSYY,EPSXY
 C----------------------------------------------------------------
 C  O U T P U T   A R G U M E N T S
 C----------------------------------------------------------------
-      my_real
-     .  SIGNXX (NEL),SIGNYY (NEL),SIGNXY (NEL),SIGNYZ (NEL),SIGNZX(NEL),
-     .  SIGVXX (NEL),SIGVYY (NEL),SIGVXY (NEL),SIGVYZ (NEL),SIGVZX(NEL),
-     .  SOUNDSP(NEL),VISCMAX(NEL)
+      my_real ,DIMENSION(NEL) :: SIGNXX,SIGNYY,SIGNXY,SIGNYZ,SIGNZX,SOUNDSP
 C----------------------------------------------------------------
 C  I N P U T  O U T P U T   A R G U M E N T S
 C----------------------------------------------------------------
       my_real
      .      UVAR(NEL,NUVAR), OFF(NEL)
 C----------------------------------------------------------------
-C  VARIABLES FOR FUNCTION INTERPOLATION
-C----------------------------------------------------------------
-      INTEGER NPF(*), NFUNC, IFUNC(NFUNC)
-      my_real FINTER,TF(*)
-      EXTERNAL FINTER
-C----------------------------------------------------------------
 C  L O C A L  V A R I B L E S
 C----------------------------------------------------------------
-      INTEGER  I,II,J,NPRONY,ITER,IFLAG,IVISC,JNV
-      my_real
-     .   MU1,MU2,MU3,MU4,MU5,AL1,AL2,AL3,AL4,AL5,SUM,FAC,FSCAL,RVT(NEL),                
-     .   TENSCUT,GMAX,NU,RBULK,SUMDWDL,SUMDDWDDL,PARTP,GVMAX,
-     .   C30(NEL),C31(NEL),DC3EV3(NEL),CD10(NEL),CD20(NEL),CD120(NEL),
-     .   CP1(NEL),CP2(NEL),CD1(NEL),CD2(NEL),CD12(NEL)
-      my_real
-     .   GI(100),TAUX(100),H30(NEL,100),H31(NEL,100),H1(100),H2(100),
-     .   H12(100),H10(100),H20(100),H120(100)
-      my_real
-     .   SV(NEL,3),SIGPRV(NEL,3),EIGV(NEL,3,2),        
-     .   RHO(NEL),RV(NEL),T(NEL,3),TRAV(NEL),ROOTV(NEL),  
-     .   EVV(NEL,3),EV(NEL,3),DEZZ(NEL),
-     .   EVM(NEL,3),EVMA1(NEL,5),EVMA2(NEL,5),EVMA3(NEL,5),DDWDDL(3),DWDL(3),
-     .   S2(NEL),CS(NEL),KT3(NEL),EPSZZ(NEL),EVMA12(NEL,5),
-     .   C11(NEL,5),C22(NEL,5),C12(NEL,5),
-     .   E11,E22,EMAX ,EA(NEL),A11,PUI11,PUI22,INVRV(NEL),INVV3(NEL)
-C
-      INTEGER IAL(5),JJ
-      my_real ALTAB(5),MUTAB(5)     
+      INTEGER :: I,J,II,NPRONY,NORDER,ITER,JNV
+      my_real :: SUM,FAC,FSCAL,TENSCUT,SUMDWDL,SUMDDWDDL,PARTP
+      my_real :: E11,E22,E12,EMAX,GMAX,GVMAX,NU,RBULK,A11,PUI11,PUI22,ALMA1,ALMA2,ALMA3
+      my_real ,DIMENSION(3)       :: DDWDDL,DWDL
+      my_real ,DIMENSION(10)      :: MU,AL    
+      my_real ,DIMENSION(100)     :: GI,TAUX,H1,H2,H12,H10,H20,H120
+      my_real ,DIMENSION(NEL,100) :: H30,H31
+      my_real ,DIMENSION(NEL)     :: RVT,C30,C31,DC3EV3,CD10,CD20,CD120
+      my_real ,DIMENSION(NEL)     :: CP1,CP2,CD1,CD2,CD12,EA,INVRV,INVV3,DEZZ,RV,TRAV,ROOTV
+      my_real ,DIMENSION(NEL)     :: S2,CS,KT3,EPSZZ,RHO
+      my_real ,DIMENSION(NEL,10)  :: EVMA1,EVMA2,EVMA3,C11,C22,C12
+      my_real ,DIMENSION(NEL,3)   :: T,SV,SIGPRV,EVV,EV,EVM        
+      my_real ,DIMENSION(NEL,3,2) :: EIGV(NEL,3,2)      
 C=======================================================================
 C SET INITIAL MATERIAL CONSTANTS
+
+      NORDER = IPARAM(1)
+      NPRONY = IPARAM(2)
       
-      MU1    =UPARAM(1)
-      MU2    =UPARAM(2)
-      MU3    =UPARAM(3)
-      MU4    =UPARAM(4)
-      MU5    =UPARAM(5)
-      AL1    =UPARAM(6)
-      AL2    =UPARAM(7)
-      AL3    =UPARAM(8)
-      AL4    =UPARAM(9)
-      AL5    =UPARAM(10)
-      RBULK  =UPARAM(11)
-      TENSCUT=UPARAM(12)
-      IFLAG  =UPARAM(13)
-      NU     =UPARAM(14)
-      FSCAL  =UPARAM(15)
-      NPRONY =UPARAM(16)
-      IVISC = 0
+      MU(1)  = UPARAM(1)
+      MU(2)  = UPARAM(2)
+      MU(3)  = UPARAM(3)
+      MU(4)  = UPARAM(4)
+      MU(5)  = UPARAM(5)
+      MU(6)  = UPARAM(6)
+      MU(7)  = UPARAM(7)
+      MU(8)  = UPARAM(8)
+      MU(9)  = UPARAM(9)
+      MU(10) = UPARAM(10)
+      AL(1)  = UPARAM(11)
+      AL(2)  = UPARAM(12)
+      AL(3)  = UPARAM(13)
+      AL(4)  = UPARAM(14)
+      AL(5)  = UPARAM(15)
+      AL(6)  = UPARAM(16)
+      AL(7)  = UPARAM(17)
+      AL(8)  = UPARAM(18)
+      AL(9)  = UPARAM(19)
+      AL(10) = UPARAM(20)
+      RBULK  = UPARAM(21)
+      NU     = UPARAM(22)
+      TENSCUT= UPARAM(23)
+      FSCAL  = UPARAM(24)
 !     ------------------
-!     Check if AL1,2,3,4 or 5 are egal to 0
-      DO I=1,5
-       MUTAB(I) = UPARAM(I)
-       ALTAB(I) = UPARAM(5+I)
-       IF(ALTAB(I)==ZERO) THEN
-        IAL(I) = 0
-       ELSE
-        IAL(I) = 1
-       ENDIF
-      ENDDO
-!     ------------------      
-      IF(NPRONY > 0) IVISC = 1
+      GMAX  = ZERO
       GVMAX = ZERO
       DO I=1,NPRONY                       
-        GI(I)   = UPARAM(17 + I)          
-        TAUX(I) = UPARAM(17 + NPRONY + I) 
-        GVMAX = GVMAX +  GI(I)
+        GI(I)   = UPARAM(24 + I)          
+        TAUX(I) = UPARAM(24 + NPRONY + I) 
+        GVMAX   = GVMAX + GI(I)
       ENDDO                               
-      GMAX=MU1*AL1+MU2*AL2+MU3*AL3+MU4*AL4+MU5*AL5
+      DO I=1,NORDER                       
+        GMAX = GMAX + MU(I)*AL(I)
+      ENDDO                               
       GMAX = GMAX + GVMAX
 C
 C     User variables initialisation
@@ -170,9 +152,9 @@ C     principal stretch (def gradient eigenvalues)
         EA(I) = ZERO
       ENDDO
 C-- avoid NaN---------        
-      IF(ISMSTR == 10) THEN
+      IF (ISMSTR == 10) THEN
         DO I=1,NEL
-          IF (MIN(EVV(I,1),EVV(I,2))<=-ONE) THEN
+          IF (MIN(EVV(I,1),EVV(I,2)) <= -ONE) THEN
            EVV(I,1) = ZERO
            EVV(I,2) = ZERO
            OFF(I) = FOUR_OVER_5
@@ -192,10 +174,10 @@ C     rot matrix (eigenvectors)
           INVRV(I) = ONE / ROOTV(I)                                 
           EIGV(I,1,1) = (EPSXX(I)-EVV(I,2)) * INVRV(I)
           EIGV(I,2,1) = (EPSYY(I)-EVV(I,2)) * INVRV(I)
-          EIGV(I,3,1) = (HALF*EPSXY(I))   * INVRV(I)
+          EIGV(I,3,1) = (HALF*EPSXY(I))     * INVRV(I)
           EIGV(I,1,2) = (EVV(I,1)-EPSXX(I)) * INVRV(I) 
           EIGV(I,2,2) = (EVV(I,1)-EPSYY(I)) * INVRV(I)
-          EIGV(I,3,2) =-(HALF*EPSXY(I))   * INVRV(I)  
+          EIGV(I,3,2) =-(HALF*EPSXY(I))     * INVRV(I)  
         ENDIF                          
       ENDDO
 C     Strain definition
@@ -218,26 +200,23 @@ C     Strain definition
           EV(I,3)=ONE/EV(I,1)/EV(I,2)
         ENDDO
       ENDIF
-      IF(IVISC >  0) THEN
-        DO I=1,NEL
-            EV(I,3)=UVAR(I,3)
-        ENDDO 
-      ENDIF
+      IF (NPRONY >  0) EV(1:NEL,3) = UVAR(1:NEL,3)
+
       DO I=1,NEL
         IF (OFF(I)==ZERO.OR.OFF(I)==FOUR_OVER_5) EV(I,1:3)=ONE
       ENDDO 
 C--------------------------------------
 C     Newton method =>  Find EV(3) : T3(EV(3)) = 0
 C--------------------------------------
-      IF(IVISC  > 0) THEN
+      IF (NPRONY  > 0) THEN
 C--------------------------------------
-C     Newton method =>  Find EV(3) : T3(EV(3)) = 0
+C       Newton method =>  Find EV(3) : T3(EV(3)) = 0
 C--------------------------------------                                                             
-       DO ITER = 1,5
+        DO ITER = 1,5
 !       ----------------------- 
-         DO I=1,NEL 
+          DO I=1,NEL 
             RV(I) = EV(I,1)*EV(I,2)*EV(I,3)                                    
-c----     normalized stretch => unified compressible/uncompressible formulation   
+c----       normalized stretch => unified compressible/uncompressible formulation   
             ! RVT = RV(I)**(-THIRD)
             ! RV = 0 --> RVT = 0
             ! else   --> RVT = exp( -third * ln( RV)) 
@@ -251,55 +230,60 @@ c----     normalized stretch => unified compressible/uncompressible formulation
             EVM(I,1) = EV(I,1)*RVT(I)                                      
             EVM(I,2) = EV(I,2)*RVT(I)                                      
             EVM(I,3) = EV(I,3)*RVT(I)
-         ENDDO  ! 1,NEL    
+          ENDDO  ! 1,NEL    
 !       -----------------------                                   
-C----     partial derivatives of strain energy
-         DO JJ = 1,5
-           DO I=1,NEL 
-             ! EVMA(I) = MU * EVM(I) ** AL(I) :
-             ! EVM = 0 --> EVMA(I) = 0
-             ! AL  = 0 --> EVMA(I) = MU
-             ! else    --> EVMA(I) = MU * exp(AL(I) * ln( EVM(I)))
-             IF(EVM(I,1)==ZERO) THEN
-               EVMA1(I,JJ) = ZERO
-             ELSE
-              IF(IAL(JJ)==0) THEN
-               EVMA1(I,JJ) = MUTAB(JJ)
+          ! partial derivatives of strain energy
+          DO J = 1,NORDER
+            DO I=1,NEL 
+              ! EVMA(I) = MU * EVM(I) ** AL(I) :
+              ! EVM = 0 --> EVMA(I) = 0
+              ! AL  = 0 --> EVMA(I) = MU
+              ! else    --> EVMA(I) = MU * exp(AL(I) * ln( EVM(I)))
+              IF(EVM(I,1)==ZERO) THEN
+                EVMA1(I,J) = ZERO
               ELSE
-               EVMA1(I,JJ) = MUTAB(JJ) * EXP(ALTAB(JJ)* LOG(EVM(I,1)) )
+               IF (AL(J) == ZERO) THEN
+                 EVMA1(I,J) = MU(J)
+               ELSE
+                 EVMA1(I,J) = MU(J) * EXP(AL(J)* LOG(EVM(I,1)) )
+               ENDIF
               ENDIF
-             ENDIF
 !
-             IF(EVM(I,2)==ZERO) THEN
-              EVMA2(I,JJ) = ZERO
-             ELSE
-              IF(IAL(JJ)==0) THEN
-               EVMA2(I,JJ) = MUTAB(JJ)
+              IF(EVM(I,2)==ZERO) THEN
+                EVMA2(I,J) = ZERO
               ELSE
-               EVMA2(I,JJ) = MUTAB(JJ) * EXP(ALTAB(JJ)* LOG(EVM(I,2)) )
+               IF (AL(J) == ZERO) THEN
+                 EVMA2(I,J) = MU(J)
+               ELSE
+                 EVMA2(I,J) = MU(J) * EXP(AL(J)* LOG(EVM(I,2)) )
+               ENDIF
               ENDIF
-             ENDIF
-!             
-             IF(EVM(I,3)==ZERO) THEN
-              EVMA3(I,JJ) = ZERO
-             ELSE
-              IF(IAL(JJ)==0) THEN
-               EVMA3(I,JJ) = MUTAB(JJ)
+!              
+              IF(EVM(I,3)==ZERO) THEN
+                EVMA3(I,J) = ZERO
               ELSE
-               EVMA3(I,JJ) = MUTAB(JJ) * EXP(ALTAB(JJ)* LOG(EVM(I,3)) )
-              ENDIF
-             ENDIF    
-           ENDDO       ! 1,NEL    
-         ENDDO         ! JJ=1,5
+                IF (AL(J) == ZERO) THEN
+                  EVMA3(I,J) = MU(J)
+                ELSE
+                  EVMA3(I,J) = MU(J) * EXP(AL(J)* LOG(EVM(I,3)) )
+               ENDIF
+              ENDIF    
+            ENDDO       ! 1,NEL    
+          ENDDO         ! J=1,NORDER
 !       -----------------------                   
-         DO I=1,NEL                                                 
-            DWDL(1) = EVMA1(I,1)+EVMA1(I,2)+EVMA1(I,3)+EVMA1(I,4)+EVMA1(I,5)                
-            DWDL(2) = EVMA2(I,1)+EVMA2(I,2)+EVMA2(I,3)+EVMA2(I,4)+EVMA2(I,5)                
-            DWDL(3) = EVMA3(I,1)+EVMA3(I,2)+EVMA3(I,3)+EVMA3(I,4)+EVMA3(I,5)                
-            SUMDWDL = (DWDL(1)+DWDL(2)+DWDL(3))* THIRD                            
+          DO I=1,NEL
+            DWDL(1) = ZERO          
+            DWDL(2) = ZERO          
+            DWDL(3) = ZERO          
+            DO J=1,NORDER                                                
+              DWDL(1) = DWDL(1) + EVMA1(I,J)        
+              DWDL(2) = DWDL(2) + EVMA2(I,J)        
+              DWDL(3) = DWDL(3) + EVMA3(I,J)
+            END DO        
+            SUMDWDL = (DWDL(1) + DWDL(2) + DWDL(3)) * THIRD                            
             PARTP   = RBULK*(RV(I)- ONE)                                           
 c---------
-c         principal cauchy stress
+c           principal cauchy stress
             IF (EV(I,3) == ZERO) THEN
               INVV3(I) = ZERO
             ELSE
@@ -311,50 +295,53 @@ c         principal cauchy stress
 c---------
             KT3(I) = -THIRD*(DWDL(1) + DWDL(2)) + TWO_THIRD*(DWDL(3))          
             KT3(I) = -EV(I,1)*EV(I,2)*KT3(I)*INVRV(I)*INVRV(I)  + RBULK*EV(I,1)*EV(I,2)
-            KT3(I) = KT3(I) + ( ONE_OVER_9*(AL1*EVMA1(I,1) + AL2*EVMA1(I,2) + AL3*EVMA1(I,3) 
-     .              +  AL4*EVMA1(I,4)+AL5*EVMA1(I,5) 
-     .              +  AL1*EVMA2(I,1)+AL2*EVMA2(I,2) + AL3*EVMA2(I,3) 
-     .              +  AL4*EVMA2(I,4)+AL5*EVMA2(I,5) 
-     .              +  FOUR*(AL1*EVMA3(I,1) + AL2*EVMA3(I,2) + AL3*EVMA3(I,3)
-     .              +  AL4*EVMA3(I,4)+AL5*EVMA3(I,5))))*INVRV(I)*INVV3(I)                                            
-C viscosty traitement            
-           C30(I) = UVAR(I,5) 
+!
+            ALMA1 = ZERO
+            ALMA2 = ZERO
+            ALMA3 = ZERO
+            DO J=1,NORDER
+              ALMA1 = ALMA1 + AL(J)*EVMA1(I,J)                                             
+              ALMA2 = ALMA2 + AL(J)*EVMA2(I,J)                                             
+              ALMA3 = ALMA3 + AL(J)*EVMA3(I,J)                                             
+            END DO        
+            KT3(I) = KT3(I) + (ONE_OVER_9*(ALMA1 + ALMA2 + FOUR*(ALMA3))) * INVRV(I)*INVV3(I)                                            
+C           viscosty traitement            
+            C30(I) = UVAR(I,5) 
 C
-           SUM = THIRD*(EVM(I,1)**2 +  EVM(I,2)**2 + EVM(I,3)**2)
-           C31(I)   =  EVM(I,3)**2 - SUM 
-!!         SV3 = ZERO
-           DC3EV3(I) = FOUR_OVER_3*RVT(I)*EVM(I,3)-TWO_THIRD*(TWO_THIRD*EVM(I,3)**2 - 
-     .                                        THIRD* EVM(I,1)**2 - 
-     .                                        THIRD* EVM(I,2)**2)*INVV3(I)
-         ENDDO  ! 1,NEL
+            SUM = THIRD*(EVM(I,1)**2 +  EVM(I,2)**2 + EVM(I,3)**2)
+            C31(I)   =  EVM(I,3)**2 - SUM 
+            ! SV3 = ZERO
+            DC3EV3(I) = FOUR_OVER_3*RVT(I)*EVM(I,3)-TWO_THIRD*INVV3(I)* 
+     .                 (TWO_THIRD*EVM(I,3)**2 - THIRD*EVM(I,1)**2 - THIRD*EVM(I,2)**2)
+          ENDDO  ! 1,NEL
 !       -----------------------  
-         JNV = 8
-         DO II= 1,NPRONY
-             FAC= -TIMESTEP/TAUX(II)                          
-             H30(1:NEL,II)  =  UVAR(1:NEL,JNV + II)                
-             H31(1:NEL,II)  = EXP(FAC)*H30(1:NEL,II)+ EXP(HALF*FAC)*(C31(1:NEL) - C30(1:NEL)) 
-         ENDDO
-C           Kirchoff visco stress --->
-C   PK2 stress, PK2 = F**(-1)*Taux* F**(-T)n 
-C   cauchy =Taux/RV is used here
-         DO II = 1,NPRONY
+          JNV = 8
+          DO II= 1,NPRONY
+            FAC= -TIMESTEP/TAUX(II)                          
+            H30(1:NEL,II) = UVAR(1:NEL,JNV + II)                
+            H31(1:NEL,II) = EXP(FAC)*H30(1:NEL,II)+ EXP(HALF*FAC)*(C31(1:NEL) - C30(1:NEL)) 
+          ENDDO
+C         Kirchoff visco stress --->
+C         PK2 stress, PK2 = F**(-1)*Taux* F**(-T)n 
+C         cauchy =Taux/RV is used here
+          DO II = 1,NPRONY
                   FAC= -TIMESTEP/TAUX(II) 
                   T(1:NEL,3) = T(1:NEL,3) + GI(II)*H31(1:NEL,II)*INVRV(1:NEL)
                   KT3(1:NEL) = KT3(1:NEL) - GI(II)*H31(1:NEL,II)*INVV3(1:NEL)*INVRV(1:NEL)
      .                 + DC3EV3(1:NEL)*GI(II)*EXP(HALF*FAC)*INVRV(1:NEL)
-         ENDDO
-         DO I=1,NEL                                                 
-          IF (OFF(I)==ZERO.OR.OFF(I)==FOUR_OVER_5) CYCLE
-          IF (ABS(KT3(I))>EM20) EV(I,3) = EV(I,3)  - T(I,3)/KT3(I)
-         ENDDO
-       ENDDO  ! iteration
+          ENDDO
+          DO I=1,NEL                                                 
+            IF (OFF(I)==ZERO.OR.OFF(I)==FOUR_OVER_5) CYCLE
+            IF (ABS(KT3(I))>EM20) EV(I,3) = EV(I,3)  - T(I,3)/KT3(I)
+          ENDDO
+        ENDDO  ! iteration
 !       -----------------------
-C stored converged solution
-       JNV = 8
-       DO II= 1,NPRONY
-          UVAR(1:NEL,JNV  + II) =  H31(1:NEL,II)
-       ENDDO
-       DO I=1,NEL
+C       stored converged solution
+        JNV = 8
+        DO II= 1,NPRONY
+           UVAR(1:NEL,JNV  + II) =  H31(1:NEL,II)
+        ENDDO
+        DO I=1,NEL
            UVAR(I,5) = C31(I) 
 C           
            RV(I)   = EV(I,1)*EV(I,2)*EV(I,3)
@@ -387,9 +374,9 @@ C
            SV(I,1) = ZERO
            SV(I,2) = ZERO
            SV(I,3) = ZERO
-       ENDDO 
-       JNV = 8 + NPRONY    
-       DO II= 1,NPRONY
+        ENDDO 
+        JNV = 8 + NPRONY    
+        DO II= 1,NPRONY
           DO I=1,NEL
               FAC= -TIMESTEP/TAUX(II)                          
               H10(II)   =  UVAR(I,JNV + II )                        
@@ -406,11 +393,12 @@ C           Kirchoff visco stress
               SV(I,2) = SV(I,2) + GI(II)*H2(II)
               SV(I,3) = SV(I,3) + GI(II)*H12(II)
             ENDDO       ! 1,NEL                                                                   
-       ENDDO  !  NPRONY
+        ENDDO  !  NPRONY
                              
+!     -----------------------
       ELSE ! lam3=1/lam1/lam2 (incompressible formulation) with out viscosity
-!       -----------------------
-       DO JJ = 1,5                                                                 
+!     -----------------------
+        DO J = 1,NORDER                                                                
 c----     normalized stretch => unified compressible/uncompressible formulation   
 C----     partial derivatives of strain energy
           ! EVMA(I) = MU * EV(I) ** AL(I) :
@@ -418,124 +406,125 @@ C----     partial derivatives of strain energy
           ! AL  = 0 --> EVMA(I) = MU
           ! else    --> EVMA(I) = MU * PUI
           ! with PUI = exp(AL(I) * ln( EV(I)))
-          ! EVMA12 = MU * ( EV(1) * EV(2) )** (-AL(I))
-          ! --> EVMA12 = MU/ (PUI11 * PUI22)
+          ! EVMA3 = MU * ( EV(1) * EV(2) )** (-AL(I))
+          ! --> EVMA3 = MU/ (PUI11 * PUI22)
           DO I=1,NEL 
-           IF(EV(I,1)==ZERO) THEN
-            EVMA1(I,JJ) = ZERO
-           ELSE
-            IF(IAL(JJ)==0) THEN
-             EVMA1(I,JJ) = MUTAB(JJ)
-             PUI11 = ONE
+            IF(EV(I,1)==ZERO) THEN
+              EVMA1(I,J) = ZERO
             ELSE
-             PUI11 = EXP(ALTAB(JJ)* LOG(EV(I,1)) )
-             EVMA1(I,JJ) = MUTAB(JJ) * PUI11
+              IF (AL(J) == ZERO) THEN
+                EVMA1(I,J) = MU(J)
+                PUI11 = ONE
+              ELSE
+                PUI11 = EXP(AL(J)* LOG(EV(I,1)) )
+                EVMA1(I,J) = MU(J) * PUI11
+              ENDIF
             ENDIF
-           ENDIF
-!           
-           IF(EV(I,2)==ZERO) THEN
-            EVMA2(I,JJ) = ZERO
-           ELSE
-            IF(IAL(JJ)==0) THEN
-             EVMA2(I,JJ) = MUTAB(JJ)
-             PUI22 = ONE
+!            
+            IF(EV(I,2)==ZERO) THEN
+              EVMA2(I,J) = ZERO
             ELSE
-             PUI22 = EXP(ALTAB(JJ)* LOG(EV(I,2)) )
-             EVMA2(I,JJ) = MUTAB(JJ) * PUI22
+              IF (AL(J) == ZERO) THEN
+                EVMA2(I,J) = MU(J)
+                PUI22 = ONE
+              ELSE
+                PUI22 = EXP(AL(J)* LOG(EV(I,2)) )
+                EVMA2(I,J) = MU(J) * PUI22
+              ENDIF
             ENDIF
-           ENDIF
-!           
-           IF((EV(I,1)*EV(I,2))==ZERO) THEN
-            EVMA12(I,JJ) = ZERO
-           ELSE
-            IF(IAL(JJ)==0) THEN
-             EVMA12(I,JJ) = MUTAB(JJ)
+!            
+            IF((EV(I,1)*EV(I,2))==ZERO) THEN
+              EVMA3(I,J) = ZERO
             ELSE
-             EVMA12(I,JJ) = MUTAB(JJ)/(PUI11*PUI22)
+              IF (AL(J) == ZERO) THEN
+                EVMA3(I,J) = MU(J)
+              ELSE
+                EVMA3(I,J) = MU(J)/(PUI11*PUI22)
+              ENDIF
             ENDIF
-           ENDIF
-        ENDDO   ! 1,NEL 
-       ENDDO      ! 1,5
+          ENDDO    ! 1,NEL 
+        ENDDO      ! 1,NORDER
 !       -----------------------
-       DO I=1,NEL
-          DWDL(1) = EVMA1(I,1)+EVMA1(I,2)+EVMA1(I,3)+EVMA1(I,4)+EVMA1(I,5)
-          DWDL(2) = EVMA2(I,1)+EVMA2(I,2)+EVMA2(I,3)+EVMA2(I,4)+EVMA2(I,5)
-          DWDL(3) = EVMA12(I,1)+EVMA12(I,2)+EVMA12(I,3)+EVMA12(I,4)+EVMA12(I,5)
+        DO I=1,NEL
+          DWDL(1) = ZERO          
+          DWDL(2) = ZERO          
+          DWDL(3) = ZERO          
+          DO J=1,NORDER                                                
+            DWDL(1) = DWDL(1) + EVMA1(I,J)        
+            DWDL(2) = DWDL(2) + EVMA2(I,J)        
+            DWDL(3) = DWDL(3) + EVMA3(I,J)
+          END DO        
 c---------
 c         principal cauchy stress
-          T(I,1)  =  DWDL(1) -  DWDL(3)                       
-          T(I,2)  =  DWDL(2) -  DWDL(3)                                     
-          T(I,3)  = ZERO            
-       ENDDO                                                     
+          T(I,1) = DWDL(1) - DWDL(3)                       
+          T(I,2) = DWDL(2) - DWDL(3)                                     
+          T(I,3) = ZERO            
+        ENDDO                                                     
 !       -----------------------
 !       compute rigidity
-       DO JJ = 1,5
-          ! CXX = 1/2 * MU * [1/2 * AL - 1] * EVX ** (AL - 4)
-          ! CXY = 1/2 * MU * [1/2 * AL + 1] * (EVX * EVY) **(-AL - 4)
-          ! AL - 4 = 0 --> CXX =  1/2 * MU * [1/2 * AL - 1]
-          !            --> CXY = 1/2 * MU * [1/2 * AL + 1] * (EVX * EVY) **(-8)
-          ! AL = 0     --> CXX =  1/2 * MU * [1/2 * AL - 1]* EVX ** (- 4)
-          !            --> CXY = 1/2 * MU * [1/2 * AL + 1] * (EVX * EVY) **(-4)
-          ! else       --> CXX =  1/2 * MU * [1/2 * AL - 1]* PUIXX / EVX**(4)
-          !                 with PUIXX = exp( AL * ln(EVX) )
-          !            --> CXY = 1/2 * MU * [1/2 * AL + 1] / ( PUIXX*PUIYY*(EVX**(4)*EVY**(4) )
-         DO I=1,NEL
-           IF((ALTAB(JJ)-FOUR)==0) THEN
-            C11(I,JJ) = HALF*MUTAB(JJ)*(HALF*ALTAB(JJ)-ONE)
-            C22(I,JJ) = HALF*MUTAB(JJ)*(HALF*ALTAB(JJ)-ONE)
-            C12(I,JJ) = HALF*MUTAB(JJ)*(HALF*ALTAB(JJ) + ONE) /
-     .                (EV(I,1)*EV(I,2))**(8)
-           ELSEIF(ALTAB(JJ)==0) THEN
-            C11(I,JJ) = HALF*MUTAB(JJ)*(HALF*ALTAB(JJ)-ONE) / 
-     .                EV(I,1)**(4)
-            C22(I,JJ) = HALF*MUTAB(JJ)*(HALF*ALTAB(JJ)-ONE) /
-     .                EV(I,2)**(4)
-     
-            C12(I,JJ) = HALF*MUTAB(JJ)*(HALF*ALTAB(JJ) + ONE) /
-     .                (EV(I,1)*EV(I,2))**(4)
-           ELSE
-            IF(EV(I,1)/=ZERO) THEN
-             PUI11 = EXP((ALTAB(JJ) )* LOG(EV(I,1)) )
-             C11(I,JJ) = HALF*MUTAB(JJ)*(HALF*ALTAB(JJ) - ONE)*PUI11 / 
-     .                 EV(I,1)**(4)
+        DO J = 1,NORDER
+           ! CXX = 1/2 * MU * [1/2 * AL - 1] * EVX ** (AL - 4)
+           ! CXY = 1/2 * MU * [1/2 * AL + 1] * (EVX * EVY) **(-AL - 4)
+           ! AL - 4 = 0 --> CXX =  1/2 * MU * [1/2 * AL - 1]
+           !            --> CXY = 1/2 * MU * [1/2 * AL + 1] * (EVX * EVY) **(-8)
+           ! AL = 0     --> CXX =  1/2 * MU * [1/2 * AL - 1]* EVX ** (- 4)
+           !            --> CXY = 1/2 * MU * [1/2 * AL + 1] * (EVX * EVY) **(-4)
+           ! else       --> CXX =  1/2 * MU * [1/2 * AL - 1]* PUIXX / EVX**(4)
+           !                 with PUIXX = exp( AL * ln(EVX) )
+           !            --> CXY = 1/2 * MU * [1/2 * AL + 1] / ( PUIXX*PUIYY*(EVX**(4)*EVY**(4) )
+          DO I=1,NEL
+            IF (AL(J) == FOUR) THEN
+              C11(I,J) = HALF*MU(J)*(HALF*AL(J)-ONE)
+              C22(I,J) = HALF*MU(J)*(HALF*AL(J)-ONE)
+              C12(I,J) = HALF*MU(J)*(HALF*AL(J) + ONE) / (EV(I,1)*EV(I,2))**(8)
+            ELSEIF (AL(J) == ZERO) THEN
+              C11(I,J) = HALF*MU(J)*(HALF*AL(J)-ONE)   /  EV(I,1)**(4)
+              C22(I,J) = HALF*MU(J)*(HALF*AL(J)-ONE)   /  EV(I,2)**(4)
+              C12(I,J) = HALF*MU(J)*(HALF*AL(J) + ONE) / (EV(I,1)*EV(I,2))**(4)
             ELSE
-             C11(I,JJ) = ZERO
-             PUI11 = ONE
-            ENDIF
-            IF(EV(I,2)/=ZERO) THEN
-             PUI22 = EXP((ALTAB(JJ))* LOG(EV(I,2)) )
-             C22(I,JJ) = HALF*MUTAB(JJ)*(HALF*ALTAB(JJ) - ONE)*PUI22 /
-     .                 EV(I,2)**(4)
-            ELSE
-             C22(I,JJ) = ZERO
-             PUI22 = ONE
-            ENDIF
-            IF(EV(I,1)*EV(I,2)/=ZERO) THEN
-             C12(I,JJ) = HALF*MUTAB(JJ)*(HALF*ALTAB(JJ) + ONE)       /
-     .                 ( (PUI11 * PUI22)*(EV(I,1)**4 * EV(I,2)**4) )
-            ELSE
-             C12(I,JJ) = ZERO
-            ENDIF
-           ENDIF     
-         ENDDO  ! 1,NEL
-       ENDDO    ! 1,5
+              IF(EV(I,1) /= ZERO) THEN
+                PUI11 = EXP((AL(J) )* LOG(EV(I,1)) )
+                C11(I,J) = HALF*MU(J)*(HALF*AL(J) - ONE)*PUI11 / EV(I,1)**(4)
+              ELSE
+                C11(I,J) = ZERO
+                PUI11 = ONE
+              ENDIF
+              IF(EV(I,2) /= ZERO) THEN
+                PUI22 = EXP((AL(J))* LOG(EV(I,2)) )
+                C22(I,J) = HALF*MU(J)*(HALF*AL(J) - ONE)*PUI22 / EV(I,2)**(4)
+              ELSE
+                C22(I,J) = ZERO
+                PUI22 = ONE
+              ENDIF
+              IF(EV(I,1)*EV(I,2) /= ZERO) THEN
+                C12(I,J) = HALF*MU(J)*(HALF*AL(J) + ONE)       /
+     .                   ( (PUI11 * PUI22)*(EV(I,1)**4 * EV(I,2)**4) )
+              ELSE
+                C12(I,J) = ZERO
+              ENDIF
+            ENDIF     
+          ENDDO  ! 1,NEL
+        ENDDO    ! 1,NORDER
 !       -----------------------             
-       DO I=1,NEL       
-          E11 = C11(I,1) + C11(I,2) + C11(I,3)+C11(I,4)+C11(I,5) + 
-     .          (C12(I,1) + C12(I,2) + C12(I,3)+C12(I,4)+C12(I,5))*EV(I,2)**4
-          E22 = C22(I,1) + C22(I,2) + C22(I,3)+C22(I,4)+C22(I,5) + 
-     .          (C12(I,1) + C12(I,2) + C12(I,3)+C12(I,4)+C12(I,5))*EV(I,1)**4
-          EA(I) = MAX(E11,E22)  
-          
-C        
+        DO I=1,NEL
+          E11 = ZERO
+          E22 = ZERO
+          E12 = ZERO
+          DO J=1,NORDER
+            E11 = E11 + C11(I,J)
+            E22 = E22 + C22(I,J)
+            E12 = E12 + C12(I,J)
+          END DO
+          E11 = E11 + E12 * EV(I,2)**4
+          E22 = E22 + E12 * EV(I,1)**4
+          EA(I) = MAX(E11,E22)
           SV(I,1) = ZERO
           SV(I,2) = ZERO
           SV(I,3) = ZERO
-       ENDDO  ! 1,NEL
+        ENDDO  ! 1,NEL
 !       -----------------------
-      ENDIF                                                                              
+      ENDIF ! PRONY                                                                             
 C-------------------------------------------------------------
-C--------------------------------------
 c     tension cut                                                            
       DO I=1,NEL                                                             
         IF (OFF(I) /= ZERO .AND.                                             
@@ -548,7 +537,7 @@ c     tension cut
       ENDDO                                                                  
 C-------------------------------------------------------------
 C     transform principal Cauchy stress to global directions
-      
+C-------------------------------------------------------------      
       IF (ISMSTR == 1 .OR. ISMSTR == 3 .OR. ISMSTR == 11) THEN  ! engineering strain
         DO I=1,NEL
           EPSZZ(I)  = EV(I,3) - ONE
@@ -556,12 +545,12 @@ C     transform principal Cauchy stress to global directions
         ENDDO
       ELSEIF (ISMSTR == 10) THEN  ! left gauchy-green strain
         DO I=1,NEL
-          EPSZZ(I) =EV(I,3) - ONE
+          EPSZZ(I)  = EV(I,3) - ONE
           UVAR(I,3) = EV(I,3)
         ENDDO
       ELSE  ! true strain
         DO I=1,NEL
-          EPSZZ(I) =LOG(EV(I,3))
+          EPSZZ(I)  = LOG(EV(I,3))
           UVAR(I,3) = EV(I,3)
         ENDDO
       ENDIF
@@ -574,16 +563,15 @@ c
           INVRV(I) = ZERO
         ENDIF
 c
-        DEZZ(I) =-NU/(ONE-NU)*(DEPSXX(I)+DEPSYY(I))
+        DEZZ(I) = -NU/(ONE-NU)*(DEPSXX(I)+DEPSYY(I))
 !!        DEZZ(I) = EPSZZ(I) - UVAR(I,4)
         SIGNXX(I) = EIGV(I,1,1)*T(I,1) + EIGV(I,1,2)*T(I,2) + SV(I,1)*INVRV(I)
         SIGNYY(I) = EIGV(I,2,1)*T(I,1) + EIGV(I,2,2)*T(I,2) + SV(I,2)*INVRV(I)
         SIGNXY(I) = EIGV(I,3,1)*T(I,1) + EIGV(I,3,2)*T(I,2) + SV(I,3)*INVRV(I)
-        SIGNYZ(I) = SIGOYZ(I)+GS(I)*DEPSYZ(I)
-        SIGNZX(I) = SIGOZX(I)+GS(I)*DEPSZX(I)
+        SIGNYZ(I) = SIGNYZ(I)+GS(I)*DEPSYZ(I)
+        SIGNZX(I) = SIGNZX(I)+GS(I)*DEPSZX(I)
         RHO(I)    = RHO0(I)*INVRV(I)
         THKN(I)   = THKN(I) + DEZZ(I)*THKLYL(I)*OFF(I)
-        VISCMAX(I)= ZERO
         UVAR(I,4) = EPSZZ(I)  
 C         
         EMAX = GMAX*(ONE + NU)
@@ -594,3 +582,5 @@ C
 C-----------
       RETURN
       END
+
+      end module sigeps42c_mod

--- a/engine/source/materials/mat_share/mulaw.F90
+++ b/engine/source/materials/mat_share/mulaw.F90
@@ -420,7 +420,7 @@
           integer :: nuvarr
 
           integer nv46, numel, inloc
-          integer i,npar,nparf,iadbuf,iadvis,nfunc,numtabl,israte,ipg,nptr,npts,&
+          integer i,npar,nparf,nuparam0,nuparam,niparam,iadbuf,iadvis,nfunc,numtabl,israte,ipg,nptr,npts,&
           &ibid,ibidon1,ibidon2,ibidon3,ibidon4 ,n48,nix,ilaw_user,igtyp,&
           &nvarf,ir,irupt,imat,isvis,ivisc,nuvarv,nuparv,iseq,idev,ntabl_fail,&
           &l_planl,l_epsdnl,l_dmg
@@ -451,7 +451,7 @@
           my_real tt_local
           my_real, dimension(nel), target  :: le_max
 !----
-          my_real, dimension(:), pointer   :: uparam,uparf,uparvis,uvarf,dfmax,&
+          my_real, dimension(:), pointer   :: uparam0,uparam,uparf,uparvis,uvarf,dfmax,&
           &tdel,el_temp,yldfac,dam,el_len,&
           &el_pla,damini
           my_real, dimension(:), allocatable ,target  :: bufzero
@@ -461,7 +461,7 @@
           type(matparam_struct_) , pointer :: matparam
           logical :: logical_userl_avail
           my_real :: user_uelr(mvsiz)
-          integer, dimension(:) ,pointer   :: fld_idx,foff,ifunc,itable,itabl_fail,iparf
+          integer, dimension(:) ,pointer   :: fld_idx,foff,ifunc,itable,itabl_fail,iparf,iparam
           integer                          :: mat_comp,mat_smstr,mat_formu
           integer                          :: dmg_flag,lf_dammx,niparf
 !
@@ -512,10 +512,14 @@
           iadbuf = ipm(7,imat)
           nfunc  = ipm(10,imat)
           numtabl= ipm(226,imat)
-          uparam => bufmat(iadbuf:iadbuf+npar-1)
+          uparam0=> bufmat(iadbuf:iadbuf+npar-1)
           ifunc  => ipm(10+1:10+nfunc,imat)
           itable => ipm(226+1:226+numtabl,imat)
           matparam => mat_elem%mat_param(imat)
+          nuparam  =  mat_elem%mat_param(imat)%nuparam
+          niparam  =  mat_elem%mat_param(imat)%niparam
+          uparam   => mat_elem%mat_param(imat)%uparam
+          iparam   => mat_elem%mat_param(imat)%iparam
           nuvarr = ipm(221,imat)
           !==================================================
           ! recovering data from matparam data structure
@@ -982,7 +986,7 @@
             &ipm ,mat ,amu )
           elseif (mtn == 33) then
             call sigeps33(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,&
+            &npf ,tf  ,tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,&
             &ep1 ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
@@ -993,7 +997,7 @@
             &ssp ,vis ,uvar,off  )
           elseif (mtn == 34) then
             call sigeps34(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,&
+            &npf ,tf  ,tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,&
             &ep1 ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
@@ -1004,7 +1008,7 @@
             &ssp ,vis ,uvar,off  )
           elseif (mtn == 35) then
             call sigeps35(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,&
+            &npf ,tf  ,tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,&
             &ep1 ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
@@ -1019,8 +1023,8 @@
             call mstrain_rate(nel    ,israte ,asrate ,epsd   ,idev   ,&
             &ep1    ,ep2    ,ep3    ,ep4    ,ep5    ,ep6)
 !
-            nrate = nint(uparam(1))
-            fisokin = uparam(6+2*nrate+8)
+            nrate = nint(uparam0(1))
+            fisokin = uparam0(6+2*nrate+8)
             if(fisokin>0) then
               sigbxx => lbuf%sigb(1      :  nel)
               sigbyy => lbuf%sigb(nel+1  :2*nel)
@@ -1038,7 +1042,7 @@
               sigbzx => vecnul(1:nel)
             endif
             call sigeps36(nel    ,nuvar  ,nfunc  ,ifunc  ,npf ,&
-            &tf     ,tt     ,dt1    ,uparam ,rho0,&
+            &tf     ,tt     ,dt1    ,uparam0 ,rho0,&
             &de1    ,de2    ,de3    ,de4    ,de5    ,de6   ,&
             &es1    ,es2    ,es3    ,es4    ,es5    ,es6   ,&
             &so1    ,so2    ,so3    ,so4    ,so5    ,so6   ,&
@@ -1058,7 +1062,7 @@
               nix = nixq
             endif
             call sigeps37(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,&
+            &npf ,tf  ,tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,&
             &ep1 ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
@@ -1070,7 +1074,7 @@
             &nft)
           elseif (mtn == 38) then
             call sigeps38(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,&
+            &npf ,tf  ,tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,&
             &ep1 ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
@@ -1084,7 +1088,7 @@
             &ihet ,gbuf%off,epsd )
           elseif (mtn == 40) then
             call sigeps40(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,&
+            &npf ,tf  ,tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,&
             &ep1 ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
@@ -1095,7 +1099,7 @@
             &ssp ,vis ,uvar,off  )
           elseif (mtn == 41) then
             call sigeps41(nel ,npar,nuvar,&
-            &tt,dt1,uparam,&
+            &tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,&
             &so1 ,so2 ,so3 ,&
             &s1  ,s2  ,s3  ,s4   ,s5   ,s6  ,&
@@ -1104,19 +1108,19 @@
             &lbuf%temp)
           elseif (mtn == 42) then
             call sigeps42(&
-            &nel     ,npar    ,nuvar   ,nfunc   ,ifunc   ,npf     ,&
-            &tf      ,tt      ,dt1     ,uparam,rho0,rho   ,&
+            &nel     ,nuparam ,nuvar   ,nfunc   ,ifunc   ,npf     ,&
+            &tf      ,tt      ,dt1     ,uparam  ,rho0    ,rho     ,&
             &voln    ,eint    ,uvar    ,off     ,gbuf%off,ssp     ,&
             &ep1     ,ep2     ,ep3     ,ep4     ,ep5     ,ep6     ,&
             &es1     ,es2     ,es3     ,es4     ,es5     ,es6     ,&
             &s1      ,s2      ,s3      ,s4      ,s5      ,s6      ,&
             &mfxx    ,mfxy    ,mfxz    ,mfyx    ,mfyy    ,mfyz    ,&
             &mfzx    ,mfzy    ,mfzz    ,vis     ,ismstr  ,et      ,&
-            &ihet    ,epsth3  ,iexpan  )
+            &ihet    ,epsth3  ,iexpan  ,niparam ,iparam  )
 !
           elseif (mtn == 44) then
             call sigeps44(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,rho0,rho ,&
+            &npf ,tf  ,tt,dt1,uparam0,rho0,rho ,&
             &voln,eint,matparam%ieos,dpdm   ,&
             &ep1 ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
@@ -1130,7 +1134,7 @@
             &vartmp,et    )
           elseif (mtn == 45) then
             call sigeps45(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,&
+            &npf ,tf  ,tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,&
             &ep1 ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
@@ -1159,7 +1163,7 @@
             &amu )
           elseif (mtn == 50) then
             call sigeps50(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,&
+            &npf ,tf  ,tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,nvartmp ,vartmp  ,&
             &ep1 ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
@@ -1183,7 +1187,7 @@
             !numerical viscosity is managed inside sigeps51.f
             !facq0 = zero
             call sigeps51(nel       ,npar        ,nuvar   ,nfunc ,ifunc     ,&
-            &npf       ,tf          ,tt      ,dt1   ,uparam    ,numel     ,&
+            &npf       ,tf          ,tt      ,dt1   ,uparam0    ,numel     ,&
             &rho       ,vol         ,eint    ,vk    ,&
             &ep1       ,ep2         ,ep3     ,ep4   ,ep5       ,ep6       ,&
             &de1       ,de2         ,de3     ,de4   ,de5       ,de6       ,&
@@ -1262,7 +1266,7 @@
             &dpla ,amu )
           elseif (mtn == 62) then
             call sigeps62(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,&
+            &npf ,tf  ,tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,&
             &ep1 ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
@@ -1320,7 +1324,7 @@
             &amu )
           elseif (mtn == 67) then
             call sigeps67(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,&
+            &npf ,tf  ,tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,&
             &ep1 ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
@@ -1355,7 +1359,7 @@
             end if
 
             call sigeps69(nel  ,npar,nuvar,nfunc,ifunc,npf  ,&
-            &tf   ,tt,dt1,uparam,rho0 ,rho  ,&
+            &tf   ,tt,dt1,uparam0,rho0 ,rho  ,&
             &voln ,eint,ivisc,nuparv,uparvis ,&
             &ep1  ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1  ,de2 ,de3 ,de4  ,de5  ,de6 ,&
@@ -1398,7 +1402,7 @@
 !
           elseif (mtn == 71) then
             call sigeps71(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,&
+            &npf ,tf  ,tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,&
             &ep1 ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
@@ -1410,7 +1414,7 @@
             &mat ,jthe,tempel,ismstr,et)!,et
           elseif (mtn == 72) then
             call sigeps72(nel      ,npar     ,nuvar    ,&
-            &tt       ,dt1      ,uparam   ,rho0     ,rho      ,&
+            &tt       ,dt1      ,uparam0   ,rho0     ,rho      ,&
             &de1      ,de2      ,de3      ,de4      ,de5      ,de6      ,&
             &so1      ,so2      ,so3      ,so4      ,so5      ,so6      ,&
             &s1       ,s2       ,s3       ,s4       ,s5       ,s6       ,&
@@ -1437,7 +1441,7 @@
 !
           elseif (mtn == 75) then
             call sigeps75(nel     ,npar   ,nuvar ,nfunc ,ifunc ,&
-            &npf     ,tf     ,tt    ,dt1   ,uparam,&
+            &npf     ,tf     ,tt    ,dt1   ,uparam0,&
             &rho0    ,rho    ,voln  ,eint  ,muold ,&
             &ep1     ,ep2    ,ep3   ,ep4   ,ep5   ,ep6 ,&
             &de1     ,de2    ,de3   ,de4   ,de5   ,de6 ,&
@@ -1451,7 +1455,7 @@
 !
           elseif (mtn == 76) then
             call sigeps76(nel      ,npar     ,nuvar    ,nfunc    ,ifunc    ,ngl       ,&
-            &npf      ,tf       ,tt       ,dt1      ,uparam   ,matparam  ,&
+            &npf      ,tf       ,tt       ,dt1      ,uparam0   ,matparam  ,&
             &rho0     ,dpla     ,et       ,ssp      ,sigy     ,uvar      ,&
             &de1      ,de2      ,de3      ,de4      ,de5      ,de6       ,&
             &so1      ,so2      ,so3      ,so4      ,so5      ,so6       ,&
@@ -1461,7 +1465,7 @@
 !
           elseif (mtn == 78) then
             call sigeps78(nel ,npar,nuvar,nfunc,ifunc,npf ,&
-            &tf  ,tt,dt1,uparam,rho0,rho ,&
+            &tf  ,tt,dt1,uparam0,rho0,rho ,&
             &lbuf%siga,lbuf%sigb,lbuf%sigc,uvar,defp,dpla,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
             &so1 ,so2 ,so3 ,so4  ,so5  ,so6 ,&
@@ -1473,7 +1477,7 @@
             &ep1    ,ep2    ,ep3    ,ep4    ,ep5    ,ep6)
 !
             call sigeps77(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,&
+            &npf ,tf  ,tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,&
             &ep1 ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
@@ -1490,7 +1494,7 @@
             &ep1    ,ep2    ,ep3    ,ep4    ,ep5    ,ep6)
 !
             call sigeps79(&
-            &nel      ,npar     ,nuvar    ,tt       ,dt1      ,uparam   ,&
+            &nel      ,npar     ,nuvar    ,tt       ,dt1      ,uparam0   ,&
             &rho0     ,rho      ,ngl      ,sigy     ,dpla     ,defp     ,&
             &de1      ,de2      ,de3      ,de4      ,de5      ,de6      ,&
             &so1      ,so2      ,so3      ,so4      ,so5      ,so6      ,&
@@ -1502,7 +1506,7 @@
             call sigeps80(&
             &nel,     npar,    nuvar,   nfunc,&
             &ifunc,   npf,     tf,      tt,&
-            &dt1,     uparam,  rho0,    rho,&
+            &dt1,     uparam0,  rho0,    rho,&
             &voln,    eint,    ep1,     ep2,&
             &ep3,     ep4,     ep5,     ep6,&
             &de1,     de2,     de3,     de4,&
@@ -1525,7 +1529,7 @@
 
           elseif (mtn == 81) then
             call sigeps81(nel   ,npar ,nuvar,nfunc ,ifunc ,ngl   ,&
-            &npf   ,tf   ,tt   ,uparam,rho0  ,rho   ,&
+            &npf   ,tf   ,tt   ,uparam0,rho0  ,rho   ,&
             &voln  ,amu  ,defp ,ssp   ,vis   ,uvar  ,&
             &ep1   ,ep2  ,ep3  ,ep4   ,ep5   ,ep6   ,&
             &de1   ,de2  ,de3  ,de4   ,de5   ,de6   ,&
@@ -1537,7 +1541,7 @@
 
           elseif (mtn == 82) then
             call sigeps82(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,&
+            &npf ,tf  ,tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,ngl,&
             &ep1 ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
@@ -1553,7 +1557,7 @@
             call sigeps84(&
             &nel,     npar,    nuvar,   nfunc,&
             &ifunc,   npf,     tf,      tt,&
-            &dt1,     uparam,  rho0,    rho,&
+            &dt1,     uparam0,  rho0,    rho,&
             &voln,    eint,    tempel,  ngl,&
             &ep1,     ep2,     ep3,     ep4,&
             &ep5,     ep6,     de1,     de2,&
@@ -1569,7 +1573,7 @@
             &ipm,     mat,     jthe)
           elseif (mtn == 88) then
             call sigeps88(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,&
+            &npf ,tf  ,tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,ngl,&
             &ep1 ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
@@ -1586,7 +1590,7 @@
 !     visco-hypereslatic law defined by stress strain curve
 !-------------------
             call sigeps90(nel ,nuvar,nfunc,ifunc,npf ,&
-            &tf  ,tt,uparam,rho0,&
+            &tf  ,tt,uparam0,rho0,&
             &ep1 ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &es1 ,es2 ,es3 ,es4  ,es5  ,es6 ,&
             &s1  ,s2  ,s3  ,s4   ,s5   ,s6  ,&
@@ -1595,7 +1599,7 @@
 !
           elseif (mtn == 92) then
             call sigeps92(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,&
+            &npf ,tf  ,tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,ngl,&
             &ep1 ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
@@ -1607,7 +1611,7 @@
             &ihet,gbuf%off ,epsth3,iexpan, lbuf%epsa)
           elseif (mtn == 94) then
             call sigeps94(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,&
+            &npf ,tf  ,tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,ngl,&
             &ep1 ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
@@ -1619,7 +1623,7 @@
             &ihet,gbuf%off,epsth3,iexpan )
           elseif (mtn == 93) then
             call sigeps93(nel    ,npar   ,nuvar  ,nfunc  ,ifunc  ,&
-            &npf    ,tf     ,tt     ,dt1    ,uparam ,&
+            &npf    ,tf     ,tt     ,dt1    ,uparam0 ,&
             &ep1    ,ep2    ,ep3    ,ep4    ,ep5    ,ep6    ,&
             &de1    ,de2    ,de3    ,de4    ,de5    ,de6    ,&
             &so1    ,so2    ,so3    ,so4    ,so5    ,so6    ,&
@@ -1641,7 +1645,7 @@
               uparf => vec0
             endif
             call sigeps95(nel  ,npar ,nuvar,nfunc,ifunc,&
-            &npf  ,tf   ,tt   ,dt1  ,uparam,&
+            &npf  ,tf   ,tt   ,dt1  ,uparam0,&
             &rho0 ,rho  ,voln ,eint ,ngl,&
             &ep1  ,ep2  ,ep3  ,ep4  ,ep5  ,ep6 ,&
             &de1  ,de2  ,de3  ,de4  ,de5  ,de6 ,&
@@ -1659,7 +1663,7 @@
           elseif (mtn == 96) then
             call sigeps96(&
             &nel     ,ngl     ,npar    ,nuvar    ,nfunc   ,ifunc   ,&
-            &npf     ,tf      ,uparam,uvar,jthe   ,&
+            &npf     ,tf      ,uparam0,uvar,jthe   ,&
             &rho     ,tempel  ,defp    ,ssp      ,gbuf%off,epsd    ,&
             &ep1     ,ep2     ,ep3     ,ep4      ,ep5     ,ep6     ,&
             &de1     ,de2     ,de3     ,de4      ,de5     ,de6     ,&
@@ -1675,7 +1679,7 @@
               nix = nixq
             endif
             call sigeps97(nel       ,npar   ,nuvar    ,nfunc  ,ifunc     ,lbuf%tb   ,&
-            &npf       ,tf     ,tt       ,dt1    ,uparam    ,lbuf%bfrac,&
+            &npf       ,tf     ,tt       ,dt1    ,uparam0    ,lbuf%bfrac,&
             &rho0      ,rho    ,vol      ,eint   ,sigy      ,deltax    ,&
             &ep1       ,ep2    ,ep3      ,ep4    ,ep5       ,ep6       ,&
             &de1       ,de2    ,de3      ,de4    ,de5       ,de6       ,&
@@ -1705,7 +1709,7 @@
             endif
 !
             call sigeps100(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,&
+            &npf ,tf  ,tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,ngl,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
             &es1 ,es2 ,es3 ,es4  ,es5  ,es6 ,&
@@ -1761,7 +1765,7 @@
             &upsxx  ,upsyy    , upszz  , upsxy  , upsyz  ,&
             &upsxz  )
             call sigeps101(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,&
+            &npf ,tf  ,tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,ngl,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
             &es1 ,es2 ,es3 ,es4  ,es5  ,es6 ,&
@@ -1777,7 +1781,7 @@
 
           elseif (mtn == 102) then
 
-            call sigeps102(nel    ,npar    ,nuvar  ,uparam , rho0     ,rho    ,&
+            call sigeps102(nel    ,npar    ,nuvar  ,uparam0 , rho0     ,rho    ,&
             &de1    ,de2     ,de3    ,de4    , de5      ,de6    ,&
             &so1    ,so2     ,so3    ,so4    , so5      ,so6    ,&
             &s1     ,s2      ,s3     ,s4     , s5       ,s6     ,&
@@ -1791,7 +1795,7 @@
             &ep1    ,ep2    ,ep3    ,ep4    ,ep5    ,ep6)
 !
             call sigeps103(nel    ,npar     ,nuvar  ,nfunc  , ifunc         ,&
-            &npf    ,tf       ,tt     ,dt1    , uparam,&
+            &npf    ,tf       ,tt     ,dt1    , uparam0,&
             &rho0   ,rho      ,voln   ,eint   ,&
             &de1    ,de2      ,de3    ,de4    , de5           ,de6  ,&
             &es1    ,es2      ,es3    ,es4    , es5           ,es6  ,&
@@ -1805,7 +1809,7 @@
           elseif (mtn == 104) then
 !
             call sigeps104(nel    ,ngl    ,npar   ,nuvar  ,npg    ,gbuf%uelr,&
-            &tt     ,dt1    ,uparam ,uvar   ,jthe   ,lbuf%off,&
+            &tt     ,dt1    ,uparam0 ,uvar   ,jthe   ,lbuf%off,&
             &rho0   ,rho    ,defp   ,dpla   ,epsd   ,ssp    ,&
             &de1    ,de2    ,de3    ,de4    ,de5    ,de6    ,&
             &so1    ,so2    ,so3    ,so4    ,so5    ,so6    ,&
@@ -1823,7 +1827,7 @@
               nix = nixq
             endif
             call sigeps105(nel       ,npar   ,nuvar    ,nfunc      ,ifunc           ,lbuf%tb   ,&
-            &npf       ,tf     ,tt       ,dt1        ,uparam  ,lbuf%bfrac,&
+            &npf       ,tf     ,tt       ,dt1        ,uparam0  ,lbuf%bfrac,&
             &rho0      ,rho    ,vol      ,eint       ,sigy            ,deltax    ,&
             &ep1       ,ep2    ,ep3      ,ep4        ,ep5             ,ep6       ,&
             &de1       ,de2    ,de3      ,de4        ,de5             ,de6       ,&
@@ -1844,7 +1848,7 @@
             &ep1    ,ep2    ,ep3    ,ep4    ,ep5    ,ep6)
 !
             call sigeps106(nel    ,npar     ,nuvar  ,nfunc  , ifunc         ,&
-            &npf    ,tf       ,tt     ,dt1    , uparam,&
+            &npf    ,tf       ,tt     ,dt1    , uparam0,&
             &rho0   ,rho      ,voln   ,eint   ,&
             &de1    ,de2      ,de3    ,de4    , de5           ,de6  ,&
             &es1    ,es2      ,es3    ,es4    , es5           ,es6  ,&
@@ -1857,7 +1861,7 @@
           elseif (mtn == 107) then
 !
             call sigeps107(nel    ,ngl    ,npar   ,nuvar  ,tt     ,dt1    ,&
-            &uparam ,uvar   ,jthe   ,off    ,rho0   ,rho    ,&
+            &uparam0 ,uvar   ,jthe   ,off    ,rho0   ,rho    ,&
             &lbuf%pla,dpla  ,lbuf%epsd,ssp    ,&
             &de1    ,de2    ,de3    ,de4    ,de5    ,de6    ,&
             &so1    ,so2    ,so3    ,so4    ,so5    ,so6    ,&
@@ -1868,7 +1872,7 @@
           elseif (mtn == 109) then
             call sigeps109(&
             &nel      ,ngl     ,npar     ,nuvar    ,nvartmp  ,numtabl  ,&
-            &uparam   ,uvar    ,vartmp   ,itable   ,table    ,jthe     ,&
+            &uparam0   ,uvar    ,vartmp   ,itable   ,table    ,jthe     ,&
             &tt       ,dt1     ,off      ,rho0     ,lbuf%pla ,dpla     ,&
             &ssp      ,sigy    ,et       ,el_temp  ,epsd     ,dpdm     ,&
             &de1      ,de2     ,de3      ,de4      ,de5      ,de6      ,&
@@ -1878,7 +1882,7 @@
 !
           elseif (mtn == 111) then
             call sigeps111(nel ,npar,nuvar,nfunc,ifunc,&
-            &npf ,tf  ,tt,dt1,uparam,&
+            &npf ,tf  ,tt,dt1,uparam0,&
             &rho0,rho ,voln,eint,ngl,&
             &ep1 ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1 ,de2 ,de3 ,de4  ,de5  ,de6 ,&
@@ -1894,7 +1898,7 @@
           elseif (mtn == 112) then
 !
             call sigeps112(nel    ,ngl    ,npar   ,nuvar  ,tt     ,dt1    ,&
-            &uparam ,uvar   ,jthe   ,off    ,rho0   ,rho    ,&
+            &uparam0 ,uvar   ,jthe   ,off    ,rho0   ,rho    ,&
             &lbuf%pla,dpla  ,lbuf%epsd      ,ssp    ,es3    ,&
             &de1    ,de2    ,de3    ,de4    ,de5    ,de6    ,&
             &so1    ,so2    ,so3    ,so4    ,so5    ,so6    ,&
@@ -1905,7 +1909,7 @@
           elseif (mtn == 115) then
 !
             call sigeps115(nel    ,ngl    ,npar   ,nuvar  ,gbuf%rho,&
-            &tt     ,dt1    ,uparam ,uvar   ,off    ,sigy   ,&
+            &tt     ,dt1    ,uparam0 ,uvar   ,off    ,sigy   ,&
             &rho0   ,defp   ,dpla   ,ssp    ,et     ,lbuf%seq,&
             &de1    ,de2    ,de3    ,de4    ,de5    ,de6    ,&
             &so1    ,so2    ,so3    ,so4    ,so5    ,so6    ,&
@@ -1916,7 +1920,7 @@
 
             call sigeps120(nel    ,npar   ,nuvar  ,nvartmp,numtabl,itable ,&
             &table  ,tt     ,dt1    ,ssp    ,uvar   ,vartmp ,&
-            &uparam ,ngl    ,off    ,defp   ,epsd   ,tempel ,&
+            &uparam0 ,ngl    ,off    ,defp   ,epsd   ,tempel ,&
             &ep1    ,ep2    ,ep3    ,ep4    ,ep5    ,ep6    ,&
             &de1    ,de2    ,de3    ,de4    ,de5    ,de6    ,&
             &so1    ,so2    ,so3    ,so4    ,so5    ,so6    ,&
@@ -1926,7 +1930,7 @@
           elseif (mtn == 121) then
 !
             call sigeps121(nel    ,ngl    ,npar   ,nuvar  ,nfunc  ,ifunc  ,&
-            &npf    ,tf     ,dt1    ,tt     ,uparam ,uvar   ,&
+            &npf    ,tf     ,dt1    ,tt     ,uparam0 ,uvar   ,&
             &rho    ,defp   ,dpla   ,ssp    ,epsd   ,off    ,&
             &lbuf%off,&
             &de1    ,de2    ,de3    ,de4    ,de5    ,de6    ,&
@@ -1942,7 +1946,7 @@
             call mstrain_rate(nel    ,israte ,asrate ,epsd   ,idev   ,&
             &ep1    ,ep2    ,ep3    ,ep4    ,ep5    ,ep6)
 !
-            call sigeps122(nel    ,npar   ,nuvar  ,uparam ,uvar   ,rho0   ,&
+            call sigeps122(nel    ,npar   ,nuvar  ,uparam0 ,uvar   ,rho0   ,&
             &es1    ,es2    ,es3    ,defp   ,dpla   ,&
             &de1    ,de2    ,de3    ,de4    ,de5    ,de6    ,&
             &so2    ,so3    ,so4    ,so5    ,so6    ,&
@@ -1957,7 +1961,7 @@
             call mstrain_rate(nel    ,israte ,asrate ,epsd   ,idev   ,&
             &ep1    ,ep2    ,ep3    ,ep4    ,ep5    ,ep6)
             call sigeps124(nel    ,ngl    ,npar   ,nuvar  ,dt1    ,tt     ,&
-            &uparam ,uvar   ,rho    ,defp   ,dpla   ,&
+            &uparam0 ,uvar   ,rho    ,defp   ,dpla   ,&
             &ssp    ,epsd   ,off    ,lbuf%off,ipg   ,npg    ,&
             &de1    ,de2    ,de3    ,de4    ,de5    ,de6    ,&
             &es1    ,es2    ,es3    ,es4    ,es5    ,es6    ,&
@@ -1979,7 +1983,7 @@
 !
           elseif (mtn == 187) then !barlat 2000
             call sigeps187(nel   ,npar  ,nuvar ,nfunc ,ifunc ,&
-            &npf   ,tf    ,tt    ,dt1   ,uparam,&
+            &npf   ,tf    ,tt    ,dt1   ,uparam0,&
             &rho0  ,rho   ,voln  ,eint  ,tempel,ngl   ,&
             &ep1   ,ep2   ,ep3   ,ep4   ,ep5   ,ep6   ,&
             &de1   ,de2   ,de3   ,de4   ,de5   ,de6   ,&

--- a/engine/source/materials/mat_share/mulaw8.F
+++ b/engine/source/materials/mat_share/mulaw8.F
@@ -156,7 +156,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER NPAR,IADBUF,NFUNC,I,J,IPT,JPT,IR,ISRATE,
+      INTEGER NPAR,NUPARAM,NIPARAM,IADBUF,NFUNC,I,J,IPT,JPT,IR,ISRATE,
      .  IFUNC(MAXFUNC),IDUM1,IRUPT,IMAT,NTABL_FAIL,
      .  NVARF, IEXPAN8,JJ(6),INLOC,IEOS,DMG_FLAG
       my_real 
@@ -179,9 +179,9 @@ C-----------------------------------------------
      .   SS5,SS6,Q1,Q2,Q3,ASRATE,EPSP,
      .   BID,DUM1,BIDON,BIDON1,BIDON2,BIDON3,BIDON4,BIDON5
       my_real TT_LOCAL     
-      my_real,
-     .  DIMENSION(:)  ,POINTER :: SIGP,SIGLP,STRAIN,UVAR,UVARF,DFMAX,TDELE,UPARAM,UPARAMF
-      INTEGER, DIMENSION(:), POINTER :: VARTMP,ITABL_FAIL
+      my_real, DIMENSION(:), POINTER :: SIGP,SIGLP,STRAIN,UVAR,UVARF,DFMAX,TDELE
+      my_real, DIMENSION(:), POINTER :: UPARAM0,UPARAM,UPARAMF
+      INTEGER, DIMENSION(:), POINTER :: VARTMP,ITABL_FAIL,IPARAM
       TYPE(L_BUFEL_)  ,POINTER :: LBUF
 !
       CHARACTER OPTION*256
@@ -191,15 +191,19 @@ C-----------------------------------------------
       my_real, DIMENSION(NEL), TARGET :: VECNUL
       my_real, DIMENSION(:), POINTER  :: SIGBXX,SIGBYY,SIGBZZ,SIGBXY,SIGBYZ,SIGBZX
 C=======================================================================
-      IMAT = MAT(LFT)
-      INLOC  = MAT_PARAM(IMAT)%NLOC
-      IEOS   = MAT_PARAM(IMAT)%IEOS
-      NPAR   = IPM(9,IMAT)
-      IADBUF = IPM(7,IMAT)
-      NFUNC  = IPM(10,IMAT)
-      NUVAR  = BUFLY%NVAR_MAT
-      NVARTMP= BUFLY%NVARTMP
-      UPARAM => BUFMAT(IADBUF:IADBUF+NPAR)
+      IMAT    = MAT(LFT)
+      IADBUF  =  IPM(7,IMAT)
+      INLOC   =  MAT_PARAM(IMAT)%NLOC
+      IEOS    =  MAT_PARAM(IMAT)%IEOS
+      NUPARAM =  MAT_PARAM(IMAT)%NUPARAM
+      NIPARAM =  MAT_PARAM(IMAT)%NIPARAM
+      IPARAM  => MAT_PARAM(IMAT)%IPARAM
+      UPARAM  => MAT_PARAM(IMAT)%UPARAM
+      NPAR    =  IPM(9,IMAT)
+      UPARAM0 => BUFMAT(IADBUF:IADBUF+NPAR)
+      NFUNC   =  IPM(10,IMAT)
+      NUVAR   =  BUFLY%NVAR_MAT
+      NVARTMP =  BUFLY%NVARTMP
       DMG_FLAG = BUFLY%L_DMGSCL
 C
       DO J=1,6
@@ -563,8 +567,8 @@ C-------------------
           ENDIF
         ENDDO
 
-        NRATE = NINT(UPARAM(1))
-        FISOKIN = UPARAM(6+2*NRATE+8)
+        NRATE = NINT(UPARAM0(1))
+        FISOKIN = UPARAM0(6+2*NRATE+8)
         IF(FISOKIN>0) THEN
           SIGBXX => LBUF%SIGB(1      :  NEL) 
           SIGBYY => LBUF%SIGB(NEL+1  :2*NEL)
@@ -584,7 +588,7 @@ C-------------------
 
         CALL SIGEPS36(
      2    LLT      ,NUVAR    ,NFUNC    ,IFUNC    ,NPF ,
-     3    TF       ,TT       ,DT1      ,UPARAM   ,RHO0,
+     3    TF       ,TT       ,DT1      ,UPARAM0   ,RHO0,
      5    DE1      ,DE2      ,DE3      ,DE4      ,DE5      ,DE6   ,
      6    ES1      ,ES2      ,ES3      ,ES4      ,ES5      ,ES6   ,
      7    SO1      ,SO2      ,SO3      ,SO4      ,SO5      ,SO6   ,
@@ -636,7 +640,7 @@ c
      .    LBUF%TEMP)
       ELSEIF(MTN == 42)THEN
         CALL SIGEPS42(
-     1       LLT     ,NPAR    ,NUVAR   ,NFUNC   ,IFUNC   ,NPF     ,
+     1       LLT     ,NUPARAM ,NUVAR   ,NFUNC   ,IFUNC   ,NPF     ,
      2       TF      ,TT      ,DT1     ,BUFMAT(IADBUF),RHO0,RHO   ,
      3       VOLN    ,EINT    ,UVAR    ,OFF     ,OFFG    ,SSPP    ,
      4       EP1     ,EP2     ,EP3     ,EP4     ,EP5     ,EP6     ,
@@ -644,7 +648,7 @@ c
      6       S1      ,S2      ,S3      ,S4      ,S5      ,S6      ,
      7       BIDON   ,BIDON   ,BIDON   ,BIDON   ,BIDON   ,BIDON   ,
      8       BIDON   ,BIDON   ,BIDON   ,VIS     ,ISMSTR  ,ET      ,
-     9       IHET    ,BIDON   ,IEXPAN8 )
+     9       IHET    ,BIDON   ,IEXPAN8 ,NIPARAM ,IPARAM  )
 c
       ELSEIF(MTN == 44)THEN
 C
@@ -667,7 +671,7 @@ C
 !         ENDDO
         CALL SIGEPS44(
      2    LLT      ,NPAR     ,NUVAR    ,NFUNC    ,IFUNC    ,NPF      ,
-     3    TF       ,TT       ,DT1      ,UPARAM   ,RHO0     ,RHO      ,
+     3    TF       ,TT       ,DT1      ,UPARAM0   ,RHO0     ,RHO      ,
      4    VOLN     ,EINT     ,IEOS     ,BIDV     ,
      5    EP1      ,EP2      ,EP3      ,EP4      ,EP5      ,EP6   ,
      6    DE1      ,DE2      ,DE3      ,DE4      ,DE5      ,DE6   ,
@@ -677,7 +681,8 @@ C
      A    SV1      ,SV2      ,SV3      ,SV4      ,SV5      ,SV6   ,
      B    SSPP     ,VIS      ,UVAR     ,OFF      ,NGL      ,IPT   ,
      C    IPM      ,MAT      ,EPSD     ,IPLA     ,SIGY     ,LBUF%PLA  ,
-     D    DPLA     ,AMU      ,ISRATE   ,ASRATE   ,NVARTMP  ,VARTMP)
+     D    DPLA     ,AMU      ,ISRATE   ,ASRATE   ,NVARTMP  ,VARTMP,
+     E    ET       )
         DEFP(1:LLT)   =  LBUF%PLA(1:LLT)
       ELSEIF(MTN == 45)THEN
         CALL SIGEPS45(

--- a/engine/source/materials/mat_share/mulawc.F
+++ b/engine/source/materials/mat_share/mulawc.F
@@ -178,6 +178,7 @@ C-----------------------------------------------
       USE NLOCAL_REG_MOD
       USE SENSOR_MOD
       USE SIGEPS125C_MOD 
+      USE SIGEPS42C_MOD 
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -1111,20 +1112,16 @@ C
      C          DPLA   ,G_IMP  ,SIGKSI  ,SHF      ,HARDM  ,
      D          YLDFAC ,INLOC ,VARNL(1,IT),LBUF%DMG,LBUF%PLANL,
      E          SIGBXX,SIGBYY,SIGBXY,LBUF%OFF) 
+
           ELSEIF (ILAW == 42) THEN
            CALL SIGEPS42C(
-     1         JLT    , NUPARAM0, NUVAR   , NFUNC , IFUNC , NPF   ,
-     2         NPT    , IPT    , 
-     2         TF     , TT     , DT1C    , UPARAM0, RHO  , 
-     3         AREA   , EINT   , THKLYL  ,
-     4         EPSPXX , EPSPYY , EPSPXY  , EPSPYZ, EPSPZX, 
-     5         DEPSXX , DEPSYY , DEPSXY  , DEPSYZ, DEPSZX,
-     6         EPSXX  , EPSYY  , EPSXY   , EPSYZ , EPSZX ,
-     7         LBUF%SIG(IJ1),LBUF%SIG(IJ2),LBUF%SIG(IJ3),LBUF%SIG(IJ4),LBUF%SIG(IJ5),
-     8         SIGNXX , SIGNYY , SIGNXY  , SIGNYZ, SIGNZX,
-     9         SIGVXX , SIGVYY , SIGVXY  , SIGVYZ, SIGVZX,
-     A         SSP    , VISCMX , THKN    , UVAR   ,
-     B         OFF    , NGL    , ISMSTR  , IPM   , GS)
+     1         NEL    , NUPARAM, NIPARAM , NUVAR   , ISMSTR  , 
+     2         TT     , DT1    , UPARAM  , IPARAM  , RHO     ,  
+     3         DEPSXX , DEPSYY , DEPSXY  , DEPSYZ  , DEPSZX  ,
+     4         EPSXX  , EPSYY  , EPSXY   , THKN    , THKLYL  ,
+     5         SIGNXX , SIGNYY , SIGNXY  , SIGNYZ  , SIGNZX  ,
+     6         SSP    , GS     , UVAR    , OFF     )
+
           ELSEIF (ILAW == 43) THEN
            CALL SIGEPS43C(
      1        JLT    ,NUPARAM0,NUVAR   ,NPF      ,TF      ,

--- a/starter/source/elements/sh3n/coque3n/c3derii.F
+++ b/starter/source/elements/sh3n/coque3n/c3derii.F
@@ -34,11 +34,12 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .                   AREA ,DT  ,X31G,Y31G,Z31G,
      .                   E1X  ,E2X ,E3X ,E1Y ,E2Y ,E3Y ,
      .                   E1Z  ,E2Z ,E3Z ,X2  ,X3  ,Y3  ,
-     .                   GROUP_PARAM)
+     .                   GROUP_PARAM,NUMMAT,MAT_PARAM)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE GROUP_PARAM_MOD            
+      USE MATPARAM_DEF_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -56,6 +57,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+      INTEGER ,INTENT(IN) :: NUMMAT
       INTEGER JFT, JLT, ILEV,ISUBSTACK,IMAT,IPROP
       INTEGER IXTG(NIXTG,*), SH3TREE(KSH3TREE,*),IPM(NPROPMI,*),
      .         IGEO(NPROPGI,*)
@@ -70,16 +72,14 @@ C     REAL
      .     E2X(MVSIZ), E2Y(MVSIZ), E2Z(MVSIZ),
      .     E3X(MVSIZ), E3Y(MVSIZ), E3Z(MVSIZ)
       TYPE (GROUP_PARAM_)  :: GROUP_PARAM
+      TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(INOUT) :: MAT_PARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I, N, IADB,I1,I3,IPTHK,IPPOS,IGTYP,I2,
-     .        IPMAT,MATLY,IPGMAT,IGMAT,IPOS
+      INTEGER I,J,N, IADB,IGTYP,NORDER,IPGMAT,IGMAT
       my_real ALDTV(MVSIZ)
       my_real VISCMX, A11, G, STI,STIR,SHF,VISCDEF,
-     .     AL1, AL2, AL3, ALMAX, SSP,YOUNG,NU,RHO,BULK,GMAX,
-     .     C1,IZ,THICKT,THKLY,POSLY,A1THK,C1THK,
-     .     GTHK,A11R,FAC,A12,E,ETHK,NUTHK,A12THK,RHOG
+     .     AL1,AL2,AL3,ALMAX, SSP,YOUNG,NU,RHO,BULK,GMAX,C1,A11R,FAC,E
 C=======================================================================
       SSP = ZERO 
       
@@ -110,30 +110,41 @@ C
      .       ((IGTYP == 17 .OR. IGTYP == 51) .AND. IGMAT > 0 )) THEN
            SSP = PM_STACK(9 ,ISUBSTACK)
         ELSE
-         IF (MTN<=28) THEN
-          SSP=PM(27,IMAT)
-         ELSEIF (MTN == 42 .OR. MTN  == 69 ) THEN
-          IADB = IPM(7,IMAT)-1                                               
-          BULK = UPARAM(IADB+11) 
-          NU   = UPARAM(IADB+14)                             
-          GMAX = UPARAM(IADB+1)*UPARAM(IADB+6)                 
-     .         + UPARAM(IADB+2)*UPARAM(IADB+7)
-     .         + UPARAM(IADB+3)*UPARAM(IADB+8) 
-     .         + UPARAM(IADB+4)*UPARAM(IADB+9) 
-     .         + UPARAM(IADB+5)*UPARAM(IADB+10) 
-          RHO  = PM(1,IMAT)      
-          A11 = GMAX*(ONE + NU)/(ONE - NU**2)                             
-          SSP=MAX(SSP, SQRT(A11/RHO))     
-         ELSEIF (MTN == 65) THEN
-          RHO  =PM(1,IMAT)
-          YOUNG=PM(20,IMAT)
-          SSP=SQRT(YOUNG/RHO)
-         ELSE
-          RHO  =PM(1,IMAT)
-          YOUNG=PM(20,IMAT)
-          NU   =PM(21,IMAT)
-          SSP=SQRT(YOUNG/(ONE-NU*NU)/RHO)
-         ENDIF
+          IF (MTN<=28) THEN
+            SSP = PM(27,IMAT)
+          ELSEIF (MTN == 42) THEN
+            NORDER = MAT_PARAM(IMAT)%IPARAM(1)
+            BULK   = MAT_PARAM(IMAT)%UPARAM(21)
+            NU     = MAT_PARAM(IMAT)%UPARAM(22)
+            GMAX   = ZERO
+            DO J=1,NORDER
+              GMAX = GMAX + MAT_PARAM(IMAT)%UPARAM(J)*MAT_PARAM(IMAT)%UPARAM(J+10)
+            END DO
+            RHO = PM(1,IMAT)
+            A11 = GMAX*(ONE + NU)/(ONE - NU**2)
+            SSP = MAX(SSP, SQRT(A11/RHO)) 
+          ELSEIF (MTN  == 69 ) THEN
+           IADB = IPM(7,IMAT)-1                                               
+           BULK = UPARAM(IADB+11) 
+           NU   = UPARAM(IADB+14)                             
+           GMAX = UPARAM(IADB+1)*UPARAM(IADB+6)                 
+     .          + UPARAM(IADB+2)*UPARAM(IADB+7)
+     .          + UPARAM(IADB+3)*UPARAM(IADB+8) 
+     .          + UPARAM(IADB+4)*UPARAM(IADB+9) 
+     .          + UPARAM(IADB+5)*UPARAM(IADB+10) 
+           RHO  = PM(1,IMAT)      
+           A11 = GMAX*(ONE + NU)/(ONE - NU**2)                             
+           SSP=MAX(SSP, SQRT(A11/RHO))     
+          ELSEIF (MTN == 65) THEN
+           RHO  =PM(1,IMAT)
+           YOUNG=PM(20,IMAT)
+           SSP=SQRT(YOUNG/RHO)
+          ELSE
+           RHO  =PM(1,IMAT)
+           YOUNG=PM(20,IMAT)
+           NU   =PM(21,IMAT)
+           SSP=SQRT(YOUNG/(ONE-NU*NU)/RHO)
+          ENDIF
         ENDIF 
         VISCMX = GROUP_PARAM%VISC_DM
         IF (VISCMX == ZERO) VISCMX = VISCDEF

--- a/starter/source/elements/sh3n/coque3n/c3init3.F
+++ b/starter/source/elements/sh3n/coque3n/c3init3.F
@@ -317,7 +317,7 @@ C-----------------------------------------------
      .             AREA ,DT  ,X31 ,Y31 ,Z31 ,
      .             E1X  ,E2X ,E3X ,E1Y ,E2Y ,E3Y ,
      .             E1Z  ,E2Z ,E3Z ,X2L ,X3L ,Y3L ,
-     .             GROUP_PARAM)
+     .             GROUP_PARAM,NUMMAT,MAT_PARAM)
 C
       CALL C1BUF3(GEO,GBUF%THK,GBUF%OFF,THK,KSH3TREE,SH3TREE)
 C

--- a/starter/source/elements/sh3n/coquedk/cdkderii.F
+++ b/starter/source/elements/sh3n/coquedk/cdkderii.F
@@ -29,7 +29,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       SUBROUTINE CDKDERII(JFT   ,JLT,PM ,GEO ,PX2,PY2,PX3,PY3,
      .                    STIFN ,STIFR  ,IXTG ,THK ,SH3TREE ,
      .                    ALDT  ,UPARAM ,IPM  ,IGEO,PM_STACK,
-     .                    ISUBSTACK,STRTG,GROUP_PARAM, 
+     .                    ISUBSTACK,STRTG,GROUP_PARAM,NUMMAT,MAT_PARAM, 
      .                    IMAT,IPROP,AREA,   DT  ,
      .                    X1G ,X2G ,X3G ,Y1G ,Y2G ,Y3G ,
      .                    Z1G ,Z2G ,Z3G ,E1X ,E2X ,E3X ,
@@ -38,6 +38,7 @@ C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE GROUP_PARAM_MOD            
+      USE MATPARAM_DEF_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -55,6 +56,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+      INTEGER ,INTENT(IN) :: NUMMAT
       INTEGER JFT, JLT, ILEV,ISUBSTACK,IMAT,IPROP
       INTEGER IXTG(NIXTG,*), SH3TREE(KSH3TREE,*),IPM(NPROPMI,*),
      .        IGEO(NPROPGI,*),PM_STACK(20,*)
@@ -68,11 +70,11 @@ C-----------------------------------------------
      .   E2X(MVSIZ), E2Y(MVSIZ), E2Z(MVSIZ),
      .   E3X(MVSIZ), E3Y(MVSIZ), E3Z(MVSIZ)
       TYPE (GROUP_PARAM_)  :: GROUP_PARAM
+      TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(INOUT) :: MAT_PARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I, NG, N,IADB,I1,I3,IPTHK,IPPOS,IGTYP,I2,
-     .        MATLY,IGMAT,IPGMAT,IPOS
+      INTEGER I,J,N,NG,IADB,IPTHK,IGTYP,NORDER,IGMAT,IPGMAT
       my_real
      .   X21G(MVSIZ), Y21G(MVSIZ), Z21G(MVSIZ),
      .   X31G(MVSIZ), Y31G(MVSIZ), Z31G(MVSIZ),
@@ -134,29 +136,40 @@ c
           SSP = PM_STACK(9 ,ISUBSTACK)
         ELSE
           IF(MTN<=28)THEN
-          SSP=PM(27,IMAT)
-         ELSEIF (MTN == 42 .OR. MTN  == 69) THEN
-          IADB = IPM(7,IMAT)-1                                               
-          BULK = UPARAM(IADB+11)                                                
-          NU = UPARAM(IADB+14)                              
-          GMAX = UPARAM(IADB+1)*UPARAM(IADB+6)                 
-     .         + UPARAM(IADB+2)*UPARAM(IADB+7)  
-     .         + UPARAM(IADB+3)*UPARAM(IADB+8) 
-     .         + UPARAM(IADB+4)*UPARAM(IADB+9)  
-     .         + UPARAM(IADB+5)*UPARAM(IADB+10) 
-          RHO  = PM(1,IMAT)
-          A11 = GMAX*(ONE + NU)/(ONE - NU**2)                                   
-          SSP  = MAX(SSP, SQRT(A11/RHO))
-         ELSEIF (MTN == 65) THEN
-          RHO  =PM(1,IMAT)
-          YOUNG=PM(20,IMAT)
-          SSP=SQRT(YOUNG/RHO)
-         ELSE
-          RHO  =PM(1,IMAT)
-          YOUNG=PM(20,IMAT)
-          NU   =PM(21,IMAT)
-          SSP=SQRT(YOUNG/(ONE-NU*NU)/RHO)
-         ENDIF
+            SSP=PM(27,IMAT)
+          ELSEIF (MTN == 42) THEN
+            NORDER = MAT_PARAM(IMAT)%IPARAM(1)
+            BULK   = MAT_PARAM(IMAT)%UPARAM(21)
+            NU     = MAT_PARAM(IMAT)%UPARAM(22)
+            GMAX   = ZERO
+            DO J=1,NORDER
+              GMAX = GMAX + MAT_PARAM(IMAT)%UPARAM(J)*MAT_PARAM(IMAT)%UPARAM(J+10)
+            END DO
+            RHO = PM(1,IMAT)
+            A11 = GMAX*(ONE + NU)/(ONE - NU**2)
+            SSP = MAX(SSP, SQRT(A11/RHO)) 
+          ELSEIF (MTN  == 69) THEN
+            IADB = IPM(7,IMAT)-1                                             
+            BULK = UPARAM(IADB+11)                                              
+            NU = UPARAM(IADB+14)                            
+            GMAX = UPARAM(IADB+1)*UPARAM(IADB+6)               
+     .           + UPARAM(IADB+2)*UPARAM(IADB+7)  
+     .           + UPARAM(IADB+3)*UPARAM(IADB+8) 
+     .           + UPARAM(IADB+4)*UPARAM(IADB+9)  
+     .           + UPARAM(IADB+5)*UPARAM(IADB+10) 
+            RHO  = PM(1,IMAT)
+            A11 = GMAX*(ONE + NU)/(ONE - NU**2)                                 
+            SSP  = MAX(SSP, SQRT(A11/RHO))
+          ELSEIF (MTN == 65) THEN
+           RHO  =PM(1,IMAT)
+           YOUNG=PM(20,IMAT)
+           SSP=SQRT(YOUNG/RHO)
+          ELSE
+           RHO  =PM(1,IMAT)
+           YOUNG=PM(20,IMAT)
+           NU   =PM(21,IMAT)
+           SSP=SQRT(YOUNG/(ONE-NU*NU)/RHO)
+          ENDIF
         ENDIF 
         VISCMX = GROUP_PARAM%VISC_DM
         IF (VISCMX == ZERO) VISCMX = VISCDEF

--- a/starter/source/elements/sh3n/coquedk/cdkinit3.F
+++ b/starter/source/elements/sh3n/coquedk/cdkinit3.F
@@ -247,7 +247,7 @@ C------------
       CALL CDKDERII(LFT,LLT,PM,GEO,PX2,PY2,PX3,PY3,
      .             STIFN   ,STIFR   ,IXTG(1,NFT+1),THK, SH3TREE,
      .             ALDT    ,BUFMAT  ,IPM ,IGEO,STACK%PM, 
-     .             ISUBSTACK,STRTG(NFT+1),GROUP_PARAM, 
+     .             ISUBSTACK,STRTG(NFT+1),GROUP_PARAM,NUMMAT,MAT_PARAM, 
      .             IMAT ,IPROP,AREA,   DT  ,
      .             X1   ,X2  ,X3  ,Y1  ,Y2  ,Y3  ,
      .             Z1   ,Z2  ,Z3  ,E1X ,E2X ,E3X ,

--- a/starter/source/elements/shell/coque/cdleni.F
+++ b/starter/source/elements/shell/coque/cdleni.F
@@ -30,13 +30,14 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .                  PX1 ,PX2 ,PY1   ,PY2  ,THK,
      .                  IGEO,DT  ,SH4TREE,ALDT,UPARAM ,
      .                  IPM ,NLAY,PM_STACK,ISUBSTACK,STRC,
-     .                  AREA    ,IMAT    ,IPROP   ,
+     .                  AREA    ,IMAT    ,IPROP   ,NUMMAT,
      .                  X2L ,X3L ,X4L  ,Y2L ,Y3L  ,Y4L     ,
-     .                  IGEO_STACK ,GROUP_PARAM)
+     .                  IGEO_STACK ,GROUP_PARAM,MAT_PARAM)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE GROUP_PARAM_MOD            
+      USE MATPARAM_DEF_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -54,6 +55,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+      INTEGER ,INTENT(IN) :: NUMMAT
       INTEGER IMAT,IPROP
       INTEGER IXC(NIXC,*), IGEO(NPROPGI,*), SH4TREE(KSH4TREE,*),
      .   IPM(NPROPMI,*),NLAY,ISUBSTACK,IGEO_STACK(4*NPT_STACK+2,*)
@@ -63,17 +65,18 @@ C-----------------------------------------------
      .   AREA(MVSIZ), STRC(*),
      .   X2L(MVSIZ),X3L(MVSIZ),X4L(MVSIZ),Y2L(MVSIZ),Y3L(MVSIZ),Y4L(MVSIZ)
       TYPE (GROUP_PARAM_)  :: GROUP_PARAM
+      TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(INOUT) :: MAT_PARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I, J, N, IMT, IPMAT, IGTYP,IPPID,IADB,
+      INTEGER I, J, N, IMT, IPMAT, IGTYP,IPPID,IADB,NORDER,
      .        I1,I3,IPTHK,IPPOS,I2,MATLY,IGMAT,IPGMAT,IPOS,NIP,MLAWLY
       my_real
      .   SSP(MVSIZ), AL1(MVSIZ),AL(MVSIZ), ALMIN(MVSIZ),
      .   AL2(MVSIZ), AL3(MVSIZ), AL4(MVSIZ), AL5(MVSIZ), AL6(MVSIZ)
       my_real
      .   VISCMX,A11,A11R,A12,B1,B2,C1,VV,STI,STIR,VISCDEF,DTDYN,RHO, 
-     .   YOUNG,NU,BULK,GMAX,THKLY,POSLY,FAC,Z0
+     .   YOUNG,NU,BULK,GMAX,FAC,Z0
        my_real, DIMENSION(MVSIZ) :: ZOFFSET
 C======================================================================|
       IGTYP = NINT(GEO(12,IPROP))
@@ -113,7 +116,23 @@ c
               SSP(I)=MAX(SSP(I),PM(27,IMT))
             ENDDO
           ENDDO
-        ELSEIF (MTN == 42 .OR. MTN  == 69) THEN
+        ELSEIF (MTN == 42) THEN
+          DO I=LFT,LLT
+            DO N=1,NPT
+              IMT = IGEO(IPMAT+N,IPROP)
+              NORDER = MAT_PARAM(IMT)%IPARAM(1)
+              BULK   = MAT_PARAM(IMT)%UPARAM(21)
+              NU     = MAT_PARAM(IMT)%UPARAM(22)
+              GMAX   = ZERO
+              DO J=1,NORDER
+                GMAX = GMAX + MAT_PARAM(IMT)%UPARAM(J)*MAT_PARAM(IMT)%UPARAM(J+10)
+              END DO
+              RHO  = PM(1,IMT)
+              A11 = GMAX*(ONE + NU)/(ONE - NU**2)
+              SSP(I)=MAX(SSP(I), SQRT(A11/RHO)) 
+            ENDDO
+          ENDDO
+        ELSEIF (MTN  == 69) THEN
           DO I=LFT,LLT
             DO N=1,NPT
               J=I+(N-1)*LLT
@@ -174,10 +193,25 @@ c
               SSP(I)=MAX(SSP(I),PM(27,IMT))
             ENDDO
           ENDDO
-        ELSEIF (MTN == 42 .OR. MTN  == 69) THEN
+        ELSEIF (MTN == 42) THEN
           DO I=LFT,LLT
             DO N=1,NIP
-              J=I+(N-1)*LLT
+              IMT = IGEO_STACK(IPMAT + N,ISUBSTACK)
+              NORDER = MAT_PARAM(IMT)%IPARAM(1)
+              BULK   = MAT_PARAM(IMT)%UPARAM(21)
+              NU     = MAT_PARAM(IMT)%UPARAM(22)
+              GMAX   = ZERO
+              DO J=1,NORDER
+                GMAX = GMAX + MAT_PARAM(IMT)%UPARAM(J)*MAT_PARAM(IMT)%UPARAM(J+10)
+              END DO
+              RHO  = PM(1,IMT)
+              A11 = GMAX*(ONE + NU)/(ONE - NU**2)
+              SSP(I)=MAX(SSP(I), SQRT(A11/RHO)) 
+            ENDDO
+          ENDDO
+        ELSEIF (MTN  == 69) THEN
+          DO I=LFT,LLT
+            DO N=1,NIP
               IMT = IGEO_STACK(IPMAT + N,ISUBSTACK)
               IADB = IPM(7,IMT)-1                                           
               BULK = UPARAM(IADB+11)
@@ -223,7 +257,18 @@ c
             MLAWLY = NINT(PM(19,IMT))
             IF (MLAWLY <= 28) THEN
               SSP(I)=MAX(SSP(I),PM(27,IMT))
-            ELSEIF (MLAWLY == 42 .OR. MLAWLY  == 69) THEN
+            ELSEIF (MLAWLY == 42) THEN
+              NORDER = MAT_PARAM(IMT)%IPARAM(1)
+              BULK   = MAT_PARAM(IMT)%UPARAM(21)
+              NU     = MAT_PARAM(IMT)%UPARAM(22)
+              GMAX   = ZERO
+              DO J=1,NORDER
+                GMAX = GMAX + MAT_PARAM(IMT)%UPARAM(J)*MAT_PARAM(IMT)%UPARAM(J+10)
+              END DO
+              RHO  = PM(1,IMT)
+              A11 = GMAX*(ONE + NU)/(ONE - NU**2)
+              SSP(I)=MAX(SSP(I), SQRT(A11/RHO)) 
+            ELSEIF (MLAWLY  == 69) THEN
               IADB = IPM(7,IMT)-1                                           
               BULK = UPARAM(IADB+11)                                          
               NU = UPARAM(IADB+14)
@@ -252,7 +297,20 @@ c
         DO I=LFT,LLT
           SSP(I)=PM(27,IMAT)
         ENDDO
-      ELSEIF (MTN == 42 .OR. MTN  == 69) THEN
+      ELSEIF (MTN == 42) THEN
+        DO I=LFT,LLT
+          NORDER = MAT_PARAM(IMAT)%IPARAM(1)
+          BULK   = MAT_PARAM(IMAT)%UPARAM(21)
+          NU     = MAT_PARAM(IMAT)%UPARAM(22)
+          GMAX   = ZERO
+          DO J=1,NORDER
+            GMAX = GMAX + MAT_PARAM(IMAT)%UPARAM(J)*MAT_PARAM(IMAT)%UPARAM(J+10)
+          END DO
+          RHO  = PM(1,IMAT)
+          A11 = GMAX*(ONE + NU)/(ONE - NU**2)
+          SSP(I)=MAX(SSP(I), SQRT(A11/RHO)) 
+        ENDDO
+      ELSEIF (MTN  == 69) THEN
         DO I=LFT,LLT
           IADB = IPM(7,IMAT)-1 
           BULK = UPARAM(IADB+11) 

--- a/starter/source/elements/shell/coque/cinit3.F
+++ b/starter/source/elements/shell/coque/cinit3.F
@@ -294,9 +294,9 @@ C-----------------------------------------------
      .            PX1G    ,PX2G    ,PY1G    ,PY2G    ,THK         ,
      .            IGEO    ,DT      ,SH4TREE ,ALDT    ,BUFMAT      ,
      .            IPM     ,NLAY    ,STACK%PM,ISUBSTACK,STRC(NFT+1),
-     .            AREA    ,IMAT    ,IPROP   ,
+     .            AREA    ,IMAT    ,IPROP   ,NUMMAT,
      .            X2L     ,X3L     ,X4L     ,Y2L     ,Y3L     ,Y4L ,
-     .            STACK%IGEO,GROUP_PARAM)
+     .            STACK%IGEO,GROUP_PARAM    ,MAT_PARAM)
       CALL C1BUF3(GEO,GBUF%THK,GBUF%OFF,THK,KSH4TREE,SH4TREE)
 C-----------------------------------------------
       IF (IXFEM > 0) THEN

--- a/starter/source/elements/shell/coqueba/cbainit3.F
+++ b/starter/source/elements/shell/coqueba/cbainit3.F
@@ -302,7 +302,7 @@ C---------------------------
      .            BUFMAT   ,IPM     ,NLAY    ,STACK%PM,ISUBSTACK,
      .            STRC(NFT+1),AREA  ,IMAT    ,IPROP   ,DTEL     , 
      .            X2L ,X3L ,X4L ,Y2L ,Y3L ,Y4L ,
-     .            STACK%IGEO ,GROUP_PARAM)
+     .            STACK%IGEO ,GROUP_PARAM,NUMMAT,MAT_PARAM)
       CALL C1BUF3(GEO,GBUF%THK,GBUF%OFF,THKE,KSH4TREE,SH4TREE)
 c---------------------------
       IF (IXFEM > 0) THEN

--- a/starter/source/elements/shell/coqueba/cndleni.F
+++ b/starter/source/elements/shell/coqueba/cndleni.F
@@ -31,11 +31,12 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .           UPARAM  ,IPM     ,NLAY    ,PM_STACK, ISUBSTACK,               
      .           STRC    ,AREA    ,IMAT    ,IPROP   ,DTEL    ,  
      .           X2L     ,X3L     ,X4L     ,Y2L     ,Y3L     ,Y4L    ,
-     .           IGEO_STACK       ,GROUP_PARAM)        
+     .           IGEO_STACK       ,GROUP_PARAM,NUMMAT,MAT_PARAM)        
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE GROUP_PARAM_MOD            
+      USE MATPARAM_DEF_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -53,6 +54,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+      INTEGER ,INTENT(IN) :: NUMMAT
       INTEGER IMAT, IPROP
       INTEGER IXC(NIXC,*),IGEO(NPROPGI,*),IHBE, SH4TREE(KSH4TREE,*),
      .   IPM(NPROPMI,*),NLAY,ISUBSTACK,IGEO_STACK(4*NPT_STACK+2,*)
@@ -65,7 +67,7 @@ C     REAL
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I, J, N, IMT, IPMAT, IGTYP,IADB,
+      INTEGER I, J, N, IMT, IPMAT, IGTYP,IADB,NORDER,
      .        I1,I3,IPTHK,IPPOS,I2,MATLY,IPGMAT,IGMAT,IPOS,NIP,MLAWLY
       my_real
      .   AREA(MVSIZ),SSP(MVSIZ), AL1(MVSIZ), 
@@ -76,6 +78,7 @@ C-----------------------------------------------
      .   X13,X24,Y13,Y24,L13,L24,C1,C2,THKLY,POSLY,
      .   FAC,VISCE,RX,RY,SX,SY,S1,FAC1,FAC2,FACI,FAC11,BULK,GMAX,Z0
        my_real, DIMENSION(MVSIZ) ::   ZOFFSET
+      TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(INOUT) :: MAT_PARAM
 C=======================================================================
       FAC = TWO
 C
@@ -119,7 +122,23 @@ C
                    SSP(I)=MAX(SSP(I),PM(27,IMT))
                  ENDDO
                ENDDO
-             ELSEIF (MTN == 42 .OR. MTN  == 69) THEN
+             ELSEIF (MTN == 42) THEN
+               DO I=LFT,LLT
+                 DO N=1,NIP
+                   IMT  = IGEO(IPMAT+N,IPROP)
+                   NORDER = MAT_PARAM(IMT)%IPARAM(1)
+                   BULK   = MAT_PARAM(IMT)%UPARAM(21)
+                   NU     = MAT_PARAM(IMT)%UPARAM(22)
+                   GMAX   = ZERO
+                   DO J=1,NORDER
+                     GMAX = GMAX + MAT_PARAM(IMT)%UPARAM(J)*MAT_PARAM(IMT)%UPARAM(J+10)
+                   END DO
+                   RHO  = PM(1,IMT)
+                   A11 = GMAX*(ONE + NU)/(ONE - NU**2)
+                   SSP(I)=MAX(SSP(I), SQRT(A11/RHO)) 
+                 ENDDO
+               ENDDO
+             ELSEIF (MTN  == 69) THEN
                DO I=LFT,LLT
                  DO N=1,NIP
                    J=I+(N-1)*LLT
@@ -171,10 +190,25 @@ CCC
                    SSP(I)=MAX(SSP(I),PM(27,IMT))
                  ENDDO
                ENDDO
-             ELSEIF (MTN == 42 .OR. MTN  == 69) THEN
+             ELSEIF (MTN == 42) THEN
                DO I=LFT,LLT
                  DO N=1,NIP
-                   J=I+(N-1)*LLT
+                   IMT  = IGEO_STACK(IPMAT + N,ISUBSTACK)
+                   NORDER = MAT_PARAM(IMT)%IPARAM(1)
+                   BULK   = MAT_PARAM(IMT)%UPARAM(21)
+                   NU     = MAT_PARAM(IMT)%UPARAM(22)
+                   GMAX   = ZERO
+                   DO J=1,NORDER
+                     GMAX = GMAX + MAT_PARAM(IMT)%UPARAM(J)*MAT_PARAM(IMT)%UPARAM(J+10)
+                   END DO
+                   RHO  = PM(1,IMT)
+                   A11 = GMAX*(ONE + NU)/(ONE - NU**2)
+                   SSP(I)=MAX(SSP(I), SQRT(A11/RHO)) 
+                 ENDDO
+               ENDDO
+             ELSEIF (MTN  == 69) THEN
+               DO I=LFT,LLT
+                 DO N=1,NIP
                    IMT  = IGEO_STACK(IPMAT + N,ISUBSTACK)
                    IADB = IPM(7,IMT)-1                                      
                    BULK = UPARAM(IADB+11)                                     
@@ -220,7 +254,19 @@ CCC
               MLAWLY = NINT(PM(19,IMT))
               IF (MLAWLY <= 28) THEN
                 SSP(I)=MAX(SSP(I),PM(27,IMT))
-              ELSEIF (MLAWLY == 42 .OR. MLAWLY  == 69) THEN
+              ELSEIF (MLAWLY == 42) THEN
+                IADB = IPM(7,IMT)-1                                         
+                NORDER = MAT_PARAM(IMT)%IPARAM(1)
+                BULK   = MAT_PARAM(IMT)%UPARAM(21)
+                NU     = MAT_PARAM(IMT)%UPARAM(22)
+                GMAX   = ZERO
+                DO J=1,NORDER
+                  GMAX = GMAX + MAT_PARAM(IMT)%UPARAM(J)*MAT_PARAM(IMT)%UPARAM(J+10)
+                END DO
+                RHO  = PM(1,IMT)
+                A11 = GMAX*(ONE + NU)/(ONE - NU**2)
+                SSP(I)=MAX(SSP(I), SQRT(A11/RHO)) 
+              ELSEIF (MLAWLY  == 69) THEN
                 IADB = IPM(7,IMT)-1                                         
                 BULK = UPARAM(IADB+11)                                        
                 NU = UPARAM(IADB+14)
@@ -242,8 +288,8 @@ CCC
                 NU   =PM(21,IMT)
                 SSP(I)=MAX(SSP(I), SQRT(YOUNG/(ONE-NU*NU)/RHO))
               ENDIF
-              ENDDO
             ENDDO
+          ENDDO
       ELSEIF (IGTYP == 11 .AND. IGMAT > 0) THEN
           DO I=LFT,LLT
             SSP(I) = GEO(IPGMAT +9 ,IPROP)
@@ -257,20 +303,33 @@ CCC
           DO I=LFT,LLT
             SSP(I)=PM(27,IMAT)
           ENDDO
-      ELSEIF (MTN == 42 .OR. MTN  == 69) THEN
-          DO I=LFT,LLT
-            IADB = IPM(7,IMAT)-1                                             
-            BULK = UPARAM(IADB+11)                                             
-            NU = UPARAM(IADB+14)         
-            GMAX = UPARAM(IADB+1)*UPARAM(IADB+6)               
-     .           + UPARAM(IADB+2)*UPARAM(IADB+7) 
-     .           + UPARAM(IADB+3)*UPARAM(IADB+8) 
-     .           + UPARAM(IADB+4)*UPARAM(IADB+9) 
-     .           + UPARAM(IADB+5)*UPARAM(IADB+10) 
-             RHO  = PM(1,IMAT) 
-             A11 = GMAX*(ONE + NU)/(ONE - NU**2)                                
-             SSP(I)=MAX(SSP(I), SQRT(A11/RHO))    
-          ENDDO
+      ELSEIF (MTN == 42) THEN
+        DO I=LFT,LLT
+          NORDER = MAT_PARAM(IMAT)%IPARAM(1)                                             
+          BULK   = MAT_PARAM(IMAT)%UPARAM(21)                                            
+          NU     = MAT_PARAM(IMAT)%UPARAM(22)                                            
+          GMAX   = ZERO                                                                  
+          DO J=1,NORDER                                                                  
+            GMAX = GMAX + MAT_PARAM(IMAT)%UPARAM(J)*MAT_PARAM(IMAT)%UPARAM(J+10)         
+          END DO                                                                         
+          RHO   = PM(1,IMAT)                                                              
+          A11   = GMAX*(ONE + NU)/(ONE - NU**2)                                            
+          SSP(I)=MAX(SSP(I), SQRT(A11/RHO))                                              
+        ENDDO
+      ELSEIF (MTN  == 69) THEN
+        DO I=LFT,LLT
+          IADB = IPM(7,IMAT)-1                                             
+          BULK = UPARAM(IADB+11)                                             
+          NU = UPARAM(IADB+14)         
+          GMAX = UPARAM(IADB+1)*UPARAM(IADB+6)               
+     .         + UPARAM(IADB+2)*UPARAM(IADB+7) 
+     .         + UPARAM(IADB+3)*UPARAM(IADB+8) 
+     .         + UPARAM(IADB+4)*UPARAM(IADB+9) 
+     .         + UPARAM(IADB+5)*UPARAM(IADB+10) 
+           RHO  = PM(1,IMAT) 
+           A11 = GMAX*(ONE + NU)/(ONE - NU**2)                                
+           SSP(I)=MAX(SSP(I), SQRT(A11/RHO))    
+        ENDDO
       ELSEIF (MTN == 65) THEN
           DO I=LFT,LLT
             RHO  =PM(1,IMAT)

--- a/starter/source/materials/mat/hm_read_mat.F
+++ b/starter/source/materials/mat/hm_read_mat.F
@@ -611,9 +611,9 @@ c-------
           CASE ('LAW42','OGDEN')
             ILAW = 42  
             CALL HM_READ_MAT42(
-     .           UPARAM   ,MAXUPARAM,NUPARAM  ,NUVAR    ,IFUNC    ,
-     .           MAXFUNC  ,NFUNC    ,PARMAT   ,IMATVIS  ,UNITAB   ,
-     .           MAT_ID   ,TITR     ,LSUBMODEL,PM(1,I)  ,MATPARAM )
+     .           MATPARAM ,NUVAR    ,MAXFUNC  ,NFUNC    ,IFUNC    ,
+     .           PARMAT   ,IMATVIS  ,UNITAB   ,LSUBMODEL,MAT_ID   ,
+     .           TITR     ,PM(1,I)  )
 c-------
           CASE ('LAW43','HILL_TAB')
             ILAW = 43

--- a/starter/source/materials/mat/mat042/hm_read_mat42.F
+++ b/starter/source/materials/mat/mat042/hm_read_mat42.F
@@ -37,9 +37,9 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    submodel_mod               ../starter/share/modules1/submodel_mod.F
       !||====================================================================
       SUBROUTINE HM_READ_MAT42(
-     .           UPARAM   ,MAXUPARAM,NUPARAM  ,NUVAR    ,IFUNC    ,
-     .           MAXFUNC  ,NFUNC    ,PARMAT   ,IMATVIS  ,UNITAB   ,
-     .           ID       ,TITR     ,LSUBMODEL,PM       ,MATPARAM )
+     .           MATPARAM ,NUVAR    ,MAXFUNC  ,NFUNC    ,IFUNC    ,
+     .           PARMAT   ,IMATVIS  ,UNITAB   ,LSUBMODEL,ID       ,
+     .           TITR     ,PM       )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -71,13 +71,14 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+      INTEGER, INTENT(IN)      :: ID,MAXFUNC
+      INTEGER, INTENT(INOUT)   :: NUVAR
+      INTEGER, INTENT(INOUT)   :: NFUNC
+      INTEGER, INTENT(INOUT)   :: IMATVIS
       TYPE (UNIT_TYPE_),INTENT(IN) ::UNITAB 
-      INTEGER, INTENT(IN)    :: ID,MAXUPARAM,MAXFUNC
       my_real, DIMENSION(NPROPM) ,INTENT(INOUT) :: PM     
       CHARACTER*nchartitle ,INTENT(IN) :: TITR
-      INTEGER, INTENT(INOUT)   :: IMATVIS,NUPARAM,NUVAR,NFUNC
       INTEGER, DIMENSION(MAXFUNC)   ,INTENT(INOUT) :: IFUNC
-      my_real, DIMENSION(MAXUPARAM) ,INTENT(INOUT)   :: UPARAM
       my_real, DIMENSION(100),INTENT(INOUT) :: PARMAT
       TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
       TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
@@ -85,11 +86,10 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       LOGICAL :: IS_AVAILABLE,IS_ENCRYPTED
-      INTEGER :: I,J,K,IFORM,IFLAG,IFUNC_BLK,NPRONY,IVISC,ILAW
-      my_real :: RHO0,RHOR,BULK,SMAX,GS,MU,NU,GVMAX,C1,ZEP495,FSCAL,FSCAL_UNIT,
-     .           AL1,AL2,AL3,AL4,AL5,AL6,AL7,AL8,AL9,AL10,
-     .           MU1,MU2,MU3,MU4,MU5,MU6,MU7,MU8,MU9,MU10       
-      my_real, DIMENSION(100) ::  GI,TAUX
+      INTEGER :: I,IFORM,IFUNC_BLK,NPRONY,NUPARAM,NIPARAM,NORDER,ILAW
+      my_real :: RHO0,RHOR,BULK,SMAX,GS,MU0,NU,GVMAX,C1,ZEP495,FSCAL,FSCAL_UNIT
+      my_real, DIMENSION(10)  :: MU,AL
+      my_real, DIMENSION(100) :: GI,TAUX
 C=======================================================================
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
@@ -109,24 +109,36 @@ c
       CALL HM_GET_INTV  ('ORDER'      ,NPRONY   ,IS_AVAILABLE,LSUBMODEL)
       CALL HM_GET_INTV  ('IFORM'      ,IFORM    ,IS_AVAILABLE,LSUBMODEL)      
 !card3 - Shear hyperelastic modulus parameters
-      CALL HM_GET_FLOATV('MAT_MUE1'   ,MU1      ,IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('MAT_MUE2'   ,MU2      ,IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('MAT_MUE3'   ,MU3      ,IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('MAT_MUE4'   ,MU4      ,IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('MAT_MUE5'   ,MU5      ,IS_AVAILABLE, LSUBMODEL, UNITAB)   
-!card4 - Material exponents
-      CALL HM_GET_FLOATV('MAT_ALPHA11',AL1      ,IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('MAT_ALPHA22',AL2      ,IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('MAT_ALPHA33',AL3      ,IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('MAT_ALPHA44',AL4      ,IS_AVAILABLE, LSUBMODEL, UNITAB)
-      CALL HM_GET_FLOATV('MAT_ALPHA55',AL5      ,IS_AVAILABLE, LSUBMODEL, UNITAB)
-!card5 - Prony series      
+      CALL HM_GET_FLOATV('MAT_MUE1'   ,MU(1)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_MUE2'   ,MU(2)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_MUE3'   ,MU(3)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_MUE4'   ,MU(4)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_MUE5'   ,MU(5)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)   
+!card4 - Shear hyperelastic modulus parameters
+      CALL HM_GET_FLOATV('MAT_MUE6'   ,MU(6)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_MUE7'   ,MU(7)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_MUE8'   ,MU(8)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_MUE9'   ,MU(9)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_MUE10'  ,MU(10)   ,IS_AVAILABLE, LSUBMODEL, UNITAB)   
+!card5 - Material exponents
+      CALL HM_GET_FLOATV('MAT_ALPHA11',AL(1)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_ALPHA22',AL(2)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_ALPHA33',AL(3)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_ALPHA44',AL(4)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_ALPHA55',AL(5)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+!card6 - Material exponents
+      CALL HM_GET_FLOATV('MAT_ALPHA6 ',AL(6)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_ALPHA7 ',AL(7)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_ALPHA8 ',AL(8)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_ALPHA9 ',AL(9)    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_ALPHA10',AL(10)   ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+!card7 - Prony series      
       IF (NPRONY > 0) THEN
-        DO J=1,NPRONY    
-          CALL HM_GET_FLOAT_ARRAY_INDEX('Gamma_arr',GI(J)  ,J,IS_AVAILABLE,LSUBMODEL,UNITAB)
+        DO I=1,NPRONY    
+          CALL HM_GET_FLOAT_ARRAY_INDEX('Gamma_arr',GI(I)  ,I,IS_AVAILABLE,LSUBMODEL,UNITAB)
         ENDDO
-        DO J=1,NPRONY     
-          CALL HM_GET_FLOAT_ARRAY_INDEX('Tau_arr'  ,TAUX(J),J,IS_AVAILABLE,LSUBMODEL,UNITAB)
+        DO I=1,NPRONY     
+          CALL HM_GET_FLOAT_ARRAY_INDEX('Tau_arr'  ,TAUX(I),I,IS_AVAILABLE,LSUBMODEL,UNITAB)
         ENDDO
       ENDIF
 c
@@ -143,7 +155,6 @@ c
 c 
       ! Tensile stress limit
       IF (SMAX <= ZERO)  SMAX  = EP20
-      IFLAG = 0
 c
       ! Scale factor for bulk tabulation
       CALL HM_GET_FLOATV_DIM('MAT_FScale',FSCAL_UNIT    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
@@ -156,36 +167,52 @@ c
 c
       ! Ground state shear modulus
       GVMAX = ZERO
-      DO K=1,NPRONY
-        GVMAX = GVMAX + GI(K)
+      DO I=1,NPRONY
+        GVMAX = GVMAX + GI(I)
       ENDDO      
-      GS = MU1*AL1+MU2*AL2+MU3*AL3+MU4*AL4+MU5*AL5
+c 
+      ! Viscosity parameters
+      IMATVIS = 1
+      IF (NPRONY > 0 ) THEN
+        IMATVIS = 3
+      ENDIF
+!------------------------------------------------------------
+!     Check Ogden parameter order (skip zero values of mu)
+!------------------------------------------------------------
+      NORDER = 0
+      DO I = 1,10
+        IF (MU(I) /= ZERO) THEN
+          NORDER = NORDER + 1
+          MU(NORDER) = MU(I)
+          AL(NORDER) = AL(I)
+        END IF
+      END DO
+!
+      GS = ZERO
+      DO I = 1,NORDER
+        GS = GS + MU(I)*AL(I)
+      END DO
       IF (GS <= ZERO) THEN
-        CALL ANCMSG(MSGID=828,
-     .              MSGTYPE=MSGERROR,
-     .              ANMODE=ANINFO,
+        CALL ANCMSG(MSGID=828, MSGTYPE=MSGERROR, ANMODE=ANINFO,
      .              I1=ID,
      .              C1=TITR)
       END IF
 c 
       ! Initial shear and bulk modulus
-      MU   = GS/TWO
+      MU0  = GS/TWO
       BULK = GS*(ONE+NU)/MAX(EM20,THREE*(ONE-TWO*NU))
-c 
-      ! Viscosity parameters
-      IVISC   = 0  
-      IMATVIS = 1
-      IF (NPRONY > 0 ) THEN
-        IVISC   = 1
-        IMATVIS = 3
-      ENDIF
-c
 c--------------------------
 c     Filling buffer tables
 c-------------------------- 
       ! Number of material parameters
-      NUPARAM = 17
+      NIPARAM = 3
+      NUPARAM = 24
       IF (NPRONY > 0) NUPARAM = NUPARAM + 2*NPRONY
+      MATPARAM%NIPARAM = NIPARAM
+      MATPARAM%NUPARAM = NUPARAM
+      ALLOCATE (MATPARAM%IPARAM(NIPARAM))
+      ALLOCATE (MATPARAM%UPARAM(NUPARAM))
+      
       ! Number of functions
       NFUNC   = 1
       ! Number of user variables 
@@ -193,27 +220,38 @@ c--------------------------
       IF (NPRONY > 0) NUVAR   = NUVAR   + 6*NPRONY 
 c          
       ! Material parameters
-      UPARAM(1)  = MU1
-      UPARAM(2)  = MU2
-      UPARAM(3)  = MU3
-      UPARAM(4)  = MU4
-      UPARAM(5)  = MU5
-      UPARAM(6)  = AL1
-      UPARAM(7)  = AL2
-      UPARAM(8)  = AL3
-      UPARAM(9)  = AL4
-      UPARAM(10) = AL5
-      UPARAM(11) = BULK
-      UPARAM(12) = SMAX
-      UPARAM(13) = IFLAG
-      UPARAM(14) = NU
-      UPARAM(15) = FSCAL
-      UPARAM(16) = NPRONY
-      UPARAM(17) = IFORM
+      MATPARAM%IPARAM(1)  = NORDER
+      MATPARAM%IPARAM(2)  = NPRONY
+      MATPARAM%IPARAM(3)  = IFORM
+      
+      MATPARAM%UPARAM(1)  = MU(1)   
+      MATPARAM%UPARAM(2)  = MU(2)   
+      MATPARAM%UPARAM(3)  = MU(3)   
+      MATPARAM%UPARAM(4)  = MU(4)   
+      MATPARAM%UPARAM(5)  = MU(5)   
+      MATPARAM%UPARAM(6)  = MU(6)   
+      MATPARAM%UPARAM(7)  = MU(7)   
+      MATPARAM%UPARAM(8)  = MU(8)   
+      MATPARAM%UPARAM(9)  = MU(9)   
+      MATPARAM%UPARAM(10) = MU(10)  
+      MATPARAM%UPARAM(11) = AL(1)   
+      MATPARAM%UPARAM(12) = AL(2)   
+      MATPARAM%UPARAM(13) = AL(3)   
+      MATPARAM%UPARAM(14) = AL(4)   
+      MATPARAM%UPARAM(15) = AL(5)   
+      MATPARAM%UPARAM(16) = AL(6)   
+      MATPARAM%UPARAM(17) = AL(7)   
+      MATPARAM%UPARAM(18) = AL(8)   
+      MATPARAM%UPARAM(19) = AL(9)   
+      MATPARAM%UPARAM(20) = AL(10)  
+      MATPARAM%UPARAM(21) = BULK  
+      MATPARAM%UPARAM(22) = NU    
+      MATPARAM%UPARAM(23) = SMAX
+      MATPARAM%UPARAM(24) = FSCAL 
       IF (NPRONY > 0) THEN
-        DO K=1,NPRONY
-          UPARAM(17 + K) = GI(K) 
-          UPARAM(17 + NPRONY + K) = TAUX(K)
+        DO I=1,NPRONY
+          MATPARAM%UPARAM(24 + I) = GI(I) 
+          MATPARAM%UPARAM(24 + NPRONY + I) = TAUX(I)
         ENDDO
       ENDIF
 c
@@ -229,10 +267,11 @@ c
       PARMAT(16) = 2
       PARMAT(17) = GS/(C1 + TWO_THIRD*GS)
 c
-      ! PM table
-      PM(1)  = RHOR
-      PM(2)  = GS
-      PM(89) = RHO0
+      ! PM /matparam common parameters
+      
+      MATPARAM%RHO  = RHOR
+      MATPARAM%RHO0 = RHO0
+      PM(2)  = GS      
       PM(100)= BULK      
 c      
       ! MATPARAM keywords
@@ -254,12 +293,15 @@ c--------------------------
       ELSE
         WRITE(IOUT,1200) RHO0
         WRITE(IOUT,1300) NU,SMAX,IFUNC_BLK,FSCAL,IFORM
-        WRITE(IOUT,1400) MU1,MU2,MU3,MU4,MU5
-        WRITE(IOUT,1500) AL1,AL2,AL3,AL4,AL5,MU,BULK
+        WRITE(IOUT,1400) NORDER
+        DO I = 1,NORDER
+          WRITE(IOUT,1500) I,MU(I),AL(I) 
+        ENDDO 
+        WRITE(IOUT,1600) MU0,BULK
         IF (NPRONY > 0) THEN 
-          WRITE(IOUT,1600) NPRONY
-          DO K = 1, NPRONY
-            WRITE(IOUT,1700) K,GI(K),TAUX(K) 
+          WRITE(IOUT,1700) NPRONY
+          DO I = 1, NPRONY
+            WRITE(IOUT,1800) I,GI(I),TAUX(I) 
           ENDDO 
         ENDIF
       ENDIF     
@@ -285,29 +327,23 @@ C-----------------
      & 5X,'  IFORM = 1: STANDARD STRAIN ENERGY DENSITY (DEFAULT)',/,
      & 5X,'  IFORM = 2: MODIFIED STRAIN ENERGY DENSITY          ',/)
  1400 FORMAT(
-     & 5X,'SHEAR HYPERELASTIC MODULUS PARAMETERS:            ',/,
-     & 5X,'--------------------------------------            ',/,
-     & 5X,'1ST PARAM. MU1. . . . . . . . . . . . . . . . . .=',1PG20.13/, 
-     & 5X,'2ND PARAM. MU2. . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'3RD PARAM. MU3. . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'4TH PARAM. MU4. . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'5TH PARAM. MU5. . . . . . . . . . . . . . . . . .=',1PG20.13/)
+     & 5X,'OGDEN MODEL PARAMETERS:                           ',/,
+     & 5X,'------------------------                          ',/,
+     & 5X,'                                                  ',/,
+     & 5X,'NUMBER OF TERMS IN OGDEN MODEL. . . . . . . . . .=',I8/)
  1500 FORMAT(
-     & 5X,'MATERIAL EXPONENTS:                               ',/,
-     & 5X,'-------------------                               ',/,
-     & 5X,'1ST EXPO. AL1 . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'2ND EXPO. AL2 . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'3RD EXPO. AL3 . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'4TH EXPO. AL4 . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'5TH EXPO. AL5 . . . . . . . . . . . . . . . . . .=',1PG20.13/,
+     & 5X,'OGDEN TERM NUMBER # '                              ,I8/,
+     & 5X,'GROUND SHEAR MODULUS. . . . . . . . . . . . . . .=',1PG20.13/,
+     & 5X,'EXPONENT ALPHA. . . . . . . . . . . . . . . . . .=',1PG20.13/)  
+ 1600 FORMAT(
      & 5X,'INITIAL SHEAR MODULUS . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'BULK MODULUS  . . . . . . . . . . . . . . . . . .=',1PG20.13/) 
- 1600 FORMAT(
+ 1700 FORMAT(
      & 5X,'PRONY SERIES PARAMETERS:                          ',/,
      & 5X,'------------------------                          ',/,
      & 5X,'                                                  ',/,
      & 5X,'NUMBER OF TERMS IN PRONY SERIES M . . . . . . . .=',I8/)
- 1700 FORMAT(
+ 1800 FORMAT(
      & 5X,'PRONY TERM NUMBER # '                              ,I8/,
      & 5X,'SHEAR STIFFNESS . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'RELAXATION TIME . . . . . . . . . . . . . . . . .=',1PG20.13/)  

--- a/starter/source/materials/mat/mat042/law42_upd.F
+++ b/starter/source/materials/mat/mat042/law42_upd.F
@@ -28,12 +28,14 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    message_mod   ../starter/share/message_module/message_mod.F
       !||    table_mod     ../starter/share/modules1/table_mod.F
       !||====================================================================
-      SUBROUTINE LAW42_UPD(IOUT,TITR    ,MAT_ID,UPARAM, PM, GAMA_INF)
+
+      SUBROUTINE LAW42_UPD(MAT_PARAM,IOUT,TITR    ,MAT_ID,PM, GAMA_INF)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE MESSAGE_MOD
       USE TABLE_MOD
+      USE MATPARAM_DEF_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -48,14 +50,13 @@ C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       CHARACTER*nchartitle  :: TITR
       INTEGER MAT_ID,IOUT
-      my_real 
-     .         UPARAM(*)
       my_real, DIMENSION(NPROPM) ,INTENT(INOUT) :: PM  
       my_real , INTENT(IN)  :: GAMA_INF
+      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MAT_PARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER NDATA,I,K,INDX
+      INTEGER I,K,NDATA,INDX,NORDER
       my_real
      .   MU(5),AL(5),LAM_MIN,LAM_MAX,STRAIN_MIN,STRAIN_MAX,
      .   D11,D22,D12,LAM1,LAM2,LAM3,LAM12,INVD1,INVD2,GS,BULK,YOUNG,
@@ -66,21 +67,23 @@ C-----------------------------------------------
 C=======================================================================
 !       CHECK the material stability (Drucker proguer conditions)
 !====================================================================
-       NDATA = 10000  ! La=0.1,10, EM3!!
-       LAM_MIN = EM3                                         
-       LAM_MAX = TEN 
-       GS = ZERO
+      NDATA = 10000  ! La=0.1,10, EM3!!
+      LAM_MIN = EM3                                         
+      LAM_MAX = TEN
+        
+      NORDER = MAT_PARAM%IPARAM(1)   ! Order of Ogden model
 C      
-       IF(GAMA_INF <  ONE) THEN 
-         DO I=1,5
-           UPARAM(I) = UPARAM(I)/GAMA_INF
-           MU(I) = UPARAM(I)
-           AL(I) = UPARAM(5+I)
+       GS = ZERO
+       IF (GAMA_INF <  ONE) THEN 
+         DO I=1,NORDER
+           MAT_PARAM%UPARAM(I) = MAT_PARAM%UPARAM(I)/GAMA_INF
+           MU(I) = MAT_PARAM%UPARAM(I)
+           AL(I) = MAT_PARAM%UPARAM(10+I)
            GS = GS + MU(I)*AL(I)
          ENDDO 
-         NU = UPARAM(14)
+         NU = MAT_PARAM%UPARAM(22)
          BULK = GS*(ONE+NU)/MAX(EM20,THREE*(ONE-TWO*NU)) 
-         UPARAM(11) = BULK
+         MAT_PARAM%UPARAM(21) = BULK
          !! parameters 
           YOUNG  = GS*(ONE + NU)                                              
           PM(20) = YOUNG                                                
@@ -95,9 +98,9 @@ C     Formulation for solid elements time step computation.
          WRITE(IOUT,2100) HALF*GS,BULK
          WRITE(IOUT,2200) MU(1),MU(2),MU(3),MU(4),MU(5)          
        ELSE
-         DO I=1,5
-           MU(I) = UPARAM(I)
-           AL(I) = UPARAM(5+I)
+         DO I=1,NORDER
+           MU(I) = MAT_PARAM%UPARAM(I)
+           AL(I) = MAT_PARAM%UPARAM(10+I)
          ENDDO  
        ENDIF 
 C

--- a/starter/source/materials/mat/mat042/sigeps42.F
+++ b/starter/source/materials/mat/mat042/sigeps42.F
@@ -30,9 +30,9 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    valpvecdp   ../starter/source/materials/tools/matrix.F
       !||====================================================================
       SUBROUTINE SIGEPS42(
-     1      NEL      ,NUPARAM  ,NUVAR    ,NFUNC    ,IFUNC    ,NPF      ,
-     2      TF       ,TIME     ,TIMESTEP ,UPARAM   ,RHO0     ,RHO      ,
-     3      VOLUME   ,EINT     ,
+     1      NEL      ,NUVAR    ,NFUNC    ,IFUNC    ,NPF      ,
+     2      TF       ,TIME     ,TIMESTEP ,RHO0     ,RHO      ,
+     3      VOLUME   ,EINT     ,MAT_PARAM,
      4      EPSPXX   ,EPSPYY   ,EPSPZZ   ,EPSPXY   ,EPSPYZ   ,EPSPZX   , 
      5      DEPSXX   ,DEPSYY   ,DEPSZZ   ,DEPSXY   ,DEPSYZ   ,DEPSZX   ,
      6      EPSXX    ,EPSYY    ,EPSZZ    ,EPSXY    ,EPSYZ    ,EPSZX    ,
@@ -41,6 +41,10 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      A      SOUNDSP  ,VISCMAX  ,UVAR     ,OFF      ,WXXDT    ,WYYDT    ,
      B      WZZDT    ,ISMSTR   ,MFXX     ,MFXY     ,MFXZ     ,MFYX     ,    
      C      MFYY     ,MFYZ     ,MFZX     ,MFZY     ,MFZZ     )
+C-----------------------------------------------
+C   M o d u l e s
+C-----------------------------------------------
+      USE MATPARAM_DEF_MOD
 C-----------------------------------------------
 C   I M P L I C I T   T Y P E S
 C-----------------------------------------------
@@ -57,9 +61,9 @@ C-----------------------------------------------
 C----------------------------------------------------------------
 C  I N P U T   A R G U M E N T S
 C----------------------------------------------------------------
-      INTEGER, INTENT(IN) :: NEL,NUPARAM,NUVAR,ISMSTR
+      INTEGER, INTENT(IN) :: NEL,NUVAR,ISMSTR
+      my_real, INTENT(IN) :: TIME, TIMESTEP
       my_real, INTENT(IN) ::
-     .      TIME       , TIMESTEP   , UPARAM(NUPARAM),
      .      RHO   (NEL), RHO0  (NEL), VOLUME(NEL), EINT(NEL),
      .      EPSPXX(NEL), EPSPYY(NEL), EPSPZZ(NEL),
      .      EPSPXY(NEL), EPSPYZ(NEL), EPSPZX(NEL),
@@ -73,6 +77,7 @@ C----------------------------------------------------------------
      .      MFYX(NEL)  ,   MFYY(NEL),   MFYZ(NEL),
      .      MFZX(NEL)  ,   MFZY(NEL),   MFZZ(NEL),    
      .      WZZDT(MVSIZ),WYYDT(MVSIZ),WXXDT(MVSIZ)
+      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MAT_PARAM
 C----------------------------------------------------------------
 C  O U T P U T   A R G U M E N T S
 C----------------------------------------------------------------
@@ -94,41 +99,55 @@ C----------------------------------------------------------------
 C----------------------------------------------------------------
 C  L O C A L  V A R I B L E S
 C----------------------------------------------------------------
-      INTEGER I,J,K,KFP,IFORM
+      INTEGER I,J,K,KFP,IFORM,NORDER
       my_real
-     .  MU1,MU2,MU3,MU4,MU5,AL1,AL2,AL3,AL4,AL5,         
      .  TENSIONCUT,GMAX,FFAC
       my_real
      .  SIGPRV(3,MVSIZ),EV(3,MVSIZ),EVM(3,MVSIZ),DWDL(3,MVSIZ),
      .  T1(3,MVSIZ),SUMDWDL(MVSIZ),RV(MVSIZ),P(MVSIZ),
      .  DWDRV(MVSIZ),RBULK,DPDMU,AV(6,MVSIZ),EVV(3,MVSIZ),
      .  DIRPRV(3,3,MVSIZ),A(3,3),DPRA(3,3),EIGEN(3)                
+      my_real ,DIMENSION(10) :: MU,AL   
 C----------------------------------------------------------------
       !=======================================================================
       ! - RECOVERING MATERIAL PARAMETERS
       !=======================================================================
+      NORDER = MAT_PARAM%IPARAM(1) ! order of Ogden formulation (number of terms)     
+      IFORM  = MAT_PARAM%IPARAM(3) ! Flag for strain energy density formulation
+!
       ! Shear hyperelastic modulus parameters
-      MU1 = UPARAM(1)
-      MU2 = UPARAM(2)
-      MU3 = UPARAM(3)
-      MU4 = UPARAM(4)
-      MU5 = UPARAM(5)
+      MU(1)  = MAT_PARAM%UPARAM(1)
+      MU(2)  = MAT_PARAM%UPARAM(2)
+      MU(3)  = MAT_PARAM%UPARAM(3)
+      MU(4)  = MAT_PARAM%UPARAM(4)
+      MU(5)  = MAT_PARAM%UPARAM(5)
+      MU(6)  = MAT_PARAM%UPARAM(6)
+      MU(7)  = MAT_PARAM%UPARAM(7)
+      MU(8)  = MAT_PARAM%UPARAM(8)
+      MU(9)  = MAT_PARAM%UPARAM(9)
+      MU(10) = MAT_PARAM%UPARAM(10)
       ! Material exponents
-      AL1 = UPARAM(6)
-      AL2 = UPARAM(7)
-      AL3 = UPARAM(8)
-      AL4 = UPARAM(9)
-      AL5 = UPARAM(10)
+      AL(1)  = MAT_PARAM%UPARAM(11)
+      AL(2)  = MAT_PARAM%UPARAM(12)
+      AL(3)  = MAT_PARAM%UPARAM(13)
+      AL(4)  = MAT_PARAM%UPARAM(14)
+      AL(5)  = MAT_PARAM%UPARAM(15)
+      AL(6)  = MAT_PARAM%UPARAM(16)
+      AL(7)  = MAT_PARAM%UPARAM(17)
+      AL(8)  = MAT_PARAM%UPARAM(18)
+      AL(9)  = MAT_PARAM%UPARAM(19)
+      AL(10) = MAT_PARAM%UPARAM(20)
       ! Shear modulus
-      GMAX = MU1*AL1+MU2*AL2+MU3*AL3+MU4*AL4+MU5*AL5
+      GMAX  = ZERO
+      DO I=1,NORDER                       
+        GMAX = GMAX + MU(I)*AL(I)
+      ENDDO                               
       ! Bulk modulus
-      RBULK = UPARAM(11)
+      RBULK = MAT_PARAM%UPARAM(21)
       ! Cutoff stress in tension
-      TENSIONCUT = UPARAM(12)
+      TENSIONCUT = MAT_PARAM%UPARAM(23)
       ! Bulk function scale factor
-      FFAC = UPARAM(15)
-      ! Flag for strain energy density formulation
-      IFORM = UPARAM(17)
+      FFAC = MAT_PARAM%UPARAM(24)
       ! Tabulated bulk function ID
       KFP = IFUNC(1)
 c
@@ -202,11 +221,14 @@ c
       ! Isochoric strain energy density derivation
       ! Note: here, the table DWDL(:,J) corresponds to the product EVM(J)*DWDEVM(:,J)
       DO I=1,NEL
-        DO J=1,3
-          DWDL(J,I) = (MU1*(EVM(J,I)**AL1-1) + MU2*(EVM(J,I)**AL2-1) +
-     .                 MU3*(EVM(J,I)**AL3-1) + MU4*(EVM(J,I)**AL4-1) +
-     .                 MU5*(EVM(J,I)**AL5-1))
-        ENDDO
+        DWDL(1,I) = ZERO          
+        DWDL(2,I) = ZERO          
+        DWDL(3,I) = ZERO          
+        DO J=1,NORDER                                                
+          DWDL(1,I) = DWDL(1,I) + MU(J)*(EVM(1,I)**AL(J) - ONE)        
+          DWDL(2,I) = DWDL(2,I) + MU(J)*(EVM(2,I)**AL(J) - ONE)         
+          DWDL(3,I) = DWDL(3,I) + MU(J)*(EVM(3,I)**AL(J) - ONE) 
+        END DO        
       ENDDO
 c 
       ! Volumic strain energy density derivation + trace of isochoric derivative

--- a/starter/source/materials/mat_share/mulaw.F
+++ b/starter/source/materials/mat_share/mulaw.F
@@ -251,9 +251,9 @@ C ====================================================================
      .                  RBID,ISMSTR,MFXX,MFXY,MFXZ,MFYX, 
      .                  MFYY ,MFYZ ,MFZX ,MFZY,MFZZ)
       ELSEIF(MTN==42)THEN
-          CALL SIGEPS42(LLT ,NPAR,NUVAR,NFUNC,IFUNC ,
-     2                  NPF ,TF  ,TIME,TIMESTEP,BUFMAT(IADBUF),
-     3                  RHO0,RHO ,VOLN ,EINT ,
+          CALL SIGEPS42(LLT ,NUVAR,NFUNC,IFUNC ,
+     2                  NPF ,TF  ,TIME,TIMESTEP,
+     3                  RHO0,RHO ,VOLN ,EINT ,MATPARAM(IMAT),
      4                  EP1 ,EP2 ,EP3 ,EP4  ,EP5  ,EP6 ,
      5                  DE1 ,DE2 ,DE3 ,DE4  ,DE5  ,DE6 ,
      6                  ES1 ,ES2 ,ES3 ,ES4  ,ES5  ,ES6 ,

--- a/starter/source/materials/updmat.F
+++ b/starter/source/materials/updmat.F
@@ -232,7 +232,7 @@ c-------------------------
      .                    MTAG   ,NFUNCT )        
 c-------------------------
           CASE (42) 
-            CALL LAW42_UPD(IOUT,TITR,MAT_ID,UPARAM,PM(1,IMAT),GAMA_INF)        
+            CALL LAW42_UPD(MAT_PARAM(IMAT),IOUT,TITR,MAT_ID,PM(1,IMAT),GAMA_INF)        
 c-------------------------
           CASE (50) 
             CALL LAW50_UPD(MATPARAM,NPARAM,UPARAM,NFUNC,IFUNC,SNPC,STF,NPC,PLD)        


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

added new input for new Ogden material law parameters, old format remains valid

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

updated cfg, input reading and reference metric routines in starter 
modified material law code using parameter arrays instead of scalar parameters
used new mat_param structure storage instead of old bufmat/uparam tables

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
