### PR TITLE
/INTER/TYPE25 print less error messages in case of high velocities

### DIFF
--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -3694,6 +3694,7 @@ C===============================================================================
         ELSE
           CALL ASSIGN_PTRX(ptrX,NODES%X,NUMNOD)
         ENDIF
+        INTER_ERRORS = 0
 
 !$OMP PARALLEL PRIVATE(ITSK,DT2TT,NELTSTT,ITYPTSTT)
         DT2TT = DT2T

--- a/engine/source/interfaces/intsort/intcrit.F
+++ b/engine/source/interfaces/intsort/intcrit.F
@@ -89,6 +89,7 @@ C-----------------------------------------------
       INTEGER I,J,KK,IGN,IGE,JJ, NSN, NMN,
      .        IAD,K,N,IADD,ICOMP,NTY,NME,NMES,NMET,
      .        NBNEW, LISTNEW(NBINTC), ISENS, INTERACT,DELTA_PMAX_GAP_NOD
+      INTEGER :: JMAX
       my_real
      .        XX,XY,XZ,DIST0,VX,VY,VZ,GAPINF,VV,DTI,VMAXDT,
      .        STARTT, STOPT, MINBOX,TZINFL,GAPSUP,PMAX_GAP,
@@ -395,15 +396,17 @@ c (no need to communicate VMAXDT in SPMD)
            ENDIF
            NSN = IPARI(5,I)
            NMN = IPARI(6,I)
+           D1 = ZERO
+           JMAX = 1
            DO JJ=1,NSN
              J=INTBUF_TAB(I)%NSV(JJ)
              IF(INTBUF_TAB(I)%STFNS(JJ)/=ZERO .AND. J<=NUMNOD .AND. J > 0) THEN
                VX = V(1,J) 
                VY = V(2,J) 
                VZ = V(3,J) 
-               D1 = SQRT(VX**2+VY**2+VZ**2)
-               IF(D1 > FIVE * MARGE0 /TWO) THEN
-                 WRITE(ISTDO,*) "ERROR: NODAL VELOCITY IS TOO HIGH FOR NODE",ITAB(J),D1
+               IF( SQRT(VX**2+VY**2+VZ**2) > D1) THEN
+                 D1 = SQRT(VX**2+VY**2+VZ**2)
+                 JMAX = J
                ENDIF
              ENDIF
            END DO
@@ -413,16 +416,18 @@ c (no need to communicate VMAXDT in SPMD)
                VX = V(1,J) 
                VY = V(2,J) 
                VZ = V(3,J) 
-               D1 = SQRT(VX**2+VY**2+VZ**2)
-               IF(D1 > FIVE * MARGE0 /TWO ) THEN
-                 WRITE(ISTDO,*) "ERROR: NODAL VELOCITY IS TOO HIGH FOR NODE",ITAB(J),D1
+               IF( SQRT(VX**2+VY**2+VZ**2) > D1) THEN
+                 D1 = SQRT(VX**2+VY**2+VZ**2)
+                 JMAX = J
                ENDIF
              ENDIF
            ENDDO
+           IF(D1 > FIVE * MARGE0 /TWO ) THEN
+             WRITE(ISTDO,*) "ERROR: NODAL VELOCITY IS TOO HIGH FOR NODE",ITAB(JMAX),D1
+             WRITE(IOUT,*) "ERROR: NODAL VELOCITY IS TOO HIGH FOR NODE",ITAB(JMAX),D1
+           ENDIF
            INTBUF_TAB(I)%VARIABLES(24) = MARGE0
          ENDIF
-
-
 
 
          IF(DIST0<=ZERO.OR.KFORSMS/=0.OR.FORCE_COMPUTATION(I)) THEN

--- a/engine/source/interfaces/intsort/inttri.F
+++ b/engine/source/interfaces/intsort/inttri.F
@@ -621,7 +621,6 @@ C
 C
 C Partie non parallele smt
 C
-      ERRORS = 0 
 !$OMP SINGLE
 
       IF (IMONM > 0) THEN


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
In case of high velocities, too many nodes were printed. Now we print only one node per spmd domain per interface.



<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
