### PR TITLE
Change default values of initial temperature for LAW2 and /HEAT/MAT

### DIFF
--- a/engine/source/materials/mat/mat002/m2iter_imp.F
+++ b/engine/source/materials/mat/mat002/m2iter_imp.F
@@ -70,28 +70,20 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER  NEL
-      my_real :: CN,FISOKIN,EPMX
-      my_real
-     .   SIG(NEL,6), EPXE(NEL),EPD(NEL),
-     .   G(NEL), AK(NEL),QH(NEL), AJ2(NEL), 
-     .   CA(NEL), CB(NEL), 
-     .   SIGMX,DPLA1(NEL),SIGY(NEL)
+      INTEGER :: NEL
+      my_real :: FISOKIN,EPMX,CB,CN
+      my_real ,DIMENSION(NEL)   :: EPXE,EPD,G,AK,QH,AJ2,CA,SIGMX,DPLA1,SIGY
+      my_real ,DIMENSION(NEL,6) :: SIG
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I, ITER, NITER
-C
-C     REAL
-      MY_REAL
-     .   XSI,DXSI,LHS,RHS,ALPHA_RADIAL,BETA,G3(MVSIZ),HTOT
-C
+      INTEGER :: I, ITER, NITER
+      MY_REAL :: XSI,DXSI,LHS,RHS,ALPHA_RADIAL,BETA,G3(MVSIZ),HTOT
+C=======================================================================
 c ---- max number of iterations ----
        NITER = 10
 C       
        DO 100 I=1,NEL
-C
-C------------------------------------------
 C
        XSI = ZERO
 C
@@ -100,7 +92,7 @@ C      -- PREVIOUS TIME-STEP EQUIVALENT PLASTIC STRAIN
        G3(I) =MAX(THREE*G(I),EM15)
 C
 C      -- PREVIOUS TIME-STEP YIELD STRESS !!!!! if EPXE=0!!!!!
-C       AK(I)=CA(I)+CB(I)*EPXE(I)**CN(I) !..SIGMA0(EPS_P)
+C       AK(I)=CA(I)(I)+CB*EPXE(I)**CN !..SIGMA0(EPS_P)
 C
 C      -- COMPARE IT WITH ELASTIC PREDICTOR
        IF(AJ2(I)<AK(I)) GO TO 90 
@@ -109,17 +101,17 @@ C
        DO 80 ITER = 1,NITER ! .. NR ITERATIONS ..
 C
        IF(EPXE(I)>ZERO) THEN !..TESTING FOR ZERO EQUIV.PL.STRN
-         AK(I)=CA(I)+BETA*CB(I)*EPXE(I)**CN !..SIGMA0(EPS_P)
+         AK(I)=CA(I)+BETA*CB*EPXE(I)**CN !..SIGMA0(EPS_P)
 C
 C      --COMPUTE THE HARDENING PARAMETER H
 C      --(JUST THE DERIVATIVE OF THE SIG-EPS_PL FUNCTION)
 C
          IF(CN>ONE) THEN
-           QH(I) = (CB(I)*CN*EPXE(I)**(CN - ONE))*EPD(I)
+           QH(I) = (CB*CN*EPXE(I)**(CN - ONE))*EPD(I)
          ELSEIF(CN==ONE) THEN !.. LINEAR HARDENING
-           QH(I)= CB(I)*EPD(I)
+           QH(I)= CB*EPD(I)
          ELSE !.. POWER LESS THAN UNITY
-           QH(I) = (CB(I)*CN/EPXE(I)**(ONE -CN))*EPD(I)
+           QH(I) = (CB*CN/EPXE(I)**(ONE -CN))*EPD(I)
          ENDIF
 C
        ELSEIF(EPXE(I)==ZERO) THEN
@@ -129,7 +121,7 @@ C
          IF(CN>ONE )THEN
                QH(I) = ZERO
          ELSEIF(CN==ONE) THEN 
-               QH(I) = CB(I)*EPD(I)
+               QH(I) = CB*EPD(I)
          ELSE
                QH(I) = EP10 *EPD(I) !.. SHOULD BE +INFINITY
          ENDIF
@@ -162,8 +154,8 @@ C
 C     .. ENFORCING SOME CUT-OFFS, LEFT UNCHANGED
 C  ----!!!cette partie devrait etre   interieure de boucle ---  tester
        AK(I)=AK(I)*EPD(I)
-       IF(SIGMX<AK(I))THEN
-        AK(I)=SIGMX
+       IF(SIGMX(I)<AK(I))THEN
+        AK(I)=SIGMX(I)
         QH(I)=ZERO
        ENDIF
 C       SIGY(I) = AK(I)

--- a/engine/source/materials/mat/mat002/m2law.F
+++ b/engine/source/materials/mat/mat002/m2law.F
@@ -107,16 +107,15 @@ C-----------------------------------------------
       INTEGER :: I, J, ICC,IRTY,ISRATE,VP,IDEV,MX,IBID,IKFLG,NINDX
       INTEGER :: INDX(NEL)
       my_real
-     .   RHO0, PLAP1,POLD,PSHIFT,BULK,P, EPMX,CC, CN,EPDR, CMX, 
+     .   RHO0, PLAP1,POLD,PSHIFT,BULK,P, EPMX,CC,CN,EPDR, CMX, 
      .   Z3,Z4,RHOCPI,T_REF,T_MELT,ASRATE,
-     .   E1, E2, E3, E4, E5,E6, EINC, G2, G1,
+     .   E1, E2, E3, E4, E5,E6, EINC, G0,G1,G2,G3,G3H,
      .   SCALE, BID1, BID2, BID3, DTA,MT,
      .   DSXX,DSYY,DSZZ,DSXY,DSYZ,DSZX,ALPHA,HKIN,
-     .   FACQ0,FISOKIN,BETA,VM,VM_1,G3,G3H,NORM_1,
-     .   G_1,CA,CB,SIGMX
+     .   FACQ0,FISOKIN,BETA,VM,VM_1,NORM_1,CA0,CB,SIGM0
       my_real
      .   EPD(MVSIZ),G(MVSIZ), AK(MVSIZ),PC(MVSIZ), QH(MVSIZ), 
-     .   AJ2(MVSIZ), DAV(MVSIZ),
+     .   AJ2(MVSIZ), DAV(MVSIZ),CA(MVSIZ),SIGMX(MVSIZ),
      .   SIGEXX(MVSIZ),SIGEYY(MVSIZ),SIGEZZ(MVSIZ),
      .   SIGEXY(MVSIZ),SIGEYZ(MVSIZ),SIGEZX(MVSIZ)
       my_real, DIMENSION(MVSIZ) :: BIDMVSIZ
@@ -137,10 +136,10 @@ C
       ISRATE  = IPM(3,MX)
       ASRATE  = MIN(ONE,PM(9,MX)*DT1)
       FISOKIN = PM(55,MX)
-      G_1     = PM(22,MX)
-      CA      = PM(38,MX)
+      G0      = PM(22,MX)
+      CA0     = PM(38,MX)
       CB      = PM(39,MX)
-      SIGMX   = PM(42,MX)
+      SIGM0   = PM(42,MX)
       VP      = IPM(255,MX)
       PSHIFT  = PM(88,MX)
 !
@@ -156,7 +155,9 @@ C
       END IF
 !
       DO I=1,NEL
-        G(I)    = G_1*OFF(I)
+        G(I)    = G0*OFF(I)
+        CA(I)   = CA0
+        SIGMX(I)= SIGM0
         ETSE(I) = ONE
       ENDDO
 C
@@ -165,38 +166,35 @@ C     ECROUISSAGE CINE
 C------------------------------------------
       IKFLG=0
       DO I=1,NEL
-         IF (FISOKIN /= ZERO ) THEN
-          SIG(I,1)=SIG(I,1)-SIGBAK(I,1)
-          SIG(I,2)=SIG(I,2)-SIGBAK(I,2)
-          SIG(I,3)=SIG(I,3)-SIGBAK(I,3)
-          SIG(I,4)=SIG(I,4)-SIGBAK(I,4)
-          SIG(I,5)=SIG(I,5)-SIGBAK(I,5)
-          SIG(I,6)=SIG(I,6)-SIGBAK(I,6)
-          IKFLG = IKFLG + 1
-         ENDIF           
+        IF (FISOKIN /= ZERO ) THEN
+         SIG(I,1)=SIG(I,1)-SIGBAK(I,1)
+         SIG(I,2)=SIG(I,2)-SIGBAK(I,2)
+         SIG(I,3)=SIG(I,3)-SIGBAK(I,3)
+         SIG(I,4)=SIG(I,4)-SIGBAK(I,4)
+         SIG(I,5)=SIG(I,5)-SIGBAK(I,5)
+         SIG(I,6)=SIG(I,6)-SIGBAK(I,6)
+         IKFLG = IKFLG + 1
+        ENDIF           
       ENDDO
 C      
       DO I=1,NEL
-       P  =-THIRD*(SIG(I,1)+SIG(I,2)+SIG(I,3))
-       DAV(I)=-THIRD*(D1(I)+D2(I)+D3(I))
-       G1=DT1*G(I)
-       G2=TWO*G1
-       SSP(I)=SQRT((ONEP333*G(I)+BULK)/RHO0)
-C-------------------------------
-C     CONTRAINTES DEVIATORIQUES
-C-------------------------------
-c     -- deviatoric elastic stress predictor
-       SIG(I,1)=SIG(I,1)+P+G2*(D1(I)+DAV(I))
-       SIG(I,2)=SIG(I,2)+P+G2*(D2(I)+DAV(I))
-       SIG(I,3)=SIG(I,3)+P+G2*(D3(I)+DAV(I))
-       SIG(I,4)=SIG(I,4)+G1*D4(I)
-       SIG(I,5)=SIG(I,5)+G1*D5(I)
-       SIG(I,6)=SIG(I,6)+G1*D6(I)
+        P  =-THIRD*(SIG(I,1)+SIG(I,2)+SIG(I,3))
+        DAV(I)=-THIRD*(D1(I)+D2(I)+D3(I))
+        G1=DT1*G(I)
+        G2=TWO*G1
+        SSP(I)=SQRT((ONEP333*G(I)+BULK)/RHO0)
+c      -- deviatoric elastic stress predictor
+        SIG(I,1)=SIG(I,1)+P+G2*(D1(I)+DAV(I))
+        SIG(I,2)=SIG(I,2)+P+G2*(D2(I)+DAV(I))
+        SIG(I,3)=SIG(I,3)+P+G2*(D3(I)+DAV(I))
+        SIG(I,4)=SIG(I,4)+G1*D4(I)
+        SIG(I,5)=SIG(I,5)+G1*D5(I)
+        SIG(I,6)=SIG(I,6)+G1*D6(I)
 C
-c     -- von Mises stress at elastic predictor
-       AJ2(I)=HALF*(SIG(I,1)**2+SIG(I,2)**2+SIG(I,3)**2)
-     1               +SIG(I,4)**2+SIG(I,5)**2+SIG(I,6)**2
-       AJ2(I)=SQRT(THREE*AJ2(I))
+c      -- von Mises stress at elastic predictor
+        AJ2(I)=HALF*(SIG(I,1)**2+SIG(I,2)**2+SIG(I,3)**2)
+     .             + SIG(I,4)**2+SIG(I,5)**2+SIG(I,6)**2
+        AJ2(I)=SQRT(THREE*AJ2(I))
       ENDDO
 C
 c     --  storing elastic predictors for stiffness computation
@@ -238,13 +236,13 @@ c
              MT=MAX(EM15,Z3)
              EPD(I)= MAX(ZERO,EPD(I))
              EPD(I)= (ONE +CC * EPD(I))*(ONE -TSTAR(I)**MT)
-             IF(ICC==1)SIGMX= SIGMX*EPD(I)
+             IF(ICC==1) SIGMX(I)= SIGM0*EPD(I)
           ENDDO
         ELSEIF (IRTY==1) THEN
           DO I=1,NEL
              EPD(I)= CC*EXP((-Z3+Z4 * EPD(I))*TEMPEL(I))
-             IF (ICC==1)SIGMX= SIGMX + EPD(I)
-             CA = CA + EPD(I)
+             IF (ICC==1) SIGMX(I) = SIGM0 + EPD(I)
+             CA(I) = CA0 + EPD(I)
              EPD(I)=ONE
           ENDDO
         END IF
@@ -258,27 +256,27 @@ C     CRITERE
 C-------------
       IF (IKFLG == 0 ) THEN  ! isotropic hardening
         IF(CN==ONE) THEN
-          AK(1:NEL)= CA+CB*EPXE(1:NEL)
+          AK(1:NEL)= CA(1:NEL)+CB*EPXE(1:NEL)
           QH(1:NEL)= CB*EPD(1:NEL)
         ELSE
           DO  I=1,NEL
             IF(EPXE(I)>ZERO) THEN
-              AK(I)=CA+CB*EPXE(I)**CN
+              AK(I)=CA(I)+CB*EPXE(I)**CN
               IF(CN>ONE) THEN
                 QH(I) = (CB*CN*EPXE(I)**(CN - ONE))*EPD(I)
               ELSE
                 QH(I) = (CB*CN/EPXE(I)**(ONE -CN))*EPD(I)
               ENDIF
             ELSE
-              AK(I)=CA
+              AK(I)=CA(I)
               QH(I)=ZERO
             ENDIF
           ENDDO
         ENDIF
         DO  I=1,NEL
           AK(I)=AK(I)*EPD(I)
-          IF(SIGMX<AK(I))THEN
-            AK(I)=SIGMX
+          IF(SIGMX(I)<AK(I))THEN
+            AK(I)=SIGMX(I)
             QH(I)=ZERO
           ENDIF
           SIGY(I) = AK(I)
@@ -294,31 +292,31 @@ C-------------
           BETA = ONE-FISOKIN
           ! SIGY is used for hourglass stress compute--        
           IF(CN==ONE) THEN
-            SIGY(I) = CA+CB*EPXE(I)
-            AK(I)= CA+BETA*CB*EPXE(I)
+            SIGY(I) = CA(I)+CB*EPXE(I)
+            AK(I)= CA(I)+BETA*CB*EPXE(I)
             QH(I)= CB*EPD(I)
           ELSE
             IF(EPXE(I)>ZERO) THEN
-              SIGY(I)=CA+CB*EPXE(I)**CN
-              AK(I)=CA+BETA*CB*EPXE(I)**CN
+              SIGY(I)=CA(I)+CB*EPXE(I)**CN
+              AK(I)=CA(I)+BETA*CB*EPXE(I)**CN
               IF(CN>ONE) THEN
                 QH(I)= (CB*CN*EPXE(I)**(CN - ONE))*EPD(I)
               ELSE
                 QH(I)= (CB*CN/EPXE(I)**(ONE -CN))*EPD(I)
               ENDIF
             ELSE
-             AK(I)=CA
-             SIGY(I)=CA
+             AK(I)=CA(I)
+             SIGY(I)=CA(I)
              QH(I)=ZERO
             ENDIF
           ENDIF
           AK(I)=AK(I)*EPD(I)
           SIGY(I)=SIGY(I)*EPD(I)
-          IF(SIGMX<AK(I))THEN
-            AK(I)=SIGMX
+          IF(SIGMX(I)<AK(I))THEN
+            AK(I)=SIGMX(I)
             QH(I)=ZERO
           ENDIF
-          SIGY(I)=MIN(SIGY(I),SIGMX)
+          SIGY(I)=MIN(SIGY(I),SIGMX(I))
           IF(EPXE(I)>EPMX)THEN
             AK(I)=ZERO
             QH(I)=ZERO

--- a/starter/source/materials/mat/mat002/hm_read_mat02.F
+++ b/starter/source/materials/mat/mat002/hm_read_mat02.F
@@ -368,7 +368,7 @@ C-----
       IF (ANU == HALF) ANU=ZEP499
 C
       IF (ICC == 0) ICC=1
-      IF (PMIN  == ZERO) PMIN  =-EP20
+      IF (PMIN  == ZERO) PMIN =-EP20
 C
       IF (EPSM == ZERO) EPSM  = EP20
       IF (SIGM == ZERO) SIGM  = EP20
@@ -445,7 +445,7 @@ C-----
       PARMAT(5) = ASRATE
       PM(37)= PMIN    ! default pressure cut-off for EOS
 C
-      IF (TREF <= ZERO) TREF = TWOHUNDRED98
+      IF (TREF <= ZERO) TREF = THREE100
 c
 C--------------------------------
       

--- a/starter/source/materials/therm/hm_read_therm.F
+++ b/starter/source/materials/therm/hm_read_therm.F
@@ -232,8 +232,8 @@ c
 c--------------------------------------------------
 c       Default Values
 c--------------------------------------------------
-        IF (TREF  == ZERO) TREF  = PM(23,IMAT) / RHO_CP     ! E0 / rho_cp        
-        IF (TREF  == ZERO) TREF  = 300.0 
+        IF (TREF  == ZERO) TREF  = PM(23,IMAT) / MAX(EM20,RHO_CP)     ! E0 / rho_cp        
+        IF (TREF  == ZERO) TREF  = THREE100 
         IF (TMELT == ZERO) TMELT = EP20                              
         IF (EFRAC < ZERO)  EFRAC = ZERO        
         IF (EFRAC > ONE )  EFRAC = ONE


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

possible slight change of law2 results with thermal options

corrected bug in law2 for solids concerning max hardening stress with strain rate dependency

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Default value of reference temperature was modified to be the same as in all other thermal laws and options

The same initial temperature was defined in /heat/mat to avoid incorrect zero Kelvin and possible numerical singularity

bug correction : max stress value should be vector depending of element strain rate instead of scalar (solids only)

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
