### PR TITLE
Correction of hm_read_therm_stress to F90 format

### DIFF
--- a/starter/source/materials/therm/hm_read_therm.F
+++ b/starter/source/materials/therm/hm_read_therm.F
@@ -177,9 +177,6 @@ c--------------------------------------------------
             CALL ANCMSG(MSGID=765, MSGTYPE=MSGWARNING, ANMODE=ANINFO_BLIND_1,
      &                  I1=MAT_ID, C3=TITR, I2=MAT_ID, I3=MAT_ID)
           ENDIF
-          IF (RHO_CP == ZERO) RHO_CP = PM(69,IMAT)  ! MAT_PARAM(IMAT)%THERM%RHOCP
-          IF (TREF   == ZERO) TREF   = PM(79,IMAT)  ! MAT_PARAM(IMAT)%THERM%T0
-          IF (TMELT  == ZERO) TMELT  = PM(80,IMAT)  ! MAT_PARAM(IMAT)%THERM%TMELT
 c--------------------------------------------------
 c       Specific Case : law73
 c--------------------------------------------------

--- a/starter/source/materials/therm/hm_read_therm_stress.F90
+++ b/starter/source/materials/therm/hm_read_therm_stress.F90
@@ -100,26 +100,26 @@
 !     count eos models using cfg files
 !--------------------------------------------------
 !      
-      call hm_option_count('/therm_stress',ntherm_st)
+      call hm_option_count('/THERM_STRESS',ntherm_st)
 !
 !--------------------------------------------------
 !     start browsing /therm_stress models
 !--------------------------------------------------
 !
-      call hm_option_start('/therm_stress')
+      call hm_option_start('/THERM_STRESS')
 !
 !--------------------------------------------------
       do ith = 1,ntherm_st
 !
         call hm_option_read_key(lsubmodel, option_id = mat_id , option_titr = titr , keyword2 = key )
 
-        if (key(1:3) == 'mat') then   
-          call hm_get_intv  ('funct_id'      ,ifunc_alpha    ,is_available, lsubmodel) 
-          call hm_get_floatv('cload_scale_y' ,fscal_alpha    ,is_available, lsubmodel, unitab)
+        if (key(1:3) == 'MAT') then   
+          call hm_get_intv  ('FUNCT_ID'      ,ifunc_alpha    ,is_available, lsubmodel) 
+          call hm_get_floatv('CLOAD_SCALE_Y' ,fscal_alpha    ,is_available, lsubmodel, unitab)
 
           if (fscal_alpha == zero) fscal_alpha=one
           do imat=1,nummat-1
-            if (mat_id == mat_param(i)%mat_id) then
+            if (mat_id == mat_param(imat)%mat_id) then
               titr = mat_param(imat)%title
               ilaw = mat_param(imat)%ilaw
               jthe = mat_param(imat)%itherm


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

/THERM_STRESS option was not treated correctly

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

correction of keyword formats
revert default thermal parameters for material law 2 to be conform with actual documentation

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
