### PR TITLE
Correct scale factor on input radius in /PLCYL

### DIFF
--- a/engine/source/loads/general/load_pcyl/press_seg3.F
+++ b/engine/source/loads/general/load_pcyl/press_seg3.F
@@ -84,7 +84,7 @@ c=======================================================================
       BETA  = DIR(2)
       GAMMA = DIR(3)
       NPT   = SIZE(TABLE(IFUNC)%X(1)%VALUES)
-      RMAX  = TABLE(IFUNC)%X(1)%VALUES(NPT) / XFACR
+      RMAX  = TABLE(IFUNC)%X(1)%VALUES(NPT) * XFACR
       P1    = ZERO
       P2    = ZERO
       P3    = ZERO


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

scale factor applied to radius of pressure cylinder in /PCYL option was wrong

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

correction : multiplication of radius by scale factor instead of division

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
