### PR TITLE
/TETRA10 + /RBODY: starter segfault for SPMD

### DIFF
--- a/starter/source/spmd/domain_decomposition/grid2mat.F
+++ b/starter/source/spmd/domain_decomposition/grid2mat.F
@@ -1855,7 +1855,7 @@ C
                     I = LPBY(J+K)
                     DO IJK = ADSKY(I),ADSKY(I+1)-1
                         CC2 = IJK
-                        NUMG2 = CNE(CC2)
+                        NUMG2 = ABS(CNE(CC2))
                         NUMBER_OF_ELEMENT_RBODY = NUMBER_OF_ELEMENT_RBODY + 1
                         LIST_ELEMENT_RBODY( NUMBER_OF_ELEMENT_RBODY ) = NUMG2
                         BOOL_RBODY=.TRUE.
@@ -1865,7 +1865,7 @@ C
                 !   main node
                 DO IJK = ADSKY(M),ADSKY(M+1)-1
                     CC2 = IJK
-                    NUMG2 = CNE(CC2)
+                    NUMG2 = ABS(CNE(CC2))
                     NUMBER_OF_ELEMENT_RBODY = NUMBER_OF_ELEMENT_RBODY + 1
                     LIST_ELEMENT_RBODY( NUMBER_OF_ELEMENT_RBODY ) = NUMG2
                 ENDDO


### PR DESCRIPTION


#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Segfault when small rigid bodies are attached to tetra10 middle nodes

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
