### PR TITLE
QAPRINT : Handling Situations Without User-Provided EBCS Titles

### DIFF
--- a/starter/source/output/qaprint/st_qaprint_ebcs.F
+++ b/starter/source/output/qaprint/st_qaprint_ebcs.F
@@ -36,6 +36,7 @@ C-----------------------------------------------
         USE ALE_EBCS_MOD
         USE RESTMOD
         USE EBCS_MOD
+        USE NAMES_AND_TITLES_MOD , ONLY : NCHARTITLE
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -52,6 +53,7 @@ C-----------------------------------------------
       INTEGER :: II, JJ
       DOUBLE PRECISION :: TMPVAL
       CLASS(t_ebcs), POINTER :: EBCS
+      CHARACTER(LEN=NCHARTITLE) :: TITLE
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
@@ -62,7 +64,12 @@ C-----------------------------------------------
       IF (OK_QA) THEN
          DO II = 1, NEBCS
             EBCS => EBCS_TAB%tab(ii)%poly
-            CALL QAPRINT(EBCS%title,0,0.0_8)
+            TITLE = EBCS%title
+            IF(LEN_TRIM(TITLE) /= 0)THEN
+              CALL QAPRINT(EBCS%title,0,0.0_8)
+            ELSE
+              CALL QAPRINT('EBCS_FAKE_TITLE',0,0.0_8)
+            ENDIF
             CALL QAPRINT('EBCS ID ',EBCS%ebcs_id,0.0_8)
             CALL QAPRINT('EBCS TYPE ',EBCS%type,0.0_8)
             CALL QAPRINT('EBCS SURF_ID ',EBCS%surf_id,0.0_8)


### PR DESCRIPTION
#### QAPRINT : Handling Situations Without User-Provided EBCS Titles

#### Description of the changes
EBCS title was introduced with Pull Request : https://github.com/OpenRadioss/OpenRadioss/pull/3226  (e423c43726ab32182846a923b1236b9c54374c0e)
QAPRINT subroutines required a title to be output for each option. With this current update, when title is not provided by the user then 'EBCS_FAKE_TITLE' is now output instead.