### PR TITLE
clean references to IPM parameters in viscosity models

### DIFF
--- a/engine/source/materials/mat/mat069/sigeps69.F
+++ b/engine/source/materials/mat/mat069/sigeps69.F
@@ -32,7 +32,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       SUBROUTINE SIGEPS69(
      1           NEL    , NUPARAM, NUVAR   , NFUNC  , IFUNC   , NPF    ,
      2           TF     , TIME   , TIMESTEP, UPARAM , RHO0    , RHO    ,
-     3           VOLUME , EINT   , IVISC   , NUPARV , UPARVIS ,
+     3           VOLUME , EINT   , 
      4           EPSPXX , EPSPYY , EPSPZZ  , EPSPXY , EPSPYZ  , EPSPZX ,
      5           DEPSXX , DEPSYY , DEPSZZ  , DEPSXY , DEPSYZ  , DEPSZX ,
      6           EPSXX  , EPSYY  , EPSZZ   , EPSXY  , EPSYZ   , EPSZX  ,
@@ -60,9 +60,9 @@ C-----------------------------------------------
 C----------------------------------------------------------------
 C  I N P U T   A R G U M E N T S
 C----------------------------------------------------------------
-      INTEGER :: NEL,NUPARAM,NUVAR,ISMSTR,IHET,NUVARV,NUPARV,IVISC,IEXPAN
+      INTEGER :: NEL,NUPARAM,NUVAR,ISMSTR,IHET,NUVARV,IEXPAN
       my_real
-     .      TIME       , TIMESTEP   , UPARAM(NUPARAM),UPARVIS(NUPARV),
+     .      TIME       , TIMESTEP   , UPARAM(NUPARAM),
      .      RHO   (NEL), RHO0  (NEL), VOLUME(NEL), EINT(NEL),
      .      EPSPXX(NEL), EPSPYY(NEL), EPSPZZ(NEL),
      .      EPSPXY(NEL), EPSPYZ(NEL), EPSPZX(NEL),
@@ -108,8 +108,8 @@ C----------------------------------------------------------------
      .   EVV(MVSIZ,3),EV(MVSIZ,3),EVM1(MVSIZ),EVM2(MVSIZ),EVM3(MVSIZ),P(MVSIZ),
      .   MU(5),AL(5),DWDL(3),T(MVSIZ,3),RV(MVSIZ),AV(MVSIZ,6),DIRPRV(MVSIZ,3,3)
        my_real  
-     .   GI(100),BETA(100),H0(100),H(100),C0(MVSIZ,6),C1(MVSIZ,6),AA,SV(MVSIZ,6),
-     .   CC,FAC,INVDT,FFT(3),P_FAC(NEL),NU_1,AMIN,LAM_AL(3),GTMAX(NEL),GVMAX,ETV
+     .   H0(100),H(100),C0(MVSIZ,6),C1(MVSIZ,6),AA,SV(MVSIZ,6),
+     .   CC,FAC,INVDT,FFT(3),P_FAC(NEL),NU_1,AMIN,LAM_AL(3),GTMAX(NEL)
       my_real, DIMENSION(NEL,3) :: CII
       DOUBLE PRECISION AMAX1
 C----------------------------------------------------------------
@@ -135,21 +135,6 @@ C
       DO I = 1,NORDRE
         GMAX  = GMAX  + MU(I)*AL(I)
       ENDDO
-C
-      GVMAX = ZERO
-      ETV   = ZERO
-C add viscosity using /visc/prony
-      IF (IVISC > 0) THEN 
-         NPRONY = INT(UPARVIS(1))
-c             
-         DO I=1,NPRONY
-          GI(I)    = UPARVIS(1 + I)
-          BETA(I)  = UPARVIS(1 + NPRONY + I)
-          GVMAX = GVMAX + GI(I)
-         ENDDO 
-         ETV = MIN(GVMAX,RBULK)/GMAX
-       ENDIF             
-C
 C
       DO I=1,NEL
         AV(I,1)=EPSXX(I)
@@ -254,7 +239,7 @@ C----THERM STRESS COMPUTATION-----
       ENDDO
 c
       ! For HEPH Hourglass treatment and soundspeed computation
-      GTMAX(1:NEL) = GMAX + GVMAX
+      GTMAX(1:NEL) = GMAX
       ETI(1:NEL) = ZERO
       CII(1:NEL,1:3) = ZERO
       DO II = 1,NORDRE
@@ -273,8 +258,8 @@ c
       DO I = 1,NEL
         AMAX = AMAX1*MAX(CII(I,1),CII(I,2),CII(I,3))
         ETI(I) = MAX(ONE,AMAX) 
-        GTMAX(I) = GMAX*ETI(I) + GVMAX
-        ET(I) = ETI(I)+ETV
+        GTMAX(I) = GMAX*ETI(I)
+        ET(I) = ETI(I)
       ENDDO
       DO I=1,NEL
         DWDL(1) = ZERO                             
@@ -344,84 +329,6 @@ C     transform principal Cauchy stress to global directions
      .            + DIRPRV(I,3,1)*DIRPRV(I,1,1)*T(I,1)
      .            + DIRPRV(I,3,2)*DIRPRV(I,1,2)*T(I,2)
       ENDDO
-C        Viscous model
-      IF(IVISC > 0) THEN
-        DO I=1,NEL 
-C            
-             C0(I,1) = UVAR(I,4)
-             C0(I,2) = UVAR(I,5)
-             C0(I,3) = UVAR(I,6)  
-             C0(I,4) = UVAR(I,7)
-             C0(I,5) = UVAR(I,8)
-             C0(I,6) = UVAR(I,9)
-C              
-              CC = THIRD*(EVM1(I)**2 +  EVM2(I)**2 + EVM3(I)**2)
-              FFT(1) =  EVM1(I)**2 - CC
-              FFT(2) =  EVM2(I)**2 - CC
-              FFT(3) =  EVM3(I)**2 - CC   
-C the strain at t_n and t_n+1 must be in the same frame  (GLOBAL DIRECTIONS)     
-              C1(I,1) = DIRPRV(I,1,1)*DIRPRV(I,1,1)*FFT(1)
-     .              + DIRPRV(I,1,2)*DIRPRV(I,1,2)*FFT(2)
-     .              + DIRPRV(I,1,3)*DIRPRV(I,1,3)*FFT(3)
-c     
-              C1(I,2) = DIRPRV(I,2,2)*DIRPRV(I,2,2)*FFT(2)
-     .              + DIRPRV(I,2,3)*DIRPRV(I,2,3)*FFT(3)
-     .              + DIRPRV(I,2,1)*DIRPRV(I,2,1)*FFT(1)
-c     
-              C1(I,3) = DIRPRV(I,3,3)*DIRPRV(I,3,3)*FFT(3)
-     .              + DIRPRV(I,3,1)*DIRPRV(I,3,1)*FFT(1)
-     .              + DIRPRV(I,3,2)*DIRPRV(I,3,2)*FFT(2)
-c     
-              C1(I,4) = DIRPRV(I,1,1)*DIRPRV(I,2,1)*FFT(1)
-     .              + DIRPRV(I,1,2)*DIRPRV(I,2,2)*FFT(2)
-     .              + DIRPRV(I,1,3)*DIRPRV(I,2,3)*FFT(3)
-c     
-              C1(I,5) = DIRPRV(I,2,2)*DIRPRV(I,3,2)*FFT(2)
-     .              + DIRPRV(I,2,3)*DIRPRV(I,3,3)*FFT(3)
-     .              + DIRPRV(I,2,1)*DIRPRV(I,3,1)*FFT(1)
-c     
-              C1(I,6) = DIRPRV(I,3,3)*DIRPRV(I,1,3)*FFT(3)
-     .              + DIRPRV(I,3,1)*DIRPRV(I,1,1)*FFT(1)
-     .              + DIRPRV(I,3,2)*DIRPRV(I,1,2)*FFT(2)  
-C              
-              UVAR(I,4) = C1(I,1)    
-              UVAR(I,5) = C1(I,2)
-              UVAR(I,6) = C1(I,3) 
-              UVAR(I,7) = C1(I,4)  
-              UVAR(I,8) = C1(I,5)
-              UVAR(I,9) = C1(I,6) 
-        ENDDO   
-C
-C  compute krchoff visco stress
-C              
-        DO J=1,6
-              SV(1:NEL,J) = ZERO
-              DO II= 1,NPRONY 
-                FAC= -TIMESTEP*BETA(II) 
-                DO I=1,NEL
-                     H0(II) = UVARV((II-1)*6*NEL + NEL*(J-1) + I)     
-                     H(II)  = EXP(FAC)*H0(II) +
-     .                  EXP(HALF*FAC)*(C1(I,J) - C0(I,J))
-                     UVARV((II-1)*6*NEL + NEL*(J-1) + I) =  H(II)
-                ENDDO
-              ENDDO                 
-              DO II = 1,NPRONY
-                DO I=1,NEL
-                      SV(I,J) = SV(I,J) + GI(II)*H(II)
-                ENDDO                           
-              ENDDO         
-        ENDDO   
-C *  Add VISCO CAUCHY STRESSES TO GLOBAL DIRECTIONS         
-C
-        DO I=1,NEL              
-            SIGNXX(I) = SIGNXX(I) + SV(I,1)/RV(I)
-            SIGNYY(I) = SIGNYY(I) + SV(I,2)/RV(I)
-            SIGNZZ(I) = SIGNZZ(I) + SV(I,3)/RV(I)
-            SIGNXY(I) = SIGNXY(I) + SV(I,4)/RV(I)
-            SIGNYZ(I) = SIGNYZ(I) + SV(I,5)/RV(I)
-            SIGNZX(I) = SIGNZX(I) + SV(I,6)/RV(I) 
-        ENDDO
-      ENDIF      
 C-----------------------------------------------------------
 C     set sound speed & viscosity
       DO I=1,NEL

--- a/engine/source/materials/mat/mat069/sigeps69c.F
+++ b/engine/source/materials/mat/mat069/sigeps69c.F
@@ -28,9 +28,8 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    finter      ../engine/source/tools/curve/finter.F
       !||====================================================================
               SUBROUTINE SIGEPS69C(
-     1      NEL    , NUPARAM, NUVAR   , NFUNC , IFUNC , NPF   ,
-     2      NPT0   , ILAYER ,
-     2      TF     , TIME   , TIMESTEP, UPARAM, RHO0  ,
+     1      NEL    , NUPARAM, NUVAR   ,NPT0   , ILAYER ,
+     2      TIME   , TIMESTEP, UPARAM, RHO0  ,
      3      AREA   , EINT   , THKLYL,
      4      EPSPXX , EPSPYY , EPSPXY, EPSPYZ, EPSPZX,
      5      DEPSXX , DEPSYY , DEPSXY, DEPSYZ, DEPSZX,
@@ -39,8 +38,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      8      SIGNXX , SIGNYY , SIGNXY, SIGNYZ, SIGNZX,
      9      SIGVXX , SIGVYY , SIGVXY, SIGVYZ, SIGVZX,
      A      SOUNDSP, VISCMAX, THKN  , UVAR  , NGL   ,
-     B      OFF    , ISMSTR, IPM     , GS   ,MAT    ,
-     C      NUVARV ,UVARV )
+     B      OFF    , ISMSTR , GS    )
 C-----------------------------------------------
 C   I M P L I C I T   T Y P E S
 C-----------------------------------------------
@@ -53,10 +51,9 @@ C-----------------------------------------------
 C----------------------------------------------------------------
 C  I N P U T   A R G U M E N T S
 C----------------------------------------------------------------
-      INTEGER NEL,NUPARAM,NUVAR,ISMSTR,NPT0,ILAYER,NUVARV
-      INTEGER IPM(NPROPMI,*),MAT(NEL),NGL(NEL)
-      my_real
-     .   TIME,TIMESTEP
+      INTEGER NEL,NUPARAM,NUVAR,ISMSTR,NPT0,ILAYER
+      INTEGER NGL(NEL)
+      my_real :: TIME,TIMESTEP
       my_real
      .  UPARAM(*),THKN(NEL),THKLYL(NEL),
      .  RHO0(NEL),AREA(NEL),EINT(NEL,2),GS(NEL),
@@ -74,67 +71,41 @@ C----------------------------------------------------------------
 C----------------------------------------------------------------
 C  I N P U T  O U T P U T   A R G U M E N T S
 C----------------------------------------------------------------
-      my_real
-     .      UVAR(NEL,NUVAR), OFF(NEL),UVARV(*)
-!!     .      UVAR(NEL,NUVAR), OFF(NEL),UVARV(NEL*NUVARV)
-C----------------------------------------------------------------
-C  VARIABLES FOR FUNCTION INTERPOLATION
-C----------------------------------------------------------------
-      INTEGER NPF(*), NFUNC, IFUNC(NFUNC)
-      my_real FINTER,FINTTE,TF(*),FINT2V
-      EXTERNAL FINTER,FINTTE
+      my_real :: UVAR(NEL,NUVAR), OFF(NEL)
 C----------------------------------------------------------------
 C  L O C A L  V A R I B L E S
 C----------------------------------------------------------------
-      INTEGER  I,J,K,ITER,NORDRE,NPRONY,IVISC,II,IADBUF,JNV
-      my_real
-     .   NU,RBULK,TENSCUT,GMAX,RVT,SUM,SUMDWDL,PARTP,KT3(NEL),
-     .   EMAX,A11         
+      INTEGER :: I,J,K,ITER,NORDER
+      my_real :: NU,RBULK,TENSCUT,GMAX,RVT,SUM,SUMDWDL,PARTP,EMAX,A11         
       my_real
      .   MU(5),AL(5),EVMA1(NEL,5),EVMA2(NEL,5),EVMA3(NEL,5),EVM(NEL,3),
      .   EIGV(NEL,3,2),TRAV(NEL),ROOTV(NEL),EVV(NEL,3),EV(NEL,3),
-     .   RHO(NEL),DEZZ(NEL),DWDL(3),DDWDDL(3),RV(NEL),T(NEL,3),EA(NEL),
-     .   EPSZZ(NEL),GI(100),BETA(100),SV(NEL,3),
-     .   FAC,H30(100),H31(NEL,100),H1(100),H10(100),
-     .   H2(100),H20(100),H12(100),H120(100),SV3,
+     .   RHO(NEL),DEZZ(NEL),DWDL(3),DDWDDL(3),RV(NEL),T(NEL,3),
+     .   EPSZZ(NEL),SV(NEL,3),
+     .   H30(100),H31(NEL,100),H1(100),H10(100),
+     .   H2(100),H20(100),H12(100),H120(100),
      .   CD1(NEL),CD2(NEL),CD12(NEL),CD10(NEL),
-     .   CD20(NEL),CD120(NEL), CP1,CP2,DC3EV3(NEL),C31(NEL),C30(NEL)
+     .   CD20(NEL),CD120(NEL), DC3EV3(NEL),C31(NEL),C30(NEL),KT3(NEL)
 C=======================================================================
-      IADBUF = IPM(7,MAT(1))
-      MU(1)  = UPARAM(IADBUF)
-      MU(2)  = UPARAM(IADBUF+1)
-      MU(3)  = UPARAM(IADBUF+2)
-      MU(4)  = UPARAM(IADBUF+3)
-      MU(5)  = UPARAM(IADBUF+4)
-      AL(1)  = UPARAM(IADBUF+5)
-      AL(2)  = UPARAM(IADBUF+6)
-      AL(3)  = UPARAM(IADBUF+7)
-      AL(4)  = UPARAM(IADBUF+8)
-      AL(5)  = UPARAM(IADBUF+9)
-      RBULK  = UPARAM(IADBUF+10)
-      TENSCUT= UPARAM(IADBUF+11)
-      NU     = UPARAM(IADBUF+13)
-      NORDRE = NINT(UPARAM(IADBUF+17))
-      GMAX = ZERO
-      IVISC = 0
-      
-C add viscosity using /visc/prony
-      IF(IPM(222,MAT(1)) > 0) THEN 
-         IADBUF = IPM(223,MAT(1))
-         NPRONY =  INT(UPARAM(IADBUF +1 ))
-         IVISC = 1
-c             
-         DO I=1,NPRONY
-          GI(I)    = UPARAM(IADBUF + 1 + I)
-          BETA(I)  = UPARAM(IADBUF + 1 + NPRONY + I)
-          GMAX = GMAX + GI(I)
-         ENDDO  
-       ENDIF
-C             
-       DO I= 1,NORDRE
-        GMAX  = GMAX  + MU(I)*AL(I)
-       ENDDO           
+      MU(1)  = UPARAM(1)
+      MU(2)  = UPARAM(2)
+      MU(3)  = UPARAM(3)
+      MU(4)  = UPARAM(4)
+      MU(5)  = UPARAM(5)
+      AL(1)  = UPARAM(6)
+      AL(2)  = UPARAM(7)
+      AL(3)  = UPARAM(8)
+      AL(4)  = UPARAM(9)
+      AL(5)  = UPARAM(10)
+      RBULK  = UPARAM(11)
+      TENSCUT= UPARAM(12)
+      NU     = UPARAM(14)
+      NORDER = NINT(UPARAM(18))
 C
+      GMAX = ZERO
+      DO I=1,NORDER
+        GMAX = GMAX + MU(I)*AL(I)
+      ENDDO                               
 C     User variables initialisation
       IF (TIME == ZERO .AND. ISIGI == 0) THEN 
         DO I=1,NEL                            
@@ -144,7 +115,6 @@ C     User variables initialisation
           UVAR(I,3) = ONE                      
         ENDDO                                 
       ENDIF                                   
-C
 C     principal stretch (def gradient eigenvalues)
       DO I=1,NEL
         TRAV(I)  = EPSXX(I)+EPSYY(I)
@@ -195,13 +165,11 @@ C     Strain definition
 C--------------------------------------
 C     Newton method =>  Find EV(3) : T3(EV(3)) = 0
 C--------------------------------------
-C Like law42 
-       IF(IVISC == 0)  THEN                                                       
          DO ITER = 1,5
 !       ----------------
           DO I=1,NEL  
             RV(I) = EV(I,1)*EV(I,2)*EV(I,3)  
-c----  la   normalized stretch => unified compressible/uncompressible formution                   
+c----       normalized stretch => unified compressible/uncompressible formution                   
 !            RVT    = RV(I)**(-THIRD)
             IF(RV(I)> ZERO) THEN
              RVT    = EXP((-THIRD)*LOG(RV(I)))
@@ -276,174 +244,12 @@ C
             EV(I,3) = EV(I,3)  - T(I,3)/KT3(I) 
             RV(I)   = EV(I,1)*EV(I,2)*EV(I,3) 
           ENDDO ! 1,NEL
-!       ----------------
-         ENDDO    ! ITER = 1,5   
-         SV(1:NEL,1) = ZERO    
-         SV(1:NEL,2) = ZERO   
-         SV(1:NEL,3) = ZERO          
-      ELSE ! with viscosity                                                       
-         DO ITER = 1,5
-!       ---------------- 
-          DO I=1,NEL  
-            RV(I) = EV(I,1)*EV(I,2)*EV(I,3)  
-c----  la   normalized stretch => unified compressible/uncompressible formution                                                    
-            IF(RV(I)> ZERO) THEN
-             RVT    = EXP((-THIRD)*LOG(RV(I)))
-            ELSE
-             RVT = ZERO
-            ENDIF            
-            EVM(I,1) = EV(I,1)*RVT                                        
-            EVM(I,2) = EV(I,2)*RVT                                        
-            EVM(I,3) = EV(I,3)*RVT
-          ENDDO    
-!       ----------------                                    
-C----       partial derivatives of strain energy
-          DO J=1,5
-           DO I=1,NEL 
-             IF(EVM(I,1)>ZERO) THEN
-              IF(AL(J)/=ZERO) THEN
-               EVMA1(I,J) = MU(J) * EXP(AL(J)*LOG(EVM(I,1)))
-              ELSE
-               EVMA1(I,J) = MU(J)
-              ENDIF
-             ELSE
-              EVMA1(I,J) = ZERO
-             ENDIF
-             IF(EVM(I,2)>ZERO) THEN
-              IF(AL(J)/=ZERO) THEN
-               EVMA2(I,J) = MU(J) * EXP(AL(J)*LOG(EVM(I,2)))
-              ELSE
-               EVMA2(I,J) = MU(J)
-              ENDIF
-             ELSE
-              EVMA2(I,J) = ZERO
-             ENDIF
-             IF(EVM(I,3)>ZERO) THEN
-              IF(AL(J)/=ZERO) THEN
-               EVMA3(I,J) = MU(J) * EXP(AL(J)*LOG(EVM(I,3)))
-              ELSE
-               EVMA3(I,J) = MU(J)
-              ENDIF
-             ELSE
-              EVMA3(I,J) = ZERO
-             ENDIF
-           ENDDO
-          ENDDO       ! j=1,5 
-!       ----------------          
-C  
-          DO I=1,NEL                                               
-            DWDL(1) = EVMA1(I,1)+EVMA1(I,2)+EVMA1(I,3)+EVMA1(I,4)+EVMA1(I,5)                        
-            DWDL(2) = EVMA2(I,1)+EVMA2(I,2)+EVMA2(I,3)+EVMA2(I,4)+EVMA2(I,5)                        
-            DWDL(3) = EVMA3(I,1)+EVMA3(I,2)+EVMA3(I,3)+EVMA3(I,4)+EVMA3(I,5)                        
-            SUMDWDL = (DWDL(1)+DWDL(2)+DWDL(3))* THIRD                                
-            PARTP   = RBULK*(RV(I)- ONE)                                                   
-c------  ---
-c           principal cauchy stress
-            T(I,1)  = (DWDL(1) - SUMDWDL) / RV(I) + PARTP 
-            T(I,2)  = (DWDL(2) - SUMDWDL) / RV(I) + PARTP 
-            T(I,3)  = (DWDL(3) - SUMDWDL) / RV(I) + PARTP 
-c------  ---
-
-            KT3(I) = -THIRD*(EVMA1(I,1)+EVMA1(I,2)+EVMA1(I,3)+EVMA1(I,4)+EVMA1(I,5))
-     .            -THIRD*(EVMA2(I,1)+EVMA2(I,2)+EVMA2(I,3)+EVMA2(I,4)+EVMA2(I,5))    
-     .            +TWO_THIRD*(EVMA3(I,1)+EVMA3(I,2)+EVMA3(I,3)+EVMA3(I,4)+EVMA3(I,5))
-            KT3(I) =-EV(I,1)*EV(I,2)*KT3(I)/(RV(I)**2) + RBULK*EV(I,1)*EV(I,2)
-            KT3(I) = KT3(I) 
-     .            +(ONE_OVER_9*(AL(1)*EVMA1(I,1)+AL(2)*EVMA1(I,2)+AL(3)*EVMA1(I,3) 
-     .            +  AL(4)*EVMA1(I,4)+AL(5)*EVMA1(I,5) 
-     .            +  AL(1)*EVMA2(I,1)+AL(2)*EVMA2(I,2) + AL(3)*EVMA2(I,3) 
-     .            +  AL(4)*EVMA2(I,4)+AL(5)*EVMA2(I,5) 
-     .            +  FOUR*(AL(1)*EVMA3(I,1) + AL(2)*EVMA3(I,2)
-     .            +  AL(3)*EVMA3(I,3)
-     .            +  AL(4)*EVMA3(I,4)+AL(5)*EVMA3(I,5))))/EV(I,3)/RV(I)
-                                                                  
-C viscosty model the same as law42            
-           C30(I) = UVAR(I,5) 
-           SUM = THIRD*(EVM(I,1)**2 +  EVM(I,2)**2 + EVM(I,3)**2)
-           C31(I)   =  EVM(I,3)**2 - SUM 
-!
-           DC3EV3(I) = FOUR_OVER_3*RVT*EVM(I,3)-TWO_THIRD*(TWO_THIRD*EVM(I,3)**2 - 
-     .                                          THIRD* EVM(I,1)**2 - 
-     .                                          THIRD* EVM(I,2)**2)/EV(I,3)
-          ENDDO
-!       ----------------
-          DO II= 1,NPRONY
-             FAC= -TIMESTEP*BETA(II)
-             DO I=1,NEL 
-                 H30(II)  =  UVARV(4*NEL*(II-1) + I)                
-                 H31(I,II)  = EXP(FAC)*H30(II)+ EXP(HALF*FAC)*(C31(I) - C30(I))
-C           Kirchoff visco stress --->
-C   PK2 stress, PK2 = F**(-1)*Taux* F**(-T)n 
-C   cauchy =Taux/RV is used here
-                  FAC= -TIMESTEP*BETA(II)
-                  T(I,3) = T(I,3) + GI(II)*H31(I,II)/RV(I)
-                  KT3(I)    = KT3(I) - GI(II)*H31(I,II)/EV(I,3)/RV(I)  
-     .                 + DC3EV3(I)*GI(II)*EXP(HALF*FAC)/RV(I)
-              ENDDO ! 1,NEL
-          ENDDO  ! NPRONY
-          EV(1:NEL,3) = EV(1:NEL,3)  - T(1:NEL,3)/KT3(1:NEL)                                        
-          RV(1:NEL)   = EV(1:NEL,1)*EV(1:NEL,2)*EV(1:NEL,3)   
-!       ----------------        
-         ENDDO  ! iteration 
-         UVAR(1:NEL,5) = C31(1:NEL)
-!       ----------------
-         DO II= 1,NPRONY
-              DO I=1,NEL
-               UVARV(4*NEL*(II-1) + I)   =  H31(I,II)
-              ENDDO
-         ENDDO
-!       ----------------
-! compute viscos stress
-         DO I=1,NEL                                               
-           IF(RV(I)> ZERO) THEN
-             RVT    = EXP((-THIRD)*LOG(RV(I)))
-           ELSE
-             RVT = ZERO
-           ENDIF 
-           EVM(I,1) = EV(I,1)*RVT
-           EVM(I,2) = EV(I,2)*RVT
-           EVM(I,3) = EV(I,3)*RVT
-C           
-           CD10(I) =  UVAR(I,6) 
-           CD20(I) =  UVAR(I,7) 
-           CD120(I) = UVAR(I,8) 
-C
-           SUM  = THIRD*(EVM(I,1)**2 +  EVM(I,2)**2 + EVM(I,3)**2) 
-           CP1   =  EVM(I,1)**2 - SUM                          
-           CP2   =  EVM(I,2)**2 - SUM
-           CD1(I)  = EIGV(I,1,1)*CP1 + EIGV(I,1,2)*CP2
-           CD2(I)  = EIGV(I,2,1)*CP1 + EIGV(I,2,2)*CP2
-           CD12(I) = EIGV(I,3,1)*CP1 + EIGV(I,3,2)*CP2                        
-           UVAR(I,6) = CD1(I)
-           UVAR(I,7) = CD2(I)
-           UVAR(I,8) = CD12(I)
-         ENDDO  ! 1,NEL
-!       ----------------
-         SV(1:NEL,1) = ZERO
-         SV(1:NEL,2) = ZERO
-         SV(1:NEL,3) = ZERO
-!       ---------------- 
-         DO II= 1,NPRONY
-           DO I=1,NEL 
-              FAC= -TIMESTEP*BETA(II)                          
-              H10(II)   =  UVARV(4*NEL*(II-1) +   NEL + I)           
-              H20(II)   =  UVARV(4*NEL*(II-1) + 2*NEL + I)  
-              H120(II)  =  UVARV(4*NEL*(II-1) + 3*NEL + I)
-              H1(II)  = EXP(FAC)*H10(II)+ EXP(HALF*FAC)*(CD1(I) - CD10(I))                
-              H2(II)  = EXP(FAC)*H20(II)+ EXP(HALF*FAC)*(CD2(I) - CD20(I))              
-              H12(II)  = EXP(FAC)*H120(II)+ EXP(HALF*FAC)*(CD12(I) - CD120(I)) 
-              UVARV(4*NEL*(II-1) +   NEL + I)= H1(II)              
-              UVARV(4*NEL*(II-1) + 2*NEL + I)= H2(II)   
-              UVARV(4*NEL*(II-1) + 3*NEL + I)= H12(II)        
-C         Kirchoff visco stress
-              SV(I,1) = SV(I,1) + GI(II)*H1(II)
-              SV(I,2) = SV(I,2) + GI(II)*H2(II)
-              SV(I,3) = SV(I,3) + GI(II)*H12(II)
-           ENDDO       ! 1,NPRONY                                        
-         ENDDO          ! 1,NEL  
-!       ----------------
-      ENDIF                                      
-C-------------------------------------------------------------
+      ENDDO    ! ITER = 1,5   
+C-----------------------
+      SV(1:NEL,1) = ZERO
+      SV(1:NEL,2) = ZERO
+      SV(1:NEL,3) = ZERO
+C-----------------------
       DO I=1,NEL
         UVAR(I,3) = EV(I,3)
       ENDDO
@@ -486,7 +292,6 @@ C     set sound speed & viscosity
       DO I=1,NEL
         RV(I)   = EV(I,1)*EV(I,2)*EV(I,3)  
         DEZZ(I) =-NU/(ONE-NU)*(DEPSXX(I)+DEPSYY(I))
-!!        DEZZ(I) = EPSZZ(I) - UVAR(I,4)
         SIGNXX(I) =EIGV(I,1,1)*T(I,1)+EIGV(I,1,2)*T(I,2) + SV(I,1)/RV(I)
         SIGNYY(I) =EIGV(I,2,1)*T(I,1)+EIGV(I,2,2)*T(I,2) + SV(I,2)/RV(I)
         SIGNXY(I) =EIGV(I,3,1)*T(I,1)+EIGV(I,3,2)*T(I,2) + SV(I,3)/RV(I)
@@ -495,14 +300,11 @@ C
         SIGNZX(I) = SIGOZX(I)+GS(I)*DEPSZX(I)
         RHO(I)    = RHO0(I)/RV(I)
         THKN(I) = THKN(I) + DEZZ(I)*THKLYL(I)*OFF(I)
-         VISCMAX(I)= ZERO
-!!          UVAR(I,4) = EPSZZ(I)  
-C         
-           
-          EMAX = GMAX*(ONE + NU)
-!C           EMAX = MAX(EMAX,EA(I)) 
-          A11  = EMAX/(ONE - NU**2)
-          SOUNDSP(I)= SQRT(A11/RHO0(I))
+        VISCMAX(I)= ZERO
+C                
+        EMAX = GMAX*(ONE + NU)
+        A11  = EMAX/(ONE - NU**2)
+        SOUNDSP(I)= SQRT(A11/RHO0(I))
       ENDDO
 C-----------
       RETURN

--- a/engine/source/materials/mat_share/mulaw.F90
+++ b/engine/source/materials/mat_share/mulaw.F90
@@ -427,7 +427,7 @@
           integer :: nuvarr
 
           integer nv46, numel, inloc
-          integer i,npar,nuparam,niparam,nparf,iadbuf,iadvis,nfunc,numtabl,israte,ipg,nptr,npts,&
+          integer i,npar,nuparam,niparam,nparf,iadbuf,nfunc,numtabl,israte,ipg,nptr,npts,&
           &ibid,ibidon1,ibidon2,ibidon3,ibidon4 ,n48,nix,ilaw_user,igtyp,&
           &nvarf,ir,irupt,imat,isvis,ivisc,nuvarv,nuparv,iseq,idev,ntabl_fail,&
           &l_planl,l_epsdnl,l_dmg
@@ -1351,20 +1351,10 @@
             &ipm ,mat ,amu   )
 !
           elseif (mtn == 69) then
-            ivisc  = ipm(222,imat)
-            nuparv = ipm(224,imat)
-            nuvarv = ipm(225,imat)
-            iadvis = ipm(223,imat)
-            if (ivisc > 0) then
-              uparvis => bufmat(iadvis:iadvis+nuparv)
-            else
-              allocate (bufzero(0))
-              uparvis => bufzero
-            end if
 
             call sigeps69(nel  ,npar,nuvar,nfunc,ifunc,npf  ,&
             &tf   ,tt,dt1,uparam0,rho0 ,rho  ,&
-            &voln ,eint,ivisc,nuparv,uparvis ,&
+            &voln ,eint,                      &
             &ep1  ,ep2 ,ep3 ,ep4  ,ep5  ,ep6 ,&
             &de1  ,de2 ,de3 ,de4  ,de5  ,de6 ,&
             &es1  ,es2 ,es3 ,es4  ,es5  ,es6 ,&

--- a/engine/source/materials/mat_share/mulawc.F
+++ b/engine/source/materials/mat_share/mulawc.F
@@ -354,7 +354,7 @@ C
         IF(ILAW==2) FLAG_LAW2 = .TRUE.
         IF(ILAW==22) FLAG_LAW22 = .TRUE.
         IF(ILAW==25) FLAG_LAW25 = .TRUE.
-        IF(IPM(222,IMAT) > 0) IPRONY=1
+        IF (MAT_ELEM%MAT_PARAM(IMAT)%IVISC > 0) IPRONY=1
       ENDDO
 C
 !     ZCFAC computation is only useful for CZFORC3 and CZFORC3_CRK routines
@@ -372,7 +372,6 @@ C
       IBIDON1 = 0
       IBIDON2 = 0
       IBIDON3 = 0
-c      IMAT = IPM(1, MAT(1))
       IUN=1
 c
       DMG_FLAG = 0
@@ -1392,9 +1391,8 @@ c
      E        LBUF%OFF)
           ELSEIF (ILAW == 69) THEN
            CALL SIGEPS69C(
-     1         JLT    , NUPARAM0, NUVAR   , NFUNC , IFUNC , NPF   ,
-     2         NPT    , IPT ,
-     2         TF     , TT     , DT1C    , BUFMAT, RHO   ,  
+     1         JLT    , NUPARAM0, NUVAR  ,NPT    , IPT   ,
+     2         TT     , DT1     , UPARAM0, RHO   ,  
      3         AREA   , EINT   , THKLYL  ,
      4         EPSPXX , EPSPYY , EPSPXY  , EPSPYZ, EPSPZX, 
      5         DEPSXX , DEPSYY , DEPSXY  , DEPSYZ, DEPSZX,
@@ -1402,9 +1400,9 @@ c
      7         LBUF%SIG(IJ1),LBUF%SIG(IJ2),LBUF%SIG(IJ3),LBUF%SIG(IJ4),LBUF%SIG(IJ5),
      8         SIGNXX , SIGNYY , SIGNXY  , SIGNYZ, SIGNZX,
      9         SIGVXX , SIGVYY , SIGVXY  , SIGVYZ, SIGVZX,
-     A         SSP    , VISCMX , THKN    , UVAR  ,
-     B         NGL    , OFF    , ISMSTR  , IPM   , GS    ,
-     C         MAT    , NUVARV , UVARV )
+     A         SSP    , VISCMX , THKN    , UVAR  , NGL    , 
+     B         OFF    , ISMSTR  , GS    )
+
           ELSEIF (ILAW == 71) THEN !ISMSTR = 10 always (set in cgrtails)
            CALL SIGEPS71C(
      1   JLT,          NUPARAM0,      NUVAR,        NFUNC,
@@ -1756,7 +1754,7 @@ c
 C
 C  visco elastic model (prony)
 C        
-         IF(MATPARAM%IVISC == 1 .AND. ILAW /= 25) THEN 
+          IF (MATPARAM%IVISC == 1 .AND. ILAW /= 25) THEN 
               NPRONY = MATPARAM%VISC%IPARAM(1)
               KV     = MATPARAM%VISC%UPARAM(1)
 c                 
@@ -1767,7 +1765,7 @@ c
              ENDDO
 C
              CALL PRONY_MODELC( 
-     1          NEL    ,NUVARV  ,TT    ,DT1C , 
+     1          NEL    ,NUVARV  ,DT1 , 
      2          NPRONY , KV   , GV   ,BETA    ,RHO   ,   
      3          EPSPXX ,EPSPYY ,EPSPXY  ,EPSPYZ  ,EPSPZX ,
      4          SIGVXX ,SIGVYY ,SIGVXY  ,SIGVYZ  ,SIGVZX ,

--- a/engine/source/materials/mat_share/usermat_shell.F
+++ b/engine/source/materials/mat_share/usermat_shell.F
@@ -285,7 +285,7 @@ C
         IF (IXFEM == 1 .AND. IXLAY > 0) ILAYER = IXLAY  ! xfem  multilayer
         ILAW = ELBUF_STR%BUFLY(ILAYER)%ILAW
         IMAT = ELBUF_STR%BUFLY(ILAYER)%IMAT
-        IF(IPM(222,IMAT) > 0) IPRONY=1
+        IF (MAT_ELEM%MAT_PARAM(IMAT)%IVISC > 0) IPRONY=1
       ENDDO
 C
 !     ZCFAC computation is only useful for CZFORC3 and CZFORC3_CRK routines

--- a/engine/source/materials/mat_share/usermat_solid.F
+++ b/engine/source/materials/mat_share/usermat_solid.F
@@ -1666,8 +1666,7 @@ c
 C-----------------------------------------------------------------------
 C     viscous stress (/VISC models) 
 C-----------------------------------------------------------------------
-      IVISC = IPM(222,MX)
-      IF (IVISC > 0) THEN
+      IF (MAT_ELEM%MAT_PARAM(MAT(1))%IVISC > 0) THEN
          CALL VISCMAIN(MAT_ELEM%MAT_PARAM(MAT(1))%VISC    ,NEL     ,
      .        NVARVIS ,VBUF%VAR,RHO0    ,VIS     ,SSP     ,DT1     , 
      .        EP1     ,EP2     ,EP3     ,EP4     ,EP5     ,EP6     ,

--- a/engine/source/materials/visc/prony_modelc.F
+++ b/engine/source/materials/visc/prony_modelc.F
@@ -26,7 +26,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    mulawc         ../engine/source/materials/mat_share/mulawc.F
       !||====================================================================
       SUBROUTINE PRONY_MODELC(
-     1     NEL  ,NUVAR  ,TIME   ,TIMESTEP,
+     1     NEL  ,NUVAR  ,TIMESTEP,
      2     NPRONY   ,KV     ,GI , BETA     ,RHO0  ,
      3     EPSPXX ,EPSPYY ,EPSPXY  ,EPSPYZ  ,EPSPZX ,
      4     SIGVXX ,SIGVYY ,SIGVXY  ,SIGVYZ  ,SIGVZX ,
@@ -68,7 +68,7 @@ C-----------------------------------------------
 C
       INTEGER NEL, NUVAR,NPRONY
       my_real
-     .   TIME,TIMESTEP(NEL),KV,GI(NPRONY),BETA(NPRONY),
+     .   TIMESTEP,KV,GI(NPRONY),BETA(NPRONY),
      .   RHO0(NEL), EPSPXX(NEL),EPSPYY(NEL),
      .   EPSPXY(NEL),EPSPYZ(NEL),EPSPZX(NEL)
 C-----------------------------------------------
@@ -82,30 +82,14 @@ C-----------------------------------------------
 C   I N P U T   O U T P U T   A r g u m e n t s 
 C-----------------------------------------------
       my_real
-     .    UVAR(NEL,NUVAR), OFF(NEL),THK(NEL),YLD(NEL)
-C-----------------------------------------------
-C   VARIABLES FOR FUNCTION INTERPOLATION 
-C-----------------------------------------------
-C        Y = FINTER(IFUNC(J),X,NPF,TF,DYDX)
-C        Y       : y = f(x)
-C        X       : x
-C        DYDX    : f'(x) = dy/dx
-C        IFUNC(J): FUNCTION INDEX
-C              J : FIRST(J=1), SECOND(J=2) .. FUNCTION USED FOR THIS LAW
-C        NPF,TF  : FUNCTION PARAMETER
+     .    UVAR(NEL,NUVAR), OFF(NEL),THK(NEL)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER
-     . I,J,II
-      my_real 
-     .  CC,G,DAV,EPXX,EPYY,EPZZ,SVXX,
-     .  SVYY,SVZZ,P,
+      INTEGER :: I,J
+      my_real :: G,DAV,EPXX,EPYY,EPZZ,P,
      .  AA(MVSIZ,NPRONY),BB(MVSIZ,NPRONY),H0(6),EPSPZZ(MVSIZ),
      .  H(6,NPRONY),S(6),A1(MVSIZ),A2(MVSIZ),FAC
-C-----------------------------------------------
-C     USER VARIABLES INITIALIZATION
-C-----------------------------------------------
 C------------------------------------------
 C   estiamte stress
 C------------------------------------------
@@ -120,8 +104,8 @@ C
           EPSPZZ(I) = ZERO
 C          
          DO J=1,NPRONY
-          AA(I,J) =  EXP(-BETA(J)*TIMESTEP(I)) 
-          BB(I,J) =  TIMESTEP(I)*GI(J)*EXP(-HALF*BETA(J)*TIMESTEP(I))
+          AA(I,J) =  EXP(-BETA(J)*TIMESTEP) 
+          BB(I,J) =  TIMESTEP*GI(J)*EXP(-HALF*BETA(J)*TIMESTEP)
 C
 C  for computing epszz_dot (sigzz=0)
 C
@@ -177,9 +161,7 @@ C
 C  comppute stress
 C
            
-          DO II = 1,6
-           S(II) = ZERO
-          ENDDO        
+          S(1:6) = ZERO
 
           DO  J= 1,NPRONY
             S(1) = S(1) + H(1,J)

--- a/engine/source/output/anim/generate/dfuncc_ply.F
+++ b/engine/source/output/anim/generate/dfuncc_ply.F
@@ -40,7 +40,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .                      IXC  , IXTG , MASS ,PM   ,EL2FA,
      .                      NBF  , IADP , NBF_L,EHOUR,ANIM ,
      .                      NBPART,IADG , IPM  ,IGEO ,THKE ,
-     .                      ERR_THK_SH4,ERR_THK_SH3,
+     .                      ERR_THK_SH4,ERR_THK_SH3,MAT_PARAM,
      .                      NBF_PXFEMG ,X, STACK)
 C-----------------------------------------------
 C   M o d u l e s
@@ -49,6 +49,7 @@ C-----------------------------------------------
       USE PLYXFEM_MOD
       USE ELBUFDEF_MOD     
       USE STACK_MOD       
+      USE MATPARAM_DEF_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -77,6 +78,7 @@ C     REAL
      .   ERR_THK_SH4(*), ERR_THK_SH3(*), X(3,*)
       REAL WAL(NBF_L)
       TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP), TARGET :: ELBUF_TAB
+      TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(IN) :: MAT_PARAM
       TYPE (STACK_PLY) :: STACK
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
@@ -343,7 +345,7 @@ C +
                      IADR = (N-1)*NEL                       
                       DO I=1,NEL                          
                         MATL   = STACK%IGEO(IPMAT+N,ISUBSTACK)
-                        IF(IPM(222,MATL) > 0 ) IVISC = 1
+                        IF (MAT_PARAM(MATL)%IVISC > 0 ) IVISC = 1
                       END DO                                
                   END DO                                       
                END IF  
@@ -428,7 +430,7 @@ c
                      IADR = (N-1)*NEL                       
                       DO I=1,NEL                          
                         MATL   = STACK%IGEO(IPMAT+N,ISUBSTACK)
-                        IF(IPM(222,MATL) > 0 ) IVISC = 1
+                        IF (MAT_PARAM(MATL)%IVISC > 0 ) IVISC = 1
                       END DO                                
                   END DO                                       
                 END IF  

--- a/engine/source/output/anim/generate/genani.F
+++ b/engine/source/output/anim/generate/genani.F
@@ -3193,7 +3193,7 @@ C ply information
      .                        IXC ,  IXTG    , MAS,   PM,    EL2FA_PLY,
      .                        NBF_PXFEM,IAD  , PLYNUMC,EANI,ANIN(NDMA2+1),
      .                        NPLYPART,IAD_PLYG,IPM  ,IGEO , THKE,
-     .                        ERR_THK_SH4, ERR_THK_SH3,
+     .                        ERR_THK_SH4, ERR_THK_SH3,MAT_PARAM,
      .                        NBF_PXFEMG ,X , STACK )
             ENDIF
             IF (ANIM_CRK > 0)THEN
@@ -3833,7 +3833,7 @@ C
              CALL TENSORC_PLY(IPLY,    NEL_PLY,  ELBUF_TAB ,IPARG,
      .                        IFUNC,   INVERT,   EL2FA_PLY ,NBF_PXFEM,
      .                        WAFT_PLY,TANI,     IAD,       PLYNUMC,
-     .                        NBPART,  IAD_PLYG, X,         IXC,
+     .                        NBPART,  IAD_PLYG, X,         IXC,MAT_PARAM,
      .                        IGEO,    IXTG,     NBF_PXFEMG,IPM, STACK )
           ENDIF
 C
@@ -3844,7 +3844,7 @@ C
      .               LEN_CRKX ,TANI     ,IAD      ,NBF_CRKXFEM ,
      .               NBPART   ,IAD_CRKG ,X        ,IXC         ,
      .               IGEO     ,IXTG     ,IEL_CRK  ,IADC_CRK    ,
-     .               CRKEDGE  ,INDX_CRK )
+     .               CRKEDGE  ,INDX_CRK ,MAT_PARAM)
           ENDIF
 C
           IF (ISPMD==0.AND.NFVTR>0) THEN

--- a/engine/source/output/anim/generate/tensorc.F
+++ b/engine/source/output/anim/generate/tensorc.F
@@ -37,7 +37,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       SUBROUTINE TENSORC(ELBUF_TAB,IPARG ,ITENS ,INVERT,NELCUT,
      2                   EL2FA    ,NBF   ,TENS  ,EPSDOT,IADP  ,
      3                   NBF_L    ,NBPART,IADG  ,X     ,IXC   ,
-     4                   IGEO     ,IXTG  ,IPM   ,STACK ,MATPARAM_TAB)
+     4                   IGEO     ,IXTG  ,IPM   ,STACK ,MAT_PARAM)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -72,7 +72,7 @@ C     REAL
      .   TENS(3,*),EPSDOT(6,*),X(3,*)
       TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP), TARGET :: ELBUF_TAB
       TYPE (STACK_PLY) :: STACK
-      TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(IN) :: MATPARAM_TAB
+      TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(IN) :: MAT_PARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -775,7 +775,7 @@ c
                     IL  = 1
                   END IF
                   IMAT  = ELBUF_TAB(NG)%BUFLY(IL)%IMAT                          
-                  IVISC = IPM(222,IMAT)
+                  IVISC = MAT_PARAM(IMAT)%IVISC
                   DO I=1,NEL  
                     DO IR=1,NPTR                
                       DO IS=1,NPTS 
@@ -798,7 +798,7 @@ c
                       ENDDO
                     ENDDO
                   END IF
-                  MAT_ORTH = MATPARAM_TAB(IMAT)%ORTHOTROPY
+                  MAT_ORTH = MAT_PARAM(IMAT)%ORTHOTROPY
                   IF (MAT_ORTH == 2) THEN
                    IF(IDRAPE > 0 .AND. (IGTYP == 51 .OR. IGTYP ==52)) THEN
                      DIR_A => ELBUF_TAB(NG)%BUFLY(IL)%LBUF_DIR(IPT)%DIRA 
@@ -848,7 +848,7 @@ c
                     END IF
 c  
                     IMAT  = ELBUF_TAB(NG)%BUFLY(IL)%IMAT                          
-                    IVISC = IPM(222,IMAT)    
+                    IVISC = MAT_PARAM(IMAT)%IVISC   
                     DO I=1,NEL  
                       DO IR=1,NPTR                
                         DO IS=1,NPTS 
@@ -871,7 +871,7 @@ c
                         ENDDO
                       ENDDO
                     END IF
-                    MAT_ORTH = MATPARAM_TAB(IMAT)%ORTHOTROPY
+                    MAT_ORTH = MAT_PARAM(IMAT)%ORTHOTROPY
                     IF (MAT_ORTH == 2) THEN
                       DIR_A => ELBUF_TAB(NG)%BUFLY(IL)%DIRA  
                       CALL UROTO_TENS2D(NEL,SIGE,DIR_A)
@@ -913,7 +913,7 @@ C-----
                     END IF
                   END DO
                   IMAT  = ELBUF_TAB(NG)%BUFLY(IL)%IMAT                          
-                  IVISC = IPM(222,IMAT)    
+                  IVISC = MAT_PARAM(IMAT)%IVISC
 C
                   SIGE(1:NEL,1:3) = ZERO
                   DO I=1,NEL                                          
@@ -940,7 +940,7 @@ c
                     ENDDO
                   END IF
 c
-                  MAT_ORTH = MATPARAM_TAB(IMAT)%ORTHOTROPY
+                  MAT_ORTH = MAT_PARAM(IMAT)%ORTHOTROPY
                   IF (MAT_ORTH == 2) THEN
                     DIR_A => ELBUF_TAB(NG)%BUFLY(IL)%DIRA  
                     CALL UROTO_TENS2D(NEL,SIGE,DIR_A)
@@ -972,7 +972,7 @@ C-----
                   END IF
                 END DO
                 IMAT  = ELBUF_TAB(NG)%BUFLY(IL)%IMAT                          
-                IVISC = IPM(222,IMAT)    
+                IVISC = MAT_PARAM(IMAT)%IVISC  
 C
                 SIGE(1:NEL,1:3) = ZERO
                 DO I=1,NEL                                          
@@ -999,7 +999,7 @@ c
                   ENDDO
                 END IF
 c
-                MAT_ORTH = MATPARAM_TAB(IMAT)%ORTHOTROPY
+                MAT_ORTH = MAT_PARAM(IMAT)%ORTHOTROPY
                 IF (MAT_ORTH == 2) THEN
                   DIR_A => ELBUF_TAB(NG)%BUFLY(IL)%DIRA  
                   CALL UROTO_TENS2D(NEL,SIGE,DIR_A)
@@ -1026,7 +1026,7 @@ c               /TENS/STRESS/ILAY - only compatible with IGTYP 10,11,16
 c                  IT = IUS - 10*IL 
                   IPT = 1
                   IMAT  = ELBUF_TAB(NG)%BUFLY(IL)%IMAT                          
-                  IVISC = IPM(222,IMAT)    
+                  IVISC = MAT_PARAM(IMAT)%IVISC 
 C
                   SIGE(1:NEL,1:3) = ZERO
                   DO I=1,NEL                                          
@@ -1053,7 +1053,7 @@ c
                     ENDDO
                   END IF
 c
-                  MAT_ORTH = MATPARAM_TAB(IMAT)%ORTHOTROPY
+                  MAT_ORTH = MAT_PARAM(IMAT)%ORTHOTROPY
                   IF (MAT_ORTH == 2) THEN
                     DIR_A => ELBUF_TAB(NG)%BUFLY(IL)%DIRA  
                     CALL UROTO_TENS2D(NEL,SIGE,DIR_A)
@@ -1088,7 +1088,7 @@ c
                       END IF
                       IF (ID_PLY == PLY_ANIM_STRESS(3*(IPLY - 1) + 1)) THEN
                         IMAT  = ELBUF_TAB(NG)%BUFLY(IL)%IMAT                          
-                        IVISC = IPM(222,IMAT)    
+                        IVISC = MAT_PARAM(IMAT)%IVISC    
                         IF (IPT <= ELBUF_TAB(NG)%BUFLY(IL)%NPTT) THEN 
                           DO I=1,NEL                               
                             DO IR=1,NPTR                                        
@@ -1101,7 +1101,7 @@ c
                             ENDDO    
                           ENDDO
 c
-                          MAT_ORTH = MATPARAM_TAB(IMAT)%ORTHOTROPY
+                          MAT_ORTH = MAT_PARAM(IMAT)%ORTHOTROPY
                           IF (MAT_ORTH > 0) THEN                 
                             IF (IDRAPE > 0 .AND. (IGTYP == 51 .OR. IGTYP ==52) ) THEN
                               DIR_A => ELBUF_TAB(NG)%BUFLY(IL)%LBUF_DIR(IPT)%DIRA
@@ -1156,7 +1156,7 @@ c
                 END IF
 c
                 IMAT  = ELBUF_TAB(NG)%BUFLY(IL)%IMAT                          
-                IVISC = IPM(222,IMAT)    
+                IVISC = MAT_PARAM(IMAT)%IVISC  
                 DO I=1,NEL  
                   DO IR=1,NPTR                
                     DO IS=1,NPTS 
@@ -1219,7 +1219,7 @@ c
                     END DO
                   END IF
                   IMAT  = ELBUF_TAB(NG)%BUFLY(IL)%IMAT                          
-                  IVISC = IPM(222,IMAT)    
+                  IVISC = MAT_PARAM(IMAT)%IVISC  
                   DO I=1,NEL  
                     DO IR=1,NPTR                
                       DO IS=1,NPTS 
@@ -1274,7 +1274,7 @@ c
                       END IF
                       IF (ID_PLY == IPLY) THEN
                         IMAT  = ELBUF_TAB(NG)%BUFLY(IL)%IMAT                          
-                        IVISC = IPM(222,IMAT)    
+                        IVISC = MAT_PARAM(IMAT)%IVISC   
                         IF (IPT <= ELBUF_TAB(NG)%BUFLY(IL)%NPTT) THEN 
                           DO I=1,NEL                               
                             DO IR=1,NPTR                                        

--- a/engine/source/output/anim/generate/tensorc_crk.F
+++ b/engine/source/output/anim/generate/tensorc_crk.F
@@ -39,13 +39,14 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      2                       LEN      ,EPSDOT  ,IADP      ,NBF_L   ,
      3                       NBPART   ,IADG    ,X         ,IXC     ,
      4                       IGEO     ,IXTG    ,IEL_CRK   ,IADC_CRK,
-     5                       CRKEDGE  ,INDX_CRK)
+     5                       CRKEDGE  ,INDX_CRK,MAT_PARAM )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE MY_ALLOC_MOD
       USE CRACKXFEM_MOD
       USE ELBUFDEF_MOD
+      USE MATPARAM_DEF_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -74,6 +75,7 @@ C     REAL
       TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP), TARGET :: ELBUF_TAB
       TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP,NXEL), TARGET :: XFEM_TAB
       TYPE (XFEM_EDGE_)   , DIMENSION(*) :: CRKEDGE
+      TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(IN) :: MAT_PARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -374,7 +376,7 @@ c
                     IPMAT = 100                                     
                     DO I=1,NEL
                       MATLY = IGEO(IPMAT+ILAY,PID(I))
-                      IF (IPM(222,MATLY) > 0 ) IVISC = 1
+                      IF (MAT_PARAM(MATLY)%IVISC > 0 ) IVISC = 1
                     ENDDO
 c                  ELSEIF (IGTYP == 9 .OR. IGTYP == 10) THEN
 c                  ELSEIF (IGTYP == 17) THEN

--- a/engine/source/output/anim/generate/tensorc_ply.F
+++ b/engine/source/output/anim/generate/tensorc_ply.F
@@ -37,12 +37,13 @@ C available just with ply/xfem formulation
       SUBROUTINE TENSORC_PLY(IPLY,  NEL_PLY, ELBUF_TAB, IPARG,
      1                       ITENS, INVERT,  EL2FA, NBF,
      2                       TENS,  EPSDOT,  IADP,  NBF_L,
-     3                       NBPART,IADG,    X,     IXC,
+     3                       NBPART,IADG,    X,     IXC,MAT_PARAM,
      4                       IGEO,  IXTG, NBF_PXFEMG, IPM  ,STACK)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE ELBUFDEF_MOD
+      USE MATPARAM_DEF_MOD
       USE PLYXFEM_MOD
       USE STACK_MOD
 C-----------------------------------------------
@@ -70,6 +71,7 @@ C     REAL
       my_real
      .   TENS(3,*),EPSDOT(6,*), X(3,*)
       TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP), TARGET :: ELBUF_TAB
+      TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(IN) :: MAT_PARAM
       TYPE (STACK_PLY) :: STACK
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
@@ -386,8 +388,10 @@ c------------
                      IADR = (N-1)*NEL                       
                       DO I=1,NEL                          
                         MATLY   = STACK%IGEO(IPMAT+N,ISUBSTACK)
-                        NUVARV =  MAX(NUVARV, IPM(225,MATLY)) 
-                        IF(IPM(222,MATLY) > 0 ) IVISC = 1
+                        IF (MAT_PARAM(MATLY)%IVISC > 0) THEN
+                          IVISC  = 1
+                          NUVARV =  MAX(NUVARV, MAT_PARAM(MATLY)%VISC%NUVAR) 
+                        END IF
                       END DO                                
                   END DO                                       
               END IF  

--- a/engine/source/output/dynain/dynain_c_strsg.F
+++ b/engine/source/output/dynain/dynain_c_strsg.F
@@ -39,15 +39,16 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    state_mod           ../common_source/modules/state_mod.F
       !||====================================================================
       SUBROUTINE DYNAIN_C_STRSG(
-     1                  ELBUF_TAB  ,IPARG     ,IPM        ,IGEO  ,IXC    ,
+     1                  ELBUF_TAB  ,IPARG     ,IGEO  ,IXC    ,
      2                  IXTG       ,WA        ,WAP0       ,IPARTC,IPARTTG,
      3                  DYNAIN_DATA,DYNAIN_INDXC,DYNAIN_INDXTG,SIZP0  ,
      4                  GEO        ,STACK     ,DRAPE_SH4N   ,DRAPE_SH3N,X   ,
-     5                  THKE       ,DRAPEG)
+     5                  THKE       ,DRAPEG    ,NUMMAT   ,MAT_PARAM   )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE ELBUFDEF_MOD   
+      USE MATPARAM_DEF_MOD
       USE STACK_MOD
       USE DRAPE_MOD     
       USE STATE_MOD 
@@ -66,9 +67,10 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+      INTEGER NUMMAT
       INTEGER SIZLOC,SIZP0
       INTEGER IXC(NIXC,*),IXTG(NIXTG,*),
-     .        IPARG(NPARG,*),IPM(NPROPMI,*),IGEO(NPROPGI,*),
+     .        IPARG(NPARG,*),IGEO(NPROPGI,*),
      .        IPARTC(*), IPARTTG(*), 
      .        DYNAIN_INDXC(*), DYNAIN_INDXTG(*)
       my_real   
@@ -79,6 +81,7 @@ C-----------------------------------------------
       TYPE (DRAPEG_) :: DRAPEG
       double precision WA(*),WAP0(*)
       TYPE (DYNAIN_DATABASE), INTENT(INOUT) :: DYNAIN_DATA
+      TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(IN) :: MAT_PARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -86,7 +89,7 @@ C-----------------------------------------------
      .   LLT,ITY,MLW,IH,IHBE, ID, IPRT0, IPRT,IR,IS,IT,
      .   NPG,IPG,MPT,IPT,NPTR,NPTS,NPTT,NLAY,L_PLA,ITHK,
      .   IGTYP,NPT_ALL,IL,KK(12),LARGE,IREP,IPID,IVISC,
-     .   IPMAT,IXFEM,IXLAY,ISUBSTACK,IPTT,IS_WRITTEN,
+     .   IMAT,IPMAT,IXFEM,IXLAY,ISUBSTACK,IPTT,IS_WRITTEN,
      ,   LAYNPT_MAX,NLAY_MAX,IERR,L_DIRA,L_DIRB,IORTH,
      .   JDIR,ILAY,J1,J2,SEDRAPE,NUMEL_DRAPE,KB
      
@@ -262,22 +265,25 @@ C-------------------------------------------------------
               IPMAT = 100                                     
               DO N=1,MPT                                     
                  DO I=LFT,LLT
-                    IF (IPM(222,MATLY((N-1)*LLT + I)) > 0 ) IVISC = 1       
+                   IMAT = MATLY((N-1)*LLT + I)
+                   IF (MAT_PARAM(IMAT)%IVISC > 0) IVISC = 1       
                  ENDDO                                       
               ENDDO                                          
           ELSEIF (IGTYP == 9 .OR. IGTYP == 10) THEN            
               DO N=1,MPT
                   DO I=LFT,LLT
-                    IF (IPM(222,MATLY((N-1)*LLT + I)) > 0 ) IVISC = 1         
+                    IMAT = MATLY((N-1)*LLT + I)
+                    IF (MAT_PARAM(IMAT)%IVISC > 0) IVISC = 1       
                  ENDDO                                      
               ENDDO                                         
           ELSEIF(IGTYP == 17 .OR. IGTYP == 51 .OR.IGTYP == 52)THEN                             
-                  IPMAT   = 2 + NLAY
+              IPMAT = 2 + NLAY
               DO N=1,NLAY                                      
-                  DO I=LFT,LLT
-                    IF(IPM(222,MATLY((N-1)*LLT + I)) > 0 ) IVISC = 1         
+                 DO I=LFT,LLT
+                   IMAT  = MATLY((N-1)*LLT + I)
+                   IF (MAT_PARAM(IMAT)%IVISC > 0 ) IVISC = 1       
                  END DO                                      
-               ENDDO                                          
+              ENDDO                                          
           ENDIF   ! IGTYP    
 
 C-------------------------------------------------------
@@ -1298,20 +1304,23 @@ C-------------------------------------------------------
               IPMAT = 100                                     
               DO N=1,MPT                                     
                  DO I=LFT,LLT
-                    IF (IPM(222,MATLY((N-1)*LLT + I)) > 0 ) IVISC = 1       
+                   IMAT = MATLY((N-1)*LLT + I)
+                   IF (MAT_PARAM(IMAT)%IVISC > 0 ) IVISC = 1       
                  ENDDO                                       
               ENDDO                                          
           ELSEIF (IGTYP == 9 .OR. IGTYP == 10) THEN            
               DO N=1,MPT
                   DO I=LFT,LLT
-                    IF (IPM(222,MATLY((N-1)*LLT + I)) > 0 ) IVISC = 1         
+                   IMAT = MATLY((N-1)*LLT + I)
+                   IF (MAT_PARAM(IMAT)%IVISC > 0 ) IVISC = 1       
                  ENDDO                                      
               ENDDO                                         
           ELSEIF(IGTYP == 17 .OR. IGTYP == 51 .OR.IGTYP == 52)THEN                             
-                  IPMAT   = 2 + NLAY
+              IPMAT   = 2 + NLAY
               DO N=1,NLAY                                      
                   DO I=LFT,LLT
-                    IF(IPM(222,MATLY((N-1)*LLT + I)) > 0 ) IVISC = 1         
+                   IMAT = MATLY((N-1)*LLT + I)
+                   IF (MAT_PARAM(IMAT)%IVISC > 0 ) IVISC = 1       
                  END DO                                      
                ENDDO                                          
           ENDIF   ! IGTYP   

--- a/engine/source/output/dynain/gendynain.F
+++ b/engine/source/output/dynain/gendynain.F
@@ -51,11 +51,12 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      3                PM       ,GEO      , IPARTC ,IPARTTG  ,LENG     ,
      4                LENGC    ,LENGTG   , WEIGHT ,NODGLOB  ,THKE     ,               
      5                NPBY     ,LPBY     , STACK  ,DRAPE_SH4N ,DRAPE_SH3N , 
-     6                DYNAIN_DATA,DRAPEG) 
+     6                DYNAIN_DATA,DRAPEG ,MAT_PARAM) 
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE ELBUFDEF_MOD
+      USE MATPARAM_DEF_MOD
       USE MESSAGE_MOD    
       USE INOUTFILE_MOD 
       USE STACK_MOD
@@ -91,6 +92,7 @@ C-----------------------------------------------
       TYPE (DRAPE_)  :: DRAPE_SH4N(NUMELC_DRAPE),DRAPE_SH3N(NUMELTG_DRAPE)
       TYPE (DRAPEG_) :: DRAPEG
       TYPE (DYNAIN_DATABASE), INTENT(INOUT) :: DYNAIN_DATA
+      TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(IN) :: MAT_PARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -225,11 +227,11 @@ C-----------------------------------------------
 
       IF(DYNAIN_DATA%DYNAIN_C(4)==1) THEN
          CALL DYNAIN_C_STRSG(
-     1        ELBUF_TAB  ,IPARG     ,IPM        ,IGEO  ,IXC    ,
+     1        ELBUF_TAB  ,IPARG     ,IGEO  ,IXC    ,
      2        IXTG       ,WA        ,WAP0       ,IPARTC,IPARTTG,
      3        DYNAIN_DATA,DYNAIN_INDXC,DYNAIN_INDXTG,SIZP0    ,
      4        GEO        ,STACK     ,DRAPE_SH4N ,DRAPE_SH3N,X      ,
-     5        THKE      , DRAPEG)
+     5        THKE      , DRAPEG    ,NUMMAT     ,MAT_PARAM  )
       ENDIF
 C------------------------------------------
 

--- a/engine/source/output/h3d/h3d_results/h3d_shell_tensor.F
+++ b/engine/source/output/h3d/h3d_results/h3d_shell_tensor.F
@@ -47,7 +47,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      4                   IGEO     ,IXTG  ,IPM   ,STACK,ID_ELEM   ,ITY_ELEM  ,INFO1,
      5                   INFO2    ,IS_WRITTEN_SHELL,IPARTC ,IPARTTG     ,LAYER_INPUT ,IPT_INPUT  ,
      6                   PLY_INPUT,GAUSS_INPUT,IUVAR_INPUT,H3D_PART, KEYWORD,D    ,
-     7                   ID       ,BUFMAT   ,MATPARAM_TAB,GEO, DRAPE_SH4N, DRAPE_SH3N, DRAPEG)
+     7                   ID       ,BUFMAT   ,MAT_PARAM,GEO, DRAPE_SH4N, DRAPE_SH3N, DRAPEG)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -84,7 +84,7 @@ C-----------------------------------------------
       my_real, INTENT(IN) :: GEO(NPROPG,NUMGEO)
       TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP), TARGET :: ELBUF_TAB
       TYPE (STACK_PLY) :: STACK
-      TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(IN) :: MATPARAM_TAB
+      TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(IN) :: MAT_PARAM
        CHARACTER(LEN=NCHARLINE100):: KEYWORD
       TYPE (DRAPE_) , INTENT(IN) :: DRAPE_SH4N(NUMELC_DRAPE), DRAPE_SH3N(NUMELTG_DRAPE)
       TYPE (DRAPEG_), INTENT(IN) :: DRAPEG
@@ -382,7 +382,7 @@ c               /TENS/STRESS/PLY=.../NPT=...
                   ILAY  = J
                   IF (ID_PLY == IPLY .AND. IPT <= ELBUF_TAB(NG)%BUFLY(ILAY)%NPTT) THEN
                     IMAT  = ELBUF_TAB(NG)%BUFLY(ILAY)%IMAT                          
-                    IVISC = IPM(222,IMAT)
+                    IVISC = MAT_PARAM(IMAT)%IVISC
                     ISELECT = 1
                     DO I=1,NEL  
                         DO IR=1,NPTR                
@@ -406,7 +406,7 @@ c               /TENS/STRESS/PLY=.../NPT=...
                           ENDDO
                         ENDDO
                    END IF 
-                   MAT_ORTH = MATPARAM_TAB(IMAT)%ORTHOTROPY
+                   MAT_ORTH = MAT_PARAM(IMAT)%ORTHOTROPY
                    IF (MAT_ORTH > 0) THEN                 
                         IF (IDRAPE > 0 .AND. (IGTYP == 51 .OR. IGTYP == 52) ) THEN
                           DIR_A => ELBUF_TAB(NG)%BUFLY(ILAY)%LBUF_DIR(IPT)%DIRA
@@ -430,7 +430,7 @@ c               /TENS/STRESS/LAYER=
                 IF (IGTYP == 10 .OR. IGTYP == 11 .OR. IGTYP == 16) THEN   ! shells type 10,11,16 only   
                   ISELECT = 1
                   IMAT  = ELBUF_TAB(NG)%BUFLY(ILAY)%IMAT                          
-                  IVISC = IPM(222,IMAT)    
+                  IVISC = MAT_PARAM(IMAT)%IVISC  
                   DO I=1,NEL  
                     DO IR=1,NPTR                
                       DO IS=1,NPTS 
@@ -453,7 +453,7 @@ c               /TENS/STRESS/LAYER=
                       ENDDO
                     ENDDO
                   END IF
-                  MAT_ORTH = MATPARAM_TAB(IMAT)%ORTHOTROPY
+                  MAT_ORTH = MAT_PARAM(IMAT)%ORTHOTROPY
                   IF (MAT_ORTH > 0) THEN                 
                     DIR_A => ELBUF_TAB(NG)%BUFLY(ILAY)%DIRA
                     DIR_B => ELBUF_TAB(NG)%BUFLY(ILAY)%DIRB
@@ -471,7 +471,7 @@ c               /TENS/STRESS/NPT=
                   IF (IPT <= ELBUF_TAB(NG)%BUFLY(1)%NPTT) THEN
                     ISELECT = 1
                     IMAT  = ELBUF_TAB(NG)%BUFLY(1)%IMAT                          
-                    IVISC = IPM(222,IMAT)    
+                    IVISC = MAT_PARAM(IMAT)%IVISC    
                     DO I=1,NEL  
                       DO IR=1,NPTR                
                         DO IS=1,NPTS 
@@ -494,7 +494,7 @@ c               /TENS/STRESS/NPT=
                         ENDDO
                       ENDDO
                     END IF
-                    MAT_ORTH = MATPARAM_TAB(IMAT)%ORTHOTROPY
+                    MAT_ORTH = MAT_PARAM(IMAT)%ORTHOTROPY
                     IF (MAT_ORTH == 2) THEN
                       DIR_A => ELBUF_TAB(NG)%BUFLY(1)%DIRA  
                       CALL UROTO_TENS2D(NEL,SIGE,DIR_A)
@@ -529,7 +529,7 @@ c               /TENS/MSTRESS/PLY=.../NPT=...
                   IF (ID_PLY == IPLY) THEN
                     ILAY = J
                     IMAT  = ELBUF_TAB(NG)%BUFLY(ILAY)%IMAT                          
-                    IVISC = IPM(222,IMAT)    
+                    IVISC = MAT_PARAM(IMAT)%IVISC    
                     IF (IPT <= ELBUF_TAB(NG)%BUFLY(ILAY)%NPTT) THEN 
                       ISELECT = 1
                       DO I=1,NEL  
@@ -563,7 +563,7 @@ c               /TENS/MSTRESS/LAYER=
                 IF (IGTYP == 10 .OR. IGTYP == 11 .OR. IGTYP == 16) THEN   ! shells type 10,11,16 only   
                   ISELECT = 1
                   IMAT  = ELBUF_TAB(NG)%BUFLY(ILAY)%IMAT                          
-                  IVISC = IPM(222,IMAT)    
+                  IVISC = MAT_PARAM(IMAT)%IVISC    
                   DO I=1,NEL  
                     DO IR=1,NPTR                
                       DO IS=1,NPTS 
@@ -594,7 +594,7 @@ c               /TENS/MSTRESS/NPT=
                   IF (IPT <= ELBUF_TAB(NG)%BUFLY(1)%NPTT) THEN
                     ISELECT = 1
                     IMAT  = ELBUF_TAB(NG)%BUFLY(ILAY)%IMAT                          
-                    IVISC = IPM(222,IMAT)    
+                    IVISC = MAT_PARAM(IMAT)%IVISC   
                     DO I=1,NEL  
                       DO IR=1,NPTR                
                         DO IS=1,NPTS 
@@ -866,7 +866,7 @@ c
                         ENDDO
                       ENDIF ! NPG 
                       IMAT = ELBUF_TAB(NG)%BUFLY(ILAY)%IMAT                          
-                      MAT_ORTH = MATPARAM_TAB(IMAT)%ORTHOTROPY
+                      MAT_ORTH = MAT_PARAM(IMAT)%ORTHOTROPY
                       IF (MAT_ORTH > 0) THEN                 
                         IF (IDRAPE > 0 .AND. (IGTYP == 51 .OR. IGTYP == 52) ) THEN
                           DIR_A => ELBUF_TAB(NG)%BUFLY(ILAY)%LBUF_DIR(IPT)%DIRA
@@ -916,7 +916,7 @@ c               PLY=NULL ILAYER=IL NPT=NULL
                       ENDDO
                   ENDIF
                   IMAT = ELBUF_TAB(NG)%BUFLY(ILAY)%IMAT                          
-                  MAT_ORTH = MATPARAM_TAB(IMAT)%ORTHOTROPY
+                  MAT_ORTH = MAT_PARAM(IMAT)%ORTHOTROPY
                   IF (MAT_ORTH > 0) THEN                 
                     DIR_A => ELBUF_TAB(NG)%BUFLY(ILAY)%DIRA
                     DIR_B => ELBUF_TAB(NG)%BUFLY(ILAY)%DIRB
@@ -958,7 +958,7 @@ c               PLY=NULL ILAYER=NULL NPT=IPT
                      ENDDO
                   ENDIF
                   IMAT = ELBUF_TAB(NG)%BUFLY(1)%IMAT                          
-                  MAT_ORTH = MATPARAM_TAB(IMAT)%ORTHOTROPY
+                  MAT_ORTH = MAT_PARAM(IMAT)%ORTHOTROPY
                   IF (MAT_ORTH == 2) THEN
                     DIR_A => ELBUF_TAB(NG)%BUFLY(1)%DIRA  
                     CALL ROTO_TENS2D(NEL,EPSM,DIR_A)

--- a/engine/source/output/sortie_main.F
+++ b/engine/source/output/sortie_main.F
@@ -943,7 +943,7 @@ C
      3                PM       ,GEO      , IPART(K3),IPART(K8),LENG   ,
      4                LENGC    ,LENGTG   , WEIGHT ,NODGLOB  ,THKE     ,               
      5                NPBY     ,LPBY     , STACK  ,DRAPE_SH4N ,DRAPE_SH3N , 
-     6                DYNAIN_DATA,DRAPEG) 
+     6                DYNAIN_DATA,DRAPEG ,MAT_PARAM) 
              
        IF(TT>=DYNAIN_DATA%TDYNAIN)DYNAIN_DATA%TDYNAIN=DYNAIN_DATA%TDYNAIN+DYNAIN_DATA%DTDYNAIN
        IF ((TSTOP<DYNAIN_DATA%TDYNAIN).AND.(DYNAIN_DATA%TDYNAIN<TSTOP+EM06*TSTOP)

--- a/engine/source/output/th/thcoq.F
+++ b/engine/source/output/th/thcoq.F
@@ -182,7 +182,7 @@ c
                 ENDDO                     
               ELSE                     
                 DO I=1,NEL             
-            MAT(I)=IXTG(1,NFT+I) 
+                  MAT(I)=IXTG(1,NFT+I) 
                   PID(I)=IXTG(5,NFT+I) 
                 ENDDO                     
               ENDIF                   
@@ -190,28 +190,34 @@ c---
               IF (IGTYP == 11) THEN
                 IPMAT = 100
                 DO N=1,MPT
-            DO I=1,NEL
-                      MATLY = IGEO(IPMAT+N,PID(I))
-                    NUVARV = MAX(NUVARV, IPM(225,MATLY)) 
-                    IF (IPM(222,MATLY) > 0) IVISC = 1
-            ENDDO              
+                  DO I=1,NEL
+                    MATLY = IGEO(IPMAT+N,PID(I))
+                    IF (MATPARAM_TAB(MATLY)%IVISC > 0) THEN
+                      IVISC = 1
+                      NUVARV = MAX(NUVARV, MATPARAM_TAB(IMAT)%VISC%NUVAR)
+                    END IF
+                  ENDDO              
                 ENDDO            
               ELSEIF (IGTYP == 9 .OR. IGTYP == 10) THEN 
                 DO N=1,MPT
                   DO I=1,NEL
                     MATLY=MAT(I)
-                    NUVARV =  MAX(NUVARV, IPM(225,MATLY)) 
-                    IF (IPM(222,MATLY) > 0) IVISC = 1
-            ENDDO              
+                    IF (MATPARAM_TAB(MATLY)%IVISC > 0) THEN
+                      IVISC = 1
+                      NUVARV = MAX(NUVARV, MATPARAM_TAB(IMAT)%VISC%NUVAR)
+                    END IF
+                  ENDDO              
                 ENDDO
               ELSEIF (IGTYP == 17 .OR. IGTYP == 51 .OR. IGTYP == 52) THEN
                 IPMAT   = 2 + NLAY  
                 DO N=1,NLAY
                   DO I=1,NEL
                     MATLY  = STACK%IGEO(IPMAT+N,ISUBSTACK)
-                    NUVARV = MAX(NUVARV, IPM(225,MATLY)) 
-                    IF (IPM(222,MATLY) > 0) IVISC = 1
-               ENDDO              
+                    IF (MATPARAM_TAB(MATLY)%IVISC > 0) THEN
+                      IVISC = 1
+                      NUVARV = MAX(NUVARV, MATPARAM_TAB(IMAT)%VISC%NUVAR)
+                    END IF
+                  ENDDO              
                 ENDDO
 c
                 IF (ISHPLYXFEM > 0) THEN
@@ -416,7 +422,7 @@ c
                 DO IL = 1,NLAY                                        
                   BUFLY => ELBUF_TAB(NG)%BUFLY(IL)
                   IMAT  = BUFLY%IMAT                          
-                  IVISC = IPM(222,IMAT)    
+                  IVISC = MATPARAM_TAB(IMAT)%IVISC  
                   NPTT  = BUFLY%NPTT
                   IF (IVISC > 0) THEN  
                     K = 30382+(IL-1)*5

--- a/starter/source/elements/solid/solide/sgrtails.F
+++ b/starter/source/elements/solid/solide/sgrtails.F
@@ -501,7 +501,6 @@ C         PARAMETRE GROUPE
             ITET10  = IGEO(50,PID)
 c
             ISVIS  = IGEO(33,PID)                       
-C   is a material flag   IVISC  = IGEO(34,PID)
             IPARTSPH=IGEO(38,PID)          
 C            
             IF ((ISSN == 10.OR.ISSN == 11).AND.(IGT == 14.OR.IGT == 6)) THEN
@@ -1380,8 +1379,8 @@ C-------
           ISSN = 10
           ENDIF
         ENDIF
-        IVISC = IPM(222,MID)
-        IF(IVISC == 2 .AND. ISSN /=10 .AND. ISSN /=12) THEN
+        IVISC = MATPARAM%IVISC
+        IF (IVISC == 2 .AND. ISSN /=10 .AND. ISSN /=12) THEN
             CALL ANCMSG(MSGID=3018,
      .                      MSGTYPE=MSGWARNING,
      .                      ANMODE=ANINFO_BLIND_2,

--- a/starter/source/materials/visc/hm_read_visc.F
+++ b/starter/source/materials/visc/hm_read_visc.F
@@ -179,9 +179,9 @@ c
 c-----------------------------
 c           duplicate storage for compatibility with old code and output until cleaning
 c-----------------------------
-            IPM(216 ,I) = IMATVIS
-            IPM(222 ,I) = IVISC
-            IPM(225 ,I) = MAT_PARAM(IMAT)%VISC%NUVAR
+            IPM(216 ,I) = IMATVIS  ! hourglass treatment flag specific for viscoelastic maaterials
+!            IPM(222 ,I) = IVISC
+!            IPM(225 ,I) = MAT_PARAM(IMAT)%VISC%NUVAR
 c--------------------------------------------------
           ENDIF   !IMID == MAT_ID
 c--------------------------------------------------

--- a/starter/source/spmd/domain_decomposition/initwg_solid.F
+++ b/starter/source/spmd/domain_decomposition/initwg_solid.F
@@ -76,7 +76,7 @@ C     REAL OU REAL*8
 C-----------------------------------------------
       INTEGER OFF, NPN, MID, PID, JHBE, IGT, MLN,
      .    ISTRAIN, ITHK, IHBE, IPLA, ISSN, MTN, I, J, K,L,
-     .    NFUNC,MPT,NPTS,NPTT,NPTR,NPTOT,IFLAG,JSROT,
+     .    NFUNC,MPT,NPTS,NPTT,NPTR,NPTOT,IFLAG,JSROT,IVISC,
      .    I_MID,I_PID,I_MID_OLD,I_PID_OLD,PUID,MUID,
      .    ELM_TYP,ELM_TYP_OLD,ILAW,ILAW_OLD,TEST_MAT,
      .    I_PRO,ISOL2,MUID_OLD,PUID_OLD,
@@ -302,15 +302,10 @@ C -------------------------------
             IAD = IPM(7,ABS(MID))-1
             NFUNC = NINT(BUFMAT(IAD+3))
           END IF
-          IF (NFUNC == 0) THEN
-            IF (IPM(222,ABS(MID)) > 0) THEN 
-              IAD = IPM(223,ABS(MID))
-              NFUNC = NINT(BUFMAT(IAD +1 ))
-            ENDIF
-          ENDIF
-          IF(NFUNC==0) THEN
-            INDI = 1
-            IF (MAT_PARAM(ABS(MID))%IVISC > 0) THEN 
+          IF (NFUNC==0) THEN
+            INDI  = 1
+            IVISC = MAT_PARAM(ABS(MID))%IVISC
+            IF (IVISC == 1 .or. IVISC == 2) THEN 
               VISC_PRONY = VISC_PRONY_COST * MAT_PARAM(ABS(MID))%VISC%IPARAM(1)
             ENDIF
           ELSEIF(NFUNC==1) THEN


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

possible missing viscosity stress in engin outputs

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

removed all references to IPM table in viscosity models.
IPM It was already replaced by MAT_PARAM%VISC structure, but still present in the code

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
