### PR TITLE
Fix table size location in declaration for /MAT/LAW81 update routine

### DIFF
--- a/starter/source/materials/mat/mat081/law81_upd.F90
+++ b/starter/source/materials/mat/mat081/law81_upd.F90
@@ -42,10 +42,10 @@
          type(matparam_struct_), intent(inout)     :: matparam
          integer, intent(in)                       :: nfunc
          integer, dimension(nfunc), intent(in)     :: ifunc
-         integer, dimension(snpc), intent(in)      :: npc
          integer, intent(in)                       :: snpc
-         my_real, dimension(stf), intent(in)       :: pld
+         integer, dimension(snpc), intent(in)      :: npc
          integer, intent(in)                       :: stf
+         my_real, dimension(stf), intent(in)       :: pld
          my_real, dimension(npropm), intent(inout) :: pm
          integer, intent(in)                       :: npropm
          integer, intent(in)                       :: iout


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Issue in windows compilation because table size are declared after being used

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Change table size location in declaration. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
