### PR TITLE
Update Apptainer files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ engine/extlib/scalap*
 engine/extlib/v2*
 engine/extlib/v3*
 .vscode/settings.json
+*.sif

--- a/Apptainer/arm/openradioss_arm.def
+++ b/Apptainer/arm/openradioss_arm.def
@@ -30,10 +30,10 @@ cd /opt
 git lfs install
 git clone --depth 1 --branch main https://github.com/OpenRadioss/OpenRadioss.git
 cd /opt/OpenRadioss/starter
-./build_script.sh -arch=linuxa64 -nt=$NCPU -static-link
+./build_script.sh -arch=linuxa64 -nt=$NCPU -static-link -release
 cd /opt/OpenRadioss/engine
-./build_script.sh -arch=linuxa64 -nt=$NCPU -static-link
-./build_script.sh -arch=linuxa64 -mpi=ompi -nt=$NCPU -static-link
+./build_script.sh -arch=linuxa64 -nt=$NCPU -static-link -relsease
+./build_script.sh -arch=linuxa64 -mpi=ompi -nt=$NCPU -static-link -release
 cd /opt/OpenRadioss/tools/anim_to_vtk/linux64
 ./build.bash
 cd /opt/OpenRadioss/tools/th_to_csv/linux64

--- a/Apptainer/openradioss.def
+++ b/Apptainer/openradioss.def
@@ -22,10 +22,10 @@ cd /opt
 git lfs install
 git clone --depth 1 --branch main https://github.com/OpenRadioss/OpenRadioss.git
 cd /opt/OpenRadioss/starter
-./build_script.sh -arch=linux64_gf -nt=$NCPU
+./build_script.sh -arch=linux64_gf -nt=$NCPU -release
 cd /opt/OpenRadioss/engine
-./build_script.sh -arch=linux64_gf -nt=$NCPU
-./build_script.sh -arch=linux64_gf -mpi=ompi -nt=$NCPU
+./build_script.sh -arch=linux64_gf -nt=$NCPU -release
+./build_script.sh -arch=linux64_gf -mpi=ompi -nt=$NCPU -release
 cd /opt/OpenRadioss/tools/anim_to_vtk/linux64
 ./build.bash
 cd /opt/OpenRadioss/tools/th_to_csv/linux64

--- a/Apptainer/openradioss_intel_ifx.def
+++ b/Apptainer/openradioss_intel_ifx.def
@@ -30,10 +30,10 @@ git lfs install
 git clone https://github.com/OpenRadioss/OpenRadioss.git
 cd OpenRadioss
 cd /opt/OpenRadioss/starter
-./build_script.sh -arch=linux64_intel -nt=$NCPU -release
+./build_script.sh -arch=linux64_intel_ifx -nt=$NCPU -release
 cd /opt/OpenRadioss/engine
-./build_script.sh -arch=linux64_intel -nt=$NCPU -release
-./build_script.sh -arch=linux64_intel -mpi=impi -nt=$NCPU -release
+./build_script.sh -arch=linux64_intel_ifx -nt=$NCPU -release
+./build_script.sh -arch=linux64_intel_ifx -mpi=impi -nt=$NCPU -release
 cd /opt/OpenRadioss/tools/anim_to_vtk/linux64
 ./build.bash
 cd /opt/OpenRadioss/tools/th_to_csv/linux64


### PR DESCRIPTION
#### Description of the feature or the bug
Update the Apptainer definition files to use the `-release` flag and update the Intel compiler. The changes have been made following the post earlier this year of #2272 


#### Description of the changes
The Apptainer files have been updated to use the `-release` flag so as to not have any debugging or sanitation procedures. This makes them ready for production workloads. The Intel compiler toolchain has been updated to the latest current version, which hopefully yields slight better performance and less issues.

I have not been able to build the Apptainer files locally as I currently do not have a nice stable internet connection, but they should build without issue as the changes are very minor. Nonetheless, the changes to the Intel directories have been verified.
