### PR TITLE
Add missing unit conversion for Pmin in law2 cfg file

### DIFF
--- a/engine/source/materials/mat/mat002/m2cplr.F
+++ b/engine/source/materials/mat/mat002/m2cplr.F
@@ -25,14 +25,14 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||--- called by ------------------------------------------------------
       !||    sigeps02c   ../engine/source/materials/mat/mat002/sigeps02c.F
       !||====================================================================
-      SUBROUTINE M2CPLR(JFT    ,JLT    ,EZZ      ,OFF      ,EPSEQ   ,
+      SUBROUTINE M2CPLR(NEL    ,EZZ    ,OFF      ,EPSEQ    ,
      2                  IPLA   ,TEMP   ,Z3       ,Z4       ,
      3                  IRTY   ,ETSE   ,GS       ,EPSP     ,
      4                  ISRATE ,YLD    ,G        ,A1       ,A2      ,
      5                  NU     ,CA0    ,CB0      ,CN       ,YMAX0   ,
      6                  EPCHK  ,YOUNG  ,CC       ,EPDR     ,ICC     ,
      7                  DPLA   ,TSTAR  ,FISOKIN  ,GAMA_IMP ,SIGNOR  ,
-     8                  HARDM  ,NEL    ,DEPSXX   ,DEPSYY   ,DEPSXY  ,
+     8                  HARDM  ,DEPSXX ,DEPSYY   ,DEPSXY   ,
      9                  DEPSYZ ,DEPSZX ,SIGNXX   ,SIGNYY   ,SIGNXY  ,
      A                  SIGNYZ ,SIGNZX ,SIGBAKXX ,SIGBAKYY ,SIGBAKXY,
      B                  SIGOXX ,SIGOYY ,SIGOXY   ,SIGOYZ   ,SIGOZX  ,
@@ -48,34 +48,32 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER,INTENT(IN) :: VP,JFT,JLT,IPLA,IRTY,ISRATE,NEL
+      INTEGER, INTENT(IN) :: VP,IPLA,IRTY,ISRATE,NEL
+      my_real, INTENT(IN) :: Z3,Z4,CC,A1,A2,G,EPDR,YMAX0,CA0,CB0,CN,YOUNG,NU,FISOKIN
       my_real, DIMENSION(NEL), INTENT(IN) :: EPSPXX,EPSPYY,EPSPXY,
      .   DEPSXX,DEPSYY,DEPSXY,DEPSYZ,DEPSZX,SIGOXX,SIGOYY,SIGOXY,
-     .   SIGOYZ,SIGOZX,GS,EPDR,TSTAR
+     .   SIGOYZ,SIGOZX,GS,TSTAR
       my_real, DIMENSION(NEL), INTENT(INOUT) :: SIGNXX,SIGNYY,SIGNXY,
      .   SIGNYZ,SIGNZX,SIGBAKXX,SIGBAKYY,SIGBAKXY,HARDM,EZZ,OFF,
      .   EPSEQ,ETSE,EPCHK,YLD,EPSP,TEMP,DPLA,GAMA_IMP
       my_real, DIMENSION(NEL,5), INTENT(INOUT) :: SIGNOR
-      my_real :: Z3,Z4,CC,A1,A2,G,YMAX0,CA0,CB0,CN,YOUNG,NU,FISOKIN
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER ICC,I,J,N,NINDX,INDEX(NEL),NMAX,IKFLG
-C     REAL
-      my_real
-     .   A(NEL), B(NEL)  , DPLA_I(NEL), DPLA_J(NEL), DR(NEL),
+      INTEGER :: ICC,I,J,N,NINDX,INDEX(NEL),NMAX,IKFLG
+      my_real :: ERR,F,DF,PLA_I,P2,Q2,R,S1,S2,S3,YLD_I,NNU1,NNU2,
+     .   NU3,NU4,NU5,NU6,SIGZ,PP,AA,BB,C,S11,S22,S12,S1S2,S122,UMR,
+     .   VM2,QQ,SMALL,MT,TM,BETA,AAA ,HKIN,ALPHA
+      my_real :: A(NEL), B(NEL)  , DPLA_I(NEL), DPLA_J(NEL), DR(NEL),
      .   H(NEL), NU1(NEL), NU2(NEL)   , P(NEL)     , Q(NEL), 
      .   SVM(NEL),CA(NEL), CB(NEL)    , YMAX(NEL)  ,
      .   SVM2(NEL),YLD2(NEL),HI(NEL)  ,HK(NEL)     ,
-     .   NU11(NEL),NU21(NEL),ANU1(NEL),BNU2(NEL),H2(NEL),
-     .   ERR,F,DF,PLA_I,P2,Q2,R,S1,S2,S3,YLD_I,NNU1,NNU2,
-     .   NU3,NU4,NU5,NU6,SIGZ,PP,AA,BB,C,S11,S22,S12,S1S2,S122,UMR,
-     .   VM2,QQ,SMALL,MT,TM,BETA,AAA ,HKIN,ALPHA
+     .   NU11(NEL),NU21(NEL),ANU1(NEL),BNU2(NEL),H2(NEL)
          
       DATA NMAX/3/
 C------------------------------------------------------------------
       SMALL = EM7
-      DO I=JFT,JLT
+      DO I= 1,NEL
         ETSE(I) = ONE
 c remise aux val. initiales
         CA(I)   = CA0
@@ -92,19 +90,20 @@ c remise aux val. initiales
 C------------------------------------------
 C     ECROUISSAGE CINE
 C------------------------------------------
-      IKFLG=0
       IF (FISOKIN > 0) THEN
-        DO I=JFT,JLT
+        IKFLG = 1
+        DO I = 1,NEL
           SIGNXX(I)=SIGNXX(I)-SIGBAKXX(I)
           SIGNYY(I)=SIGNYY(I)-SIGBAKYY(I)
           SIGNXY(I)=SIGNXY(I)-SIGBAKXY(I)
         ENDDO
-        IKFLG=JLT
+      ELSE
+        IKFLG = 0
       END IF !(FISOKIN(I) > 0) THEN
 C---------------------------
 C     CONTRAINTES ELASTIQUES
 C---------------------------
-      DO I=JFT,JLT
+      DO I= 1,NEL
         SIGNXX(I)=SIGNXX(I)+A1*DEPSXX(I)+A2*DEPSYY(I)
         SIGNYY(I)=SIGNYY(I)+A2*DEPSXX(I)+A1*DEPSYY(I)
         SIGNXY(I)=SIGNXY(I)+G*DEPSXY(I)
@@ -118,15 +117,15 @@ C-------------
       IF (CC /= ZERO) THEN
         IF (IRTY == 0) THEN
 #include "vectorize.inc" 
-          DO I=JFT,JLT
+          DO I= 1,NEL
             IF (ISRATE == 0 .AND. VP == 2) EPSP(I) = 
      .           MAX(ABS(EPSPXX(I)),ABS(EPSPYY(I)),HALF*ABS(EPSPXY(I)))
-            EPSP(I) = MAX(EPSP(I),EPDR(I))
+            EPSP(I) = MAX(EPSP(I),EPDR)
             MT = MAX(EM20,Z3)
             IF (TSTAR(I) == ZERO) THEN
-              Q(I) = (ONE + CC * LOG(EPSP(I)/EPDR(I)))
+              Q(I) = (ONE + CC * LOG(EPSP(I)/EPDR))
             ELSE
-              Q(I) = (ONE + CC * LOG(EPSP(I)/EPDR(I)))*
+              Q(I) = (ONE + CC * LOG(EPSP(I)/EPDR))*
      .                             (ONE-EXP(MT*LOG(TSTAR(I))))  
             ENDIF
             CA(I) = CA(I) * Q(I)
@@ -134,11 +133,11 @@ C-------------
             IF (ICC == 1) YMAX(I) = YMAX(I) * Q(I)
           ENDDO
         ELSEIF (IRTY == 1) THEN   ! Zerilli
-          DO I=JFT,JLT
+          DO I= 1,NEL
             IF (ISRATE == 0 .AND.VP == 2) EPSP(I) = 
      .           MAX(ABS(EPSPXX(I)),ABS(EPSPYY(I)),HALF*ABS(EPSPXY(I)))
             EPSP(I) = MAX(EPSP(I),EM20)
-            Q(I) = LOG(EPSP(I)/EPDR(I))
+            Q(I) = LOG(EPSP(I)/EPDR)
             Q(I) = CC*EXP((-Z3+Z4 * Q(I))*TEMP(I))
             IF (ICC == 1) YMAX(I)= YMAX(I) + Q(I)
             CA(I) = CA(I) + Q(I)
@@ -148,7 +147,7 @@ C-------------
 C-----------------------------------
 C     YIELD
 C-----------------------------------
-      DO I=JFT,JLT
+      DO I= 1,NEL
         DPLA(I) = ZERO
         IF (EPSEQ(I) == ZERO) THEN
            YLD(I)= CA(I)
@@ -165,7 +164,7 @@ C------------------------------------------
 C-------------------
 C     CONTRAINTE VM
 C-------------------
-        DO I=JFT,JLT
+        DO I= 1,NEL
           SVM(I)=SQRT(SIGNXX(I)*SIGNXX(I)
      .               +SIGNYY(I)*SIGNYY(I)
      .               -SIGNXX(I)*SIGNYY(I)
@@ -173,7 +172,7 @@ C-------------------
         ENDDO
 C projection radiale 
 #include "vectorize.inc" 
-        DO I=JFT,JLT
+        DO I= 1,NEL
           R = MIN(ONE,YLD(I)/(SVM(I)+EM15))
           IF (R < ONE) THEN 
             SIGNXX(I)=SIGNXX(I)*R
@@ -197,7 +196,7 @@ C------------------------------------------------------------------------
 C-------------------------
 C     CRITERE DE VON MISES
 C-------------------------
-        DO  I=JFT,JLT
+        DO  I= 1,NEL
           S1=SIGNXX(I)+SIGNYY(I)
           S2=SIGNXX(I)-SIGNYY(I)
           S3=SIGNXY(I)
@@ -209,7 +208,7 @@ C-------------------------
 C     GATHER PLASTIC FLOW
 C-------------------------
         NINDX=0
-        DO I=JFT,JLT
+        DO I= 1,NEL
           IF (SVM(I) > YLD(I) .AND. OFF(I) == ONE) THEN
             NINDX=NINDX+1
             INDEX(NINDX)=I
@@ -217,14 +216,14 @@ C-------------------------
         ENDDO
         IF (NINDX == 0) THEN
           IF (IKFLG > 0) THEN
-            DO I=JFT,JLT
+            DO I= 1,NEL
               SIGNXX(I)=SIGNXX(I) + SIGBAKXX(I)
               SIGNYY(I)=SIGNYY(I) + SIGBAKYY(I)
               SIGNXY(I)=SIGNXY(I) + SIGBAKXY(I)
             ENDDO
           END IF !(IKFLG > 0) THEN
           IF (IMPL_S > 0.AND.IKT > 0) THEN
-            DO I = JFT,JLT
+            DO I = 1,NEL
              GAMA_IMP(I) = ZERO
             END DO
           END IF !(IMPL_S > 0.AND.IKT > 0) THEN
@@ -345,7 +344,7 @@ C-------------------------
 C-------------------------
 C     CRITERE DE VON MISES
 C-------------------------
-        DO I=JFT,JLT
+        DO I= 1,NEL
           SVM2(I)= SIGNXX(I)*SIGNXX(I)
      .       +SIGNYY(I)*SIGNYY(I)
      .       -SIGNXX(I)*SIGNYY(I)
@@ -356,7 +355,7 @@ C-------------------------
 C     GATHER PLASTIC FLOW
 C-------------------------
         NINDX=0
-        DO I=JFT,JLT
+        DO I= 1,NEL
           YLD2(I)=YLD(I)*YLD(I)
           IF (SVM2(I) > YLD2(I) .AND. OFF(I) == ONE) THEN
             NINDX=NINDX+1
@@ -412,7 +411,7 @@ C     for tangent matrix
 C------------------------------------------
       IF (IMPL_S > 0) THEN
         IF (IKT > 0) THEN
-          DO I = JFT,JLT
+          DO I = 1,NEL
             IF (DPLA(I) > ZERO) THEN
 c ...... Parameter d(gama)
               PLA_I =EPSEQ(I)
@@ -450,7 +449,7 @@ C------YLD, H(I) should not be updated----
             ENDIF
           END DO ! DO J=1,NINDX
         END IF ! (IPLA == 1) THEN
-        DO I=JFT,JLT
+        DO I= 1,NEL
           HKIN = FISOKIN*H(I)
           ALPHA = HKIN*DPLA(I)/YLD(I)
           SIGBAKXX(I) = SIGBAKXX(I) + ALPHA*SIGNXX(I)
@@ -467,7 +466,7 @@ C
 C--------------------------------
 C     HARDENING MODULUS
 C--------------------------------
-      DO I=JFT,JLT
+      DO I= 1,NEL
         HARDM(I) = H(I)
       ENDDO
 C---

--- a/engine/source/materials/mat/mat002/sigeps02c.F
+++ b/engine/source/materials/mat/mat002/sigeps02c.F
@@ -27,20 +27,22 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||--- calls      -----------------------------------------------------
       !||    m2cplr      ../engine/source/materials/mat/mat002/m2cplr.F
       !||====================================================================
-      SUBROUTINE SIGEPS02C(
-     1                  JFT      ,JLT      ,PM       ,EINT     ,THK      ,
-     2                  OFF      ,SIGY     ,DT1      ,IPLA     ,NEL      ,
-     3                  VOL      ,GS       ,ISRATE   ,THKLYL   ,ETSE     ,
-     4                  NGL      ,EPSP     ,G_IMP    ,SIGKSI   ,IOFF_DUCT,
-     5                  DPLA     ,TSTAR    ,JTHE     ,HARDM    ,EPCHK    ,
-     6                  IMAT     ,IPT      ,NPTT     ,PLA      ,OFF_OLD  ,
-     7                  SIGOXX   ,SIGOYY   ,SIGOXY   ,SIGOYZ   ,SIGOZX   ,
-     8                  SIGNXX   ,SIGNYY   ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,
-     9                  DEPSXX   ,DEPSYY   ,DEPSXY   ,DEPSYZ   ,DEPSZX   ,
-     A                  EPSPXX   ,EPSPYY   ,EPSPXY   ,EPSPYZ   ,EPSPZX   ,
-     B                  SIGBAKXX ,SIGBAKYY ,SIGBAKXY ,INLOC    ,DPLANL   ,
-     C                  VP       ,ASRATE   ,LOFF     ,EPSD     ,
-     D                  TEMPEL   ,FHEAT    )
+      SUBROUTINE SIGEPS02C(MAT_PARAM,NEL      ,EINT     ,THK      ,
+     1                     OFF      ,SIGY     ,DT1      ,IPLA     ,
+     2                     VOL      ,GS       ,ISRATE   ,THKLYL   ,ETSE     ,
+     3                     NGL      ,EPSP     ,G_IMP    ,SIGKSI   ,IOFF_DUCT,
+     4                     DPLA     ,TSTAR    ,JTHE     ,HARDM    ,EPCHK    ,
+     5                     NPTT     ,PLA      ,OFF_OLD  ,
+     6                     SIGOXX   ,SIGOYY   ,SIGOXY   ,SIGOYZ   ,SIGOZX   ,
+     7                     SIGNXX   ,SIGNYY   ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,
+     8                     DEPSXX   ,DEPSYY   ,DEPSXY   ,DEPSYZ   ,DEPSZX   ,
+     9                     EPSPXX   ,EPSPYY   ,EPSPXY   ,EPSPYZ   ,EPSPZX   ,
+     A                     SIGBAKXX ,SIGBAKYY ,SIGBAKXY ,INLOC    ,DPLANL   ,
+     B                     ASRATE   ,LOFF     ,EPSD     ,TEMPEL   ,FHEAT    )
+C-----------------------------------------------
+C   M o d u l e s
+C-----------------------------------------------
+      USE MATPARAM_DEF_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -52,8 +54,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER, INTENT(IN) :: JFT,JLT,IPLA,NEL,JTHE,IPT,NPTT,IMAT,ISRATE,
-     .   INLOC,VP
+      INTEGER, INTENT(IN) :: NEL,IPLA,JTHE,NPTT,ISRATE,INLOC
       INTEGER, DIMENSION(NEL), INTENT(IN) :: NGL
       INTEGER, DIMENSION(NEL), INTENT(INOUT) :: IOFF_DUCT
       my_real, DIMENSION(NEL), INTENT(IN) :: EPSPXX,EPSPYY,EPSPXY,EPSPYZ,
@@ -63,81 +64,81 @@ C-----------------------------------------------
       my_real, DIMENSION(NEL), INTENT(INOUT) :: SIGNXX,SIGNYY,SIGNXY,SIGNYZ,
      .   SIGNZX,SIGBAKXX,SIGBAKYY,SIGBAKXY,PLA,DPLA,TSTAR,ETSE,THK, 
      .   SIGY,OFF,VOL,HARDM,EPCHK,G_IMP,EPSD
-      my_real, DIMENSION(NPROPM,*), INTENT(IN) :: PM
       my_real, DIMENSION(NEL,5), INTENT(INOUT) :: SIGKSI
       my_real, DIMENSION(NEL,2), INTENT(IN)    :: EINT
       my_real, DIMENSION(NEL)  , INTENT(IN)    :: LOFF
       my_real, DIMENSION(NEL)  , INTENT(INOUT) :: TEMPEL
       my_real, DIMENSION(NEL)  , INTENT(INOUT) :: FHEAT
+      TYPE(MATPARAM_STRUCT_)   , INTENT(IN)    :: MAT_PARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER :: I,ICC,IRTY
-      my_real :: EPMX,CA,CB,CN,RHOCP,CC,
-     .   DAV,DEVE1,DEVE2,DEVE3,DEVE4,Z3,Z4,FISOKIN,
+      INTEGER :: I,ICC,IFORM,VP
+      my_real :: EPMX,CA,CB,CN,RHOCPI,CC,EPDR,M_EXP,
+     .   DAV,DEVE1,DEVE2,DEVE3,DEVE4,C3,C4,FISOKIN,
      .   YOUNG,TREF,TMELT,G,A11,A12,NU,YMAX
-      my_real, DIMENSION(NEL) :: EPDR,YLD,EPSDOT,T,EZZ
+      my_real, DIMENSION(NEL) :: YLD,EPSDOT,T,EZZ
 !=======================================================================
-      ! Variable initialization
-      EZZ(1:NEL) = ZERO
-!---
       ! Recover material law parameters
-      YOUNG  = PM(20,IMAT)
-      NU     = PM(21,IMAT)
-      G      = PM(22,IMAT)
-      A11    = PM(24,IMAT)
-      A12    = PM(25,IMAT)
-      CA     = PM(38,IMAT)
-      CB     = PM(39,IMAT)
-      CN     = PM(40,IMAT)
-      EPMX   = PM(41,IMAT)
-      YMAX   = PM(42,IMAT)
-      CC     = PM(43,IMAT)
-      ICC    = NINT(PM(49,IMAT))
-      IRTY   = NINT(PM(50,IMAT))
-      Z3     = PM(51,IMAT)
-      FISOKIN= PM(55,IMAT)
+!---
+      iform  = mat_param%iparam(1)
+      icc    = mat_param%iparam(2)        
+      vp     = mat_param%iparam(3)        
+      
+      young  = mat_param%young
+      nu     = mat_param%nu 
+      g      = mat_param%shear
+      a11    = young / (one - nu**2) 
+      a12    = a11 *nu
 !
-      ! Recover internal variables
-      DO I=JFT,JLT              
-        EPDR(I) = MAX(EM20, PM(44,IMAT))      
-      ENDDO
+      ca     = mat_param%uparam(1)         ! pm(38)
+      cb     = mat_param%uparam(2)         ! pm(39)
+      cn     = mat_param%uparam(3)         ! pm(40)
+      epmx   = mat_param%uparam(4)         ! pm(41)
+      ymax   = mat_param%uparam(5)         ! pm(41)
+      cc     = mat_param%uparam(6)         ! pm(43)
+      epdr   = mat_param%uparam(7)      
+      fisokin= mat_param%uparam(8)         ! pm(55)
 !
-      IF (IRTY == 1) THEN       ! Zerilli
-        RHOCP = PM(53,IMAT)     ! = 1 /rhocp             
-        Z4    = PM(52,IMAT)                    
-        TREF  = PM(54,IMAT)                    
-        IF (JTHE /= 0) THEN      
-          DO I=JFT,JLT
-            TEMPEL(I) = TREF + RHOCP*(EINT(I,1)+EINT(I,2))/VOL(I)
-          ENDDO
-        ENDIF
-      ELSE                       ! Johnson-Cook
-        RHOCP = PM(69,IMAT)                  
-        TREF  = PM(79,IMAT)                    
-        TMELT = PM(80,IMAT)                    
-        DO I=JFT,JLT
-          TSTAR(I) = MAX( ZERO, (TEMPEL(I)-TREF)/(TMELT-TREF) )
-        ENDDO
-      END IF             
+      if (iform == 1) then        ! zerilli
+        c3      = mat_param%uparam(10)        ! pm(51)
+        c4      = mat_param%uparam(11)        ! pm(52)
+        rhocpi  = mat_param%uparam(12)        ! pm(53)       
+        tref    = mat_param%uparam(13)
+!        if (jthe == 0) then
+!          do i = 1,nel
+!            tempel(i) = tref + rhocpi*(eint(i,1)+eint(i,2))/vol(i)
+!          end do
+!        end if     
+      else                        ! johnson-cook
+        rhocpi = mat_param%uparam(10)
+        if (rhocpi > zero) rhocpi = one / rhocpi
+        tref  = mat_param%uparam(11)               
+        tmelt = mat_param%uparam(12)               
+        m_exp = mat_param%uparam(13)
+        c3    = m_exp
+        do i = 1,nel
+          tstar(i) = max(zero, (tempel(i)-tref)/(tmelt-tref) )
+        end do
+      end if
 !
       ! Specific strain rate computation
       ! -> Plastic strain rate
       ! Old filtered value already stored in EPSD
 !
       IF (VP == 1) THEN 
-        DO I=JFT,JLT
+        DO I=1,NEL
           EPSDOT(I) = EPSD(I) 
         ENDDO
       ! -> Total strain rate
       ELSEIF (VP == 2) THEN
-        DO I=JFT,JLT  
+        DO I=1,NEL  
           EPSDOT(I) = EPSP(I)  
           EPSD(I)   = EPSP(I)    
         ENDDO   
       ! -> Deviatoric strain rate    
       ELSEIF (VP == 3) THEN
-        DO I=JFT,JLT
+        DO I=1,NEL
           DAV   = (EPSPXX(I)+EPSPYY(I))*THIRD
           DEVE1 = EPSPXX(I) - DAV
           DEVE2 = EPSPYY(I) - DAV
@@ -151,17 +152,19 @@ C-----------------------------------------------
           EPSD(I) = EPSDOT(I)
         ENDDO 
       ENDIF
+      ! Variable initialization
+      EZZ(1:NEL) = ZERO
 !----------------------------
 !         CONTRAINTES PLASTIQUEMENT ADMISSIBLES
 !----------------------------
-      CALL M2CPLR(JFT     ,JLT     ,EZZ      ,OFF_OLD  ,PLA     ,
-     2            IPLA    ,TEMPEL  ,Z3       ,Z4       ,
-     3            IRTY    ,ETSE    ,GS       ,EPSDOT   ,
+      CALL M2CPLR(NEL     ,EZZ     ,OFF_OLD  ,PLA     ,
+     2            IPLA    ,TEMPEL  ,C3       ,C4       ,
+     3            IFORM   ,ETSE    ,GS       ,EPSDOT   ,
      4            ISRATE  ,YLD     ,G        ,A11      ,A12     ,
      5            NU      ,CA      ,CB       ,CN       ,YMAX    ,
      6            EPCHK   ,YOUNG   ,CC       ,EPDR     ,ICC     ,
      7            DPLA    ,TSTAR   ,FISOKIN  ,G_IMP    ,SIGKSI  ,
-     8            HARDM   ,NEL     ,DEPSXX   ,DEPSYY   ,DEPSXY  ,
+     8            HARDM   ,DEPSXX  ,DEPSYY   ,DEPSXY   ,
      9            DEPSYZ  ,DEPSZX  ,SIGNXX   ,SIGNYY   ,SIGNXY  ,
      A            SIGNYZ  ,SIGNZX  ,SIGBAKXX ,SIGBAKYY ,SIGBAKXY,
      B            SIGOXX  ,SIGOYY  ,SIGOXY   ,SIGOYZ   ,SIGOZX  ,
@@ -171,19 +174,19 @@ C-----------------------------------------------
 !     UPDATE AND FILTER PLASTIC STRAIN RATE
 !--------------------------------------------
       IF (VP == 1) THEN
-        DO I=JFT,JLT
+        DO I=1,NEL
           EPSDOT(I) = DPLA(I)/MAX(EM20,DT1)
           EPSD(I)   = ASRATE*EPSDOT(I) + (ONE - ASRATE)*EPSD(I)
         ENDDO
       ENDIF
 !--------------------------------------------
-      DO I=JFT,JLT
+      DO I=1,NEL
         SIGY(I) = SIGY(I) + YLD(I)/NPTT
       ENDDO
 !----------------------------
 !     TEST DE DUCTILE RUPTURE
 !----------------------------
-        DO I=JFT,JLT
+        DO I=1,NEL
           IF (OFF(I) == OFF_OLD(I) .and. OFF(I) > ZERO) THEN
             IF (OFF(I) == ONE .and. EPCHK(I) >= EPMX) THEN
               OFF(I)= FOUR_OVER_5
@@ -196,7 +199,7 @@ C-----------------------------------------------
 c------------------------------------            
 !     thickness update:
 c------------------------------------            
-      DO I=JFT,JLT
+      DO I=1,NEL
         IF (INLOC > 0) THEN
           IF (LOFF(I) == ONE) THEN 
             EZZ(I) = -NU*(SIGNXX(I)-SIGOXX(I)+SIGNYY(I)-SIGOYY(I))/YOUNG
@@ -211,10 +214,10 @@ c------------------------------------
 !---------------------------------------------------------
 !     calculate temperature or thermal load due to plastic work
 !---------------------------------------------------------
-      IF (JTHE == 0 .and. RHOCP > ZERO) THEN  ! update temperature in adiabatic conditions
-        IF (IRTY /= 1) THEN                   ! Johnson-Cook only
+      IF (JTHE == 0 .and. RHOCPI > ZERO) THEN  ! update temperature in adiabatic conditions
+        IF (IFORM /= 1) THEN                   ! Johnson-Cook only
           DO I=1,NEL       
-            TEMPEL(I) = TEMPEL(I) + SIGY(I)*DPLA(I) / RHOCP
+            TEMPEL(I) = TEMPEL(I) + SIGY(I)*DPLA(I) * RHOCPI
           ENDDO
         END IF
       ELSE                                    ! cumulate thermal load due to plastic work for /heat/mat

--- a/engine/source/materials/mat_share/mulawc.F
+++ b/engine/source/materials/mat_share/mulawc.F
@@ -958,22 +958,20 @@ C------------------------------------------
      3                     DEPSXX    ,DEPSYY   ,DEPSXY   ,DEPSYZ   ,DEPSZX   ,
      4                     THKN      ,THKLYL   ,OFF      ,PM       ,ISMSTR   ,
      5                     EPSXX     ,EPSYY    ,EPSXY    )
+!
           ELSEIF (ILAW == 2) THEN
-            VP =  IPM(255,IMAT)
-            CALL SIGEPS02C(
-     1                  JFT        ,JLT       ,PM       ,EINT     ,THKN     ,
-     2                  OFF        ,SIGY      ,DT1      ,IPLA     ,NEL      ,
-     3                  VOL0       ,GS        ,ISRATE   ,THKLYL   ,ETSE     ,
-     4                  NGL        ,EPSPL     ,G_IMP    ,SIGKSI   ,IOFF_DUCT,
-     5                  DPLA       ,TSTAR     ,JTHE     ,HARDM    ,EPCHK    ,
-     6                  IMAT       ,IPT       ,NPTTOT   ,LBUF%PLA ,OFF_OLD  ,
-     7        LBUF%SIG(IJ1),LBUF%SIG(IJ2),LBUF%SIG(IJ3),LBUF%SIG(IJ4),LBUF%SIG(IJ5),
-     8                  SIGNXX     ,SIGNYY    ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,
-     9                  DEPSXX     ,DEPSYY    ,DEPSXY   ,DEPSYZ   ,DEPSZX   ,
-     A                  EPSPXX     ,EPSPYY    ,EPSPXY   ,EPSPYZ   ,EPSPZX   ,
-     B                  LBUF%SIGB(IJ1),LBUF%SIGB(IJ2),LBUF%SIGB(IJ3),INLOC  ,VARNL(1,IT),
-     C                  VP         ,ASRATE    ,LBUF%OFF ,LBUF%EPSD  ,
-     D                  EL_TEMP   ,FHEAT     )
+            CALL SIGEPS02C(MATPARAM   ,NEL       ,EINT     ,THKN     ,
+     1                     OFF        ,SIGY      ,DT1      ,IPLA     ,                                
+     2                     VOL0       ,GS        ,ISRATE   ,THKLYL   ,ETSE     ,
+     3                     NGL        ,EPSPL     ,G_IMP    ,SIGKSI   ,IOFF_DUCT,
+     4                     DPLA       ,TSTAR     ,JTHE     ,HARDM    ,EPCHK    ,
+     5                     NPTTOT   ,LBUF%PLA ,OFF_OLD  ,
+     6           LBUF%SIG(IJ1),LBUF%SIG(IJ2),LBUF%SIG(IJ3),LBUF%SIG(IJ4),LBUF%SIG(IJ5),
+     7                     SIGNXX     ,SIGNYY    ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,
+     8                     DEPSXX     ,DEPSYY    ,DEPSXY   ,DEPSYZ   ,DEPSZX   ,
+     9                     EPSPXX     ,EPSPYY    ,EPSPXY   ,EPSPYZ   ,EPSPZX   ,
+     A                     LBUF%SIGB(IJ1),LBUF%SIGB(IJ2),LBUF%SIGB(IJ3),INLOC  ,VARNL(1,IT),
+     B                     ASRATE    ,LBUF%OFF ,LBUF%EPSD  ,EL_TEMP  ,FHEAT    )
 !
           ELSEIF (ILAW == 15) THEN
             CALL SIGEPS15C(

--- a/hm_cfg_files/config/CFG/radioss2025/MAT/matl2_plas_johns.cfg
+++ b/hm_cfg_files/config/CFG/radioss2025/MAT/matl2_plas_johns.cfg
@@ -228,6 +228,7 @@ optional:
     SCALAR(MAT_TMELT)       { DIMENSION="k";     }
     SCALAR(MAT_SPHEAT)      { DIMENSION="specific_heat_per_unit_volume"; }
     SCALAR(MAT_TMAX)        { DIMENSION="k";     }
+    SCALAR(MAT_PMIN)        { DIMENSION="pressure";                      }
 }
 
 

--- a/starter/source/materials/mat/hm_read_mat.F
+++ b/starter/source/materials/mat/hm_read_mat.F
@@ -224,12 +224,12 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I,J,N,I11,MAT_ID,UID,ILAW,JALE,JTUR,JTHE,
+      INTEGER I,J,K,IFORM,MAT_ID,UID,ILAW,JALE,JTUR,JTHE,
      .        IMATVIS,ISRATE,IUSER_LAW,NFUNC,NUMTABL,NUPARAM,NUVAR,NVARTMP,
-     .        MAXUPARAM,MAXFUNC,MAXTABL,IUNIT,IFLAGUNIT,K,NSUBMAT
+     .        MAXUPARAM,MAXFUNC,MAXTABL,IUNIT,IFLAGUNIT,IFORMDT
       PARAMETER (MAXUPARAM = 1048576) 
       PARAMETER (MAXFUNC  = 128, MAXTABL = 9)
-      my_real :: RHO,RHO0,RHOR,YOUNG,NU,BULK,G,SSP,ASRATE,RBID,RHO_MAX
+      my_real :: RHO,RHO0,RHOR,YOUNG,NU,BULK,G,ASRATE,RBID
       INTEGER ,DIMENSION(MAXFUNC) :: IFUNC
       INTEGER ,DIMENSION(MAXTABL) :: ITABLE
       my_real ,DIMENSION(:), ALLOCATABLE :: UPARAM
@@ -243,8 +243,7 @@ C
       TYPE(ULAWBUF) :: USERBUF
       TYPE(MATPARAM_STRUCT_) , POINTER :: MATPARAM
       TYPE(MLAW_TAG_) ,POINTER         :: MTAG
-      TYPE(TTABLE) TABLE(NTABLE)
-      LOGICAL IS_AVAILABLE
+      TYPE(TTABLE) ,DIMENSION(NTABLE)  :: TABLE
 C-----------------------------------------------
       DATA MESS/'MATERIAL DEFINITION                     '/
 
@@ -328,11 +327,16 @@ c               ISRATE = 0 => strain rate computation (for output only), no filt
 c               ISRATE > 0 => strain rate filtering using Fcut and exponential average
 c---------------------------------------------------      
         IMATVIS = 0
+        IFORMDT = 0
         NFUNC   = 0
         NUMTABL = 0
         NUVAR   = 0
         NVARTMP = 0
         NUPARAM = 0
+        YOUNG   = ZERO
+        NU      = ZERO
+        G       = ZERO 
+        BULK    = ZERO
         MTAG => MLAW_TAG(MAT_NUMBER)
         MATPARAM => MAT_PARAM(MAT_NUMBER)
         MATPARAM%TITLE = ' '
@@ -358,28 +362,25 @@ c-------
      .           MATPARAM)
 c-------
           CASE ('LAW2','LAW02','PLAS_JOHNS','JOHNS')
-            ILAW  = 2  
-            CALL HM_READ_MAT02(
-     .                       UPARAM ,MAXUPARAM ,NUPARAM  ,NUVAR     ,
-     .                       PARMAT   ,0         ,
-     .                       UNITAB ,MAT_ID    ,TITR     ,LSUBMODEL ,MTAG    ,
-     .                       PM(1,I),IPM(1,I)  ,ISRATE   ,MATPARAM  )
+            ILAW  = 2
+            IFORM = 0
+            CALL HM_READ_MAT02(MATPARAM ,MTAG     ,PARMAT   ,PM(1,I)  ,IPM(1,I) ,
+     .                         NUVAR    ,IFORM    ,NPROPM   ,NPROPMI  ,MAT_ID   ,TITR     ,
+     .                         IOUT     ,ISRATE   ,UNITAB   ,LSUBMODEL)
 c-------
           CASE ('ZERIL','PLAS_ZERIL')
             ILAW  = 2 
-            CALL HM_READ_MAT02(
-     .                       UPARAM ,MAXUPARAM ,NUPARAM  ,NUVAR     ,
-     .                       PARMAT   ,1         ,
-     .                       UNITAB ,MAT_ID    ,TITR     ,LSUBMODEL ,MTAG    ,
-     .                       PM(1,I),IPM(1,I)  ,ISRATE   ,MATPARAM  )
+            IFORM = 1
+            CALL HM_READ_MAT02(MATPARAM ,MTAG     ,PARMAT   ,PM(1,I)  ,IPM(1,I) ,
+     .                         NUVAR    ,IFORM    ,NPROPM   ,NPROPMI  ,MAT_ID   ,TITR     ,
+     .                         IOUT     ,ISRATE   ,UNITAB   ,LSUBMODEL)
 c-------
           CASE ('PLAS_PREDEF')
             ILAW  = 2 
-            CALL HM_READ_MAT02(
-     .                       UPARAM ,MAXUPARAM ,NUPARAM  ,NUVAR     ,
-     .                       PARMAT   ,2       ,
-     .                       UNITAB ,MAT_ID    ,TITR     ,LSUBMODEL ,MTAG    ,
-     .                       PM(1,I),IPM(1,I)  ,ISRATE   ,MATPARAM  )
+            IFORM = 2
+            CALL HM_READ_MAT02(MATPARAM ,MTAG     ,PARMAT   ,PM(1,I)  ,IPM(1,I) ,
+     .                         NUVAR    ,IFORM    ,NPROPM   ,NPROPMI  ,MAT_ID   ,TITR     ,
+     .                         IOUT     ,ISRATE   ,UNITAB   ,LSUBMODEL)
 c-------
           CASE ('LAW3','LAW03', 'HYDPLA')
             ILAW=3
@@ -1322,9 +1323,13 @@ c-----------------------------------------------------------------------
           WRITE(IOUT,2000) TITR,MAT_ID,IUSER_LAW
         ENDIF
 c--------------------------------------------      
-        ISRATE = MAX(ISRATE, NINT(PARMAT(4)))  ! just in case ...
-        ASRATE = PARMAT(5)*TWO*PI              ! ASRATE = 2*PI*FCUT
-!!        IF (ASRATE == ZERO) ASRATE = EP20
+        ISRATE  = MAX(ISRATE, NINT(PARMAT(4)))  ! just in case ...
+        ASRATE  = PARMAT(5)*TWO*PI              ! ASRATE = 2*PI*FCUT
+        IFORMDT = NINT(PARMAT(16))
+C---------
+C       For solid elements time step computation :
+        IPM(252,I)= IFORMDT            ! IFORMDT = 0,1,2  
+        PM(105,I) = PARMAT(17)         ! GFAC factor
 c--------------------------------------------      
         MATPARAM%ILAW   = ILAW
         MATPARAM%MAT_ID = MAT_ID        
@@ -1333,8 +1338,7 @@ c
         MTAG%NVARTMP = NVARTMP
 c--------------------------------------------      
 c       for user type laws (lecmuser)
-c---------------------------------------------------------
-        
+c---------------------------------------------------------        
         IF (ILAW > 27 .and. ILAW /= 32 .and. ILAW /= 49 
      .     .and. ILAW /= 151 .AND. ILAW /= 999) THEN
           MTAG%L_STRA = 6        ! all user type laws calculate total strain
@@ -1342,63 +1346,49 @@ c
           BULK  = PARMAT(1)
           YOUNG = PARMAT(2)
           NU    = PARMAT(3)
-          G     = HALF*YOUNG/(ONE + NU)
-          IF (ILAW==34) G=PM(22,I)
-          IF (ILAW==42) G=PARMAT(1)
-          IF (ILAW==62) G=PARMAT(2)/(ONE + NU)
-          IF (ILAW==69) G=PARMAT(1)
-          IF (ILAW==82) G=PARMAT(2)/(ONE + NU)
-          PM(20,I) = YOUNG
-          PM(21,I) = NU
-          PM(22,I) = G
+          IF (ILAW==34)  G = PM(22,I)
+          IF (ILAW==42)  G = PARMAT(1)
+          IF (ILAW==62)  G = PARMAT(2)/(ONE + NU)
+          IF (ILAW==69)  G = PARMAT(1)
+          IF (ILAW==82)  G = PARMAT(2)/(ONE + NU)
+          IF (G == ZERO) G = HALF*YOUNG/(ONE + NU)
+          IF (PM(20,I) == ZERO)  PM(20,I) = YOUNG
+          IF (PM(32,I) == ZERO)  PM(32,I) = BULK
+          IF (PM(21,I) == ZERO)  PM(21,I) = NU
+          IF (PM(22,I) == ZERO)  PM(22,I) = G
           PM(24,I) = YOUNG/(ONE - NU**2)
           PM(32,I) = BULK  
           IF (ILAW==71 ) PM(27,I)=SQRT(YOUNG/MAX(PM(1,I),EM20))  ! Sound speed
-C---------
-C         For solid elements time step computation :
-          IPM(252,I)= NINT(PARMAT(16))   ! IFORMDT = 0,1,2  
-          PM(105,I) = PARMAT(17)         ! GFAC factor
-C---------
-!-------         
-          IPM(7,I)   = IADBUF
-          IPM(8,I)   = NUVAR
-          IPM(9,I)   = NUPARAM
-          IPM(10,I)  = NFUNC
-          IPM(216,I) = IMATVIS
-          IPM(226,I) = NUMTABL
-c
-c---------------------------------------------------------
-          DO J=1,NFUNC
-            IPM(10+J,I) = IFUNC(J)
-          ENDDO
-c
-          DO J=1,NUMTABL
-            IPM(226+J,I) = ITABLE(J)
-          ENDDO
-c---------------------------------------------------------
-c         Fill UPARAM buffer
-c---------------------------------------------------------
-          DO J=1,NUPARAM
-            BUFMAT(IADBUF+J-1) = UPARAM(J)
-          ENDDO
-          IADBUF = IADBUF + NUPARAM
-          BUFLEN = BUFLEN + NUPARAM
-c
-        ELSE IF (ILAW == 19) THEN
-          MTAG%L_STRA = 6
-          IPM(7,I) = IADBUF   
-          IPM(8,I) = NUVAR    
-          IPM(9,I) = NUPARAM  
-          DO J=1,NUPARAM
-            BUFMAT(IADBUF+J-1) = UPARAM(J)
-          ENDDO
-          IADBUF = IADBUF + NUPARAM
-          BUFLEN = BUFLEN + NUPARAM
-c           
         ENDIF ! ILAW>=28 
+!-------         
+        IPM(7,I)   = IADBUF
+        IPM(8,I)   = NUVAR
+        IPM(9,I)   = NUPARAM
+        IPM(10,I)  = NFUNC
+        IPM(216,I) = IMATVIS
+        IPM(226,I) = NUMTABL
+c---------------------------------------------------------
+        DO J=1,NFUNC
+          IPM(10+J,I) = IFUNC(J)
+        ENDDO
+c
+        DO J=1,NUMTABL
+          IPM(226+J,I) = ITABLE(J)
+        ENDDO
+c---------------------------------------------------------
+        ! Fill old UPARAM buffer
+c---------------------------------------------------------
+        IF (NUPARAM > 0) THEN
+          DO J=1,NUPARAM
+            BUFMAT(IADBUF+J-1) = UPARAM(J)
+          ENDDO
+          IADBUF = IADBUF + NUPARAM
+          BUFLEN = BUFLEN + NUPARAM
+        END IF
+!
 !------- high stiffness for contact          
-         PM(107,I) = TWO*MAX(PM(32,I),PM(100,I))
-         IF (ILAW==1.OR.ILAW==62) PM(107,I) = HUNDRED*PM(107,I)
+        PM(107,I) = TWO*MAX(PM(32,I),PM(100,I))
+        IF (ILAW==1.OR.ILAW==62) PM(107,I) = HUNDRED*PM(107,I)
 c
         IPM(1,I)   = MAT_ID
         IPM(2,I)   = ILAW
@@ -1412,14 +1402,15 @@ c
         PM(72,I)   = JALE + EM01    
         IPM(217,I) = IUSER_LAW
 c---------------------------------------------------------
-c
+        ! still need double storage used in code outside of material laws :
+c---------------------------------------------------------
         IF (MATPARAM%RHO   > ZERO) PM(1 ,I) = MATPARAM%RHO
         IF (MATPARAM%RHO0  > ZERO) PM(89,I) = MATPARAM%RHO0
 !
-        IF (MATPARAM%YOUNG == ZERO) MATPARAM%YOUNG = PM(20,I)
-        IF (MATPARAM%NU    == ZERO) MATPARAM%NU    = PM(21,I)
-        IF (MATPARAM%SHEAR == ZERO) MATPARAM%SHEAR = PM(22,I)
-        IF (MATPARAM%BULK  == ZERO) MATPARAM%BULK  = PM(32,I)
+        IF (MATPARAM%YOUNG > ZERO) PM(20,I) = MATPARAM%YOUNG
+        IF (MATPARAM%NU    > ZERO) PM(21,I) = MATPARAM%NU   
+        IF (MATPARAM%SHEAR > ZERO) PM(22,I) = MATPARAM%SHEAR
+        IF (MATPARAM%BULK  > ZERO) PM(32,I) = MATPARAM%BULK 
 !
         ! to be defined
         ! IF (MATPARAM%STIFF_CONTACT == ZERO) MATPARAM%STIFF_CONTACT = PM(?,I)
@@ -1512,9 +1503,6 @@ C------------------------------
 
       DEALLOCATE( UPARAM )
 c------------------------------
-      RETURN
- 999  CALL ANCMSG(MSGID=55,ANMODE=ANINFO,MSGTYPE=MSGERROR,C1=KEY0(KCUR),C2=KLINE,C3=LINE)
-         CALL ARRET(2)
       RETURN
 c------------------------------
  2000 FORMAT(//

--- a/starter/source/materials/mat/hm_read_mat.F
+++ b/starter/source/materials/mat/hm_read_mat.F
@@ -477,7 +477,7 @@ c-------
 c-------
           CASE ('LAW19','FABRI')
             ILAW = 19 
-            CALL HM_READ_MAT19(MATPARAM,MTAG  ,PM(1,I)  ,PARMAT   ,
+            CALL HM_READ_MAT19(MATPARAM,MTAG  ,PM(1,I)  ,
      .           NUVAR    ,MAT_ID   ,TITR     ,
      .           UNITAB   ,LSUBMODEL,ISRATE   )
 c-------

--- a/starter/source/materials/mat/hm_read_mat.F
+++ b/starter/source/materials/mat/hm_read_mat.F
@@ -362,23 +362,26 @@ c-------
      .           MATPARAM)
 c-------
           CASE ('LAW2','LAW02','PLAS_JOHNS','JOHNS')
-            ILAW  = 2
-            IFORM = 0
-            CALL HM_READ_MAT02(MATPARAM ,MTAG     ,PARMAT   ,PM(1,I)  ,IPM(1,I) ,
+            ILAW    = 2
+            IFORM   = 0
+            IFORMDT = 2
+            CALL HM_READ_MAT02(MATPARAM ,MTAG     ,PM(1,I)  ,IPM(1,I) ,
      .                         NUVAR    ,IFORM    ,NPROPM   ,NPROPMI  ,MAT_ID   ,TITR     ,
      .                         IOUT     ,ISRATE   ,UNITAB   ,LSUBMODEL)
 c-------
           CASE ('ZERIL','PLAS_ZERIL')
-            ILAW  = 2 
-            IFORM = 1
-            CALL HM_READ_MAT02(MATPARAM ,MTAG     ,PARMAT   ,PM(1,I)  ,IPM(1,I) ,
+            ILAW    = 2 
+            IFORM   = 1
+            IFORMDT = 2
+            CALL HM_READ_MAT02(MATPARAM ,MTAG     ,PM(1,I)  ,IPM(1,I) ,
      .                         NUVAR    ,IFORM    ,NPROPM   ,NPROPMI  ,MAT_ID   ,TITR     ,
      .                         IOUT     ,ISRATE   ,UNITAB   ,LSUBMODEL)
 c-------
           CASE ('PLAS_PREDEF')
-            ILAW  = 2 
-            IFORM = 2
-            CALL HM_READ_MAT02(MATPARAM ,MTAG     ,PARMAT   ,PM(1,I)  ,IPM(1,I) ,
+            ILAW   = 2 
+            IFORM   = 2
+            IFORMDT = 2
+            CALL HM_READ_MAT02(MATPARAM ,MTAG     ,PM(1,I)  ,IPM(1,I) ,
      .                         NUVAR    ,IFORM    ,NPROPM   ,NPROPMI  ,MAT_ID   ,TITR     ,
      .                         IOUT     ,ISRATE   ,UNITAB   ,LSUBMODEL)
 c-------
@@ -1325,7 +1328,7 @@ c-----------------------------------------------------------------------
 c--------------------------------------------      
         ISRATE  = MAX(ISRATE, NINT(PARMAT(4)))  ! just in case ...
         ASRATE  = PARMAT(5)*TWO*PI              ! ASRATE = 2*PI*FCUT
-        IFORMDT = NINT(PARMAT(16))
+        IF (NINT(PARMAT(16)) == 0) IFORMDT = NINT(PARMAT(16))
 C---------
 C       For solid elements time step computation :
         IPM(252,I)= IFORMDT            ! IFORMDT = 0,1,2  
@@ -1394,7 +1397,6 @@ c
         IPM(2,I)   = ILAW
         IPM(3,I)   = ISRATE
 !        
-        PM(8,I)    = ISRATE          ! double stockage - a nettoyer
         IF (PM(9,I) == ZERO) PM(9,I) = ASRATE  ! old mat laws fill it directly
         PM(19,I)   = ILAW + EM01     ! double stockage - a nettoyer
         PM(70,I)   = JTUR + EM01

--- a/starter/source/materials/mat/hm_read_mat.F
+++ b/starter/source/materials/mat/hm_read_mat.F
@@ -1371,13 +1371,17 @@ c
         IPM(216,I) = IMATVIS
         IPM(226,I) = NUMTABL
 c---------------------------------------------------------
-        DO J=1,NFUNC
-          IPM(10+J,I) = IFUNC(J)
-        ENDDO
+        IF (NFUNC > 0) THEN
+          DO J=1,NFUNC
+            IPM(10+J,I) = IFUNC(J)
+          END DO
+        END IF
 c
-        DO J=1,NUMTABL
-          IPM(226+J,I) = ITABLE(J)
-        ENDDO
+        IF (NUMTABL > 0) THEN
+          DO J=1,NUMTABL
+            IPM(226+J,I) = ITABLE(J)
+          END DO
+        END IF
 c---------------------------------------------------------
         ! Fill old UPARAM buffer
 c---------------------------------------------------------
@@ -1404,7 +1408,7 @@ c
         PM(72,I)   = JALE + EM01    
         IPM(217,I) = IUSER_LAW
 c---------------------------------------------------------
-        ! still need double storage used in code outside of material laws :
+        ! still need double storage for params used outside of material law code :
 c---------------------------------------------------------
         IF (MATPARAM%RHO   > ZERO) PM(1 ,I) = MATPARAM%RHO
         IF (MATPARAM%RHO0  > ZERO) PM(89,I) = MATPARAM%RHO0

--- a/starter/source/materials/mat/mat002/hm_read_mat02.F
+++ b/starter/source/materials/mat/mat002/hm_read_mat02.F
@@ -37,11 +37,9 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    message_mod              ../starter/share/message_module/message_mod.F
       !||    submodel_mod             ../starter/share/modules1/submodel_mod.F
       !||====================================================================
-      SUBROUTINE HM_READ_MAT02(
-     .           UPARAM   ,MAXUPARAM ,NUPARAM  ,NUVAR    ,
-     .           PARMAT   ,IFORM      ,
-     .           UNITAB   ,ID        ,TITR     ,LSUBMODEL,MTAG       ,
-     .           PM       ,IPM       ,ISRATE   ,MAT_PARAM) 
+      SUBROUTINE HM_READ_MAT02(MAT_PARAM ,MTAG     ,PARMAT   ,PM        ,IPM   ,
+     .                         NUVAR     ,IFORM    ,NPROPM   ,NPROPMI   ,ID    ,TITR     ,
+     .                         IOUT      ,ISRATE   ,UNITAB   ,LSUBMODEL )     
 C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
@@ -72,22 +70,18 @@ C   I m p l i c i t   T y p e s
 C-----------------------------------------------
 #include      "implicit_f.inc"
 C-----------------------------------------------
-C   C o m m o n   B l o c k s
-C-----------------------------------------------
-#include      "units_c.inc"
-#include      "param_c.inc"
-C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       TYPE (UNIT_TYPE_),INTENT(IN) ::UNITAB 
-      INTEGER, INTENT(IN)    :: ID,MAXUPARAM,IFORM
+      INTEGER, INTENT(IN)    :: ID,IOUT,IFORM
+      INTEGER, INTENT(IN)    :: NPROPM
+      INTEGER, INTENT(IN)    :: NPROPMI
       INTEGER, INTENT(INOUT) :: ISRATE
-      INTEGER, INTENT(INOUT) :: NUPARAM,NUVAR
+      INTEGER, INTENT(INOUT) :: NUVAR
       INTEGER, INTENT(INOUT) :: IPM(NPROPMI)
       my_real, INTENT(INOUT) :: PM(NPROPM)     
       CHARACTER(LEN=NCHARTITLE) ,INTENT(IN) :: TITR
-      TYPE(SUBMODEL_DATA), DIMENSION(*),INTENT(IN) :: LSUBMODEL
-      my_real, DIMENSION(MAXUPARAM), INTENT(INOUT) :: UPARAM
+      TYPE(SUBMODEL_DATA), DIMENSION(NSUBMOD),INTENT(IN) :: LSUBMODEL
       my_real, INTENT(INOUT) :: PARMAT(100)
       TYPE(MLAW_TAG_),INTENT(INOUT)         :: MTAG
       TYPE(MATPARAM_STRUCT_),INTENT(INOUT)  :: MAT_PARAM
@@ -98,6 +92,7 @@ C-----------------------------------------------
       INTEGER :: I,VP
       my_real :: RHOR,RHO0
       INTEGER ICC,ISRAT1,IFLAG,MFLAG
+      INTEGER niparam,nuparam,nfunc,ntable
       my_real
      .   YOUNG, ANU, CA, CB, CN, EPSM, SIGM, CC, EPS0, G, E0, C0, C1,PMIN,
      .   E1MN2, EN1N2, SDSP,C3,C4,RHOCP,TREF,TMELT,M_EXP,FCUT,FISOKIN,CB0,RM,AG,CN0,
@@ -443,6 +438,7 @@ C-----
 
       PARMAT(4) = ISRATE
       PARMAT(5) = ASRATE
+      PARMAT(16) = 2       ! IPM(252,I) 
       PM(37)= PMIN    ! default pressure cut-off for EOS
 C
       IF (TREF <= ZERO) TREF = THREE100
@@ -581,6 +577,94 @@ C
      .               C1=TITR)
       ENDIF
 C-----------
+!     new mat_param storage
+C-----------
+      if (iform == 1) then
+        niparam = 4
+        nuparam = 13
+        nfunc   = 0
+        ntable  = 0
+        mat_param%niparam = niparam
+        mat_param%nuparam = nuparam
+        mat_param%nfunc   = nfunc
+        mat_param%ntable  = ntable
+        allocate (mat_param%iparam(niparam))
+        allocate (mat_param%uparam(nuparam))
+        allocate (mat_param%table(ntable))
+      
+        mat_param%iparam(1) = iform
+        mat_param%iparam(2) = icc
+        mat_param%iparam(3) = vp
+        mat_param%iparam(4) = israte
+!        
+        mat_param%uparam(1) = ca             ! pm(38)
+        mat_param%uparam(2) = cb             ! pm(39)
+        mat_param%uparam(3) = cn             ! pm(40)
+        mat_param%uparam(4) = epsm           ! pm(41)
+        mat_param%uparam(5) = sigm           ! pm(42)
+        mat_param%uparam(6) = cc             ! pm(43)
+        mat_param%uparam(7) = eps0           ! pm(44)
+        mat_param%uparam(8) = fisokin        ! pm(55)
+
+        mat_param%uparam(9) = asrate         ! pm(9)  !! general pm
+        mat_param%uparam(10)= c3             ! pm(51)
+        mat_param%uparam(11)= c4             ! pm(52)
+
+      ! common with heat mat => will be written in mat_param%therm
+
+      mat_param%uparam(12)= rhocp      ! pm(53) = 1 / rhocp
+      mat_param%uparam(13)= tref       ! pm(79) 
+      else
+        niparam = 4
+        nuparam = 14
+        nfunc   = 0
+        ntable  = 0
+!
+        mat_param%niparam = niparam
+        mat_param%nuparam = nuparam
+        mat_param%nfunc   = nfunc
+        mat_param%ntable  = ntable
+        allocate (mat_param%iparam(niparam))
+        allocate (mat_param%uparam(nuparam))
+        allocate (mat_param%table(ntable))
+!        
+        mat_param%iparam(1) = iform          ! pm(50)
+        mat_param%iparam(2) = icc            ! pm(49) 
+        mat_param%iparam(3) = vp             ! ipm(252)
+        mat_param%iparam(4) = israte         ! ipm(3)  !! general pm
+!        
+        mat_param%uparam(1) = ca             ! pm(38)
+        mat_param%uparam(2) = cb             ! pm(39)
+        mat_param%uparam(3) = cn             ! pm(40)
+        mat_param%uparam(4) = epsm           ! pm(41)
+        mat_param%uparam(5) = sigm           ! pm(42)
+        mat_param%uparam(6) = cc             ! pm(43)
+        mat_param%uparam(7) = eps0           ! pm(44)
+        mat_param%uparam(8) = fisokin        ! pm(55)
+        mat_param%uparam(9) = asrate         ! pm(9)  
+
+        ! common with heat mat => will be written in mat_param%therm
+
+        mat_param%uparam(10)= rhocp      ! pm(69) 
+        mat_param%uparam(11)= tref       ! pm(79) 
+        mat_param%uparam(12)= tmelt      ! pm(80) 
+        mat_param%uparam(13)= c3 ! m_exp      ! pm(51) 
+        mat_param%uparam(14)= pmin       ! pm(37)     ! default pressure cut-off for eos
+      
+      end if
+
+      ! mat_param common parameters
+!      
+      mat_param%rho   = rhor
+      mat_param%rho0  = rho0
+      mat_param%young = young
+      mat_param%bulk  = c1 ! bulk
+      mat_param%shear = g
+      mat_param%nu    = anu
+
+
+
+C-----------
 C     Formulation for solid elements time step computation.
       IPM(252)= 2
       PM(105) = TWO*G/(C1+FOUR_OVER_3*G)
@@ -598,7 +682,7 @@ c
       MTAG%L_SIGB  = 6
       MTAG%L_DMG   = 1
       MTAG%L_TEMP  = 1
-!
+c------------------------- 
       ! activate heat source calculation in material
       MAT_PARAM%HEAT_FLAG = 1
 c------------------------- 

--- a/starter/source/materials/mat/mat002/hm_read_mat02.F
+++ b/starter/source/materials/mat/mat002/hm_read_mat02.F
@@ -93,7 +93,7 @@ C-----------------------------------------------
       INTEGER ICC,ISRAT1,IFLAG,MFLAG
       INTEGER niparam,nuparam,nfunc,ntable
       my_real
-     .   YOUNG, ANU, CA, CB, CN, EPSM, SIGM, CC, EPS0, G, E0, C0, C1,PMIN,
+     .   YOUNG, ANU, CA, CB, CN, EPSM, SIGM, CC, EPS0, G, E0, C0, bulk,PMIN,
      .   E1MN2, EN1N2, SDSP,C3,C4,RHOCP,TREF,TMELT,M_EXP,FCUT,FISOKIN,CB0,RM,AG,CN0,
      .   FAC_DENS,FAC_PRES,EPS0_UNIT,FAC_M,FAC_L,FAC_T,ASRATE
       CHARACTER PREDEF*16
@@ -379,7 +379,7 @@ C-----
       G=YOUNG/(TWO*(ONE + ANU))
       E0=ZERO
       C0=ZERO
-      C1=YOUNG/(THREE*(ONE - TWO*ANU))
+      BULK =YOUNG/(THREE*(ONE - TWO*ANU))
       E1MN2=YOUNG/(ONE - ANU**2)
       EN1N2=ANU*E1MN2
       SDSP =SQRT(YOUNG/MAX(RHOR,EM20))       
@@ -403,6 +403,7 @@ C-----
           IF (ASRATE == ZERO) ASRATE = EP20
         ENDIF
       ENDIF
+      EPS0 = MAX(EM20, EPS0)
       FCUT = ASRATE*TWO*PI 
 C-----
       PM(1) =RHOR
@@ -420,7 +421,7 @@ C-----
       PM(29)=-ANU*PM(28)
       PM(30)=ONE/G
       PM(31)=C0
-      PM(32)=C1
+      PM(32)=BULK
       PM(38)=CA
       PM(39)=CB
       PM(40)=CN
@@ -536,9 +537,13 @@ C--------------------------------
       PM(79) = TREF      ! for J-C
       PM(80) = TMELT      
       PM(69) = RHOCP
+C-----------
+C     Formulation for solid elements time step computation.
+!      IPM(252)= 2
+      PM(105) = TWO*G/(BULK+FOUR_OVER_3*G)
 C -----------------     
       PM(55)=FISOKIN
-C      
+C--------------------------------------------------------------      
       IF (FISOKIN>ONE.OR.FISOKIN<ZERO) THEN
         CALL ANCMSG(MSGID=912,
      .              MSGTYPE=MSGERROR,
@@ -609,7 +614,7 @@ C-----------
 
       mat_param%uparam(12)= rhocp      ! pm(53) = 1 / rhocp
       mat_param%uparam(13)= tref       ! pm(79) 
-      else
+      else    ! Johnson-Cook
         niparam = 4
         nuparam = 14
         nfunc   = 0
@@ -643,7 +648,7 @@ C-----------
         mat_param%uparam(10)= rhocp      ! pm(69) 
         mat_param%uparam(11)= tref       ! pm(79) 
         mat_param%uparam(12)= tmelt      ! pm(80) 
-        mat_param%uparam(13)= c3 ! m_exp      ! pm(51) 
+        mat_param%uparam(13)= m_exp      ! pm(51) 
         mat_param%uparam(14)= pmin       ! pm(37)     ! default pressure cut-off for eos
       
       end if
@@ -653,16 +658,9 @@ C-----------
       mat_param%rho   = rhor
       mat_param%rho0  = rho0
       mat_param%young = young
-      mat_param%bulk  = c1 ! bulk
+      mat_param%bulk  = bulk
       mat_param%shear = g
       mat_param%nu    = anu
-
-
-
-C-----------
-C     Formulation for solid elements time step computation.
-      IPM(252)= 2
-      PM(105) = TWO*G/(C1+FOUR_OVER_3*G)
 !
 C---- Definition des variables internes (stockage elementaire)
 c

--- a/starter/source/materials/mat/mat002/hm_read_mat02.F
+++ b/starter/source/materials/mat/mat002/hm_read_mat02.F
@@ -37,7 +37,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    message_mod              ../starter/share/message_module/message_mod.F
       !||    submodel_mod             ../starter/share/modules1/submodel_mod.F
       !||====================================================================
-      SUBROUTINE HM_READ_MAT02(MAT_PARAM ,MTAG     ,PARMAT   ,PM        ,IPM   ,
+      SUBROUTINE HM_READ_MAT02(MAT_PARAM ,MTAG     ,PM        ,IPM   ,
      .                         NUVAR     ,IFORM    ,NPROPM   ,NPROPMI   ,ID    ,TITR     ,
      .                         IOUT      ,ISRATE   ,UNITAB   ,LSUBMODEL )     
 C-----------------------------------------------
@@ -82,7 +82,6 @@ C-----------------------------------------------
       my_real, INTENT(INOUT) :: PM(NPROPM)     
       CHARACTER(LEN=NCHARTITLE) ,INTENT(IN) :: TITR
       TYPE(SUBMODEL_DATA), DIMENSION(NSUBMOD),INTENT(IN) :: LSUBMODEL
-      my_real, INTENT(INOUT) :: PARMAT(100)
       TYPE(MLAW_TAG_),INTENT(INOUT)         :: MTAG
       TYPE(MATPARAM_STRUCT_),INTENT(INOUT)  :: MAT_PARAM
 C-----------------------------------------------
@@ -394,20 +393,17 @@ C-----
         ! If plastic strain is chosen, filtering by default
         ISRATE = 1
         IF (ASRATE == ZERO) ASRATE = 10000.0D0*UNITAB%FAC_T_WORK
-        FCUT   = ASRATE
       ELSE
         IF (CC == ZERO)THEN
           EPS0   = ONE
           ISRATE = 0
           ASRATE = ZERO
-          FCUT   = ASRATE
         ELSE     
           ISRATE = 1
           IF (ASRATE == ZERO) ASRATE = EP20
-          FCUT   = ASRATE
         ENDIF
       ENDIF
-
+      FCUT = ASRATE*TWO*PI 
 C-----
       PM(1) =RHOR
       PM(89)=RHO0      
@@ -436,9 +432,8 @@ C-----
 
       IPM(255) = VP   
 
-      PARMAT(4) = ISRATE
-      PARMAT(5) = ASRATE
-      PARMAT(16) = 2       ! IPM(252,I) 
+
+      PM(9) = FCUT
       PM(37)= PMIN    ! default pressure cut-off for EOS
 C
       IF (TREF <= ZERO) TREF = THREE100

--- a/starter/source/materials/mat/mat019/hm_read_mat19.F
+++ b/starter/source/materials/mat/mat019/hm_read_mat19.F
@@ -215,7 +215,10 @@ c-----------------------------------------
 c--------------------------
       MATPARAM%RHO   = RHOR
       MATPARAM%RHO0  = RHO0
-      MATPARAM%YOUNG = MAX(E11,E22)
+      MATPARAM%YOUNG = MAX(E11,E22)/DETC
+      MATPARAM%BULK  = C1
+      MATPARAM%NU    = SQRT(N12*N21)
+      MATPARAM%SHEAR = MAX(G12,G23,G31) 
 c --------------------------
       PARMAT(1)  = C1
       PARMAT(2)  = MAX(E11,E22)/DETC
@@ -226,6 +229,7 @@ c
 c---- Definition des variables internes (stockage elementaire)
 c
       MTAG%G_SIGI = 3
+      MTAG%L_STRA = 6
 c
       ! MATPARAM keywords
       CALL INIT_MAT_KEYWORD(MATPARAM,"TOTAL")

--- a/starter/source/materials/mat/mat019/hm_read_mat19.F
+++ b/starter/source/materials/mat/mat019/hm_read_mat19.F
@@ -35,7 +35,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    message_mod              ../starter/share/message_module/message_mod.F
       !||    submodel_mod             ../starter/share/modules1/submodel_mod.F
       !||====================================================================
-      SUBROUTINE HM_READ_MAT19(MATPARAM ,MTAG     ,PM       ,PARMAT   ,
+      SUBROUTINE HM_READ_MAT19(MATPARAM ,MTAG     ,PM       ,
      .                         NUVAR    ,MAT_ID   ,TITR     ,
      .                         UNITAB   ,LSUBMODEL,ISRATE   )
 C-----------------------------------------------
@@ -78,7 +78,6 @@ C-----------------------------------------------
       INTEGER ,INTENT(INOUT) :: NUVAR,ISRATE
       INTEGER ,INTENT(IN)    :: MAT_ID
       my_real ,INTENT(INOUT) :: PM(NPROPM)
-      my_real ,INTENT(INOUT) :: PARMAT(100)
       CHARACTER(LEN=NCHARTITLE),INTENT(IN)  :: TITR
       TYPE (UNIT_TYPE_)      ,INTENT(IN)    :: UNITAB 
       TYPE(SUBMODEL_DATA)    ,INTENT(IN)    :: LSUBMODEL((NSUBMOD))
@@ -219,12 +218,6 @@ c--------------------------
       MATPARAM%BULK  = C1
       MATPARAM%NU    = SQRT(N12*N21)
       MATPARAM%SHEAR = MAX(G12,G23,G31) 
-c --------------------------
-      PARMAT(1)  = C1
-      PARMAT(2)  = MAX(E11,E22)/DETC
-      PARMAT(3)  = SQRT(N12*N21)
-      PARMAT(4)  = ISRATE
-      PARMAT(5)  = ZERO ! FCUT
 c
 c---- Definition des variables internes (stockage elementaire)
 c

--- a/starter/source/materials/tools/table_values_2d.F
+++ b/starter/source/materials/tools/table_values_2d.F
@@ -64,7 +64,7 @@ c=======================================================================
           Y1 = Y2
           X2 = XI(IDX+1)
           Y2 = YI(IDX+1)
-          DERI  = (Y2 - Y1) / (X2 - X1)
+          DERI  = (Y2 - Y1) / MAX(EM20, (X2 - X1))
         END IF
         YF(IPT) = Y1 + DERI * (XF(IPT) - X1)
       END DO


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

there were no unit conversion for input value of Pmin in material law 2

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

updated cfg file with unit definition

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
