### PR TITLE
Reduce memory overhead due to structure ARRAY_MOD

### DIFF
--- a/common_source/modules/array_mod.F
+++ b/common_source/modules/array_mod.F
@@ -52,6 +52,8 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !       ARRAY_MOD description
 !           allocation & dealloaction of arrays (1d/2d/3d)
 !       ARRAY_MOD organization
+!       DO NOT ALLOCATE LARGE ARRAYS OF TYPE(array_type) if only a few elements are needed
+!        SIZE(array_type) == 1248 bytes (ifx) or 1152 bytes (gfortran)
 !$ENDCOMMENT
 
         TYPE array_type
@@ -83,6 +85,20 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
             REAL(kind=4), DIMENSION(:,:), ALLOCATABLE :: SP_ARRAY_2D
             REAL(kind=4), DIMENSION(:,:,:), ALLOCATABLE :: SP_ARRAY_3D
         END TYPE array_type
+        TYPE array_type_int_1d
+            INTEGER :: SIZE_INT_ARRAY_1D
+            INTEGER, DIMENSION(:), ALLOCATABLE :: INT_ARRAY_1D
+        END TYPE array_type_int_1d
+
+        interface alloc_1d_array
+            MODULE PROCEDURE alloc_1d_array_full
+            MODULE PROCEDURE alloc_int_1d_array 
+        end interface
+        interface dealloc_1d_array
+            MODULE PROCEDURE dealloc_1d_array_full
+            MODULE PROCEDURE dealloc_int_1d_array
+        end interface
+
 
         CONTAINS
             ! ----------------------------
@@ -97,7 +113,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    init_nodal_state              ../engine/source/interfaces/interf/init_nodal_state.F
       !||    spmd_exch_deleted_surf_edge   ../engine/source/mpi/interfaces/spmd_exch_deleted_surf_edge.F
       !||====================================================================
-            SUBROUTINE ALLOC_1D_ARRAY(THIS)
+            SUBROUTINE ALLOC_1D_ARRAY_FULL(THIS)
             IMPLICIT NONE
 
             TYPE(array_type), INTENT(inout) :: THIS
@@ -106,6 +122,17 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 
             RETURN
             END SUBROUTINE 
+
+            SUBROUTINE ALLOC_INT_1D_ARRAY(THIS)
+            IMPLICIT NONE
+
+            TYPE(array_type_int_1d), INTENT(inout) :: THIS
+
+            ALLOCATE( THIS%INT_ARRAY_1D( THIS%SIZE_INT_ARRAY_1D ) )
+
+            RETURN
+            END SUBROUTINE 
+ 
             ! ----------------------------
       !||====================================================================
       !||    alloc_2d_array               ../common_source/modules/array_mod.F
@@ -152,7 +179,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    inter_save_candidate          ../starter/source/interfaces/inter3d1/inter_save_candidate.F90
       !||    spmd_exch_deleted_surf_edge   ../engine/source/mpi/interfaces/spmd_exch_deleted_surf_edge.F
       !||====================================================================
-            SUBROUTINE DEALLOC_1D_ARRAY(THIS)
+            SUBROUTINE DEALLOC_1D_ARRAY_FULL(THIS)
             IMPLICIT NONE
 
             TYPE(array_type), INTENT(inout) :: THIS
@@ -162,6 +189,16 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
             RETURN
             END SUBROUTINE 
             ! ----------------------------
+           SUBROUTINE DEALLOC_INT_1D_ARRAY(THIS)
+            IMPLICIT NONE
+
+            TYPE(array_type_int_1d), INTENT(inout) :: THIS
+
+            DEALLOCATE( THIS%INT_ARRAY_1D )
+
+            RETURN
+            END SUBROUTINE 
+  
       !||====================================================================
       !||    dealloc_2d_array             ../common_source/modules/array_mod.F
       !||--- called by ------------------------------------------------------

--- a/starter/source/interfaces/inter3d1/i25sto.F
+++ b/starter/source/interfaces/inter3d1/i25sto.F
@@ -65,8 +65,8 @@ C     REAL
       my_real , INTENT(IN) :: DGAPLOAD ,DRAD
       INTEGER , INTENT(IN) :: NRTMT
 
-      type(array_type) :: local_cand_n
-      type(array_type) :: local_cand_e
+      type(array_type_int_1d) :: local_cand_n
+      type(array_type_int_1d) :: local_cand_e
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/starter/source/interfaces/inter3d1/i25trivox1.F
+++ b/starter/source/interfaces/inter3d1/i25trivox1.F
@@ -154,8 +154,8 @@ C
 
       integer, dimension(:), allocatable, save :: cand_n_size,cand_e_size
       integer, dimension(:), allocatable, save :: address_cand_n,address_cand_e
-      type(array_type) :: local_cand_n
-      type(array_type) :: local_cand_e
+      type(array_type_int_1d) :: local_cand_n
+      type(array_type_int_1d) :: local_cand_e
 C-----------------------------------------------
       ! allocation of local arrays 
       itask = omp_get_thread_num()

--- a/starter/source/interfaces/inter3d1/i7trivox1.F
+++ b/starter/source/interfaces/inter3d1/i7trivox1.F
@@ -179,8 +179,8 @@ c     .   maxaaa
       integer, save :: i_stok_old
       integer, dimension(:), allocatable, save :: cand_n_size,cand_e_size
       integer, dimension(:), allocatable, save :: address_cand_n,address_cand_e
-      type(array_type) :: local_cand_n
-      type(array_type) :: local_cand_e
+      type(array_type_int_1d) :: local_cand_n
+      type(array_type_int_1d) :: local_cand_e
 C-----------------------------------------------
       ! allocation of local arrays 
       itask = omp_get_thread_num()

--- a/starter/source/interfaces/inter3d1/inter_save_candidate.F90
+++ b/starter/source/interfaces/inter3d1/inter_save_candidate.F90
@@ -64,8 +64,8 @@
           integer, dimension(mvsiz), intent(in) :: prov_n !< list of potential S node
           integer, dimension(mvsiz), intent(in) :: prov_e !< list of potential segment
           my_real, dimension(mvsiz), intent(in) :: pene !< penetration
-          type(array_type), intent(inout) :: local_cand_n !< list of S node (local to a !$omp thread)
-          type(array_type), intent(inout) :: local_cand_e !< list of segment (local to a !$omp thread)
+          type(array_type_int_1d), intent(inout) :: local_cand_n !< list of S node (local to a !$omp thread)
+          type(array_type_int_1d), intent(inout) :: local_cand_e !< list of segment (local to a !$omp thread)
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Local variables
 ! ----------------------------------------------------------------------------------------------------------------------

--- a/starter/source/loads/general/load_pcyl/domain_decomposition_pcyl.F
+++ b/starter/source/loads/general/load_pcyl/domain_decomposition_pcyl.F
@@ -79,7 +79,7 @@ C-----------------------------------------------
         INTEGER, DIMENSION(NSPMD) :: PROC_ARRAY
         LOGICAL, DIMENSION(:), ALLOCATABLE :: BOOL
         INTEGER, DIMENSION(:), ALLOCATABLE :: TEMP_ARRAY
-        TYPE(array_type), DIMENSION(:), ALLOCATABLE :: LOCAL_ARRAY
+        TYPE(array_type_int_1d), DIMENSION(:), ALLOCATABLE :: LOCAL_ARRAY
         INTEGER :: NB_LOCAL_ARRAY
         INTEGER, DIMENSION(:), ALLOCATABLE :: INDEX_LOCAL_ARRAY
 C-----------------------------------------------

--- a/starter/source/spmd/igrsurf_split.F
+++ b/starter/source/spmd/igrsurf_split.F
@@ -95,7 +95,7 @@ C-----------------------------------------------
         INTEGER :: I_AM_HERE
         LOGICAL, DIMENSION(NSURF) :: ALREADY_DONE
         LOGICAL, DIMENSION(:), ALLOCATABLE :: I_NEED_IT
-        TYPE(array_type), DIMENSION(:), ALLOCATABLE :: PROC_LIST_PER_NODE
+        TYPE(array_type_int_1d), DIMENSION(:), ALLOCATABLE :: PROC_LIST_PER_NODE
 
         INTEGER :: UP_BOUND
         INTEGER :: INDEX_PROC,NUMBER_PROC


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
The type array_type should not be used when only a part of it is needed, because of very large memory overhead ([see here](https://godbolt.org/z/W8Wzq1qxb)).

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
