### PR TITLE
Activate conversion of LOAD_BODY for options _RX,_RY,_RZ and _VECTOR

### DIFF
--- a/hm_cfg_files/config/CFG/Keyword971_R13.0/data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R13.0/data_hierarchy.cfg
@@ -5293,11 +5293,11 @@ HIERARCHY {
           USER_ID   = 728;
           USER_NAMES = (  LOAD_BODY_X,
                           LOAD_BODY_Y,
-                          LOAD_BODY_Z/*,
+                          LOAD_BODY_Z,
                           LOAD_BODY_RX,
                           LOAD_BODY_RY,
                           LOAD_BODY_RZ,
-                          LOAD_BODY_VECTOR*/,
+                          LOAD_BODY_VECTOR,
                           LOAD_BODY_PARTS  );
      }
      HIERARCHY {


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

In data_hierarchy.cfg, activate conversion of LOAD_BODY for options _RX,_RY,_RZ and _VECTOR

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

In data_hierarchy.cfg, activate conversion of LOAD_BODY for options _RX,_RY,_RZ and _VECTOR

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
