### PR TITLE
not initialized variable for isolid=24 with distortion control

### DIFF
--- a/engine/source/elements/solid/solidez/szhour_ctl.F
+++ b/engine/source/elements/solid/solidez/szhour_ctl.F
@@ -165,6 +165,8 @@ C
       IF(((ANIM_N(IAD_GPS+400+1) == 1) .OR. (ANIM_N(IAD_GPS+400+2) == 1) .OR. 
      .   (ANIM_N(IAD_GPS+400+3) == 1) .OR. (ANIM_N(IAD_GPS+400+4) == 1) .OR. 
      .   (ANIM_N(IAD_GPS+400+5) == 1) .OR. (ANIM_N(IAD_GPS+400+6) == 1)) )THEN
+        MX = MAT(1)
+        NU=PM(21,MX)
         NU1 =TWO/(ONE-NU)
        DO I=1,NEL
         JR_1(I) = ONE/MAX(EM20,JR(I))


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
might get wrong gpstrain output value due to not initialized variable nu for isolid=24 with distortion control

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
fix not initialized variable issue

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
