### PR TITLE
improve PressFit (int24,inacti=-1) of special case

### DIFF
--- a/engine/source/interfaces/int24/i24cor3.F
+++ b/engine/source/interfaces/int24/i24cor3.F
@@ -991,9 +991,9 @@ C--- fixing min(stif) with Inacti=-1
             NN = NI - NSN
             STIF_S =ABS(STIFI(NIN)%P(NN))
           END IF
-c      STIF_R(I) = MIN(STIF_S,STF(L))/MAX(EM20,STIF(I))
           STIF(I) = MIN(STIF_S,STF(L))
-          IF(IGSTI==2) STIF(I) = HALF*(STIF_S+STF(L))
+          STIF_R(I) = STIF(I)/MAX(STIF_S,STF(L))
+          IF(IGSTI==2) STIF(I) = HALF*(STIF_S+STF(L)) !option Inacti=-2
          ENDDO
       ELSEIF (IGSTI==-1)THEN
          DO I=1,JLT
@@ -1005,8 +1005,8 @@ c      STIF_R(I) = MIN(STIF_S,STF(L))/MAX(EM20,STIF(I))
              NN = NI - NSN
              STIF_S =ABS(STIFI(NIN)%P(NN))
            END IF
-           STIF_R(I) = MIN(STIF_S,STF(L))/MAX(STIF_S,STF(L))
            STIF(I) = MIN(STIF_S,STF(L))
+           STIF_R(I) = STIF(I)/MAX(STIF_S,STF(L))
          ENDDO
       END IF
       IF(NCFIT>0)THEN
@@ -1014,10 +1014,22 @@ c      STIF_R(I) = MIN(STIF_S,STF(L))/MAX(EM20,STIF(I))
          FAB= MAX(ZERO,THREE*TNCY-ONE)
          FB = MAX(ZERO,THREE*TNCY-TWO)
          F_PFIT = EM04*(FA+FAB)+FB
-         STIF(1:JLT)=F_PFIT*STIF(1:JLT)
-         IF (FB >ZERO.AND.IGSTI/=2) IKNON(1:JLT) = 1 ! -> nonlinear stiff
+         DO I=1,JLT
+           IF (STIF_R(I)>ZEP05) THEN
+             STIF(I)=TWENTY*F_PFIT*STIF(I)
+           ELSE
+             STIF(I)=F_PFIT*STIF(I)
+           END IF
+         ENDDO
+         IF (FB >ZERO.AND.IGSTI/=2) THEN 
+           DO I=1,JLT
+             IF (STIF_R(I)<ZEP05) IKNON(I) = 1 
+           ENDDO
+         END IF
       ELSEIF (INACTI==-1.AND.IGSTI/=2)THEN
-         IKNON(1:JLT) = 1 
+         DO I=1,JLT
+           IF (STIF_R(I)<ZEP05) IKNON(I) = 1 
+         ENDDO
       ELSEIF (IGSTI ==-1)THEN
          DO I=1,JLT
            IF (STIF_R(I) > 0.9 ) THEN

--- a/engine/source/output/anim/generate/ani_pcont.F
+++ b/engine/source/output/anim/generate/ani_pcont.F
@@ -493,7 +493,7 @@ C
           END IF
 C
           DO N=1,NUMNOD
-            IF (NODAREA(N) == ZERO) THEN
+            IF (NODAREA(N) <= EM20) THEN
               CONTN(1,N)=ZERO
               CONTN(2,N)=ZERO
               CONTN(3,N)=ZERO
@@ -501,7 +501,7 @@ C
               CONTT(2,N)=ZERO
               CONTT(3,N)=ZERO
             ELSE
-              AREAINV = ONE/MAX(EM30,NODAREA(N))
+              AREAINV = ONE/MAX(EM20,NODAREA(N))
               CONTN(1,N)=AREAINV*CONTN(1,N)
               CONTN(2,N)=AREAINV*CONTN(2,N)
               CONTN(3,N)=AREAINV*CONTN(3,N)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
PressFot using interface type24 and Inacti=-1 might fail when the two contact parts have the same order of stiffness.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
improvement of PressFit of special case

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
