### PR TITLE
Correct wrong material number in MAT_PARAM in thcoq.F

### DIFF
--- a/engine/source/output/th/thcoq.F
+++ b/engine/source/output/th/thcoq.F
@@ -194,7 +194,7 @@ c---
                     MATLY = IGEO(IPMAT+N,PID(I))
                     IF (MATPARAM_TAB(MATLY)%IVISC > 0) THEN
                       IVISC = 1
-                      NUVARV = MAX(NUVARV, MATPARAM_TAB(IMAT)%VISC%NUVAR)
+                      NUVARV = MAX(NUVARV, MATPARAM_TAB(MATLY)%VISC%NUVAR)
                     END IF
                   ENDDO              
                 ENDDO            
@@ -204,7 +204,7 @@ c---
                     MATLY=MAT(I)
                     IF (MATPARAM_TAB(MATLY)%IVISC > 0) THEN
                       IVISC = 1
-                      NUVARV = MAX(NUVARV, MATPARAM_TAB(IMAT)%VISC%NUVAR)
+                      NUVARV = MAX(NUVARV, MATPARAM_TAB(MATLY)%VISC%NUVAR)
                     END IF
                   ENDDO              
                 ENDDO
@@ -215,7 +215,7 @@ c---
                     MATLY  = STACK%IGEO(IPMAT+N,ISUBSTACK)
                     IF (MATPARAM_TAB(MATLY)%IVISC > 0) THEN
                       IVISC = 1
-                      NUVARV = MAX(NUVARV, MATPARAM_TAB(IMAT)%VISC%NUVAR)
+                      NUVARV = MAX(NUVARV, MATPARAM_TAB(MATLY)%VISC%NUVAR)
                     END IF
                   ENDDO              
                 ENDDO


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

potential problem in TH output of viscous stress 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

The material number used in MAT_PARAM adress was wrong for multilayer properties

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
