### PR TITLE
/SET : Wrong definition of /INTER/TYPE25 secondary nodes in case of coating shells over solids

### DIFF
--- a/starter/source/model/sets/solid_surface_buffer.F
+++ b/starter/source/model/sets/solid_surface_buffer.F
@@ -88,17 +88,14 @@ C=======================================================================
 
       SOLID_TAG(1:NUMELS)=0
       PART_TAG(1:NPART)=0
-      
-      IF(KEYSET == 'PART' )THEN
-        DO I=1, CLAUSE%NB_PART
-            PART_TAG(CLAUSE%PART(I))=1
-        ENDDO
-      ENDIF
-      IF(KEYSET == 'SOLID' )THEN
-        DO I=1, CLAUSE%NB_SOLID
-            SOLID_TAG(CLAUSE%SOLID(I))=1
-        ENDDO
-      ENDIF
+
+      DO I=1, CLAUSE%NB_PART
+        PART_TAG(CLAUSE%PART(I))=1
+      ENDDO
+
+      DO I=1, CLAUSE%NB_SOLID
+        SOLID_TAG(CLAUSE%SOLID(I))=1
+      ENDDO
 
       FASTAG=0
 C
@@ -107,6 +104,7 @@ C
         NB_SOLID = CLAUSE%NB_SOLID
         DO IND=1,NB_SOLID
           JS = CLAUSE%SOLID(IND)
+          IF (SOLID_TAG(JS)==0) CYCLE          !case of tagged elems
           DO JJ=1,6
             DO II=1,4
               NS(II)=IXS(FACES(II,JJ)+1,JS)
@@ -150,8 +148,6 @@ C
             DO K=KNOD2ELS(NI(1))+1,KNOD2ELS(NI(1)+1)
               KS=NOD2ELS(K)
               IF (KS==JS .OR. KS > NUMELS8+NUMELS10) CYCLE
-!!              IF (CLAUSE%NB_SOLID > 0 .AND. CLAUSE%SOLID(KS)==0) CYCLE
-!!              IF (CLAUSE%NB_PART > 0  .AND. CLAUSE%PART(IPARTS(KS))==0) CYCLE
               IF (KEYSET == 'SOLID' .AND. SOLID_TAG(KS)==0) CYCLE
               IF (KEYSET == 'PART'  .AND. PART_TAG(IPARTS(KS))==0) CYCLE
 !
@@ -228,6 +224,7 @@ C-----------
         NB_SOLID = CLAUSE%NB_SOLID
         DO IND=1,NB_SOLID
           JS = CLAUSE%SOLID(IND)
+          IF (SOLID_TAG(JS)==0) CYCLE
 !
           IF (JS > NUMELS8) CYCLE   ! HEXA8 ONLY
 !
@@ -276,9 +273,7 @@ C---   find shells SURF/PART/EXT
                 NSEG = NSEG + 1
                 CALL SURF_SEGMENT(FACE(1)    ,FACE(2) ,FACE(3) ,FACE(3) ,JS  ,
      .                         BUFTMPSURF ,IAD_SURF ,1)
-!!              ELSEIF (CLAUSE%NB_PART > 0 .AND.
-              ELSEIF (KEYSET == 'PART' .AND.
-     .                IABS(PART_TAG(IPARTG(KS))) /= 1)THEN
+              ELSEIF (PART_TAG(IPARTG(KS)) /= 1)THEN
                 NSEG = NSEG + 1
                 CALL SURF_SEGMENT(FACE(1)    ,FACE(2) ,FACE(3) ,FACE(3) ,JS  ,
      .                         BUFTMPSURF ,IAD_SURF ,1)
@@ -301,9 +296,7 @@ C---   find shells SURF/PART/EXT
                NSEG = NSEG + 1
                 CALL SURF_SEGMENT(FACE(1)    ,FACE(2) ,FACE(3) ,FACE(4) ,JS  ,
      .                         BUFTMPSURF ,IAD_SURF ,1)
-!!              ELSEIF (CLAUSE%NB_PART > 0 .AND.
-              ELSEIF (KEYSET == 'PART' .AND.
-     .                IABS(PART_TAG(IPARTC(KS))) /= 1 ) THEN
+              ELSEIF (PART_TAG(IPARTC(KS)) /= 1 ) THEN
                NSEG = NSEG + 1
                 CALL SURF_SEGMENT(FACE(1)    ,FACE(2) ,FACE(3) ,FACE(4) ,JS  ,
      .                         BUFTMPSURF ,IAD_SURF ,1)
@@ -325,6 +318,7 @@ C---
         NB_SOLID = CLAUSE%NB_SOLID
         DO IND=1,NB_SOLID
           JS = CLAUSE%SOLID(IND)
+          IF (SOLID_TAG(JS)==0) CYCLE
 !
           J = JS - NUMELS8  ! TETRA10 ONLY
           IF (J <= 0) CYCLE  ! TETRA10 ONLY


### PR DESCRIPTION

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Issue wit SET_D of coating shells.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Recreate surface segments of already deleted coating shells in SET_D.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
