### PR TITLE
Compute global initial stack thickness for composite property in Radioss starter

### DIFF
--- a/starter/source/properties/composite_options/stack/lecstack_ply.F
+++ b/starter/source/properties/composite_options/stack/lecstack_ply.F
@@ -260,6 +260,8 @@ C
         IGTYP=IGEO_STACK(11,I)
         NUMS= NUMGEO_STACK(NUMGEO + I)
         IF(IGTYP == 52) THEN
+          ! Initialization of stack thickness
+          GEO_STACK(1,I) = ZERO
           !--- generalizing ZSHIFT ! kepp only IPOS= 2 as before
           IPOS =IGEO_STACK(99,I) 
           ZSHIFT = GEO_STACK(199, I)
@@ -289,6 +291,8 @@ C tag if the ply is in the  stack
      .                    I1=IGEO_STACK(1,NUMSTACK + K), I2= IGEO_STACK(1,IDS), I3= IGEO_STACK(1,I),
      .                    C1=TITR1, C2='PLY')
                     ENDIF
+C update stack thicness
+                    GEO_STACK(1,I) = GEO_STACK(1,I) + GEO_STACK(1,NUMSTACK + K)
                   lFOUND = .TRUE.
                   EXIT
                 ENDIF

--- a/starter/source/properties/hm_read_properties.F
+++ b/starter/source/properties/hm_read_properties.F
@@ -650,6 +650,8 @@ C
         IGTYP=IGEO(11,CPT)
         NUMS= NUMGEO_STACK(CPT)
         IF (IGTYP == 17 .OR. IGTYP == 51 ) THEN
+          ! Initialization of stack thickness
+          GEO(1,CPT) = ZERO
 C--- generalizing ZSHIFT ! kepp only IPOS= 2 as before
           IPOS =IGEO(99,CPT) 
           ZSHIFT = GEO(199, CPT)
@@ -676,6 +678,8 @@ C number of stack where ply is attached
                      IGEO(42   ,K) = NSTACK
 C stack whe e ply is belong                  
                      IGEO(200 + NSTACK ,K) = CPT
+C update ply thickness
+                     GEO(1,CPT) = GEO(1,CPT) + GEO(1,K)
                      GOTO 100
                    ENDIF
                  ENDDO


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

There was a need to be able to compute the initial thickness of the whole stack of plies for composites properties. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Add the computation of the initial stack thickness for properties type 17/51/52

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
