### PR TITLE
Correct strain rate TH output for material law 83

### DIFF
--- a/engine/source/output/th/thsol.F
+++ b/engine/source/output/th/thsol.F
@@ -808,6 +808,7 @@ C               Solid spotwelds : damage  DAMA1 ...DAMA4
 
               ELSEIF (MTE == 83) THEN
                 WWA(12)=GBUF%PLA(I)
+                WWA(14)=GBUF%EPSD(I)
                 NUVAR = ELBUF_TAB(NG)%BUFLY(1)%NVAR_MAT
                 DO J=1,NPTR
                   MBUF  => ELBUF_TAB(NG)%BUFLY(1)%MAT(J,1,1)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Strain rate was not output in time history for law83

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

added necessary term in th output - strain rate is calculated and stored in element buffer

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
