### PR TITLE
The dimension of array was wrong in a subroutine, introduced by a1a952b81d56d019a1732512fa3fcbf6269113aa

### DIFF
--- a/engine/source/airbag/get_volume_area.F90
+++ b/engine/source/airbag/get_volume_area.F90
@@ -89,7 +89,7 @@
           my_real, dimension(nvolu*nrvolu), intent(inout) :: rvolu !< monitored volume data (real)
           my_real, dimension(sporo), intent(inout) :: poro !<
           my_real, dimension(nvolu), intent(inout) :: vol !< volume of airbag
-          my_real, dimension(3,numnod), intent(inout) :: normal !< normal of node
+          my_real, dimension(3,numnod+numelc+numeltg), intent(inout) :: normal !< normal of node
           type(monvol_struct_), dimension(nvolu), intent(inout) :: t_monvoln !< monvol structure
           type(surf_), dimension(nsurf), intent(in) :: igrsurf !< surface structure
 ! ----------------------------------------------------------------------------------------------------------------------

--- a/engine/source/airbag/volpresp.F
+++ b/engine/source/airbag/volpresp.F
@@ -68,7 +68,7 @@ C-----------------------------------------------
      .        NPC(*),NN,IADMV(4,*),SURF_NODES(NN,4),SURF_ELTYP(NN),
      .        SURF_ELEM(NN)
       INTEGER, DIMENSION(NN,4), INTENT(in) :: CONTRIBUTION_INDEX !< index to the array CONTRIBUTION
-      INTEGER, DIMENSION(NODE_NUMBER), INTENT(in) :: CONTRIBUTION_NUMBER !< number of contribution per node
+      INTEGER, DIMENSION(NODE_NUMBER+1), INTENT(in) :: CONTRIBUTION_NUMBER !< number of contribution per node
       INTEGER, DIMENSION(NODE_NUMBER), INTENT(in) :: NODE_ID !< node id
       my_real, DIMENSION(TOTAL_CONTRIBUTION_NUMBER,3), INTENT(inout) :: CONTRIBUTION !< contribution array, the force are saved here
 


### PR DESCRIPTION

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
The dimension of NORMAL and CONTRIBUTION_NUMBER are not correct

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
The dimension of NORMAL is NUMELC+NUMELTG+NUMNOD (instead of NUMNOD)
The dimension of CONTRIBUTION_NUMBER is NODE_NUMBER+1 (instead of NODE_NUMBER)

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
