### PR TITLE
OneAPI 2025, missing openmp flag in Linux debug version

### DIFF
--- a/starter/CMake_Compilers/cmake_linux64_intel_ifx.txt
+++ b/starter/CMake_Compilers/cmake_linux64_intel_ifx.txt
@@ -85,7 +85,7 @@ if ( debug STREQUAL "1" )
   set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS " ${precision_flag} ${Tet_mesher_inc} ${cppmach} ${cpprel} -DCPP_comp=f90  -g -O0 -fp-model precise -qopenmp -ftz -extend-source -fpe0 -ftrapuv  -traceback ${ADF} " )
   
   # C source files
-  set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS " ${precision_flag} ${Tet_mesher_inc} ${cppmach} ${cpprel} ${zlib_inc} -O0 -g   -traceback " )
+  set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS " ${precision_flag} ${Tet_mesher_inc} ${cppmach} ${cpprel} ${zlib_inc} -O0 -g   -traceback -openmp " )
   
   # CXX source files
   set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS " ${precision_flag} ${Tet_mesher_inc} ${cppmach} ${cpprel} ${zlib_inc} -O0 -g  -O0 -traceback -std=c++11" )


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
OpenMP flag was missing in debug version


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
