### PR TITLE
Fix typos in hm_config directory

### DIFF
--- a/hm_cfg_files/config/CFG/Keyword971/CONTACT/BoundFluxSet.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/CONTACT/BoundFluxSet.cfg
@@ -61,7 +61,7 @@ GUI(COMMON)
     {
         ADD(0, "None");
         ADD(1, "Function versus time");
-        ADD(2, "Function versus tempreture");
+        ADD(2, "Function versus temperature");
     }
     if(tensileStressCurveFlag == 1 || tensileStressCurveFlag == 2)
     {

--- a/hm_cfg_files/config/CFG/Keyword971/MAT/mat_034.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/MAT/mat_034.cfg
@@ -269,7 +269,7 @@ GUI(COMMON)
     RADIO(LSD_MAT_CSE)
     {
         ADD(0.0, "0.0: Don't eliminate compressive stresses (default)");
-        ADD(1.0, "1.0: Eleiminate compressive stresses, doesnt apply to linear");
+        ADD(1.0, "1.0: Eliminate compressive stresses, doesnt apply to linear");
     }
     SCALAR(LSD_MAT_EL)                  {DIMENSION="pressure";}
     SCALAR(LSD_MAT_PRL)                 {DIMENSION="DIMENSIONLESS";}

--- a/hm_cfg_files/config/CFG/Keyword971_R10.1/MAT/mat_034.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R10.1/MAT/mat_034.cfg
@@ -279,7 +279,7 @@ GUI(COMMON)
     RADIO(LSD_MAT_CSE)
     {
         ADD(0.0, "0.0: Don't eliminate compressive stresses (default)");
-        ADD(1.0, "1.0: Eleiminate compressive stresses, doesnt apply to linear");
+        ADD(1.0, "1.0: Eliminate compressive stresses, doesn't apply to linear");
     }
     SCALAR(LSD_MAT_EL)                  {DIMENSION="pressure";}
     SCALAR(LSD_MAT_PRL)                 {DIMENSION="DIMENSIONLESS";}

--- a/hm_cfg_files/config/CFG/Keyword971_R11.1/MAT/mat_034.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R11.1/MAT/mat_034.cfg
@@ -294,7 +294,7 @@ GUI(COMMON)
     RADIO(LSD_MAT_CSE)
     {
         ADD(0.0, "0.0: Don't eliminate compressive stresses (default)");
-        ADD(1.0, "1.0: Eleiminate compressive stresses, doesnt apply to linear");
+        ADD(1.0, "1.0: Eliminate compressive stresses, doesn't apply to linear");
     }
     SCALAR(LSD_MAT_EL)                  {DIMENSION="pressure";}
     SCALAR(LSD_MAT_PRL)                 {DIMENSION="DIMENSIONLESS";}

--- a/hm_cfg_files/config/CFG/Keyword971_R13.0/CONTACT/contact_airbag_single_surface.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R13.0/CONTACT/contact_airbag_single_surface.cfg
@@ -506,7 +506,7 @@ optional:
      
      RADIO(SRNDE)
      {
-       ADD(0, "Free edges have their usual treatement");
+       ADD(0, "Free edges have their usual treatment");
        ADD(1, "Free edges are rounded, but without extending them");
      }
   }

--- a/hm_cfg_files/config/CFG/Keyword971_R13.0/ELEMENTS/element_seatbelt_slipring.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R13.0/ELEMENTS/element_seatbelt_slipring.cfg
@@ -26,7 +26,7 @@ ATTRIBUTES(COMMON)
     SBID1_SHELL = VALUE(SETS, "Seatbelt element 1");
     SBID2       = VALUE(ELEMS, "Seatbelt element 2");
     SBID2_SHELL = VALUE(SETS, "Seatbelt element 1");
-    FC_FLAG     = VALUE(INT, "Dynamic friction coefficent depending on time") ;
+    FC_FLAG     = VALUE(INT, "Dynamic friction coefficient depending on time") ;
     FC          = VALUE(FLOAT,"Coulomb dynamic friction coefficient");	
     FC_FUNC     = VALUE(FUNCT,"Dynamic friction coefficient vs time") ;
     SBRNID_FLAG = VALUE(INT, "Way to define SBRNID, SBID1 and SBID2");
@@ -34,7 +34,7 @@ ATTRIBUTES(COMMON)
     SBRNID      = VALUE(NODE,"Slipring node");
     SBRNID_NODES= VALUE(SETS,"Slipring node set");
     LTIME       = VALUE(FLOAT,"Slipring lock up time");
-    FCS_FLAG    = VALUE(INT, "Static friction coefficent depending on time") ;
+    FCS_FLAG    = VALUE(INT, "Static friction coefficient depending on time") ;
     FCS         = VALUE(FLOAT,"Static coulomb dynamic friction coefficient");
     FCS_FUNC    = VALUE(FUNCT,"Static friction coefficient vs time") ;
     ONID        = VALUE(NODE, "Orientation Node") ;

--- a/hm_cfg_files/config/CFG/Keyword971_R13.0/SAFETY/element_seatbelt_pretensioner.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R13.0/SAFETY/element_seatbelt_pretensioner.cfg
@@ -70,7 +70,7 @@ GUI(COMMON) {
 	 ADD(2,"Pre-loaded spring bcomes active");
    ADD(3,"Lock spring removed");
    ADD(4,"Force versus pretensioner_time retractor");
-   ADD(5,"Pyrotechnic retractor (old type in version 950) but wilh optional force limiter, limitingforce");
+   ADD(5,"Pyrotechnic retractor (old type in version 950) but with optional force limiter, limitingforce");
 	 ADD(6,"Combination of types 4 and 5");
 	 ADD(7,"Independent pretensioner/retractor");
 	 ADD(8,"Energy versus pretensioner_time retractor pretensioner with optional force limiter");

--- a/hm_cfg_files/config/CFG/Keyword971_R7.1/MAT/mat_021.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R7.1/MAT/mat_021.cfg
@@ -306,17 +306,17 @@ optional:
     FUNCTION(MATL21_LCAA)
     {
       X_TITLE = "Temperature"; X_DIMENSION = "k";
-      Y_TITLE = "Coef of thermal expension"; Y_DIMENSION = "e";
+      Y_TITLE = "Coef of thermal expansion"; Y_DIMENSION = "e";
     }
     FUNCTION(MATL21_LCAB)
     {
       X_TITLE = "Temperature"; X_DIMENSION = "k";
-      Y_TITLE = "Coef of thermal expension"; Y_DIMENSION = "e";
+      Y_TITLE = "Coef of thermal expansion"; Y_DIMENSION = "e";
     }        
     FUNCTION(MATL21_LCAC)
     {
       X_TITLE = "Temperature"; X_DIMENSION = "k";
-      Y_TITLE = "Coef of thermal expension"; Y_DIMENSION = "e";
+      Y_TITLE = "Coef of thermal expansion"; Y_DIMENSION = "e";
     }
 
     }

--- a/hm_cfg_files/config/CFG/Keyword971_R8.0/MAT/mat_034.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R8.0/MAT/mat_034.cfg
@@ -276,7 +276,7 @@ GUI(COMMON)
     RADIO(LSD_MAT_CSE)
     {
         ADD(0.0, "0.0: Don't eliminate compressive stresses (default)");
-        ADD(1.0, "1.0: Eleiminate compressive stresses, doesnt apply to linear");
+        ADD(1.0, "1.0: Eliminate compressive stresses, doesn't apply to linear");
     }
     SCALAR(LSD_MAT_EL)                  {DIMENSION="pressure";}
     SCALAR(LSD_MAT_PRL)                 {DIMENSION="DIMENSIONLESS";}

--- a/hm_cfg_files/config/CFG/Keyword971_R8.0/MAT/mat_034M.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R8.0/MAT/mat_034M.cfg
@@ -339,7 +339,7 @@ GUI(COMMON)
     RADIO(LSD_MAT_CSE)
     {
         ADD(0.0, "0.0: Don't eliminate compressive stresses (default)");
-        ADD(1.0, "1.0: Eleiminate compressive stresses, doesnt apply to linear");
+        ADD(1.0, "1.0: Eliminate compressive stresses, doesn't apply to linear");
     }
     DATA(LSD_SRFAC);
     SCALAR(LSD_BULKC);

--- a/hm_cfg_files/config/CFG/Keyword971_R9.0/MAT/mat_021.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R9.0/MAT/mat_021.cfg
@@ -315,17 +315,17 @@ optional:
     FUNCTION(MATL21_LCAA)
     {
       X_TITLE = "Temperature"; X_DIMENSION = "k";
-      Y_TITLE = "Coef of thermal expension"; Y_DIMENSION = "e";
+      Y_TITLE = "Coef of thermal expansion"; Y_DIMENSION = "e";
     }
     FUNCTION(MATL21_LCAB)
     {
       X_TITLE = "Temperature"; X_DIMENSION = "k";
-      Y_TITLE = "Coef of thermal expension"; Y_DIMENSION = "e";
+      Y_TITLE = "Coef of thermal expansion"; Y_DIMENSION = "e";
     }        
     FUNCTION(MATL21_LCAC)
     {
       X_TITLE = "Temperature"; X_DIMENSION = "k";
-      Y_TITLE = "Coef of thermal expension"; Y_DIMENSION = "e";
+      Y_TITLE = "Coef of thermal expansion"; Y_DIMENSION = "e";
     }
 
     }

--- a/hm_cfg_files/config/CFG/radioss110/CARDS/eng_rfile.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/CARDS/eng_rfile.cfg
@@ -21,7 +21,7 @@ ATTRIBUTES(COMMON)
 {
     //INPUT ATTRIBUTES
     ENG_RFILE_DEFAULT   = VALUE(INT,"Flag for RFILE DEFAULT","DEFAULT");
-    ENG_RFILE_n         = VALUE(INT,"Cycle frequecy to write R-file","Ncycle");
+    ENG_RFILE_n         = VALUE(INT,"Cycle frequency to write R-file","Ncycle");
     ENG_RFILE_nCycle    = VALUE(INT,"Flag for RFILE_n","RFILE_n");
     NUM1                = VALUE(INT,"Number of restart files to be written","n");
     NUM2                = VALUE(INT,"Cycle frequency to write R-file","Ncycle");

--- a/hm_cfg_files/config/CFG/radioss110/FAIL/fail_tab.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/FAIL/fail_tab.cfg
@@ -24,7 +24,7 @@ ATTRIBUTES(COMMON){
 
 	Ifail_sh			= VALUE( INT,   "Shell flag");
 	Ifail_so			= VALUE( INT,   "Solid flag");
-	N_rate				= SIZE("Number of strain rate dependant functions defining failure strain");
+	N_rate				= SIZE("Number of strain rate dependent functions defining failure strain");
 	P_thickfail			= VALUE( FLOAT, "Percent of thickness failure limit");
     
 	Dcrit				= VALUE( FLOAT, "Critical accumulated damage value");

--- a/hm_cfg_files/config/CFG/radioss110/MAT/matl25_compsh.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/MAT/matl25_compsh.cfg
@@ -67,7 +67,7 @@ ATTRIBUTES(COMMON) {
     MAT_DAMm                = VALUE(FLOAT,"Maximum Damage");
     Fsmooth                 = VALUE(INT,  "Smooth Strain Rate Flag");
     Fcut                    = VALUE(FLOAT,"Cutoff Frequency for Strain Rate Filtering");
-    // Formulation dependant attributes
+    // Formulation dependent attributes
 /*    if(MAT_Iflag==0) */
 /*  {*/ // Standard formulation
         MAT_BETA            = VALUE(FLOAT,"Hardening Parameter");

--- a/hm_cfg_files/config/CFG/radioss110/PROP/prop_p17_stack.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/PROP/prop_p17_stack.cfg
@@ -161,7 +161,7 @@ GUI(COMMON)
     RADIO(Ismstr)
     {
         ADD(0, "0:Use Value in /DEF_SHELL.");
-        ADD(1, "1:Small Strain fro  Time=0.");
+        ADD(1, "1:Small Strain from Time=0.");
         ADD(2, "2:Full Geometric Nonlinearities with Possible Small Strain Formulation Activation in RADIOSS Engine.");
         ADD(3, "3:Old Small Strain Formulation.");
         ADD(4, "4:Full Geometric Nonlinearities.");

--- a/hm_cfg_files/config/CFG/radioss120/MAT/matl75_75.cfg
+++ b/hm_cfg_files/config/CFG/radioss120/MAT/matl75_75.cfg
@@ -35,7 +35,7 @@ ATTRIBUTES(COMMON)
     MAT_PPRES                               = VALUE(FLOAT, "Elastic Compact Pressure");
     MAT_YPRES                               = VALUE(FLOAT, "Solid Compact Pressure");
     MAT_EXP1                                = VALUE(FLOAT, "Exponent");
-    MAT_Tol                                 = VALUE(FLOAT, "Convergence Tolerance on a Calcultion");
+    MAT_Tol                                 = VALUE(FLOAT, "Convergence Tolerance on a Calculation");
     Heat_Inp_opt                            = VALUE(INT,   "Heat");  
     SUBGRP_HEAT_MAT                         = VALUE(SUBOBJECT, "");
     THERM_STRESS                            = VALUE(INT,"Therm Stress");

--- a/hm_cfg_files/config/CFG/radioss130/FAIL/fail_tab.cfg
+++ b/hm_cfg_files/config/CFG/radioss130/FAIL/fail_tab.cfg
@@ -24,7 +24,7 @@ ATTRIBUTES(COMMON){
 
     Ifail_sh            = VALUE( INT,   "Shell flag");
     Ifail_so            = VALUE( INT,   "Solid flag");
-    N_rate              = SIZE("Number of strain rate dependant functions defining failure strain");
+    N_rate              = SIZE("Number of strain rate dependent functions defining failure strain");
     P_thickfail         = VALUE( FLOAT, "Percent of thickness failure limit");
     Ixfem               = VALUE(INT, "XFEM flag (for /SHELL and /SH_SANDW properties only)");
     

--- a/hm_cfg_files/config/CFG/radioss140/LAMINATE/laminate.cfg
+++ b/hm_cfg_files/config/CFG/radioss140/LAMINATE/laminate.cfg
@@ -41,7 +41,7 @@ ATTRIBUTES(COMMON)
     Pply_IDt                                = VALUE(PLY,"");
     Pply_IDb                                = VALUE(PLY,"");
     Current_Phi_Zi                          = VALUE(INT,"");
-    _BLANK                                  = VALUE(STRING,"To consider balnk");
+    _BLANK                                  = VALUE(STRING,"To consider blank");
 }
 
 SKEYWORDS_IDENTIFIER(COMMON)

--- a/hm_cfg_files/config/CFG/radioss140/LOADS/impdisp_fgeo.cfg
+++ b/hm_cfg_files/config/CFG/radioss140/LOADS/impdisp_fgeo.cfg
@@ -88,7 +88,7 @@ GUI(COMMON)
     RADIO(distribution, "Spring Specification")
     {
         ADD(0, "0: Spring part selection");
-        ADD(1, "1: Final node posistions");
+        ADD(1, "1: Final node positions");
     }
 
     // Card

--- a/hm_cfg_files/config/CFG/radioss140/MAT/mat_law77.cfg
+++ b/hm_cfg_files/config/CFG/radioss140/MAT/mat_law77.cfg
@@ -67,7 +67,7 @@ ATTRIBUTES(COMMON)
     //FUN_A1                                    = VALUE(MULTIOBJECT,  "fct_IDK");
     //FUN_B1                                    = VALUE(MULTIOBJECT,  "fct_IDR");
     FUN_A1                                      = VALUE(FUNCT,"Permeability scale factor function");
-    FUN_B1                                      = VALUE(FUNCT,"Porosity scale factor finction");
+    FUN_B1                                      = VALUE(FUNCT,"Porosity scale factor function");
     Heat_Inp_opt                                = VALUE(INT,   "Heat");  
     SUBGRP_HEAT_MAT                             = VALUE(SUBOBJECT, "");
     THERM_STRESS                                = VALUE(INT,"Therm Stress");

--- a/hm_cfg_files/config/CFG/radioss140/MAT/matl25_compsh.cfg
+++ b/hm_cfg_files/config/CFG/radioss140/MAT/matl25_compsh.cfg
@@ -62,7 +62,7 @@ ATTRIBUTES(COMMON) {
     MAT_DAMm                    = VALUE(FLOAT,"Maximum Damage");
     Fsmooth                     = VALUE(INT,  "Smooth Strain Rate Flag");
     Fcut                        = VALUE(FLOAT,"Cutoff Frequency for Strain Rate Filtering");
-    // Formulation dependant attributes
+    // Formulation dependent attributes
     if(MAT_Iflag==0) 
     { // Standard formulation
         MAT_BETA                = VALUE(FLOAT,"Hardening Parameter");

--- a/hm_cfg_files/config/CFG/radioss140/PROP/prop_p17_stack.cfg
+++ b/hm_cfg_files/config/CFG/radioss140/PROP/prop_p17_stack.cfg
@@ -164,7 +164,7 @@ GUI(COMMON)
     RADIO(Ismstr)
     {
         ADD(0, "0:Use Value in /DEF_SHELL.");
-        ADD(1, "1:Small Strain fro  Time=0.");
+        ADD(1, "1:Small Strain from Time=0.");
         ADD(2, "2:Full Geometric Nonlinearities with Possible Small Strain Formulation Activation in RADIOSS Engine.");
         ADD(3, "3:Old Small Strain Formulation.");
         ADD(4, "4:Full Geometric Nonlinearities.");

--- a/hm_cfg_files/config/CFG/radioss140/PROP/prop_p51.cfg
+++ b/hm_cfg_files/config/CFG/radioss140/PROP/prop_p51.cfg
@@ -196,7 +196,7 @@ GUI(COMMON)
     RADIO(Ipos)
     {
        ADD(0, "0:Layer Positions are Automatically Calculated with Regard to Layer Thicknesses.");
-       ADD(1, "1:All Layer Positions in the Ellement Thickness are User-Defined.");
+       ADD(1, "1:All Layer Positions in the Element Thickness are User-Defined.");
        ADD(2, "2:The Shell Element Reference Plane is at Z0 from the Bottom Surface of the Shell.");
        ADD(3, "3:Top Surface of the Shell is Considered as Element Reference Plane.");
        ADD(4, "4:Bottom Surface of the Shell is Considered as Element Reference Plane.");

--- a/hm_cfg_files/config/CFG/radioss2017/CARDS/shfra.cfg
+++ b/hm_cfg_files/config/CFG/radioss2017/CARDS/shfra.cfg
@@ -43,7 +43,7 @@ FORMAT(radioss51)
 {
     COMMENT("##--------------------------------------------------------------------------------------------------");
 	COMMENT("## Shell Formulation Version 4");
-    COMMENT("## This is obsolute from Radioss 14.0");
+    COMMENT("## This is obsolete from Radioss 14.0");
     COMMENT("##--------------------------------------------------------------------------------------------------");
     HEADER("/SHFRA/V4");
 

--- a/hm_cfg_files/config/CFG/radioss2017/FAIL/fail_tab.cfg
+++ b/hm_cfg_files/config/CFG/radioss2017/FAIL/fail_tab.cfg
@@ -24,7 +24,7 @@ ATTRIBUTES(COMMON){
 
 	Ifail_sh			= VALUE( INT,   "Shell flag");
 	Ifail_so			= VALUE( INT,   "Solid flag");
-	N_rate				= SIZE("Number of strain rate dependant functions defining failure strain");
+	N_rate				= SIZE("Number of strain rate dependent functions defining failure strain");
 	P_thickfail			= VALUE( FLOAT, "Percent of thickness failure limit");
 	Ixfem				= VALUE(INT, "XFEM flag (for /SHELL and /SH_SANDW properties only)");
 	

--- a/hm_cfg_files/config/CFG/radioss2017/LAMINATE/stack.cfg
+++ b/hm_cfg_files/config/CFG/radioss2017/LAMINATE/stack.cfg
@@ -75,7 +75,7 @@ ATTRIBUTES(COMMON)
     Pply_IDt                                = VALUE(PLY,"");
     Pply_IDb                                = VALUE(PLY,"");
     Current_Phi_Zi                          = VALUE(INT,"");
-    _BLANK                                  = VALUE(STRING,"To consider balnk");
+    _BLANK                                  = VALUE(STRING,"To consider blank");
     IO_FLAG                                 = VALUE(INT, "IOFLAG");
     TITLE                                   = VALUE(STRING, "Stack title");
     Line_count                              = VALUE(INT,"");

--- a/hm_cfg_files/config/CFG/radioss2018/LAMINATE/laminate_p51.cfg
+++ b/hm_cfg_files/config/CFG/radioss2018/LAMINATE/laminate_p51.cfg
@@ -42,7 +42,7 @@ ATTRIBUTES(COMMON)
     Pply_IDt                                = VALUE(PLY,"");
     Pply_IDb                                = VALUE(PLY,"");
     Current_Phi_Zi                          = VALUE(INT,"");
-    _BLANK                                  = VALUE(STRING,"To consider balnk");
+    _BLANK                                  = VALUE(STRING,"To consider blank");
 }
 
 SKEYWORDS_IDENTIFIER(COMMON)

--- a/hm_cfg_files/config/CFG/radioss2018/PROP/prop_p51.cfg
+++ b/hm_cfg_files/config/CFG/radioss2018/PROP/prop_p51.cfg
@@ -206,7 +206,7 @@ GUI(COMMON)
     RADIO(Ipos)
     {
        ADD(0, "0:Layer Positions are Automatically Calculated with Regard to Layer Thicknesses.");
-       ADD(1, "1:All Layer Positions in the Ellement Thickness are User-Defined.");
+       ADD(1, "1:All Layer Positions in the Element Thickness are User-Defined.");
        ADD(2, "2:The Shell Element Reference Plane is at Z0 from the Bottom Surface of the Shell.");
        ADD(3, "3:Top Surface of the Shell is Considered as Element Reference Plane.");
        ADD(4, "4:Bottom Surface of the Shell is Considered as Element Reference Plane.");

--- a/hm_cfg_files/config/CFG/radioss2020/MAT/mat_law77.cfg
+++ b/hm_cfg_files/config/CFG/radioss2020/MAT/mat_law77.cfg
@@ -67,7 +67,7 @@ ATTRIBUTES(COMMON)
     //FUN_A1                                    = VALUE(MULTIOBJECT,  "fct_IDK");
     //FUN_B1                                    = VALUE(MULTIOBJECT,  "fct_IDR");
     FUN_A1                                      = VALUE(FUNCT,"Permeability scale factor function");
-    FUN_B1                                      = VALUE(FUNCT,"Porosity scale factor finction");
+    FUN_B1                                      = VALUE(FUNCT,"Porosity scale factor function");
     Heat_Inp_opt                                = VALUE(INT,   "Heat");  
     SUBGRP_HEAT_MAT                             = VALUE(SUBOBJECT, "");
     THERM_STRESS                                = VALUE(INT,"Therm Stress");

--- a/hm_cfg_files/config/CFG/radioss2021/LAMINATE/laminate.cfg
+++ b/hm_cfg_files/config/CFG/radioss2021/LAMINATE/laminate.cfg
@@ -44,7 +44,7 @@ ATTRIBUTES(COMMON)
     Pply_IDt                                = VALUE(PLY,"");
     Pply_IDb                                = VALUE(PLY,"");
     Current_Phi_Zi                          = VALUE(INT,"");
-    _BLANK                                  = VALUE(STRING,"To consider balnk");
+    _BLANK                                  = VALUE(STRING,"To consider blank");
 }
 
 SKEYWORDS_IDENTIFIER(COMMON)

--- a/hm_cfg_files/config/CFG/radioss2021/PROP/prop_p17_stack.cfg
+++ b/hm_cfg_files/config/CFG/radioss2021/PROP/prop_p17_stack.cfg
@@ -171,7 +171,7 @@ GUI(COMMON)
     RADIO(Ismstr)
     {
         ADD(0, "0:Use Value in /DEF_SHELL.");
-        ADD(1, "1:Small Strain fro  Time=0.");
+        ADD(1, "1:Small Strain from Time=0.");
         ADD(2, "2:Full Geometric Nonlinearities with Possible Small Strain Formulation Activation in RADIOSS Engine.");
         ADD(3, "3:Old Small Strain Formulation.");
         ADD(4, "4:Full Geometric Nonlinearities.");

--- a/hm_cfg_files/config/CFG/radioss2021/PROP/prop_p51.cfg
+++ b/hm_cfg_files/config/CFG/radioss2021/PROP/prop_p51.cfg
@@ -209,7 +209,7 @@ GUI(COMMON)
     RADIO(Ipos)
     {
        ADD(0, "0:Layer Positions are Automatically Calculated with Regard to Layer Thicknesses.");
-       ADD(1, "1:All Layer Positions in the Ellement Thickness are User-Defined.");
+       ADD(1, "1:All Layer Positions in the Element Thickness are User-Defined.");
        ADD(2, "2:The Shell Element Reference Plane is at Z0 from the Bottom Surface of the Shell.");
        ADD(3, "3:Top Surface of the Shell is Considered as Element Reference Plane.");
        ADD(4, "4:Bottom Surface of the Shell is Considered as Element Reference Plane.");

--- a/hm_cfg_files/config/CFG/radioss2022/LAMINATE/laminate_p51.cfg
+++ b/hm_cfg_files/config/CFG/radioss2022/LAMINATE/laminate_p51.cfg
@@ -42,7 +42,7 @@ ATTRIBUTES(COMMON)
     Pply_IDt                                = VALUE(PLY,"");
     Pply_IDb                                = VALUE(PLY,"");
     Current_Phi_Zi                          = VALUE(INT,"");
-    _BLANK                                  = VALUE(STRING,"To consider balnk");
+    _BLANK                                  = VALUE(STRING,"To consider blank");
 }
 
 SKEYWORDS_IDENTIFIER(COMMON)

--- a/hm_cfg_files/config/CFG/radioss2022/LAMINATE/stack.cfg
+++ b/hm_cfg_files/config/CFG/radioss2022/LAMINATE/stack.cfg
@@ -78,7 +78,7 @@ ATTRIBUTES(COMMON)
     Pply_IDt                                = VALUE(PLY,"");
     Pply_IDb                                = VALUE(PLY,"");
     Current_Phi_Zi                          = VALUE(INT,"");
-    _BLANK                                  = VALUE(STRING,"To consider balnk");
+    _BLANK                                  = VALUE(STRING,"To consider blank");
     IO_FLAG                                 = VALUE(INT, "IOFLAG");
     TITLE                                   = VALUE(STRING, "Stack title");
     Line_count                              = VALUE(INT,"");

--- a/hm_cfg_files/config/CFG/radioss2022/PROP/prop_p17_stack.cfg
+++ b/hm_cfg_files/config/CFG/radioss2022/PROP/prop_p17_stack.cfg
@@ -171,7 +171,7 @@ GUI(COMMON)
     RADIO(Ismstr)
     {
         ADD(0, "0:Use Value in /DEF_SHELL.");
-        ADD(1, "1:Small Strain fro  Time=0.");
+        ADD(1, "1:Small Strain from Time=0.");
         ADD(2, "2:Full Geometric Nonlinearities with Possible Small Strain Formulation Activation in RADIOSS Engine.");
         ADD(3, "3:Old Small Strain Formulation.");
         ADD(4, "4:Full Geometric Nonlinearities.");

--- a/hm_cfg_files/config/CFG/radioss2022/PROP/prop_p51.cfg
+++ b/hm_cfg_files/config/CFG/radioss2022/PROP/prop_p51.cfg
@@ -216,7 +216,7 @@ GUI(COMMON)
     RADIO(Ipos)
     {
        ADD(0, "0:Layer Positions are Automatically Calculated with Regard to Layer Thicknesses.");
-       ADD(1, "1:All Layer Positions in the Ellement Thickness are User-Defined.");
+       ADD(1, "1:All Layer Positions in the Element Thickness are User-Defined.");
        ADD(2, "2:The Shell Element Reference Plane is at Z0 from the Bottom Surface of the Shell.");
        ADD(3, "3:Top Surface of the Shell is Considered as Element Reference Plane.");
        ADD(4, "4:Bottom Surface of the Shell is Considered as Element Reference Plane.");

--- a/hm_cfg_files/config/CFG/radioss2023/FAIL/fail_tsai_wu.cfg
+++ b/hm_cfg_files/config/CFG/radioss2023/FAIL/fail_tsai_wu.cfg
@@ -30,7 +30,7 @@ ATTRIBUTES(COMMON){
     SIGMA_2C                = VALUE( FLOAT, "Transverse compressive strength") ;
     SIGMA_12                = VALUE( FLOAT, "Shear strength") ;
     
-    ALPHA                   = VALUE( FLOAT, "Interation 12 coefficient") ;
+    ALPHA                   = VALUE( FLOAT, "Iteration 12 coefficient") ;
     TAU_MAX                 = VALUE( FLOAT, "Dynamic time relaxation") ;
     FCUT                    = VALUE( FLOAT, "Cutoff frequency for stress tensor");
     IFAIL_SH                = VALUE( INT,   "Flag for shell failure model") ;

--- a/hm_cfg_files/config/CFG/radioss2023/LAMINATE/stack.cfg
+++ b/hm_cfg_files/config/CFG/radioss2023/LAMINATE/stack.cfg
@@ -79,7 +79,7 @@ ATTRIBUTES(COMMON)
     Pply_IDt                                = VALUE(PLY,"");
     Pply_IDb                                = VALUE(PLY,"");
     Current_Phi_Zi                          = VALUE(INT,"");
-    _BLANK                                  = VALUE(STRING,"To consider balnk");
+    _BLANK                                  = VALUE(STRING,"To consider blank");
     IO_FLAG                                 = VALUE(INT, "IOFLAG");
     TITLE                                   = VALUE(STRING, "Stack title");
     Line_count                              = VALUE(INT,"");

--- a/hm_cfg_files/config/CFG/radioss2023/MAT/matl104_drucker.cfg
+++ b/hm_cfg_files/config/CFG/radioss2023/MAT/matl104_drucker.cfg
@@ -153,7 +153,7 @@ GUI(COMMON)
     {
         ADD(0, "0: Set to 1");
         ADD(1, "1: NICE (Next Increment Correct Error) explicit method");
-        ADD(2, "2: Cutting plane semi-implicit method (Newton interation)");
+        ADD(2, "2: Cutting plane semi-implicit method (Newton iteration)");
     } 
 
     SCALAR(SIGMA_r)         { DIMENSION="pressure"; }

--- a/hm_cfg_files/config/CFG/radioss2023/PROP/prop_p14_solid.cfg
+++ b/hm_cfg_files/config/CFG/radioss2023/PROP/prop_p14_solid.cfg
@@ -43,8 +43,8 @@ ATTRIBUTES(COMMON)
     Iplas                                   = VALUE(INT, "Flag for solid stress plasticity");
     Icstr                                   = VALUE(INT, "Flag for constant stress formulation");
     vdef_min                                = VALUE(FLOAT,  " Minimum volumetric strain");
-    vdef_max                                = VALUE(FLOAT,  " Maximun volumetric strain");
-    ASP_max                                 = VALUE(FLOAT,  " Maximun aspect ratio");
+    vdef_max                                = VALUE(FLOAT,  " Maximum volumetric strain");
+    ASP_max                                 = VALUE(FLOAT,  " Maximum aspect ratio");
     COL_min                                 = VALUE(FLOAT,  " Minimum collapse ratio");
 
     //Attributes for HM usage 

--- a/hm_cfg_files/config/CFG/radioss2023/PROP/prop_p20_tshell.cfg
+++ b/hm_cfg_files/config/CFG/radioss2023/PROP/prop_p20_tshell.cfg
@@ -34,8 +34,8 @@ ATTRIBUTES(COMMON)
     deltaT_min                              = VALUE(FLOAT,  " Minimum Time Step");
     Istrain                                 = VALUE(INT,  " Compute Strain Post-Processing Flag");
     vdef_min                                = VALUE(FLOAT,  " Minimum volumetric strain");
-    vdef_max                                = VALUE(FLOAT,  " Maximun volumetric strain");
-    ASP_max                                 = VALUE(FLOAT,  " Maximun aspect ratio");
+    vdef_max                                = VALUE(FLOAT,  " Maximum volumetric strain");
+    ASP_max                                 = VALUE(FLOAT,  " Maximum aspect ratio");
     COL_min                                 = VALUE(FLOAT,  " Minimum collapse ratio");
 
     //Attributes for HM usage 

--- a/hm_cfg_files/config/CFG/radioss2023/PROP/prop_p21_tsh_orth.cfg
+++ b/hm_cfg_files/config/CFG/radioss2023/PROP/prop_p21_tsh_orth.cfg
@@ -37,8 +37,8 @@ ATTRIBUTES(COMMON)
     MAT_BETA                                = VALUE(FLOAT,  " Angle of the First Direction of Orthotropy");
     deltaT_min                              = VALUE(FLOAT,  " Minimum Time Step");
     vdef_min                                = VALUE(FLOAT,  " Minimum volumetric strain");
-    vdef_max                                = VALUE(FLOAT,  " Maximun volumetric strain");
-    ASP_max                                 = VALUE(FLOAT,  " Maximun aspect ratio");
+    vdef_max                                = VALUE(FLOAT,  " Maximum volumetric strain");
+    ASP_max                                 = VALUE(FLOAT,  " Maximum aspect ratio");
     COL_min                                 = VALUE(FLOAT,  " Minimum collapse ratio");
     
     //Attributes for HM usage

--- a/hm_cfg_files/config/CFG/radioss2023/PROP/prop_p22_tsh_comp.cfg
+++ b/hm_cfg_files/config/CFG/radioss2023/PROP/prop_p22_tsh_comp.cfg
@@ -42,8 +42,8 @@ ATTRIBUTES(COMMON)
     Prop_mi                                 = ARRAY[N](MAT,  " Material Identifier for Layer i");
     deltaT_min                              = VALUE(FLOAT,  " Minimum Time Step");
     vdef_min                                = VALUE(FLOAT,  " Minimum volumetric strain");
-    vdef_max                                = VALUE(FLOAT,  " Maximun volumetric strain");
-    ASP_max                                 = VALUE(FLOAT,  " Maximun aspect ratio");
+    vdef_max                                = VALUE(FLOAT,  " Maximum volumetric strain");
+    ASP_max                                 = VALUE(FLOAT,  " Maximum aspect ratio");
     COL_min                                 = VALUE(FLOAT,  " Minimum collapse ratio");
     
     //Attributes for HM usage

--- a/hm_cfg_files/config/CFG/radioss2023/PROP/prop_p6_sol_orth.cfg
+++ b/hm_cfg_files/config/CFG/radioss2023/PROP/prop_p6_sol_orth.cfg
@@ -46,8 +46,8 @@ ATTRIBUTES(COMMON)
     Itetra4                                 = VALUE(INT,  " 4 node tetrahedral element formulation flag");
     ISOLID                                  = VALUE(INT,  " Solid Elements Formulation Flag");
     vdef_min                                = VALUE(FLOAT,  " Minimum volumetric strain");
-    vdef_max                                = VALUE(FLOAT,  " Maximun volumetric strain");
-    ASP_max                                 = VALUE(FLOAT,  " Maximun aspect ratio");
+    vdef_max                                = VALUE(FLOAT,  " Maximum volumetric strain");
+    ASP_max                                 = VALUE(FLOAT,  " Maximum aspect ratio");
     COL_min                                 = VALUE(FLOAT,  " Minimum collapse ratio");
       
     //Attributes for HM usage

--- a/hm_cfg_files/config/CFG/radioss2025/PROP/prop_p14_solid.cfg
+++ b/hm_cfg_files/config/CFG/radioss2025/PROP/prop_p14_solid.cfg
@@ -43,8 +43,8 @@ ATTRIBUTES(COMMON)
     Iplas                                   = VALUE(INT, "Flag for solid stress plasticity");
     Icstr                                   = VALUE(INT, "Flag for constant stress formulation");
     vdef_min                                = VALUE(FLOAT,  " Minimum volumetric strain");
-    vdef_max                                = VALUE(FLOAT,  " Maximun volumetric strain");
-    ASP_max                                 = VALUE(FLOAT,  " Maximun aspect ratio");
+    vdef_max                                = VALUE(FLOAT,  " Maximum volumetric strain");
+    ASP_max                                 = VALUE(FLOAT,  " Maximum aspect ratio");
     COL_min                                 = VALUE(FLOAT,  " Minimum collapse ratio");
     Icontrol                                = VALUE(INT, "Flag for distortion control");
 

--- a/hm_cfg_files/config/CFG/radioss2025/PROP/prop_p20_tshell.cfg
+++ b/hm_cfg_files/config/CFG/radioss2025/PROP/prop_p20_tshell.cfg
@@ -34,8 +34,8 @@ ATTRIBUTES(COMMON)
     deltaT_min                              = VALUE(FLOAT,  " Minimum Time Step");
     Istrain                                 = VALUE(INT,  " Compute Strain Post-Processing Flag");
     vdef_min                                = VALUE(FLOAT,  " Minimum volumetric strain");
-    vdef_max                                = VALUE(FLOAT,  " Maximun volumetric strain");
-    ASP_max                                 = VALUE(FLOAT,  " Maximun aspect ratio");
+    vdef_max                                = VALUE(FLOAT,  " Maximum volumetric strain");
+    ASP_max                                 = VALUE(FLOAT,  " Maximum aspect ratio");
     COL_min                                 = VALUE(FLOAT,  " Minimum collapse ratio");
     Icontrol                                = VALUE(INT, "Flag for distortion control");
 

--- a/hm_cfg_files/config/CFG/radioss2025/PROP/prop_p21_tsh_orth.cfg
+++ b/hm_cfg_files/config/CFG/radioss2025/PROP/prop_p21_tsh_orth.cfg
@@ -37,8 +37,8 @@ ATTRIBUTES(COMMON)
     MAT_BETA                                = VALUE(FLOAT,  " Angle of the First Direction of Orthotropy");
     deltaT_min                              = VALUE(FLOAT,  " Minimum Time Step");
     vdef_min                                = VALUE(FLOAT,  " Minimum volumetric strain");
-    vdef_max                                = VALUE(FLOAT,  " Maximun volumetric strain");
-    ASP_max                                 = VALUE(FLOAT,  " Maximun aspect ratio");
+    vdef_max                                = VALUE(FLOAT,  " Maximum volumetric strain");
+    ASP_max                                 = VALUE(FLOAT,  " Maximum aspect ratio");
     COL_min                                 = VALUE(FLOAT,  " Minimum collapse ratio");
     Icontrol                                = VALUE(INT, "Flag for distortion control");
     

--- a/hm_cfg_files/config/CFG/radioss2025/PROP/prop_p22_tsh_comp.cfg
+++ b/hm_cfg_files/config/CFG/radioss2025/PROP/prop_p22_tsh_comp.cfg
@@ -42,8 +42,8 @@ ATTRIBUTES(COMMON)
     Prop_mi                                 = ARRAY[N](MAT,  " Material Identifier for Layer i");
     deltaT_min                              = VALUE(FLOAT,  " Minimum Time Step");
     vdef_min                                = VALUE(FLOAT,  " Minimum volumetric strain");
-    vdef_max                                = VALUE(FLOAT,  " Maximun volumetric strain");
-    ASP_max                                 = VALUE(FLOAT,  " Maximun aspect ratio");
+    vdef_max                                = VALUE(FLOAT,  " Maximum volumetric strain");
+    ASP_max                                 = VALUE(FLOAT,  " Maximum aspect ratio");
     COL_min                                 = VALUE(FLOAT,  " Minimum collapse ratio");
     Icontrol                                = VALUE(INT, "Flag for distortion control");
     

--- a/hm_cfg_files/config/CFG/radioss2025/PROP/prop_p6_sol_orth.cfg
+++ b/hm_cfg_files/config/CFG/radioss2025/PROP/prop_p6_sol_orth.cfg
@@ -46,8 +46,8 @@ ATTRIBUTES(COMMON)
     Itetra4                                 = VALUE(INT,  " 4 node tetrahedral element formulation flag");
     ISOLID                                  = VALUE(INT,  " Solid Elements Formulation Flag");
     vdef_min                                = VALUE(FLOAT,  " Minimum volumetric strain");
-    vdef_max                                = VALUE(FLOAT,  " Maximun volumetric strain");
-    ASP_max                                 = VALUE(FLOAT,  " Maximun aspect ratio");
+    vdef_max                                = VALUE(FLOAT,  " Maximum volumetric strain");
+    ASP_max                                 = VALUE(FLOAT,  " Maximum aspect ratio");
     COL_min                                 = VALUE(FLOAT,  " Minimum collapse ratio");
     Icontrol                                = VALUE(INT, "Flag for distortion control");
       

--- a/hm_cfg_files/messages/CONFIG/msg_arrays.cfg
+++ b/hm_cfg_files/messages/CONFIG/msg_arrays.cfg
@@ -204,10 +204,10 @@ MODEL {
   0020  "ERROR: This action is not allowed for an encrypted object"
   /* LC_503_11_01_06 end */
   /* RAR#MPOST_DEV_2006_151#11_04_2006  (BEG)*/
-  0021  "Not enought memory available to perform this operation"
+  0021  "Not enough memory available to perform this operation"
   /* RAR#MPOST_DEV_2006_151#11_04_2006  (END)*/
   0022 "ERROR: %s of id %d already exists and is not compatible with offset=%d."
-  0023 "ERROR: %s of id %d can not be offseted with offset=%d."
+  0023 "ERROR: %s of id %d can not be offsetted with offset=%d."
   0024 "ERROR: %s must be defined before to be referenced."
   0025 "WARNING: Parameter field of %s id %d is changed. *Parameter previously linked to it will be disassociated."
   0026 "Do you want to restore the original position?"
@@ -655,7 +655,7 @@ READ_D00_4X {
   0294  "ERROR: \"%s\" is not a valid key's header"
   0295  "ERROR: \"%s\" will be truncated to \"%s\" (only four characters expected)"
   0296  "ERROR: The key is too short (%d characters, instead of %d)"
-  0297  "ERROR: The key will be truncated to %d chararcters (instead of %d)\n"
+  0297  "ERROR: The key will be truncated to %d characters (instead of %d)\n"
   /* !Modified LC:GDEV:00293:2.2.d:06/11/2003  (end)  */
   /* !Modified LC:GBUG:00346:2.2.g:05/03/2004 (begin) */
   0298  "ERROR: Node of ID %d is not primary node of any rigid body"
@@ -792,7 +792,7 @@ WRITE_D00_41F {
   0100  "WARNING: INTERFACE %d COULD NOT BE TRANSLATED\n"                       // write_control_interface_41_f.c
   0101  "TO FIX FORMAT\n"                                                       // write_control_interface_41_f.c
   0102  "... D00 file written with warnings.\n"                                 // writed00_f.c
-  0103  "Correction neccessary for writing file"                               // write_radiossfile41_f_window.c, CS/253 12/05/03
+  0103  "Correction necessary for writing file"                                 // write_radiossfile41_f_window.c, CS/253 12/05/03
   /* !Modified LC:GDEV:00001:1.8.a:08/04/2002 (begin) */
   0104  "WARNING: Data may be lost in monitored volume of ID %d\n"                        // write_volums_41_f.c    
   /* !Modified LC:GDEV:00001:1.8.a:08/04/2002  (end)  */


### PR DESCRIPTION
#### Description of the feature or the bug
Typos in source comments within the `hm_config/` directory

#### Description of the changes
Fixed typos. Found via `codespell -q 3 -S "./.git,./extlib" -L activ,addresse,adress,adresse,adresses,agrv,alph,als,ans,bloc,bord,bu,candidat,candidats,childs,clos,connectes,contrl,crypted,daa,datas,defaut,detecte,differents,dum,filles,fils,fixe,flagg,fonction,fonctions,fourty,fpt,fram,globaly,groupe,groupes,hashin,idel,incluse,indx,initiales,inout,invers,iself,ist,itens,ivalid,iverse,lamda,lamdas,lengt,limite,marge,mater,mot,mouvement,nam,nd,nin,ninty,nodel,normale,parametres,parm,penality,pinter,pointeur,polygone,pres,probleme,propt,rige,rin,prset,rotat,runn,sav,secnd,secnds,serie,shft,shs,sirect,siz,som,somme,sprin,substract,tage,thck,thet,transfert,treshold,trian,ue,varn,verifie,versio,zeroin`

