### PR TITLE
using standard damage formulation with out strain rate effect

### DIFF
--- a/starter/source/materials/mat/mat088/hm_read_mat88.F
+++ b/starter/source/materials/mat/mat088/hm_read_mat88.F
@@ -185,24 +185,22 @@ C
               YFAC(NFUNC) = YFAC_UNL
               RATE(NFUNC) = ZERO
               IUNL_FOR = 1  ! using unloading curve
-            ELSEIF(HYS > ZERO) THEN
-              IUNL_FOR = 3 ! based on the energy 
-            ELSEIF( HYS < ZERO ) THEN  ! old formation
+            ELSEIF(HYS /= ZERO) THEN
               IUNL_FOR = 2 ! based on the energy 
+              HYS = ABS(HYS)
             ELSE
               IUNL_FOR = 0  ! no unloading curve, 
             ENDIF     
-         ELSE ! strain rate effect
+      ELSE ! strain rate effect
             IF(IFUNC_UNLOAD > 0) THEN
               NFUNC = NFUNC + 1
               IFUNC(NFUNC) = IFUNC_UNLOAD
               YFAC(NFUNC) = YFAC_UNL
               RATE(NFUNC) = ZERO
               IUNL_FOR = 1  ! using unloading curve
-            ELSEIF(HYS > ZERO )THEN
-              IUNL_FOR = 3 ! based on the energy  ! Old IUNF_FOR = 3 
-            ELSEIF(HYS < ZERO ) THEN ! old formulation
+            ELSEIF(HYS /= ZERO )THEN
               IUNL_FOR = 3 ! based on the energy 
+              HYS = ABS(HYS)
             ELSE ! using quasistatic curve for unloading 
               NFUNC = NFUNC + 1
               IFUNC(NFUNC) = IFUNC(1)
@@ -279,7 +277,7 @@ c-----------------
         IF(IUNL_FOR == 1) THEN
          II = NL
          WRITE(IOUT,1300)IFUNC(NFUNC),YFAC_UNL 
-        ELSEIF(IUNL_FOR == 2) THEN
+        ELSEIF(IUNL_FOR == 2 .or. IUNL_FOR == 3) THEN
          write(IOUT,1400) HYS, SHAPE
         ENDIF
         WRITE(IOUT,1500) ITENS


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

with ou strain rate we should use standart formulation corresponding to hys >0 .  We ovoid numerical chane 
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Use Hys > 0 as before, when we don't considerer the strain rate effect.
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
