### PR TITLE
correction possible overflow in INISPHCEL when NUVAR > 0

### DIFF
--- a/starter/source/starter/lectur.F
+++ b/starter/source/starter/lectur.F
@@ -1271,6 +1271,10 @@ C------------------------------------------------------------------
       SFNOISE = 0
       ALLOCATE(INOISE(0))
       ALLOCATE(FNOISE(0))
+C------------------------------------------------------------------
+C Initialisation size for INISHCEL
+C------------------------------------------------------------------
+      NUSPHCEL = 0
 C----------------------------------------------
 C     ALLOCATION TO REDUCE STACKSIZE
 C----------------------------------------------
@@ -8186,7 +8190,6 @@ C
 C
       CALL TRACE_OUT1()
 C--------------------------------------------
-      NUSPHCEL = 0
       ! still need for *Y00, *sty files - not yet covered by CFG files (hm_reader)
       IF(IDDLEVEL == 0) CALL YCTRL(IGRBRIC)
 !


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
correction possible overflow in INISPHCEL when NUVAR > 0

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
move init o
This pull request includes changes to the `LECTUR` subroutine in the `starter/source/starter/lectur.F` file. The changes involve the initialization and allocation of variables, specifically related to the `NUSPHCEL` variable.

Initialization and allocation changes:

* Added initialization size for `NUSPHCEL` to 0. (`starter/source/starter/lectur.F`, [starter/source/starter/lectur.FR1274-R1277](diffhunk://#diff-b7cfbd6038ee923f835b05bcea0774e4375066ddc226b80bdd2f2cc8442f7ebdR1274-R1277))
* Removed redundant initialization of `NUSPHCEL` to 0, as it is now handled earlier in the subroutine. (`starter/source/starter/lectur.F`, [starter/source/starter/lectur.FL8189](diffhunk://#diff-b7cfbd6038ee923f835b05bcea0774e4375066ddc226b80bdd2f2cc8442f7ebdL8189))

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
