### PR TITLE
Fix uninitialized variable in /MAT/LAW187

### DIFF
--- a/engine/source/materials/mat/mat187/sigeps187.F
+++ b/engine/source/materials/mat/mat187/sigeps187.F
@@ -753,7 +753,7 @@ C     ----------------------------------------------------
      .         -G * (DU * DF5) **2 
      .         -G * (DU * DF6) **2 
 
-          DF = DF  - YLDP ! bug, YLDP not initialized here
+          DF = DF - DYDX(I)
 
           !CALCUL PAS PLASTIQUE
           DPLA(I)=DPLA(I)-FCT/DF


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Use of uninitialized variable YLDP in /MAT/LAW187.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

For this specific combination of input flags, YLDP must be replaced by DYDX. That is why YLDP was not initialized. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
