### PR TITLE
/SET : 2D surface fix

### DIFF
--- a/starter/source/model/sets/create_seg_clause.F
+++ b/starter/source/model/sets/create_seg_clause.F
@@ -34,13 +34,13 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    message_mod                 ../starter/share/message_module/message_mod.F
       !||    submodel_mod                ../starter/share/modules1/submodel_mod.F
       !||====================================================================
-      SUBROUTINE CREATE_SEG_CLAUSE(
-     .               CLAUSE,  ITABM1  ,JCLAUSE ,IS_AVAILABLE ,LSUBMODEL)
+      SUBROUTINE CREATE_SEG_CLAUSE(CLAUSE,  ITABM1  ,JCLAUSE ,IS_AVAILABLE ,LSUBMODEL)
 C-----------------------------------------------
-C   ROUTINE DESCRIPTION :
+C   D e s c r i p t i o n
+C-----------------------------------------------
 C   ===================
 C   Create PART Clause from LIST
-C------------------------------------------------------------------
+C-----------------------------------------------
 C   DUMMY ARGUMENTS DESCRIPTION:
 C   ===================
 C
@@ -51,7 +51,6 @@ C     IPARTM1       MAP Table UID -> LocalID
 C     JCLAUSE       parameter with HM_READER (current clause read)
 C     IS_AVAILABLE  Bool / Result of HM_interface
 C     LSUBMODEL     SUBMODEL Structure.
-C============================================================================
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -73,45 +72,34 @@ C-----------------------------------------------
       INTEGER JCLAUSE
       LOGICAL :: IS_AVAILABLE
       INTEGER, INTENT(IN), DIMENSION(NUMNOD,2) :: ITABM1
-!
       TYPE (SET_) ::  CLAUSE
-      TYPE(SUBMODEL_DATA),INTENT(IN):: LSUBMODEL(*)
+      TYPE(SUBMODEL_DATA),INTENT(IN):: LSUBMODEL(NSUBMOD)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I,J,NINDX,SEG_MAX,NOD_1,NOD_2,NOD_3,NOD_4,
-     . NODSYS_1,NODSYS_2,NODSYS_3,NODSYS_4,SEG_ID,LINE_SEG
-!
+      INTEGER I,J,NINDX,SEG_MAX,NOD_1,NOD_2,NOD_3,NOD_4,NODSYS_1,NODSYS_2,NODSYS_3,NODSYS_4,SEG_ID,LINE_SEG
       INTEGER, ALLOCATABLE, DIMENSION(:,:) :: BUFSURF
-!
-      INTEGER SET_USRTOS
-      EXTERNAL SET_USRTOS
-C=======================================================================
-
+      INTEGER,EXTERNAL :: SET_USRTOS
+C-----------------------------------------------
+C   S o u r c e  L i n e s
+C-----------------------------------------------
       LINE_SEG = 0
-
       CALL HM_GET_INT_ARRAY_INDEX('segmax' ,SEG_MAX ,JCLAUSE,IS_AVAILABLE,LSUBMODEL)
-
       ALLOCATE(BUFSURF(4,SEG_MAX))
-
       NINDX = 0
 !
       ! Read & convert Segs
       ! ---------------------
       DO I=1,SEG_MAX  ! always = 1 for clause 'SEG'
-
         CALL HM_GET_INT_ARRAY_2INDEXES('segid',SEG_ID,JCLAUSE ,I,IS_AVAILABLE,LSUBMODEL)
         CALL HM_GET_INT_ARRAY_2INDEXES('ids1' ,NOD_1 ,JCLAUSE ,I,IS_AVAILABLE,LSUBMODEL)
         CALL HM_GET_INT_ARRAY_2INDEXES('ids2' ,NOD_2 ,JCLAUSE ,I,IS_AVAILABLE,LSUBMODEL)
         CALL HM_GET_INT_ARRAY_2INDEXES('ids3' ,NOD_3 ,JCLAUSE ,I,IS_AVAILABLE,LSUBMODEL)
         CALL HM_GET_INT_ARRAY_2INDEXES('ids4' ,NOD_4 ,JCLAUSE ,I,IS_AVAILABLE,LSUBMODEL)
-
-
         NODSYS_1 = SET_USRTOS(NOD_1,ITABM1,NUMNOD)
         IF (NODSYS_1 == 0) THEN
            ! Node was not found. Issue a Warning & Skip.
-           CALL ANCMSG(MSGID=1903,ANMODE=ANINFO,
-     .                             MSGTYPE=MSGERROR,
+           CALL ANCMSG(MSGID=1903,ANMODE=ANINFO,MSGTYPE=MSGERROR,
      .                             I1 = CLAUSE%SET_ID,
      .                             I2=SEG_ID,
      .                             I3=NOD_1,
@@ -120,13 +108,11 @@ C=======================================================================
         ELSE
           NODSYS_1 = ITABM1(NODSYS_1,2)
         ENDIF
-        
 
         NODSYS_2 = SET_USRTOS(NOD_2,ITABM1,NUMNOD)
         IF (NODSYS_2 == 0) THEN
            ! Node was not found. Issue a Warning & Skip.
-           CALL ANCMSG(MSGID=1903,ANMODE=ANINFO,
-     .                             MSGTYPE=MSGERROR,
+           CALL ANCMSG(MSGID=1903,ANMODE=ANINFO,MSGTYPE=MSGERROR,
      .                             I1 = CLAUSE%SET_ID,
      .                             I2=SEG_ID,
      .                             I3=NOD_2,
@@ -136,19 +122,14 @@ C=======================================================================
           NODSYS_2 = ITABM1(NODSYS_2,2)
         ENDIF
 
-
         NODSYS_3 = SET_USRTOS(NOD_3,ITABM1,NUMNOD)
         NODSYS_4 = SET_USRTOS(NOD_4,ITABM1,NUMNOD)
-
         IF (NODSYS_3 == 0 .AND. NODSYS_4 == 0) LINE_SEG = 1 ! Line SEG
-
-
 
         IF (LINE_SEG == 0) THEN! Surf SEG --> continue Node check existence
           IF (NODSYS_3 == 0) THEN
             ! Node was not found. Issue a Warning & Skip.
-            CALL ANCMSG(MSGID=1903,ANMODE=ANINFO,
-     .                             MSGTYPE=MSGERROR,
+            CALL ANCMSG(MSGID=1903,ANMODE=ANINFO,MSGTYPE=MSGERROR,
      .                             I1 = CLAUSE%SET_ID,
      .                             I2=SEG_ID,
      .                             I3=NOD_3,
@@ -160,23 +141,8 @@ C=======================================================================
 
 !         correction to allow for 3 noded surface (triangle)
           IF (NODSYS_4 == 0) NODSYS_4 = NODSYS_3
-!
-!          IF (NODSYS_4 == 0) THEN
-!            ! Node was not found. Issue a Warning & Skip.
-!            CALL ANCMSG(MSGID=1903,ANMODE=ANINFO,
-!     .                             MSGTYPE=MSGERROR,
-!     .                             I1 = CLAUSE%SET_ID,
-!     .                             I2=SEG_ID,
-!     .                             I3=NOD_4,
-!     .                             C1=TRIM(CLAUSE%TITLE),
-!     .                             C2='NODE')
-!          ELSE
-!            NODSYS_4 = ITABM1(NODSYS_4,2)
-!          ENDIF
+
         ENDIF ! IF (LINE_SEG == 0)
-
-
-
 
         NINDX = NINDX+1    !   nb of CLAUSE SEGs
         BUFSURF(1,NINDX) = NODSYS_1
@@ -186,15 +152,12 @@ C=======================================================================
 
       ENDDO ! DO I=1,SEG_MAX
 
-
-
       ! Copy in final SET
       ! ------------------
 
       !------------------------------------!
       !  create SURF clause or LINE clause !
       !------------------------------------!
-
 
       IF (LINE_SEG == 0) THEN
 
@@ -224,8 +187,6 @@ C=======================================================================
         DO I=1,NINDX
           CLAUSE%LINE_NODES(I,1) = BUFSURF(1,I) ! N1
           CLAUSE%LINE_NODES(I,2) = BUFSURF(2,I) ! N2
-          CLAUSE%LINE_NODES(I,3) = 0 ! N3
-          CLAUSE%LINE_NODES(I,4) = 0 ! N4
           CLAUSE%LINE_ELTYP(I)   = 0  ! ELTYP
           CLAUSE%LINE_ELEM(I)    = 0  ! ELEM
         ENDDO

--- a/starter/source/model/sets/fill_gr.F
+++ b/starter/source/model/sets/fill_gr.F
@@ -150,6 +150,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
+      LOGICAL LINE_SEG, SURF_SEG
       INTEGER NSEG
       CHARACTER MESS*40
       DATA MESS/'SET SURF GROUP DEFINITION               '/
@@ -157,11 +158,22 @@ C-----------------------------------------------
 !
 !     create new grelem (IGRBRIC, etc) from elems of /SET
 !
-      NSEG = SET%NB_SURF_SEG
+      ! 3D or 2D
+      SURF_SEG = .FALSE.
+      LINE_SEG = .FALSE.
+      NSEG = 0
+      IF(SET%NB_SURF_SEG > 0) THEN
+        !3D case
+        NSEG = SET%NB_SURF_SEG
+        SURF_SEG = .TRUE.
+      ELSEIF(SET%NB_LINE_SEG > 0)THEN
+        !2D case
+        NSEG = SET%NB_LINE_SEG
+        LINE_SEG = .TRUE.
+      ENDIF
       !IF (NSEG == 0) RETURN      ! create a Surface if empty
 !---
       IGRS = IGRS + 1
-
 !
       IGRSURF(IGRS)%ID = SET%SET_ID
       IGRSURF(IGRS)%TITLE = SET%TITLE
@@ -193,12 +205,24 @@ C-----------------------------------------------
         CALL MY_ALLOC(IGRSURF(IGRS)%ELTYP,NSEG)
         CALL MY_ALLOC(IGRSURF(IGRS)%ELEM,NSEG)
 !
-        IGRSURF(IGRS)%NODES(1:NSEG,1) = SET%SURF_NODES(1:NSEG,1)
-        IGRSURF(IGRS)%NODES(1:NSEG,2) = SET%SURF_NODES(1:NSEG,2)
-        IGRSURF(IGRS)%NODES(1:NSEG,3) = SET%SURF_NODES(1:NSEG,3)
-        IGRSURF(IGRS)%NODES(1:NSEG,4) = SET%SURF_NODES(1:NSEG,4)
-        IGRSURF(IGRS)%ELTYP(1:NSEG)   = SET%SURF_ELTYP(1:NSEG)
-        IGRSURF(IGRS)%ELEM(1:NSEG)    = SET%SURF_ELEM(1:NSEG)
+        IF(SURF_SEG)THEN
+          IGRSURF(IGRS)%NODES(1:NSEG,1) = SET%SURF_NODES(1:NSEG,1)
+          IGRSURF(IGRS)%NODES(1:NSEG,2) = SET%SURF_NODES(1:NSEG,2)
+          IGRSURF(IGRS)%NODES(1:NSEG,3) = SET%SURF_NODES(1:NSEG,3)
+          IGRSURF(IGRS)%NODES(1:NSEG,4) = SET%SURF_NODES(1:NSEG,4)
+          IGRSURF(IGRS)%ELTYP(1:NSEG)   = SET%SURF_ELTYP(1:NSEG)
+          IGRSURF(IGRS)%ELEM(1:NSEG)    = SET%SURF_ELEM(1:NSEG)
+        ENDIF
+
+        IF(LINE_SEG)THEN
+          IGRSURF(IGRS)%NODES(1:NSEG,1) = SET%LINE_NODES(1:NSEG,1)
+          IGRSURF(IGRS)%NODES(1:NSEG,2) = SET%LINE_NODES(1:NSEG,2)
+          IGRSURF(IGRS)%NODES(1:NSEG,3) = 0
+          IGRSURF(IGRS)%NODES(1:NSEG,4) = 0
+          IGRSURF(IGRS)%ELTYP(1:NSEG)   = SET%LINE_ELTYP(1:NSEG)
+          IGRSURF(IGRS)%ELEM(1:NSEG)    = SET%LINE_ELEM(1:NSEG)
+        ENDIF
+
       ENDIF ! IF (NSEG > 0)
 
       SET%SET_NSURF_ID = IGRS

--- a/starter/source/model/sets/hm_set.F
+++ b/starter/source/model/sets/hm_set.F
@@ -636,17 +636,13 @@ C-----------------------------------------------
 
               CASE ( 'SEG' )
                   
-                  ! Surfaces and lignes LIST FROM CLAUSE
+                  ! Surfaces and lines LIST FROM CLAUSE
                   !-----------------------
-                  CALL CREATE_SEG_CLAUSE(
-     .               CLAUSE,  ITABM1  ,J     ,IS_AVAILABLE ,LSUBMODEL)
-
+                  CALL CREATE_SEG_CLAUSE(CLAUSE, ITABM1, J, IS_AVAILABLE, LSUBMODEL)
 
                   ! Line from SURFACE
-!!                  ELTYP_SEG = 0
-                  IF (CLAUSE%NB_SURF_SEG > 0)
-     .            CALL CREATE_LINE_FROM_SURFACE(CLAUSE,KEYSET,OPT_A,OPT_E,DELBUF    ,
-     .                                          .FALSE.)
+                  ! ELTYP_SEG = 0
+                  IF (CLAUSE%NB_SURF_SEG > 0)CALL CREATE_LINE_FROM_SURFACE(CLAUSE,KEYSET,OPT_A,OPT_E,DELBUF,.FALSE.)
 
                   ! Node from SEG (SURF or LINE)
                   CALL CREATE_NODE_FROM_SEG( CLAUSE )


### PR DESCRIPTION
#### /SET/GENERAL (SEG) : 2D fix

#### Description of the changes
In the 2D case, when the surface is built from user segments, specific data buffer is used (%LINE_NODES instead of %SURF_NODES). This is now taken into account and Starter is now able to build the polygonal surface from user segments.