### PR TITLE
missing initialization of WFEXT

### DIFF
--- a/engine/source/engine/radioss2.F
+++ b/engine/source/engine/radioss2.F
@@ -391,6 +391,8 @@ C                                   IF RELEASE WAS BUILT FROM SOURCE
       ABOUT = 0
 
       !External Foce Work
+      OUTPUT%WFEXT = 0.0D0
+      OUTPUT%WFEXT_MD = 0.0D0
       WFEXT => OUTPUT%WFEXT
       WFEXT_MD => OUTPUT%WFEXT_MD
 


### PR DESCRIPTION
The change initializes two variables, `OUTPUT%WFEXT` and `OUTPUT%WFEXT_MD`, to zero within the `SUBROUTINE RADIOSS2(IDATA,MIDATA,RDATA,MRDATA)`.
