### PR TITLE
Argument and Intent mismatch:

### DIFF
--- a/engine/source/elements/forintp.F
+++ b/engine/source/elements/forintp.F
@@ -160,7 +160,7 @@ C-----------------------------------------------
       TYPE(OUTPUT_), INTENT(INOUT) :: OUTPUT !< output structure
       TYPE (MAT_ELEM_) ,INTENT(INOUT) :: MAT_ELEM
       TYPE (DT_), INTENT(IN) :: DT
-      type(glob_therm_)  ,intent(in)    :: glob_therm
+      type(glob_therm_)  ,intent(inout)    :: glob_therm
       TYPE (SPH_WORK_),INTENT(INOUT) :: SPH_WORK
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s

--- a/engine/source/mpi/spmd_mod.F90
+++ b/engine/source/mpi/spmd_mod.F90
@@ -251,12 +251,16 @@
           integer, intent(in) :: tag !< Tag of the the MPI call
           integer, intent(in) :: ierr !< error of the MPI call
 ! ----------------------------------------------------------------------------------------------------------------------
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Local variables
+! ----------------------------------------------------------------------------------------------------------------------
+          integer :: ierror
 !                                                   Body
 ! ----------------------------------------------------------------------------------------------------------------------
 #ifdef MPI
           if(ierr /= MPI_SUCCESS) then
             write(6,*) 'MPI error: ', ierr,' at ',tag
-            call MPI_Abort(MPI_COMM_WORLD, ierr)
+            call MPI_Abort(MPI_COMM_WORLD, ierr,ierror)
           end if
 #ifdef DEBUG_SPMD
           write(6,*) 'Exiting MPI call: ', tag

--- a/starter/source/materials/mat/write_eosparam.F90
+++ b/starter/source/materials/mat/write_eosparam.F90
@@ -105,7 +105,7 @@
       IF (EOS%NTABLE > 0) THEN
         LENI=0
         LENR=0
-        CALL WRITE_MAT_TABLE(EOS%TABLE, NUMTABL, LENI, LENR)
+        CALL WRITE_MAT_TABLE(EOS%TABLE, NUMTABL)
       END IF
 !-----------
       RETURN

--- a/starter/source/materials/mat/write_matparam.F
+++ b/starter/source/materials/mat/write_matparam.F
@@ -144,7 +144,7 @@ C=======================================================================
       DO IMAT = 1,NUMMAT
         NUMTABL = MAT_ELEM%MAT_PARAM(IMAT)%NTABLE
         IF (NUMTABL > 0) THEN
-          CALL WRITE_MAT_TABLE(MAT_ELEM%MAT_PARAM(IMAT)%TABLE, NUMTABL, LENI, LENR)
+          CALL WRITE_MAT_TABLE(MAT_ELEM%MAT_PARAM(IMAT)%TABLE, NUMTABL)
           LEN = LEN + LENI + LENR
         END IF
       END DO

--- a/starter/source/materials/mat/write_viscparam.F
+++ b/starter/source/materials/mat/write_viscparam.F
@@ -96,7 +96,7 @@ c     write viscosity law tables if necessary
 c
       NUMTABL  = VISC%NTABLE
       IF (NUMTABL > 0) THEN
-        CALL WRITE_MAT_TABLE(VISC%TABLE, NUMTABL, LENI,  LENR)
+        CALL WRITE_MAT_TABLE(VISC%TABLE, NUMTABL)
         LEN = LEN + NFIX + LENI + LENR
       END IF
 c-----------


### PR DESCRIPTION
GLOB_THERM argument must be intent(inout) as it can be modifed in downstream routines 
Missing argument to MPI_ABORT Call
starter argument mismatch at write_mat_table.F

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
