### PR TITLE
fix segfault with TMPDIR due to #3286

### DIFF
--- a/engine/source/system/tmpenv_c.c
+++ b/engine/source/system/tmpenv_c.c
@@ -144,7 +144,6 @@ void tmpenvf_(char* tmpdir,int *tmplen){
   for (i=0;i<slen;i++) tmpdir[i]=tdir[i];
   tmpdir[slen]='\0';
   *tmplen = slen;
-  free(tdir); 
 }
 
 void tmpenvf(char* tmpdir,int *tmplen){


### PR DESCRIPTION
Regression from  #3286
This pull request includes a small change to the `engine/source/system/tmpenv_c.c` file. The change removes an unnecessary call to `free(tdir)` in the `tmpenvf_(char* tmpdir, int *tmplen)` function
