### PR TITLE
/EOS/GRUNEISEN : new P0 and PSH parameters

### DIFF
--- a/common_source/eos/eosmain.F
+++ b/common_source/eos/eosmain.F
@@ -177,7 +177,8 @@ C-----------------------------------------------
          CALL GRUNEISEN(
      1                  IFLAG  ,NEL    ,PM     ,OFF    ,EINT  ,MU  ,MU2, 
      2                  ESPE   ,DVOL   ,DF     ,VNEW   ,MAT   ,RHO0,
-     3                  PNEW   ,DPDM   ,DPDE   ,THETA  ,ECOLD )
+     3                  PNEW   ,DPDM   ,DPDE   ,THETA  ,ECOLD ,PSH ,
+     4                  NUMMAT ,NPROPM)
 
        CASE (3)
          !--------------------------------------------------!

--- a/common_source/eos/gruneisen.F
+++ b/common_source/eos/gruneisen.F
@@ -25,9 +25,18 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||--- called by ------------------------------------------------------
       !||    eosmain     ../common_source/eos/eosmain.F
       !||====================================================================
-      SUBROUTINE GRUNEISEN(IFLAG,NEL,PM   ,OFF  ,EINT ,MU   ,MU2 , 
-     2                     ESPE ,DVOL ,DF   ,VNEW ,MAT  ,RHO0,
-     3                     PNEW ,DPDM ,DPDE ,THETA,ECOLD)
+      SUBROUTINE GRUNEISEN(IFLAG , NEL    ,PM   ,OFF   ,EINT  ,MU   ,MU2 ,
+     2                     ESPE  , DVOL   ,DF   ,VNEW  ,MAT   ,RHO0,
+     3                     PNEW  , DPDM   ,DPDE ,THETA ,ECOLD ,PSH,
+     4                     NUMMAT, NPROPM)
+C-----------------------------------------------
+C   D e s c r i p t i o n
+C-----------------------------------------------
+C Mie-Gruneisen Equation of State
+C
+C     STAGGERED SCHEME : IFLG=0 : sound speed derivatives
+C                        IFLG=1 : P[n+1] and EINT[n+1]
+C    COLLOCATED SCHEME : IFLG=2 : P[n+1] and sound speed derivatives
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -36,38 +45,43 @@ C-----------------------------------------------
 C   C o m m o n   B l o c k s
 C-----------------------------------------------
 #include      "mvsiz_p.inc"
-#include      "param_c.inc"
-#include      "com04_c.inc"
-#include      "com06_c.inc"
-#include      "com08_c.inc"
-#include      "vect01_c.inc"
-#include      "scr06_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER MAT(NEL), IFLAG, NEL
-      my_real PM(NPROPM,NUMMAT), 
-     .        OFF(NEL)  ,EINT(NEL) ,MU(NEL)   , 
-     .        MU2(NEL)  ,ESPE(NEL) ,DVOL(NEL) ,DF(NEL)  , 
-     .        VNEW(NEL) ,RHO0(NEL) ,PNEW(NEL) ,DPDM(NEL),
-     .        DPDE(NEL) ,THETA(NEL),ECOLD(NEL)
+      INTEGER,INTENT(IN) :: NUMMAT            !< number of material laws  (size for PM array)
+      INTEGER,INTENT(IN) :: NPROPM            !< size for PM array
+      INTEGER,INTENT(IN) :: IFLAG             !< flag for the operation (staggered scheme IFLAG=0,1 ; collocated scheme IFLAG=2)
+      INTEGER,INTENT(IN) :: NEL               !< number of elements in the current group
+      INTEGER,INTENT(IN) :: MAT(NEL)          !< material identifier of each element
+      my_real,INTENT(IN) :: PM(NPROPM,NUMMAT) !< material buffer
+      my_real,INTENT(IN) :: OFF(NEL)          !< OFF=1 if element is active, OFF=0 if element is inactive
+      my_real,INTENT(IN) :: MU(NEL)           !< volumetric strain : rho/rho0-1
+      my_real,INTENT(IN) :: MU2(NEL)          !< MU**2 IF MU > 0 , 0 otherwise
+      my_real,INTENT(IN) :: ESPE(NEL)         !< specific internal energy
+      my_real,INTENT(IN)  :: DVOL(NEL)        !< volume change
+      my_real,INTENT(IN) :: VNEW(NEL)         !< current volume
+      my_real,INTENT(IN) :: RHO0(NEL)         !< reference density
+      my_real,INTENT(IN) :: DF(NEL)           !< relative volume (v/v0 = rho0/rho)
+      my_real,INTENT(INOUT) :: EINT(NEL)      !< internal energy
+      my_real,INTENT(INOUT) :: ECOLD(NEL)     !< cold internal energy for temperature model
+      my_real,INTENT(INOUT) :: PSH(NEL)       !< pressure shift (for relative pressure modeling)
+      my_real,INTENT(INOUT) :: PNEW(NEL)      !< current pressure      my_real,INTENT(INOUT) :: ECOLD(NEL)     !< cold internal energy (for temperature calculation)
+      my_real,INTENT(INOUT) :: THETA(NEL)     !< temperature
+      my_real,INTENT(INOUT) :: DPDE(NEL)      !< partial derivative dP/dE where E=Eint/V0
+      my_real,INTENT(INOUT) :: DPDM(NEL)      !< total derivative : DP/Dmu = dPdmu + dPdE* P/(1+mu)**2
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I, MX
-      my_real
-     .   AA, BB, DVV, FF, FG, FAC, XX, DFF, DFG, FAC1, PP, ETA
-      my_real
-     .   CC(MVSIZ),S1(MVSIZ),S2(MVSIZ),S3(MVSIZ),G0(MVSIZ),GA(MVSIZ),
-     .   PC(MVSIZ),SPH(MVSIZ)
-C--------------------------------------------------------------------
-      IF(IFLAG == 0) THEN
-C-----------------------------------------
-C     COMPUTE BULK MODULUS FOR SOUND SPEED
-C     COMPUTE COLD COMPRESSION ENERGY
-C-----------------------------------------
+      my_real AA, BB, DVV, FF, FG, FAC, XX, DFF, DFG, FAC1, PP, ETA
+      my_real CC(MVSIZ),S1(MVSIZ),S2(MVSIZ),S3(MVSIZ),G0(MVSIZ),GA(MVSIZ),PC(MVSIZ),SPH(MVSIZ)
+C-----------------------------------------------
+C   B o d y
+C-----------------------------------------------
+      IF(IFLAG == 0) THEN !--- SOUND SPEED DERIVATIVE (DPDE is partial derivative, DPDM is total derivative)
+       ! user parameters
        DO I=1,NEL
-        MX    = MAT(I)
+        MX = MAT(I)
         CC(I) = PM(33,MX)
         S1(I) = PM(34,MX)
         S2(I) = PM(160,MX)
@@ -75,9 +89,11 @@ C-----------------------------------------
         G0(I) = PM(35,MX)
         GA(I) = PM(36,MX)
         PC(I) = PM(37,MX)
-        SPH(I)= PM(69,MX)
+        SPH(I) = PM(69,MX)
+        PSH(I) = PM(88,MX)
        ENDDO
-C
+
+       ! Derivative
        DO I=1,NEL
         FAC=ONE
         FAC1=ONE
@@ -87,34 +103,31 @@ C
          FG=ONE-(S1(I)-ONE+S2(I)*XX+S3(I)*XX*XX)*MU(I)
          FAC=FF/(FG*FG)
          DFF=ONE-HALF*G0(I)-GA(I)*MU(I)
-         DFG=ONE-S1(I)+XX*(-TWO*S2(I)+XX*(S2(I)-THREE*S3(I))
-     .      +TWO*S3(I)*XX*XX)
+         DFG=ONE-S1(I)+XX*(-TWO*S2(I)+XX*(S2(I)-THREE*S3(I))+TWO*S3(I)*XX*XX)
          FAC1=FAC*(ONE+MU(I)*(DFF/FF-TWO*DFG/FG))
         ENDIF
-C
         AA=FAC*RHO0(I)*CC(I)*CC(I)*MU(I)
         BB=G0(I)+GA(I)*MU(I)
-        PP=MAX(AA+BB*ESPE(I),PC(I))*OFF(I)
+        PP=MAX(AA+BB*ESPE(I),PC(I))*OFF(I) ! total pressure need for sound speed calculation (=> no pressure shift)
         DPDM(I)=FAC1*RHO0(I)*CC(I)*CC(I)+PP*DF(I)*DF(I)*BB+GA(I)*ESPE(I)
         DPDE(I)=BB
        ENDDO
-C
+
+       ! Temperature
        DO I=1,NEL
         ECOLD(I)=-THREE100*SPH(I)
         IF(MU(I)>ZERO) THEN
           XX  = MU(I)/(ONE+MU(I))
           ETA=ONE+MU(I)
-          ECOLD(I)=ECOLD(I)*EXP((G0(I)-GA(I))*XX)*ETA**GA(I)+
-     .             HALF*RHO0(I)*CC(I)*CC(I)*MU2(I)
+          ECOLD(I)=ECOLD(I)*EXP((G0(I)-GA(I))*XX)*ETA**GA(I)+HALF*RHO0(I)*CC(I)*CC(I)*MU2(I)
         ENDIF
        ENDDO
-C
-      ELSEIF(IFLAG == 1) THEN
-C----------------------------------------
-C     UPDATE PRESSURE AND INTERNAL ENERGY
-C----------------------------------------
+
+C-----------------------------------------------
+      ELSEIF(IFLAG == 1) THEN  !--- P[n+1] and EINT[n+1]
+       ! user parameters
        DO I=1,NEL
-        MX    = MAT(I)
+        MX = MAT(I)
         CC(I) = PM(33,MX)
         S1(I) = PM(34,MX)
         S2(I) = PM(160,MX)
@@ -122,8 +135,11 @@ C----------------------------------------
         G0(I) = PM(35,MX)
         GA(I) = PM(36,MX)
         PC(I) = PM(37,MX)
+        PSH(I) = PM(88,MX)
        ENDDO
-C
+
+       ! Pressure P[n+1]
+       ! Internal Energy Eint[n+1] (2nd order integration requires P[n+1])
        DO I=1,NEL
         FAC=ONE
         IF(MU(I) > ZERO) THEN
@@ -137,34 +153,40 @@ C
         DVV=HALF*DVOL(I)*DF(I) / MAX(EM15,VNEW(I))
         PNEW(I)=(AA+BB*ESPE(I))/(ONE+BB*DVV)
         PNEW(I)= MAX(PNEW(I),PC(I))*OFF(I)
-        EINT(I)=EINT(I) - HALF*DVOL(I)*PNEW(I)
+        EINT(I)=EINT(I) - HALF*DVOL(I)*PNEW(I) !total pressure for energy integration
+        PNEW(I) = PNEW(I) - PSH(I)
        ENDDO
-C------------------------
-C     COMPUTE TEMPERATURE
-C------------------------
+
+       !Temperature
        DO I=1,NEL
-        MX     =MAT(I)
-        SPH(I) =PM(69,MX)
+        MX = MAT(I)
+        SPH(I) = PM(69,MX)
        ENDDO
        DO I=1,NEL
         XX=-ECOLD(I)
-        IF(VNEW(I)>EM15)XX=DF(I)*EINT(I)/VNEW(I)-ECOLD(I)
-        IF(OFF(I)<ONE.OR.SPH(I)<=ZERO.OR.XX<ZERO) CYCLE
+        IF(VNEW(I) > EM15)XX=DF(I)*EINT(I)/VNEW(I)-ECOLD(I)
+        IF(OFF(I) < ONE .OR. SPH(I) <= ZERO .OR. XX < ZERO) CYCLE
         THETA(I)=XX/SPH(I)
        ENDDO
-       ELSEIF(IFLAG == 2) THEN
+
+C-----------------------------------------------
+       ELSEIF(IFLAG == 2) THEN  !--- collocated scheme (law151)
+
+          ! user parameters
           DO I=1, NEL
-             MX    =MAT(I)
-             CC(I) =PM(33,MX)
-             S1(I) =PM(34,MX)
-             S2(I) =PM(160,MX)
-             S3(I) =PM(161,MX)
-             G0(I) =PM(35,MX)
-             GA(I) =PM(36,MX)
-             PC(I) =PM(37,MX)
-             SPH(I)=PM(69,MX)
+             MX = MAT(I)
+             CC(I) = PM(33,MX)
+             S1(I) = PM(34,MX)
+             S2(I) = PM(160,MX)
+             S3(I) = PM(161,MX)
+             G0(I) = PM(35,MX)
+             GA(I) = PM(36,MX)
+             PC(I) = PM(37,MX)
+             SPH(I) = PM(69,MX)
+             PSH(I) = PM(88,MX)
           ENDDO
-C     
+
+          ! pressure and sound speed derivatives
           DO I=1, NEL
              IF (VNEW(I) > ZERO) THEN
                 FAC=ONE
@@ -175,18 +197,19 @@ C
                    FG=ONE-(S1(I)-ONE+S2(I)*XX+S3(I)*XX*XX)*MU(I)
                    FAC=FF/(FG*FG)
                    DFF=ONE-HALF*G0(I)-GA(I)*MU(I)
-                   DFG=ONE-S1(I)+XX*(-TWO*S2(I)+XX*(S2(I)-THREE*S3(I))
-     .                  +TWO*S3(I)*XX*XX)
+                   DFG=ONE-S1(I)+XX*(-TWO*S2(I)+XX*(S2(I)-THREE*S3(I))+TWO*S3(I)*XX*XX)
                    FAC1=FAC*(ONE+MU(I)*(DFF/FF-TWO*DFG/FG))
                 ENDIF
-C     
                 AA=FAC*RHO0(I)*CC(I)*CC(I)*MU(I)
                 BB=G0(I)+GA(I)*MU(I)
                 PNEW(I)=MAX(AA+BB*ESPE(I),PC(I))*OFF(I)
                 DPDM(I)=FAC1*RHO0(I)*CC(I)*CC(I)+PNEW(I)*DF(I)*DF(I)*BB+GA(I)*ESPE(I)
                 DPDE(I)=BB
+                PNEW(I) = PNEW(I) - PSH(I)
              ENDIF
           ENDDO
+
       ENDIF
+C-----------------------------------------------
       RETURN
       END

--- a/hm_cfg_files/config/CFG/radioss2025/MAT/mat_EOS.cfg
+++ b/hm_cfg_files/config/CFG/radioss2025/MAT/mat_EOS.cfg
@@ -187,6 +187,8 @@ GUI(COMMON) {
         SCALAR(GAMMA)          { DIMENSION="DIMENSIONLESS"; }
         SCALAR(MAT_A)          { DIMENSION="DIMENSIONLESS"; }
         SCALAR(R0E0)           { DIMENSION="energydensity"; }
+        SCALAR(LAW5_P0)        { DIMENSION="pressure"; }
+        SCALAR(MAT_PSH)        { DIMENSION="pressure"; }
         SCALAR(Refer_Rho)      { DIMENSION="density"; }
     }
     else if(EOS_Options == 3)
@@ -537,6 +539,8 @@ FORMAT(radioss2025) {
         CARD("%20lg%20lg%20lg%20lg",MAT_C,S1,S2,S3);
         COMMENT("#                 Y0                   a                  E0");
         CARD("%20lg%20lg%20lg",GAMMA,MAT_A,R0E0);
+        COMMENT("#                 P0                 PSH");
+        CARD("%20lg%20lg",LAW5_P0,MAT_PSH);
     }
     else if(EOS_Options == 3)
     {

--- a/starter/source/materials/eos/hm_read_eos_gruneisen.F
+++ b/starter/source/materials/eos/hm_read_eos_gruneisen.F
@@ -69,9 +69,11 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      my_real :: C, S1, S2, S3, GAMA0, A, E0, RHO0,RHOI,RHOR,FAC_L,FAC_T
-      my_real :: FAC_M,FAC_C,MU,MU2,MU3,MUP1,NUM,DENOM,FAC1,DPDMU,PP,BB,AA
+      my_real :: C, S1, S2, S3, GAMA0, A, E0, RHO0,RHOI,RHOR
+      my_real :: MU,MU2,FAC1,DPDMU,PP,BB,AA
       my_real :: MU0, DF, SSP0, G0, FAC, FF, FG, XX, DFF, DFG
+      my_real :: PSH !< pressure shift
+      my_real :: P0  !< initial pressure
       LOGICAL :: IS_ENCRYPTED, IS_AVAILABLE, IS_AVAILABLE_RHO0
 C-----------------------------------------------
 C   S o u r c e   L i n e s
@@ -90,9 +92,25 @@ C-----------------------------------------------
       CALL HM_GET_FLOATV('GAMMA',GAMA0, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('MAT_A', A, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('R0E0', E0, IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV('P0', P0, IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV('PSH', PSH, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('Refer_Rho', RHO0 ,IS_AVAILABLE_RHO0,LSUBMODEL,UNITAB)
 
       IF(A == ZERO) A=GAMA0
+
+
+      IF(P0 < ZERO)THEN
+         CALL ANCMSG(MSGID=67,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=IMIDEOS,
+     .               C1='/EOS/GRUNEISEN',
+     .               C2='INITIAL PRESSURE MUST BE STRICTLY POSITIVE (TOTAL PRESSURE). USE PSH PARAMETER TO SHIFT THE PRESSURE')
+      ENDIF
+
+      IF(P0 > ZERO .AND. E0 /= ZERO)THEN
+         CALL ANCMSG(MSGID=67,MSGTYPE=MSGERROR,ANMODE=ANINFO,I1=IMIDEOS,
+     .               C1='/EOS/GRUNEISEN',
+     .               C2='INITIAL PRESSURE PROVIDED. E0 IS CONSEQUENTLY REDEFINED SUCH AS P(RHO0,E0)=P0')
+      ENDIF
+
 
       RHOR = PM(1)
       RHOI = PM(89)
@@ -104,19 +122,8 @@ C-----------------------------------------------
         RHO0=RHOR                   
       ENDIF
 
-      PM(23)  = E0
-      PM(32)  = PM(1)*C*C
-      PM(33)  = C
-      PM(34)  = S1
-      PM(35)  = GAMA0      
-      PM(36)  = A
-      PM(160) = S2
-      PM(161) = S3
-      IF(PM(79)==ZERO)PM(79)=THREE100
-
       !COMPUTE INITIAL PRESSURE FOR PM(31)->SIG(1:3,*)
       !SSP0
-      
       IF(RHOI == ZERO)THEN
         MU0 = ZERO ! error 683 already displayed
       ELSE
@@ -126,52 +133,68 @@ C-----------------------------------------------
           MU0 = ZERO ! error 683 already displayed
         ENDIF
       ENDIF
-      
+      ! Internal Energy (if P0 is provided, calculate E0 consequently)
+      IF(P0 > ZERO)THEN
+        E0 = (P0-RHO0*C*C*MU0)/(GAMA0+a*MU0)
+      ENDIF
+      !Relative volume
       IF(RHOI /= ZERO)THEN
         DF = RHOR/RHOI
       ELSE
         DF = ZERO
       ENDIF
-
+      !pressure
       MU2=MU0*MU0
-      PP=PM(31)    
       SSP0 = ZERO 
       G0 = PM(22)
       RHOI = PM(89) 
-        FAC=ONE
-        FAC1=ONE
-        IF(MU0>0)THEN
-         XX= MU0/(ONE+MU0)
-         FF=ONE+(ONE-HALF*GAMA0)*MU0-HALF*A*MU2
-         FG=ONE-(S1-ONE+S2*XX+S3*XX*XX)*MU0
-         FAC=FF/(FG*FG)
-         DFF=ONE-HALF*GAMA0-A*MU0
-         DFG=ONE-S1+XX*(-TWO*S2+XX*(S2-THREE*S3)+TWO*S3*XX*XX)
-         FAC1=FAC*(ONE+MU0*(DFF/FF-TWO*DFG/FG))        
-        ENDIF       
-        AA=FAC*RHOR*C*C*MU0
-        BB=GAMA0+A*MU0
-        PP=MAX(AA+BB*E0,PM(37))
-        DPDMU=FAC1*RHOI*C*C+PP*DF*DF*BB+A*E0
+      FAC=ONE
+      FAC1=ONE
+      IF(MU0>0)THEN
+       XX= MU0/(ONE+MU0)
+       FF=ONE+(ONE-HALF*GAMA0)*MU0-HALF*A*MU2
+       FG=ONE-(S1-ONE+S2*XX+S3*XX*XX)*MU0
+       FAC=FF/(FG*FG)
+       DFF=ONE-HALF*GAMA0-A*MU0
+       DFG=ONE-S1+XX*(-TWO*S2+XX*(S2-THREE*S3)+TWO*S3*XX*XX)
+       FAC1=FAC*(ONE+MU0*(DFF/FF-TWO*DFG/FG))
+      ENDIF
+      AA=FAC*RHOR*C*C*MU0
+      BB=GAMA0+A*MU0
+      PP=MAX(AA+BB*E0,PM(37))
+      !derivatives and sound speed
+      DPDMU=FAC1*RHOI*C*C+PP*DF*DF*BB+A*E0
       DPDMU=MAX(ZERO,DPDMU)
-      IF(RHOR > ZERO) SSP0 = SQRT((DPDMU + TWO_THIRD*G0)/RHOR) 
-      PM(27)=SSP0
-      PM(31) = PP     
-      PM(104) = PP       
+      IF(RHOR > ZERO) SSP0 = SQRT((DPDMU + TWO_THIRD*G0)/RHOR)
+
+      ! Storage in Material Buffer PM
+      PM(23)  = E0
+      PM(32)  = PM(1)*C*C
+      PM(33)  = C
+      PM(34)  = S1
+      PM(35)  = GAMA0
+      PM(36)  = A
+      PM(88)  = PSH
+      PM(160) = S2
+      PM(161) = S3
+      IF(PM(79)==ZERO)PM(79)=THREE100
+      PM(27) = SSP0
+      PM(31) = PP - PSH
+      PM(104) = PP - PSH
       
       WRITE(IOUT,1000)
       IF(IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
       ELSE
-        WRITE(IOUT,1500)C,S1,S2,S3,GAMA0,A,E0,PM(31)
+        WRITE(IOUT,1500)C,S1,S2,S3,GAMA0,A,E0,PP,PSH,PP-PSH
         IF(IS_AVAILABLE_RHO0)WRITE(IOUT,1501)PM(1)
       ENDIF
 
       RETURN
       
  1000 FORMAT(
-     & 5X,'  GRUNEISEN EOS     ',/,
-     & 5X,'  --------------     ',/)
+     & 5X,'  MIE-GRUNEISEN EOS     ',/,
+     & 5X,'  -----------------     ',/)
  1500 FORMAT(
      & 5X,'C . . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'S1. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
@@ -180,7 +203,9 @@ C-----------------------------------------------
      & 5X,'GAMA0 . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'A . . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'INITIAL INTERNAL ENERGY PER UNIT VOLUME .=',1PG20.13/,
-     & 5X,'INITIAL PRESSURE . .  . . . . . . . . . .=',1PG20.13)
+     & 5X,'INITIAL PRESSURE . .  . . . . . . . . . .=',1PG20.13/,
+     & 5X,'PRESSURE SHIFT . . .  . . . . . . . . . .=',1PG20.13/,
+     & 5X,'INITIAL PRESSURE (SHIFTED)  . . . . . . .=',1PG20.13)
  1501 FORMAT(     
      & 5X,'EOS REFERENCE DENSITY . . . . . . . . . .=',1PG20.13)
  


### PR DESCRIPTION
#### /EOS/GRUNEISEN : new P0 and PSH parameters

#### Description of the changes

- **PSH parameter available** : The PSH parameter was added in Mie-Gruneisen EoS. It allows to model relative pressure by shifting pressure.
- **P0 parameter available** : E0 is now automatically calculated when user provides P0.  E0 is such as P(µ0, E0) = P0

Verification (isentropic path expansion/compression)
![image](https://github.com/user-attachments/assets/6150f8aa-c226-49f6-a988-84940c714ba5)
![image](https://github.com/user-attachments/assets/73d1d487-4f6f-4d69-b382-0d1372f416dc)

