### PR TITLE
strain rate must defined in ascending order

### DIFF
--- a/starter/source/materials/mat/mat070/hm_read_mat70.F
+++ b/starter/source/materials/mat/mat070/hm_read_mat70.F
@@ -176,7 +176,7 @@ c---------------------------------------------------------------------------
         IERR  = 0
         ISORT = 0
         DO I=1,NRATEP-1
-          IF (RATE(I) == RATE(I+1) .and. IFUNC(I) /= IFUNC(I+1)) THEN
+          IF (RATE(I) == RATE(I+1) ) THEN
             IERR  = 1
           ELSE IF (RATE(I) > RATE(I+1)) THEN
             ISORT = 1
@@ -218,7 +218,7 @@ c---------------------------------------------------------------------------
         ISORT = 0
         DO I=1,NRATEN-1
           J = I + NRATEP
-          IF (RATE(J) == RATE(J+1) .and. IFUNC(J) /= IFUNC(J+1)) THEN
+          IF (RATE(J) == RATE(J+1)) THEN
             IERR  = 1
           ELSE IF (RATE(J) > RATE(J+1)) THEN
             ISORT = 1


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

NaN when two function have the same strain rate. (Wrong input)
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

checking if the strain rate is defined in asending order in this case

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
