### PR TITLE
/INIVOL enhancement : default submat is the prevalent one

### DIFF
--- a/common_source/modules/constant_mod.F
+++ b/common_source/modules/constant_mod.F
@@ -275,6 +275,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
         my_real, parameter ::  SEVEN_OVER_5     = SEVEN/FIVE
         my_real, parameter ::  SEVEN_OVER_9    = SEVEN/NINE
         my_real, parameter ::  NINE_OVER_2  = NINE/TWO
+        my_real, parameter ::  NINE_OVER_10  = NINE/TEN
         my_real, parameter ::  NSEIZE    = NINE/SIXTEEN
         my_real, parameter ::  NINE_OVER_20    = NINE/TWENTY
         my_real, parameter ::  ZEP11     = ZEP1 + ZEP01

--- a/starter/source/initial_conditions/inivol/hm_read_inivol.F
+++ b/starter/source/initial_conditions/inivol/hm_read_inivol.F
@@ -194,18 +194,16 @@ C
 
           WRITE(IOUT,'(2X,I10,I10,I9,I6,F20.0)')IDSURF,SUBMAT_ID,IREVERSED,ICUMU,VFRAC
 
-          !IF(FLAG == 0)THEN
-            IF((SUBMAT_ID < 0 .OR. SUBMAT_ID > 4).AND.  .NOT.MULTI_FVM%IS_USED )THEN
-              CALL ANCMSG(MSGID=887,MSGTYPE=MSGERROR, ANMODE=ANINFO,I1=ID,C1=TITR)
-            ENDIF
-            IF(IREVERSED < 0 .OR. IREVERSED > 1)THEN
-              CALL ANCMSG(MSGID=888,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=ID,C1=TITR)
-            ENDIF
-            IF(VFRAC < ZERO .or. VFRAC > ONE)THEN
-              CALL ANCMSG(MSGID=1596,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=ID,C1=TITR)
-            ENDIF
-          !ENDIF
-                                                                                                  
+          IF((SUBMAT_ID <= 0 .OR. SUBMAT_ID > 4).AND.  .NOT.MULTI_FVM%IS_USED )THEN
+            CALL ANCMSG(MSGID=887,MSGTYPE=MSGERROR, ANMODE=ANINFO,I1=ID,C1=TITR)
+          ENDIF
+          IF(IREVERSED < 0 .OR. IREVERSED > 1)THEN
+            CALL ANCMSG(MSGID=888,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=ID,C1=TITR)
+          ENDIF
+          IF(VFRAC < ZERO .or. VFRAC > ONE)THEN
+            CALL ANCMSG(MSGID=1596,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=ID,C1=TITR)
+          ENDIF
+
           IMAT = IPART(LIPART1*(PART_ID-1)+1)
           ILAW=   IPM((IMAT-1)*NPROPMI + 2)     !IPM(2,IMAT)
           IF(ILAW/=51 .AND. ILAW/=151)THEN
@@ -214,7 +212,7 @@ C
 
           !!get bijective application to retrieve internal order of submaterial.
           !! (internally & historically submat4 is explosive submaterial)
-          IF(ILAW==51)THEN                    
+          IF(ILAW == 51)THEN
             IADBUF = IPM((IMAT-1)*NPROPMI + 7)!IPM(7,IMAT)                       
             NUPARAM= IPM((IMAT-1)*NPROPMI + 9)!IPM(9,IMAT)                       
             UPARAM => BUFMAT(IADBUF:IADBUF+NUPARAM)          

--- a/starter/source/initial_conditions/inivol/iniphase.F
+++ b/starter/source/initial_conditions/inivol/iniphase.F
@@ -38,6 +38,7 @@ C   M o d u l e s
 C-----------------------------------------------
       USE ELBUFDEF_MOD
       USE MULTI_FVM_MOD
+      USE CONSTANT_MOD , ONLY : NINE_OVER_10
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -45,23 +46,33 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER,INTENT(IN) :: N2D, NUMELS, NUMELTG, NUMELQ, NUMNOD, NGROUP
+      INTEGER,INTENT(IN) :: N2D !< 2d/3d flag
+      INTEGER,INTENT(IN) :: NUMELS, NUMELTG, NUMELQ, NUMNOD, NGROUP !array sizes
+      INTEGER,INTENT(IN) :: NBSUBMAT
       INTEGER IXS(NIXS,NUMELS),IPART_(*),IPHASE(NBSUBMAT+1,*),IDP,NUPARAM
-      INTEGER ITAGNSOL(NUMNOD),NBIP(NBSUBMAT,*),NTRACE
-      INTEGER ISOLNOD,PART_FILL(*),IXQ(NIXQ,NUMELQ), IXTG(NIXTG,NUMELTG),ITYP
-      my_real KVOL(NBSUBMAT,*),UPARAM(NUPARAM)
-      INTEGER,INTENT(IN) :: NBSUBMAT, MLW, NG
+      INTEGER ITAGNSOL(NUMNOD)
+      INTEGER :: NBIP(NBSUBMAT,NEL)   !< number of internal points
+      INTEGER :: NTRACE               !<  maximum number of internal points (NBIP <= NTRACE, default 7*7*7)
+      INTEGER ISOLNOD,PART_FILL(*)
+      INTEGER,INTENT(IN) :: IXQ(NIXQ,NUMELQ) !< quad connectivity buffer
+      INTEGER,INTENT(IN) :: IXTG(NIXTG,NUMELTG) !< triangles connectivity buffer
+      INTEGER, INTENT(IN) :: ITYP !< elem types of the current group (quad, tirangles, hexa,)
+      my_real KVOL(NBSUBMAT,NEL)      !< volume fractions
+      my_real UPARAM(NUPARAM)
+      INTEGER,INTENT(IN) :: MLW !< material law (type)
+      INTEGER,INTENT(IN) :: NG  !< current elem group
       TYPE(ELBUF_STRUCT_), TARGET, DIMENSION(NGROUP), INTENT(IN) :: ELBUF_TAB
       TYPE (MULTI_FVM_STRUCT), INTENT(IN) :: MULTI_FVM
-      INTEGER, INTENT(IN) :: NEL
+      INTEGER, INTENT(IN) :: NEL !< number of elements in the group
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I,K,J
-      INTEGER IX(4)
-      my_real AV(NBSUBMAT)
-      TYPE(G_BUFEL_) ,POINTER :: GBUF  
-      TYPE(L_BUFEL_) ,POINTER :: LBUF  
+      INTEGER :: I,K,J !< loop and temporary integers
+      INTEGER :: IMAT  !< submat identifier (in 1:NBSUBMAT)
+      INTEGER :: IX(4) !< working array for shell nodes
+      my_real :: AV(NBSUBMAT) !< working array for volume fractions
+      TYPE(G_BUFEL_) ,POINTER :: GBUF  !< global elem buffer
+      TYPE(L_BUFEL_) ,POINTER :: LBUF  !< local elem buffer (submaterials)
 C-----------------------------------------------
 C---
 C FILL ELEMENTS INPUT PHASES
@@ -85,11 +96,13 @@ C
               KVOL(1:NBSUBMAT,I)   = AV(1:NBSUBMAT)
               PART_FILL(IPART_(I)) = 1
             ELSEIF (IPART_(I) == IDP) THEN
-              IPHASE(1,I)          = 1
+              IMAT=MAXLOC(AV(1:NBSUBMAT),1) ! The default phase is the one that is most prevalent.
+              IF(AV(IMAT) < NINE_OVER_10)IMAT=1 ! no prevalence : use first one.
+              IPHASE(1,I)       = IMAT
               IPHASE(NBSUBMAT+1,I) = 1
-              KVOL(1,I)            = ZERO
-              IF (NBIP(1,I) == 0) THEN
-                NBIP(1,I) = NTRACE
+              KVOL(1,I)         = ZERO
+              IF (NBIP(IMAT,I) == 0) THEN
+                NBIP(IMAT,I) = NTRACE
               ENDIF
               IF (ISOLNOD == 8) THEN
                 DO K=2,9

--- a/starter/source/initial_conditions/inivol/inivol_set.F
+++ b/starter/source/initial_conditions/inivol/inivol_set.F
@@ -37,6 +37,7 @@ C-----------------------------------------------
       USE MULTI_FVM_MOD
       USE ELBUFDEF_MOD 
       USE MESSAGE_MOD
+      USE CONSTANT_MOD, ONLY : NINE_OVER_10
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -64,9 +65,44 @@ C-----------------------------------------------
       TYPE(G_BUFEL_) ,POINTER :: GBUF   
       TYPE(L_BUFEL_) ,POINTER :: LBUF   
       my_real                 :: P, P1,P2,P3,P4,SUMVF,RATIO
+      INTEGER                 :: default_SUBMAT_id(NEL)
 C-----------------------------------------------
 C   S o u r c e  L i n e s
 C-----------------------------------------------
+
+      ! DETERMINE DEFAULT SUBMAT ID
+      default_SUBMAT_id(1:NEL) = 1
+      DO I=1,NEL
+        IF(IPART(I+NFT) /= IDP)CYCLE
+
+        IF(MLW == 51)THEN
+          DO IMAT=1,4
+            KK = N0PHAS + (IMAT-1)*NVPHAS
+            IF(UVAR(I,1+KK) >= NINE_OVER_10)THEN
+              default_SUBMAT_id(I) = IMAT
+              EXIT
+            ENDIF
+          ENDDO
+
+        ELSEIF(MLW == 37)THEN
+          IF(UVAR(I,4)  >= NINE_OVER_10) THEN
+            default_SUBMAT_id(I) = 1
+          ELSEIF(UVAR(I,5)  >= NINE_OVER_10)THEN
+            default_SUBMAT_id(I) = 2
+          ENDIF
+
+        ELSEIF(MLW == 151)THEN
+          GBUF => ELBUF_TAB(NG)%GBUF
+          DO IMAT=1,MULTI_FVM%NBMAT
+            LBUF => ELBUF_TAB(NG)%BUFLY(IMAT)%LBUF(1,1,1)
+            IF(LBUF%VOL(I) / GBUF%VOL(I) >= NINE_OVER_10)THEN
+              default_SUBMAT_id(I) = IMAT
+              EXIT
+            ENDIF
+          ENDDO
+        ENDIF
+
+      ENDDO!next I
 
       !---ADD CONTRIBUTION FROM 2D POLYGONAL CLIPPING
       IF(REQUIRED_2D_POLYGON_CLIPPING) THEN
@@ -77,15 +113,17 @@ C-----------------------------------------------
         ENDDO
       ENDIF
 
-      !---CHECK UNOCCUPIPED SUBVOLUME AND FILL WITH PHASE 1. IF SUM(vfrac>1) display an error message.
+      !---CHECK UNOCCUPIPED SUBVOLUME AND FILL WITH DEFAULT PHASE IF SUM(vfrac>1) display an error message.
       DO I=1,NEL
        IF(IPART(I+NFT) /= IDP)CYCLE
         SUMVF = SUM(KVOL(1:NBSUBMAT,I))
+        IMAT = default_SUBMAT_id(I)
         IF(SUMVF > ONE+EM06)THEN
           !not expected, user input must be checked : error message
-          SUMVF = SUM(KVOL(2:NBSUBMAT,I))
+          SUMVF = SUM(KVOL(1:NBSUBMAT,I))
+          SUMVF = SUMVF - KVOL(IMAT,I)
           IF(SUMVF <= ONE .AND. SUMVF > ZERO)THEN  ! sumvf is here calculated in range 2:nbsumat
-            KVOL(1,I)=ONE-SUMVF
+            KVOL(IMAT,I)=ONE-SUMVF
           ELSE
             SUMVF = SUM(KVOL(1:NBSUBMAT,I))
             RATIO=ONE/SUMVF
@@ -93,7 +131,7 @@ C-----------------------------------------------
           ENDIF
         ELSEIF(SUMVF < ONE-EM06)THEN
           !fill unoccupied subvolume with phase-1
-          KVOL(1,I) = KVOL(1,I) + ONE-SUMVF
+          KVOL(IMAT,I) = KVOL(IMAT,I) + ONE-SUMVF
         ELSEIF(SUMVF >= ONE-EM06 .AND. SUMVF <= ONE+EM06)THEN
           !get rid of precision issue so that sumvf is exactly 1.000000
           RATIO=ONE/SUMVF


### PR DESCRIPTION
#### /INIVOL enhancement : default submat is the prevalent one

#### Option Reminder
The /INIVOL option is an initial condition that allows setting volume fractions using a provided surface (which can consist of 3D shells, 2D segments, 2D/3D ellipsoids, or infinite planes). The user specifies surfaces and submaterial identifiers to fill one side of the surface with the given ratio.

At the end of the process, the sum of the volume fractions must total 100%, ensuring that the element volume is correctly partitioned. If the sum does not reach 100%, the remaining volume is automatically filled with the default submaterial.

#### Description of Changes
The default submaterial ID has been updated. Previously, the default submaterial ID was set to 1. It is now set to the prevalent submaterial, which is defined when multimaterial laws (e.g., law51 or law151) are applied. This change makes the process more intuitive from the user's perspective.

By the way : 

- error message introduced with inivol defines isubmat=0 (hm_read_inivol.F : 197)
- comments added in iniphase.F (purpose of local variables)

