### PR TITLE
Correction friction Law Ifric=4 formulation

### DIFF
--- a/engine/source/interfaces/int07/i7for3.F
+++ b/engine/source/interfaces/int07/i7for3.F
@@ -1959,8 +1959,8 @@ C---        Exponential decay model
      .         + (VY(I) - N2(I)*AA)**2
      .         + (VZ(I) - N3(I)*AA)**2
             VV = SQRT(MAX(EM30,V2))
-            XMU(I) = FRICC(I)
-     .             + (FRIC_COEFS(I,1)-FRICC(I))*EXP(-FRIC_COEFS(I,2)*VV)
+            XMU(I) = FRIC_COEFS(I,1)
+     .             + (FRICC(I)-FRIC_COEFS(I,1))*EXP(-FRIC_COEFS(I,2)*VV)
             XMU(I) = MAX(XMU(I),EM30)
           ENDDO
         ENDIF
@@ -2258,8 +2258,8 @@ C---        Exponential decay model
      .         + (VY(I) - N2(I)*AA)**2
      .         + (VZ(I) - N3(I)*AA)**2
             VV = SQRT(MAX(EM30,V2))
-            XMU(I) = FRICC(I)
-     .             + (FRIC_COEFS(I,1)-FRICC(I))*EXP(-FRIC_COEFS(I,2)*VV)
+            XMU(I) = FRIC_COEFS(I,1)
+     .             + (FRICC(I)-FRIC_COEFS(I,1))*EXP(-FRIC_COEFS(I,2)*VV)
             XMU(I) = MAX(XMU(I),EM30)
           ENDDO
 c
@@ -2274,8 +2274,9 @@ c
 c
             V2 = VX(I)*DIR2(I,1) +VY(I)*DIR2(I,2)+VZ(I)*DIR2(I,3)
             VV  = MAX(EM30,V2)
-            XMU2(I) = FRICC2(I)
-     .             + (FRIC_COEFS2(I,1)-FRICC2(I))*EXP(-FRIC_COEFS2(I,2)*VV)
+            XMU2(I) = FRIC_COEFS2(I,1)
+     .             + (FRICC2(I)-FRIC_COEFS2(I,1))*EXP(-FRIC_COEFS2(I,2)*VV)
+
             XMU(I) = MAX(XMU(I),EM30)
             XMU2(I) = MAX(XMU2(I),EM30)
           ENDDO

--- a/engine/source/interfaces/int20/i20for3.F
+++ b/engine/source/interfaces/int20/i20for3.F
@@ -1220,8 +1220,8 @@ C---    Exponential decay model
      .       + (VY(I) - N2(I)*AA)**2
      .       + (VZ(I) - N3(I)*AA)**2
            VV = SQRT(MAX(EM30,V2))
-           XMU(I) = FRIC
-     .        + (FROT_P(1)-FRIC)*EXP(-FROT_P(2)*VV)
+           XMU(I) = FROT_P(1)
+     .        + (FRIC-FROT_P(1))*EXP(-FROT_P(2)*VV)
            XMU(I) = MAX(XMU(I),EM30)
          ENDDO
       ENDIF

--- a/engine/source/interfaces/int21/i21for3.F
+++ b/engine/source/interfaces/int21/i21for3.F
@@ -472,8 +472,8 @@ C---        Exponential decay model
      .       + (VY(I) - NY(I)*AA)**2 
      .       + (VZ(I) - NZ(I)*AA)**2
            VV = SQRT(MAX(EM30,V2))
-           XMU(I) = FRIC
-     .            + (FROT_P(1)-FRIC)*EXP(-FROT_P(2)*VV)
+           XMU(I) = FROT_P(1)
+     .            + (FRIC-FROT_P(1))*EXP(-FROT_P(2)*VV)
            XMU(I) = MAX(XMU(I),EM30)
         ENDDO
       ENDIF

--- a/engine/source/interfaces/int23/i23for3.F
+++ b/engine/source/interfaces/int23/i23for3.F
@@ -414,8 +414,8 @@ C---    Exponential decay model
      .       + (VY(I) - NY(I)*AA)**2 
      .       + (VZ(I) - NZ(I)*AA)**2
            VV = SQRT(MAX(EM30,V2))
-           XMU(I) = FRIC
-     .        + (FROT_P(1)-FRIC)*EXP(-FROT_P(2)*VV)
+           XMU(I) = FROT_P(1)
+     .        + (FRIC-FROT_P(1))*EXP(-FROT_P(2)*VV)
            XMU(I) = MAX(XMU(I),EM30)
          ENDDO
       ENDIF

--- a/engine/source/interfaces/int24/i24for3.F
+++ b/engine/source/interfaces/int24/i24for3.F
@@ -1497,8 +1497,8 @@ C---        Exponential decay model
      .           + (VY(I) - N2(I)*AA)**2
      .           + (VZ(I) - N3(I)*AA)**2
               VV = SQRT(MAX(EM30,V2))
-              XMU(I) = FRICC(I)
-     .             + (FRIC_COEFS(I,1)-FRICC(I))*EXP(-FRIC_COEFS(I,2)*VV)
+              XMU(I) = FRIC_COEFS(I,1)
+     .               + (FRICC(I)-FRIC_COEFS(I,1))*EXP(-FRIC_COEFS(I,2)*VV)
               XMU(I) = MAX(XMU(I),EM30)
             ENDDO
         ENDIF
@@ -1805,8 +1805,8 @@ C---        Exponential decay model
      .           + (VY(I) - N2(I)*AA)**2
      .           + (VZ(I) - N3(I)*AA)**2
               VV = SQRT(MAX(EM30,V2))
-              XMU(I) = FRICC(I)
-     .               + (FRIC_COEFS(I,1)-FRICC(I))*EXP(-FRIC_COEFS(I,2)*VV)
+              XMU(I) = FRIC_COEFS(I,1)
+     .               + (FRICC(I)-FRIC_COEFS(I,1))*EXP(-FRIC_COEFS(I,2)*VV)
               XMU(I) = MAX(XMU(I),EM30)
             ENDDO
 c
@@ -1826,8 +1826,8 @@ c
 c
               V2 = VX(I)*DIR2(I,1) +VY(I)*DIR2(I,2)+VZ(I)*DIR2(I,3)
               VV  = MAX(EM30,V2)
-              XMU2(I) = FRICC2(I)
-     .             + (FRIC_COEFS2(I,1)-FRICC2(I))*EXP(-FRIC_COEFS2(I,2)*VV)
+              XMU2(I) = FRIC_COEFS2(I,1)
+     .             + (FRICC2(I)-FRIC_COEFS2(I,1))*EXP(-FRIC_COEFS2(I,2)*VV)
               XMU(I) = MAX(XMU(I),EM30)
               XMU2(I) = MAX(XMU2(I),EM30)
            ENDDO

--- a/engine/source/interfaces/int25/i25for3.F
+++ b/engine/source/interfaces/int25/i25for3.F
@@ -1331,8 +1331,8 @@ C---        Exponential decay model
      .           + (VY(I) - N2(I)*AA)**2
      .           + (VZ(I) - N3(I)*AA)**2
               VV = SQRT(MAX(EM30,V2))
-              XMU(I) = FRICC(I)
-     .             + (FRIC_COEFS(I,1)-FRICC(I))*EXP(-FRIC_COEFS(I,2)*VV)
+              XMU(I) = FRIC_COEFS(I,1)
+     .             + (FRICC(I)-FRIC_COEFS(I,1))*EXP(-FRIC_COEFS(I,2)*VV)
               XMU(I) = MAX(XMU(I),EM30)
             ENDDO
           ENDIF
@@ -1671,8 +1671,8 @@ C---        Exponential decay model
      .           + (VY(I) - N2(I)*AA)**2
      .           + (VZ(I) - N3(I)*AA)**2
               VV = SQRT(MAX(EM30,V2))
-              XMU(I) = FRICC(I)
-     .               + (FRIC_COEFS(I,1)-FRICC(I))*EXP(-FRIC_COEFS(I,2)*VV)
+              XMU(I) = FRIC_COEFS(I,1)
+     .               + (FRICC(I)-FRIC_COEFS(I,1))*EXP(-FRIC_COEFS(I,2)*VV)
               XMU(I) = MAX(XMU(I),EM30)
             ENDDO
 c
@@ -1693,8 +1693,8 @@ c
 c
               V2 = VX(I)*DIR2(I,1) +VY(I)*DIR2(I,2)+VZ(I)*DIR2(I,3)
               VV  = MAX(EM30,V2)
-              XMU2(I) = FRICC2(I)
-     .             + (FRIC_COEFS2(I,1)-FRICC2(I))*EXP(-FRIC_COEFS2(I,2)*VV)
+              XMU2(I) = FRIC_COEFS2(I,1)
+     .             + (FRICC2(I)-FRIC_COEFS2(I,1))*EXP(-FRIC_COEFS2(I,2)*VV)
               XMU(I) = MAX(XMU(I),EM30)
               XMU2(I) = MAX(XMU2(I),EM30)
            ENDDO


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
Problem of formula of mu computation of friction Law Ifric=4  : mu=c1+(fric - c1 ) e-c2V instead of mu=fric+(c1- fric ) e-C2V
fr
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
