### PR TITLE
/H3D : bug fix for QUAD elements and vectors output

### DIFF
--- a/engine/source/output/h3d/h3d_results/h3d_quad_vector.F
+++ b/engine/source/output/h3d/h3d_results/h3d_quad_vector.F
@@ -231,12 +231,11 @@ C--------------------------------------------------
                ENDIF
 C--------------------------------------------------
             ENDIF  ! KEYWORD
-
-          ENDIF  ! ITY 
 C-----------------------------------------------
-          CALL H3D_WRITE_VECTORS(IOK_PART,IS_WRITTEN_QUAD,QUAD_VECTOR,NEL,0,NFT,
-     .                                    EVAR,IS_WRITTEN_VECTOR)
-c
+          CALL H3D_WRITE_VECTORS(IOK_PART,IS_WRITTEN_QUAD,QUAD_VECTOR,NEL,0,NFT,EVAR,IS_WRITTEN_VECTOR)
+C-----------------------------------------------
+          ENDIF  ! ITY
+
 C-----------------------------------------------
        ENDIF     ! MLW /= 13
  900  CONTINUE   ! NG 


### PR DESCRIPTION
#### /H3D : bug fix for QUAD elements and vectors output

#### Description of the changes
The call of subroutine responsible for writing vector results for QUAD elements has been moved inside the conditional block. This change prevents unexpected data from being written to the H3D file. For example, in a scenario where the input file contains 1 QUAD element (group NG=1) and 4 TRUSS elements (group NG=2), the previous implementation would incorrectly set QUAD_VECTORS(1:3, **1,:4**) despite the allocation being only for QUAD_VECTORS(1:3, **1:1**). This mismatch was causing **memory corruption**.