### PR TITLE
H3D and QUAD : fix

### DIFF
--- a/engine/source/output/h3d/h3d_results/h3d_quad_scalar_1.F90
+++ b/engine/source/output/h3d/h3d_results/h3d_quad_scalar_1.F90
@@ -259,9 +259,6 @@
 ! ----------------------------------------------------------------------------------------------------------------------
           ilay = layer_input
           iuvar = iuvar_input
-          do i=1,numelq
-            is_written_quad(i) = 0
-          enddo
           call initbuf(iparg    ,ng      ,&
           &mlw     ,nel     ,nft     ,iad     ,ity     ,&
           &npt     ,jale    ,ismstr  ,jeul    ,jturb   ,&


### PR DESCRIPTION
#### H3D and QUAD : fix

#### Description of the changes
**Fix related to commit 298ec0762594c58de83ef78573b19601ef018643**

The **Is_written_quad** array was unexpectedly reset to 0 during the group loop for **'NG = 1, NGROUP'**.