### PR TITLE
Add lower limit for strain rate extrapolation in law128 to avoid hardening lower than static value

### DIFF
--- a/engine/source/materials/mat/mat128/sigeps128s.F90
+++ b/engine/source/materials/mat/mat128/sigeps128s.F90
@@ -169,11 +169,6 @@
       dpla(1:nel) = zero
       epsp(1:nel) = uvar(1:nel,1)  ! filtered plastic strain rate from previous time step
       soundsp(1:nel) = sqrt((bulk + four_over_3*shear) / rho0)     ! sound-speed
-      if (cc > zero)  then
-        cowp(1:nel) = one + (cc*epsp(1:nel))**cp
-      else
-        cowp(1:nel) = one
-      end if
 !---------------------------------------------------------------------
       ! element deletion condition
       do i=1,nel
@@ -184,6 +179,11 @@
       ! computing yield stress
 !
       if (mat_param%ntable == 0) then     ! analytical yield formulation
+        if (cc > zero)  then
+          cowp(1:nel) = one + (epsp(1:nel)/cc)**cp
+        else
+          cowp(1:nel) = one
+        end if
         do i = 1,nel
           yld(i) = sigy * cowp(i)                                         &
                  + qr1*(one - exp(-cr1*pla(i)))                           &
@@ -377,8 +377,8 @@
       do i=1,nel        
         dpdt    = dpla(i) / dtime
         epsp(i) = asrate * dpdt + (one - asrate) * uvar(i,1)
+        uvar(i,1) = max(cc, epsp(i))  ! strain rate effect below static limit is ignored
       enddo 
-      uvar(1:nel,1)  = epsp(1:nel)  
 !-----------
       return
       end

--- a/starter/source/materials/mat/mat128/hm_read_mat128.F90
+++ b/starter/source/materials/mat/mat128/hm_read_mat128.F90
@@ -178,12 +178,6 @@
       cii   = lam + shear*two
       cij   = lam      
 !      
-      if (epsp_ref > zero) then
-        cc = one / epsp_ref
-      else
-        cc = zero
-      end if              
-!      
       if (yfac == zero) yfac = one * pres_unit
       if (xfac == zero) xfac = one * epsp_unit
       xfac = one / xfac
@@ -199,6 +193,7 @@
 !-------------------------------------
       ! create local function table in case of tabulated yield function input
 !-------------------------------------
+      ndim = 0
       if (func_id > 0) then
         allocate (mat_param%table(1))           ! allocate material table array
         mat_param%ntable  = 1
@@ -228,6 +223,15 @@
         end if
       end if
 !          
+      ! reference (static) strain rate      
+      if (func_id > 0 .and. ndim == 2) then
+        cc = mat_param%table(1)%x(2)%values(1) 
+      else if (epsp_ref > zero) then
+        cc = epsp_ref
+      else
+        cc = zero
+      end if              
+!      
 !-------------------------------------
       mat_param%niparam = 0
       mat_param%nuparam = 18


### PR DESCRIPTION

#### Description of the feature
<!--- Describe the problem, ideally from the user viewpoint -->

Correction to avoid problems with high reference strain rate value in the input. Hardening should never be lower than static curve.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Added lower limit of strain rate in Cowper-Symonds factor and tabulated curve extrapolation. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
