### PR TITLE
Replace sysfus function by hash table (engine)

### DIFF
--- a/common_source/tools/container/umap.cpp
+++ b/common_source/tools/container/umap.cpp
@@ -1,0 +1,69 @@
+//Copyright>    OpenRadioss
+//Copyright>    Copyright (C) 1986-2024 Altair Engineering Inc.
+//Copyright>
+//Copyright>    This program is free software: you can redistribute it and/or modify
+//Copyright>    it under the terms of the GNU Affero General Public License as published by
+//Copyright>    the Free Software Foundation, either version 3 of the License, or
+//Copyright>    (at your option) any later version.
+//Copyright>
+//Copyright>    This program is distributed in the hope that it will be useful,
+//Copyright>    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//Copyright>    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//Copyright>    GNU Affero General Public License for more details.
+//Copyright>
+//Copyright>    You should have received a copy of the GNU Affero General Public License
+//Copyright>    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//Copyright>
+//Copyright>
+//Copyright>    Commercial Alternative: Altair Radioss Software
+//Copyright>
+//Copyright>    As an alternative to this open-source version, Altair also offers Altair Radioss
+//Copyright>    software under a commercial license.  Contact Altair to discuss further if the
+//Copyright>    commercial version may interest you: https://www.altair.com/radioss/.
+
+#include <unordered_map>
+#include <cstdint>
+#include <stdexcept>
+
+//       Using C++14, we have no std::shared_mutex, so no internal locking is shown here.
+//       The container should be fully populated before concurrent reads to ensure safety.
+
+extern "C" {
+
+void* cpp_create_umap() noexcept {
+    // Create a new unordered_map on the heap and return it as a void pointer.
+    auto* umap = new std::unordered_map<int,int>();
+    return static_cast<void*>(umap);
+}
+
+void cpp_free_umap(void* umap_ptr) noexcept {
+    // Delete the map, freeing the allocated memory.
+    // Caller must ensure umap_ptr is a pointer returned by create_umap.
+    auto umap = static_cast<std::unordered_map<int,int>*>(umap_ptr);
+    delete umap;
+}
+
+void cpp_add_entry_umap(void* umap_ptr, int key, int value) noexcept {
+    // Insert or update the value at the given key.
+    // This is not thread-safe if called concurrently with reads/writes.
+    auto umap = static_cast<std::unordered_map<int,int>*>(umap_ptr);
+    (*umap)[key] = value;
+}
+
+int cpp_get_value_umap(void* umap_ptr, int key, int default_value) noexcept {
+    // Retrieve a value from the map. If the key is not found, return default_value.
+    // Safe for concurrent calls *only if* no other thread modifies the map.
+    auto umap = static_cast<std::unordered_map<int,int>*>(umap_ptr);
+    auto it = umap->find(key);
+    return (it != umap->end()) ? it->second : default_value;
+}
+
+void cpp_reserve_umap(void* umap_ptr, std::size_t n) noexcept {
+    // Reserve space for at least n elements.
+    // This can improve performance of subsequent insertions by avoiding rehashing.
+    // Must be called before concurrent reads, and never during them.
+    auto umap = static_cast<std::unordered_map<int,int>*>(umap_ptr);
+    umap->reserve(n);
+}
+
+} // extern "C"

--- a/common_source/tools/container/umap_mod.F90
+++ b/common_source/tools/container/umap_mod.F90
@@ -1,0 +1,86 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 1986-2024 Altair Engineering Inc.
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Altair Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+!Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+!Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+module umap_mod
+   use iso_c_binding
+   implicit none
+
+   interface
+      function create_umap() bind(C, name="cpp_create_umap")
+         use iso_c_binding
+         type(C_PTR) :: create_umap
+      end function create_umap
+
+      subroutine free_umap(umap_ptr) bind(C, name="cpp_free_umap")
+         use iso_c_binding
+         type(C_PTR), value :: umap_ptr
+      end subroutine free_umap
+
+      subroutine add_entry_umap(umap_ptr, key, value) bind(C, name="cpp_add_entry_umap")
+         use iso_c_binding
+         type(C_PTR), value :: umap_ptr
+         integer(C_INT), value :: key
+         integer(C_INT), value :: value
+      end subroutine add_entry_umap
+
+      function get_value_umap(umap_ptr, key, default_value) result(val) bind(C, name="cpp_get_value_umap")
+         use iso_c_binding
+         type(C_PTR), value :: umap_ptr
+         integer(C_INT), value :: key
+         integer(C_INT), value :: default_value
+         integer(C_INT) :: val
+      end function get_value_umap
+
+      subroutine reserve_umap(umap_ptr, n) bind(C, name="cpp_reserve_umap")
+         use iso_c_binding
+         type(C_PTR), value :: umap_ptr
+         ! size_t is typically mapped to C_SIZE_T
+         integer(C_SIZE_T), value :: n
+      end subroutine reserve_umap
+   end interface
+
+contains
+
+   subroutine add_entry(m, key, value)
+      type(C_PTR), intent(in) :: m
+      integer, intent(in)     :: key, value
+!$OMP CRITICAL
+      call add_entry_umap(m, int(key, C_INT), int(value, C_INT))
+!$OMP END CRITICAL
+   end subroutine add_entry
+
+   function get_value(m, key, default_value) result(val)
+      type(C_PTR), intent(in) :: m
+      integer, intent(in)     :: key, default_value
+      integer                 :: val
+      val = get_value_umap(m, int(key, C_INT), int(default_value, C_INT))
+   end function get_value
+
+   subroutine reserve_capacity(m, n)
+      type(C_PTR), intent(in) :: m
+      integer, intent(in)     :: n
+!$OMP CRITICAL
+      call reserve_umap(m, int(n, C_SIZE_T))
+!$OMP END CRITICAL
+   end subroutine reserve_capacity
+
+end module umap_mod

--- a/engine/source/constraints/general/bcs/lcbcsf.F
+++ b/engine/source/constraints/general/bcs/lcbcsf.F
@@ -68,8 +68,6 @@ C   E x t e r n a l   F u n c t i o n s
 C-----------------------------------------------
       INTEGER SYSFUS2
 C     REAL
-      my_real
-     .   SYSFUS
 C-----------------------------------------------
 C
       DATA MESS/'BOUNDARY CONDITIONS                     '/

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -2441,11 +2441,11 @@ C Init var parallel SMP
      2   IPMTSK,PARTFTSK,PARTLTSK,NWAFTSK,IGMTSK  ,
      3      GREFTSK,GRELTSK)
 
-          CALL TAGOFF3N(
+          CALL TAGOFF3N(NODES,
      1       GEO        ,IXS       ,IXS(L1)   ,IXS(L1)   ,IXS(L3)  ,IXQ    ,
      2       ELEMENT%SHELL%IXC         ,IXT      ,IXP       ,IXR       ,IXTG     ,
      3       WA(NUMNOD+1),NODFTSK  ,NODLTSK   ,IPARG     ,ELBUF    ,ITSK   ,
-     4       WA(NWAFTSK) ,IXTG1    ,IAD_ELEM  ,FR_ELEM   ,NODES%ITAB     ,NODES%ITABM1 ,
+     4       WA(NWAFTSK) ,IXTG1    ,IAD_ELEM  ,FR_ELEM   ,NODES%ITAB     ,
      5       ADDCNEL     ,CNEL     ,KXSP      ,ELBUF_TAB ,TAGEL    ,IEXLNK , 
      6       IGRNOD      ,DD_R2R   ,DD_R2R_ELEM,SDD_R2R_ELEM,IDEL7NOK_SAV ,
      7       IDEL7NOK_R2R,TAGTRIMC,TAGTRIMTG,S_ELEM_STATE,ELEM_STATE,
@@ -2474,7 +2474,7 @@ C Init var parallel SMP
           ! exchange of surfaces (ie. 4 nodes) to deactivate and deactivation
           ! ONLY FOR LOCAL SURFACE / REMOTE ELEMENT
           IF(NSPMD>1) THEN 
-            IF(ITSK==0) CALL SPMD_EXCH_DELETED_SURF_EDGE( IAD_ELEM,NODES%ITABM1,SHOOT_STRUCT,INTERFACES%INTBUF_TAB,NEWFRONT,
+            IF(ITSK==0) CALL SPMD_EXCH_DELETED_SURF_EDGE( IAD_ELEM,NODES,SHOOT_STRUCT,INTERFACES%INTBUF_TAB,NEWFRONT,
      .                           IPARI,GEO,
      .                           IXS,ELEMENT%SHELL%IXC,IXT,IXP,IXR,IXTG,IXS(L1),
      .                           ADDCNEL,CNEL,WA(NWAFTSK),TAGEL )
@@ -2532,7 +2532,7 @@ C Init var parallel SMP
           ENDIF
           ! ---------------------
 
-          CALL CHKSTFN3N(
+          CALL CHKSTFN3N(NODES,
      1       IPARI   ,GEO         ,IXS      ,IXQ         ,ELEMENT%SHELL%IXC     ,IXT       ,
      2       IXP     ,IXR         ,IXTG     ,WA(NUMNOD+1),IPARG   ,ITSK      ,
      3       NEWFRONT,WA(NWAFTSK) ,NODES%MS       ,NODES%IN          ,ANIN(NDMA+1),NODES%ITAB  ,
@@ -5531,11 +5531,11 @@ C WA global : utilise de NUMNOD+1 a 3*NUMNOD
 C WA local  : utilise de 1 a NUMNOD
 
         IF ((IDEL7NG>=1.AND.IDEL7NOK==1).OR.(PDEL>0.AND.IDEL7NOK==1)) THEN
-          CALL TAGOFF3N(
+          CALL TAGOFF3N(NODES,
      1       GEO        ,IXS       ,IXS(L1)   ,IXS(L1)   ,IXS(L3)  ,IXQ    ,
      2       ELEMENT%SHELL%IXC         ,IXT      ,IXP       ,IXR       ,IXTG     ,
      3       WA(NUMNOD+1),NODFTSK  ,NODLTSK   ,IPARG     ,ELBUF    ,ITSK   ,
-     4       WA(NWAFTSK) ,IXTG1    ,IAD_ELEM  ,FR_ELEM   ,NODES%ITAB     ,NODES%ITABM1 ,
+     4       WA(NWAFTSK) ,IXTG1    ,IAD_ELEM  ,FR_ELEM   ,NODES%ITAB     ,
      5       ADDCNEL     ,CNEL     ,KXSP      ,ELBUF_TAB ,TAGEL    ,IEXLNK , 
      6       IGRNOD      ,DD_R2R   ,DD_R2R_ELEM,SDD_R2R_ELEM,IDEL7NOK_SAV  ,
      7       IDEL7NOK_R2R,TAGTRIMC,TAGTRIMTG,S_ELEM_STATE,ELEM_STATE,
@@ -5564,7 +5564,7 @@ C WA local  : utilise de 1 a NUMNOD
           ! exchange of surfaces (ie. 4 nodes) to deactivate and deactivation
           ! ONLY FOR LOCAL SURFACE / REMOTE ELEMENT
           IF(NSPMD>1) THEN 
-            IF(ITSK==0) CALL SPMD_EXCH_DELETED_SURF_EDGE( IAD_ELEM,NODES%ITABM1,SHOOT_STRUCT,INTERFACES%INTBUF_TAB,NEWFRONT,
+            IF(ITSK==0) CALL SPMD_EXCH_DELETED_SURF_EDGE( IAD_ELEM,NODES,SHOOT_STRUCT,INTERFACES%INTBUF_TAB,NEWFRONT,
      .                           IPARI,GEO,
      .                           IXS,ELEMENT%SHELL%IXC,IXT,IXP,IXR,IXTG,IXS(L1),
      .                           ADDCNEL,CNEL,WA(NWAFTSK),TAGEL )
@@ -5626,7 +5626,7 @@ C WA local  : utilise de 1 a NUMNOD
         ENDIF
 
         IF (IDEL7NG>=1.AND.IDEL7NOK==1) THEN
-          CALL CHKSTFN3N(
+          CALL CHKSTFN3N(NODES,
      1       IPARI   ,GEO         ,IXS      ,IXQ         ,ELEMENT%SHELL%IXC     ,IXT       ,
      2       IXP     ,IXR         ,IXTG     ,WA(NUMNOD+1),IPARG   ,ITSK      ,
      3       NEWFRONT,WA(NWAFTSK) ,NODES%MS       ,NODES%IN          ,ANIN(NDMA+1),NODES%ITAB  ,

--- a/engine/source/interfaces/chkload.F
+++ b/engine/source/interfaces/chkload.F
@@ -33,9 +33,11 @@ C
       SUBROUTINE CHKLOAD(
      1    IB     ,IXS     ,IXQ     ,IXC    ,IXT     ,IXP     ,
      2    IXR    ,IXTG    ,ITAG   ,ITASK   ,ITAGL   ,ITAB    ,
-     3    ITABM1 ,ADDCNEL ,CNEL   ,TAGEL   ,IPARG   ,GEO     ,
+     3    NODES ,ADDCNEL ,CNEL   ,TAGEL   ,IPARG   ,GEO     ,
      4    IBUFS  ,NINDEX  ,NINDG  ,NPRESLOAD,LOADP_TAGDEL    ,
      5    ILOADP ,LLOADP  ,IAD_ELEM)
+C-----------------------------------------------
+      USE nodal_arrays_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -57,12 +59,13 @@ C-----------------------------------------------
       INTEGER IB(NIBCLD,*), ITAG(*),
      .        IXS(NIXS,*),IXQ(NIXQ,*),IXC(NIXC,*), IXT(NIXT,*), IXP(NIXP,*),
      .        IXR(NIXR,*), IXTG(NIXTG,*),IPARG(NPARG,*), ITAGL(*), ITAB(*),
-     .        ITABM1(*), CNEL(0:*), ADDCNEL(0:*), TAGEL(*), IBUFS(*) , NINDEX(*)
+     .        CNEL(0:*), ADDCNEL(0:*), TAGEL(*), IBUFS(*) , NINDEX(*)
       INTEGER, INTENT(INOUT) :: LOADP_TAGDEL(NPRESLOAD)
       INTEGER, INTENT(IN) :: LLOADP(SLLOADP), ILOADP(SIZLOADP,NLOADP)
       INTEGER, DIMENSION(2,NSPMD+1), INTENT(in) :: IAD_ELEM
       my_real
      .        GEO(NPROPG,*)
+      TYPE(nodal_arrays_), intent(in) :: NODES
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -273,7 +276,7 @@ C
        CALL SPMD_INIT_IDEL(4*NINDG  , IRSIZE, IRECV,IAD_ELEM)
        CALL SPMD_EXCHSEG_IDEL(
      1         IBUFS  ,4*NINDG   ,IXS    ,IXC    ,IXTG   , 
-     2         IXQ    ,IPARG     ,ITAGL  ,ITABM1 ,TAGEL  ,
+     2         IXQ    ,IPARG     ,ITAGL  ,NODES,TAGEL  ,
      3         IRSIZE ,IRECV     ,CNEL   ,ADDCNEL,OFC    ,
      4         OFT    ,OFTG      ,OFUR   ,OFR    ,OFP    ,
      5         OFQ    ,NINDG     ,IXP    ,IXR    ,IXT    ,

--- a/engine/source/interfaces/interf/chkstfn3.F
+++ b/engine/source/interfaces/interf/chkstfn3.F
@@ -561,11 +561,11 @@ C
       !||    remesh_mod           ../engine/share/modules/remesh_mod.F
       !||    shooting_node_mod    ../engine/share/modules/shooting_node_mod.F
       !||====================================================================
-      SUBROUTINE TAGOFF3N(
+      SUBROUTINE TAGOFF3N(NODES,
      1    GEO     ,IXS   ,IXS10   ,IXS20   ,IXS16  ,IXQ    ,
      2    IXC     ,IXT    ,IXP    ,IXR     ,IXTG   ,
      3    ITAG    ,NODFT  ,NODLT  ,IPARG   ,EV     ,ITASK  ,
-     4    ITAGL   ,IXTG1  ,IAD_ELEM,FR_ELEM,ITAB   ,ITABM1 ,
+     4    ITAGL   ,IXTG1  ,IAD_ELEM,FR_ELEM,ITAB   ,
      5    ADDCNEL ,CNEL   ,KXSP   ,ELBUF_TAB,TAGEL ,IEXLNK ,
      6    IGRNOD  ,DD_R2R,DD_R2R_ELEM,SDD_R2R_ELEM,IDEL7NOK_SAV,
      7    IDEL7NOK_R2R,TAGTRIMC,TAGTRIMTG,S_ELEM_STATE,ELEM_STATE,
@@ -573,6 +573,7 @@ C
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
+      USE nodal_arrays_mod
       USE ELBUFDEF_MOD
       USE RAD2R_MOD     
       USE REMESH_MOD
@@ -597,13 +598,14 @@ C-----------------------------------------------
 C-----------------------------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+      TYPE(nodal_arrays_) :: NODES
       INTEGER 
      .   LINDIDEL, LBUFIDEL,
      .   IXS(NIXS,*),IXS10(6,*),IXS20(12,*),IXS16(8,*),
      .   IXQ(NIXQ,*),IXC(NIXC,*), IXT(NIXT,*), IXP(NIXP,*),
      .   IXR(NIXR,*), IXTG(NIXTG,*),IXTG1(4,*),ITAG(*),
      .   IPARG(NPARG,*), NODFT,NODLT,ITASK, ITAGL (*),
-     .   IAD_ELEM(2,*),FR_ELEM(*),ITAB(*),ITABM1(*),
+     .   IAD_ELEM(2,*),FR_ELEM(*),ITAB(*),
      .   ADDCNEL(0:*),CNEL(0:*),KXSP(NISP,*),
      .   TAGEL(*),
      .   IEXLNK(NR2R,NR2RLNK),DD_R2R(NSPMD+1,*), 
@@ -634,10 +636,6 @@ C-----------------------------------------------
       TYPE(G_BUFEL_) ,POINTER :: GBUF
       INTEGER, DIMENSION(:), ALLOCATABLE :: LOCAL_ELEM_INDEX
       INTEGER :: SHIFT
-C-----------------------------------------------
-C   E x t e r n a l   F u n c t i o n s
-C-----------------------------------------------
-      INTEGER SYSFUS2      
 C-----------------------------------------------
       ! allocation of local list of deactivated element
       ALLOCATE( LOCAL_ELEM_INDEX(S_ELEM_STATE) )
@@ -1189,7 +1187,7 @@ C-----------------------------------------------------------------
             CALL EXCH_TAGEL_C(NTAGEL_R2R_RECV,TAGEL_R2R_RECV,1)
           ENDIF
           DO I=1,NTAGEL_R2R_RECV
-            N1 = SYSFUS2(TAGEL_R2R_RECV((I-1)*3+2),ITABM1,NUMNOD)          
+            N1 = GET_LOCAL_NODE_ID(NODES,TAGEL_R2R_RECV((I-1)*3+2)) 
             IF (N1 > 0) THEN
               ITY = TAGEL_R2R_RECV((I-1)*3+3)
               DO J = ADDCNEL(N1),ADDCNEL(N1+1)-1            
@@ -1266,7 +1264,7 @@ C
       !||--- uses       -----------------------------------------------------
       !||    elbufdef_mod        ../common_source/modules/mat_elem/elbufdef_mod.F90
       !||====================================================================
-      SUBROUTINE CHKSTFN3N(
+      SUBROUTINE CHKSTFN3N(NODES,
      1    IPARI   ,GEO     ,IXS    ,IXQ       ,IXC      ,IXT     ,
      2    IXP     ,IXR     ,IXTG   ,ITAG      ,IPARG    ,ITASK   ,
      3    NEWFRONT,ITAGL   ,MS     ,IN        ,ADM      ,ITAB    ,
@@ -1276,6 +1274,7 @@ C
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
+      USE nodal_arrays_mod
       USE ELBUFDEF_MOD
       USE INTBUFDEF_MOD    
 C----6---------------------------------------------------------------7---------8
@@ -1293,6 +1292,7 @@ C-----------------------------------------------
 C-----------------------------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+      TYPE(nodal_arrays_), intent(inout) :: NODES
       INTEGER 
      .   IPARI(NPARI,*), LINDIDEL, LBUFIDEL,
      .   IXS(NIXS,*),IXQ(NIXQ,*),IXC(NIXC,*), IXT(NIXT,*), IXP(NIXP,*),
@@ -1321,11 +1321,6 @@ C-----------------------------------------------
      .        TAGEL_SIZE,LEVEL
       INTEGER, DIMENSION(:),ALLOCATABLE ::IBUFSEGLO_SAV,INDSEGLO_sav
       TYPE(G_BUFEL_) ,POINTER :: GBUF
-C-----------------------------------------------
-C   E x t e r n a l   F u n c t i o n s
-C-----------------------------------------------
-      INTEGER SYSFUS2      
-C-----------------------------------------------
 C
       OFQ=NUMELS
       OFC=OFQ+NUMELQ
@@ -1796,7 +1791,7 @@ C Partie non parallele
        CALL SPMD_INIT_IDEL(IDBS-1, IRSIZE, IRECV,IAD_ELEM)
        CALL SPMD_EXCHMSR_IDEL(
      1         IBUFS  ,IDBS-1 ,IXS    ,IXC    ,IXTG   , 
-     2         IXQ    ,IPARG  ,ITAGL  ,ITABM1 ,
+     2         IXQ    ,IPARG  ,ITAGL  ,NODES,
      3         IRSIZE ,IRECV  ,CNEL   ,ADDCNEL,OFC    ,
      4         OFT    ,OFTG   ,OFUR   ,OFR    ,OFP    ,
      5         IDB-1  ,IXP    ,IXR    ,IXT    ,GEO    ,

--- a/engine/source/interfaces/interf/count_remote_nb_elem_edge.F
+++ b/engine/source/interfaces/interf/count_remote_nb_elem_edge.F
@@ -28,7 +28,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    sysfus2                     ../engine/source/system/sysfus.F
       !||====================================================================
         SUBROUTINE COUNT_REMOTE_NB_ELEM_EDGE( SIZE_BUFFER,BUFFER,GEO,IXS,IXC,
-     .                                 IXT,IXP,IXR,IXTG,ADDCNEL,ITABM1,CNEL,CHUNK)
+     .                                 IXT,IXP,IXR,IXTG,ADDCNEL,NODES,CNEL,CHUNK)
 !$COMMENT
 !       COUNT_REMOTE_NB_ELEM_EDGE description
 !           check if a list of node is associated 
@@ -41,6 +41,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !           - if it's true, send to the remote processor "you need to deactivate
 !             the nodes from your interface!"
 !$ENDCOMMENT
+       USE nodal_arrays_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -64,7 +65,7 @@ C-----------------------------------------------
         INTEGER, DIMENSION(NIXR,NUMELR),TARGET, INTENT(in) :: IXR! spring array
         INTEGER, DIMENSION(NIXTG,NUMELTG),TARGET, INTENT(in) :: IXTG! triangle array
         INTEGER, DIMENSION(0:NUMNOD+1), INTENT(in) :: ADDCNEL ! address for the CNEL array
-        INTEGER, DIMENSION(NUMNOD), INTENT(in) :: ITABM1    ! array of global id
+        TYPE(nodal_arrays_), intent(inout) :: NODES
         my_real, DIMENSION(NPROPG,NUMGEO), INTENT(in) :: GEO
         INTEGER, DIMENSION(0:LCNEL), INTENT(in) :: CNEL ! connectivity node-->element
 C-----------------------------------------------
@@ -84,7 +85,6 @@ C-----------------------------------------------
         INTEGER, DIMENSION(:), ALLOCATABLE :: LIST_ELEMENT
         LOGICAL, DIMENSION(:), ALLOCATABLE :: ALREADY_HERE
 
-        INTEGER :: SYSFUS2 ! external function : give the local ID of a global node ID
 C-----------------------------------------------
         ! --------------------------
         OFFSET_SOLID = 0
@@ -110,12 +110,12 @@ C-----------------------------------------------
         DO J=1,SIZE_BUFFER,CHUNK
             NIN = BUFFER(J)
             GLOBAL_NODE(1:4) = BUFFER(J+2:J+CHUNK-1)
-            LOCAL_NODE(1) = SYSFUS2(GLOBAL_NODE(1),ITABM1,NUMNOD)
-            LOCAL_NODE(2) = SYSFUS2(GLOBAL_NODE(2),ITABM1,NUMNOD)
+            LOCAL_NODE(1) = GET_LOCAL_NODE_ID(NODES,GLOBAL_NODE(1))
+            LOCAL_NODE(2) = GET_LOCAL_NODE_ID(NODES,GLOBAL_NODE(2))
             LOCAL_NODE(3:4) = NUMNOD+1
             NUMBER_NODE = 2 ! for type 11, there are 2 nodes per segments
-            IF(GLOBAL_NODE(3)/=0) LOCAL_NODE(3) = SYSFUS2(GLOBAL_NODE(3),ITABM1,NUMNOD)
-            IF(GLOBAL_NODE(4)/=0) LOCAL_NODE(4) = SYSFUS2(GLOBAL_NODE(4),ITABM1,NUMNOD)
+            IF(GLOBAL_NODE(3)/=0) LOCAL_NODE(3) = GET_LOCAL_NODE_ID(NODES, GLOBAL_NODE(3))
+            IF(GLOBAL_NODE(4)/=0) LOCAL_NODE(4) = GET_LOCAL_NODE_ID(NODES, GLOBAL_NODE(4)) 
             IF( (GLOBAL_NODE(3)/=0).AND.(GLOBAL_NODE(4)/=0) ) NUMBER_NODE = 4 ! for type 7, there are 4 nodes per segments
             BUFFER(J+2:J+3) = 0
             N1 = LOCAL_NODE(1)

--- a/engine/source/interfaces/interf/find_edge_from_remote_proc.F
+++ b/engine/source/interfaces/interf/find_edge_from_remote_proc.F
@@ -30,7 +30,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||--- uses       -----------------------------------------------------
       !||    shooting_node_mod             ../engine/share/modules/shooting_node_mod.F
       !||====================================================================
-        SUBROUTINE FIND_EDGE_FROM_REMOTE_PROC(SHOOT_STRUCT,NB_EDGE,LIST_NODE,INTBUF_TAB,ITABM1,
+        SUBROUTINE FIND_EDGE_FROM_REMOTE_PROC(SHOOT_STRUCT,NB_EDGE,LIST_NODE,INTBUF_TAB,NODES,
      .                                        NEWFRONT,IPARI,GEO,
      .                                        IXS,IXC,IXT,IXP,IXR,IXTG,IXS10,
      .                                        ADDCNEL,CNEL,TAG_NODE,TAG_ELEM )
@@ -44,6 +44,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !           local procs find the local edge/interfaces 
 !           local procs deactivate the edge from the interfaces     
 !$ENDCOMMENT
+        USE nodal_arrays_mod
         USE INTBUFDEF_MOD   
         USE SHOOTING_NODE_MOD
 C-----------------------------------------------
@@ -59,9 +60,9 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+        TYPE(nodal_arrays_), INTENT(inout) :: NODES
         INTEGER, INTENT(in) :: NB_EDGE   ! number of "edge" (ie. 2 nodes)
         INTEGER, DIMENSION(2*NB_EDGE), INTENT(in) :: LIST_NODE   ! list of 2 nodes
-        INTEGER, DIMENSION(NUMNOD), INTENT(in) :: ITABM1    ! array of global id
         TYPE(shooting_node_type), INTENT(inout) :: SHOOT_STRUCT ! structure for shooting node algo  
         TYPE(INTBUF_STRUCT_), DIMENSION(NINTER), INTENT(inout) :: INTBUF_TAB    ! interface data         
          INTEGER, DIMENSION(NINTER), INTENT(inout) :: NEWFRONT   !< flag to force some exchanges related to S nodes between processor (if a S node becomes a shooting node - all interface) / force the collision detection algo if a new segment is activated for the (interface 25 + solid erosion)
@@ -94,7 +95,6 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   E x t e r n a l   F u n c t i o n s
 C-----------------------------------------------
-        INTEGER SYSFUS2 
 C-----------------------------------------------
         ALLOCATE( LIST_EDGE_R_PROC(4*NB_EDGE) )
         NB_EDGE_R_PROC_M = 0
@@ -110,7 +110,7 @@ C-----------------------------------------------
         DO I=1,NB_EDGE
             GLOBAL_NODE(1:2) = LIST_NODE( (I-1)*2+1:(I-1)*2+2)
             DO J=1,2
-                LOCAL_NODE(J) = SYSFUS2(GLOBAL_NODE(J),ITABM1,NUMNOD)
+                LOCAL_NODE(J) = GET_LOCAL_NODE_ID(NODES,GLOBAL_NODE(J))
             ENDDO
             ! ------------------
             ! MAIN NODE
@@ -156,7 +156,7 @@ C-----------------------------------------------
         DO I=1,NB_EDGE
             GLOBAL_NODE(1:2) = LIST_NODE( (I-1)*2+1:(I-1)*2+2)
             DO J=1,2
-                LOCAL_NODE(J) = SYSFUS2(GLOBAL_NODE(J),ITABM1,NUMNOD)
+                LOCAL_NODE(J) = GET_LOCAL_NODE_ID(NODES,GLOBAL_NODE(J))
             ENDDO
             ! ------------------
             ! SECONDARY NODE

--- a/engine/source/interfaces/interf/find_surface_from_remote_proc.F
+++ b/engine/source/interfaces/interf/find_surface_from_remote_proc.F
@@ -30,7 +30,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||--- uses       -----------------------------------------------------
       !||    shooting_node_mod               ../engine/share/modules/shooting_node_mod.F
       !||====================================================================
-        SUBROUTINE FIND_SURFACE_FROM_REMOTE_PROC(SHOOT_STRUCT,NB_SURFACE,LIST_NODE,INTBUF_TAB,ITABM1,
+        SUBROUTINE FIND_SURFACE_FROM_REMOTE_PROC(SHOOT_STRUCT,NB_SURFACE,LIST_NODE,INTBUF_TAB,NODES,
      .                                           IPARI,GEO,
      .                                           IXS,IXC,IXT,IXP,IXR,IXTG,IXS10,
      .                                           ADDCNEL,CNEL,TAG_NODE,TAG_ELEM )
@@ -43,6 +43,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !           - intersection of lists of surface for the node to obtain the surface id
 !           - deactivation of the surface 
 !$ENDCOMMENT
+        USE nodal_arrays_mod
         USE INTBUFDEF_MOD   
         USE SHOOTING_NODE_MOD
 C-----------------------------------------------
@@ -60,7 +61,7 @@ C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
         INTEGER, INTENT(in) :: NB_SURFACE   ! number of "surface" (ie. 4 nodes)
         INTEGER, DIMENSION(4*NB_SURFACE), INTENT(in) :: LIST_NODE   ! list of 4 nodes
-        INTEGER, DIMENSION(NUMNOD), INTENT(in) :: ITABM1    ! array of global id
+        TYPE(nodal_arrays_), INTENT(INOUT) :: NODES
         TYPE(shooting_node_type), INTENT(inout) :: SHOOT_STRUCT ! structure for shooting node algo  
         TYPE(INTBUF_STRUCT_), DIMENSION(NINTER), INTENT(inout) :: INTBUF_TAB    ! interface data         
 
@@ -93,7 +94,6 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   E x t e r n a l   F u n c t i o n s
 C-----------------------------------------------
-        INTEGER SYSFUS2 
 C-----------------------------------------------
         ALLOCATE( LIST_SURFACE_R_PROC(4*NB_SURFACE) )
         NB_SURFACE_R_PROC = 0
@@ -108,7 +108,7 @@ C-----------------------------------------------
         DO I=1,NB_SURFACE
             GLOBAL_NODE(1:4) = LIST_NODE( (I-1)*4+1:(I-1)*4+4)
             DO J=1,4
-                LOCAL_NODE(J) = SYSFUS2(GLOBAL_NODE(J),ITABM1,NUMNOD)
+                LOCAL_NODE(J) = GET_LOCAL_NODE_ID(NODES,GLOBAL_NODE(J))
             ENDDO
             NODE_ID = LOCAL_NODE(1)    ! get the node ID
       

--- a/engine/source/interfaces/interf/init_nodal_state.F
+++ b/engine/source/interfaces/interf/init_nodal_state.F
@@ -35,7 +35,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    shooting_node_mod           ../engine/share/modules/shooting_node_mod.F
       !||====================================================================
         SUBROUTINE INIT_NODAL_STATE( IPARI,SHOOT_STRUCT,INTBUF_TAB,IAD_ELEM,FR_ELEM,
-     .                               ITAB,ITABM1,GEO,ADDCNEL,CNEL,
+     .                               ITAB,NODES,GEO,ADDCNEL,CNEL,
      .                               IXS,IXC,IXT,IXP,IXR,IXTG,
      .                               SIZE_ADDCNEL,SIZE_CNEL,
      .                               numelsg,numelqg,numelcg,numeltrg,numelpg,
@@ -57,7 +57,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !           - the number of surface where the node is defined
 !           - the list of surface where the node is defined
 !$ENDCOMMENT
-
+        USE nodal_arrays_mod
         USE INTBUFDEF_MOD  
         USE SHOOTING_NODE_MOD
         USE ARRAY_MOD
@@ -96,7 +96,7 @@ C-----------------------------------------------
         TYPE(shooting_node_type), INTENT(inout) :: SHOOT_STRUCT !< structure for shooting node algo
         TYPE(INTBUF_STRUCT_), DIMENSION(NINTER), INTENT(inout) :: INTBUF_TAB    !< interface data
         INTEGER, DIMENSION(NUMNOD), INTENT(in) :: ITAB !< array to convert local id to global id
-        INTEGER, DIMENSION(NUMNOD), INTENT(in) :: ITABM1    !< array of global id
+        type(nodal_arrays_), INTENT(INOUT) :: NODES !< nodal data
         my_real, DIMENSION(NPROPG,NUMGEO), INTENT(in) :: GEO !< property data
         INTEGER, DIMENSION(0:SIZE_ADDCNEL), INTENT(in) :: ADDCNEL !< address for the CNEL array
         INTEGER, DIMENSION(0:SIZE_CNEL), INTENT(in) :: CNEL !< connectivity node --> element
@@ -735,14 +735,14 @@ C-----------------------------------------------
             DO I=1,NSPMD
                 IF(R_BUFFER_MAIN(I)%SIZE_INT_ARRAY_1D>0) THEN
                     CALL COUNT_REMOTE_NB_ELEM_EDGE( R_BUFFER_MAIN(I)%SIZE_INT_ARRAY_1D,R_BUFFER_MAIN(I)%INT_ARRAY_1D,
-     .                                              GEO,IXS,IXC,IXT,IXP,IXR,IXTG,ADDCNEL,ITABM1,CNEL,CHUNK)
+     .                                              GEO,IXS,IXC,IXT,IXP,IXR,IXTG,ADDCNEL,NODES,CNEL,CHUNK)
                     CALL MPI_ISEND( R_BUFFER_MAIN(I)%INT_ARRAY_1D,R_BUFFER_MAIN(I)%SIZE_INT_ARRAY_1D,
      .                             MPI_INTEGER,IT_SPMD(I),MSGTYP,MPI_COMM_WORLD,REQUEST_S2(I),IERROR )     
    
                 ENDIF
                 IF(R_BUFFER_SECOND(I)%SIZE_INT_ARRAY_1D>0) THEN
                     CALL COUNT_REMOTE_NB_ELEM_EDGE( R_BUFFER_SECOND(I)%SIZE_INT_ARRAY_1D,R_BUFFER_SECOND(I)%INT_ARRAY_1D,
-     .                                              GEO,IXS,IXC,IXT,IXP,IXR,IXTG,ADDCNEL,ITABM1,CNEL,CHUNK)
+     .                                              GEO,IXS,IXC,IXT,IXP,IXR,IXTG,ADDCNEL,NODES,CNEL,CHUNK)
                     CALL MPI_ISEND( R_BUFFER_SECOND(I)%INT_ARRAY_1D,R_BUFFER_SECOND(I)%SIZE_INT_ARRAY_1D,
      .                             MPI_INTEGER,IT_SPMD(I),MSGTYP,MPI_COMM_WORLD,REQUEST_S3(I),IERROR )
                 ENDIF

--- a/engine/source/mpi/interfaces/spmd_exch_deleted_surf_edge.F
+++ b/engine/source/mpi/interfaces/spmd_exch_deleted_surf_edge.F
@@ -33,7 +33,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    array_mod                       ../common_source/modules/array_mod.F
       !||    shooting_node_mod               ../engine/share/modules/shooting_node_mod.F
       !||====================================================================
-        SUBROUTINE SPMD_EXCH_DELETED_SURF_EDGE( IAD_ELEM,ITABM1,SHOOT_STRUCT,INTBUF_TAB,NEWFRONT,
+        SUBROUTINE SPMD_EXCH_DELETED_SURF_EDGE( IAD_ELEM,NODES,SHOOT_STRUCT,INTBUF_TAB,NEWFRONT,
      .                                          IPARI,GEO,
      .                                          IXS,IXC,IXT,IXP,IXR,IXTG,IXS10,
      .                                          ADDCNEL,CNEL,TAG_NODE,TAG_ELEM )
@@ -46,6 +46,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !           step 3 : exchange the list of edge and surface
 !           step 4 : deactivate the edge/surface
 !$ENDCOMMENT
+        USE nodal_arrays_mod
         USE ARRAY_MOD
         USE SHOOTING_NODE_MOD
         USE INTBUFDEF_MOD 
@@ -71,7 +72,7 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
         INTEGER, DIMENSION(2,NSPMD+1), INTENT(in) :: IAD_ELEM
-        INTEGER, DIMENSION(NUMNOD), INTENT(in) :: ITABM1    ! array of global id
+        TYPE(nodal_arrays_), INTENT(INOUT) :: NODES
         TYPE(shooting_node_type), INTENT(inout) :: SHOOT_STRUCT ! structure for shooting node algo   
         TYPE(INTBUF_STRUCT_), DIMENSION(NINTER), INTENT(inout) :: INTBUF_TAB    ! interface data 
          INTEGER, DIMENSION(NINTER), INTENT(inout) :: NEWFRONT   ! array for sorting : 1 --> need to sort the interface NIN
@@ -239,13 +240,13 @@ C-----------------------------------------------
             NB_SURFACE = REMOTE_SURF_PER_PROC_2(1,K)
             ADDRESS = INDEX_BUFFER_R_2(K)
 
-            CALL FIND_SURFACE_FROM_REMOTE_PROC(SHOOT_STRUCT,NB_SURFACE,BUFFER_R(ADDRESS),INTBUF_TAB,ITABM1,
+            CALL FIND_SURFACE_FROM_REMOTE_PROC(SHOOT_STRUCT,NB_SURFACE,BUFFER_R(ADDRESS),INTBUF_TAB,NODES,
      .                                         IPARI,GEO,
      .                                         IXS,IXC,IXT,IXP,IXR,IXTG,IXS10,
      .                                         ADDCNEL,CNEL,TAG_NODE,TAG_ELEM )
             NB_EDGE = REMOTE_SURF_PER_PROC_2(2,K)
             ADDRESS = INDEX_BUFFER_R_2(K)+4*NB_SURFACE  
-            CALL FIND_EDGE_FROM_REMOTE_PROC( SHOOT_STRUCT,NB_EDGE,BUFFER_R(ADDRESS),INTBUF_TAB,ITABM1,
+            CALL FIND_EDGE_FROM_REMOTE_PROC( SHOOT_STRUCT,NB_EDGE,BUFFER_R(ADDRESS),INTBUF_TAB,NODES,
      .                                       NEWFRONT,IPARI,GEO,
      .                                       IXS,IXC,IXT,IXP,IXR,IXTG,IXS10,
      .                                       ADDCNEL,CNEL,TAG_NODE,TAG_ELEM )

--- a/engine/source/mpi/interfaces/spmd_exchmsr_idel.F
+++ b/engine/source/mpi/interfaces/spmd_exchmsr_idel.F
@@ -30,11 +30,12 @@ C
       !||====================================================================
       SUBROUTINE SPMD_EXCHMSR_IDEL(
      1    BUFS  ,LBUFS,IXS    ,IXC    ,IXTG   ,
-     2    IXQ   ,IPARG ,ITAGL  ,ITABM1 ,
+     2    IXQ   ,IPARG ,ITAGL  ,NODES,
      3    IRSIZE,IRECV ,CNEL   ,ADDCNEL,OFC    ,
      4    OFT   ,OFTG  ,OFUR   ,OFR    ,OFP    ,
      5    LINDEX,IXP   ,IXR    ,IXT    ,GEO    ,
      6    TAGEL ,IAD_ELEM)
+       USE nodal_arrays_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -55,9 +56,10 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+      TYPE(nodal_arrays_), INTENT(INOUT) :: NODES
       INTEGER IXS(NIXS,*), IXQ(NIXQ,*), IXC(NIXC,*), IXP(NIXP,*),
      .        IXR(NIXR,*), IXT(NIXT,*), TAGEL(*),
-     .        IXTG(NIXTG,*), IPARG(NPARG,*), ITABM1(*),
+     .        IXTG(NIXTG,*), IPARG(NPARG,*), 
      .        BUFS(*),ITAGL(*), IRECV(*), CNEL(0:*), ADDCNEL(0:*),
      .        IRSIZE, LBUFS, OFC, OFT, OFTG, OFUR, OFR, OFP, LINDEX
       INTEGER, DIMENSION(2,NSPMD+1), INTENT(in) :: IAD_ELEM
@@ -80,10 +82,6 @@ C-----------------------------------------------
       INTEGER :: SIZ
       DATA MSGOFF2/188/
       DATA MSGOFF3/189/
-C-----------------------------------------------
-C   E x t e r n a l   F u n c t i o n s
-C-----------------------------------------------
-      INTEGER SYSFUS2
 C-----------------------------------------------
       ALLOCATE(BUFR(IRSIZE))
       LOC_PROC = ISPMD+1
@@ -136,14 +134,14 @@ C
      +          ITYP==20.OR.ITYP==22.OR.ITYP==23.OR.ITYP==24.OR.
      +          ITYP==25.OR.ITYP==2 ).AND.IDEL==2)  )THEN
             DO NN = 1, NBEL
-             N1 = SYSFUS2(BUFR(IDEB-1+4*(NN-1)+1),ITABM1,NUMNOD)
+             N1 = get_local_node_id(NODES, BUFR(IDEB-1+4*(NN-1)+1))
              BUFR(NN+IOFF) = 0
              IF(N1/=0) THEN
-              N2 = SYSFUS2(BUFR(IDEB-1+4*(NN-1)+2),ITABM1,NUMNOD)
+              N2 = get_local_node_id(NODES, BUFR(IDEB-1+4*(NN-1)+2))
               IF(N2/=0) THEN
-               N3 = SYSFUS2(BUFR(IDEB-1+4*(NN-1)+3),ITABM1,NUMNOD)
+               N3 = get_local_node_id(NODES, BUFR(IDEB-1+4*(NN-1)+3))
                IF(N3/=0) THEN
-                N4 = SYSFUS2(BUFR(IDEB-1+4*(NN-1)+4),ITABM1,NUMNOD)
+                N4 = get_local_node_id(NODES, BUFR(IDEB-1+4*(NN-1)+4))
                 IF(N4/=0) THEN
                   DO J=ADDCNEL(N1),ADDCNEL(N1+1)-1
                    II = CNEL(J)
@@ -187,14 +185,14 @@ C
      +             .OR.ITYP==20.OR.ITYP==22.OR.ITYP==23.OR.ITYP==24
      +             .OR.ITYP==25.OR.ITYP==2) .AND. IDEL == 1))THEN
             DO NN = 1, NBEL
-             N1 = SYSFUS2(BUFR(IDEB-1+4*(NN-1)+1),ITABM1,NUMNOD)
+             N1 = get_local_node_id(NODES, BUFR(IDEB-1+4*(NN-1)+1))
              BUFR(NN+IOFF) = 0
              IF(N1/=0) THEN
-              N2 = SYSFUS2(BUFR(IDEB-1+4*(NN-1)+2),ITABM1,NUMNOD)
+              N2 = get_local_node_id(NODES, BUFR(IDEB-1+4*(NN-1)+2))
               IF(N2/=0) THEN
-               N3 = SYSFUS2(BUFR(IDEB-1+4*(NN-1)+3),ITABM1,NUMNOD)
+               N3 = get_local_node_id(NODES, BUFR(IDEB-1+4*(NN-1)+3))
                IF(N3/=0) THEN
-                N4 = SYSFUS2(BUFR(IDEB-1+4*(NN-1)+4),ITABM1,NUMNOD)
+                N4 = get_local_node_id(NODES, BUFR(IDEB-1+4*(NN-1)+4))
                 IF(N4/=0) THEN
                  DO J=ADDCNEL(N1),ADDCNEL(N1+1)-1
                   II = CNEL(J)
@@ -236,10 +234,10 @@ C
             IDEB = IDEB + 4*NBEL
            ELSEIF((ITYP==11.OR.ITYP==-20).AND.IDEL==2)THEN  ! -20 => type20 edge
             DO NN = 1, NBEL
-             N1 = SYSFUS2(BUFR(IDEB-1+2*(NN-1)+1),ITABM1,NUMNOD)
+             N1 = get_local_node_id(NODES, BUFR(IDEB-1+2*(NN-1)+1))
              BUFR(NN+IOFF) = 0
              IF(N1/=0) THEN
-              N2 = SYSFUS2(BUFR(IDEB-1+2*(NN-1)+2),ITABM1,NUMNOD)
+              N2 = get_local_node_id(NODES, BUFR(IDEB-1+2*(NN-1)+2))
               IF(N2/=0) THEN
                DO J=ADDCNEL(N1),ADDCNEL(N1+1)-1
                 II = CNEL(J)
@@ -300,10 +298,10 @@ C
             IDEB = IDEB + 2*NBEL
            ELSEIF((ITYP==11.OR.ITYP==-20).AND.IDEL==1)THEN  ! -20 => type20 edge
             DO NN = 1, NBEL
-             N1 = SYSFUS2(BUFR(IDEB-1+2*(NN-1)+1),ITABM1,NUMNOD)
+             N1 = get_local_node_id(NODES, BUFR(IDEB-1+2*(NN-1)+1))
              BUFR(NN+IOFF) = 0
              IF(N1/=0) THEN
-              N2 = SYSFUS2(BUFR(IDEB-1+2*(NN-1)+2),ITABM1,NUMNOD)
+              N2 = get_local_node_id(NODES, BUFR(IDEB-1+2*(NN-1)+2))
               IF(N2/=0) THEN
                DO J=ADDCNEL(N1),ADDCNEL(N1+1)-1
                 II = CNEL(J)

--- a/engine/source/mpi/kinematic_conditions/spmd_exchseg_idel.F
+++ b/engine/source/mpi/kinematic_conditions/spmd_exchseg_idel.F
@@ -31,12 +31,12 @@ C
       !||====================================================================
       SUBROUTINE SPMD_EXCHSEG_IDEL(
      1    BUFS  ,LBUFS ,IXS    ,IXC    ,IXTG   ,
-     2    IXQ   ,IPARG ,ITAGL  ,ITABM1 ,TAGEL  ,
+     2    IXQ   ,IPARG ,ITAGL  ,NODES,TAGEL  ,
      3    IRSIZE,IRECV ,CNEL   ,ADDCNEL,OFC    ,
      4    OFT   ,OFTG  ,OFUR   ,OFR    ,OFP    ,
      5    OFQ   ,LINDEX,IXP    ,IXR    ,IXT    ,
      6    GEO   ,IAD_ELEM)
-
+       USE nodal_arrays_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -57,9 +57,10 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+      TYPE(nodal_arrays_), INTENT(INOUT) :: NODES
       INTEGER IXS(NIXS,*), IXQ(NIXQ,*), IXC(NIXC,*), IXP(NIXP,*),
      .        IXR(NIXR,*), IXT(NIXT,*), TAGEL(*),
-     .        IXTG(NIXTG,*), IPARG(NPARG,*), ITABM1(*),
+     .        IXTG(NIXTG,*), IPARG(NPARG,*),
      .        BUFS(*),ITAGL(*), IRECV(*), CNEL(0:*), ADDCNEL(0:*),
      .        IRSIZE, LBUFS, OFC, OFT, OFTG, OFUR, OFR, OFP, LINDEX,
      .        OFQ
@@ -82,10 +83,6 @@ C-----------------------------------------------
 
       DATA MSGOFF2/188/
       DATA MSGOFF3/189/
-C-----------------------------------------------
-C   E x t e r n a l   F u n c t i o n s
-C-----------------------------------------------
-      INTEGER SYSFUS2
 C-----------------------------------------------    
       ALLOCATE(BUFR(IRSIZE))
       LOC_PROC = ISPMD+1
@@ -133,17 +130,17 @@ C
           IRECV(I)=0
 
           DO NN = 1, NBEL
-             N1 = SYSFUS2(BUFR(IDEB+4*(NN-1)+1),ITABM1,NUMNOD)
+             N1 = GET_LOCAL_NODE_ID(NODES, BUFR(IDEB+4*(NN-1)+1))
              BUFR(NN+IOFF) = 0
              IF(N1/=0) THEN
 
-              N2 = SYSFUS2(BUFR(IDEB+4*(NN-1)+2),ITABM1,NUMNOD)
+              N2 = GET_LOCAL_NODE_ID(NODES, BUFR(IDEB+4*(NN-1)+2))
               IF(N2/=0) THEN
 
-               N3 = SYSFUS2(BUFR(IDEB+4*(NN-1)+3),ITABM1,NUMNOD)
+               N3 = GET_LOCAL_NODE_ID(NODES, BUFR(IDEB+4*(NN-1)+3))
                IF(N3/=0) THEN
 
-                N4 = SYSFUS2(BUFR(IDEB+4*(NN-1)+4),ITABM1,NUMNOD)
+                N4 = GET_LOCAL_NODE_ID(NODES, BUFR(IDEB+4*(NN-1)+4))
                 IF(N4/=0) THEN
 
                  DO J=ADDCNEL(N1),ADDCNEL(N1+1)-1

--- a/engine/source/output/anim/generate/animx.F
+++ b/engine/source/output/anim/generate/animx.F
@@ -28,7 +28,6 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    ancmsg          ../engine/source/output/message/message.F
       !||    arret           ../engine/source/system/arret.F
       !||    sav_buf_point   ../engine/source/user_interface/eng_callback_c.c
-      !||    sysfus          ../engine/source/system/sysfus.F
       !||    xanim28         ../engine/source/elements/xelem/xanim28.F
       !||    xanim29         ../engine/source/output/anim/generate/xanim29.F
       !||    xanim30         ../engine/source/output/anim/generate/xanim30.F
@@ -99,8 +98,6 @@ C-----------------------------------------------
 C   E x t e r n a l   F u n c t i o n s
 C-----------------------------------------------
 C     REAL
-      my_real
-     .   SYSFUS
 C-----------------------------------------------
       DATA MESS/'MULTI-PURPOSE ELEMENT DISCRETIZATION    '/
 C-----------------------------------------------

--- a/engine/source/output/restart/rdresb.F
+++ b/engine/source/output/restart/rdresb.F
@@ -352,6 +352,8 @@ C
         CALL READ_I_C(IXR,SIXR)
 
         CALL READ_I_C(NODES%ITAB,SITAB)
+        ! Create the map from global to local ids
+        CALL INIT_GLOBAL_ID(NODES,NUMNOD)
 
         CALL READ_I_C(NODES%ITABM1,SITABM1)
 


### PR DESCRIPTION
SYSFUS is using ITABM1 which is of size 2:NUMNOD.
Hash table should perform better than linear search, and it is easier to update when nodes are added

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
