### PR TITLE
/MAT/LAW128 : update cfg file with optional name, correct ortotropic parameter initialization

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2025/MAT/Law128_hill_visc_plast.cfg
+++ b/hm_cfg_files/config/CFG/radioss2025/MAT/Law128_hill_visc_plast.cfg
@@ -137,17 +137,24 @@ GUI(COMMON)
         ADD(2, "Show in Menu/Export");
         ADD(3, "Do Not Export");
     }
-    if( CommentEnumField == 2)
+    if( CommentEnumField == 2 )
     {
-       SIZE(NUM_COMMENTS);
-       ARRAY(NUM_COMMENTS,"")
-       {
-          SCALAR(COMMENTS);
-       }
+        SIZE(NUM_COMMENTS);
+        ARRAY(NUM_COMMENTS,"")
+        {
+            SCALAR(COMMENTS);
+        }
     }
-    
-    ASSIGN(KEYWORD_STR, "/MAT");
-    ASSIGN(KEYWORD_STR, "/LAW128/");
+    if(Mat_Name_OR_LawNo == 2)
+    {
+        ASSIGN(KEYWORD_STR, "/MAT");
+        ASSIGN(KEYWORD_STR, "/LAW128/");
+    }
+    else 
+    {
+        ASSIGN(KEYWORD_STR, "/MAT");
+        ASSIGN(KEYWORD_STR, "/HILL_VISC_PLAST/");
+    }
    
     mandatory:
 
@@ -192,10 +199,24 @@ FORMAT (radioss2025)
 {
     ASSIGN(IO_FLAG, 0, EXPORT);
     ASSIGN(IO_FLAG, 1,IMPORT);
-    if(IO_FLAG == 1)
+    if (IO_FLAG == 1)
     {
         HEADER("/MAT/%3s",LAW_NO);
+        if(LAW_NO == "LAW" )
+        {
+            ASSIGN(Mat_Name_OR_LawNo,2);
+        }
     }
+    else if(IO_FLAG == 0 && Mat_Name_OR_LawNo == 2)
+    {
+        HEADER("/MAT/LAW128/%d",_ID_);
+        CARD("%-100s", TITLE);
+    }
+    else
+    {
+        HEADER("/MAT/HILL_VISC_PLAST/%d",_ID_);
+        CARD("%-100s", TITLE);
+    }    
     
     COMMENT("#              Rho_i");
     CARD("%20lg",MAT_RHO);

--- a/hm_cfg_files/config/CFG/radioss2025/data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/radioss2025/data_hierarchy.cfg
@@ -1570,10 +1570,10 @@ HIERARCHY {
        HIERARCHY {
             KEYWORD    = MLAW128;
             TITLE      = "MLAW128";
-            FILE       = "MAT/Law128_hill_ortho.cfg";
+            FILE       = "MAT/Law128_hill_visc_plast.cfg";
             SUBTYPE    = USER;
             // USER_ID    = 8599;
-            USER_NAMES = (LAW128);
+            USER_NAMES = (LAW128,HILL_VISC_PLAST);
         }        
     }
     HIERARCHY {

--- a/starter/source/materials/mat/mat128/hm_read_mat128.F90
+++ b/starter/source/materials/mat/mat128/hm_read_mat128.F90
@@ -63,7 +63,7 @@
       use table_mod
       use unitab_mod
       use submodel_mod
-      use constant_mod , only : pi,zero,half,three_half,one,two,three,four_over_3
+      use constant_mod , only : pi,zero,half,fourth,three_half,one,two,three,four_over_3
       use constant_mod , only : infinity,ep20
       use mat_table_copy_mod
 !-----------------------------------------------
@@ -166,7 +166,7 @@
         if (mm   == zero) mm   = three_half
         if (nn   == zero) nn   = three_half
       else                                     ! use Lankford coefficients
-        rr = (r00 + r45*two + r90)
+        rr = (r00 + r45*two + r90) * fourth
         hh = rr / (one + rr)
         gg = hh / r00
         ff = hh / r90


### PR DESCRIPTION
Added optional material law name in cfg file
Corrected mean value of orthotropic Lankford parameter in starter used as default 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
