### PR TITLE
/INIVOL : the result of getphase was not correct if the surface used coarse mesh

### DIFF
--- a/starter/source/initial_conditions/inivol/ale_box_coloration.F
+++ b/starter/source/initial_conditions/inivol/ale_box_coloration.F
@@ -135,26 +135,38 @@ C-----------------------------------------------
                     ! c |       |       |       |
                     !   * ----- * ----- * ----- *
                 
-
+                    LOW_X = NB_CELL_X + 1
+                    UP_X = -1
+                    LOW_Y = NB_CELL_Y + 1
+                    UP_Y = -1
+                    LOW_Z = NB_CELL_Z + 1
+                    UP_Z = -1
                     DO J=1,4
-                        LOW_Z = MAX(1,IZ(J))
-                        UP_Z = MIN(NB_CELL_Z,IZ(J+1))
-                        LOW_Y = MAX(1,IY(J))
-                        UP_Y = MIN(NB_CELL_Y,IY(J+1))
-                        LOW_X = MAX(1,IX(J))
-                        UP_X = MIN(NB_CELL_X,IX(J+1))
-                        DO KK=LOW_Z,UP_Z
-                            DO JJ=LOW_Y,UP_Y
-                                DO II=LOW_X,UP_X
-                                ! ------------------
-                                    ! the cell (ii,jj,kk) contains a node of a surface or is crossed by the segment
-                                    IF(CELL(I)%INT_ARRAY_3D(II,JJ,KK)/=2) THEN
-                                        CELL(I)%INT_ARRAY_3D(II,JJ,KK) = 2
-                                    ENDIF
-                                    ! ------------------
-                                ENDDO
-                            ENDDO
+                      LOW_Z = MIN(LOW_Z,IZ(J))
+                      UP_Z = MAX(UP_Z,IZ(J+1))
+                      LOW_Y = MIN(LOW_Y,IY(J))
+                      UP_Y = MAX(UP_Y,IY(J+1))
+                      LOW_X = MIN(LOW_X,IX(J))
+                      UP_X = MAX(UP_X,IX(J+1))
+                    ENDDO
+                    LOW_Z = MAX(1,LOW_Z)
+                    UP_Z = MIN(NB_CELL_Z,UP_Z)
+                    LOW_Y = MAX(1,LOW_Y)
+                    UP_Y = MIN(NB_CELL_Y,UP_Y)
+                    LOW_X = MAX(1,LOW_X)
+                    UP_X = MIN(NB_CELL_X,UP_X)
+                    ! ------------------
+                    DO KK=LOW_Z,UP_Z
+                      DO JJ=LOW_Y,UP_Y
+                        DO II=LOW_X,UP_X
+                          ! ------------------
+                          ! the cell (ii,jj,kk) contains a node of a surface or is crossed by the segment
+                          IF(CELL(I)%INT_ARRAY_3D(II,JJ,KK)/=2) THEN
+                            CELL(I)%INT_ARRAY_3D(II,JJ,KK) = 2
+                          ENDIF
+                          ! ------------------
                         ENDDO
+                      ENDDO
                     ENDDO
                     ! ------------------
                 ENDDO


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
/INIVOL algorithm uses a voxel. The cells crossed by the surface (defined by segments) of /INIVOL must be tagged. But there was an issue with this part of the code : only the cells containing the 4 nodes of the segment were tagged

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Fix the issue

Issue :
![image](https://github.com/user-attachments/assets/ee563220-15f8-470f-b93c-2a85c1d5089a)
Ideal case : 
![image](https://github.com/user-attachments/assets/d53f209d-1c7d-4d92-921e-9425b206c94a)
Fix :
![image](https://github.com/user-attachments/assets/2e0140ed-bbb9-4288-b652-110e35a3deea)

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
