### PR TITLE
reverse the change of density and bulk modulus adress in mulaw8.F90

### DIFF
--- a/engine/source/materials/mat_share/mulaw8.F90
+++ b/engine/source/materials/mat_share/mulaw8.F90
@@ -321,7 +321,8 @@
           cst1(lft:llt) = one
 
           do i=lft,llt
-             rho0(i)= mat_param(imat)%rho  ! rho reference !
+             c1(i)  = pm(32,imat)
+             rho0(i)= pm( 1,imat)
              vis(i) = zero
              ssp(i) = zero
              sv1(i) = zero
@@ -1242,7 +1243,7 @@
 !     define dynamic viscosity (for viscous law)
 !-----------------------
       do i=lft,llt
-        if (ssp(i) == zero) ssp(i) = sqrt(mat_param(imat)%bulk/mat_param(imat)%rho) ! rho reference ! 
+        if(ssp(i) == zero) ssp(i)=sqrt(c1(i)/rho0(i))
       enddo
 !-------------------------------------------
 !   bulk viscosity and time step computation


### PR DESCRIPTION
modified storage of material law density and bulk modulus to avoid non initialized values for some older laws in mulaw8.F90
The same change was already  made in mulaw.F90

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
