### PR TITLE
/MAT/LAW151 : default vfrac filling

### DIFF
--- a/starter/source/initial_conditions/inivol/hm_read_inivol.F
+++ b/starter/source/initial_conditions/inivol/hm_read_inivol.F
@@ -118,6 +118,13 @@ C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
 
+
+      IF (MULTI_FVM%IS_USED)THEN
+        NBSUBMAT = MULTI_FVM%NBMAT
+      ELSE
+        NBSUBMAT = 4
+      ENDIF
+
       !---OUTPUT MESSAGE & SIZES
       SKVOL = 0
       SINIVOL = 0
@@ -128,8 +135,6 @@ C-----------------------------------------------
         WRITE(ISTDO,'(A)')' .. INITIAL VOLUME FRACTION'                                          
         WRITE(IOUT,'(//A)')'     INITIAL VOLUME FRACTION'                                      
         WRITE(IOUT,'(A/)') '     -----------------------'
-        NBSUBMAT = 4 !(LAW51)   
-        IF (MULTI_FVM%IS_USED) NBSUBMAT = MAX(NBSUBMAT, MULTI_FVM%NBMAT)  !up to 20 (LAW151)
         NUMEL_TOT = MAX(NUMELTG,MAX(NUMELS,NUMELQ))
         SKVOL = NBSUBMAT*NUMEL_TOT
         SINIVOL = NUM_INIVOL
@@ -300,10 +305,7 @@ C
         ENDDO   !next line 
         WRITE(IOUT,'(A//)') 
       END DO !next option
-  
-      NBSUBMAT = 4
-      IF (MULTI_FVM%IS_USED)NBSUBMAT = MAX(NBSUBMAT, MULTI_FVM%NBMAT)
-             
+
 C-----------------------------
       RETURN
 C-----------------------------

--- a/starter/source/initial_conditions/inivol/iniphase.F
+++ b/starter/source/initial_conditions/inivol/iniphase.F
@@ -77,7 +77,10 @@ C-----------------------------------------------
 C---
 C FILL ELEMENTS INPUT PHASES
 C---
+        AV(1:NBSUBMAT) = ZERO
+
         IF(MLW==51)THEN
+          !when using LAW51 nbsubmat=4
           AV(1) = UPARAM(4)
           AV(2) = UPARAM(5)
           AV(3) = UPARAM(6)

--- a/starter/source/materials/mat/mat151/hm_read_mat151.F
+++ b/starter/source/materials/mat/mat151/hm_read_mat151.F
@@ -128,6 +128,7 @@ C     Reading submaterial IDS and corresponding volumic fractions
             CALL ANCMSG(MSGID = 1512, MSGTYPE = MSGERROR, ANMODE = ANINFO, C1 = "ERROR", I1 = ID, R1 = SUM_FRAC_VOL)
          ELSE
             CALL ANCMSG(MSGID = 1512, MSGTYPE = MSGWARNING, ANMODE = ANINFO, C1 = "WARNING", I1 = ID, R1 = SUM_FRAC_VOL)
+            IF(SUM_FRAC_VOL == ZERO)PM(20 + 1) = ONE
          ENDIF
       ENDIF
 


### PR DESCRIPTION
#### /MAT/LAW151 : default vfrac filling

#### Description of the changes
When using INIVOL with /MAT/LAW151 user can defines vrfrac =(0,0,..,0) because INIVOL is supposed to set volume fractions.
to avoid any unexpected division by zero, default dubmaterial is then set to 1 by defining vfrac = (1.0 , 0 ... 0)