### PR TITLE
INIVOL 2d : manage superellipse and infinite plane with polygonal clipping method

### DIFF
--- a/starter/share/modules1/inivol_mod.F
+++ b/starter/share/modules1/inivol_mod.F
@@ -63,8 +63,6 @@ C-----------------------------------------------
           INTEGER   :: IREVERSED ! Filling option parameter for filling action (inside or outside the container) 
                        ! 0 ! filling the side along normal direction 
                        ! 1 ! filling the side against normal direction
-          LOGICAL   :: REQUIRED_MONTE_CARLO_METHOD
-          LOGICAL   :: REQUIRED_2D_POLYGON_CLIPPING
         END TYPE CONTAINER_
         
 C-----------------------------------------------
@@ -75,9 +73,8 @@ C-----------------------------------------------
           INTEGER :: PART_ID
           INTEGER :: SIZE
           INTEGER :: NUM_CONTAINER
-          LOGICAL :: REQUIRED_MONTE_CARLO_METHOD   !set to true if at least one container is using this method
-          LOGICAL :: REQUIRED_2D_POLYGON_CLIPPING  !set to true if at least one container is using this method
           TYPE (CONTAINER_) ,DIMENSION(:) ,ALLOCATABLE :: CONTAINER
+          my_real :: XYZ(6) !global min,max
         END TYPE INIVOL_STRUCT_
 
 C-----------------------------------------------

--- a/starter/source/initial_conditions/inivol/ale_box_coloration.F
+++ b/starter/source/initial_conditions/inivol/ale_box_coloration.F
@@ -78,7 +78,6 @@ C-----------------------------------------------
         INTEGER :: LOW_Z,UP_Z
         my_real :: XMIN,YMIN,ZMIN
         my_real :: XMAX,YMAX,ZMAX
-        LOGICAL :: REQUIRED_MONTE_CARLO_METHOD
 C-----------------------------------------------
 
         !   ------------------
@@ -93,8 +92,6 @@ C-----------------------------------------------
         !   ------------------
         ! loop over the surface
         DO I=1,SURFACE_NUMBER
-            REQUIRED_MONTE_CARLO_METHOD = INIVOL%CONTAINER(I)%REQUIRED_MONTE_CARLO_METHOD
-            IF(.NOT.REQUIRED_MONTE_CARLO_METHOD)CYCLE
             ! ------------------
             ! allocation of CELL array
             CELL(I)%SIZE_INT_ARRAY_3D(1) = NB_CELL_X

--- a/starter/source/initial_conditions/inivol/hm_read_inivol.F90
+++ b/starter/source/initial_conditions/inivol/hm_read_inivol.F90
@@ -114,8 +114,6 @@ contains
       character(len=ncharline) :: outp_msg
       logical is_encrypted,is_available
       logical detected_error
-      logical :: required_2d_polygon_clipping ! 2d polygons
-      logical :: required_monte_carlo_method  ! 3d discretized surface, infinita plane, ellipsoids
 !-----------------------------------------------
 !   c o m m e n t s
 !-----------------------------------------------
@@ -201,8 +199,6 @@ contains
          inivol(igs)%title = titr(1:len_trim(titr))
          inivol(igs)%num_container = nlin
          inivol(igs)%part_id = part_id
-         inivol(igs)%required_monte_carlo_method = .false.
-         inivol(igs)%required_2d_polygon_clipping = .false.
          allocate(inivol(igs)%container(nlin))
 
          write(iout, '(A)') "     surf_ID SUBMAT_ID IREVERSED     ICUMU               VFRAC"
@@ -280,8 +276,6 @@ contains
                   enddo
                endif
 
-               required_2d_polygon_clipping = .false.
-               required_monte_carlo_method = .false.
                if(isu > 0 .and. nn > 1 .and. n2d /= 0)then
                   !test surface closure (closed polygon)
                   if(igrsurf(isu)%nodes(1,1) /= igrsurf(isu)%nodes(nn,2)) then
@@ -298,9 +292,7 @@ contains
                   if(detected_error)then
                      call ancmsg(msgid=3064,msgtype=msgerror,anmode=aninfo,i1=id,i2=igrsurf(isu)%id,c1=titr)
                   endif
-                  required_2d_polygon_clipping = .true.
                elseif(isu > 0)then
-                  required_monte_carlo_method = .true.
                   if(isu > 0 .and. nn <= 2 .and. n2d /= 0 .and. srftyp == 0)then
                      call ancmsg(msgid=3064,msgtype=msgerror,anmode=aninfo,i1=id,i2=igrsurf(isu)%id,c1=titr) !not enough points to define a polygon
                   endif
@@ -311,10 +303,6 @@ contains
                inivol(igs)%container(kk)%ireversed = ireversed
                inivol(igs)%container(kk)%vfrac = int(vfrac*ep9)
                inivol(igs)%container(kk)%icumu = icumu
-               inivol(igs)%container(kk)%required_monte_carlo_method = required_monte_carlo_method
-               inivol(igs)%container(kk)%required_2d_polygon_clipping = required_2d_polygon_clipping
-               if(required_monte_carlo_method)  inivol(igs)%required_monte_carlo_method = .true.
-               if(required_2d_polygon_clipping) inivol(igs)%required_2d_polygon_clipping = .true.
 !
                if(n2d == 0 .and. fac == 0)then
                   call ancmsg(msgid=890,msgtype=msgerror,anmode=aninfo,i1=id,c1=titr)

--- a/starter/source/initial_conditions/inivol/inivol_set.F
+++ b/starter/source/initial_conditions/inivol/inivol_set.F
@@ -28,8 +28,8 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    message_mod          ../starter/share/message_module/message_mod.F
       !||====================================================================
       SUBROUTINE INIVOL_SET(UVAR     , NUVAR , NEL     , KVOL         , MLW                         ,
-     .                      ELBUF_TAB, NG    , NBSUBMAT, MULTI_FVM    , REQUIRED_2D_POLYGON_CLIPPING,
-     .                      IDP      , IPART , NFT     , KVOL_2D_POLYG, IMID,
+     .                      ELBUF_TAB, NG    , NBSUBMAT, MULTI_FVM    ,
+     .                      IDP      , IPART , NFT     , IMID,
      .                      MAT_PARAM)
 C-----------------------------------------------
 C   M o d u l e s
@@ -56,11 +56,9 @@ C-----------------------------------------------
       INTEGER,INTENT(IN)                 :: IMID
       INTEGER,INTENT(IN)                 :: NEL, NUVAR, MLW, NG, NBSUBMAT,IDP,IPART(*),NFT
       my_real,INTENT(INOUT)              :: KVOL(NBSUBMAT,NEL)
-      my_real,INTENT(INOUT)              :: KVOL_2D_POLYG(NBSUBMAT,NEL)
       my_real,INTENT(INOUT)              :: UVAR(NEL,NUVAR)
       TYPE(MULTI_FVM_STRUCT),INTENT(IN)  :: MULTI_FVM
       TYPE(ELBUF_STRUCT_), TARGET, DIMENSION(NGROUP),INTENT(INOUT) :: ELBUF_TAB
-      LOGICAL,INTENT(IN) :: REQUIRED_2D_POLYGON_CLIPPING
       TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(IN) :: MAT_PARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
@@ -78,15 +76,6 @@ C-----------------------------------------------
       ! DETERMINE DEFAULT SUBMAT ID
       vfrac0(1:nbsubmat) = MAT_PARAM(IMID)%MULTIMAT%VFRAC(1:NBSUBMAT)
       default_SUBMAT_id(1:NEL) = MAX(1, MAXLOC(vfrac0,1))
-
-      !---ADD CONTRIBUTION FROM 2D POLYGONAL CLIPPING
-      IF(REQUIRED_2D_POLYGON_CLIPPING) THEN
-        DO I=1,NEL
-          DO IMAT=1,NBSUBMAT
-            KVOL(IMAT,I) = KVOL(IMAT,I) + KVOL_2D_POLYG(IMAT,I)
-          ENDDO
-        ENDDO
-      ENDIF
 
       !---CHECK UNOCCUPIPED SUBVOLUME AND FILL WITH DEFAULT PHASE IF SUM(vfrac>1) display an error message.
       DO I=1,NEL

--- a/starter/source/initial_conditions/inivol/surface_min_max_computation.F
+++ b/starter/source/initial_conditions/inivol/surface_min_max_computation.F
@@ -58,16 +58,14 @@ C-----------------------------------------------
         INTEGER :: I,J,K
         INTEGER :: SURFACE_ID,SURFACE_NODE_NUMBER,SURFACE_TYPE
         INTEGER :: NODE_ID
-        LOGICAL :: REQUIRED_MONTE_CARLO_METHOD
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
         DO I=1,SURFACE_NUMBER
           SURFACE_ID = INIVOL%CONTAINER(I)%SURF_ID ! surface id
-          REQUIRED_MONTE_CARLO_METHOD = INIVOL%CONTAINER(I)%REQUIRED_MONTE_CARLO_METHOD
           SURFACE_NODE_NUMBER = IGRSURF(SURFACE_ID)%NSEG ! number of segment of the surface
           SURFACE_TYPE = IGRSURF(SURFACE_ID)%TYPE ! type of surface
-          IF(SURFACE_TYPE /= 200 .AND. SURFACE_TYPE /= 101 .AND. REQUIRED_MONTE_CARLO_METHOD) THEN
+          IF(SURFACE_TYPE /= 200 .AND. SURFACE_TYPE /= 101) THEN
             DO J=1,4
               DO K=1,SURFACE_NODE_NUMBER
                 NODE_ID = IGRSURF(SURFACE_ID)%NODES(K,J)


### PR DESCRIPTION
#### INIVOL 2d : manage superellipse and infinite plane with polygonal clipping method


#### Description of the changes
The INIVOL option calculates the initial volume fraction by filling submaterial fractions based on the user-defined surface. Recently, polygon clipping was introduced to handle user-defined surfaces in 2D (polygons)

With this update, polygon clipping now also manages super-ellipses (/SURF/ELLIPS) and infinite planes (/SURF/PLANE), replacing the previous method (Monte Carlo) for these shapes.

#### Numercial changes : 
_This change improves the precision of the calculations, as the clipping method is more accurate than the legacy Monte Carlo method. As a result, you may notice slight changes in the numerical solution when using super-ellipses or infinite planes, as the new clipping method offers better precision._
_(No difference to expect if /INIVOL option is not use with /SURF/ELLIPS or /SURF/PLANE)_
