### PR TITLE
/TH/BRIC : new available output (VSTRAIN and WPLA)

### DIFF
--- a/engine/source/output/th/hist2.F
+++ b/engine/source/output/th/hist2.F
@@ -828,7 +828,7 @@ C-------------------------------------------------------
         CALL THQUAD(ELBUF_TAB,NTHGRP2  ,ITHGRP    ,
      1              IPARG    ,ITHBUF   ,WA_QUAD(ID_HIST)%WA_REAL      ,
      2              IPM      ,IXQ      ,IXTG      ,X       ,MULTI_FVM ,
-     3              V        ,W        ,GLOB_THERM%ITHERM  ,
+     3              V        ,W        ,GLOB_THERM%ITHERM  ,PM        ,
      .              NUMELQ   ,NUMMAT   ,NUMNOD    ,SITHBUF   ,NUMELTG)
         !   send WA_QUAD to PROC0
         IF(NSPMD>1) THEN
@@ -928,8 +928,8 @@ C-------------------------------------------------------
         !   end of NSTRAND treatment
         !   ----------------------------------
 !   -------------------------------------
-       NRWA=NRWALL
-          DO N=1,NTHGRP2
+        NRWA=NRWALL
+        DO N=1,NTHGRP2
           ITYP=ITHGRP(2,N)
           NN  =ITHGRP(4,N)
           IAD =ITHGRP(5,N)

--- a/engine/source/output/th/thquad.F
+++ b/engine/source/output/th/thquad.F
@@ -38,7 +38,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      1                  IPARG    ,ITHBUF   ,WA     ,
      2                  IPM      ,IXQ      ,IXTG   ,
      3                  X        ,MULTI_FVM,V      ,
-     4                  W        ,ITHERM   ,
+     4                  W        ,ITHERM   ,PM     ,
      .                  NUMELQ   ,NUMMAT   ,NUMNOD ,SITHBUF, NUMELTG)
 
 C-----------------------------------------------
@@ -120,10 +120,11 @@ C-----------------------------------------------
       INTEGER, INTENT(IN) :: NTHGRP2
       INTEGER, INTENT(IN) :: ITHERM
       INTEGER, DIMENSION(NITHGR,*), INTENT(IN) :: ITHGRP
+      my_real,INTENT(IN) :: PM(NPROPM,NUMMAT)
       my_real,INTENT(INOUT) :: WA(*)
       my_real,INTENT(IN) :: X(3,NUMNOD), V(3,NUMNOD), W(3,NUMNOD)
       TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP), TARGET :: ELBUF_TAB
-      TYPE(MULTI_FVM_STRUCT), INTENT(IN) :: MULTI_FVM      
+      TYPE(MULTI_FVM_STRUCT), INTENT(IN) :: MULTI_FVM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -138,7 +139,7 @@ C-----------------------------------------------
      .        T22,T23,T32,T33,
      .        S1,S2,S3,S4,
      .        T1,T2,T3,T4,CS,CT,EVAR(6),GAMA(6),
-     .        TMP(3,4),VEL(3),SSP,BFRAC
+     .        TMP(3,4),VEL(3),SSP,BFRAC,RHO0
       my_real, dimension(:), allocatable :: WWA
       TYPE(L_BUFEL_) ,POINTER :: LBUF,LBUF1,LBUF2
       TYPE(G_BUFEL_) ,POINTER :: GBUF     
@@ -146,7 +147,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
-        ALLOCATE(WWA(239552))
+        ALLOCATE(WWA(239555))
         IJK = 0
         DO NITER=1,NTHGRP2
             ITYP=ITHGRP(2,NITER)
@@ -548,6 +549,18 @@ C SSP
                 ENDIF
 
               ENDIF
+
+              !VOLUMETRIC STRAIN (MU)
+              IF(NUMELTG > 0)THEN
+                RHO0 = PM(01,IXTG(1,1+NFT))
+              ELSE
+                RHO0 = PM(01,IXQ(1,11+NFT))
+              ENDIF
+              IF(RHO0 > ZERO)THEN
+                WWA(239555) = GBUF%RHO(I) / RHO0  - ONE
+              ELSE
+                WWA(239555) = ZERO
+              ENDIF
 c
               DO L=IADV,IADV+NVAR-1
                 K=ITHBUF(L)
@@ -561,7 +574,7 @@ c
 c --------------          
          ENDIF  ! mte /= 13 
         ENDIF  
-      ENDDO ! groupe
+      ENDDO ! next group
 !   -----------------------------
             ENDIF
  666    continue    

--- a/engine/source/output/th/thsol.F
+++ b/engine/source/output/th/thsol.F
@@ -160,6 +160,7 @@ C-----------------------------------------------
      .   STRAIN(6),GAMA(6),EVAR_TMP(6),EVAR(6),SIGG(6),
      .   VEL(3),V(3,*),W(3,*),TMP_2(MVSIZ,3),BFRAC,SSP
         my_real, DIMENSION(:), ALLOCATABLE :: WWA
+        my_real :: RHO0
 C----
       TYPE(L_BUFEL_) ,POINTER :: LBUF
       TYPE(G_BUFEL_) ,POINTER :: GBUF
@@ -197,7 +198,7 @@ C--------------------------------------------
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
-        ALLOCATE(WWA(239554))
+        ALLOCATE(WWA(239555))
 
         IJK = 0
         DO NITER=1,NTHGRP2
@@ -209,7 +210,6 @@ C-----------------------------------------------
             II=0
             IF(ITYP==1)THEN
 !   -------------------------------
-
 
       DO J1=1,7
         DO J2=1,9
@@ -761,6 +761,8 @@ C-----------------------------------------------------
                 WWA(239552)=LBUF%RK(I) ! VK in /TH/BRICK
                 WWA(12)=LBUF%PLA(I)
                 WWA(30)=GBUF%PLA(I)
+              ELSEIF (MTE == 25) THEN
+                WWA(32)=LBUF%PLA(I)      !WPLA
               ELSEIF (MTE == 26) THEN
                 WWA(12)=LBUF%PLA(I)
                 WWA(13)=LBUF%TEMP(I)
@@ -930,6 +932,15 @@ c
                   ENDDO
                 ENDDO
               ENDIF
+
+              !VOLUMETRIC STRAIN (MU)
+              RHO0 = PM(01,IXS(1,NFT+I))
+              IF(RHO0 > ZERO)THEN
+                WWA(239555) = ELBUF_TAB(NG)%GBUF%RHO(I) / RHO0  - ONE
+              ELSE
+                WWA(239555) = ZERO
+              ENDIF
+
 C------------------------------------------------------------------------------
 C                 2- TH tab filling with stresses  and stain in element
 C                           and per integration point

--- a/starter/source/output/th/hm_read_thgrou.F
+++ b/starter/source/output/th/hm_read_thgrou.F
@@ -146,7 +146,7 @@ C-----------------------------------------------
       CHARACTER MESS*40
       CHARACTER(LEN=NCHARLINE) :: KEY,COPT
       INTEGER NVARN,NVARN1,NVARN1A,NVARN2,NVARNPINCH,NVARS,NVARC,NVART,NVARP,NVARR,NVARUR
-      INTEGER NVARS1,NVARS2,NVARS3,NVARS4,NVARS5,NVARS6,NVARS7,NVARS8,NVARS9,NVARSNLOC
+      INTEGER NVARS1,NVARS2,NVARS3,NVARS4,NVARS5,NVARS6,NVARS7,NVARS8,NVARS9,NVARS10,NVARSNLOC
       INTEGER NVARNS,NVARSPH
       INTEGER NVARIN,NVARRW,NVARRB,NVARAC,NVARSE,NVARJO,NVARFX,NVARFXM
       INTEGER NVARAB,NVARMV4,NVARMV,NVARPA,NVARMVENT,NVARSENS,NVARSENSG
@@ -164,8 +164,8 @@ C-----------------------------------------------
 C-----------------------------------------------
       PARAMETER (NVARN = 637,NVARN1 = 19,NVARN1A = 600,NVARN2 = 9 ,NVARNPINCH = 9)
       PARAMETER (NVARS1 = 196,NVARS2 = 567,NVARS3 = 369,NVARS4 = 492,NVARS5 = 22)
-      PARAMETER (NVARS6 = 97200,NVARS7 = 97200,NVARS8 = 516,NVARS9 = 6,NVARSNLOC = 2)
-      PARAMETER (NVARS =239554 ,NVARC = 37856,NVART = 6)
+      PARAMETER (NVARS6 = 97200,NVARS7 = 97200,NVARS8 = 516,NVARS9 = 6,NVARS10 = 1,NVARSNLOC = 2)
+      PARAMETER (NVARS =239555 ,NVARC = 37856,NVART = 6)
       PARAMETER (NVARP = 337,NVARR = 66,NVARUR = 12)
       PARAMETER (NVARNS = 4,NVARSPH = 41)
       PARAMETER (NVARIN = 29,NVARRW = 6,NVARRB =15,NVARFX =4)
@@ -180,7 +180,7 @@ C-----------------------------------------------
       CHARACTER(LEN=10),DIMENSION(:),ALLOCATABLE::VARS
       CHARACTER(LEN=10),DIMENSION(:),ALLOCATABLE::VARC
       CHARACTER*10 VARS1(NVARS1),VARS2(NVARS2), VARS3(NVARS3), VARS4(NVARS4),
-     .             VARS5(NVARS5),VARS8(NVARS8),VARS9(NVARS9),
+     .             VARS5(NVARS5),VARS8(NVARS8),VARS9(NVARS9),VARS10(NVARS10),
      .             VARN1(NVARN1),VARN1A(NVARN1A),
      .             VARN2(NVARN2),
      .             VARNPINCH(NVARNPINCH),
@@ -268,7 +268,7 @@ C-----------------------------------------------
       CHARACTER(LEN=100),DIMENSION(:),ALLOCATABLE:: VARN1_TITLE,VARN1A_TITLE,VARN2_TITLE,VARNPINCH_TITLE,
      .                              VARP_TITLE,VARR_TITLE,VART_TITLE,
      .                              VARS1_TITLE,VARS2_TITLE,VARS3_TITLE,VARS4_TITLE,
-     .                              VARS5_TITLE,VARS6_TITLE,VARS7_TITLE,VARS8_TITLE,VARS9_TITLE,
+     .                              VARS5_TITLE,VARS6_TITLE,VARS7_TITLE,VARS8_TITLE,VARS9_TITLE,VARS10_TITLE,
      .                              VARC_TITLE,
      .                              VARSNLOC_TITLE,VARNS_TITLE,VARSPH_TITLE,
      .                              VARIN_TITLE,VARRW_TITLE,VARRB_TITLE,
@@ -297,7 +297,7 @@ C-----------------------------------------------
      .         VARP_TITLE(NVARP),VARR_TITLE(NVARR),VART_TITLE(NVART),
      .         VARS1_TITLE(NVARS1),VARS2_TITLE(NVARS2),VARS3_TITLE(NVARS3),VARS4_TITLE(NVARS4),
      .         VARS5_TITLE(NVARS5),VARS6_TITLE(NVARS6),VARS7_TITLE(NVARS7),VARS8_TITLE(NVARS8),VARS9_TITLE(NVARS9),
-     .         VARC_TITLE(NVARC),
+     .         VARC_TITLE(NVARC),VARS10_TITLE(NVARS10),
      .         VARSNLOC_TITLE(NVARSNLOC),VARNS_TITLE(NVARNS),VARSPH_TITLE(NVARSPH),
      .         VARIN_TITLE(NVARIN),VARRW_TITLE(NVARRW),VARRB_TITLE(NVARRB),
      .         VARMV_TITLE(NVARMV),VARSE_TITLE(NVARSE),VARAC_TITLE(NVARAC),
@@ -311,7 +311,7 @@ C-----------------------------------------------
       CALL TH_TITLES(
      1      NVARN1        ,NVARN1A       ,NVARN2           ,NVARNPINCH        ,NVARS1           ,
      1      NVARS2        ,NVARS3        ,NVARS4           ,NVARS5            ,NVARS6           ,
-     1      NVARS7        ,NVARS8        ,NVARS9           ,NVARSNLOC         ,
+     1      NVARS7        ,NVARS8        ,NVARS9           ,NVARS10           ,NVARSNLOC        ,
      1      NVARP         ,NVARR         ,NVART            ,NVARNS            ,NVARSPH          ,
      2      NVARIN        ,NVARRW        ,NVARRB           ,NVARMV            ,NVARSE           ,
      3      NVARAC        ,NVARJO        ,NVARMVENT        ,NVARPA            ,NVARFX           ,
@@ -321,7 +321,7 @@ C-----------------------------------------------
      a      VARNPINCH_TITLE,VARP_TITLE   ,VARR_TITLE       ,VART_TITLE        ,
      6      VARS1_TITLE   ,VARS2_TITLE   ,VARS3_TITLE      ,VARS4_TITLE       ,VARS5_TITLE      ,
      6      VARS6_TITLE   ,VARS7_TITLE   ,VARS8_TITLE      ,VARS9_TITLE       ,VARSNLOC_TITLE   ,
-     6      VARC_TITLE    ,
+     6      VARC_TITLE    ,VARS10_TITLE  ,
      7      VARNS_TITLE   ,VARSPH_TITLE  ,VARIN_TITLE      ,
      8      VARRW_TITLE   ,VARRB_TITLE   ,VARMV_TITLE      ,VARSE_TITLE       ,VARAC_TITLE      ,
      9      VARJO_TITLE   ,VARMVENT_TITLE,VARPA_TITLE      ,VARFX_TITLE       ,VARGAU_TITLE     ,
@@ -760,6 +760,10 @@ C Definition of VARS8 : strain matrix output
 
       DATA VARSNLOC/
      . 'NL_PLAS ','NL_PLSR '/
+
+      DATA VARS10/
+     . 'VSTRAIN ' /
+
 
 C   shells
 c  VARC = VARC1 + VARC2 + VARC3
@@ -1782,6 +1786,9 @@ C
       ENDDO
       DO I=1,NVARSNLOC
        VARS(239552 + I) = VARSNLOC(I)
+      ENDDO
+      DO I=1,NVARS10
+       VARS(239554 + I) = VARS10(I)
       ENDDO
 C   (VARSG1, VARSG2, VARSG3 )----> VARSG
       DO I=1,202
@@ -3184,7 +3191,7 @@ C-------------------------------------
         CALL WRITE_THNMS1(
      1      NVARN1        ,NVARN1A       ,NVARN2           ,NVARNPINCH        ,NVARS1           ,
      2      NVARS2        ,NVARS3        ,NVARS4           ,NVARS5            ,NVARS6           ,
-     3      NVARS7        ,NVARS8        ,NVARS9           ,NVARSNLOC         ,
+     3      NVARS7        ,NVARS8        ,NVARS9           ,NVARS10           ,NVARSNLOC        ,
      4      NVARP         ,NVARR         ,NVART            ,NVARNS            ,NVARSPH          ,
      5      NVARIN        ,NVARRW        ,NVARRB           ,NVARMV            ,NVARSE           ,
      5      NVARAC        ,NVARJO        ,NVARMVENT        ,NVARPA            ,NVARFX           ,
@@ -3194,7 +3201,7 @@ C-------------------------------------
      9      VARNPINCH_TITLE,VARP_TITLE   ,VARR_TITLE       ,VART_TITLE        ,
      A      VARS1_TITLE   ,VARS2_TITLE   ,VARS3_TITLE      ,VARS4_TITLE       ,VARS5_TITLE      ,
      B      VARS6_TITLE   ,VARS7_TITLE   ,VARS8_TITLE      ,VARS9_TITLE       ,VARSNLOC_TITLE   ,
-     C      VARC_TITLE    ,
+     C      VARC_TITLE    ,VARS10_TITLE  ,
      D      VARNS_TITLE   ,VARSPH_TITLE  ,VARIN_TITLE      ,
      E      VARRW_TITLE   ,VARRB_TITLE   ,VARMV_TITLE      ,VARSE_TITLE       ,VARAC_TITLE      ,
      F      VARJO_TITLE   ,VARMVENT_TITLE,VARPA_TITLE      ,VARFX_TITLE       ,VARGAU_TITLE     ,
@@ -3203,7 +3210,7 @@ C-------------------------------------
      I      VARN1         ,VARN1A        ,VARN2            ,VARNPINCH        ,
      J      VARP          ,VARR          ,VART             ,VARS1             ,VARS2            ,
      K      VARS3         ,VARS4         ,VARS5            ,VARS6             ,VARS7            ,
-     L      VARS8         ,VARS9         ,VARSNLOC         ,
+     L      VARS8         ,VARS9         ,VARS10           ,VARSNLOC         ,
      M      VARC          ,
      N      VARNS         ,VARSPH        ,VARIN            ,
      O      VARRW         ,VARRB         ,VARMV            ,VARSE             ,VARAC            ,
@@ -3229,7 +3236,7 @@ C-------------------------------------
      .           VARP_TITLE,VARR_TITLE,VART_TITLE,
      .           VARS1_TITLE,VARS2_TITLE,VARS3_TITLE,VARS4_TITLE,
      .           VARS5_TITLE,VARS6_TITLE,VARS7_TITLE,VARS8_TITLE,VARS9_TITLE,
-     .           VARC_TITLE,
+     .           VARC_TITLE,VARS10_TITLE,
      .           VARNS_TITLE,VARSPH_TITLE,
      .           VARIN_TITLE,VARRW_TITLE,VARRB_TITLE,
      .           VARMV_TITLE,VARSE_TITLE,VARAC_TITLE,

--- a/starter/source/output/th/th_titles.F90
+++ b/starter/source/output/th/th_titles.F90
@@ -40,7 +40,7 @@
       !||====================================================================
         subroutine th_titles(nvarn1        ,nvarn1a       ,nvarn2           ,nvarnpinch        ,nvars1           ,&
           nvars2        ,nvars3        ,nvars4           ,nvars5            ,nvars6          ,&
-          nvars7        ,nvars8        ,nvars9           ,nvarsnloc         ,&
+          nvars7        ,nvars8        ,nvars9           ,nvars10           ,nvarsnloc         ,&
           nvarp         ,nvarr         ,nvart            ,nvarns            ,nvarsph          ,&
           nvarin        ,nvarrw        ,nvarrb           ,nvarmv            ,nvarse           ,&
           nvarac        ,nvarjo        ,nvarmvent        ,nvarpa            ,nvarfx           ,&
@@ -50,7 +50,7 @@
           varnpinch_title,varp_title   ,varr_title       ,vart_title        ,&
           vars1_title   ,vars2_title   ,vars3_title      ,vars4_title       ,vars5_title      ,&
           vars6_title   ,vars7_title   ,vars8_title      ,vars9_title       ,varsnloc_title   ,&
-          varc_title    ,&
+          varc_title    ,vars10_title  ,&
           varns_title   ,varsph_title  ,varin_title      ,&
           varrw_title   ,varrb_title   ,varmv_title      ,varse_title       ,varac_title      ,&
           varjo_title   ,varmvent_title,varpa_title      ,varfx_title       ,vargau_title     ,&
@@ -82,6 +82,7 @@
           integer,                                   intent(in) :: nvars7
           integer,                                   intent(in) :: nvars8
           integer,                                   intent(in) :: nvars9
+          integer,                                   intent(in) :: nvars10
           integer,                                   intent(in) :: nvarsnloc
           integer,                                   intent(in) :: nvarp
           integer,                                   intent(in) :: nvarr
@@ -124,6 +125,7 @@
           character(len=100),                        intent(out) :: vars7_title(nvars7)
           character(len=100),                        intent(out) :: vars8_title(nvars8)
           character(len=100),                        intent(out) :: vars9_title(nvars9)
+          character(len=100),                        intent(out) :: vars10_title(nvars10)
           character(len=100),                        intent(out) :: varsnloc_title(nvarsnloc)
           character(len=100),                        intent(out) :: varc_title(nvarc)
           character(len=100),                        intent(out) :: varns_title(nvarns)
@@ -2006,6 +2008,10 @@
             'SPEED OF SOUND',&
             'MACH NUMBER',&
             'YIELD SCALE FACTOR FROM FAILURE SURFACE'/)
+
+          vars10_title = (/&
+            character(len=100) ::&
+            'VOLUMETRIC STRAIN' /)
 
           varsnloc_title = (/&
             character(len=100) ::&

--- a/starter/source/output/th/write_thnms1.F90
+++ b/starter/source/output/th/write_thnms1.F90
@@ -44,7 +44,7 @@
       !||====================================================================
         subroutine write_thnms1(nvarn1        ,nvarn1a       ,nvarn2           ,nvarnpinch        ,nvars1           ,&
           nvars2        ,nvars3        ,nvars4           ,nvars5            ,nvars6           ,&
-          nvars7        ,nvars8        ,nvars9           ,nvarsnloc         ,&
+          nvars7        ,nvars8        ,nvars9           ,nvars10           ,nvarsnloc        ,&
           nvarp         ,nvarr         ,nvart            ,nvarns            ,nvarsph          ,&
           nvarin        ,nvarrw        ,nvarrb           ,nvarmv            ,nvarse           ,&
           nvarac        ,nvarjo        ,nvarmvent        ,nvarpa            ,nvarfx           ,&
@@ -54,7 +54,7 @@
           varnpinch_title,varp_title   ,varr_title       ,vart_title        ,&
           vars1_title   ,vars2_title   ,vars3_title      ,vars4_title       ,vars5_title      ,&
           vars6_title   ,vars7_title   ,vars8_title      ,vars9_title       ,varsnloc_title   ,&
-          varc_title    ,&
+          varc_title    ,vars10_title  ,&
           varns_title   ,varsph_title  ,varin_title      ,&
           varrw_title   ,varrb_title   ,varmv_title      ,varse_title       ,varac_title      ,&
           varjo_title   ,varmvent_title,varpa_title      ,varfx_title       ,vargau_title     ,&
@@ -63,7 +63,7 @@
           varn1         ,varn1a        ,varn2            ,varnpinch         ,&
           varp          ,varr          ,vart             ,vars1             ,vars2            ,&
           vars3         ,vars4         ,vars5            ,vars6             ,vars7            ,&
-          vars8         ,vars9         ,varsnloc         ,&
+          vars8         ,vars9         ,vars10           ,varsnloc         ,&
           varc          ,&
           varns         ,varsph        ,varin            ,&
           varrw         ,varrb         ,varmv            ,varse             ,varac            ,&
@@ -99,6 +99,7 @@
           integer,                                   intent(in) :: nvars7
           integer,                                   intent(in) :: nvars8
           integer,                                   intent(in) :: nvars9
+          integer,                                   intent(in) :: nvars10
           integer,                                   intent(in) :: nvarsnloc
           integer,                                   intent(in) :: nvarp
           integer,                                   intent(in) :: nvarr
@@ -141,6 +142,7 @@
           character(len=100),                        intent(in) :: vars7_title(nvars7)
           character(len=100),                        intent(in) :: vars8_title(nvars8)
           character(len=100),                        intent(in) :: vars9_title(nvars9)
+          character(len=100),                        intent(in) :: vars10_title(nvars10)
           character(len=100),                        intent(in) :: varsnloc_title(nvarsnloc)
           character(len=100),                        intent(in) :: varc_title(nvarc)
           character(len=100),                        intent(in) :: varns_title(nvarns)
@@ -180,6 +182,7 @@
           character(len=10),                        intent(in) :: vars7(nvars7)
           character(len=10),                        intent(in) :: vars8(nvars8)
           character(len=10),                        intent(in) :: vars9(nvars9)
+          character(len=10),                        intent(in) :: vars10(nvars10)
           character(len=10),                        intent(in) :: varsnloc(nvarsnloc)
           character(len=10),                        intent(in) :: varc(nvarc)
           character(len=10),                        intent(in) :: varns(nvarns)
@@ -270,6 +273,7 @@
           call write_thnms1_titles(io,nvars8,vars8_title,vars8,239030)
           call write_thnms1_titles(io,nvars9,vars9_title,vars9,239030+nvars8)
           call write_thnms1_titles(io,nvarsnloc,varsnloc_title,varsnloc,239030+nvars8+nvars9)
+          call write_thnms1_titles(io,nvars10,vars10_title,vars10,239030+nvars8+nvars9+nvarsnloc)
 
           write(io, *) '$$ ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++'
           write(io, *) '$$ SHELL'
@@ -401,6 +405,7 @@
           call write_thnms1_titles(io,nvars8,vars8_title,vars8,239030)
           call write_thnms1_titles(io,nvars9,vars9_title,vars9,239030+nvars8)
           call write_thnms1_titles(io,nvarsnloc,varsnloc_title,varsnloc,239030+nvars8+nvars9)
+          call write_thnms1_titles(io,nvars10,vars10_title,vars10,239030+nvars8+nvars9+nvarsnloc)
 
           write(io, *) '$$ ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++'
           write(io, *) '$$ QUAD'
@@ -416,6 +421,7 @@
           call write_thnms1_titles(io,nvars8,vars8_title,vars8,239030)
           call write_thnms1_titles(io,nvars9,vars9_title,vars9,239030+nvars8)
           call write_thnms1_titles(io,nvarsnloc,varsnloc_title,varsnloc,239030+nvars8+nvars9)
+          call write_thnms1_titles(io,nvars10,vars10_title,vars10,239030+nvars8+nvars9+nvarsnloc)
 
           write(io, *) '$$ ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++'
           write(io, *) '$$ SLIPRING'


### PR DESCRIPTION
#### /TH : new available output (VSTRAIN and WPLA)

#### Description of the changes
- /TH/BRIC (WPLA) : now available for law25 in addition to law14
- /TH/BRIC (VSTRAIN) : volumetric strain
- /TH/QUAD (VSTRAIN) : volumetric strain

