### PR TITLE
Correction of material law weight calculation with /visc/prony

### DIFF
--- a/starter/source/spmd/domain_decomposition/initwg_shell.F
+++ b/starter/source/spmd/domain_decomposition/initwg_shell.F
@@ -58,12 +58,12 @@ C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER  NUMELC,OFF,
      .  NUMMAT,NUMGEO,IXC(NIXC,*),
-     .  IGEO(NPROPGI,*),IPM(NPROPMI,*),TABMP_L
+     .  IGEO(NPROPGI,NUMGEO),IPM(NPROPMI,NUMMAT),TABMP_L
       INTEGER, INTENT(IN) :: SIZE_IRUP ! maximum number of rupture criteria
 
 C     REAL OU REAL*8
       my_real
-     .    PM(NPROPM,*), GEO(NPROPG,*),BUFMAT(*)
+     .    PM(NPROPM,NUMMAT), GEO(NPROPG,NUMGEO),BUFMAT(*)
       REAL WD(*)
       INTEGER MID_OLD,PID_OLD,MLN_OLD,RECHERCHE
       my_real TELT_PRO
@@ -213,16 +213,15 @@ C-----------------------------------------------
         ! law 42,62 and 69 : prony option
         ELSEIF((MLN==42).OR.(MLN==62).OR.(MLN==69)) THEN
 !       check the NPRONY model
-           NFUNC = 0
+           NFUNC = 0   ! NPRONY
            IF (MLN==42) NFUNC = MAT_PARAM(ABS(MID))%IPARAM(2)
            IF (MLN==62) THEN
              IAD=IPM(7,ABS(MID))-1
              NFUNC = NINT(BUFMAT(IAD+3))
            END IF
            IF (NFUNC == 0) THEN
-             IF(IPM(222,ABS(MID)) > 0) THEN 
-               IAD = IPM(223,ABS(MID))
-               NFUNC =  NINT(BUFMAT(IAD +1 ))
+             IF (MAT_PARAM(ABS(MID))%IVISC > 0) THEN 
+               NFUNC = MAT_PARAM(ABS(MID))%VISC%IPARAM(1) !  = NPRONY
              ENDIF
            ENDIF
            IF(NFUNC==0) THEN

--- a/starter/source/spmd/domain_decomposition/initwg_tri.F
+++ b/starter/source/spmd/domain_decomposition/initwg_tri.F
@@ -189,16 +189,15 @@ C loi 36+86 en fonction des fct
            INDI = 3
           ENDIF
         ELSEIF((MLN==42).OR.(MLN==62).OR.(MLN==69)) THEN  ! check prony option
-           NFUNC = 0
+           NFUNC = 0   ! NPRONY
            IF (MLN==42) NFUNC = MAT_PARAM(ABS(MID))%IPARAM(2)
            IF (MLN==62) THEN
              IAD=IPM(7,ABS(MID))-1
              NFUNC = NINT(BUFMAT(IAD+3))
            END IF
            IF (NFUNC == 0) THEN
-             IF (IPM(222,ABS(MID)) > 0) THEN 
-               IAD = IPM(223,ABS(MID))
-               NFUNC =  NINT(BUFMAT(IAD +1 ))
+             IF (MAT_PARAM(ABS(MID))%IVISC > 0) THEN 
+               NFUNC = MAT_PARAM(ABS(MID))%VISC%IPARAM(1) !  = NPRONY
              ENDIF
            ENDIF
            IF(NFUNC==0) THEN


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Correct a bug in starter during material law weight calculation for domdec, with material laws + /visc/prony
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

number of Prony series terms was checked using old obsolete adress in IPM instead of MAT_PARAM%VISC

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
