### PR TITLE
Coating shell elements were not compatible with the erosion of solid element + interface /TYPE25

### DIFF
--- a/engine/share/modules/shooting_node_mod.F
+++ b/engine/share/modules/shooting_node_mod.F
@@ -50,6 +50,23 @@ C   m y _ r e a l
 C-----------------------------------------------
 #include      "my_real.inc"
 C-----------------------------------------------
+        type offset_elem_
+          integer :: sol_up_bound !< upper bound for solid
+          integer :: sol_low_bound !< lower bound for solid
+          integer :: quad_up_bound !< upper bound for quad
+          integer :: quad_low_bound!< lower bound for quad
+          integer :: shell_up_bound !< upper bound for shell
+          integer :: shell_low_bound!< lower bound for shell
+          integer :: truss_up_bound !< upper bound for truss
+          integer :: truss_low_bound!< lower bound for truss
+          integer :: beam_up_bound !< upper bound for beam
+          integer :: beam_low_bound!< lower bound for beam
+          integer :: spring_up_bound !< upper bound for spring
+          integer :: spring_low_bound!< lower bound for spring
+          integer :: shell3n_up_bound !< upper bound for shell3n
+          integer :: shell3n_low_bound!< lower bound for shell3n
+        end type offset_elem_
+
         TYPE working_array
             INTEGER, DIMENSION(:), ALLOCATABLE :: SURF  ! working array for surface
             INTEGER, DIMENSION(:), ALLOCATABLE :: PROC  ! working array for processor            
@@ -125,6 +142,7 @@ C-----------------------------------------------
 
 
             TYPE(remote_elm), DIMENSION(:), ALLOCATABLE :: INTER
+            type(offset_elem_) :: offset_elem !< upper and lower bound
         END TYPE shooting_node_type 
 
 

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -2293,7 +2293,9 @@ C ---------------------
       CALL INIT_NODAL_STATE( IPARI,SHOOT_STRUCT,INTERFACES%INTBUF_TAB,IAD_ELEM,FR_ELEM,
      .                       ITAB,ITABM1,GEO,ADDCNEL,CNEL,
      .                       IXS,IXC,IXT,IXP,IXR,IXTG,
-     .                       SIZE_ADDCNEL,SIZE_CNEL )
+     .                       SIZE_ADDCNEL,SIZE_CNEL ,
+     .                       numelsg,numelqg,numelcg,numeltrg,numelpg,
+     .                       numelrg,numeltgg )
       ! -------------------------
 C========================================================================================
 C                                     NON PARALLEL SECTION (SMP)
@@ -2467,9 +2469,14 @@ C Init var parallel SMP
                 ENDIF
                 IF(CHECK_NEIGH_FLAG_RES > 0 ) THEN
                   call get_neighbour_surface( ispmd,nspmd,ninter25,npari,ninter,  
-     .                                        nbintc,nixs,numnod,numels,s_elem_state,nbddedgt,nbddedg_max,  
-     .                                        elem_state,ipari,intlist,itab,itabm1,newfront,ixs,iad_elem,x,         
+     .                                        nbintc,nixs,nixc,nixtg,numnod,  
+     .                                        numels,numelc,numeltg,s_elem_state, 
+     .                                        nbddedgt,nbddedg_max,  
+     .                                        elem_state,ipari,intlist,itab,itabm1,
+     .                                        newfront,ixs,ixc,ixtg,
+     .                                        iad_elem,x,         
      .                                        interfaces%intbuf_tab,interfaces%spmd_arrays,shoot_struct  )
+
                 ENDIF
               ENDIF
               CALL MY_BARRIER()
@@ -5515,9 +5522,13 @@ C WA local  : utilise de 1 a NUMNOD
                 ENDIF
                IF(CHECK_NEIGH_FLAG_RES > 0 ) THEN
                   call get_neighbour_surface( ispmd,nspmd,ninter25,npari,ninter,  
-     .                                         nbintc,nixs,numnod,numels,s_elem_state,nbddedgt,nbddedg_max,  
-     .                                         elem_state,ipari,intlist,itab,itabm1,newfront,ixs,iad_elem,x,         
-     .                                         interfaces%intbuf_tab,interfaces%spmd_arrays,shoot_struct  )
+     .                                        nbintc,nixs,nixc,nixtg,numnod,  
+     .                                        numels,numelc,numeltg,s_elem_state, 
+     .                                        nbddedgt,nbddedg_max,  
+     .                                        elem_state,ipari,intlist,itab,itabm1,
+     .                                        newfront,ixs,ixc,ixtg,
+     .                                        iad_elem,x,         
+     .                                        interfaces%intbuf_tab,interfaces%spmd_arrays,shoot_struct  )
                ENDIF
               ENDIF
               CALL MY_BARRIER()

--- a/engine/source/interfaces/interf/get_neighbour_surface_from_remote_proc.F90
+++ b/engine/source/interfaces/interf/get_neighbour_surface_from_remote_proc.F90
@@ -45,7 +45,6 @@
       !||    get_segment_edge                         ../engine/source/interfaces/interf/get_segment_edge.F90
       !||    get_segment_interface_id                 ../engine/source/interfaces/interf/get_segment_interface_id.F90
       !||    get_segment_normal                       ../engine/source/interfaces/interf/get_segment_normal.F90
-      !||    get_segment_orientation                  ../engine/source/interfaces/interf/get_segment_orientation.F90
       !||    sysfus2                                  ../engine/source/system/sysfus.F
       !||--- uses       -----------------------------------------------------
       !||    array_mod                                ../common_source/modules/array_mod.F
@@ -53,12 +52,11 @@
       !||    get_segment_edge_mod                     ../engine/source/interfaces/interf/get_segment_edge.F90
       !||    get_segment_interface_id_mod             ../engine/source/interfaces/interf/get_segment_interface_id.F90
       !||    get_segment_normal_mod                   ../engine/source/interfaces/interf/get_segment_normal.F90
-      !||    get_segment_orientation_mod              ../engine/source/interfaces/interf/get_segment_orientation.F90
       !||    shooting_node_mod                        ../engine/share/modules/shooting_node_mod.F
       !||====================================================================
-        subroutine get_neighbour_surface_from_remote_proc( ninter,numnod,nspmd,nixs,numels,s_elem_state,  &
+        subroutine get_neighbour_surface_from_remote_proc( ninter,numnod,nspmd,  &
                                                              size_r_buffer,nb_r_segment,s_buffer_2_size, &
-                                                             elem_state,ixs,itabm1,r_buffer,s_buffer_2, &
+                                                             itabm1,r_buffer,s_buffer_2, &
                                                              x,intbuf_tab,shoot_struct ,&
                                                              ispmd,proc_id_0 )
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -68,7 +66,6 @@
           use intbufdef_mod , only : intbuf_struct_
           use shooting_node_mod , only : shooting_node_type
           use get_segment_interface_id_mod , only : get_segment_interface_id
-          use get_segment_orientation_mod , only : get_segment_orientation
           use get_segment_normal_mod , only : get_segment_normal
           use get_segment_edge_mod , only : get_segment_edge
           use array_mod , only : array_type,alloc_my_real_1d_array,dealloc_my_real_1d_array
@@ -88,13 +85,8 @@
           integer, intent(in) :: nspmd !< total number of mpi tasks
           integer, intent(in) :: size_r_buffer !< size of r_buffer
           integer, intent(in) :: nb_r_segment !< number of new remote segment
-          integer, intent(in) :: nixs !< 1rst dim of "ixs" array
-          integer, intent(in) :: numels !< number of solid element
-          integer, intent(in) :: s_elem_state !< dim of elem_state
           integer, intent(in) :: proc_id_0 !< S processor id
           integer, intent(in) :: ispmd !< current processor id
-          integer, dimension(nixs,numels), intent(in) :: ixs !< solid element data
-          logical, dimension(s_elem_state), intent(in) :: elem_state !< state of the element : on or off
           integer, dimension(3,nspmd), intent(inout) :: s_buffer_2_size !< size of s_buffer_2
           integer, dimension(numnod), intent(in) :: itabm1 !< global to local node id
           my_real, dimension(size_r_buffer) :: r_buffer !< mpi buffer (rcv)
@@ -225,8 +217,6 @@
             do ijk=1,my_reduced_nb
               ! segment/surface orientation
               n_segment_id = my_reduced_list(ijk,1) ! connected segment id
-              call get_segment_orientation( n_segment_id,s_elem_state,nixs,numels,numnod, &
-                                            elem_state,ixs,x,intbuf_tab(nin) )
               ! compute the normal to the segment "n_segment_id"
               call get_segment_normal( n_segment_id,segment_node_id,segment_position,n_normal(1,ijk),intbuf_tab(nin),numnod,x )
               ! find the edge id of n_segment_id

--- a/engine/source/interfaces/interf/get_segment_orientation.F90
+++ b/engine/source/interfaces/interf/get_segment_orientation.F90
@@ -44,14 +44,17 @@
       !||    constant_mod                             ../common_source/modules/constant_mod.F
       !||    get_segment_normal_mod                   ../engine/source/interfaces/interf/get_segment_normal.F90
       !||====================================================================
-        subroutine get_segment_orientation( segment_id,s_elem_state,nixs,numels,numnod, &
-                                            elem_state,ixs,x,intbuf_tab )
+        subroutine get_segment_orientation( segment_id,s_elem_state,nixs,nixc,nixtg, &
+                                            numels,numelc,numeltg,numnod, &
+                                            elem_state,ixs,ixc,ixtg,x,  &
+                                            intbuf_tab,shoot_struct )
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   modules
 ! ----------------------------------------------------------------------------------------------------------------------
           use constant_mod , only : zero,one
           use intbufdef_mod , only : intbuf_struct_
           use get_segment_normal_mod , only : get_segment_normal
+          use shooting_node_mod , only : shooting_node_type
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   implicit none
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -66,18 +69,26 @@
           integer, intent(in) :: segment_id  !< id of the segment
           integer, intent(in) :: s_elem_state !< dim of elem_state
           integer, intent(in) :: nixs !< 1rst dim of "ixs" array
+          integer, intent(in) :: nixc !< 1rst dim of "ixc" array
+          integer, intent(in) :: nixtg !< 1rst dim of "ixtg" array
           integer, intent(in) :: numels !< number of solid element
+          integer, intent(in) :: numelc !< number of shell element
+          integer, intent(in) :: numeltg !< number of shell3n element
           integer, intent(in) :: numnod !< number of node
           logical, dimension(s_elem_state), intent(in) :: elem_state !< state of the element : on or off
           integer, dimension(nixs,numels), intent(in) :: ixs !< solid element data
+          integer, dimension(nixc,numelc), intent(in) :: ixc !< shell element data
+          integer, dimension(nixtg,numeltg), intent(in) :: ixtg !< shell3n element data
           my_real, dimension(3,numnod), intent(in) :: x !< nodal position
           type(intbuf_struct_), intent(inout) :: intbuf_tab    !< interface data 
+          type(shooting_node_type), intent(inout) :: shoot_struct !< structure for shooting node algo
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   local variables
 ! ----------------------------------------------------------------------------------------------------------------------
+          logical :: need_orientation
           integer :: i,j
           integer :: node_id,elem_id
-          integer :: real_nb_node,error
+          integer :: node_number,real_nb_node,error
           integer, dimension(4) :: segment_node_id
           integer, dimension(8) :: list,node_id_list,perm_list
           my_real :: dds,ratio
@@ -97,81 +108,119 @@
           call get_segment_normal( segment_id,segment_node_id,segment_position,normal,intbuf_tab,numnod,x )
 
           ! orientation of the element
-          elem_id = intbuf_tab%ielem_m(2*(segment_id-1)+1) ! get the element id 
           xc = zero
           yc = zero
           zc = zero
-
-          ! ----------------
-          do j=1,8
-            list(j) = ixs(j+1,elem_id) ! get the node id of the element : a node can appeared several time in ixs... (tetra or degenerated element)
-          enddo
-          call myqsort_int(8,list,perm_list,error) ! sort the list 
-          ! ----------------
-          
-          ! ----------------
-          ! check the number of node of the element & save the list of node
-          node_id = list(1)
-          real_nb_node = 1
-          node_id_list(real_nb_node) = node_id
-          do j=2,8
-            if(node_id/=list(j)) then
-              real_nb_node = real_nb_node + 1
-              node_id = list(j)
-              node_id_list(real_nb_node) = node_id
-            endif
-          enddo
-          ! ----------------
-
-          ! ----------------
-          ratio = one / real_nb_node
-          do j=1,real_nb_node
-            node_id = node_id_list(j)
-            xc = xc+x(1,node_id)
-            yc = yc+x(2,node_id)
-            zc = zc+x(3,node_id)
-          enddo
-          xc=xc*ratio
-          yc=yc*ratio
-          zc=zc*ratio
-          ! ----------------
-
-          dds=normal(1)*(xc-segment_position(1))+normal(2)*(yc-segment_position(2))+normal(3)*(zc-segment_position(3))
-          
-          ! check if the element associated to the segment "segment_id" is deleted
-          ! if the element is deleted --> need to consider the opposite condition for DDS
-          !     c = barycentre of the element
-          !     s = barycentre of the segment
-          !
-          !    element is on
-          !     ________
-          !    |        |
-          !    |   c--->|     s----> 
-          !    |________|
-          !
-          !
-          !    element is off
-          !     ________
-          !    |        |
-          !    |   c--->| <---- s 
-          !    |________|
-          !
-          !
-          if( .not.elem_state( elem_id ) ) then
-            dds = -dds
+          elem_id = intbuf_tab%ielem_m(2*(segment_id-1)+1) ! get the element id
+          node_number = 0
+          list(:) = 0
+          need_orientation = .false.
+          ! -----------------
+          ! find the kinf of element : solid, shell or shell3n
+          ! for solid : elem_id = elem_id - 0
+          ! for shell : elem_id = elem_id - global number of solid + quad
+          ! for shell3n : elem_id = elem_id - global number of solid + quad + shell + truss + beam + spring
+          ! -----------------
+          ! solid element :
+          if( (shoot_struct%offset_elem%sol_low_bound<elem_id ).and.& 
+              (elem_id<=shoot_struct%offset_elem%sol_up_bound) )then
+            elem_id = elem_id - shoot_struct%offset_elem%sol_low_bound
+            node_number = 8
+            ! ----------------
+            do j=1,node_number
+              list(j) = ixs(j+1,elem_id) ! get the node id of the solid element : a node can appeared several time in ixs... (tetra or degenerated element)
+            enddo
+            call myqsort_int(node_number,list,perm_list,error) ! sort the list 
+            need_orientation = .true.
+            ! ----------------
+          ! -----------------
+          ! shell element : 
+          elseif( (shoot_struct%offset_elem%shell_low_bound<elem_id ).and.& 
+              (elem_id<=shoot_struct%offset_elem%shell_up_bound) )then
+            elem_id = elem_id - shoot_struct%offset_elem%shell_low_bound
+            node_number = 4
+            do j=1,node_number
+              list(j) = ixc(j+1,elem_id) ! get the node id of the shell
+            enddo
+            need_orientation = .false.
+          ! -----------------
+          ! shell3n element :
+          elseif( (shoot_struct%offset_elem%shell3n_low_bound<elem_id ).and.& 
+              (elem_id<=shoot_struct%offset_elem%shell3n_up_bound) )then
+            elem_id = elem_id - shoot_struct%offset_elem%shell3n_low_bound
+            node_number = 3
+            do j=1,node_number
+              list(j) = ixtg(j+1,elem_id) ! get the node id of the shell3n
+            enddo
+            need_orientation = .false.
           endif
+          ! -----------------
+         
+          if(need_orientation) then
+            ! ----------------
+            ! check the number of node of the element & save the list of node
+            node_id = list(1)
+            real_nb_node = 1
+            node_id_list(real_nb_node) = node_id
+            do j=2,node_number
+              if(node_id/=list(j)) then
+                real_nb_node = real_nb_node + 1
+                node_id = list(j)
+                node_id_list(real_nb_node) = node_id
+              endif
+            enddo
+            ! ----------------
 
-          if(dds  >= zero) then
-            if(segment_node_id(3)==segment_node_id(4)) then
-              intbuf_tab%irectm(4*(segment_id-1)+1)=segment_node_id(2)
-              intbuf_tab%irectm(4*(segment_id-1)+2)=segment_node_id(1)
-            else
-              do i=1,4
-                intbuf_tab%irectm(4*(segment_id-1)+i)=segment_node_id(4-i+1)
-              enddo
+            ! ----------------
+            ratio = one / real_nb_node
+            do j=1,real_nb_node
+              node_id = node_id_list(j)
+              xc = xc+x(1,node_id)
+              yc = yc+x(2,node_id)
+              zc = zc+x(3,node_id)
+            enddo
+            xc=xc*ratio
+            yc=yc*ratio
+            zc=zc*ratio
+            ! ----------------
+
+            dds=normal(1)*(xc-segment_position(1))+normal(2)*(yc-segment_position(2))+normal(3)*(zc-segment_position(3))
+            
+            ! check if the element associated to the segment "segment_id" is deleted
+            ! if the element is deleted --> need to consider the opposite condition for DDS
+            !     c = barycentre of the element
+            !     s = barycentre of the segment
+            !
+            !    element is on
+            !     ________
+            !    |        |
+            !    |   c--->|     s----> 
+            !    |________|
+            !
+            !
+            !    element is off
+            !     ________
+            !    |        |
+            !    |   c--->| <---- s 
+            !    |________|
+            !
+            !
+            if( .not.elem_state( elem_id ) ) then
+              dds = -dds
             endif
+
+            if(dds  >= zero) then
+              if(segment_node_id(3)==segment_node_id(4)) then
+                intbuf_tab%irectm(4*(segment_id-1)+1)=segment_node_id(2)
+                intbuf_tab%irectm(4*(segment_id-1)+2)=segment_node_id(1)
+              else
+                do i=1,4
+                  intbuf_tab%irectm(4*(segment_id-1)+i)=segment_node_id(4-i+1)
+                enddo
+              endif
+            endif
+            ! -------------------------
           endif
-          ! -------------------------
 !
 ! ----------------------------------------------------------------------------------------------------------------------
         end subroutine get_segment_orientation

--- a/engine/source/interfaces/interf/init_nodal_state.F
+++ b/engine/source/interfaces/interf/init_nodal_state.F
@@ -37,7 +37,9 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
         SUBROUTINE INIT_NODAL_STATE( IPARI,SHOOT_STRUCT,INTBUF_TAB,IAD_ELEM,FR_ELEM,
      .                               ITAB,ITABM1,GEO,ADDCNEL,CNEL,
      .                               IXS,IXC,IXT,IXP,IXR,IXTG,
-     .                               SIZE_ADDCNEL,SIZE_CNEL )
+     .                               SIZE_ADDCNEL,SIZE_CNEL,
+     .                               numelsg,numelqg,numelcg,numeltrg,numelpg,
+     .                               numelrg,numeltgg )
 !$COMMENT
 !       INIT_NODAL_STATE description
 !           initialization of structures for the new shooting node algo    
@@ -80,23 +82,30 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-        INTEGER, INTENT(in) :: SIZE_ADDCNEL,SIZE_CNEL ! array size : cnel & addcnel
+        INTEGER, INTENT(in) :: SIZE_ADDCNEL,SIZE_CNEL !< array size : cnel & addcnel
+        integer, intent(in) :: numelsg !< global number of solid
+        integer, intent(in) :: numelqg !< global number of quad
+        integer, intent(in) :: numelcg !< global number of shell
+        integer, intent(in) :: numeltrg !< global number of truss
+        integer, intent(in) :: numelpg !< global number of beam
+        integer, intent(in) :: numelrg !< global number of spring
+        integer, intent(in) :: numeltgg !< global number of shell3n
         INTEGER, DIMENSION(NPARI,NINTER), INTENT(in) :: IPARI
-        INTEGER, DIMENSION(2,NSPMD+1), INTENT(in) :: IAD_ELEM  ! adress for frontier node
-        INTEGER, DIMENSION(SFR_ELEM), INTENT(in) :: FR_ELEM    ! frontier node id 
-        TYPE(shooting_node_type), INTENT(inout) :: SHOOT_STRUCT ! structure for shooting node algo
-        TYPE(INTBUF_STRUCT_), DIMENSION(NINTER), INTENT(inout) :: INTBUF_TAB    ! interface data
-        INTEGER, DIMENSION(NUMNOD), INTENT(in) :: ITAB ! array to convert local id to global id
-        INTEGER, DIMENSION(NUMNOD), INTENT(in) :: ITABM1    ! array of global id
-        my_real, DIMENSION(NPROPG,NUMGEO), INTENT(in) :: GEO
-        INTEGER, DIMENSION(0:SIZE_ADDCNEL), INTENT(in) :: ADDCNEL ! address for the CNEL array
-        INTEGER, DIMENSION(0:SIZE_CNEL), INTENT(in) :: CNEL ! connectivity node --> element
-        INTEGER, DIMENSION(NIXS,NUMELS),TARGET, INTENT(in) :: IXS   ! solid array
-        INTEGER, DIMENSION(NIXC,NUMELC),TARGET, INTENT(in) :: IXC   ! shell array
-        INTEGER, DIMENSION(NIXT,NUMELT),TARGET, INTENT(in) :: IXT! truss array
-        INTEGER, DIMENSION(NIXP,NUMELP),TARGET, INTENT(in) :: IXP! beam array
-        INTEGER, DIMENSION(NIXR,NUMELR),TARGET, INTENT(in) :: IXR! spring array
-        INTEGER, DIMENSION(NIXTG,NUMELTG),TARGET, INTENT(in) :: IXTG! triangle array
+        INTEGER, DIMENSION(2,NSPMD+1), INTENT(in) :: IAD_ELEM  !< adress for frontier node
+        INTEGER, DIMENSION(SFR_ELEM), INTENT(in) :: FR_ELEM    !< frontier node id 
+        TYPE(shooting_node_type), INTENT(inout) :: SHOOT_STRUCT !< structure for shooting node algo
+        TYPE(INTBUF_STRUCT_), DIMENSION(NINTER), INTENT(inout) :: INTBUF_TAB    !< interface data
+        INTEGER, DIMENSION(NUMNOD), INTENT(in) :: ITAB !< array to convert local id to global id
+        INTEGER, DIMENSION(NUMNOD), INTENT(in) :: ITABM1    !< array of global id
+        my_real, DIMENSION(NPROPG,NUMGEO), INTENT(in) :: GEO !< property data
+        INTEGER, DIMENSION(0:SIZE_ADDCNEL), INTENT(in) :: ADDCNEL !< address for the CNEL array
+        INTEGER, DIMENSION(0:SIZE_CNEL), INTENT(in) :: CNEL !< connectivity node --> element
+        INTEGER, DIMENSION(NIXS,NUMELS),TARGET, INTENT(in) :: IXS   !< solid array
+        INTEGER, DIMENSION(NIXC,NUMELC),TARGET, INTENT(in) :: IXC   !< shell array
+        INTEGER, DIMENSION(NIXT,NUMELT),TARGET, INTENT(in) :: IXT !< truss array
+        INTEGER, DIMENSION(NIXP,NUMELP),TARGET, INTENT(in) :: IXP !< beam array
+        INTEGER, DIMENSION(NIXR,NUMELR),TARGET, INTENT(in) :: IXR !< spring array
+        INTEGER, DIMENSION(NIXTG,NUMELTG),TARGET, INTENT(in) :: IXTG !<triangle array
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -133,6 +142,32 @@ C-----------------------------------------------
         INTEGER, DIMENSION(NSPMD) :: R_SIZE_BUFFER_MAIN,R_SIZE_BUFFER_SECOND
 
 C-----------------------------------------------
+        ! --------------------------------
+        ! Upper & lower bound, only used by the erosion of solid element + /TYPE25
+        ! to get the kind of element (solid,shell or shell3n)
+        ! --------------------------------
+        ! solid
+        shoot_struct%offset_elem%sol_low_bound = 0
+        shoot_struct%offset_elem%sol_up_bound = numelsg
+        ! quad
+        shoot_struct%offset_elem%quad_low_bound = shoot_struct%offset_elem%sol_up_bound + 1
+        shoot_struct%offset_elem%quad_up_bound = shoot_struct%offset_elem%sol_up_bound + numelqg
+        ! shell
+        shoot_struct%offset_elem%shell_low_bound = shoot_struct%offset_elem%quad_up_bound + 1
+        shoot_struct%offset_elem%shell_up_bound = shoot_struct%offset_elem%quad_up_bound + numelcg
+        ! truss
+        shoot_struct%offset_elem%truss_low_bound = shoot_struct%offset_elem%shell_up_bound + 1
+        shoot_struct%offset_elem%truss_up_bound = shoot_struct%offset_elem%shell_up_bound + numeltrg
+        ! beam
+        shoot_struct%offset_elem%beam_low_bound = shoot_struct%offset_elem%truss_up_bound + 1
+        shoot_struct%offset_elem%beam_up_bound = shoot_struct%offset_elem%truss_up_bound + numelpg
+        ! spring
+        shoot_struct%offset_elem%spring_low_bound = shoot_struct%offset_elem%truss_up_bound + 1
+        shoot_struct%offset_elem%spring_up_bound = shoot_struct%offset_elem%truss_up_bound + numelrg
+        ! shell3n
+        shoot_struct%offset_elem%shell3n_low_bound = shoot_struct%offset_elem%spring_up_bound + 1
+        shoot_struct%offset_elem%shell3n_up_bound = shoot_struct%offset_elem%spring_up_bound + numeltgg
+        ! --------------------------------        
 
         ALLOCATE( BUFFER_SECOND(NSPMD) )
         ALLOCATE( BUFFER_MAIN(NSPMD) )

--- a/engine/source/mpi/interfaces/spmd_exch_neighbour_segment.F90
+++ b/engine/source/mpi/interfaces/spmd_exch_neighbour_segment.F90
@@ -66,9 +66,9 @@
       !||    spmd_mod                                     ../engine/source/mpi/spmd_mod.F90
       !||====================================================================
         subroutine spmd_exch_neighbour_segment(nspmd,ispmd, &
-                                                ninter,numnod,nixs,numels,s_elem_state, &
+                                                ninter,numnod, &
                                                 s_buffer_size,r_buffer_size,s_buffer_2_size,r_buffer_2_size,&
-                                                iad_elem,itabm1,ixs,elem_state,x, &
+                                                iad_elem,itabm1,x, &
                                                 s_buffer,r_buffer,s_buffer_2,r_buffer_2, &
                                                 intbuf_tab,shoot_struct)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -97,17 +97,12 @@
           integer, intent(in) :: ispmd !< processor id
           integer, intent(in) :: ninter !< number of interface
           integer, intent(in) :: numnod !< number of node
-          integer, intent(in) :: nixs !< 1rst dim of "ixs" array
-          integer, intent(in) :: numels !< number of solid element
-          integer, intent(in) :: s_elem_state !< dim of elem_state
           integer, dimension(2,nspmd), intent(inout) :: s_buffer_size !< size of S buffer
           integer, dimension(2,nspmd), intent(inout) :: r_buffer_size !< size of R buffer
           integer, dimension(3,nspmd), intent(inout) :: s_buffer_2_size !< size of S buffer
           integer, dimension(3,nspmd), intent(inout) :: r_buffer_2_size !< size of R buffer
           integer, dimension(2,nspmd+1), intent(in) :: iad_elem !< frontier between processor
           integer, dimension(numnod), intent(in) :: itabm1 !< global to local node id
-          integer, dimension(nixs,numels), intent(in) :: ixs !< solid element data
-          logical, dimension(s_elem_state), intent(in) :: elem_state !< state of the element : on or off
           my_real, dimension(3,numnod), intent(in) :: x !< nodal position
           type(array_type), dimension(nspmd), intent(inout) :: s_buffer !< mpi buffer (send)
           type(array_type), dimension(nspmd), intent(inout) :: r_buffer !< mpi buffer (rcv)
@@ -223,9 +218,9 @@
             do i=1,recv_nb_2
                 call spmd_waitany(recv_nb_2, request_r_2, my_index, status_mpi)
                 proc_id = index_r_proc_2(my_index)
-                call get_neighbour_surface_from_remote_proc( ninter,numnod,nspmd,nixs,numels,s_elem_state,  &
+                call get_neighbour_surface_from_remote_proc( ninter,numnod,nspmd,  &
                                                              r_buffer_size(1,proc_id),r_buffer_size(2,proc_id),s_buffer_2_size, &
-                                                             elem_state,ixs,itabm1,r_buffer(proc_id)%my_real_array_1d,s_buffer_2, &
+                                                             itabm1,r_buffer(proc_id)%my_real_array_1d,s_buffer_2, &
                                                              x,intbuf_tab,shoot_struct ,&
                                                              ispmd,proc_id )
             enddo

--- a/starter/source/restart/ddsplit/split_interfaces.F
+++ b/starter/source/restart/ddsplit/split_interfaces.F
@@ -2708,8 +2708,10 @@ c     .                            TAG_II_E2E)
           ENDIF
 
           CALL SPLIT_SEG_IELEM(INTBUF_TAB(NI)%IELEM_M,INTBUF_TAB(NI)%PROC_MVOISIN, INTBUF_TAB(NI)%MVOISIN,NRTM,
-     .                           NRTM_L               ,TAG_SEGM                   ,CEP                    ,CEL  ,
-     .                           IDEL25_SOLID         ,INTERCEP(1,NI)             ,PROC                  ,NUMELS)
+     .                         NRTM_L ,TAG_SEGM ,CEP,CEL  ,
+     .                         IDEL25_SOLID,INTERCEP(1,NI),PROC,NUMELS,
+     .                         NUMELQ    ,NUMELC         ,NUMELT   ,NUMELP    ,
+     .                         NUMELR    ,NUMELTG)
 
 c split and write on disk floating arrays 
 

--- a/starter/source/restart/ddsplit/split_seg_ielem.F
+++ b/starter/source/restart/ddsplit/split_seg_ielem.F
@@ -30,7 +30,9 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||====================================================================
       SUBROUTINE SPLIT_SEG_IELEM(IELEM_M    ,PROC_MVOISIN  ,MVOISIN  ,NRTM      ,
      .                           NRTM_L     ,TAG_SEG       ,CEP      ,CEL       ,
-     .                           IDEL_SOLID,INTERCEP       ,PROC     ,NUMELS    )
+     .                           IDEL_SOLID,INTERCEP       ,PROC     ,NUMELS    ,
+     .                           NUMELQ    ,NUMELC         ,NUMELT   ,NUMELP    ,
+     .                           NUMELR    ,NUMELTG)
 c
 c split & write segments array (type INTEGER) with local value
 c
@@ -46,35 +48,56 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER  , INTENT(IN) :: NRTM ,NRTM_L ! number of main segments global and local
-      INTEGER  , INTENT(IN) ::  PROC        ! current proc
-      INTEGER  , INTENT(IN) ::  NUMELS      ! number of solid elements
-      INTEGER  , INTENT(IN) :: IDEL_SOLID   ! solid eroosion flag
-      INTEGER  , INTENT(IN) :: IELEM_M(2,NRTM) !  elements connected to main segments 
-      INTEGER  , INTENT(IN) :: TAG_SEG(NRTM_L)   ! local seg to global segement
-      INTEGER  , INTENT(IN) :: CEP(*),CEL(*)     ! arrays of proc of elements and local number of element
-      INTEGER  , INTENT(IN) :: MVOISIN(4,NRTM)   ! neighbhoors of main segments 
-      INTEGER  , INTENT(INOUT) :: PROC_MVOISIN(4,NRTM) ! procs of neighbhoors of main segments : to be build
-      TYPE(INTERSURFP)     :: INTERCEP ! procs of main segments
+      INTEGER  , INTENT(IN) :: NRTM !< number of main segments (global)
+      INTEGER  , INTENT(IN) :: NRTM_L !< number of main segments (local)
+      INTEGER  , INTENT(IN) ::  PROC        !< current proc
+      INTEGER  , INTENT(IN) ::  NUMELS      !< number of solid elements (global)
+      INTEGER  , INTENT(IN) ::  NUMELQ      !< number of quad elements (global)
+      INTEGER  , INTENT(IN) ::  NUMELC      !< number of shell elements (global)
+      INTEGER  , INTENT(IN) ::  NUMELT      !< number of truss elements (global)
+      INTEGER  , INTENT(IN) ::  NUMELP      !< number of beam elements (global)
+      INTEGER  , INTENT(IN) ::  NUMELR      !< number of spring elements (global)
+      INTEGER  , INTENT(IN) ::  NUMELTG      !< number of shell3n elements (global)
+
+      INTEGER  , INTENT(IN) :: IDEL_SOLID   !< solid eroosion flag
+      INTEGER  , INTENT(IN) :: IELEM_M(2,NRTM) !< elements connected to main segments 
+      INTEGER  , INTENT(IN) :: TAG_SEG(NRTM_L)   !< local seg to global segement
+      INTEGER  , INTENT(IN) :: CEP(*),CEL(*)     !< arrays of proc of elements and local number of element
+      INTEGER  , INTENT(IN) :: MVOISIN(4,NRTM)   !< neighbhoors of main segments 
+      INTEGER  , INTENT(INOUT) :: PROC_MVOISIN(4,NRTM) !< procs of neighbhoors of main segments : to be build
+      TYPE(INTERSURFP)     :: INTERCEP !< procs of main segments
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,J,K,GLOB,IE1,IEL1,IE2,IEL2,N
+      INTEGER :: OFFSET_SHELL,OFFSET_SHELL3N
       INTEGER, DIMENSION(:),ALLOCATABLE :: IBUF1,IBUF3
 C ----------------------------------------
       ALLOCATE(IBUF1(2*NRTM_L))
       ALLOCATE(IBUF3(4*NRTM_L))
       IBUF1(1:2*NRTM_L) = 0
       IF(IDEL_SOLID > 0) IBUF3(1:4*NRTM_L) = 0
-
+      OFFSET_SHELL=NUMELS+NUMELQ
+      OFFSET_SHELL3N=OFFSET_SHELL+NUMELC+NUMELT+NUMELP+NUMELR
+      ! ---------------------
+      ! loop over the segment of the currect proc
+      ! a segment can be connected to :
+      !  * a solid --> no offset
+      !  * a shell --> offset = global number of solid+quad, ielem_ m = local shell id + offset
+      !  * a shell 3n --> offset = global number of solid+quad+shell+truss+beam+spring ielem_ m = local shell3n id + offset
       DO I=1, NRTM_L
-        K=TAG_SEG(I)
-        IE1 = IELEM_M(1,K)
-        IF(IE1 <= NUMELS) THEN ! distinguish case solid or not
+        K=TAG_SEG(I) ! get the segment id
+        IE1 = IELEM_M(1,K) ! get the element id (element of the segment)
+        ! ----------------
+        ! convert the global element id to local element id (local to the processor)
+        IF(IE1 <= NUMELS) THEN ! segment is connected to a solid
            IEL1 = CEL(IE1)
-        ELSE
-          IEL1 = NUMELS+CEL(IE1)
+        ELSEIF(OFFSET_SHELL<IE1.AND.IE1<=OFFSET_SHELL+NUMELC) THEN  ! segment is connected to a shell
+          IEL1 = OFFSET_SHELL+CEL(IE1)
+        ELSEIF(OFFSET_SHELL3N<IE1.AND.IE1<=OFFSET_SHELL3N+NUMELTG) THEN ! segment is connected to a shell3n
+          IEL1 = OFFSET_SHELL3N+CEL(IE1)
         ENDIF
+        ! ----------------
         IE2 = IELEM_M(2,K)
         IEL2 = 0
         IF(IE2 > 0) THEN
@@ -91,25 +114,24 @@ C ----------------------------------------
           ENDIF        
         ENDIF 
       ENDDO
-
-        DO I = 1, NRTM        
-           DO J = 1,4
-              K = MVOISIN(J,I)
-              IF(K /= 0) PROC_MVOISIN(J,I) = INTERCEP%P(K)
-           ENDDO
+      ! ---------------------
+      DO I = 1, NRTM        
+        DO J = 1,4
+          K = MVOISIN(J,I)
+          IF(K /= 0) PROC_MVOISIN(J,I) = INTERCEP%P(K)
         ENDDO
-        DO I = 1, NRTM_L         
-           K=TAG_SEG(I)
-           DO J = 1,4
-             N = MVOISIN(J,K)
-             IF(N /= 0) IBUF3(4*(I-1)+J) = PROC_MVOISIN(J,K)
-           ENDDO
-       ENDDO
+      ENDDO
+      DO I = 1, NRTM_L         
+        K=TAG_SEG(I)
+        DO J = 1,4
+          N = MVOISIN(J,K)
+          IF(N /= 0) IBUF3(4*(I-1)+J) = PROC_MVOISIN(J,K)
+        ENDDO
+      ENDDO
       
       CALL WRITE_I_C(IBUF1,2*NRTM_L)
       CALL WRITE_I_C(IBUF3,4*NRTM_L)
 
-!     WRITE(6,*) __FILE__,__LINE__,IBUF(1)
       DEALLOCATE(IBUF1)
       DEALLOCATE(IBUF3)
 


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
2 issues : 
* coating shell elements were not compatible with the erosion of solid element of the interface /TYPE25
* orientation of segment of wrapped elements can lead to bad numerical response 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
To support coating shell element : 
 * ielem_m array contains element ID (solid, shell or shell3n)
 * the element id are shifted : 0 for solid, NUMELS+NUMELQ for shell, NUMELS+NUMELQ+NUMELC+NUMELR+NUMELT+NUMELP 
 * the "real" element id is found thanks to this shift

Orientation : 
Orientations of all segments were computed. Now only the orientation of new active segments is computed

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
