### PR TITLE
Implement error message when *CONTROL_UNITS not available with unit d…

### DIFF
--- a/hm_cfg_files/messages/CONFIG/msg_hw_radioss_reader.txt
+++ b/hm_cfg_files/messages/CONFIG/msg_hw_radioss_reader.txt
@@ -339,3 +339,15 @@ Only one %s card is allowed
 /MESSAGE/200039/DESCRIPTION
 %s : CURVE id: %u,  At least one of the input parameters must be non zero: VMAX, TEND.
 #------------------------------------------------------------------------------
+
+/MESSAGE/200040/TITLE
+** ERROR IN LS-DYNA IMPORT
+/MESSAGE/200040/DESCRIPTION
+%s (id: %u, name: %s), *CONTROL_UNITS card is mandatory for conversion of *MAT_SPOTWELD used with 1D elements.
+#------------------------------------------------------------------------------
+
+/MESSAGE/200041/TITLE
+** ERROR IN LS-DYNA IMPORT
+/MESSAGE/200041/DESCRIPTION
+%s (id: %u, name: %s), *CONTROL_UNITS card is mandatory for conversion of this card.
+#------------------------------------------------------------------------------


### PR DESCRIPTION
…ependent conversion

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Implement an error message for case when *MAT_SPOTWELD used for 1D elements and  *CONSTRAINED_SPOTWELD
 cards are used w/o *CONTROL_UNITS.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Implement an error message for case when *MAT_SPOTWELD used for 1D elements and  *CONSTRAINED_SPOTWELD
 cards are used w/o *CONTROL_UNITS.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
