### PR TITLE
ST_QAPRINT_SET : update for 2D case

### DIFF
--- a/starter/source/output/qaprint/st_qaprint_set.F
+++ b/starter/source/output/qaprint/st_qaprint_set.F
@@ -107,10 +107,7 @@ C-----------------------------------------------
 !
           DO IGS = 1, NSETS
 !---
-            CALL HM_OPTION_READ_KEY(LSUBMODEL,
-     .                              OPTION_ID   = ID,
-     .                              OPTION_TITR = TITLE,
-     .                              KEYWORD2    = KEY)
+            CALL HM_OPTION_READ_KEY(LSUBMODEL,OPTION_ID=ID,OPTION_TITR=TITLE,KEYWORD2=KEY)
             WRITE(VARNAME,'(A)') TRIM(TITLE)
             CALL QAPRINT(TITLE(1:LEN_TRIM(VARNAME)), ID, 0.0_8)
 !---
@@ -395,10 +392,14 @@ C-----------------------------------------------
                   CALL QAPRINT(VARNAME(1:LEN_TRIM(VARNAME)),ITAB(IGRSURF(IGR)%NODES(N,1)),0.0_8)
                   WRITE(VARNAME,'(A,I0,A,I0,A)') 'SET_',ID,'_'//'SURFACE_SEG_',N,'_NODE_2'
                   CALL QAPRINT(VARNAME(1:LEN_TRIM(VARNAME)),ITAB(IGRSURF(IGR)%NODES(N,2)),0.0_8)
-                  WRITE(VARNAME,'(A,I0,A,I0,A)') 'SET_',ID,'_'//'SURFACE_SEG_',N,'_NODE_3'
-                  CALL QAPRINT(VARNAME(1:LEN_TRIM(VARNAME)),ITAB(IGRSURF(IGR)%NODES(N,3)),0.0_8)
-                  WRITE(VARNAME,'(A,I0,A,I0,A)') 'SET_',ID,'_'//'SURFACE_SEG_',N,'_NODE_4'
-                  CALL QAPRINT(VARNAME(1:LEN_TRIM(VARNAME)),ITAB(IGRSURF(IGR)%NODES(N,4)),0.0_8)
+                  IF(IGRSURF(IGR)%NODES(N,3) > 0)THEN
+                    WRITE(VARNAME,'(A,I0,A,I0,A)') 'SET_',ID,'_'//'SURFACE_SEG_',N,'_NODE_3'
+                    CALL QAPRINT(VARNAME(1:LEN_TRIM(VARNAME)),ITAB(IGRSURF(IGR)%NODES(N,3)),0.0_8)
+                  ENDIF
+                  IF(IGRSURF(IGR)%NODES(N,4) > 0)THEN
+                    WRITE(VARNAME,'(A,I0,A,I0,A)') 'SET_',ID,'_'//'SURFACE_SEG_',N,'_NODE_4'
+                    CALL QAPRINT(VARNAME(1:LEN_TRIM(VARNAME)),ITAB(IGRSURF(IGR)%NODES(N,4)),0.0_8)
+                  ENDIF
                   WRITE(VARNAME,'(A,I0,A,I0,A)') 'SET_',ID,'_'//'SURFACE_SEG_',N,'_ELTYP'
                   CALL QAPRINT(VARNAME(1:LEN_TRIM(VARNAME)),IGRSURF(IGR)%ELTYP(N),0.0_8)
                   WRITE(VARNAME,'(A,I0,A,I0,A)') 'SET_',ID,'_'//'SURFACE_SEG_',N,'_ELEM'


### PR DESCRIPTION
#### Description of the feature or the bug
ST_QAPRINT_SET : update for 2D case


#### Description of the changes
A recent fix has been introduced for the /SET/GENERAL (SEG) functionality in 2D (commit: 3c95cb8041379bd5270fba631782cc1d9aab218b). Previously, surfaces composed of segments were not being correctly constructed. The ST_QAPRINT_SET subroutine now properly handles and displays non-empty surfaces. However, this also revealed that the 2D case was not initially anticipated.

The display of user node identifiers has been refined to ensure they are only shown when relevant. In the 2D case, when IGRSURF(IGR)%NODES(N, 3:4) is set to 0, these indices should not be used to reference the ITAB array. This issue has now been resolved. Consequently, user node identifiers 3 and 4 are no longer displayed when not applicable to the 2D case.

No effect on numerical solution. This affects only verification file RD.extract generated from QAPRINT module.


