### PR TITLE
INIVOL / LAW51 : bug fix

### DIFF
--- a/starter/source/initial_conditions/inivol/inivol_set.F
+++ b/starter/source/initial_conditions/inivol/inivol_set.F
@@ -76,7 +76,38 @@ C-----------------------------------------------
 
       ! DETERMINE DEFAULT SUBMAT ID
       vfrac0(1:nbsubmat) = pm(20+1:20+nbsubmat,imid)
-      default_SUBMAT_id(1:NEL) = MAXLOC(vfrac0,1)
+      default_SUBMAT_id(1:NEL) = 1
+      DO I=1,NEL
+        IF(IPART(I+NFT) /= IDP)CYCLE
+
+        IF(MLW == 51)THEN
+          DO IMAT=1,4
+            KK = N0PHAS + (IMAT-1)*NVPHAS
+            IF(UVAR(I,1+KK) >= NINE_OVER_10)THEN
+              default_SUBMAT_id(I) = IMAT
+              EXIT
+            ENDIF
+          ENDDO
+
+        ELSEIF(MLW == 37)THEN
+          IF(UVAR(I,4)  >= NINE_OVER_10) THEN
+            default_SUBMAT_id(I) = 1
+          ELSEIF(UVAR(I,5)  >= NINE_OVER_10)THEN
+            default_SUBMAT_id(I) = 2
+          ENDIF
+
+        ELSEIF(MLW == 151)THEN
+          GBUF => ELBUF_TAB(NG)%GBUF
+          DO IMAT=1,MULTI_FVM%NBMAT
+            LBUF => ELBUF_TAB(NG)%BUFLY(IMAT)%LBUF(1,1,1)
+            IF(LBUF%VOL(I) / GBUF%VOL(I) >= NINE_OVER_10)THEN
+              default_SUBMAT_id(I) = IMAT
+              EXIT
+            ENDIF
+          ENDDO
+        ENDIF
+
+      ENDDO!next I
 
       !---ADD CONTRIBUTION FROM 2D POLYGONAL CLIPPING
       IF(REQUIRED_2D_POLYGON_CLIPPING) THEN

--- a/starter/source/materials/mat/mat051/hm_read_mat51.F
+++ b/starter/source/materials/mat/mat051/hm_read_mat51.F
@@ -959,11 +959,6 @@ C     !============================!
       PM(38) = UPARAM(42)  !VDET
       PARMAT(1) = MAX(C1(1), C1(2), C1(3), C1(4))
       PM(27) = MAXVAL(SSP(1:4))
-      ! volume fraction (same storage loacation as material law151 : 20+1:NBMAT)
-      PM(20+1) = tAV(1)
-      PM(20+2) = tAV(2)
-      PM(20+3) = tAV(3)
-      PM(20+4) = tAV(4)
       !============================!
       ! Starter Listing File       !
       !============================!


### PR DESCRIPTION
#### INIVOL / LAW51 : bug fix

#### Description of the changes
A potential issue was introduced with commit 7a5fa806dd297c7b7211286c1a63b7e3befdd08b. The array PM(20+1 : 20+NB_SUBMAT) was being used for laws 20 and 151, but it is not compatible with law 51.

This issue has now been resolved. A dedicated data structure is going to be introduced in a future update to standardize data storage and improve overall readability using MAT_PARAM data structure.