### PR TITLE
/CONVEC : noninitialized variable was initialized in wrong place

### DIFF
--- a/engine/source/constraints/thermic/convec.F
+++ b/engine/source/constraints/thermic/convec.F
@@ -86,6 +86,8 @@ C=======================================================================
       FCY_OLD= ZERO
       HEAT_CONV_L = ZERO
       S1 = NUMNOD
+      T_INF = ZERO
+!
       IF(IPARIT==0) THEN
         ITSK = OMP_GET_THREAD_NUM()
 
@@ -119,7 +121,6 @@ C
          FCY   = FCONV(1,NL)
          FCX   = FCONV(2,NL)
          H     = FCONV(3,NL)
-         T_INF = ZERO
 C----------------------
 C       CONVECTION FLUX
 C----------------------
@@ -230,7 +231,6 @@ C---------------------
             FCY    = FCONV(1,NL)
             FCX    = FCONV(2,NL)
             H      = FCONV(3,NL)
-            T_INF  = ZERO
             IF(IFUNC_OLD /= IFUNC .OR. TS_OLD /= TS) THEN
               ISMOOTH = 0
               IF (IFUNC > 0) ISMOOTH = NPC(2*NFUNCT+IFUNC+1)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

possible PON issue using /CONVEC

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Initialize variable T_INF outside the loop. It was initially non initialized but previous correction put it in a wrong place

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
