### PR TITLE
Missing arg wfext

### DIFF
--- a/engine/source/ale/alemain.F
+++ b/engine/source/ale/alemain.F
@@ -684,7 +684,8 @@ C     -------------------------
      .                 NERCVOIS, NESDVOIS, LERCVOIS, LESDVOIS, 
      .                 ITAB, ITABM1, TT - DT1, 
      .                 STIFN, FSKY, IADS, FSKYM, 
-     .                 CONDN, CONDNSKY, BUFMAT, FV, .FALSE.,ID_GLOBAL_VOIS,FACE_VOIS,EBCS_TAB,NPC,TF,FSAVSURF,MATPARAM)
+     .                 CONDN, CONDNSKY, BUFMAT, FV, .FALSE.,ID_GLOBAL_VOIS,FACE_VOIS,EBCS_TAB,NPC,TF,FSAVSURF,MATPARAM,
+     .                 OUTPUT%WFEXT)
                   CALL MY_BARRIER
 
                   IF (MULTI_FVM%NS_DIFF) THEN

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -5922,7 +5922,7 @@ C Assemblage TYPE21
 C
       IF(NINTSTAMP/=0)THEN
         CALL INTSTAMP_ASS(INTSTAMP,NODES%MS ,NODES%IN ,NODES%A ,NODES%AR ,
-     .                    NODES%STIFN   ,NODES%STIFR  ,NODES%WEIGHT)
+     .                    NODES%STIFN   ,NODES%STIFR  ,NODES%WEIGHT, OUTPUT%WFEXT)
       END IF
 C-----------------------------------------------------
 C         RIGID BODY: SUM forces, stiff.


### PR DESCRIPTION
#### Missing arg wfext

#### Description of the changes
Missing arguments introduced with changes e560c0c4280e38f1c42e829b8603aa41c5b5ace9.
It is related to STAPMING simulation and LAW151
