### PR TITLE
alemain.F:arguments update

### DIFF
--- a/engine/source/ale/alemain.F
+++ b/engine/source/ale/alemain.F
@@ -886,37 +886,38 @@ C
                     pQMV => BID
                   ENDIF   
                   CALL QFORC2(
-     .                  ELBUF_TAB,NG ,
-     1                  PM           ,GEO          ,IXQ         ,X         ,A        ,  
-     2                  V            ,MS           ,W           ,WA        ,VAL2     ,  
-     3                  VEUL         ,ALE_CONNECTIVITY       ,IPARG    ,NLOC_DMG,
-     4                  TF           ,NPC          ,BUFMAT      ,PARTSAV   ,
-     5                  DT2T         ,NELTST       ,ITYPTST     ,STIFN     ,OFFSET   ,  
-     6                  EANI         ,IPARTQ(1+NFT),NEL         ,IADQ      ,FSKY     ,  
-     9                  IPM          ,BUFVOIS      ,pQMV        ,
-     A                  GRESAV       ,GRTH         ,IGRTH       ,TABLE     ,IGEO     ,
-     B                  VOLN         ,ITASK        ,MS_2D       ,FSKYM     ,IOUTPRT  ,MAT_ELEM,
-     C              H3D_DATA%STRAIN  ,SZ_BUFVOIS   ,SNPC        ,STF       ,SBUFMAT  ,
-     D                  SVIS,NSVOIS,IRESP       ,TT        ,DT1,      
-     .                  IDEL7NOK     ,IDTMIN      ,MAXFUNC,  
-     .                  IMON_MAT,USERL_AVAIL, heat_meca, impl_s,     idyna) 
+     .                  ELBUF_TAB       ,NG               ,
+     1                  PM              ,GEO              ,IXQ         ,X         ,A        ,  
+     2                  V               ,MS               ,W           ,WA        ,VAL2     ,  
+     3                  VEUL            ,ALE_CONNECTIVITY ,IPARG       ,NLOC_DMG  ,
+     4                  TF              ,NPC              ,BUFMAT      ,PARTSAV   ,
+     5                  DT2T            ,NELTST           ,ITYPTST     ,STIFN     ,OFFSET   ,  
+     6                  EANI            ,IPARTQ(1+NFT)    ,NEL         ,IADQ      ,FSKY     ,  
+     9                  IPM             ,BUFVOIS          ,pQMV        ,
+     A                  GRESAV          ,GRTH             ,IGRTH       ,TABLE     ,IGEO     ,
+     B                  VOLN            ,ITASK            ,MS_2D       ,FSKYM     ,IOUTPRT  ,
+     C                  MAT_ELEM        ,H3D_DATA%STRAIN  ,SZ_BUFVOIS  ,SNPC      ,STF      ,SBUFMAT  ,
+     D                  SVIS            ,NSVOIS           ,IRESP       ,TT        ,DT1      ,      
+     .                  IDEL7NOK        ,IDTMIN           ,MAXFUNC     ,  
+     .                  IMON_MAT        ,USERL_AVAIL      ,heat_meca   ,impl_s,     idyna) 
 c
                  ELSEIF (ITY == 2 .AND. JMULT /= 0) THEN
-                  CALL BFORC2(ELBUF_TAB,NG      ,
-     1                  PM          , GEO           , IXQ       , X               ,
-     2                  A           , V             , MS        , W               , WA          ,
-     3                  VAL2        , VEUL          ,  ALE_CONNECTIVITY, IPARG       ,
-     4                  IPARG(1,NG) , FILL          , DFILL     , IMS             , NLOC_DMG    ,
-     5                  TF    ,NPC  , BUFMAT        , PARTSAV   ,
-     6                  DT2T        , NELTST,ITYPTST, STIFN     , OFFSET          ,
-     7                  EANI        , IPARTQ(1+NFT) , NEL,IADQ  , FSKY            ,
-     8                  IPM ,BUFVOIS,
-     9                  GRESAV,GRTH , IGRTH         , TABLE     , IGEO            ,
-     O                  VOLN  ,ITASK, MS_2D         , FSKYM     , MAT_ELEM        ,
-     B                  IBID,OUTPUT,SZ_BUFVOIS      ,SNPC,STF,SBUFMAT,SVIS,NSVOIS,IRESP,
-     C                  IDEL7NOK    ,IDTMIN         ,MAXFUNC,
-     E                  IMON_MAT    , USERL_AVAIL   ,heat_meca  ,impl_s,
-     F                  idyna)
+                  CALL BFORC2(
+     .                  ELBUF_TAB   , NG            ,
+     1                  PM          , GEO           ,IXQ             , X         ,
+     2                  A           , V             ,MS              , W         , WA        ,
+     3                  VAL2        , VEUL          ,ALE_CONNECTIVITY, IPARG     ,
+     4                  IPARG(1,NG) , FILL          ,DFILL           , IMS       , NLOC_DMG  ,
+     5                  TF          , NPC           ,BUFMAT          , PARTSAV   ,
+     6                  DT2T        , NELTST        ,ITYPTST         , STIFN     , OFFSET    ,
+     7                  EANI        , IPARTQ(1+NFT) ,NEL             , IADQ      , FSKY      ,
+     8                  IPM         , BUFVOIS       ,
+     9                  GRESAV      , GRTH          ,IGRTH           , TABLE     , IGEO      ,
+     O                  VOLN        , ITASK         ,MS_2D           , FSKYM     , MAT_ELEM  ,
+     B                  IBID        , OUTPUT        ,SZ_BUFVOIS      , SNPC      , STF       ,SBUFMAT, SVIS,
+     C                  NSVOIS      , IRESP         ,IDEL7NOK        , 
+     D                  IDTMIN      , MAXFUNC       ,IMON_MAT        , 
+     E                  USERL_AVAIL ,heat_meca      , impl_s         , idyna)
                  ENDIF
                 ENDIF
               ENDIF
@@ -1060,38 +1061,37 @@ C     ALE ON / OFF
                     pQMV => BID
                   ENDIF  
                   CALL QFORC2(
-     .              ELBUF_TAB,NG ,
-     1              PM           ,GEO          ,IXQ         ,X        ,A         ,  
-     2              V            ,MS           ,W           ,WA       ,VAL2      ,      
-     3              VEUL         ,ALE_CONNECTIVITY       ,IPARG    ,NLOC_DMG  ,              
-     4              TF           ,NPC          ,BUFMAT      ,PARTSAV  ,              
-     5              DT2T         ,NELTST       ,ITYPTST     ,STIFN    ,OFFSET    ,
-     6              EANI         ,IPARTQ(1+NFT),NEL         ,IADQ     ,FSKY      ,
-     9              IPM          ,BUFVOIS      ,pQMV        ,
-     A              GRESAV       ,GRTH         ,IGRTH       ,TABLE    ,IGEO      ,
-     B              VOLN         ,ITASK        ,MS_2D       ,FSKYM    ,IOUTPRT   ,MAT_ELEM ,
-     C              H3D_DATA%STRAIN,SZ_BUFVOIS   ,SNPC      ,STF,SBUFMAT,SVIS,NSVOIS,IDTMINS,
-     D              IRESP        ,TT           ,DT1,      
-     .              IDEL7NG,     IDEL7NOK,    IDTMIN,     MAXFUNC ,  
-     .              IMON_MAT,USERL_AVAIL, heat_meca, impl_s,     idyna)
+     .              ELBUF_TAB ,NG    ,
+     1              PM        ,GEO              ,IXQ         ,X        ,A         ,  
+     2              V         ,MS               ,W           ,WA       ,VAL2      ,      
+     3              VEUL      ,ALE_CONNECTIVITY ,IPARG       ,NLOC_DMG ,              
+     4              TF        ,NPC              ,BUFMAT      ,PARTSAV  ,              
+     5              DT2T      ,NELTST           ,ITYPTST     ,STIFN    ,OFFSET    ,
+     6              EANI      ,IPARTQ(1+NFT)    ,NEL         ,IADQ     ,FSKY      ,
+     9              IPM       ,BUFVOIS          ,pQMV        ,
+     A              GRESAV    ,GRTH             ,IGRTH       ,TABLE    ,IGEO      ,
+     B              VOLN      ,ITASK            ,MS_2D       ,FSKYM    ,IOUTPRT   ,
+     C              MAT_ELEM  ,H3D_DATA%STRAIN  ,SZ_BUFVOIS  ,SNPC     ,STF       ,SBUFMAT,
+     D              SVIS      ,NSVOIS           ,IRESP       ,TT       ,DT1       ,      
+     .              IDEL7NOK  ,IDTMIN           ,MAXFUNC     ,  
+     .              IMON_MAT  ,USERL_AVAIL      ,heat_meca   ,impl_s   ,idyna)
 c
                       ELSEIF(ITY == 2 .AND. JMULT /= 0)THEN
                   CALL BFORC2(ELBUF_TAB  ,NG           ,
-     1                        PM         ,GEO          ,IXQ     ,X                ,    
-     2                        A          ,V            ,MS      ,W                ,WA        ,  
-     3                        VAL2       ,VEUL         ,ALE_CONNECTIVITY ,IPARG     ,
-     4                        IPARG(1,NG),FILL         ,DFILL   ,IMS              ,NLOC_DMG  ,    
-     5                        TF         ,NPC          ,BUFMAT  ,PARTSAV          ,       
-     5                        DT2T       ,NELTST       ,ITYPTST ,STIFN            ,OFFSET    ,  
-     6                        EANI       ,IPARTQ(1+NFT),NEL     ,IADQ             ,FSKY      ,  
+     1                        PM         ,GEO          ,IXQ              ,X          ,    
+     2                        A          ,V            ,MS               ,W          ,WA        ,  
+     3                        VAL2       ,VEUL         ,ALE_CONNECTIVITY ,IPARG      ,
+     4                        IPARG(1,NG),FILL         ,DFILL            ,IMS        ,NLOC_DMG  ,    
+     5                        TF         ,NPC          ,BUFMAT           ,PARTSAV    ,       
+     5                        DT2T       ,NELTST       ,ITYPTST          ,STIFN      ,OFFSET    ,  
+     6                        EANI       ,IPARTQ(1+NFT),NEL              ,IADQ       ,FSKY      ,  
      7                        IPM        ,BUFVOIS      ,
-     8                        GRESAV     ,GRTH         ,IGRTH   ,TABLE            ,IGEO      ,
-     9                        VOLN       ,ITASK        ,MS_2D   ,FSKYM            ,MAT_ELEM,
-     B                        IBID       ,OUTPUT       ,SZ_BUFVOIS      ,SNPC,STF,SBUFMAT,SVIS,
-     *                        NSVOIS     ,IDTMINS      ,IRESP,
-     C                       IDEL7NG     ,IDEL7NOK     ,IDTMIN     ,MAXFUNC,
-     E                       IMON_MAT    , USERL_AVAIL   ,heat_meca  ,impl_s,
-     F                       idyna)
+     8                        GRESAV     ,GRTH         ,IGRTH            ,TABLE      ,IGEO      ,
+     9                        VOLN       ,ITASK        ,MS_2D            ,FSKYM      ,MAT_ELEM,
+     A                        IBID       ,OUTPUT       ,SZ_BUFVOIS       ,SNPC       ,STF       ,SBUFMAT ,SVIS,
+     B                        NSVOIS     ,IRESP        ,IDEL7NOK         ,
+     C                        IDTMIN     ,MAXFUNC      ,IMON_MAT         ,
+     E                        USERL_AVAIL,heat_meca    ,impl_s           ,idyna)
 
                  ENDIF
                 ENDIF

--- a/engine/source/ale/bimat/bforc2.F
+++ b/engine/source/ale/bimat/bforc2.F
@@ -64,21 +64,21 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    output_mod             ../common_source/modules/output/output_mod.F90
       !||    table_mod              ../engine/share/modules/table_mod.F
       !||====================================================================
-      SUBROUTINE BFORC2(ELBUF_TAB,NG   ,
-     1                   PM     ,GEO    ,IC     ,X       ,
-     2                   A      ,V      ,MS     ,W      ,FLUX    ,
-     3                   FLU1   ,VEUL   ,ALE_CONNECT  ,IPARG   ,
-     4                   JPARG  ,FILL   ,DFILL  ,IMS    ,NLOC_DMG,
-     5                   TF     ,NPF    ,BUFMAT ,PARTSAV ,
-     6                   DT2T   ,NELTST ,ITYPTST,STIFN  ,OFFSET  ,
-     7                   EANI   ,IPARTQ ,NEL    ,IADQ   ,FSKY    ,
-     8                   IPM    ,BUFVOIS,
-     9                   GRESAV ,GRTH   ,IGRTH  ,TABLE  ,IGEO    ,
-     O                   VOLN   ,ITASK  ,MS_2D  ,FSKYM  ,MAT_ELEM,
-     B                   H3D_STRAIN,OUTPUT,SZ_BUFVOIS,SNPC,STF,SBUFMAT,SVIS,
-     C                   NSVOIS, IRESP,     IDEL7NOK, 
-     D                   IDTMIN, MAXFUNC, IMON_MAT,   
-     E                   USERL_AVAIL, heat_meca,   impl_s,      idyna)
+      SUBROUTINE BFORC2(ELBUF_TAB   ,NG        ,
+     1                   PM         ,GEO       ,IC         ,X       ,
+     2                   A          ,V         ,MS         ,W       ,FLUX    ,
+     3                   FLU1       ,VEUL      ,ALE_CONNECT,IPARG   ,
+     4                   JPARG      ,FILL      ,DFILL      ,IMS     ,NLOC_DMG,
+     5                   TF         ,NPF       ,BUFMAT     ,PARTSAV ,
+     6                   DT2T       ,NELTST    ,ITYPTST    ,STIFN   ,OFFSET  ,
+     7                   EANI       ,IPARTQ    ,NEL        ,IADQ    ,FSKY    ,
+     8                   IPM        ,BUFVOIS   ,
+     9                   GRESAV     ,GRTH      ,IGRTH      ,TABLE  ,IGEO     ,
+     A                   VOLN       ,ITASK     ,MS_2D      ,FSKYM  ,MAT_ELEM ,
+     B                   H3D_STRAIN ,OUTPUT    ,SZ_BUFVOIS ,SNPC   ,STF      ,SBUFMAT, SVIS,
+     C                   NSVOIS     , IRESP    ,IDEL7NOK   ,
+     D                   IDTMIN     , MAXFUNC  ,IMON_MAT   ,
+     E                   USERL_AVAIL, heat_meca,impl_s     ,idyna)
 C-----------------------------------------------
 C   M o d u l e s 
 C-----------------------------------------------
@@ -280,7 +280,7 @@ C-----------
      .      MAT, NC1, NC2, NC3, NC4)
       ENDIF
 C-----------------------------------------------------
-C     SUBMATERIAL 1
+C     SUBMATERIAL 1 (MAT LAW20)
 C-----------------------------------------------------
       IMULT=JMULT
       JMULT=1
@@ -497,7 +497,7 @@ C--------------
       
       
 C-----------------------------------------------------
-C     SUBMATERIAL 2
+C     SUBMATERIAL 2 (MAT LAW20)
 C-----------------------------------------------------
       IF(IMULT > 1)THEN
         JMULT = 2

--- a/engine/source/elements/solid_2d/quad/qforc2.F
+++ b/engine/source/elements/solid_2d/quad/qforc2.F
@@ -60,20 +60,20 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    nlocal_reg_mod         ../common_source/modules/nlocal_reg_mod.F
       !||    table_mod              ../engine/share/modules/table_mod.F
       !||====================================================================
-      SUBROUTINE QFORC2(ELBUF_TAB,NG      ,
-     1                  PM       ,GEO     ,IC          ,X        ,A       ,
-     2                  V        ,MS      ,W           ,FLUX     ,FLU1    ,
-     3                  VEUL     ,ALE_CONNECT ,IPARG    ,NLOC_DMG,
-     4                  TF       ,NPF     ,BUFMAT      ,PARTSAV  ,
-     5                  DT2T     ,NELTST  ,ITYPTST     ,STIFN    ,OFFSET  ,
-     6                  EANI     ,IPARTQ  ,NEL         ,IADQ     ,FSKY    ,
-     9                  IPM      ,BUFVOIS ,QMV         ,
-     A                  GRESAV   ,GRTH    ,IGRTH       ,TABLE    ,IGEO    ,
-     B                  VOLN     ,ITASK   ,MS_2D       ,FSKYM    ,IOUTPRT ,
-     C                  MAT_ELEM ,H3D_STRAIN,SZ_BUFVOIS,SNPC,STF,SBUFMAT  ,
-     D                  SVIS,NSVOIS,IRESP,TT,DT1,      
-     .                  IDEL7NOK,    IDTMIN,     MAXFUNC,  
-     .                  IMON_MAT,USERL_AVAIL, heat_meca, impl_s,     idyna)
+      SUBROUTINE QFORC2(ELBUF_TAB  ,NG          ,
+     1                  PM         ,GEO         ,IC          ,X        ,A           ,
+     2                  V          ,MS          ,W           ,FLUX     ,FLU1        ,
+     3                  VEUL       ,ALE_CONNECT ,IPARG       ,NLOC_DMG ,
+     4                  TF         ,NPF         ,BUFMAT      ,PARTSAV  ,
+     5                  DT2T       ,NELTST      ,ITYPTST     ,STIFN    ,OFFSET      ,
+     6                  EANI       ,IPARTQ      ,NEL         ,IADQ     ,FSKY        ,
+     9                  IPM        ,BUFVOIS     ,QMV         ,
+     A                  GRESAV     ,GRTH        ,IGRTH       ,TABLE    ,IGEO        ,
+     B                  VOLN       ,ITASK       ,MS_2D       ,FSKYM    ,IOUTPRT     ,
+     C                  MAT_ELEM   ,H3D_STRAIN  ,SZ_BUFVOIS  ,SNPC     ,STF         ,SBUFMAT ,
+     D                  SVIS       ,NSVOIS      ,IRESP       ,TT       ,DT1         ,
+     .                  IDEL7NOK   ,IDTMIN      ,MAXFUNC     ,
+     .                  IMON_MAT   ,USERL_AVAIL ,heat_meca   ,impl_s   ,idyna)
 C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------


### PR DESCRIPTION
#### alemain.F:arguments update

#### Description of the changes
Two unnecessary arguments were removed from the subroutine calls to bforc2 and qforc2 in alemain.F. These arguments exceeded the required number for the function calls. This update streamlines the code by ensuring only the necessary arguments are passed.