### PR TITLE
Fix doubled printing message when elements are deleted

### DIFF
--- a/engine/source/materials/fail/fail_setoff_c.F
+++ b/engine/source/materials/fail/fail_setoff_c.F
@@ -35,7 +35,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .                         THK_LY   ,THKLY    ,OFF      ,STACK    ,
      .                         ISUBSTACK,IGTYP    ,FAILWAVE ,FWAVE_EL ,
      .                         NLAY_MAX ,LAYNPT_MAX,NUMGEO  ,NUMSTACK ,
-     .                         IGEO     )
+     .                         IGEO     ,PRINT_FAIL)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -69,7 +69,8 @@ C-----------------------------------------------
       TYPE (STACK_PLY), INTENT(IN)                  :: STACK
       TYPE (FAILWAVE_STR_), INTENT(IN), TARGET      :: FAILWAVE 
       INTEGER, DIMENSION(NEL), INTENT(INOUT)        :: FWAVE_EL
-      TYPE (MAT_ELEM_) ,INTENT(INOUT) :: MAT_ELEM
+      TYPE (MAT_ELEM_) ,INTENT(INOUT)               :: MAT_ELEM
+      LOGICAL, DIMENSION(NEL), INTENT(INOUT)        :: PRINT_FAIL
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -164,6 +165,7 @@ c
               IF (((THFACT(IEL) >= PTHKF(IL,IFL)).AND.(PTHKF(IL,IFL) > ZERO)).OR.
      .            ((NPFAIL(IEL) >= ABS(PTHKF(IL,IFL))).AND.(PTHKF(IL,IFL) < ZERO))) THEN
                 OFF(IEL) = FOUR_OVER_5
+                PRINT_FAIL(IEL) = .FALSE.
                 FAIL_NAME(IEL) = MAT_ELEM%MAT_PARAM(IMAT)%FAIL(IFL)%KEYWORD
 #include      "lockon.inc"                           
                 WRITE(IOUT, 1000) TRIM(FAIL_NAME(IEL)),NGL(IEL)

--- a/engine/source/materials/fail/fail_setoff_npg_c.F
+++ b/engine/source/materials/fail/fail_setoff_npg_c.F
@@ -37,7 +37,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .           OFF      ,NPG      ,STACK    ,ISUBSTACK,
      .           IGTYP    ,FAILWAVE ,FWAVE_EL ,NLAY_MAX ,
      .           LAYNPT_MAX,NUMGEO  ,IPG      ,NUMSTACK ,
-     .           IGEO     )
+     .           IGEO     ,PRINT_FAIL)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -72,7 +72,8 @@ C-----------------------------------------------
       TYPE (STACK_PLY), INTENT(IN)                  :: STACK    
       TYPE (FAILWAVE_STR_), INTENT(IN), TARGET      :: FAILWAVE 
       INTEGER, DIMENSION(NEL), INTENT(INOUT)        :: FWAVE_EL
-      TYPE (MAT_ELEM_) ,INTENT(INOUT) :: MAT_ELEM
+      TYPE (MAT_ELEM_) ,INTENT(INOUT)               :: MAT_ELEM
+      LOGICAL, DIMENSION(NEL), INTENT(INOUT)        :: PRINT_FAIL
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -185,6 +186,7 @@ c
               ENDDO ! |-> IG
               IF (COUNTPG == 0) THEN
                 OFF(IEL)  = FOUR_OVER_5  
+                PRINT_FAIL(IEL) = .FALSE.
                 FAIL_NAME = MAT_ELEM%MAT_PARAM(IMAT)%FAIL(FAIL_NUM(IEL))%KEYWORD 
 #include      "lockon.inc"                           
                 WRITE(IOUT, 1000) TRIM(FAIL_NAME),NGL(IEL)

--- a/engine/source/materials/mat_share/mulawc.F
+++ b/engine/source/materials/mat_share/mulawc.F
@@ -289,6 +289,7 @@ c----
       LOGICAL :: LOGICAL_USERL_AVAIL
       LOGICAL :: FLAG_EPS,FLAG_EPSP,FLAG_ZCFAC,FLAG_ETIMP
       LOGICAL :: FLAG_LAW1,FLAG_LAW2,FLAG_LAW25,FLAG_LAW22
+      LOGICAL, DIMENSION(NEL) :: PRINT_FAIL
 !
       CHARACTER OPTION*256
       INTEGER SIZE
@@ -2596,6 +2597,9 @@ c     END OF LOOP OVER INTEGRATION POINTS (LAYERS)
 c--------------------------------------------------
 c     TEST OF ELEMENT FAILURE 
 c--------------------------------------------------
+      ! Flag for printing element deletion message
+      PRINT_FAIL(1:NEL) = .TRUE.
+      ! Check element deletion from failure criterion
       IF (IFAILURE == 1 .and. IXFEM == 0) THEN
         IF (ORTH_DAMAGE == 1) THEN   ! /fail/alter + front_wave only
           TFAIL => GBUF%DMG(1+NEL:NEL*2)  ! only for /FAIL/ALTER          
@@ -2612,7 +2616,7 @@ c--------------------------------------------------
      .                       THK_LY   ,THKLY    ,OFF      ,STACK    ,
      .                       ISUBSTACK,IGTYP    ,FAILWAVE ,FWAVE_EL ,
      .                       NLAY_MAX ,LAYNPT_MAX,NUMGEO  ,NUMSTACK ,
-     .                       IGEO     )
+     .                       IGEO     ,PRINT_FAIL)
         ELSE
           CALL FAIL_SETOFF_NPG_C(
      .                       ELBUF_STR,MAT_ELEM ,GEO      ,PID(1)   ,
@@ -2621,10 +2625,11 @@ c--------------------------------------------------
      .                       OFF      ,NPG      ,STACK    ,ISUBSTACK, 
      .                       IGTYP    ,FAILWAVE ,FWAVE_EL ,NLAY_MAX ,
      .                       LAYNPT_MAX,NUMGEO  ,IPG      ,NUMSTACK ,
-     .                       IGEO     )
+     .                       IGEO     ,PRINT_FAIL)
         ENDIF
       ENDIF  
 c---
+      ! Checking element deletion and printing element deletion messages (if needed)
       NINDX = 0
       IF (IXFEM == 0) THEN
         DO I=JFT,JLT
@@ -2633,7 +2638,8 @@ c---
      .        OFF(I) > ZERO   .and. OFF(I) < ONE .and. DMG_FLAG == 1 .and. 
      .        DMG_GLOB_SCALE(I) < EM02) THEN  
             OFF(I) = ZERO
-            IF (NLAY > 1) THEN 
+            ! Printing message not always mandatory
+            IF (PRINT_FAIL(I)) THEN 
               NINDX  = NINDX + 1
               INDX(NINDX) = I
             ENDIF

--- a/engine/source/materials/mat_share/usermat_shell.F
+++ b/engine/source/materials/mat_share/usermat_shell.F
@@ -239,6 +239,7 @@ c----
 c----
       LOGICAL :: LOGICAL_USERL_AVAIL
       LOGICAL :: FLAG_EPS,FLAG_EPSP,FLAG_ZCFAC
+      LOGICAL, DIMENSION(NEL) :: PRINT_FAIL
       CHARACTER*256 MDS_LIBNAME
       INTEGER LENGTH
 !
@@ -1971,6 +1972,9 @@ c     FIN DE BOUCLE SUR POINTS INTEGRATION (LAYERS)
 c--------------------------------------------------
 c     TEST OF ELEMENT FAILURE 
 c--------------------------------------------------
+      ! Flag for printing element deletion message
+      PRINT_FAIL(1:NEL) = .TRUE.
+      ! Check element deletion from failure criterion
       IF (IFAILURE == 1 .and. IXFEM == 0) THEN
         IF (ORTH_DAMAGE == 1) THEN   ! /fail/alter + front_wave only
           TFAIL => GBUF%DMG(1+NEL:NEL*2)  ! only for /FAIL/ALTER          
@@ -1987,7 +1991,7 @@ c--------------------------------------------------
      .                       THK_LY   ,THKLY    ,OFF      ,STACK    ,
      .                       ISUBSTACK,IGTYP    ,FAILWAVE ,FWAVE_EL ,
      .                       NLAY_MAX ,LAYNPT_MAX,NUMGEO  ,NUMSTACK ,
-     .                       IGEO     )
+     .                       IGEO     ,PRINT_FAIL)
         ELSE
           CALL FAIL_SETOFF_NPG_C(
      .                       ELBUF_STR,MAT_ELEM ,GEO      ,PID(1)   ,
@@ -1996,10 +2000,11 @@ c--------------------------------------------------
      .                       OFF      ,NPG      ,STACK    ,ISUBSTACK, 
      .                       IGTYP    ,FAILWAVE ,FWAVE_EL ,NLAY_MAX ,
      .                       LAYNPT_MAX,NUMGEO  ,IPG      ,NUMSTACK ,
-     .                       IGEO     )
+     .                       IGEO     ,PRINT_FAIL)
         ENDIF
       ENDIF  
 c---
+      ! Checking element deletion and printing element deletion messages (if needed)
       NINDX = 0
       IF (IXFEM == 0) THEN
         DO I=JFT,JLT
@@ -2008,7 +2013,8 @@ c---
      .        OFF(I) > ZERO   .and. OFF(I) < ONE .and. DMG_FLAG == 1 .and. 
      .        DMG_GLOB_SCALE(I) < EM02) THEN  
             OFF(I) = ZERO
-            IF (NLAY > 1) THEN 
+            ! Printing message not always mandatory
+            IF (PRINT_FAIL(I)) THEN 
               NINDX  = NINDX + 1
               INDX(NINDX) = I
             ENDIF


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

For some cases, shell element deletion messages can be doubled or disappear. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Avoid the disappearance or the doubling of the message by adding a flag to distinguish cases where element deletion printing message coming from mulawc.F is needed. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
