### PR TITLE
restart file fix

### DIFF
--- a/engine/source/interfaces/int22/w_bufbric_22.F
+++ b/engine/source/interfaces/int22/w_bufbric_22.F
@@ -166,10 +166,10 @@ C-----------------------------------------------
         DO J=1,9 ; CALL WRITE_I_C ( BRICK_LIST(NIN,1:I22LEN)%POLY(J)%FACE(K)%Adjacent_Cell(I)   , I22LEN) ; ENDDO      
         ENDDO          
         DO I=1,5       
-        DO J=1,9 ; CALL WRITE_I_C ( BRICK_LIST(NIN,1:I22LEN)%POLY(J)%FACE(K)%Adjacent_FLUX(I)   , I22LEN) ; ENDDO      
+        DO J=1,9 ; CALL WRITE_DB ( BRICK_LIST(NIN,1:I22LEN)%POLY(J)%FACE(K)%Adjacent_FLUX(I)   , I22LEN) ; ENDDO
         ENDDO 
         DO I=1,5       
-        DO J=1,9 ; CALL WRITE_I_C ( BRICK_LIST(NIN,1:I22LEN)%POLY(J)%FACE(K)%Adjacent_upwFLUX(I), I22LEN) ; ENDDO      
+        DO J=1,9 ; CALL WRITE_DB ( BRICK_LIST(NIN,1:I22LEN)%POLY(J)%FACE(K)%Adjacent_upwFLUX(I), I22LEN) ; ENDDO
         ENDDO 
         DO I=1,3       
         DO J=1,9 ; CALL WRITE_DB ( BRICK_LIST(NIN,1:I22LEN)%POLY(J)%FACE(K)%Center(I)           , I22LEN) ; ENDDO      


### PR DESCRIPTION
#### restart file fix

#### Description of the changes
Additional update following 5908984f37d026b0c2483879e7d5335590f9231b where Integer Read/Write was replaced with Real Read/Write.   Arrays Adjacent_FLUX and Adjacent_upwFLUX are real arrays and must be Read/Write with subroutines READ_DB and WRITE_DB instead of READ_I_C and WRITE_I_C
