### PR TITLE
input correction for law125 and law127 according to dyna input

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2025/MAT/matl125_laminated_composite.cfg
+++ b/hm_cfg_files/config/CFG/radioss2025/MAT/matl125_laminated_composite.cfg
@@ -29,9 +29,9 @@ ATTRIBUTES(COMMON) {
     LSD_MAT_GAB             = VALUE(FLOAT,"Shear modulus in plane 12");
     LSD_MAT_GBC             = VALUE(FLOAT,"Shear modulus in plane 23");
     LSD_MAT_GCA             = VALUE(FLOAT,"Shear modulus in plane 13");
-    LSD_MAT_PRBA            = VALUE(FLOAT,"Poisson's ratio in plane 12");
-    LSD_MAT_PRAC            = VALUE(FLOAT,"Poisson's ratio in plane 13");
-    LSD_MAT_PRBC            = VALUE(FLOAT,"Poisson's ratio in plane 23");
+    LSD_MAT_PRBA            = VALUE(FLOAT,"Poisson's ratio in plane 21");
+    LSD_MAT_PRCA            = VALUE(FLOAT,"Poisson's ratio in plane 31");
+    LSD_MAT_PRCB            = VALUE(FLOAT,"Poisson's ratio in plane 32");
 
     LSD_FS                  = VALUE(INT  ,"Failure surface type");
     LSD_SOFT                = VALUE(FLOAT  ,"Softening reduction factor");
@@ -141,8 +141,8 @@ SKEYWORDS_IDENTIFIER(COMMON)
     LSD_MAT_GBC       = -1; 
     LSD_MAT_GCA       = -1; 
     LSD_MAT_PRBA      = -1; 
-    LSD_MAT_PRAC      = -1; 
-    LSD_MAT_PRBC      = -1; 
+    LSD_MAT_PRCA      = -1; 
+    LSD_MAT_PRCB      = -1; 
     MATL58_GAMMA1     = -1; 
     MATL58_TAU1       = -1; 
     LSD_FS            = -1; 
@@ -256,8 +256,8 @@ GUI(COMMON)
     SCALAR(LSD_MAT_GBC)     { DIMENSION="pressure";      }
     SCALAR(LSD_MAT_GCA)     { DIMENSION="pressure";      }
     SCALAR(LSD_MAT_PRBA)        { DIMENSION="DIMENSIONLESS"; }
-    SCALAR(LSD_MAT_PRBC)        { DIMENSION="DIMENSIONLESS"; }
-    SCALAR(LSD_MAT_PRAC)        { DIMENSION="DIMENSIONLESS"; }
+    SCALAR(LSD_MAT_PRCB)        { DIMENSION="DIMENSIONLESS"; }
+    SCALAR(LSD_MAT_PRCA)        { DIMENSION="DIMENSIONLESS"; }
     SCALAR(MATL58_GAMMA1)       { DIMENSION="DIMENSIONLESS"; }
     SCALAR(MATL58_TAU1)         { DIMENSION="pressure";      }
     SCALAR(MATL58_GAMMA2)       { DIMENSION="DIMENSIONLESS"; }
@@ -338,8 +338,8 @@ FORMAT(radioss2025)
     CARD("%20lg%20lg%20lg%20lg%10d",LSD_MAT_EA,LSD_MAT_EB,LSD_MAT_EC,LSD_SOFT,LSD_FS);
     COMMENT("#                G12                G13                G23");
     CARD("%20lg%20lg%20lg",LSD_MAT_GAB,LSD_MAT_GCA,LSD_MAT_GBC);
-      COMMENT("#                Nu12                Nu13                Nu23");
-    CARD("%20lg%20lg%20lg",LSD_MAT_PRBA,LSD_MAT_PRAC,LSD_MAT_PRBC);
+      COMMENT("#                Nu21                Nu31                Nu32");
+    CARD("%20lg%20lg%20lg",LSD_MAT_PRBA,LSD_MAT_PRCA,LSD_MAT_PRCB);
     
     COMMENT("#         LCE11T                 E11T      LCXT                  XT              SLIMT1");
     CARD("%10d%20lg%10d%20lg%20lg",LSD_LCID12,LSD_M11T,LSD_LCID2,LSD_MAT_XT,MATL58_SLIMT1);

--- a/hm_cfg_files/config/CFG/radioss2025/MAT/matl127_enhanced_composite.cfg
+++ b/hm_cfg_files/config/CFG/radioss2025/MAT/matl127_enhanced_composite.cfg
@@ -30,9 +30,9 @@ ATTRIBUTES(COMMON) {
     LSDYNA_GBC             = VALUE(FLOAT,"Shear modulus in plane 23");
     LSDYNA_GCA             = VALUE(FLOAT,"Shear modulus in plane 13");
     
-    LSDYNA_PRBA            = VALUE(FLOAT,"Poisson's ratio in plane 12");
-    LSDYNA_PRCA            = VALUE(FLOAT,"Poisson's ratio in plane 13");
-    LSDYNA_PRCB            = VALUE(FLOAT,"Poisson's ratio in plane 23");
+    LSDYNA_PRBA            = VALUE(FLOAT,"Poisson's ratio in plane 21");
+    LSDYNA_PRCA            = VALUE(FLOAT,"Poisson's ratio in plane 31");
+    LSDYNA_PRCB            = VALUE(FLOAT,"Poisson's ratio in plane 32");
 
     LSD_SOFT               = VALUE(FLOAT, "Softening reduction factor for material strength in crashfront elements");
     LSD_FBRT               = VALUE(FLOAT, "Softening for fiber tensile strength");
@@ -218,7 +218,7 @@ FORMAT(radioss2025)
     CARD("%20lg%20lg%20lg",LSDYNA_EA,LSDYNA_EB,LSDYNA_EC);
     COMMENT("#                G12                G13                G23");
     CARD("%20lg%20lg%20lg",LSDYNA_GAB,LSDYNA_GCA,LSDYNA_GBC);
-    COMMENT("#                Nu12                Nu31                Nu32");
+    COMMENT("#                Nu21                Nu31                Nu32");
     CARD("%20lg%20lg%20lg",LSDYNA_PRBA,LSDYNA_PRCA,LSDYNA_PRCB);
     
     COMMENT("#      Ifiunc_XT              XT          SLIMT1");

--- a/starter/source/materials/mat/mat125/hm_read_mat125.F90
+++ b/starter/source/materials/mat/mat125/hm_read_mat125.F90
@@ -121,9 +121,9 @@
       call hm_get_floatv('LSD_MAT_GBC'   ,g23      ,is_available, lsubmodel, unitab)
       call hm_get_floatv('LSD_MAT_GCA'   ,g13      ,is_available, lsubmodel, unitab)
 !card4 -  poisson's ratio
-      call hm_get_floatv('LSD_MAT_PRBA'  ,nu12     ,is_available, lsubmodel, unitab)
-      call hm_get_floatv('LSD_MAT_PRBC'  ,nu23     ,is_available, lsubmodel, unitab)
-      call hm_get_floatv('LSD_MAT_PRAC'  ,nu13     ,is_available, lsubmodel, unitab) 
+      call hm_get_floatv('LSD_MAT_PRBA'  ,nu21     ,is_available, lsubmodel, unitab)
+      call hm_get_floatv('LSD_MAT_PRCB'  ,nu32     ,is_available, lsubmodel, unitab)
+      call hm_get_floatv('LSD_MAT_PRCA'  ,nu31     ,is_available, lsubmodel, unitab) 
 !card5 - dir 11 tention 
       call hm_get_floatv  ('LSD_M11T'        ,em11t      ,is_available, lsubmodel, unitab)
       call hm_get_floatv  ('LSD_MAT_XT'      ,xt         ,is_available, lsubmodel, unitab)
@@ -209,45 +209,48 @@
       ! shear modulus
       if (g13 == zero) g13 = g12
       if (g23 == zero) g23 = g13
+
+      if(nu31 == zero) nu31 = nu21
+      if(nu32 == zero) nu32 = nu21
 !-----------------------------
  !     check and default values
  !-----------------------------
       ! poisson's ratio
-      if (nu12 < zero .or. nu12 >= half) then
+      if (nu21 < zero .or. nu21 >= half) then
         call ancmsg(msgid=3032,                        &
                   msgtype=msgerror,                    &
                   anmode=aninfo_blind_2,               &
-                  r1=nu12,                             &
+                  r1=nu21,                             &
                   i1=mat_id,                           &
                   c1=titr)
       endif    
-      nu21 = nu12*e2/e1
-      if (nu21 < zero .or. nu21 >= half) then
+      nu12 = nu21*e1/e2
+      if (nu12 < zero .or. nu12 >= half) then
         call ancmsg(msgid=3033,                      &                              
                   msgtype=msgerror,                  &
                   anmode=aninfo_blind_2,             &
-                  r1=nu21,                           &
+                  r1=nu12,                           &
                   i1=mat_id,                         &
                   c1=titr)   
       endif
-      if (nu23 < zero .or. nu23 >= half) then
+      if (nu32 < zero .or. nu32 >= half) then
         call ancmsg(msgid=3034,                        &
                     msgtype=msgerror,                  &
                     anmode=aninfo_blind_2,             &
-                    r1=nu23,                           &
+                    r1=nu32,                           &
                     i1=mat_id,                         &
                     c1=titr)
       endif
-      nu32 = nu23*e3/e2
-      if (nu32 < zero .or. nu32 >= half) then
+      nu23 = nu32*e2/e3
+      if (nu23 < zero .or. nu23 >= half) then
         call ancmsg(msgid=3035,                     &
                  msgtype=msgerror,                  &
                  anmode=aninfo_blind_2,             &
-                 r1=nu32,                           &
+                 r1=nu23,                           &
                  i1=mat_id,                         &
                  c1=titr)
       endif
-      if (nu13 < zero .or. nu13 >= half) then
+      if (nu31 < zero .or. nu31 >= half) then
         call ancmsg(msgid=3036,                     &
                  msgtype=msgerror,                  &
                  anmode=aninfo_blind_2,             &
@@ -255,8 +258,8 @@
                  i1=mat_id,                         &
                  c1=titr)
       endif 
-      nu31 = nu13*e3/e1
-      if (nu31 < zero .or. nu31 >= half) then
+      nu13 = nu31*e1/e3
+      if (nu13  < zero .or. nu13 >= half) then
         call ancmsg(msgid=3037,                     &
                   msgtype=msgerror,                 &
                   anmode=aninfo_blind_2,            &

--- a/starter/source/materials/mat/mat127/hm_read_mat127.F90
+++ b/starter/source/materials/mat/mat127/hm_read_mat127.F90
@@ -109,9 +109,9 @@
       call hm_get_floatv('LSDYNA_GBC'   ,g23      ,is_available, lsubmodel, unitab)
       call hm_get_floatv('LSDYNA_GCA'   ,g13      ,is_available, lsubmodel, unitab)     
 !card4 -  poisson's ratio ! tocheck
-      call hm_get_floatv('LSDYNA_PRBA'  ,nu12     ,is_available, lsubmodel, unitab)
-      call hm_get_floatv('LSDYNA_PRCB'  ,nu23     ,is_available, lsubmodel, unitab)
-      call hm_get_floatv('LSDYNA_PRCA'  ,nu13     ,is_available, lsubmodel, unitab) 
+      call hm_get_floatv('LSDYNA_PRBA'  ,nu21     ,is_available, lsubmodel, unitab)
+      call hm_get_floatv('LSDYNA_PRCB'  ,nu32     ,is_available, lsubmodel, unitab)
+      call hm_get_floatv('LSDYNA_PRCA'  ,nu31    ,is_available, lsubmodel, unitab) 
 !card5 - dir 11 tention 
       call hm_get_floatv  ('LSD_MAT_XT'       ,xt         ,is_available, lsubmodel, unitab)
       call hm_get_floatv  ('LSD_MAT_SLIMT1'   ,slimt1     ,is_available, lsubmodel, unitab)
@@ -145,45 +145,48 @@
       ! shear modulus
       if (g13 == zero) g13 = g12
       if (g23 == zero) g23 = g13
+        ! ratio poisson's
+      if(nu31 == zero) nu31 = nu21
+      if(nu32 == zero) nu32 = nu21
 !-----------------------------
  !     check and default values
  !-----------------------------
       ! poisson's ratio
-      if (nu12 < zero .or. nu12 >= half) then
+      if (nu21 < zero .or. nu21 >= half) then
         call ancmsg(msgid=3032,                        &
                   msgtype=msgerror,                    &
                   anmode=aninfo_blind_2,               &
-                  r1=nu12,                             &
+                  r1=nu21,                             &
                   i1=mat_id,                           &
                   c1=titr)
       endif    
-      nu21 = nu12*e2/e1
-      if (nu21 < zero .or. nu21 >= half) then
+      nu12 = nu21*e1/e2
+      if (nu12 < zero .or. nu12 >= half) then
         call ancmsg(msgid=3033,                      &                              
                   msgtype=msgerror,                  &
                   anmode=aninfo_blind_2,             &
-                  r1=nu21,                           &
+                  r1=nu12,                           &
                   i1=mat_id,                         &
                   c1=titr)   
       endif
-      if (nu23 < zero .or. nu23 >= half) then
+      if (nu32 < zero .or. nu32 >= half) then
         call ancmsg(msgid=3034,                        &
                     msgtype=msgerror,                  &
                     anmode=aninfo_blind_2,             &
-                    r1=nu23,                           &
+                    r1=nu32,                           &
                     i1=mat_id,                         &
                     c1=titr)
       endif
-      nu32 = nu23*e3/e2
-      if (nu32 < zero .or. nu32 >= half) then
+      nu23 = nu32*e2/e3
+      if (nu23 < zero .or. nu23 >= half) then
         call ancmsg(msgid=3035,                     &
                  msgtype=msgerror,                  &
                  anmode=aninfo_blind_2,             &
-                 r1=nu32,                           &
+                 r1=nu23,                           &
                  i1=mat_id,                         &
                  c1=titr)
       endif
-      if (nu13 < zero .or. nu13 >= half) then
+      if (nu31 < zero .or. nu31 >= half) then
         call ancmsg(msgid=3036,                     &
                  msgtype=msgerror,                  &
                  anmode=aninfo_blind_2,             &
@@ -191,8 +194,8 @@
                  i1=mat_id,                         &
                  c1=titr)
       endif 
-      nu31 = nu13*e3/e1
-      if (nu31 < zero .or. nu31 >= half) then
+      nu13 = nu31*e1/e3
+      if (nu13 < zero .or. nu13 >= half) then
         call ancmsg(msgid=3037,                     &
                   msgtype=msgerror,                 &
                   anmode=aninfo_blind_2,            &


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Not corresponding to dyna input for poisson ratio's
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Use the same input as dyna law nu21, nu31 and Nu32 instead nu12, nu13,nu23

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
