### PR TITLE
Issue in /H3D/NODA/CSE_FRIC option:

### DIFF
--- a/engine/source/mpi/interfaces/spmd_i7tool.F
+++ b/engine/source/mpi/interfaces/spmd_i7tool.F
@@ -5050,23 +5050,7 @@ C
                 CALL ANCMSG(MSGID=20,ANMODE=ANINFO)
                 CALL ARRET(2)
               ENDIF
-C
             ENDIF
-          ENDIF
-C
-          IF(H3D_DATA%N_SCAL_CSE_FRICINT >0)THEN
-            IF(H3D_DATA%N_CSE_FRIC_INTER (I) >0)THEN
-              IERROR = 0
-              ALLOCATE(EFRICFI(I)%P(LENR),STAT=IERROR)
-              IF(IERROR/=0) THEN
-                CALL ANCMSG(MSGID=20,ANMODE=ANINFO)
-                CALL ARRET(2)
-c              ELSEIF(S_EFRICINT >0) THEN ! to be corrected if inters
-c                CALL READ_DB(EFRICFI(I)%P(1),LENR)  
-              ELSE
-                  EFRICFI(I)%P(1:LENR)=ZERO            
-              END IF                   
-            END IF
           ENDIF
 C
           IF(H3D_DATA%N_SCAL_CSE_FRIC >0)THEN

--- a/engine/source/output/h3d/h3d_build_fortran/lech3d.F
+++ b/engine/source/output/h3d/h3d_build_fortran/lech3d.F
@@ -101,6 +101,7 @@ C-----------------------------------------------
         USE LOADS_MOD
         USE NAMES_AND_TITLES_MOD, ONLY: NCHARLINE100,NCHARKEY
         USE MATPARAM_DEF_MOD
+        USE TRI7BOX
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -159,6 +160,10 @@ C-----------------------------------------------
      .          IS_MODE,MODE,MODE_MAX,IS_MODE_ALL,NFAIL,NIP_PLY_MAX,NIP_ELEM_MAX
         INTEGER MLW,NEL,NG,JTURB,NLAY,NUVAR,IPLY,IMAT,ISUBSTACK,ID_PLY_TMP
         INTEGER CPT_MOD,NMOD,CPT_LAWID
+        INTEGER IERROR  ! Error value from Allocate
+        INTEGER LENS    ! Size of Remote interface send values
+        INTEGER LENR    ! Size of Remote interface recieve values
+
         INTEGER IBID1,IBID2,IBID3
 
         CHARACTER(LEN=NCHARKEY)::KEY2
@@ -2488,6 +2493,25 @@ c        DO J=1,H3D_DATA%OUTPUT_LIST(I)%N_H3D_PART_LIST
 c          print *,'liste des parts',H3D_DATA%OUTPUT_LIST(I)%H3D_PART_LIST(J)
 c        ENDDO
 c      ENDDO
+
+        IF (H3D_DATA%N_SCAL_CSE_FRICINT > 0)THEN
+          ! Allocate INTERFACE Remote EFRICFI Array
+          DO I=1,NINTER
+            IF(H3D_DATA%N_CSE_FRIC_INTER(I) >0) THEN
+               LENR=0
+               DO P = 1, NSPMD
+                     LENR = LENR + NSNFI(I)%P(P)
+               ENDDO
+               IERROR = 0
+               ALLOCATE(EFRICFI(I)%P(LENR),STAT=IERROR)
+               IF(IERROR/=0) THEN
+                  CALL ANCMSG(MSGID=20,ANMODE=ANINFO)
+                  CALL ARRET(2)
+               ENDIF
+              EFRICFI(I)%P(1:LENR)=ZERO
+            ENDIF
+          ENDDO
+        ENDIF
 C
         DEALLOCATE(H3D_KEYWORD_NODAL_SCALAR)
         DEALLOCATE(H3D_KEYWORD_NODAL_VECTOR)


### PR DESCRIPTION
Allocation of Remote EFRICFI array in i7tools.F requires values which are set after. Move this allocation to the routine settings all values.

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
