### PR TITLE
/FUNCT/PYTHON regression fix for nodal value callback

### DIFF
--- a/common_source/modules/cpp_python_funct.cpp
+++ b/common_source/modules/cpp_python_funct.cpp
@@ -99,7 +99,7 @@ std::string node_parenthesis_to_underscore(const std::string &input)
 std::string parenthesis_to_underscore(const std::string &input)
 {
     std::string result = node_parenthesis_to_underscore(input);
-    return element_parenthesis_to_underscore(input, ELEMENT_KEYWORDS);
+    return element_parenthesis_to_underscore(result, ELEMENT_KEYWORDS);
 }
 
 // Function to extract numbers based on the pattern and fill the global set
@@ -121,6 +121,7 @@ void extract_node_uid(const std::string &input)
 
     for (auto i = begin; i != end; ++i)
     {
+	
         auto match = *i;
         std::string match_str = match.str();
         size_t underscore_pos = match_str.find('_');
@@ -128,7 +129,6 @@ void extract_node_uid(const std::string &input)
         {
             int number = std::stoi(match_str.substr(underscore_pos + 1));
             nodes_uid.insert(number);
-            // std::cout<<"[PYTHON] uid found: "<<number<<std::endl;
         }
     }
 }
@@ -585,9 +585,11 @@ extern "C"
                 // add the null char at the end of the string
                 name[function_name.size()] = '\0';
             }
-            extract_node_uid(tmp_string);
-            //            std::cout << tmp_string << std::endl;  // Print the line (optional)
+
             const std::string s = parenthesis_to_underscore(tmp_string);
+            extract_node_uid(s);
+
+
             extract_element_keywords(s);
             function_code << s << std::endl; // Add the line to the function code
             i++;                             // Move past the null character

--- a/engine/source/mpi/spmd_mod.F90
+++ b/engine/source/mpi/spmd_mod.F90
@@ -1158,6 +1158,9 @@
 
           call MPI_Reduce(sendbuf, recvbuf, buf_count, MPI_REAL, mpi_op, root, used_comm, ierr)
           call spmd_out(TAG_REDUCE,ierr)
+#else
+          recvbuf(1:buf_count) = sendbuf(1:buf_count)
+
 #endif
         end subroutine spmd_reduce_doubles
 ! ======================================================================================================================
@@ -1191,6 +1194,9 @@
 
           call MPI_Allreduce(sendbuf, recvbuf, buf_count, MPI_INTEGER, mpi_op, used_comm, ierr)
           call spmd_out(TAG_ALLREDUCE,ierr)
+#else
+          recvbuf(1:buf_count) = sendbuf(1:buf_count)
+
 #endif
         end subroutine
 ! ======================================================================================================================
@@ -1224,6 +1230,9 @@
 
           call MPI_Allreduce(sendbuf, recvbuf, buf_count, MPI_DOUBLE_PRECISION, mpi_op, used_comm, ierr)
           call spmd_out(TAG_ALLREDUCE,ierr)
+#else
+          recvbuf(1:buf_count) = sendbuf(1:buf_count)
+
 #endif
         end subroutine
 ! ======================================================================================================================
@@ -1257,6 +1266,8 @@
 
           call MPI_Allreduce(sendbuf, recvbuf, buf_count, MPI_REAL, mpi_op, used_comm, ierr)
           call spmd_out(TAG_ALLREDUCE,ierr)
+#else
+          recvbuf(1:buf_count) = sendbuf(1:buf_count)
 #endif
         end subroutine
 ! ======================================================================================================================


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
The syntax CX(1) was broken in the python callback to Fortran nodal variables

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
