### PR TITLE
VSTRAIN output for TRIA and ALE-multimaterial compatibility

### DIFF
--- a/engine/source/output/anim/generate/dfunc0.F
+++ b/engine/source/output/anim/generate/dfunc0.F
@@ -41,10 +41,11 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       SUBROUTINE DFUNC0(ELBUF_TAB, FUNC             ,IFUNC     ,IPARG   ,
      2                  MASS     , PM               ,EL2FA     ,NBF     ,
      3                  NBPART   , IADG             ,SPBUF     ,IPART   ,
-     4                  IPARTSP  , ALE_CONNECTIVITY ,IXQ       ,IPM     ,
+     4                  IPARTSP  , ALE_CONNECTIVITY ,IPM       ,
      5                  X        , V                ,W         ,ITHERM  ,
      6                  NERCVOIS , NESDVOIS         ,LERCVOIS  ,LESDVOIS, 
-     7                  BUFMAT   , MULTI_FVM        ,KXSP      ,DEFAULT_OUTPUT)
+     7                  BUFMAT   , MULTI_FVM        ,KXSP      ,DEFAULT_OUTPUT,
+     8                  MAT_PARAM)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -55,6 +56,8 @@ C-----------------------------------------------
       USE SCHLIEREN_MOD    
       USE ALE_CONNECTIVITY_MOD
       USE my_alloc_mod
+      USE MATPARAM_DEF_MOD , ONLY : MATPARAM_STRUCT_
+      USE MULTIMAT_PARAM_MOD , ONLY : M51_N0PHAS, M51_NVPHAS
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -68,21 +71,24 @@ C-----------------------------------------------
 #include      "com04_c.inc"
 #include      "sphcom.inc"
 #include      "scr17_c.inc"
+#include      "scr25_c.inc"
 #include      "param_c.inc"
 #include      "task_c.inc"
 #include      "spmd_c.inc"
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      my_real FUNC(*), MASS(*) ,PM(NPROPM,NUMMAT),SPBUF(NSPBUF,*),BUFMAT(*),X(3,NUMNOD),V(3,NUMNOD), W(*)
+      my_real FUNC(*), MASS(*) ,PM(NPROPM,NUMMAT),SPBUF(NSPBUF,*),X(3,NUMNOD),V(3,NUMNOD), W(*)
+      my_real, TARGET :: BUFMAT(*)
       INTEGER IPARG(NPARG,NGROUP),EL2FA(*),IFUNC,NBF,
      .        NBPART,IADG(NSPMD,*),IPART(LIPART1,*),IPARTSP(*),
-     .        NERCVOIS(*),NESDVOIS(*),LERCVOIS(*),LESDVOIS(*),IXQ(NIXQ,NUMELQ),IPM(NPROPMI,NUMMAT)
+     .        NERCVOIS(*),NESDVOIS(*),LERCVOIS(*),LESDVOIS(*),IPM(NPROPMI,NUMMAT)
       INTEGER, INTENT(IN) :: ITHERM
       INTEGER, INTENT(IN) :: KXSP(NISP,NUMSPH),DEFAULT_OUTPUT
       TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP), TARGET :: ELBUF_TAB
       TYPE(MULTI_FVM_STRUCT), INTENT(IN) :: MULTI_FVM
       TYPE(t_ale_connectivity), INTENT(IN) :: ALE_CONNECTIVITY
+      TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(IN) :: MAT_PARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -91,10 +97,19 @@ C-----------------------------------------------
       REAL R4
       REAL,DIMENSION(:),ALLOCATABLE :: WA
       TYPE(G_BUFEL_) ,POINTER :: GBUF
-      TYPE(L_BUFEL_) ,POINTER :: LBUF
+      TYPE(L_BUFEL_) ,POINTER :: LBUF, LBUF1,LBUF2
       TYPE(BUF_MAT_) ,POINTER :: MBUF
       TYPE(BUF_EOS_)  ,POINTER :: EBUF
       my_real, DIMENSION(:),POINTER  ::  DFMAX
+      my_real, DIMENSION(:) ,POINTER  :: UPARAM
+      INTEGER MID,IMAT,NUPARAM,IPOS,IADBUF,ISUBMAT,IU(4),ILAY
+      my_real :: vi(21) !< submaterial volumes at reference densities (max submat : 21)
+      my_real :: v0i(21) !< submaterial volumes at reference densities (max submat : 21)
+      my_real :: v0g !< global volume at reference density (mixture)
+      my_real :: RHO0i(21) !< submaterial initial mass densities (max submat : 21)
+      my_real :: RHOi(21) !< submaterial  mass densities (max submat : 21)
+      my_real :: RHO0g !< global initial mass density (mixture)
+      LOGICAL detected
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
@@ -109,7 +124,7 @@ C-----------------------------------------------
       ENDIF!(IFUNC==4892)
 
 C-----------------------------------------------
-      DO 900 NG=1,NGROUP
+      DO NG=1,NGROUP
         MLW = IPARG(1,NG)     
         NEL = IPARG(2,NG)                                          
         NFT = IPARG(3,NG)
@@ -295,19 +310,7 @@ c-----------
            N = I + NFT          
            FUNC(EL2FA(NN1+N)) = DFMAX(I)    
              ENDDO
-           ENDDO  
-c-----------
-            ELSEIF(IFUNC == 4892) THEN  
-             IALEL=IPARG(7,NG)+IPARG(11,NG)
-             IF(IALEL == 0)THEN
-               EVAR(LFT:LLT) = ZERO
-             ELSE
-               CALL OUTPUT_SCHLIEREN(
-     1                        EVAR    ,IXQ    ,X           ,
-     2                        IPARG   ,WA_L   ,ELBUF_TAB   ,ALE_CONNECTIVITY   ,GBUF%VOL,
-     3                        NG      ,NIXQ   ,ITY)
-             ENDIF  
-             FUNC(EL2FA(NN1+NFT+1:NN1+NFT+LLT)) = EVAR(1:LLT)      
+           ENDDO
 c-----------      
            ELSEIF (IFUNC == 4893) THEN                     
              DO I=LFT,LLT                                               
@@ -373,7 +376,6 @@ c-----------
                ELSEIF(IFUNC==4941)THEN
                  DO I=LFT,LLT
                   N     = I + NFT
-!                  IAD0  = (I-1)*3
                   IF(EL2FA(NN1+N)/=0)THEN
                      FUNC(EL2FA(NN1+N)) = SQRT( GBUF%MOM(II(1) + I)+GBUF%MOM(II(1) + I) 
      +                                         +GBUF%MOM(II(2) + I)+GBUF%MOM(II(2) + I) )  
@@ -382,7 +384,6 @@ c-----------
                ELSEIF(IFUNC==4942)THEN
                  DO I=LFT,LLT
                   N     = I + NFT
-!                  IAD0  = (I-1)*3
                   IF(EL2FA(NN1+N)/=0)THEN
                      FUNC(EL2FA(NN1+N)) = SQRT( GBUF%MOM(II(2) + I)+GBUF%MOM(II(2) + I)
      +                                         +GBUF%MOM(II(3) + I)+GBUF%MOM(II(3) + I) )  
@@ -391,7 +392,6 @@ c-----------
                ELSEIF(IFUNC==4943)THEN
                  DO I=LFT,LLT
                   N     = I + NFT
-!                  IAD0  = (I-1)*3
                   IF(EL2FA(NN1+N)/=0)THEN
                      FUNC(EL2FA(NN1+N)) = SQRT( GBUF%MOM(II(1) + I)+GBUF%MOM(II(1) + I) 
      +                                         +GBUF%MOM(II(3) + I)+GBUF%MOM(II(3) + I) )  
@@ -400,7 +400,6 @@ c-----------
                ELSEIF(IFUNC==4944)THEN
                  DO I=LFT,LLT
                   N     = I + NFT
-!                  IAD0  = (I-1)*3
                   IF(EL2FA(NN1+N)/=0)THEN
                      FUNC(EL2FA(NN1+N)) = SQRT( GBUF%MOM(II(1) + I)+GBUF%MOM(II(1) + I) 
      +                                         +GBUF%MOM(II(2) + I)+GBUF%MOM(II(2) + I)
@@ -422,7 +421,6 @@ c-----------
                ELSEIF(IFUNC==4948)THEN
                  DO I=LFT,LLT
                   N     = I + NFT
-!                  IAD0  = (I-1)*3
                   IF(EL2FA(NN1+N)/=0)THEN
                      FUNC(EL2FA(NN1+N)) = SQRT( GBUF%MOM(II(1) + I)+GBUF%MOM(II(1) + I) 
      +                                         +GBUF%MOM(II(2) + I)+GBUF%MOM(II(2) + I) )  / GBUF%RHO(I)      
@@ -431,7 +429,6 @@ c-----------
                ELSEIF(IFUNC==4949)THEN
                  DO I=LFT,LLT
                   N     = I + NFT
-!                  IAD0  = (I-1)*3
                   IF(EL2FA(NN1+N)/=0)THEN
                      FUNC(EL2FA(NN1+N)) = SQRT( GBUF%MOM(II(2) + I)+GBUF%MOM(II(2) + I) 
      +                                         +GBUF%MOM(II(3) + I)+GBUF%MOM(II(3) + I) )  / GBUF%RHO(I)      
@@ -440,7 +437,6 @@ c-----------
                ELSEIF(IFUNC==4950)THEN
                  DO I=LFT,LLT
                   N     = I + NFT
-!                  IAD0  = (I-1)*3
                   IF(EL2FA(NN1+N)/=0)THEN
                      FUNC(EL2FA(NN1+N)) = SQRT( GBUF%MOM(II(1) + I)+GBUF%MOM(II(1) + I) 
      +                                         +GBUF%MOM(II(3) + I)+GBUF%MOM(II(3) + I) )  / GBUF%RHO(I)      
@@ -449,7 +445,6 @@ c-----------
                ELSEIF(IFUNC==4951)THEN
                  DO I=LFT,LLT
                   N     = I + NFT
-!                  IAD0  = (I-1)*3
                   IF(EL2FA(NN1+N)/=0)THEN
                      FUNC(EL2FA(NN1+N)) = SQRT( GBUF%MOM(II(1) + I)+GBUF%MOM(II(1) + I) 
      +                                         +GBUF%MOM(II(2) + I)+GBUF%MOM(II(2) + I)
@@ -578,7 +573,7 @@ c-----------
 C-----------------------------------------------
 C       FIN DE BOUCLE SUR LES GROUPES
 C-----------------------------------------------
- 900  CONTINUE
+      ENDDO ! next NG
 C-----------------------------------------------
 
       IF (NSPMD == 1) THEN

--- a/engine/source/output/anim/generate/dfunc6.F
+++ b/engine/source/output/anim/generate/dfunc6.F
@@ -81,6 +81,7 @@ C-----------------------------------------------
 #include      "sphcom.inc"
 #include      "scr14_c.inc"
 #include      "scr17_c.inc"
+#include      "scr25_c.inc"
 #include      "param_c.inc"
 #include      "task_c.inc"
 #include      "spmd_c.inc"
@@ -89,9 +90,8 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      my_real
-     .   FUNC(*), MASS(*) ,PM(NPROPM,NUMMAT), GEO(NPROPG,NUMGEO),
-     .   EHOUR(*),ANIM(*), SPBUF(*),X(3,NUMNOD),V(3,NUMNOD), W(3,NUMNOD),BUFMAT(*)
+      my_real FUNC(*), MASS(*) ,PM(NPROPM,NUMMAT), GEO(NPROPG,NUMGEO),
+     .        EHOUR(*),ANIM(*), SPBUF(*),X(3,NUMNOD),V(3,NUMNOD), W(3,NUMNOD),BUFMAT(*)
       TYPE(FANI_CELL_), INTENT(IN) :: FANI_CELL
       INTEGER IPARG(NPARG,*),EL2FA(*),IXS(NIXS,NUMELS),IFUNC,NBF,ISPH3D,
      .        NBPART,IADG(NSPMD,*),IPM(NPROPMI,NUMMAT),
@@ -115,26 +115,31 @@ C-----------------------------------------------
      .        IDEB, IPOS, ITRIMAT,IVISC,JJ(6),IFRAC,IMAT,IADBUF,
      .        NUPARAM,IDX,ISUBMAT,IU(4),NFRAC,IS_ALE,IS_EULER,
      .        IMAT_TILLOTSON,NTILLOTSON,FAC,NVAREOS,IEOS
-      my_real
-     .   EVAR(MVSIZ), USER(MVSIZ),
-     .   OFF, P, VONM2, VONM, S1, S2, S3, VALUE,VALUES(MVSIZ),GAMA(6),
-     .   T11,T21,T31,T12,T22,T32,T13,T23,T33,
-     .   PHI,TETA,PSI,DAMMAX,S11,S22,S33,S4,S5,S6,
-     .   SIG1(MVSIZ),SIG2(MVSIZ),SIG3(MVSIZ),SIG4(MVSIZ),SIG5(MVSIZ),
-     .   SIG6(MVSIZ),FF0,GG0,HH0,LL0,MM0,NN0,CRIT,VEL(0:4),VFRAC(MVSIZ,21),TMP(3,8)
+      my_real EVAR(MVSIZ), USER(MVSIZ),
+     .        OFF, P, VONM2, VONM, S1, S2, S3, VALUE,VALUES(MVSIZ),GAMA(6),
+     .        T11,T21,T31,T12,T22,T32,T13,T23,T33,
+     .        PHI,TETA,PSI,DAMMAX,S11,S22,S33,S4,S5,S6,
+     .        SIG1(MVSIZ),SIG2(MVSIZ),SIG3(MVSIZ),SIG4(MVSIZ),SIG5(MVSIZ),
+     .        SIG6(MVSIZ),FF0,GG0,HH0,LL0,MM0,NN0,CRIT,VEL(0:4),VFRAC(MVSIZ,21),TMP(3,8)
       REAL R4
       REAL,DIMENSION(:),ALLOCATABLE::WAL
       TYPE(G_BUFEL_)  ,POINTER :: GBUF     
-      TYPE(L_BUFEL_)  ,POINTER :: LBUF    
+      TYPE(L_BUFEL_)  ,POINTER :: LBUF,LBUF1,LBUF2
       TYPE(BUF_MAT_)  ,POINTER :: MBUF  
       TYPE(BUF_EOS_)  ,POINTER :: EBUF
       
-      my_real, 
-     .   DIMENSION(:),POINTER  :: 
-     .   UVARF, DAMF,DFMAX,TDELE
+      my_real,  DIMENSION(:),POINTER  :: UVARF, DAMF,DFMAX,TDELE
       my_real, DIMENSION(:) ,POINTER  :: UPARAM
       TARGET :: BUFMAT
       my_real :: MY_VALUE,MY_ONE
+      INTEGER MID,ILAY
+      my_real :: vi(21) !< submaterial volumes at reference densities (max submat : 21)
+      my_real :: v0i(21) !< submaterial volumes at reference densities (max submat : 21)
+      my_real :: v0g !< global volume at reference density (mixture)
+      my_real :: RHO0i(21) !< submaterial initial mass densities (max submat : 21)
+      my_real :: RHOi(21) !< submaterial  mass densities (max submat : 21)
+      my_real :: RHO0g !< global initial mass density (mixture)
+      LOGICAL detected
 C=======================================================================
       CALL MY_ALLOC(WAL,NBF)
       NN1  = 1
@@ -149,13 +154,12 @@ C-----------------------------------------------
       !     INITIALIZATION IF SCHLIEREN DEFINED               !
       !-------------------------------------------------------!      
       IF(IFUNC==4892)THEN
-        CALL SCHLIEREN_BUFFER_GATHERING(NERCVOIS ,NESDVOIS ,LERCVOIS ,LESDVOIS, IPARG, ELBUF_TAB, MULTI_FVM,
-     .                                  ITHERM)
+        CALL SCHLIEREN_BUFFER_GATHERING(NERCVOIS ,NESDVOIS ,LERCVOIS ,LESDVOIS, IPARG, ELBUF_TAB, MULTI_FVM,ITHERM)
       ENDIF!(IFUNC==4892)
    
 
 C-----------------------------------------------
-      DO 900 NG=1,NGROUP
+      DO NG=1,NGROUP
         CALL INITBUF(IPARG    ,NG      ,                    
      2          MLW     ,NEL     ,NFT     ,IAD     ,ITY     ,  
      3          NPT     ,JALE    ,ISMSTR  ,JEUL    ,JTUR    ,  
@@ -1662,43 +1666,203 @@ c------------------------------------ Tillotson Region id
               ENDIF
 
 c------------------------------------ Volumetric Strain (VSTRAIN)
-            ELSEIF( IFUNC == 5173 ) THEN
-              EVAR(1:NEL) = ZERO
-              MT = IXS(1,NFT+1)
-              IF(PM(89,MT) > ZERO)THEN
-                DO I=1,NEL
-                  EVAR(I) = GBUF%RHO(I) / PM(89,MT) - ONE
-                ENDDO
-              ENDIF
+            elseif(IFUNC == 5173) then
+!--------------------------------------------------
+              DO I=1,NEL
+                FUNC(EL2FA(NN1+NFT+I)) = ZERO
+              ENDDO
 
-           ELSEIF(IFUNC >= 5173+1 .AND. IFUNC <= 5173+21)THEN
-              EVAR(1:NEL) = ZERO
-              ISUBMAT = IFUNC-5173
-              IF(MLW == 151)THEN
-                MT = IXS(1,1+NFT)
-                MT = MAT_PARAM(MT)%MULTIMAT%MID(ISUBMAT)
-                DO I=1,NEL
-                  EVAR(I) = MULTI_FVM%RHO(I + NFT)  / PM(89,MT) - ONE
-                ENDDO
-              ELSEIF(MLW == 51)THEN
-                   ISUBMAT   = IFUNC - 5173
-                   !bijection for iform=12
-                   IMAT = IXS(1,NFT+1)
-                   IADBUF = IPM(7,IMAT)
-                   NUPARAM= IPM(9,IMAT)
-                   UPARAM => BUFMAT(IADBUF:IADBUF+NUPARAM)
-                   ISUBMAT = UPARAM(276+ISUBMAT) !bijective order
-                   IUS=M51_N0PHAS+(ISUBMAT-1)*M51_NVPHAS
-                   !
-                   LLT       = IPARG(2,NG)
-                   IPOS      = 20
-                   K         = LLT * ((IUS )+IPOS-1)
-                   MT = IXS(1,1+NFT)
-                   MT = MAT_PARAM(MT)%MULTIMAT%MID(ISUBMAT)
-                   DO I=LFT,LLT
-                     EVAR(I) = MBUF%VAR(K+I) / PM(89,MT) - ONE
-                   ENDDO
-              ENDIF
+              mt = ixs(1,nft+1)
+
+              do i=1,nel
+
+                if(mlw == 151)then
+                  !multimaterial 151 (collocated scheme)
+                    do ilay=1,multi_fvm%nbmat
+                      mid = MAT_PARAM(mt)%multimat%mid(ilay)
+                      rho0i (ilay) = pm(89,mid)
+                      Vi (ilay) = multi_fvm%phase_alpha(ilay,i+nft) * gbuf%vol(i)
+                      V0i (ilay) =  multi_fvm%phase_rho(ilay,i+nft) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                    enddo
+                    V0g = sum(V0i)
+                    RHO0g = zero
+                    do ilay=1,multi_fvm%nbmat
+                      RHO0g = RHO0g + rho0i(ilay)*V0i(ilay)
+                    end do
+                    RHO0g = RHO0g / V0g
+                    FUNC(EL2FA(NN1+NFT+I)) = multi_fvm%rho(i+nft) / RHO0g - ONE
+
+                elseif(mlw == 51)then
+                  !multimaterial 51 (staggered scheme)
+                  imat   = ixs(1,nft+1)
+                  iadbuf = ipm(7,imat)
+                  nuparam= ipm(9,imat)
+                  uparam => bufmat(iadbuf:iadbuf+nuparam)
+                  mbuf => elbuf_tab(ng)%bufly(1)%mat(1,1,1)
+                  ipos = 1
+                  !bijective order           !indexes
+                  isubmat = nint(uparam(276+1));   iu(1)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                  isubmat = nint(uparam(276+2));   iu(2)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                  isubmat = nint(uparam(276+3));   iu(3)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                  isubmat = nint(uparam(276+4));   iu(4)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                  vfrac(i,1) = mbuf%var(i+iu(1)*nel)
+                  vfrac(i,2) = mbuf%var(i+iu(2)*nel)
+                  vfrac(i,3) = mbuf%var(i+iu(3)*nel)
+                  vfrac(i,4) = mbuf%var(i+iu(4)*nel)
+                  ipos = 12
+                  !bijective order           !indexes
+                  isubmat = nint(uparam(276+1));   iu(1)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                  isubmat = nint(uparam(276+2));   iu(2)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                  isubmat = nint(uparam(276+3));   iu(3)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                  isubmat = nint(uparam(276+4));   iu(4)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                  rhoi(1) = mbuf%var(i+iu(1)*nel)
+                  rhoi(2) = mbuf%var(i+iu(2)*nel)
+                  rhoi(3) = mbuf%var(i+iu(3)*nel)
+                  rhoi(4) = mbuf%var(i+iu(4)*nel)
+                  do ilay=1,4
+                    mid = MAT_PARAM(mt)%multimat%mid(ilay)
+                    rho0i (ilay) = pm(89,mid)
+                    Vi (ilay) = vfrac(i,ilay) * gbuf%vol(i)
+                    ipos = 12
+                    V0i (ilay) =  rhoi(ilay) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                  enddo
+                  V0g = sum(V0i)
+                  RHO0g = zero
+                  do ilay=1,4
+                    RHO0g = RHO0g + rho0i(ilay)*V0i(ilay)
+                  end do
+                  RHO0g = RHO0g / V0g
+                  FUNC(EL2FA(NN1+NFT+I)) = gbuf%rho(i) / RHO0g - ONE
+
+                elseif(mlw == 37)then
+                  !multimaterial 37 (staggered scheme)
+                  imat   = ixs(1,nft+1)
+                  iadbuf = ipm(7,imat)
+                  nuparam= ipm(9,imat)
+                  uparam => bufmat(iadbuf:iadbuf+nuparam)
+                  mbuf => elbuf_tab(ng)%bufly(1)%mat(1,1,1)
+                  rho0i(1) = uparam(11)
+                  rho0i(2) = uparam(12)
+                  Vi(1) = mbuf%var(i+3*nel) * gbuf%vol(i) !UVAR(I,4)  = VFRAC1
+                  Vi(2) = mbuf%var(i+4*nel) * gbuf%vol(i) !UVAR(I,5)  = VFRAC2
+                  rhoi(1) = mbuf%var(i+2*nel) !UVAR(I,3)  = RHO1
+                  rhoi(2) = mbuf%var(i+1*nel) !UVAR(I,2)  = RHO2
+                  V0i(1) =  rhoi(1) * Vi(1) / rho0i(1)         !rho0.V0 = rho.V
+                  V0i(2) =  rhoi(2) * Vi(2) / rho0i(2)         !rho0.V0 = rho.V
+                  V0g = sum(V0i)
+                  RHO0g = zero
+                  do ilay=1,2
+                    RHO0g = RHO0g + rho0i(ilay)*V0i(ilay)
+                  end do
+                  RHO0g = RHO0g / V0g
+                  FUNC(EL2FA(NN1+NFT+I)) = gbuf%rho(i) / RHO0g - ONE
+
+                elseif(mlw == 20)then
+                  !multimaterial 20 (staggered scheme)
+                  lbuf1  => elbuf_tab(ng)%bufly(1)%lbuf(1,1,1)
+                  lbuf2  => elbuf_tab(ng)%bufly(2)%lbuf(1,1,1)
+                  mid = MAT_PARAM(mt)%multimat%mid(1)
+                  rho0i(1) = pm(89,mid)
+                  mid = MAT_PARAM(mt)%multimat%mid(2)
+                  rho0i(2) = pm(89,mid)
+                  Vi(1) = lbuf1%vol(i)
+                  Vi(2) = lbuf2%vol(i)
+                  rhoi(1) = lbuf1%rho(i)
+                  rhoi(2) = lbuf2%rho(i)
+                  V0i(1) =  rhoi(1) * Vi(1) / rho0i(1)         !rho0.V0 = rho.V
+                  V0i(2) =  rhoi(2) * Vi(2) / rho0i(2)         !rho0.V0 = rho.V
+                  V0g = sum(V0i)
+                  RHO0g = zero
+                  do ilay=1,2
+                    RHO0g = RHO0g + rho0i(ilay)*V0i(ilay)
+                  end do
+                  RHO0g = RHO0g / V0g
+                  FUNC(EL2FA(NN1+NFT+I)) = gbuf%rho(i) / RHO0g - ONE
+
+                else
+                  !general case (monomaterial law)
+                  if(pm(89,mt) > zero)then
+                    FUNC(EL2FA(NN1+NFT+I)) = gbuf%rho(i) / pm(89,mt) - one
+                  end if
+                end if
+
+              enddo
+c------------------------------------ Volumetric Strain (VSTRAIN)
+            elseif(IFUNC >= 5173+1 .and. IFUNC <= 5173+10) then
+!--------------------------------------------------
+                detected = .false.
+                ilay = IFUNC - (15899 + 4*MX_PLY_ANIM)
+                if(mlw == 151 .and. ilay <= min(10,multi_fvm%nbmat))detected = .true.
+                if(mlw ==  51 .and. ilay <= 4                      )detected = .true.
+                if(mlw ==  37 .and. ilay <= 2                      )detected = .true.
+                if(mlw ==  20 .and. ilay <= 2                      )detected = .true.
+
+                if(detected)then
+
+                  mt = ixs(1,nft+1)
+
+                  do i=1,nel
+
+                     if(mlw == 151)then
+                      !multimaterial 151 (collocated scheme)
+                        mid = MAT_PARAM(mt)%multimat%mid(ilay)
+                        rho0i(ilay) = pm(89,mid)
+                        Vi(ilay) = multi_fvm%phase_alpha(ilay,i+nft) * gbuf%vol(i)
+                        V0i(ilay) = multi_fvm%phase_rho(ilay,i+nft) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                        FUNC(EL2FA(NN1+NFT+I)) = multi_fvm%phase_rho(ilay,i+nft) / rho0i(ilay) - ONE
+
+                    elseif(mlw == 51)then
+                      !multimaterial 51 (staggered scheme)
+                      imat = ixs(1,nft+1)
+                      iadbuf = ipm(7,imat)
+                      nuparam= ipm(9,imat)
+                      uparam => bufmat(iadbuf:iadbuf+nuparam)
+                      mbuf => elbuf_tab(ng)%bufly(1)%mat(1,1,1)
+                      mid = MAT_PARAM(mt)%multimat%mid(ilay)
+                      rho0i(ilay) = pm(89,mid)
+                      ipos = 1
+                      !bijective order           !indexes
+                      isubmat = nint(uparam(276+ilay));   iu(1)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                      vfrac(i,ilay) = mbuf%var(i+iu(ilay)*nel)
+                      Vi(ilay) = vfrac(i,ilay) * gbuf%vol(i)
+                      ipos = 12
+                      !bijective order           !indexes
+                      isubmat = nint(uparam(276+ilay));   iu(ilay)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                      rhoi(ilay) = mbuf%var(i+iu(ilay)*nel)
+                      V0i (ilay) =  rhoi(ilay) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                      FUNC(EL2FA(NN1+NFT+I)) = rhoi(ilay) / rho0i(ilay) - ONE
+
+                    elseif(mlw == 37)then
+                      !multimaterial 37 (staggered scheme)
+                      imat = ixs(1,nft+1)
+                      iadbuf = ipm(7,imat)
+                      nuparam= ipm(9,imat)
+                      uparam => bufmat(iadbuf:iadbuf+nuparam)
+                      mbuf => elbuf_tab(ng)%bufly(1)%mat(1,1,1)
+                      rho0i(ilay) = uparam(10+ilay)
+                      Vi(ilay) = mbuf%var(i+(ilay+2)*nel) * gbuf%vol(i)
+                      rhoi(ilay) = mbuf%var(i+(3-ilay)*nel) !UVAR(I,3)  = RHO1
+                      V0i(ilay) =  rhoi(ilay) * Vi(ilay) / rho0i(ilay)
+                      FUNC(EL2FA(NN1+NFT+I)) = rhoi(ilay) / rho0i(ilay) - ONE
+
+                    elseif(mlw == 20)then
+                      !multimaterial 20 (staggered scheme)
+                      lbuf  => elbuf_tab(ng)%bufly(ilay)%lbuf(1,1,1)
+                      mid = MAT_PARAM(mt)%multimat%mid(ilay)
+                      rho0i(ilay) = pm(89,mid)
+                      Vi(ilay) = lbuf%vol(i)
+                      rhoi(ilay) = lbuf%rho(i)
+                      V0i(ilay) =  rhoi(ilay) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                      FUNC(EL2FA(NN1+NFT+I)) = rhoi(ilay) / rho0i(ilay) - ONE
+
+                    else
+                      !general case (monomaterial law)
+                      FUNC(EL2FA(NN1+NFT+I)) = ZERO
+                    end if
+                enddo
+
+              end if
+
 c------------------------------------ 
               !OTHER IFUNC VALUES
               ELSE 
@@ -2163,7 +2327,7 @@ C-----------
               ENDDO
             ENDIF   ! IFUNC
 C-----------------------------------------------
-          ELSEIF (ITY==101) THEN
+          ELSEIF (ITY == 101) THEN
 C           ISOGEOMETRIC ELEMENT  A VERIFIER
 C-----------------------------------------------
             GBUF => ELBUF_TAB(NG)%GBUF
@@ -2177,7 +2341,7 @@ c-----------
                   ENDIF
                 ENDDO
 c
-              ELSEIF(IFUNC==6.OR.IFUNC==7)THEN   
+              ELSEIF(IFUNC == 6 .OR. IFUNC == 7)THEN
                   DO I=LFT,LLT
                      N = I + NFT
                       S11 =  GBUF%SIG(JJ(1) + I) 
@@ -2207,23 +2371,18 @@ c
                       ENDIF
                       EVAR(I) = VALUE
                   ENDDO
+
               ELSEIF(IFUNC==2)THEN
                 DO I=LFT,LLT                                            
                   EVAR(I) = GBUF%RHO(I)  
-                ENDDO 
+                ENDDO
+
               ELSEIF(IFUNC==3)THEN
                 DO I=LFT,LLT                                                                             
                   VALUE = GBUF%EINT(I)/MAX(EM30,GBUF%RHO(I))
                   EVAR(I) = VALUE 
                 ENDDO  
-c                  IALEL=IPARG(7,NG)+IPARG(11,NG)                        
-c                  IF (IALEL == 0) THEN                                    
-c                    MT=IXS(1,N)                                         
-c                    VALUE = GBUF%EINT(I)/MAX(EM30,PM(1,MT))          
-c                  ELSE                                                  
-c                    VALUE = GBUF%EINT(I)/MAX(EM30,GBUF%RHO(I))
-c                  ENDIF                                                 
-c                  EVAR(I) = VALUE 
+
               ELSEIF(IFUNC == 26) THEN
                  IF (ISRAT > 0) THEN
                    DO I=LFT,LLT
@@ -2253,7 +2412,7 @@ C
 C-----------------------------------------------
         ENDDO       ! FIN DE BOUCLE SUR LES OFFSET
        ENDIF        ! mlw /= 13
- 900  CONTINUE 
+      ENDDO !next NG
 C-----------------------------------------------
        
       IF (NSPMD == 1) THEN

--- a/engine/source/output/anim/generate/dfuncc.F
+++ b/engine/source/output/anim/generate/dfuncc.F
@@ -135,14 +135,21 @@ C-----------------------------------------------
       TYPE(BUF_EOS_)  ,POINTER :: EBUF  
       TYPE(L_BUFEL_DIR_) ,POINTER :: LBUF_DIR
       
-      my_real,
-     .  DIMENSION(:), POINTER  :: UVAR,OFFL
+      my_real,DIMENSION(:), POINTER  :: UVAR,OFFL
       TYPE(L_BUFEL_) ,POINTER  :: LBUF1,LBUF2 
       my_real, DIMENSION(:) ,POINTER  :: UPARAM
       TARGET :: BUFMAT
       my_real TMP(3,4)
       DATA NS/10/
       TYPE(t_ale_connectivity), INTENT(IN) :: ALE_CONNECTIVITY
+      INTEGER MID
+      my_real :: vi(21) !< submaterial volumes at reference densities (max submat : 21)
+      my_real :: v0i(21) !< submaterial volumes at reference densities (max submat : 21)
+      my_real :: v0g !< global volume at reference density (mixture)
+      my_real :: RHO0i(21) !< submaterial initial mass densities (max submat : 21)
+      my_real :: RHOi(21) !< submaterial  mass densities (max submat : 21)
+      my_real :: RHO0g !< global initial mass density (mixture)
+      LOGICAL detected
 C-----------------------------------------------
       CALL MY_ALLOC(WAL,NBF_L)
       NINTY = 90.
@@ -985,54 +992,212 @@ c------------------------------------ Tillotson Region id
               ENDIF
 
 c------------------------------------ Volumetric Strain (VSTRAIN)
-            ELSEIF( IFUNC == 15899 + 4*MX_PLY_ANIM  ) THEN
+            elseif(IFUNC == 15899 + 4*MX_PLY_ANIM .and. N2D > 0) then
+!--------------------------------------------------
               DO I=LFT,LLT
                 FUNC(EL2FA(NN3+NFT+I)) = ZERO
               ENDDO
-              IF(ITY == 2)THEN
-                MT = IXQ(1,NFT+1)
-              ELSEIF(ITY == 7 .AND. N2D > 0)THEN
-                MT = IXTG(1,NFT+1)
-              ENDIF
-              IF(PM(89,MT) > ZERO)THEN
-                DO I=LFT,LLT
-                  FUNC(EL2FA(NN3+NFT+I)) = GBUF%RHO(I) / PM(89,MT) - ONE
-                ENDDO
-              ENDIF
 
-           ELSEIF(IFUNC >= 14999+4*MX_PLY_ANIM+1 .AND. IFUNC <= 14999+4*MX_PLY_ANIM+21 )THEN
-              EVAR(LFT:LLT) = ZERO
-              ISUBMAT = IFUNC-(14999+4*MX_PLY_ANIM)
-                IF(ITY ==2)THEN
-                  MT = IXQ(1,1+NFT)
-                ELSEIF(ITY == 7 .AND. N2D > 0)THEN
-                  MT = IXTG(1,1+NFT)
-                ENDIF
-              IF(MLW == 151)THEN
-                MT = MAT_PARAM(MT)%MULTIMAT%MID(ISUBMAT)
-                DO I=LFT,LLT
-                  EVAR(I) = MULTI_FVM%RHO(I + NFT)  / PM(89,MT) - ONE
-                ENDDO
-              ELSEIF(MLW == 51)THEN
-                   ISUBMAT = IFUNC - 5173
-                   !bijection for iform=12
-                   IADBUF = IPM(7,MT)
-                   NUPARAM= IPM(9,MT)
-                   UPARAM => BUFMAT(IADBUF:IADBUF+NUPARAM)
-                   ISUBMAT = UPARAM(276+ISUBMAT) !bijective order
-                   IUS=M51_N0PHAS+(ISUBMAT-1)*M51_NVPHAS
-                   !
-                   LLT       = IPARG(2,NG)
-                   IPOS      = 20
-                   K         = LLT * ((IUS )+IPOS-1)
-                   MT = MAT_PARAM(MT)%MULTIMAT%MID(ISUBMAT)
-                   DO I=LFT,LLT
-                     EVAR(I) = MBUF%VAR(K+I) / PM(89,MT) - ONE
-                   ENDDO
-              ENDIF
-              DO I = LFT,LLT
-                FUNC(EL2FA(NN3+NFT+I)) = EVAR(I)
-              ENDDO
+              if(ity == 2)then
+                mt = ixq(1,nft+1)
+              elseif(ity == 7 .and. n2d > 0)then
+                mt = ixtg(1,nft+1)
+              endif
+              imat = mt
+
+              do i=1,nel
+
+                if(mlw == 151)then
+                  !multimaterial 151 (collocated scheme)
+                    do ilay=1,multi_fvm%nbmat
+                      mid = MAT_PARAM(mt)%multimat%mid(ilay)
+                      rho0i (ilay) = pm(89,mid)
+                      Vi (ilay) = multi_fvm%phase_alpha(ilay,i+nft) * gbuf%vol(i)
+                      V0i (ilay) =  multi_fvm%phase_rho(ilay,i+nft) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                    enddo
+                    V0g = sum(V0i)
+                    RHO0g = zero
+                    do ilay=1,multi_fvm%nbmat
+                      RHO0g = RHO0g + rho0i(ilay)*V0i(ilay)
+                    end do
+                    RHO0g = RHO0g / V0g
+                    FUNC(EL2FA(NN3+NFT+I)) = multi_fvm%rho(i+nft) / RHO0g - ONE
+
+                elseif(mlw == 51)then
+                  !multimaterial 51 (staggered scheme)
+                  iadbuf = ipm(7,imat)
+                  nuparam= ipm(9,imat)
+                  uparam => bufmat(iadbuf:iadbuf+nuparam)
+                  mbuf => elbuf_tab(ng)%bufly(1)%mat(1,1,1)
+                  ipos = 1
+                  !bijective order           !indexes
+                  isubmat = nint(uparam(276+1));   iu(1)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                  isubmat = nint(uparam(276+2));   iu(2)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                  isubmat = nint(uparam(276+3));   iu(3)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                  isubmat = nint(uparam(276+4));   iu(4)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                  vfrac(i,1) = mbuf%var(i+iu(1)*nel)
+                  vfrac(i,2) = mbuf%var(i+iu(2)*nel)
+                  vfrac(i,3) = mbuf%var(i+iu(3)*nel)
+                  vfrac(i,4) = mbuf%var(i+iu(4)*nel)
+                  ipos = 12
+                  !bijective order           !indexes
+                  isubmat = nint(uparam(276+1));   iu(1)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                  isubmat = nint(uparam(276+2));   iu(2)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                  isubmat = nint(uparam(276+3));   iu(3)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                  isubmat = nint(uparam(276+4));   iu(4)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                  rhoi(1) = mbuf%var(i+iu(1)*nel)
+                  rhoi(2) = mbuf%var(i+iu(2)*nel)
+                  rhoi(3) = mbuf%var(i+iu(3)*nel)
+                  rhoi(4) = mbuf%var(i+iu(4)*nel)
+                  do ilay=1,4
+                    mid = MAT_PARAM(mt)%multimat%mid(ilay)
+                    rho0i (ilay) = pm(89,mid)
+                    Vi (ilay) = vfrac(i,ilay) * gbuf%vol(i)
+                    ipos = 12
+                    V0i (ilay) =  rhoi(ilay) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                  enddo
+                  V0g = sum(V0i)
+                  RHO0g = zero
+                  do ilay=1,4
+                    RHO0g = RHO0g + rho0i(ilay)*V0i(ilay)
+                  end do
+                  RHO0g = RHO0g / V0g
+                  FUNC(EL2FA(NN3+NFT+I))= gbuf%rho(i) / RHO0g - ONE
+
+                elseif(mlw == 37)then
+                  !multimaterial 37 (staggered scheme)
+                  iadbuf = ipm(7,imat)
+                  nuparam= ipm(9,imat)
+                  uparam => bufmat(iadbuf:iadbuf+nuparam)
+                  mbuf => elbuf_tab(ng)%bufly(1)%mat(1,1,1)
+                  rho0i(1) = uparam(11)
+                  rho0i(2) = uparam(12)
+                  Vi(1) = mbuf%var(i+3*nel) * gbuf%vol(i) !UVAR(I,4)  = VFRAC1
+                  Vi(2) = mbuf%var(i+4*nel) * gbuf%vol(i) !UVAR(I,5)  = VFRAC2
+                  rhoi(1) = mbuf%var(i+2*nel) !UVAR(I,3)  = RHO1
+                  rhoi(2) = mbuf%var(i+1*nel) !UVAR(I,2)  = RHO2
+                  V0i(1) =  rhoi(1) * Vi(1) / rho0i(1)         !rho0.V0 = rho.V
+                  V0i(2) =  rhoi(2) * Vi(2) / rho0i(2)         !rho0.V0 = rho.V
+                  V0g = sum(V0i)
+                  RHO0g = zero
+                  do ilay=1,2
+                    RHO0g = RHO0g + rho0i(ilay)*V0i(ilay)
+                  end do
+                  RHO0g = RHO0g / V0g
+                  FUNC(EL2FA(NN3+NFT+I)) = gbuf%rho(i) / RHO0g - ONE
+
+                elseif(mlw == 20)then
+                  !multimaterial 20 (staggered scheme)
+                  lbuf1  => elbuf_tab(ng)%bufly(1)%lbuf(1,1,1)
+                  lbuf2  => elbuf_tab(ng)%bufly(2)%lbuf(1,1,1)
+                  mid = MAT_PARAM(mt)%multimat%mid(1)
+                  rho0i(1) = pm(89,mid)
+                  mid = MAT_PARAM(mt)%multimat%mid(2)
+                  rho0i(2) = pm(89,mid)
+                  Vi(1) = lbuf1%vol(i)
+                  Vi(2) = lbuf2%vol(i)
+                  rhoi(1) = lbuf1%rho(i)
+                  rhoi(2) = lbuf2%rho(i)
+                  V0i(1) =  rhoi(1) * Vi(1) / rho0i(1)         !rho0.V0 = rho.V
+                  V0i(2) =  rhoi(2) * Vi(2) / rho0i(2)         !rho0.V0 = rho.V
+                  V0g = sum(V0i)
+                  RHO0g = zero
+                  do ilay=1,2
+                    RHO0g = RHO0g + rho0i(ilay)*V0i(ilay)
+                  end do
+                  RHO0g = RHO0g / V0g
+                  FUNC(EL2FA(NN3+NFT+I)) = gbuf%rho(i) / RHO0g - ONE
+
+                else
+                  !general case (monomaterial law)
+                  if(pm(89,mt) > zero)then
+                    FUNC(EL2FA(NN3+NFT+I))= gbuf%rho(i) / pm(89,mt) - one
+                  end if
+                end if
+
+              enddo
+c------------------------------------ Volumetric Strain (VSTRAIN)
+            elseif(   IFUNC >= 15899 + 4*MX_PLY_ANIM +1
+     .          .and. IFUNC <= 15899 + 4*MX_PLY_ANIM +10
+     .          .and. N2D > 0) then
+!--------------------------------------------------
+                detected = .false.
+                ilay = IFUNC - (15899 + 4*MX_PLY_ANIM)
+                if(mlw == 151 .and. ilay <= min(10,multi_fvm%nbmat))detected = .true.
+                if(mlw ==  51 .and. ilay <= 4                      )detected = .true.
+                if(mlw ==  37 .and. ilay <= 2                      )detected = .true.
+                if(mlw ==  20 .and. ilay <= 2                      )detected = .true.
+
+                if(detected)then
+
+                  if(ity == 2)then
+                    mt = ixq(1,nft+1)
+                  elseif(ity == 7 .and. n2d > 0)then
+                    mt = ixtg(1,nft+1)
+                  endif
+                  imat = mt
+
+                  do i=1,nel
+
+                     if(mlw == 151)then
+                      !multimaterial 151 (collocated scheme)
+                        mid = MAT_PARAM(mt)%multimat%mid(ilay)
+                        rho0i(ilay) = pm(89,mid)
+                        Vi(ilay) = multi_fvm%phase_alpha(ilay,i+nft) * gbuf%vol(i)
+                        V0i(ilay) = multi_fvm%phase_rho(ilay,i+nft) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                        FUNC(EL2FA(NN3+NFT+I)) = multi_fvm%phase_rho(ilay,i+nft) / rho0i(ilay) - ONE
+
+                    elseif(mlw == 51)then
+                      !multimaterial 51 (staggered scheme)
+                      iadbuf = ipm(7,imat)
+                      nuparam= ipm(9,imat)
+                      uparam => bufmat(iadbuf:iadbuf+nuparam)
+                      mbuf => elbuf_tab(ng)%bufly(1)%mat(1,1,1)
+                      mid = MAT_PARAM(mt)%multimat%mid(ilay)
+                      rho0i(ilay) = pm(89,mid)
+                      ipos = 1
+                      !bijective order           !indexes
+                      isubmat = nint(uparam(276+ilay));   iu(1)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                      vfrac(i,ilay) = mbuf%var(i+iu(ilay)*nel)
+                      Vi(ilay) = vfrac(i,ilay) * gbuf%vol(i)
+                      ipos = 12
+                      !bijective order           !indexes
+                      isubmat = nint(uparam(276+ilay));   iu(ilay)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                      rhoi(ilay) = mbuf%var(i+iu(ilay)*nel)
+                      V0i (ilay) =  rhoi(ilay) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                      FUNC(EL2FA(NN3+NFT+I)) = rhoi(ilay) / rho0i(ilay) - ONE
+
+                    elseif(mlw == 37)then
+                      !multimaterial 37 (staggered scheme)
+                      iadbuf = ipm(7,imat)
+                      nuparam= ipm(9,imat)
+                      uparam => bufmat(iadbuf:iadbuf+nuparam)
+                      mbuf => elbuf_tab(ng)%bufly(1)%mat(1,1,1)
+                      rho0i(ilay) = uparam(10+ilay)
+                      Vi(ilay) = mbuf%var(i+(ilay+2)*nel) * gbuf%vol(i)
+                      rhoi(ilay) = mbuf%var(i+(3-ilay)*nel) !UVAR(I,3)  = RHO1
+                      V0i(ilay) =  rhoi(ilay) * Vi(ilay) / rho0i(ilay)
+                      FUNC(EL2FA(NN3+NFT+I)) = rhoi(ilay) / rho0i(ilay) - ONE
+
+                    elseif(mlw == 20)then
+                      !multimaterial 20 (staggered scheme)
+                      lbuf  => elbuf_tab(ng)%bufly(ilay)%lbuf(1,1,1)
+                      mid = MAT_PARAM(mt)%multimat%mid(ilay)
+                      rho0i(ilay) = pm(89,mid)
+                      Vi(ilay) = lbuf%vol(i)
+                      rhoi(ilay) = lbuf%rho(i)
+                      V0i(ilay) =  rhoi(ilay) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                      FUNC(EL2FA(NN3+NFT+I)) = rhoi(ilay) / rho0i(ilay) - ONE
+
+                    else
+                      !general case (monomaterial law)
+                      FUNC(EL2FA(NN3+NFT+I)) = ZERO
+                    end if
+                enddo
+
+              end if
+
+
 
 c------------------------------------ 
             ELSE                                                      

--- a/engine/source/output/anim/generate/genani.F
+++ b/engine/source/output/anim/generate/genani.F
@@ -2551,16 +2551,16 @@ C all NPTT for PID51
 
         !---Volumetric Strain EoS
         IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain',17)
-        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 1',20)
-        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 2',20)
-        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 3',20)
-        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 4',20)
-        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 5',20)
-        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 6',20)
-        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 7',20)
-        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 8',20)
-        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 9',20)
-        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 10',20)
+        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 1',21)
+        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 2',21)
+        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 3',21)
+        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 4',21)
+        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 5',21)
+        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 6',21)
+        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 7',21)
+        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 8',21)
+        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 9',21)
+        IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 10',22)
 
         !---NEXT ANIM
         !IDX=IDX+1
@@ -4687,6 +4687,16 @@ C
         ENDDO
         IF(ANIM_SE(5172)==1)CALL ANI_TXT('Region identifier in p,v diagram',32)
         IF(ANIM_SE(5173)==1)CALL ANI_TXT('Volumetric Strain',17)
+        IF(ANIM_SE(5174)==1)CALL ANI_TXT('Volumetric Strain - 1',21)
+        IF(ANIM_SE(5175)==1)CALL ANI_TXT('Volumetric Strain - 2',21)
+        IF(ANIM_SE(5176)==1)CALL ANI_TXT('Volumetric Strain - 3',21)
+        IF(ANIM_SE(5177)==1)CALL ANI_TXT('Volumetric Strain - 4',21)
+        IF(ANIM_SE(5178)==1)CALL ANI_TXT('Volumetric Strain - 5',21)
+        IF(ANIM_SE(5179)==1)CALL ANI_TXT('Volumetric Strain - 6',21)
+        IF(ANIM_SE(5180)==1)CALL ANI_TXT('Volumetric Strain - 7',21)
+        IF(ANIM_SE(5181)==1)CALL ANI_TXT('Volumetric Strain - 8',21)
+        IF(ANIM_SE(5182)==1)CALL ANI_TXT('Volumetric Strain - 9',21)
+        IF(ANIM_SE(5183)==1)CALL ANI_TXT('Volumetric Strain - 10',22)
         
 C-----------------------------------------------                                         
       ENDIF !(ISPMD==0)
@@ -6461,10 +6471,11 @@ C     Default output for SPH - diameter + nb of neignbours
         CALL DFUNC0(ELBUF_TAB ,WAFT            ,IFUNC    ,IPARG   ,
      2              MAS       ,PM              ,EL2FA    ,NNN     ,
      3              NBPART    ,IADG            ,SPBUF    ,IPART   ,
-     4              IPARTSP   ,ALE_CONNECTIVITY,IXQ      ,IPM     ,
+     4              IPARTSP   ,ALE_CONNECTIVITY,IPM      ,
      5              X         ,V               ,W        ,GLOB_THERM%ITHERM,
      6              NERCVOIS  ,NESDVOIS        ,LERCVOIS ,LESDVOIS,
-     7              BUFMAT    ,MULTI_FVM       ,KXSP     ,DEFAULT_OUTPUT)
+     7              BUFMAT    ,MULTI_FVM       ,KXSP     ,DEFAULT_OUTPUT,
+     8              MAT_PARAM)
       ENDDO
 C      
 C     other output for SPH
@@ -6475,10 +6486,11 @@ C     other output for SPH
           CALL DFUNC0(ELBUF_TAB ,WAFT            ,IFUNC    ,IPARG   ,
      2                MAS       ,PM              ,EL2FA    ,NNN     ,
      3                NBPART    ,IADG            ,SPBUF    ,IPART   ,
-     4                IPARTSP   ,ALE_CONNECTIVITY,IXQ      ,IPM     ,
+     4                IPARTSP   ,ALE_CONNECTIVITY,IPM      ,
      5                X         ,V               ,W        ,GLOB_THERM%ITHERM,
      6                NERCVOIS  ,NESDVOIS        ,LERCVOIS ,LESDVOIS,
-     7                BUFMAT    ,MULTI_FVM       ,KXSP     ,DEFAULT_OUTPUT)
+     7                BUFMAT    ,MULTI_FVM       ,KXSP     ,DEFAULT_OUTPUT,
+     8                MAT_PARAM)
         ENDIF 
       ENDDO
 C-----------------------------------------------

--- a/engine/source/output/anim/reader/anim_dcod_key_0.F
+++ b/engine/source/output/anim/reader/anim_dcod_key_0.F
@@ -1499,7 +1499,7 @@ c
         ELSEIF(KEY3(1:7) == 'VSTRAIN')THEN
           IDX = 15898 + 4*MX_PLY_ANIM
           read(KEY4, '(I2)') ILAY
-          if(ILAY >= 1 .and. ILAY <= 21)then
+          if(ILAY >= 1 .and. ILAY <= 10)then
             ANIM_CE(IDX+ILAY) = 1
           else
             ANIM_CE(IDX) = 1
@@ -2040,7 +2040,7 @@ C         ANIM_SE(4936) ==> !   law37 -    gas
       ELSEIF(KEY3(1:7)=='VSTRAIN')THEN
           read(KEY4, '(I2)',ERR=2206) ILAY
 2206      CONTINUE
-          if(ILAY >= 1 .and. ILAY <= 21)then
+          if(ILAY >= 1 .and. ILAY <= 10)then
             ANIM_SE(5173+ILAY) = 1
           else
             ANIM_SE(5173) = 1
@@ -2711,7 +2711,7 @@ C--------------------------
          ILAY = 0
          read(KEY4, '(I2)', ERR=2205) ILAY
 2205     CONTINUE
-         if(ILAY >= 1 .and. ILAY <= 21)then
+         if(ILAY >= 1 .and. ILAY <= 10)then
            ANIM_CE(IDX+ILAY) = 1
            ANIM_SE(5173+ILAY) = 1
          else

--- a/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
@@ -43,16 +43,16 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    stack_mod                      ../engine/share/modules/stack_mod.F
       !||====================================================================
       SUBROUTINE H3D_SHELL_SCALAR_1( CALLED_FROM_PYTHON,
-     .                  ELBUF_TAB   ,SHELL_SCALAR,IPARG       ,GEO        ,
-     .                  IXC       ,IXTG      ,PM          ,BUFMAT     ,
-     .                  EHOUR     ,
-     .                  IPM         ,IGEO      ,THKE      ,ERR_THK_SH4 ,ERR_THK_SH3,
-     .                  X         ,V         ,W           ,ALE_CONNECT,
-     .                  STACK       ,ID_ELEM   ,ITY_ELEM  ,
-     .                  IS_WRITTEN_SHELL,IPARTC,IPARTTG   ,LAYER_INPUT ,IPT_INPUT  ,
-     .                  PLY_INPUT   ,IUVAR_INPUT,H3D_PART  ,KEYWORD    ,
-     .                  D           ,NG         ,MULTI_FVM,IDMDS       ,IMDSVAR    ,
-     .                  MDS_MATID   ,ID         ,MODE     ,MAT_PARAM   )
+     .                  ELBUF_TAB       ,SHELL_SCALAR,IPARG     ,GEO        ,
+     .                  IXC             ,IXTG        ,PM        ,BUFMAT     ,
+     .                  EHOUR           ,
+     .                  IPM             ,IGEO        ,THKE      ,ERR_THK_SH4 ,ERR_THK_SH3,
+     .                  X               ,V           ,W         ,ALE_CONNECT,
+     .                  STACK           ,ID_ELEM     ,ITY_ELEM  ,
+     .                  IS_WRITTEN_SHELL,IPARTC      ,IPARTTG   ,LAYER_INPUT ,IPT_INPUT  ,
+     .                  PLY_INPUT       ,IUVAR_INPUT ,H3D_PART  ,KEYWORD     ,
+     .                  D               ,NG          ,MULTI_FVM ,IDMDS       ,IMDSVAR    ,
+     .                  MDS_MATID       ,ID          ,MODE      ,MATPARAM    )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -100,7 +100,7 @@ C-----------------------------------------------
         TYPE (MULTI_FVM_STRUCT), INTENT(IN) :: MULTI_FVM
         TYPE(t_ale_connectivity), INTENT(IN) :: ALE_CONNECT
         INTEGER ,INTENT(IN) :: MODE
-        TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(IN) :: MAT_PARAM
+        TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(IN) :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -122,7 +122,7 @@ C-----------------------------------------------
      .          IPLY,
      .          IOK_PART(MVSIZ),JJ(5),NPGT,IUVAR,
      .          IS_WRITTEN_VALUE(MVSIZ),IV,KFACE,NB_FACE,IADBUF,NUPARAM,ISUBMAT,IS_EULER,IS_ALE,
-     .          IPINCH,IPG,USER_OK,IALEL,IMODE,NMOD,MAT_ID
+     .          IPINCH,IPG,USER_OK,IALEL,IMODE,NMOD,MAT_ID,MID,IERR,MT
         LOGICAL DETECTED
         CHARACTER*5 BUFF
         TYPE(G_BUFEL_)  ,POINTER :: GBUF
@@ -134,6 +134,12 @@ C-----------------------------------------------
         TYPE(L_BUFEL_DIR_) ,POINTER :: LBUF_DIR
         my_real, DIMENSION(:), POINTER  :: UVAR
         my_real, DIMENSION(:) ,POINTER  :: UPARAM
+        my_real :: vi(21) !< submaterial volumes at reference densities (max submat : 21)
+        my_real :: v0i(21) !< submaterial volumes at reference densities (max submat : 21)
+        my_real :: v0g !< global volume at reference density (mixture)
+        my_real :: RHO0i(21) !< submaterial initial mass densities (max submat : 21)
+        my_real :: RHOi(21) !< submaterial  mass densities (max submat : 21)
+        my_real :: RHO0g !< global initial mass density (mixture)
         DATA NS/10/
 C-----------------------------------------------
 C   S o u r c e   L i n e s
@@ -4036,7 +4042,7 @@ c
                       DO I = 1,NEL
                         DO N = 1,NLAY
                           IMAT = ELBUF_TAB(NG)%BUFLY(N)%IMAT
-                          MAT_ID = MAT_PARAM(IMAT)%MAT_ID
+                          MAT_ID = MATPARAM(IMAT)%MAT_ID
                           IF ((ID == -1) .OR. ((ID > 0).AND.(MAT_ID == ID))) THEN 
                             IF (ELBUF_TAB(NG)%BUFLY(N)%L_DMG > 0) THEN
                               NPTT = ELBUF_TAB(NG)%BUFLY(N)%NPTT
@@ -4060,7 +4066,7 @@ c
                       IF (ELBUF_TAB(NG)%BUFLY(1)%L_DMG > 0) THEN
                         NPTT = ELBUF_TAB(NG)%BUFLY(1)%NPTT
                         IMAT = ELBUF_TAB(NG)%BUFLY(1)%IMAT
-                        MAT_ID = MAT_PARAM(IMAT)%MAT_ID
+                        MAT_ID = MATPARAM(IMAT)%MAT_ID
                         IF ((ID == -1) .OR. ((ID > 0).AND.(MAT_ID == ID))) THEN 
                           DO I = 1,NEL
                             DO IT = 1,NPTT
@@ -4082,7 +4088,7 @@ c
                   ELSEIF (IPLY > 0 .AND. IPT <= MPT .AND. IPT > 0) THEN
                     DO J = 1,NLAY
                       IMAT = ELBUF_TAB(NG)%BUFLY(J)%IMAT
-                      MAT_ID = MAT_PARAM(IMAT)%MAT_ID
+                      MAT_ID = MATPARAM(IMAT)%MAT_ID
                       IF ((ID == -1) .OR. ((ID > 0).AND.(MAT_ID == ID))) THEN 
                         IF (ELBUF_TAB(NG)%BUFLY(J)%L_DMG > 0) THEN
                           NPTT = ELBUF_TAB(NG)%BUFLY(J)%NPTT
@@ -4114,7 +4120,7 @@ c
                   ELSEIF (IPLY > 0 .AND. IPT == -1) THEN
                     DO J = 1,NLAY
                       IMAT = ELBUF_TAB(NG)%BUFLY(J)%IMAT
-                      MAT_ID = MAT_PARAM(IMAT)%MAT_ID
+                      MAT_ID = MATPARAM(IMAT)%MAT_ID
                       IF ((ID == -1) .OR. ((ID > 0).AND.(MAT_ID == ID))) THEN 
                         IF (ELBUF_TAB(NG)%BUFLY(J)%L_DMG > 0) THEN
                           NPTT = ELBUF_TAB(NG)%BUFLY(J)%NPTT
@@ -4147,7 +4153,7 @@ c
                     IPT = 1
                     IF (IGTYP == 10 .OR. IGTYP == 11 .OR. IGTYP == 16) THEN
                       IMAT = ELBUF_TAB(NG)%BUFLY(ILAY)%IMAT
-                      MAT_ID = MAT_PARAM(IMAT)%MAT_ID
+                      MAT_ID = MATPARAM(IMAT)%MAT_ID
                       IF ((ID == -1) .OR. ((ID > 0).AND.(MAT_ID == ID))) THEN 
                         IF (ELBUF_TAB(NG)%BUFLY(ILAY)%L_DMG > 0) THEN
                           DO I=1,NEL
@@ -4168,7 +4174,7 @@ c
                   ELSEIF (IPT <= NPT .AND. IPT > 0) THEN
                     IF (IGTYP == 1 .OR. IGTYP == 9) THEN
                       IMAT = ELBUF_TAB(NG)%BUFLY(1)%IMAT
-                      MAT_ID = MAT_PARAM(IMAT)%MAT_ID
+                      MAT_ID = MATPARAM(IMAT)%MAT_ID
                       IF ((ID == -1) .OR. ((ID > 0).AND.(MAT_ID == ID))) THEN 
                         IF (ELBUF_TAB(NG)%BUFLY(1)%L_DMG > 0) THEN
                           DO I=1,NEL
@@ -4195,8 +4201,8 @@ c
                       DO I = 1,NEL
                         DO N = 1,NLAY
                           IMAT = ELBUF_TAB(NG)%BUFLY(N)%IMAT
-                          NMOD = MAT_PARAM(IMAT)%NMOD
-                          MAT_ID = MAT_PARAM(IMAT)%MAT_ID
+                          NMOD = MATPARAM(IMAT)%NMOD
+                          MAT_ID = MATPARAM(IMAT)%MAT_ID
                           IF ((NMOD > 0 .AND. MODE <= NMOD) .AND. (MAT_ID == ID)) THEN 
                             IF (ELBUF_TAB(NG)%BUFLY(N)%L_DMG > 0) THEN
                               NPTT = ELBUF_TAB(NG)%BUFLY(N)%NPTT
@@ -4218,8 +4224,8 @@ c
                       ! -> Mean value among all layers and integration points
                     ELSEIF (MPT > 0) THEN
                       IMAT = ELBUF_TAB(NG)%BUFLY(1)%IMAT
-                      NMOD = MAT_PARAM(IMAT)%NMOD
-                      MAT_ID = MAT_PARAM(IMAT)%MAT_ID
+                      NMOD = MATPARAM(IMAT)%NMOD
+                      MAT_ID = MATPARAM(IMAT)%MAT_ID
                       IF ((NMOD > 0 .AND. MODE <= NMOD) .AND. (MAT_ID == ID)) THEN 
                         IF (ELBUF_TAB(NG)%BUFLY(1)%L_DMG > 0) THEN
                           NPTT = ELBUF_TAB(NG)%BUFLY(1)%NPTT
@@ -4243,8 +4249,8 @@ c
                   ELSEIF (IPLY > 0 .AND. IPT <= MPT .AND. IPT > 0) THEN
                     DO J = 1,NLAY
                       IMAT = ELBUF_TAB(NG)%BUFLY(J)%IMAT
-                      NMOD = MAT_PARAM(IMAT)%NMOD
-                      MAT_ID = MAT_PARAM(IMAT)%MAT_ID
+                      NMOD = MATPARAM(IMAT)%NMOD
+                      MAT_ID = MATPARAM(IMAT)%MAT_ID
                       IF ((NMOD > 0 .AND. MODE <= NMOD) .AND. (MAT_ID == ID)) THEN 
                         IF (ELBUF_TAB(NG)%BUFLY(J)%L_DMG > 0) THEN
                           NPTT = ELBUF_TAB(NG)%BUFLY(J)%NPTT
@@ -4276,8 +4282,8 @@ c
                   ELSEIF (IPLY > 0 .AND. IPT == -1) THEN
                     DO J = 1,NLAY
                       IMAT = ELBUF_TAB(NG)%BUFLY(J)%IMAT
-                      NMOD = MAT_PARAM(IMAT)%NMOD
-                      MAT_ID = MAT_PARAM(IMAT)%MAT_ID
+                      NMOD = MATPARAM(IMAT)%NMOD
+                      MAT_ID = MATPARAM(IMAT)%MAT_ID
                       IF ((NMOD > 0 .AND. MODE <= NMOD) .AND. (MAT_ID == ID)) THEN 
                         IF (ELBUF_TAB(NG)%BUFLY(J)%L_DMG > 0) THEN
                           NPTT = ELBUF_TAB(NG)%BUFLY(J)%NPTT
@@ -4310,8 +4316,8 @@ c
                     IPT = 1
                     IF (IGTYP == 10 .OR. IGTYP == 11 .OR. IGTYP == 16) THEN
                       IMAT = ELBUF_TAB(NG)%BUFLY(ILAY)%IMAT
-                      NMOD = MAT_PARAM(IMAT)%NMOD
-                      MAT_ID = MAT_PARAM(IMAT)%MAT_ID
+                      NMOD = MATPARAM(IMAT)%NMOD
+                      MAT_ID = MATPARAM(IMAT)%MAT_ID
                       IF ((NMOD > 0 .AND. MODE <= NMOD) .AND. (MAT_ID == ID)) THEN 
                         IF (ELBUF_TAB(NG)%BUFLY(ILAY)%L_DMG > 0) THEN
                           DO I=1,NEL
@@ -4332,8 +4338,8 @@ c
                   ELSEIF (IPT <= NPT .AND. IPT > 0) THEN
                     IF (IGTYP == 1 .OR. IGTYP == 9) THEN
                       IMAT = ELBUF_TAB(NG)%BUFLY(1)%IMAT
-                      NMOD = MAT_PARAM(IMAT)%NMOD
-                      MAT_ID = MAT_PARAM(IMAT)%MAT_ID
+                      NMOD = MATPARAM(IMAT)%NMOD
+                      MAT_ID = MATPARAM(IMAT)%MAT_ID
                       IF ((NMOD > 0 .AND. MODE <= NMOD) .AND. (MAT_ID == ID)) THEN 
                         IF (ELBUF_TAB(NG)%BUFLY(1)%L_DMG > 0) THEN
                           DO I=1,NEL
@@ -5944,6 +5950,206 @@ C--------------------------------------------------
                   IS_WRITTEN_VALUE(I) = 1
                 ENDDO
               ENDIF
+!--------------------------------------------------
+              elseif(keyword == 'VSTRAIN' .and. N2D > 0) then
+!--------------------------------------------------
+                do i=1,nel
+                  mt = ixtg(1,i+nft)
+                  if(mlw == 151)then
+                    !multimaterial 151 (collocated scheme)
+                      do ilay=1,nlay
+                        mid = MATPARAM(mt)%multimat%mid(ilay)
+                        rho0i (ilay) = pm(89,mid)
+                        Vi (ilay) = multi_fvm%phase_alpha(ilay,i+nft) * gbuf%vol(i)
+                        V0i (ilay) =  multi_fvm%phase_rho(ilay,i+nft) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                      enddo
+                      V0g = sum(V0i)
+                      RHO0g = zero
+                      do ilay=1,nlay
+                        RHO0g = RHO0g + rho0i(ilay)*V0i(ilay)
+                      end do
+                      RHO0g = RHO0g / V0g
+                      value(i) = multi_fvm%rho(i+nft) / RHO0g - ONE
+                      is_written_value(i) = 1
+
+                  elseif(mlw == 51)then
+                    !multimaterial 51 (staggered scheme)
+                    imat   = ixtg(1,nft+1)
+                    iadbuf = ipm(7,imat)
+                    nuparam= ipm(9,imat)
+                    uparam => bufmat(iadbuf:iadbuf+nuparam)
+                    mbuf => elbuf_tab(ng)%bufly(1)%mat(1,1,1)
+                    ipos = 1
+                    !bijective order           !indexes
+                    isubmat = nint(uparam(276+1));   iu(1)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                    isubmat = nint(uparam(276+2));   iu(2)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                    isubmat = nint(uparam(276+3));   iu(3)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                    isubmat = nint(uparam(276+4));   iu(4)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                    vfrac(i,1) = mbuf%var(i+iu(1)*nel)
+                    vfrac(i,2) = mbuf%var(i+iu(2)*nel)
+                    vfrac(i,3) = mbuf%var(i+iu(3)*nel)
+                    vfrac(i,4) = mbuf%var(i+iu(4)*nel)
+                    ipos = 12
+                    !bijective order           !indexes
+                    isubmat = nint(uparam(276+1));   iu(1)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                    isubmat = nint(uparam(276+2));   iu(2)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                    isubmat = nint(uparam(276+3));   iu(3)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                    isubmat = nint(uparam(276+4));   iu(4)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                    rhoi(1) = mbuf%var(i+iu(1)*nel)
+                    rhoi(2) = mbuf%var(i+iu(2)*nel)
+                    rhoi(3) = mbuf%var(i+iu(3)*nel)
+                    rhoi(4) = mbuf%var(i+iu(4)*nel)
+                    do ilay=1,4
+                      mid = MATPARAM(mt)%multimat%mid(ilay)
+                      rho0i (ilay) = pm(89,mid)
+                      Vi (ilay) = vfrac(i,ilay) * gbuf%vol(i)
+                      ipos = 12
+                      V0i (ilay) =  rhoi(ilay) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                    enddo
+                    V0g = sum(V0i)
+                    RHO0g = zero
+                    do ilay=1,4
+                      RHO0g = RHO0g + rho0i(ilay)*V0i(ilay)
+                    end do
+                    RHO0g = RHO0g / V0g
+                    value(i) = gbuf%rho(i) / RHO0g - ONE
+                    is_written_value(i) = 1
+
+                  elseif(mlw == 37)then
+                    !multimaterial 37 (staggered scheme)
+                    imat   = ixtg(1,nft+1)
+                    iadbuf = ipm(7,imat)
+                    nuparam= ipm(9,imat)
+                    uparam => bufmat(iadbuf:iadbuf+nuparam)
+                    mbuf => elbuf_tab(ng)%bufly(1)%mat(1,1,1)
+                    rho0i(1) = uparam(11)
+                    rho0i(2) = uparam(12)
+                    Vi(1) = mbuf%var(i+3*nel) * gbuf%vol(i) !UVAR(I,4)  = VFRAC1
+                    Vi(2) = mbuf%var(i+4*nel) * gbuf%vol(i) !UVAR(I,5)  = VFRAC2
+                    rhoi(1) = mbuf%var(i+2*nel) !UVAR(I,3)  = RHO1
+                    rhoi(2) = mbuf%var(i+1*nel) !UVAR(I,2)  = RHO2
+                    V0i(1) =  rhoi(1) * Vi(1) / rho0i(1)         !rho0.V0 = rho.V
+                    V0i(2) =  rhoi(2) * Vi(2) / rho0i(2)         !rho0.V0 = rho.V
+                    V0g = sum(V0i)
+                    RHO0g = zero
+                    do ilay=1,nlay
+                      RHO0g = RHO0g + rho0i(ilay)*V0i(ilay)
+                    end do
+                    RHO0g = RHO0g / V0g
+                    value(i) = gbuf%rho(i) / RHO0g - ONE
+                    is_written_value(i) = 1
+
+                  elseif(mlw == 20)then
+                    !multimaterial 20 (staggered scheme)
+                    lbuf1  => elbuf_tab(ng)%bufly(1)%lbuf(1,1,1)
+                    lbuf2  => elbuf_tab(ng)%bufly(2)%lbuf(1,1,1)
+                    mid = MATPARAM(mt)%multimat%mid(1)
+                    rho0i(1) = pm(89,mid)
+                    mid = MATPARAM(mt)%multimat%mid(2)
+                    rho0i(2) = pm(89,mid)
+                    Vi(1) = lbuf1%vol(i)
+                    Vi(2) = lbuf2%vol(i)
+                    rhoi(1) = lbuf1%rho(i)
+                    rhoi(2) = lbuf2%rho(i)
+                    V0i(1) =  rhoi(1) * Vi(1) / rho0i(1)         !rho0.V0 = rho.V
+                    V0i(2) =  rhoi(2) * Vi(2) / rho0i(2)         !rho0.V0 = rho.V
+                    V0g = sum(V0i)
+                    RHO0g = zero
+                    do ilay=1,nlay
+                      RHO0g = RHO0g + rho0i(ilay)*V0i(ilay)
+                    end do
+                    RHO0g = RHO0g / V0g
+                    value(i) = gbuf%rho(i) / RHO0g - ONE
+                    is_written_value(i) = 1
+
+                  else
+                    !general case (monomaterial law)
+                    if(pm(89,mt) > zero)then
+                      value(i) = gbuf%rho(i) / pm(89,mt) - one
+                      is_written_value(i) = 1
+                    end if
+                  end if
+
+                enddo
+!--------------------------------------------------
+              elseif(keyword(1:8) == 'VSTRAIN/' .and. N2D > 0) then
+!--------------------------------------------------
+                detected = .false.
+                read(keyword(9:), '(I2)', IOSTAT=ierr) ilay
+                if(ierr == 0 .and. ilay > 0) then
+                  if(mlw == 151 .and. ilay <= min(10,multi_fvm%nbmat))detected = .true.
+                  if(mlw ==  51 .and. ilay <= 4                      )detected = .true.
+                  if(mlw ==  37 .and. ilay <= 2                      )detected = .true.
+                  if(mlw ==  20 .and. ilay <= 2                      )detected = .true.
+                end if
+                if(detected)then
+                  do i=1,nel
+                    mt = ixtg(1,i+nft)
+
+                    if(mlw == 151)then
+                      !multimaterial 151 (collocated scheme)
+                        mid = MATPARAM(mt)%multimat%mid(ilay)
+                        rho0i(ilay) = pm(89,mid)
+                        Vi(ilay) = multi_fvm%phase_alpha(ilay,i+nft) * gbuf%vol(i)
+                        V0i(ilay) = multi_fvm%phase_rho(ilay,i+nft) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                        value(i) = multi_fvm%phase_rho(ilay,i+nft) / rho0i(ilay) - ONE
+                        is_written_value(i) = 1
+
+                    elseif(mlw == 51)then
+                      !multimaterial 51 (staggered scheme)
+                      imat = ixtg(1,nft+1)
+                      iadbuf = ipm(7,imat)
+                      nuparam= ipm(9,imat)
+                      uparam => bufmat(iadbuf:iadbuf+nuparam)
+                      mbuf => elbuf_tab(ng)%bufly(1)%mat(1,1,1)
+                      mid = MATPARAM(mt)%multimat%mid(ilay)
+                      rho0i(ilay) = pm(89,mid)
+                      ipos = 1
+                      !bijective order           !indexes
+                      isubmat = nint(uparam(276+ilay));   iu(1)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                      vfrac(i,ilay) = mbuf%var(i+iu(ilay)*nel)
+                      Vi(ilay) = vfrac(i,ilay) * gbuf%vol(i)
+                      ipos = 12
+                      !bijective order           !indexes
+                      isubmat = nint(uparam(276+ilay));   iu(ilay)=m51_n0phas+(isubmat-1)*m51_nvphas + ipos-1
+                      rhoi(ilay) = mbuf%var(i+iu(ilay)*nel)
+                      V0i (ilay) =  rhoi(ilay) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                      value(i) = rhoi(ilay) / rho0i(ilay) - ONE
+                      is_written_value(i) = 1
+
+                    elseif(mlw == 37)then
+                      !multimaterial 37 (staggered scheme)
+                      imat = ixtg(1,nft+1)
+                      iadbuf = ipm(7,imat)
+                      nuparam= ipm(9,imat)
+                      uparam => bufmat(iadbuf:iadbuf+nuparam)
+                      mbuf => elbuf_tab(ng)%bufly(1)%mat(1,1,1)
+                      rho0i(ilay) = uparam(10+ilay)
+                      Vi(ilay) = mbuf%var(i+(ilay+2)*nel) * gbuf%vol(i)
+                      rhoi(ilay) = mbuf%var(i+(3-ilay)*nel) !UVAR(I,3)  = RHO1
+                      V0i(ilay) =  rhoi(ilay) * Vi(ilay) / rho0i(ilay)
+                      value(i) = rhoi(ilay) / rho0i(ilay) - ONE
+                      is_written_value(i) = 1
+
+                    elseif(mlw == 20)then
+                      !multimaterial 20 (staggered scheme)
+                      lbuf  => elbuf_tab(ng)%bufly(ilay)%lbuf(1,1,1)
+                      mid = MATPARAM(mt)%multimat%mid(ilay)
+                      rho0i(ilay) = pm(89,mid)
+                      Vi(ilay) = lbuf%vol(i)
+                      rhoi(ilay) = lbuf%rho(i)
+                      V0i(ilay) =  rhoi(ilay) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                      value(i) = rhoi(ilay) / rho0i(ilay) - ONE
+                      is_written_value(i) = 1
+
+                    else
+                      !general case (monomaterial law)
+                      is_written_value(i) = 0
+                    end if
+                enddo
+
+              end if
+!--------------------------------------------------
 C--------------------------------------------------
             ENDIF  ! KEYWORD
 C--------------------------------------------------

--- a/engine/source/output/h3d/h3d_results/h3d_solid_scalar_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_solid_scalar_1.F
@@ -49,15 +49,15 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||====================================================================
       SUBROUTINE H3D_SOLID_SCALAR_1(CALLED_FROM_PYTHON,
      .                  ELBUF_TAB       ,SOLID_SCALAR ,IPARG       ,
-     .                  IXS          ,PM          ,BUFMAT      ,
-     .                  EHOUR        ,
-     .                  IPM            ,
-     .                  X            ,V         ,W           ,ALE_CONNECT ,
-     .                  ID_ELEM      ,ITY_ELEM  ,IPARTS      ,LAYER_INPUT ,
-     .                  IR_INPUT        ,IS_INPUT     ,IT_INPUT  ,IUVAR_INPUT ,H3D_PART    ,
-     .                  IS_WRITTEN_SOLID,INFO1        ,KEYWORD   ,FANI_CELL   ,
-     .                  MULTI_FVM       , NG        ,IDMDS       ,IMDSVAR     ,
-     .                  ID              ,MAT_PARAM ,MODE        )
+     .                  IXS             ,PM           ,BUFMAT      ,
+     .                  EHOUR           ,
+     .                  IPM             ,
+     .                  X               ,V            ,W           ,ALE_CONNECT ,
+     .                  ID_ELEM         ,ITY_ELEM     ,IPARTS      ,LAYER_INPUT ,
+     .                  IR_INPUT        ,IS_INPUT     ,IT_INPUT    ,IUVAR_INPUT , H3D_PART    ,
+     .                  IS_WRITTEN_SOLID,INFO1        ,KEYWORD     ,FANI_CELL   ,
+     .                  MULTI_FVM       ,NG           ,IDMDS       ,IMDSVAR     ,
+     .                  ID              ,MAT_PARAM    ,MODE        )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -142,14 +142,20 @@ C-----------------------------------------------
         LOGICAL DETECTED
         CHARACTER*5 BUFF
         TYPE(G_BUFEL_)  ,POINTER :: GBUF
-        TYPE(L_BUFEL_)  ,POINTER :: LBUF
+        TYPE(L_BUFEL_)  ,POINTER :: LBUF, LBUF1,LBUF2
         TYPE(BUF_MAT_)  ,POINTER :: MBUF
         TYPE(BUF_FAIL_) ,POINTER :: FBUF
         TYPE(BUF_EOS_)  ,POINTER :: EBUF
         my_real, DIMENSION(:), POINTER  :: UVARF,DAMF,DFMAX,TDELE
         my_real, DIMENSION(:) ,POINTER  :: UPARAM
         INTEGER :: ISUBMAT,NVAREOS,NTILLOTSON,IMAT_TILLOTSON
-
+        INTEGER :: MID,IERR
+        my_real :: vi(21) !< submaterial volumes at reference densities (max submat : 21)
+        my_real :: v0i(21) !< submaterial volumes at reference densities (max submat : 21)
+        my_real :: v0g !< global volume at reference density (mixture)
+        my_real :: RHO0i(21) !< submaterial initial mass densities (max submat : 21)
+        my_real :: RHOi(21) !< submaterial  mass densities (max submat : 21)
+        my_real :: RHO0g !< global initial mass density (mixture)
 C-----------------------------------------------
 
         CALL INITBUF(   IPARG   ,NG      ,
@@ -719,7 +725,7 @@ c UVAR=IUVAR
                     IF (ISOLNOD == 8 .AND. MLW == 59) THEN
 c                     output = global damage variables of /fail/connect
                       MT = IXS(1,NFT+1)
-                      IRUPT = MAT_PARAM(MT)%FAIL(1)%IRUPT
+                      IRUPT = mat_param(MT)%FAIL(1)%IRUPT
                       NFAIL = ELBUF_TAB(NG)%BUFLY(1)%NFAIL
                       IF (IRUPT == 20) THEN
                         NPTG = 4
@@ -1189,7 +1195,7 @@ c ILAYER=NULL IR=NULL IS=NULL IT=NULL
                   IF (ISOLNOD == 8 .AND. MLW == 83) THEN
 c                   output = damage variables of /fail/snconnect
                     MT = IXS(1,NFT+1)
-                    IRUPT = MAT_PARAM(MT)%FAIL(1)%IRUPT
+                    IRUPT = mat_param(MT)%FAIL(1)%IRUPT
                     NFAIL = ELBUF_TAB(NG)%BUFLY(1)%NFAIL! ng= ngroup
                     IF (IRUPT == 26) THEN
                       NPTG = 4
@@ -1214,7 +1220,7 @@ c ILAYER=NULL IR= IS= IT=
                   IF (ISOLNOD == 8 .AND. MLW == 83) THEN
 c                   output = damage variables of /fail/snconnect
                     MT = IXS(1,NFT+1)
-                    IRUPT = MAT_PARAM(MT)%FAIL(1)%IRUPT
+                    IRUPT = mat_param(MT)%FAIL(1)%IRUPT
                     NFAIL = ELBUF_TAB(NG)%BUFLY(1)%NFAIL! ng= ngroup
                     IF (IRUPT == 26) THEN
                       DO IIR=1,NFAIL
@@ -1239,7 +1245,7 @@ c ILAYER=NULL IR=NULL IS=NULL IT=NULL
                   IF (ISOLNOD == 8 .AND. MLW == 83) THEN
 c                   output = damage variables of /fail/snconnect
                     MT = IXS(1,NFT+1)
-                    IRUPT = MAT_PARAM(MT)%FAIL(1)%IRUPT
+                    IRUPT = mat_param(MT)%FAIL(1)%IRUPT
                     NFAIL = ELBUF_TAB(NG)%BUFLY(1)%NFAIL! ng= ngroup
                     IF (IRUPT == 26) THEN
                       NPTG = 4
@@ -1264,7 +1270,7 @@ c ILAYER=NULL IR= IS= IT=
                   IF (ISOLNOD == 8 .AND. MLW == 83) THEN
 c                   output = damage variables of /fail/snconnect
                     MT = IXS(1,NFT+1)
-                    IRUPT = MAT_PARAM(MT)%FAIL(1)%IRUPT
+                    IRUPT = mat_param(MT)%FAIL(1)%IRUPT
                     NFAIL = ELBUF_TAB(NG)%BUFLY(1)%NFAIL! ng= ngroup
                     IF (IRUPT == 26) THEN
                       DO IIR=1,NFAIL
@@ -1289,7 +1295,7 @@ c ILAYER=NULL IR=NULL IS=NULL IT=NULL
                   IF (ISOLNOD == 8 .AND. MLW == 83) THEN
 c                   output = damage variables of /fail/snconnect
                     MT = IXS(1,NFT+1)
-                    IRUPT = MAT_PARAM(MT)%FAIL(1)%IRUPT
+                    IRUPT = mat_param(MT)%FAIL(1)%IRUPT
                     NFAIL = ELBUF_TAB(NG)%BUFLY(1)%NFAIL! ng= ngroup
                     IF (IRUPT == 26) THEN
                       NPTG = 4
@@ -1314,7 +1320,7 @@ c ILAYER=NULL IR= IS= IT=
                   IF (ISOLNOD == 8 .AND. MLW == 83) THEN
 c                   output = damage variables of /fail/snconnect
                     MT = IXS(1,NFT+1)
-                    IRUPT = MAT_PARAM(MT)%FAIL(1)%IRUPT
+                    IRUPT = mat_param(MT)%FAIL(1)%IRUPT
                     NFAIL = ELBUF_TAB(NG)%BUFLY(1)%NFAIL! ng= ngroup
                     IF (IRUPT == 26) THEN
                       DO IIR=1,NFAIL
@@ -1437,9 +1443,9 @@ c ILAYER=NULL IR=NULL IS=NULL IT=NULL
                       NLAY_FAIL = 0
                       DO IL=1,NLAY
                         IMAT = ELBUF_TAB(NG)%BUFLY(IL)%IMAT
-                        NFAIL = MAT_PARAM(IMAT)%NFAIL
+                        NFAIL = mat_param(IMAT)%NFAIL
                         DO IFAIL = 1,NFAIL
-                          FAIL_ID = MAT_PARAM(IMAT)%FAIL(IFAIL)%FAIL_ID
+                          FAIL_ID = mat_param(IMAT)%FAIL(IFAIL)%FAIL_ID
                           IF (FAIL_ID == ID) THEN
                             DO IS=1,NPTS
                               DO IT=1,NPTT
@@ -1466,9 +1472,9 @@ c ILAYER=NULL IR= IS= IT=
                         NLAY_FAIL = 0
                         DO IL=1,NLAY
                           IMAT = ELBUF_TAB(NG)%BUFLY(IL)%IMAT
-                          NFAIL = MAT_PARAM(IMAT)%NFAIL
+                          NFAIL = mat_param(IMAT)%NFAIL
                           DO IFAIL = 1,NFAIL
-                            FAIL_ID = MAT_PARAM(IMAT)%FAIL(IFAIL)%FAIL_ID
+                            FAIL_ID = mat_param(IMAT)%FAIL(IFAIL)%FAIL_ID
                             IF (FAIL_ID == ID) THEN
                               FBUF => ELBUF_TAB(NG)%BUFLY(IL)%FAIL(IIR,IS,IT)
                               VALUE(I) = VALUE(I) + FBUF%FLOC(IFAIL)%DAMMX(I)
@@ -1483,9 +1489,9 @@ c ILAYER=NULL IR= IS= IT=
                   ELSEIF ( ILAY > 0 .AND. ILAY <= NLAY .AND. IR >= 0 .AND. IR <= NPTR .AND.
      .                     IS >= 0 .AND.  IS <= NPTS) THEN
                     IMAT = ELBUF_TAB(NG)%BUFLY(ILAY)%IMAT
-                    NFAIL = MAT_PARAM(IMAT)%NFAIL
+                    NFAIL = mat_param(IMAT)%NFAIL
                     DO IFAIL = 1,NFAIL
-                      FAIL_ID = MAT_PARAM(IMAT)%FAIL(IFAIL)%FAIL_ID
+                      FAIL_ID = mat_param(IMAT)%FAIL(IFAIL)%FAIL_ID
                       IF (FAIL_ID == ID) THEN
                         FBUF => ELBUF_TAB(NG)%BUFLY(ILAY)%FAIL(IR,IS,IT)
                         DO I = 1,NEL
@@ -1502,10 +1508,10 @@ c ILAYER=NULL IR=NULL IS=NULL IT=NULL
                       NLAY_FAIL = 0
                       DO IL=1,NLAY
                         IMAT = ELBUF_TAB(NG)%BUFLY(IL)%IMAT
-                        NFAIL = MAT_PARAM(IMAT)%NFAIL
+                        NFAIL = mat_param(IMAT)%NFAIL
                         DO IFAIL = 1,NFAIL
-                          FAIL_ID = MAT_PARAM(IMAT)%FAIL(IFAIL)%FAIL_ID
-                          NMOD    = MAT_PARAM(IMAT)%FAIL(IFAIL)%NMOD
+                          FAIL_ID = mat_param(IMAT)%FAIL(IFAIL)%FAIL_ID
+                          NMOD    = mat_param(IMAT)%FAIL(IFAIL)%NMOD
                           IF ((FAIL_ID == ID).AND.(MODE <= NMOD)) THEN
                             DO IS=1,NPTS
                               DO IT=1,NPTT
@@ -1532,10 +1538,10 @@ c ILAYER=NULL IR= IS= IT=
                         NLAY_FAIL = 0
                         DO IL=1,NLAY
                           IMAT = ELBUF_TAB(NG)%BUFLY(IL)%IMAT
-                          NFAIL = MAT_PARAM(IMAT)%NFAIL
+                          NFAIL = mat_param(IMAT)%NFAIL
                           DO IFAIL = 1,NFAIL
-                            FAIL_ID = MAT_PARAM(IMAT)%FAIL(IFAIL)%FAIL_ID
-                            NMOD    = MAT_PARAM(IMAT)%FAIL(IFAIL)%NMOD
+                            FAIL_ID = mat_param(IMAT)%FAIL(IFAIL)%FAIL_ID
+                            NMOD    = mat_param(IMAT)%FAIL(IFAIL)%NMOD
                             IF ((FAIL_ID == ID).AND.(MODE <= NMOD)) THEN
                               FBUF => ELBUF_TAB(NG)%BUFLY(IL)%FAIL(IIR,IS,IT)
                               VALUE(I) = VALUE(I) + FBUF%FLOC(IFAIL)%DAMMX(MODE*NEL + I)
@@ -1550,10 +1556,10 @@ c ILAYER=NULL IR= IS= IT=
                   ELSEIF ( ILAY > 0 .AND. ILAY <= NLAY .AND. IR >= 0 .AND. IR <= NPTR .AND.
      .                     IS >= 0 .AND.  IS <= NPTS) THEN
                     IMAT  = ELBUF_TAB(NG)%BUFLY(ILAY)%IMAT
-                    NFAIL = MAT_PARAM(IMAT)%NFAIL    
+                    NFAIL = mat_param(IMAT)%NFAIL
                     DO IFAIL = 1,NFAIL
-                      FAIL_ID = MAT_PARAM(IMAT)%FAIL(IFAIL)%FAIL_ID
-                      NMOD    = MAT_PARAM(IMAT)%FAIL(IFAIL)%NMOD
+                      FAIL_ID = mat_param(IMAT)%FAIL(IFAIL)%FAIL_ID
+                      NMOD    = mat_param(IMAT)%FAIL(IFAIL)%NMOD
                       IF ((FAIL_ID == ID).AND.(MODE <= NMOD)) THEN
                         FBUF => ELBUF_TAB(NG)%BUFLY(ILAY)%FAIL(IR,IS,IT)
                         DO I = 1,NEL
@@ -1583,7 +1589,7 @@ c
                       ! Filling the value table
                       DO IL=1,NLAY
                         IMAT = ELBUF_TAB(NG)%BUFLY(IL)%IMAT
-                        MAT_ID = MAT_PARAM(IMAT)%MAT_ID
+                        MAT_ID = mat_param(IMAT)%MAT_ID
                         IF ((ID == -1) .OR. ((ID > 0).AND.(MAT_ID == ID))) THEN 
                           DO IS=1,NPTS
                             DO IT=1,NPTT
@@ -1607,7 +1613,7 @@ c
                       ! Filling the value table
                       DO IL=1,NLAY
                         IMAT = ELBUF_TAB(NG)%BUFLY(IL)%IMAT
-                        MAT_ID = MAT_PARAM(IMAT)%MAT_ID
+                        MAT_ID = mat_param(IMAT)%MAT_ID
                         IF ((ID == -1) .OR. ((ID > 0).AND.(MAT_ID == ID))) THEN 
                           LBUF => ELBUF_TAB(NG)%BUFLY(IL)%LBUF(IR,IS,IT)
                           DO I=1,NEL
@@ -1620,7 +1626,7 @@ c
                     ! If the layer is specified by the user
                     ELSEIF (ILAY > 0 .AND. ILAY <= NLAY) THEN
                       IMAT = ELBUF_TAB(NG)%BUFLY(ILAY)%IMAT
-                      MAT_ID = MAT_PARAM(IMAT)%MAT_ID
+                      MAT_ID = mat_param(IMAT)%MAT_ID
                       IF ((ID == -1) .OR. ((ID > 0).AND.(MAT_ID == ID))) THEN 
                         DO IS=1,NPTS
                           DO IT=1,NPTT
@@ -1644,8 +1650,8 @@ c
                       ! Filling the value table
                       DO IL=1,NLAY
                         IMAT = ELBUF_TAB(NG)%BUFLY(IL)%IMAT
-                        NMOD = MAT_PARAM(IMAT)%NMOD
-                        MAT_ID = MAT_PARAM(IMAT)%MAT_ID
+                        NMOD = mat_param(IMAT)%NMOD
+                        MAT_ID = mat_param(IMAT)%MAT_ID
                         IF ((NMOD > 0 .AND. MODE <= NMOD) .AND. (MAT_ID == ID)) THEN 
                           DO IS=1,NPTS
                             DO IT=1,NPTT
@@ -1669,8 +1675,8 @@ c
                       ! Filling the value table
                       DO IL=1,NLAY
                         IMAT = ELBUF_TAB(NG)%BUFLY(IL)%IMAT
-                        NMOD = MAT_PARAM(IMAT)%NMOD
-                        MAT_ID = MAT_PARAM(IMAT)%MAT_ID
+                        NMOD = mat_param(IMAT)%NMOD
+                        MAT_ID = mat_param(IMAT)%MAT_ID
                         IF ((NMOD > 0 .AND. MODE <= NMOD) .AND. (MAT_ID == ID)) THEN 
                           LBUF => ELBUF_TAB(NG)%BUFLY(IL)%LBUF(IR,IS,IT)
                           DO I=1,NEL
@@ -1683,8 +1689,8 @@ c
                     ! If the layer is specified by the user
                     ELSEIF (ILAY > 0 .AND. ILAY <= NLAY) THEN
                       IMAT = ELBUF_TAB(NG)%BUFLY(ILAY)%IMAT
-                      NMOD = MAT_PARAM(IMAT)%NMOD
-                      MAT_ID = MAT_PARAM(IMAT)%MAT_ID
+                      NMOD = mat_param(IMAT)%NMOD
+                      MAT_ID = mat_param(IMAT)%MAT_ID
                       IF ((NMOD > 0 .AND. MODE <= NMOD) .AND. (MAT_ID == ID)) THEN 
                         DO IS=1,NPTS
                           DO IT=1,NPTT
@@ -2807,7 +2813,7 @@ C--------------------------------------------------
                   !count number of submaterial based on /EOS/TILLOTSON (IEOS=3)
                   NTILLOTSON = 0
                   DO IMAT=1,NLAY
-                    IEOS =  IPM(4, MAT_PARAM(MT)%MULTIMAT%MID(IMAT) )
+                    IEOS =  IPM(4, mat_param(MT)%MULTIMAT%MID(IMAT) )
                     IF(IEOS == 3)THEN
                       NTILLOTSON = NTILLOTSON + 1
                       IMAT_TILLOTSON = IMAT
@@ -2817,7 +2823,7 @@ C--------------------------------------------------
                   IF(NTILLOTSON > 1)THEN
                     FAC=ONE
                     DO IMAT=1,NLAY
-                      IEOS =  IPM(4, MAT_PARAM(MT)%MULTIMAT%MID(IMAT) )
+                      IEOS =  IPM(4, mat_param(MT)%MULTIMAT%MID(IMAT) )
                       IF(IEOS == 3)THEN
                         EBUF => ELBUF_TAB(NG)%BUFLY(IMAT)%EOS(1,1,1)
                         NVAREOS = ELBUF_TAB(NG)%BUFLY(IMAT)%NVAR_EOS
@@ -2872,15 +2878,205 @@ C--------------------------------------------------
                     ENDDO
                 ENDIF
 !--------------------------------------------------
-              ELSEIF (KEYWORD == 'VSTRAIN') then
+              elseif(keyword == 'VSTRAIN') then
 !--------------------------------------------------
-                DO I=1,NEL
-                  MT = IXS(1,I+NFT)
-                  IF(PM(89,MT) > ZERO)THEN
-                    VALUE(I) = GBUF%RHO(I) / PM(89,MT) - ONE
-                    IS_WRITTEN_VALUE(I) = 1
-                  END IF
-                ENDDO
+                do i=1,nel
+                  mt = ixs(1,i+nft)
+                  if(mlw == 151)then
+                    !multimaterial 151 (collocated scheme)
+                      do ilay=1,nlay
+                        mid = mat_param(mt)%multimat%mid(ilay)
+                        rho0i (ilay) = pm(89,mid)
+                        Vi (ilay) = multi_fvm%phase_alpha(ilay,i+nft) * gbuf%vol(i)
+                        V0i (ilay) =  multi_fvm%phase_rho(ilay,i+nft) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                      enddo
+                      V0g = sum(V0i)
+                      RHO0g = zero
+                      do ilay=1,nlay
+                        RHO0g = RHO0g + rho0i(ilay)*V0i(ilay)
+                      end do
+                      RHO0g = RHO0g / V0g
+                      value(i) = multi_fvm%rho(i+nft) / RHO0g - ONE
+                      is_written_value(i) = 1
+
+                  elseif(mlw == 51)then
+                    !multimaterial 51 (staggered scheme)
+                    imat   = ixs(1,nft+1)
+                    iadbuf = ipm(7,imat)
+                    nuparam= ipm(9,imat)
+                    uparam => bufmat(iadbuf:iadbuf+nuparam)
+                    mbuf => elbuf_tab(ng)%bufly(1)%mat(1,1,1)
+                    ipos = 1
+                    !bijective order           !indexes
+                    isubmat = nint(uparam(276+1));   iu(1)=m51_n0phas +(isubmat-1)*m51_nvphas  + ipos-1
+                    isubmat = nint(uparam(276+2));   iu(2)=m51_n0phas +(isubmat-1)*m51_nvphas  + ipos-1
+                    isubmat = nint(uparam(276+3));   iu(3)=m51_n0phas +(isubmat-1)*m51_nvphas  + ipos-1
+                    isubmat = nint(uparam(276+4));   iu(4)=m51_n0phas +(isubmat-1)*m51_nvphas  + ipos-1
+                    vfrac(i,1) = mbuf%var(i+iu(1)*nel)
+                    vfrac(i,2) = mbuf%var(i+iu(2)*nel)
+                    vfrac(i,3) = mbuf%var(i+iu(3)*nel)
+                    vfrac(i,4) = mbuf%var(i+iu(4)*nel)
+                    ipos = 12
+                    !bijective order           !indexes
+                    isubmat = nint(uparam(276+1));   iu(1)=m51_n0phas +(isubmat-1)*m51_nvphas  + ipos-1
+                    isubmat = nint(uparam(276+2));   iu(2)=m51_n0phas +(isubmat-1)*m51_nvphas  + ipos-1
+                    isubmat = nint(uparam(276+3));   iu(3)=m51_n0phas +(isubmat-1)*m51_nvphas  + ipos-1
+                    isubmat = nint(uparam(276+4));   iu(4)=m51_n0phas +(isubmat-1)*m51_nvphas  + ipos-1
+                    rhoi(1) = mbuf%var(i+iu(1)*nel)
+                    rhoi(2) = mbuf%var(i+iu(2)*nel)
+                    rhoi(3) = mbuf%var(i+iu(3)*nel)
+                    rhoi(4) = mbuf%var(i+iu(4)*nel)
+                    do ilay=1,4
+                      mid = mat_param(mt)%multimat%mid(ilay)
+                      rho0i (ilay) = pm(89,mid)
+                      Vi (ilay) = vfrac(i,ilay) * gbuf%vol(i)
+                      ipos = 12
+                      V0i (ilay) =  rhoi(ilay) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                    enddo
+                    V0g = sum(V0i)
+                    RHO0g = zero
+                    do ilay=1,4
+                      RHO0g = RHO0g + rho0i(ilay)*V0i(ilay)
+                    end do
+                    RHO0g = RHO0g / V0g
+                    value(i) = gbuf%rho(i) / RHO0g - ONE
+                    is_written_value(i) = 1
+
+                  elseif(mlw == 37)then
+                    !multimaterial 37 (staggered scheme)
+                    imat   = ixs(1,nft+1)
+                    iadbuf = ipm(7,imat)
+                    nuparam= ipm(9,imat)
+                    uparam => bufmat(iadbuf:iadbuf+nuparam)
+                    mbuf => elbuf_tab(ng)%bufly(1)%mat(1,1,1)
+                    rho0i(1) = uparam(11)
+                    rho0i(2) = uparam(12)
+                    Vi(1) = mbuf%var(i+3*nel) * gbuf%vol(i) !UVAR(I,4)  = VFRAC1
+                    Vi(2) = mbuf%var(i+4*nel) * gbuf%vol(i) !UVAR(I,5)  = VFRAC2
+                    rhoi(1) = mbuf%var(i+2*nel) !UVAR(I,3)  = RHO1
+                    rhoi(2) = mbuf%var(i+1*nel) !UVAR(I,2)  = RHO2
+                    V0i(1) =  rhoi(1) * Vi(1) / rho0i(1)         !rho0.V0 = rho.V
+                    V0i(2) =  rhoi(2) * Vi(2) / rho0i(2)         !rho0.V0 = rho.V
+                    V0g = sum(V0i)
+                    RHO0g = zero
+                    do ilay=1,nlay
+                      RHO0g = RHO0g + rho0i(ilay)*V0i(ilay)
+                    end do
+                    RHO0g = RHO0g / V0g
+                    value(i) = gbuf%rho(i) / RHO0g - ONE
+                    is_written_value(i) = 1
+
+                  elseif(mlw == 20)then
+                    !multimaterial 20 (staggered scheme)
+                    lbuf1  => elbuf_tab(ng)%bufly(1)%lbuf(1,1,1)
+                    lbuf2  => elbuf_tab(ng)%bufly(2)%lbuf(1,1,1)
+                    mid = mat_param(mt)%multimat%mid(1)
+                    rho0i(1) = pm(89,mid)
+                    mid = mat_param(mt)%multimat%mid(2)
+                    rho0i(2) = pm(89,mid)
+                    Vi(1) = lbuf1%vol(i)
+                    Vi(2) = lbuf2%vol(i)
+                    rhoi(1) = lbuf1%rho(i)
+                    rhoi(2) = lbuf2%rho(i)
+                    V0i(1) =  rhoi(1) * Vi(1) / rho0i(1)         !rho0.V0 = rho.V
+                    V0i(2) =  rhoi(2) * Vi(2) / rho0i(2)         !rho0.V0 = rho.V
+                    V0g = sum(V0i)
+                    RHO0g = zero
+                    do ilay=1,nlay
+                      RHO0g = RHO0g + rho0i(ilay)*V0i(ilay)
+                    end do
+                    RHO0g = RHO0g / V0g
+                    value(i) = gbuf%rho(i) / RHO0g - ONE
+                    is_written_value(i) = 1
+
+                  else
+                    !general case (monomaterial law)
+                    if(pm(89,mt) > zero)then
+                      value(i) = gbuf%rho(i) / pm(89,mt) - one
+                      is_written_value(i) = 1
+                    end if
+                  end if
+
+                enddo
+!--------------------------------------------------
+              elseif(keyword(1:8) == 'VSTRAIN/') then
+!--------------------------------------------------
+                detected = .false.
+                read(keyword(9:), '(I2)', IOSTAT=ierr) ilay
+                if(ierr == 0 .and. ilay > 0) then
+                  if(mlw == 151 .and. ilay <= min(10,multi_fvm%nbmat))detected = .true.
+                  if(mlw ==  51 .and. ilay <= 4                      )detected = .true.
+                  if(mlw ==  37 .and. ilay <= 2                      )detected = .true.
+                  if(mlw ==  20 .and. ilay <= 2                      )detected = .true.
+                end if
+                if(detected)then
+                  do i=1,nel
+                    mt = ixs(1,i+nft)
+
+                    if(mlw == 151)then
+                      !multimaterial 151 (collocated scheme)
+                        mid = mat_param(mt)%multimat%mid(ilay)
+                        rho0i(ilay) = pm(89,mid)
+                        Vi(ilay) = multi_fvm%phase_alpha(ilay,i+nft) * gbuf%vol(i)
+                        V0i(ilay) = multi_fvm%phase_rho(ilay,i+nft) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                        value(i) = multi_fvm%phase_rho(ilay,i+nft) / rho0i(ilay) - ONE
+                        is_written_value(i) = 1
+
+                    elseif(mlw == 51)then
+                      !multimaterial 51 (staggered scheme)
+                      imat = ixs(1,nft+1)
+                      iadbuf = ipm(7,imat)
+                      nuparam= ipm(9,imat)
+                      uparam => bufmat(iadbuf:iadbuf+nuparam)
+                      mbuf => elbuf_tab(ng)%bufly(1)%mat(1,1,1)
+                      mid = mat_param(mt)%multimat%mid(ilay)
+                      rho0i(ilay) = pm(89,mid)
+                      ipos = 1
+                      !bijective order           !indexes
+                      isubmat = nint(uparam(276+ilay));   iu(1)=m51_n0phas +(isubmat-1)*m51_nvphas  + ipos-1
+                      vfrac(i,ilay) = mbuf%var(i+iu(ilay)*nel)
+                      Vi(ilay) = vfrac(i,ilay) * gbuf%vol(i)
+                      ipos = 12
+                      !bijective order           !indexes
+                      isubmat = nint(uparam(276+ilay));   iu(ilay)=m51_n0phas +(isubmat-1)*m51_nvphas  + ipos-1
+                      rhoi(ilay) = mbuf%var(i+iu(ilay)*nel)
+                      V0i (ilay) =  rhoi(ilay) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                      value(i) = rhoi(ilay) / rho0i(ilay) - ONE
+                      is_written_value(i) = 1
+
+                    elseif(mlw == 37)then
+                      !multimaterial 37 (staggered scheme)
+                      imat = ixs(1,nft+1)
+                      iadbuf = ipm(7,imat)
+                      nuparam= ipm(9,imat)
+                      uparam => bufmat(iadbuf:iadbuf+nuparam)
+                      mbuf => elbuf_tab(ng)%bufly(1)%mat(1,1,1)
+                      rho0i(ilay) = uparam(10+ilay)
+                      Vi(ilay) = mbuf%var(i+(ilay+2)*nel) * gbuf%vol(i)
+                      rhoi(ilay) = mbuf%var(i+(3-ilay)*nel) !UVAR(I,3)  = RHO1
+                      V0i(ilay) =  rhoi(ilay) * Vi(ilay) / rho0i(ilay)
+                      value(i) = rhoi(ilay) / rho0i(ilay) - ONE
+                      is_written_value(i) = 1
+
+                    elseif(mlw == 20)then
+                      !multimaterial 20 (staggered scheme)
+                      lbuf  => elbuf_tab(ng)%bufly(ilay)%lbuf(1,1,1)
+                      mid = mat_param(mt)%multimat%mid(ilay)
+                      rho0i(ilay) = pm(89,mid)
+                      Vi(ilay) = lbuf%vol(i)
+                      rhoi(ilay) = lbuf%rho(i)
+                      V0i(ilay) =  rhoi(ilay) * Vi(ilay) / rho0i(ilay)         !rho0.V0 = rho.V
+                      value(i) = rhoi(ilay) / rho0i(ilay) - ONE
+                      is_written_value(i) = 1
+
+                    else
+                      !general case (monomaterial law)
+                      is_written_value(i) = 0
+                    end if
+                enddo
+
+              end if
+!--------------------------------------------------
 !--------------------------------------------------
               ENDIF
 C--------------------------------------------------

--- a/engine/source/output/h3d/input_list/h3d_list_shell_scalar.F
+++ b/engine/source/output/h3d/input_list/h3d_list_shell_scalar.F
@@ -618,6 +618,62 @@ c-----------------------------------------------
       H3D_KEYWORD_SHELL_SCALAR(I)%TEXT1  = 'div(u)'
       H3D_KEYWORD_SHELL_SCALAR(I)%COMMENT  = 'Volumetric dilatation rate'
 c-----------------------------------------------
+c-----------------------------------------------
+      I = I + 1
+      H3D_KEYWORD_SHELL_SCALAR(I)%KEY3  = 'VSTRAIN'
+      H3D_KEYWORD_SHELL_SCALAR(I)%TEXT1  = 'Volumetric Strain'
+      H3D_KEYWORD_SHELL_SCALAR(I)%COMMENT  = 'mu=rho/rho0-1'
+c-----------------------------------------------
+      I = I + 1
+      H3D_KEYWORD_SHELL_SCALAR(I)%KEY3  = 'VSTRAIN/1'
+      H3D_KEYWORD_SHELL_SCALAR(I)%TEXT1  = 'Volumetric Strain 1'
+      H3D_KEYWORD_SHELL_SCALAR(I)%COMMENT  = 'mu=rho/rho0-1'
+c-----------------------------------------------
+      I = I + 1
+      H3D_KEYWORD_SHELL_SCALAR(I)%KEY3  = 'VSTRAIN/2'
+      H3D_KEYWORD_SHELL_SCALAR(I)%TEXT1  = 'Volumetric Strain 2'
+      H3D_KEYWORD_SHELL_SCALAR(I)%COMMENT  = 'mu=rho/rho0-1'
+c-----------------------------------------------
+      I = I + 1
+      H3D_KEYWORD_SHELL_SCALAR(I)%KEY3  = 'VSTRAIN/3'
+      H3D_KEYWORD_SHELL_SCALAR(I)%TEXT1  = 'Volumetric Strain 3'
+      H3D_KEYWORD_SHELL_SCALAR(I)%COMMENT  = 'mu=rho/rho0-1'
+c-----------------------------------------------
+      I = I + 1
+      H3D_KEYWORD_SHELL_SCALAR(I)%KEY3  = 'VSTRAIN/4'
+      H3D_KEYWORD_SHELL_SCALAR(I)%TEXT1  = 'Volumetric Strain 4'
+      H3D_KEYWORD_SHELL_SCALAR(I)%COMMENT  = 'mu=rho/rho0-1'
+c-----------------------------------------------
+      I = I + 1
+      H3D_KEYWORD_SHELL_SCALAR(I)%KEY3  = 'VSTRAIN/5'
+      H3D_KEYWORD_SHELL_SCALAR(I)%TEXT1  = 'Volumetric Strain 5'
+      H3D_KEYWORD_SHELL_SCALAR(I)%COMMENT  = 'mu=rho/rho0-1'
+c-----------------------------------------------
+      I = I + 1
+      H3D_KEYWORD_SHELL_SCALAR(I)%KEY3  = 'VSTRAIN/6'
+      H3D_KEYWORD_SHELL_SCALAR(I)%TEXT1  = 'Volumetric Strain 6'
+      H3D_KEYWORD_SHELL_SCALAR(I)%COMMENT  = 'mu=rho/rho0-1'
+c-----------------------------------------------
+      I = I + 1
+      H3D_KEYWORD_SHELL_SCALAR(I)%KEY3  = 'VSTRAIN/7'
+      H3D_KEYWORD_SHELL_SCALAR(I)%TEXT1  = 'Volumetric Strain 7'
+      H3D_KEYWORD_SHELL_SCALAR(I)%COMMENT  = 'mu=rho/rho0-1'
+c-----------------------------------------------
+      I = I + 1
+      H3D_KEYWORD_SHELL_SCALAR(I)%KEY3  = 'VSTRAIN/8'
+      H3D_KEYWORD_SHELL_SCALAR(I)%TEXT1  = 'Volumetric Strain 8'
+      H3D_KEYWORD_SHELL_SCALAR(I)%COMMENT  = 'mu=rho/rho0-1'
+c-----------------------------------------------
+      I = I + 1
+      H3D_KEYWORD_SHELL_SCALAR(I)%KEY3  = 'VSTRAIN/9'
+      H3D_KEYWORD_SHELL_SCALAR(I)%TEXT1  = 'Volumetric Strain 9'
+      H3D_KEYWORD_SHELL_SCALAR(I)%COMMENT  = 'mu=rho/rho0-1'
+c-----------------------------------------------
+      I = I + 1
+      H3D_KEYWORD_SHELL_SCALAR(I)%KEY3  = 'VSTRAIN/10'
+      H3D_KEYWORD_SHELL_SCALAR(I)%TEXT1  = 'Volumetric Strain 10'
+      H3D_KEYWORD_SHELL_SCALAR(I)%COMMENT  = 'mu=rho/rho0-1'
+c-----------------------------------------------
 
       NKEY=I
       END

--- a/hm_cfg_files/config/CFG/radioss2025/OUTPUTBLOCK/th_bric.cfg
+++ b/hm_cfg_files/config/CFG/radioss2025/OUTPUTBLOCK/th_bric.cfg
@@ -1,0 +1,292 @@
+//Copyright>    CFG Files and Library ("CFG")
+//Copyright>    Copyright (C) 1986-2025 Altair Engineering Inc.
+//Copyright>
+//Copyright>    Altair Engineering Inc. grants to third parties limited permission to
+//Copyright>    use and modify CFG solely in connection with OpenRadioss software, provided
+//Copyright>    that any modification to CFG by a third party must be provided back to
+//Copyright>    Altair Engineering Inc. and shall be deemed a Contribution under and therefore
+//Copyright>    subject to the CONTRIBUTOR LICENSE AGREEMENT for OpenRadioss software.
+//Copyright>
+//Copyright>    CFG IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//Copyright>    INCLUDING, BUT NOT LIMITED TO, THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+//Copyright>    A PARTICULAR PURPOSE, AND NONINFRINGEMENT.  IN NO EVENT SHALL ALTAIR ENGINEERING
+//Copyright>    INC. OR ITS AFFILIATES BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY,
+//Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
+//Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
+//
+// Time history (BRIC) Setup File
+// 
+
+ATTRIBUTES(COMMON) 
+{
+    //INPUT ATTRIBUTES
+    idsmax              = SIZE("Number of elements");
+    ids                 = ARRAY[idsmax](ELEMS, "Identifiers of the objects to be saved");
+    NAME_ARRAY          = ARRAY[idsmax](STRING, "Name of the objects to be saved");
+    Number_Of_Variables = SIZE("Number Variables saved for TH");
+    VAR                 = ARRAY[Number_Of_Variables](STRING, "Variables saved for TH");
+
+    // HM INTERNAL
+    KEYWORD_STR         = VALUE(STRING, "Solver Keyword");
+    TITLE               = VALUE(STRING, "TH group name");
+    TH_OPTION           = VALUE(INT, "TH group name");
+// ----- CFG Local attribute
+    IO_FLAG             = VALUE(INT, "Import/Export flag");
+    PREFIX_STR          = VALUE(STRING, "prefix Keyword");
+}
+
+SKEYWORDS_IDENTIFIER(COMMON)
+{
+    KEYWORD_STR         = 9000;
+    Number_Of_Variables = 7045;
+    VAR                 = 7044;
+    NAME_ARRAY          = 7043;
+    TH_OPTION           = 4674;
+    IO_FLAG             =-1;
+    PREFIX_STR          =-1;
+}
+
+DEFAULTS(COMMON) 
+{
+
+}
+
+GUI(COMMON) 
+{
+    RADIO(TH_OPTION) 
+    {
+     /*   ADD(0,"Default TH");*/
+        ADD(1,"/TH");
+        ADD(2,"/ATH");
+        ADD(3,"/BTH");
+        ADD(4,"/CTH");
+        ADD(5,"/DTH");
+        ADD(6,"/ETH");
+        ADD(7,"/FTH");
+        ADD(8,"/GTH");
+        ADD(9,"/HTH");
+        ADD(10,"/ITH");
+    }
+    if(TH_OPTION==0 || TH_OPTION == 1)
+    {
+        ASSIGN(KEYWORD_STR, "/TH/BRIC/"); 
+    }
+    else if( TH_OPTION == 2)
+    {
+        ASSIGN(KEYWORD_STR, "/ATH/BRIC/"); 
+    }
+    else if( TH_OPTION == 3)
+    {
+        ASSIGN(KEYWORD_STR, "/BTH/BRIC/"); 
+    }
+    else if( TH_OPTION == 4)
+    {
+        ASSIGN(KEYWORD_STR, "/CTH/BRIC/"); 
+    }
+    else if( TH_OPTION == 5)
+    {
+        ASSIGN(KEYWORD_STR, "/DTH/BRIC/"); 
+    }
+    else if( TH_OPTION == 6)
+    {
+        ASSIGN(KEYWORD_STR, "/ETH/BRIC/"); 
+    }
+    else if( TH_OPTION == 7)
+    {
+        ASSIGN(KEYWORD_STR, "/FTH/BRIC/"); 
+    }
+    else if( TH_OPTION == 8)
+    {
+        ASSIGN(KEYWORD_STR, "/GTH/BRIC/"); 
+    }
+    else if( TH_OPTION == 9)
+    {
+        ASSIGN(KEYWORD_STR, "/HTH/BRIC/"); 
+    }
+    else if( TH_OPTION == 10)
+    {
+        ASSIGN(KEYWORD_STR, "/ITH/BRIC/"); 
+    }
+    SIZE(Number_Of_Variables);
+    ARRAY(Number_Of_Variables,"Variables") 
+    {
+        RADIO(VAR) 
+        {
+            ADD("DEF","DEF: Default");
+            ADD("OFF","OFF: Element flag for deactivation");
+            ADD("SX","SX: Component of the stress matrix in the global frame");
+            ADD("SY","SY: Component of the stress matrix in the global frame");
+            ADD("SZ","SZ: Component of the stress matrix in the global frame");
+            ADD("SXY","SXY: Component of the stress matrix in the global frame");
+            ADD("SYZ","SYZ: Component of the stress matrix in the global frame");
+            ADD("SXZ","SXZ: Component of the stress matrix in the global frame");
+            ADD("LSX","LSX: Component of the stress matrix in the local frame");
+            ADD("LSY","LSY: Component of the stress matrix in the local frame");
+            ADD("LSZ","LSZ: Component of the stress matrix in the local frame");
+            ADD("LSXY","LSXY: Component of the stress matrix in the local frame");
+            ADD("LSYZ","LSYZ: Component of the stress matrix in the local frame");
+            ADD("LSXZ","LSXZ: Component of the stress matrix in the local frame");
+            ADD("IE","IE: Internal energy density (internal energy per unit volume)");
+            ADD("DENS","DENS: Density");
+            ADD("BULK","BULK: Bulk Viscosity        ");
+            ADD("VOL","VOL: Volume");
+            ADD("PLAS","PLAS: Plastic strain");
+            ADD("TEMP","TEMP: Temperature");
+            ADD("PLSR","PLSR: Strain rate");
+            ADD("DAM1","DAM1: Tensile damage in direction 1");
+            ADD("DAM2","DAM2: Tensile damage in direction 2");
+            ADD("DAM3","DAM3: Tensile damage in direction 3");
+            ADD("DAM4","DAM4: Tensile damage in direction 1 Tsai Wu yield function");
+            ADD("DAM5","DAM5: Tensile damage in direction 23");
+            ADD("DAMA","DAMA: Sum of damages");
+            ADD("SA1","SA1: Stress reinforced in direction 1");
+            ADD("SA2","SA2: Stress reinforced in direction 2");
+            ADD("SA3","SA3: Stress reinforced in direction 3");
+            ADD("CR","CR: Volume of open cracks");
+            ADD("CAP","CAP: Cap parameter");
+            ADD("K0","K0: Plastic parameter");
+            ADD("RK","RK: Turbulent energy");
+            ADD("TD","TD: Turbulent dissipation");
+            ADD("EFIB","EFIB: Fiber strain");
+            ADD("ISTA","ISTA: Phase state");
+            ADD("VPLA","VPLA: Equivalent volumetric plastic strain");
+            ADD("BFRAC","BFRAC: Burn fraction");
+            ADD("WPLA","WPLA: Plastic work");
+            ADD("SFIB","SFIB: Stress in fibers");
+            ADD("EPSXX","EPSXX: Strain tensor values");
+            ADD("EPSYY","EPSYY: Strain tensor values");
+            ADD("EPSZZ","EPSZZ: Strain tensor values");
+            ADD("EPSXY","EPSXY: Strain tensor values");
+            ADD("EPSZX","EPSZX: Strain tensor values");
+            ADD("EPSYZ","EPSYZ: Strain tensor values");
+            ADD("STRESS","STRESS: Stress matrix in the global frame (SX SY SZ SXY SYZ SZX)");
+            ADD("LOCSTRESS","LOCSTRESS: Stress matrix in the local frame (LSX LSY LSZ LSXY LSYZ LSZX)");
+            ADD("VSTRAIN","Volumetric strain");
+        }
+    }
+    SIZE(idsmax);
+    ARRAY(idsmax,"Elements")
+    {
+        DATA(ids,"Element ID");
+        SCALAR(NAME_ARRAY,"Element Name");
+    }
+}
+
+// File format
+FORMAT(radioss51)
+{
+    ASSIGN(IO_FLAG, 1, IMPORT);
+    ASSIGN(IO_FLAG, 2, EXPORT);
+ 
+    
+    if(IO_FLAG == 1 )
+    {
+        HEADER("/%-s/BRIC/%d",PREFIX_STR, _ID_);
+        if(PREFIX_STR=="TH")
+        {
+             ASSIGN(TH_OPTION,1, IMPORT);
+        }
+        else if(PREFIX_STR=="ATH")
+        {
+            ASSIGN(TH_OPTION, 2, IMPORT);
+        }
+        else if(PREFIX_STR=="BTH")
+        {
+            ASSIGN(TH_OPTION, 3, IMPORT);
+        }
+        else if(PREFIX_STR=="CTH")
+        {
+            ASSIGN(TH_OPTION, 4, IMPORT);
+        }
+        else if(PREFIX_STR=="DTH")
+        {
+            ASSIGN(TH_OPTION, 5, IMPORT);
+        }
+        else if(PREFIX_STR=="ETH")
+        {
+            ASSIGN(TH_OPTION, 6, IMPORT);
+        }
+         else if(PREFIX_STR=="FTH")
+        {
+            ASSIGN(TH_OPTION, 7, IMPORT);
+        }
+        else if(PREFIX_STR=="GTH")
+        {
+            ASSIGN(TH_OPTION, 8, IMPORT);
+        }
+        else if(PREFIX_STR=="HTH")
+        {
+            ASSIGN(TH_OPTION, 9, IMPORT);
+        }                
+        else if(PREFIX_STR=="ITH")
+        {
+            ASSIGN(TH_OPTION, 10, IMPORT);
+        }
+        
+    }
+    if(IO_FLAG == 2 )
+    {
+        if(TH_OPTION==0 || TH_OPTION == 1)
+        {
+            HEADER("/TH/BRIC/%d", _ID_); 
+        }
+        else if( TH_OPTION == 2)
+        {
+            HEADER("/ATH/BRIC/%d", _ID_); 
+        }
+        else if( TH_OPTION == 3)
+        {
+            HEADER("/BTH/BRIC/%d", _ID_); 
+        }
+        else if( TH_OPTION == 4)
+        {
+            HEADER("/CTH/BRIC/%d", _ID_); 
+        }
+        else if( TH_OPTION == 5)
+        {
+            HEADER("/DTH/BRIC/%d", _ID_); 
+        }
+        else if( TH_OPTION == 6)
+        {
+            HEADER("/ETH/BRIC/%d", _ID_); 
+        }
+        else if( TH_OPTION == 7)
+        {
+            HEADER("/FTH/BRIC/%d", _ID_); 
+        }
+        else if( TH_OPTION == 8)
+        {
+            HEADER("/GTH/BRIC/%d", _ID_); 
+        }
+        else if( TH_OPTION == 9)
+        {
+            HEADER("/HTH/BRIC/%d", _ID_); 
+        }
+        else if( TH_OPTION == 10)
+        {
+            HEADER("/ITH/BRIC/%d", _ID_); 
+        }
+    }
+    CARD("%-100s", TITLE);
+    // ASSIGN(Number_Of_Variables,7); // Dummy value, pending an improvement of the FREE_CELL_LIST
+    COMMENT("#      var       var       var       var       var       var       var       var       var       var");
+    FREE_CELL_LIST(Number_Of_Variables,"%-10s",VAR,100);
+    COMMENT("#  elem_ID          elem_name");
+    FREE_CARD_LIST(idsmax)
+    {
+        CARD("%10d          %-80s",ids,NAME_ARRAY);
+    }
+}
+
+FORMAT(radioss41) 
+{
+    HEADER("/TH/BRIC/%d/%s",_ID_,TITLE);
+    // ASSIGN(Number_Of_Variables,7); // Dummy value, pending an improvement of the FREE_CELL_LIST
+    COMMENT("#    var     var     var     var     var     var     var     var     var     var");
+    FREE_CELL_LIST(Number_Of_Variables,"%-8s",VAR,80);
+    COMMENT("#elem_ID elem_name");
+    FREE_CARD_LIST(idsmax)
+    {
+        CARD("%8d        %-40s",ids,NAME_ARRAY);
+    }
+}

--- a/hm_cfg_files/config/CFG/radioss2025/OUTPUTBLOCK/th_quad.cfg
+++ b/hm_cfg_files/config/CFG/radioss2025/OUTPUTBLOCK/th_quad.cfg
@@ -1,0 +1,447 @@
+//Copyright>    CFG Files and Library ("CFG")
+//Copyright>    Copyright (C) 1986-2025 Altair Engineering Inc.
+//Copyright>
+//Copyright>    Altair Engineering Inc. grants to third parties limited permission to
+//Copyright>    use and modify CFG solely in connection with OpenRadioss software, provided
+//Copyright>    that any modification to CFG by a third party must be provided back to
+//Copyright>    Altair Engineering Inc. and shall be deemed a Contribution under and therefore
+//Copyright>    subject to the CONTRIBUTOR LICENSE AGREEMENT for OpenRadioss software.
+//Copyright>
+//Copyright>    CFG IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//Copyright>    INCLUDING, BUT NOT LIMITED TO, THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+//Copyright>    A PARTICULAR PURPOSE, AND NONINFRINGEMENT.  IN NO EVENT SHALL ALTAIR ENGINEERING
+//Copyright>    INC. OR ITS AFFILIATES BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY,
+//Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
+//Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
+//
+// /TH/QUAD/
+//
+
+ATTRIBUTES(COMMON)
+{
+    //INPUT ATTRIBUTES
+    Number_Of_Variables                     = SIZE("Number Variables saved for TH");
+    VAR                                     = ARRAY[Number_Of_Variables](STRING, "Variables saved for TH");
+
+    idsmax                                  = SIZE("Number of ELEMENTS");
+    ids                                     = ARRAY[idsmax](ELEMS, "Identifiers of the objects to be saved")  { SUBTYPES = (/ELEMS/QUAD ) ; }
+    NAME_ARRAY                              = ARRAY[idsmax](STRING, "Name of the objects to be saved");
+
+    // HM INTERNAL
+    KEYWORD_STR                             = VALUE(STRING, "Solver Keyword");
+
+    TITLE                                   = VALUE(STRING, "TH group name");
+    TH_OPTION           = VALUE(INT, "TH group name");
+// ----- CFG Local attribute
+    IO_FLAG             = VALUE(INT, "Import/Export flag");
+    PREFIX_STR          = VALUE(STRING, "prefix Keyword");
+}
+
+SKEYWORDS_IDENTIFIER(COMMON)
+{
+    //INPUT ATTRIBUTES
+    VAR                                     = 7044;
+    NAME_ARRAY                              = 7043;
+
+    Number_Of_Variables                     = 7045;
+
+    // HM INTERNAL
+    KEYWORD_STR                             = 9000;
+
+    TITLE                                   = -1;
+    TH_OPTION           = 4674;
+    IO_FLAG             =-1;
+    PREFIX_STR          =-1;
+}
+
+DEFAULTS(COMMON)
+{
+    VAR                                     = "DEF";
+    Number_Of_Variables                     = 1;
+}
+
+GUI(COMMON) 
+{
+    RADIO(TH_OPTION) 
+    {
+     /*   ADD(0,"Default TH");*/
+        ADD(1,"/TH");
+        ADD(2,"/ATH");
+        ADD(3,"/BTH");
+        ADD(4,"/CTH");
+        ADD(5,"/DTH");
+        ADD(6,"/ETH");
+        ADD(7,"/FTH");
+        ADD(8,"/GTH");
+        ADD(9,"/HTH");
+        ADD(10,"/ITH");
+    }
+    if(TH_OPTION==0 || TH_OPTION == 1)
+    {
+        ASSIGN(KEYWORD_STR, "/TH/QUAD/"); 
+    }
+    else if( TH_OPTION == 2)
+    {
+        ASSIGN(KEYWORD_STR, "/ATH/QUAD/"); 
+    }
+    else if( TH_OPTION == 3)
+    {
+        ASSIGN(KEYWORD_STR, "/BTH/QUAD/"); 
+    }
+    else if( TH_OPTION == 4)
+    {
+        ASSIGN(KEYWORD_STR, "/CTH/QUAD/"); 
+    }
+    else if( TH_OPTION == 5)
+    {
+        ASSIGN(KEYWORD_STR, "/DTH/QUAD/"); 
+    }
+    else if( TH_OPTION == 6)
+    {
+        ASSIGN(KEYWORD_STR, "/ETH/QUAD/"); 
+    }
+    else if( TH_OPTION == 7)
+    {
+        ASSIGN(KEYWORD_STR, "/FTH/QUAD/"); 
+    }
+    else if( TH_OPTION == 8)
+    {
+        ASSIGN(KEYWORD_STR, "/GTH/QUAD/"); 
+    }
+    else if( TH_OPTION == 9)
+    {
+        ASSIGN(KEYWORD_STR, "/HTH/QUAD/"); 
+    }
+    else if( TH_OPTION == 10)
+    {
+        ASSIGN(KEYWORD_STR, "/ITH/QUAD/"); 
+    }
+    SIZE(Number_Of_Variables);
+    ARRAY(Number_Of_Variables, "NUM_VARIABLES")
+    {
+       RADIO(VAR)
+       {
+         ADD("DEF",    "Default");
+         ADD("STRESS", "Stress Matrix in Global Frame (SX, SY, SZ, SXY, SYZ, SXZ)");
+         ADD("LOCSTRS","Component of the Stress Matrix in the local frame (LSX, LSY, LSZ, LSXY, LSYZ, LSXZ)");
+         ADD("STRAIN","Strain component in the global system (EPSXX, EPSYY, EPSZZ, EPSXY, EPSZX, EPSYZ)");
+         ADD("LOCSTRN","Strain component in the local system (LEPSX, LEPSY, LEPSZ, LEPSXY, LEPSZX, LEPSYZ)");
+         ADD("OFF",    "Element flag for deactivation");
+         ADD("SX",     "Component of the Stress Matrix in the global frame");
+         ADD("SY",     "Component of the Stress Matrix in the global frame");
+         ADD("SZ",     "Component of the Stress Matrix in the global frame");
+         ADD("SXY",    "Component of the Stress Matrix in the global frame");
+         ADD("SYZ",    "Component of the Stress Matrix in the global frame");
+         ADD("SXZ",    "Component of the Stress Matrix in the global frame");
+         ADD("IE",     "Internal Energy per volume unit");
+         ADD("DENS",   "Density");
+         ADD("QVIS",   "Artificial viscosity (pseudo-viscosity)");
+         ADD("BULK",   "Bulk Viscosity");
+         ADD("VOL",    "Volume");
+         ADD("PLAS",   "Plastic Strain");
+         ADD("TEMP",   "Temperature");
+         ADD("PLSR",   "Strain Rate");
+         ADD("DAM1",   "Tensile Damage in direction 1");
+         ADD("DAM2",   "Tensile Damage in direction 2");
+         ADD("DAM3",   "Tensile Damage in direction 3");
+         ADD("DAM4",   "Tensile Damage in direction 1 Tsai-Wu yield function");
+         ADD("DAM5",   "Tensile damage in direction 23");
+         ADD("DAMA",   "Sum of damages");
+         ADD("SA1",    "Stress reinforced in direction 1");
+         ADD("SA2",    "Stress reinforced in direction 2");
+         ADD("SA3",    "Stress reinforced in direction 3");
+         ADD("CR",     "Volume of opened cracks");
+         ADD("CAP",    "Cap Parameter");
+         ADD("K0",     "Plastic Parameter");
+         ADD("RK",     "Turbulent Energy");
+         ADD("TD",     "Turbulent Dissipation");
+         ADD("EFIB",   "Fiber Strain");
+         ADD("ISTA",   "Phase State");
+         ADD("VPLA",   "Equivalent volumetric Plastic Strain");
+         ADD("BFRAC",  "Burn Fraction");
+         ADD("WPLA",   "Plastic Work");
+         ADD("SFIB",   "Stress in fibers");
+         ADD("AUX1",   "User variable");
+         ADD("AUX2",   "User variable");
+         ADD("AUX3",   "User variable");
+         ADD("LSX",    "Component of the Stress Matrix in the local frame");
+         ADD("LSY",    "Component of the Stress Matrix in the local frame");
+         ADD("LSZ",    "Component of the Stress Matrix in the local frame");
+         ADD("LSXY",   "Component of the Stress Matrix in the local frame");
+         ADD("LSXZ",   "Component of the Stress Matrix in the local frame");
+         ADD("LSYZ",   "Component of the Stress Matrix in the local frame");
+         ADD("EPSXX",  "Strain component in the global system");
+         ADD("EPSYY",  "Strain component in the global system");
+         ADD("EPSZZ",  "Strain component in the global system");
+         ADD("EPSXY",  "Strain component in the global system");
+         ADD("EPSZX",  "Strain component in the global system");
+         ADD("EPSYZ",  "Strain component in the global system");
+         ADD("LEPSX",  "Strain component in the local system");
+         ADD("LEPSY",  "Strain component in the local system");
+         ADD("LEPSZ",  "Strain component in the local system");
+         ADD("LEPSXY", "Strain component in the local system");
+         ADD("LEPSZX", "Strain component in the local system");
+         ADD("LEPSYZ", "Strain component in the local system");
+         ADD("EPSX111","Strain component per integration point in the global system");
+         ADD("EPSY111","Strain component per integration point in the global system");
+         ADD("EPSZ111","Strain component per integration point in the global system");
+         ADD("EPSXY111","Strain component per integration point in the global system");
+         ADD("EPSZX111","Strain component per integration point in the global system");
+         ADD("EPSYZ111","Strain component per integration point in the global system");
+         ADD("EPSX121","Strain component per integration point in the global system");
+         ADD("EPSY121","Strain component per integration point in the global system");
+         ADD("EPSZ121","Strain component per integration point in the global system");
+         ADD("EPSXY121","Strain component per integration point in the global system");
+         ADD("EPSZX121","Strain component per integration point in the global system");
+         ADD("EPSYZ121","Strain component per integration point in the global system");
+         ADD("EPSX221","Strain component per integration point in the global system");
+         ADD("EPSY221","Strain component per integration point in the global system");
+         ADD("EPSZ221","Strain component per integration point in the global system");
+         ADD("EPSXY221","Strain component per integration point in the global system");
+         ADD("EPSZX221","Strain component per integration point in the global system");
+         ADD("EPSYZ221","Strain component per integration point in the global system");
+         ADD("VSTRAIN","Volumetric strain");
+      }
+    }
+
+    SIZE(idsmax);
+    ARRAY(idsmax, "Elements")
+    {
+        DATA(ids,"Element ID");
+        SCALAR(NAME_ARRAY,"Element Name")   { DIMENSION="DIMENSIONLESS"; }
+    }
+}
+
+// File format
+FORMAT(radioss41)
+{
+    HEADER("/TH/QUAD/%d/%s", _ID_, TITLE);
+
+    // Card 1
+    COMMENT("#    var     var     var     var     var     var     var     var     var     var");
+    FREE_CELL_LIST(Number_Of_Variables,"%-8s", VAR, 80);
+
+    // Card 2
+    COMMENT("#   ELid        ELname");
+    FREE_CARD_LIST(idsmax)
+    {
+        CARD("%8d%8s%-40s", ids, _BLANK_, NAME_ARRAY);
+    }
+}
+
+FORMAT(radioss51)
+{
+    ASSIGN(IO_FLAG, 1, IMPORT);
+    ASSIGN(IO_FLAG, 2, EXPORT);
+ 
+    
+    if(IO_FLAG == 1 )
+    {
+        HEADER("/%-s/QUAD/%d",PREFIX_STR, _ID_);
+        if(PREFIX_STR=="TH")
+        {
+             ASSIGN(TH_OPTION,1, IMPORT);
+        }
+        else if(PREFIX_STR=="ATH")
+        {
+            ASSIGN(TH_OPTION, 2, IMPORT);
+        }
+        else if(PREFIX_STR=="BTH")
+        {
+            ASSIGN(TH_OPTION, 3, IMPORT);
+        }
+        else if(PREFIX_STR=="CTH")
+        {
+            ASSIGN(TH_OPTION, 4, IMPORT);
+        }
+        else if(PREFIX_STR=="DTH")
+        {
+            ASSIGN(TH_OPTION, 5, IMPORT);
+        }
+        else if(PREFIX_STR=="ETH")
+        {
+            ASSIGN(TH_OPTION, 6, IMPORT);
+        }
+         else if(PREFIX_STR=="FTH")
+        {
+            ASSIGN(TH_OPTION, 7, IMPORT);
+        }
+        else if(PREFIX_STR=="GTH")
+        {
+            ASSIGN(TH_OPTION, 8, IMPORT);
+        }
+        else if(PREFIX_STR=="HTH")
+        {
+            ASSIGN(TH_OPTION, 9, IMPORT);
+        }                
+        else if(PREFIX_STR=="ITH")
+        {
+            ASSIGN(TH_OPTION, 10, IMPORT);
+        }
+        
+    }
+    if(IO_FLAG == 2 )
+    {
+        if(TH_OPTION==0 || TH_OPTION == 1)
+        {
+            HEADER("/TH/QUAD/%d", _ID_); 
+        }
+        else if( TH_OPTION == 2)
+        {
+            HEADER("/ATH/QUAD/%d", _ID_); 
+        }
+        else if( TH_OPTION == 3)
+        {
+            HEADER("/BTH/QUAD/%d", _ID_); 
+        }
+        else if( TH_OPTION == 4)
+        {
+            HEADER("/CTH/QUAD/%d", _ID_); 
+        }
+        else if( TH_OPTION == 5)
+        {
+            HEADER("/DTH/QUAD/%d", _ID_); 
+        }
+        else if( TH_OPTION == 6)
+        {
+            HEADER("/ETH/QUAD/%d", _ID_); 
+        }
+        else if( TH_OPTION == 7)
+        {
+            HEADER("/FTH/QUAD/%d", _ID_); 
+        }
+        else if( TH_OPTION == 8)
+        {
+            HEADER("/GTH/QUAD/%d", _ID_); 
+        }
+        else if( TH_OPTION == 9)
+        {
+            HEADER("/HTH/QUAD/%d", _ID_); 
+        }
+        else if( TH_OPTION == 10)
+        {
+            HEADER("/ITH/QUAD/%d", _ID_); 
+        }
+    }
+
+    CARD("%-100s", TITLE);
+
+    // Card 1
+    COMMENT("#   var_ID    var_ID    var_ID    var_ID    var_ID    var_ID    var_ID    var_ID    var_ID    var_ID");
+    FREE_CELL_LIST(Number_Of_Variables,"%-10s", VAR, 100);
+
+    // Card 2
+    COMMENT("#     ELid          ELname");
+    FREE_CARD_LIST(idsmax)
+    {
+        CARD("%10d%10s%-80s", ids, _BLANK_, NAME_ARRAY);
+    }
+}
+
+FORMAT(radioss90)
+{
+    ASSIGN(IO_FLAG, 1, IMPORT);
+    ASSIGN(IO_FLAG, 2, EXPORT);
+ 
+    
+    if(IO_FLAG == 1 )
+    {
+        HEADER("/%-s/QUAD/%d",PREFIX_STR, _ID_);
+        if(PREFIX_STR=="TH")
+        {
+             ASSIGN(TH_OPTION,1, IMPORT);
+        }
+        else if(PREFIX_STR=="ATH")
+        {
+            ASSIGN(TH_OPTION, 2, IMPORT);
+        }
+        else if(PREFIX_STR=="BTH")
+        {
+            ASSIGN(TH_OPTION, 3, IMPORT);
+        }
+        else if(PREFIX_STR=="CTH")
+        {
+            ASSIGN(TH_OPTION, 4, IMPORT);
+        }
+        else if(PREFIX_STR=="DTH")
+        {
+            ASSIGN(TH_OPTION, 5, IMPORT);
+        }
+        else if(PREFIX_STR=="ETH")
+        {
+            ASSIGN(TH_OPTION, 6, IMPORT);
+        }
+         else if(PREFIX_STR=="FTH")
+        {
+            ASSIGN(TH_OPTION, 7, IMPORT);
+        }
+        else if(PREFIX_STR=="GTH")
+        {
+            ASSIGN(TH_OPTION, 8, IMPORT);
+        }
+        else if(PREFIX_STR=="HTH")
+        {
+            ASSIGN(TH_OPTION, 9, IMPORT);
+        }                
+        else if(PREFIX_STR=="ITH")
+        {
+            ASSIGN(TH_OPTION, 10, IMPORT);
+        }
+        
+    }
+    if(IO_FLAG == 2 )
+    {
+        if(TH_OPTION==0 || TH_OPTION == 1)
+        {
+            HEADER("/TH/QUAD/%d", _ID_); 
+        }
+        else if( TH_OPTION == 2)
+        {
+            HEADER("/ATH/QUAD/%d", _ID_); 
+        }
+        else if( TH_OPTION == 3)
+        {
+            HEADER("/BTH/QUAD/%d", _ID_); 
+        }
+        else if( TH_OPTION == 4)
+        {
+            HEADER("/CTH/QUAD/%d", _ID_); 
+        }
+        else if( TH_OPTION == 5)
+        {
+            HEADER("/DTH/QUAD/%d", _ID_); 
+        }
+        else if( TH_OPTION == 6)
+        {
+            HEADER("/ETH/QUAD/%d", _ID_); 
+        }
+        else if( TH_OPTION == 7)
+        {
+            HEADER("/FTH/QUAD/%d", _ID_); 
+        }
+        else if( TH_OPTION == 8)
+        {
+            HEADER("/GTH/QUAD/%d", _ID_); 
+        }
+        else if( TH_OPTION == 9)
+        {
+            HEADER("/HTH/QUAD/%d", _ID_); 
+        }
+        else if( TH_OPTION == 10)
+        {
+            HEADER("/ITH/QUAD/%d", _ID_); 
+        }
+    }
+    CARD("%-100s", TITLE);
+
+    // Card 1
+    COMMENT("#   var_ID    var_ID    var_ID    var_ID    var_ID    var_ID    var_ID    var_ID    var_ID    var_ID");
+    FREE_CELL_LIST(Number_Of_Variables,"%-10s", VAR, 100);
+
+    // Card 2
+    COMMENT("#  elem_ID          elem_name");
+    FREE_CARD_LIST(idsmax)
+    {
+        CARD("%10d%10s%-50s", ids, _BLANK_, NAME_ARRAY);
+    }
+}

--- a/hm_cfg_files/config/CFG/radioss2025/OUTPUTBLOCK/th_tria.cfg
+++ b/hm_cfg_files/config/CFG/radioss2025/OUTPUTBLOCK/th_tria.cfg
@@ -1,0 +1,323 @@
+//Copyright>    CFG Files and Library ("CFG")
+//Copyright>    Copyright (C) 1986-2025 Altair Engineering Inc.
+//Copyright>
+//Copyright>    Altair Engineering Inc. grants to third parties limited permission to
+//Copyright>    use and modify CFG solely in connection with OpenRadioss software, provided
+//Copyright>    that any modification to CFG by a third party must be provided back to
+//Copyright>    Altair Engineering Inc. and shall be deemed a Contribution under and therefore
+//Copyright>    subject to the CONTRIBUTOR LICENSE AGREEMENT for OpenRadioss software.
+//Copyright>
+//Copyright>    CFG IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//Copyright>    INCLUDING, BUT NOT LIMITED TO, THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+//Copyright>    A PARTICULAR PURPOSE, AND NONINFRINGEMENT.  IN NO EVENT SHALL ALTAIR ENGINEERING
+//Copyright>    INC. OR ITS AFFILIATES BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY,
+//Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
+//Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
+//
+// /TH/TRIA/
+//
+
+ATTRIBUTES(COMMON)
+{
+    //INPUT ATTRIBUTES
+    Number_Of_Variables                     = SIZE("Number Variables saved for TH");
+    VAR                                     = ARRAY[Number_Of_Variables](STRING, "Variables saved for TH");
+
+    idsmax                                  = SIZE("Number of ELEMENTS");
+    ids                                     = ARRAY[idsmax](ELEMS, "Identifiers of the objects to be saved")  { SUBTYPES = (/ELEMS/TRIA ) ; }
+    NAME_ARRAY                              = ARRAY[idsmax](STRING, "Name of the objects to be saved");
+
+    // HM INTERNAL
+    KEYWORD_STR                             = VALUE(STRING, "Solver Keyword");
+
+    TITLE                                   = VALUE(STRING, "TH group name");
+    TH_OPTION                               = VALUE(INT, "TH group name");
+    // ----- CFG Local attribute
+    IO_FLAG                                 = VALUE(INT, "Import/Export flag");
+    PREFIX_STR                              = VALUE(STRING, "prefix Keyword");
+}
+
+SKEYWORDS_IDENTIFIER(COMMON)
+{
+    //INPUT ATTRIBUTES
+    VAR                                     = 7044;
+    NAME_ARRAY                              = 7043;
+
+    Number_Of_Variables                     = 7045;
+
+    // HM INTERNAL
+    KEYWORD_STR                             = 9000;
+
+    TITLE                                   = -1;
+    TH_OPTION                               = 4674;
+    IO_FLAG                                 =-1;
+    PREFIX_STR                              =-1;
+}
+
+DEFAULTS(COMMON)
+{
+    VAR                                     = "DEF";
+    Number_Of_Variables                     = 1;
+}
+
+GUI(COMMON) 
+{
+    RADIO(TH_OPTION) 
+    {
+     /*   ADD(0,"Default TH");*/
+        ADD(1,"/TH");
+        ADD(2,"/ATH");
+        ADD(3,"/BTH");
+        ADD(4,"/CTH");
+        ADD(5,"/DTH");
+        ADD(6,"/ETH");
+        ADD(7,"/FTH");
+        ADD(8,"/GTH");
+        ADD(9,"/HTH");
+        ADD(10,"/ITH");
+    }
+    if(TH_OPTION==0 || TH_OPTION == 1)
+    {
+        ASSIGN(KEYWORD_STR, "/TH/TRIA/"); 
+    }
+    else if( TH_OPTION == 2)
+    {
+        ASSIGN(KEYWORD_STR, "/ATH/TRIA/"); 
+    }
+    else if( TH_OPTION == 3)
+    {
+        ASSIGN(KEYWORD_STR, "/BTH/TRIA/"); 
+    }
+    else if( TH_OPTION == 4)
+    {
+        ASSIGN(KEYWORD_STR, "/CTH/TRIA/"); 
+    }
+    else if( TH_OPTION == 5)
+    {
+        ASSIGN(KEYWORD_STR, "/DTH/TRIA/"); 
+    }
+    else if( TH_OPTION == 6)
+    {
+        ASSIGN(KEYWORD_STR, "/ETH/TRIA/"); 
+    }
+    else if( TH_OPTION == 7)
+    {
+        ASSIGN(KEYWORD_STR, "/FTH/TRIA/"); 
+    }
+    else if( TH_OPTION == 8)
+    {
+        ASSIGN(KEYWORD_STR, "/GTH/TRIA/"); 
+    }
+    else if( TH_OPTION == 9)
+    {
+        ASSIGN(KEYWORD_STR, "/HTH/TRIA/"); 
+    }
+    else if( TH_OPTION == 10)
+    {
+        ASSIGN(KEYWORD_STR, "/ITH/TRIA/"); 
+    }
+    // Card 1
+    SIZE(Number_Of_Variables);
+    ARRAY(Number_Of_Variables, "NUM_VARIABLES")
+    {
+       RADIO(VAR)
+       {
+         ADD("DEF",    "Default");
+         ADD("STRESS", "Stress Matrix in Global Frame (SX, SY, SZ, SXY, SYZ, SXZ)");
+         ADD("LOCSTRS","Component of the Stress Matrix in the local frame (LSX, LSY, LSZ, LSXY, LSYZ, LSXZ)");
+         ADD("STRAIN","Strain component in the global system (EPSXX, EPSYY, EPSZZ, EPSXY, EPSZX, EPSYZ)");
+         ADD("LOCSTRN","Strain component in the local system (LEPSX, LEPSY, LEPSZ, LEPSXY, LEPSZX, LEPSYZ)");
+         ADD("OFF",    "Element flag for deactivation");
+         ADD("SX",     "Component of the Stress Matrix in the global frame");
+         ADD("SY",     "Component of the Stress Matrix in the global frame");
+         ADD("SZ",     "Component of the Stress Matrix in the global frame");
+         ADD("SXY",    "Component of the Stress Matrix in the global frame");
+         ADD("SYZ",    "Component of the Stress Matrix in the global frame");
+         ADD("SXZ",    "Component of the Stress Matrix in the global frame");
+         ADD("IE",     "Internal Energy per volume unit");
+         ADD("DENS",   "Density");
+         ADD("QVIS",   "Artificial viscosity (pseudo-viscosity)");
+         ADD("BULK",   "Bulk Viscosity");
+         ADD("VOL",    "Volume");
+         ADD("PLAS",   "Plastic Strain");
+         ADD("TEMP",   "Temperature");
+         ADD("PLSR",   "Strain Rate");
+         ADD("DAM1",   "Tensile Damage in direction 1");
+         ADD("DAM2",   "Tensile Damage in direction 2");
+         ADD("DAM3",   "Tensile Damage in direction 3");
+         ADD("DAM4",   "Tensile Damage in direction 1 Tsai-Wu yield function");
+         ADD("DAM5",   "Tensile damage in direction 23");
+         ADD("DAMA",   "Sum of damages");
+         ADD("SA1",    "Stress reinforced in direction 1");
+         ADD("SA2",    "Stress reinforced in direction 2");
+         ADD("SA3",    "Stress reinforced in direction 3");
+         ADD("CR",     "Volume of opened cracks");
+         ADD("CAP",    "Cap Parameter");
+         ADD("K0",     "Plastic Parameter");
+         ADD("RK",     "Turbulent Energy");
+         ADD("TD",     "Turbulent Dissipation");
+         ADD("EFIB",   "Fiber Strain");
+         ADD("ISTA",   "Phase State");
+         ADD("VPLA",   "Equivalent volumetric Plastic Strain");
+         ADD("BFRAC",  "Burn Fraction");
+         ADD("WPLA",   "Plastic Work");
+         ADD("SFIB",   "Stress in fibers");
+         ADD("AUX1",   "User variable");
+         ADD("AUX2",   "User variable");
+         ADD("AUX3",   "User variable");
+         ADD("LSX",    "Component of the Stress Matrix in the local frame");
+         ADD("LSY",    "Component of the Stress Matrix in the local frame");
+         ADD("LSZ",    "Component of the Stress Matrix in the local frame");
+         ADD("LSXY",   "Component of the Stress Matrix in the local frame");
+         ADD("LSXZ",   "Component of the Stress Matrix in the local frame");
+         ADD("LSYZ",   "Component of the Stress Matrix in the local frame");
+         ADD("EPSXX",  "Strain component in the global system");
+         ADD("EPSYY",  "Strain component in the global system");
+         ADD("EPSZZ",  "Strain component in the global system");
+         ADD("EPSXY",  "Strain component in the global system");
+         ADD("EPSZX",  "Strain component in the global system");
+         ADD("EPSYZ",  "Strain component in the global system");
+         ADD("LEPSX",  "Strain component in the local system");
+         ADD("LEPSY",  "Strain component in the local system");
+         ADD("LEPSZ",  "Strain component in the local system");
+         ADD("LEPSXY", "Strain component in the local system");
+         ADD("LEPSZX", "Strain component in the local system");
+         ADD("LEPSYZ", "Strain component in the local system");
+         ADD("EPSX111","Strain component per integration point in the global system");
+         ADD("EPSY111","Strain component per integration point in the global system");
+         ADD("EPSZ111","Strain component per integration point in the global system");
+         ADD("EPSXY111","Strain component per integration point in the global system");
+         ADD("EPSZX111","Strain component per integration point in the global system");
+         ADD("EPSYZ111","Strain component per integration point in the global system");
+         ADD("EPSX121","Strain component per integration point in the global system");
+         ADD("EPSY121","Strain component per integration point in the global system");
+         ADD("EPSZ121","Strain component per integration point in the global system");
+         ADD("EPSXY121","Strain component per integration point in the global system");
+         ADD("EPSZX121","Strain component per integration point in the global system");
+         ADD("EPSYZ121","Strain component per integration point in the global system");
+         ADD("EPSX221","Strain component per integration point in the global system");
+         ADD("EPSY221","Strain component per integration point in the global system");
+         ADD("EPSZ221","Strain component per integration point in the global system");
+         ADD("EPSXY221","Strain component per integration point in the global system");
+         ADD("EPSZX221","Strain component per integration point in the global system");
+         ADD("EPSYZ221","Strain component per integration point in the global system");
+         ADD("VSTRAIN","Volumetric strain");
+      }
+    }
+
+    SIZE(idsmax);
+    ARRAY(idsmax, "Elements")
+    {
+        DATA(ids,"Element ID");
+        SCALAR(NAME_ARRAY,"Element Name")   { DIMENSION="DIMENSIONLESS"; }
+    }
+}
+
+// File format
+
+FORMAT(radioss2022)
+{
+
+    ASSIGN(IO_FLAG, 1, IMPORT);
+    ASSIGN(IO_FLAG, 2, EXPORT);
+    
+    if(IO_FLAG == 1 )
+    {
+        HEADER("/%-s/TRIA/%d",PREFIX_STR, _ID_);
+        if(PREFIX_STR=="TH")
+        {
+             ASSIGN(TH_OPTION,1, IMPORT);
+        }
+        else if(PREFIX_STR=="ATH")
+        {
+            ASSIGN(TH_OPTION, 2, IMPORT);
+        }
+        else if(PREFIX_STR=="BTH")
+        {
+            ASSIGN(TH_OPTION, 3, IMPORT);
+        }
+        else if(PREFIX_STR=="CTH")
+        {
+            ASSIGN(TH_OPTION, 4, IMPORT);
+        }
+        else if(PREFIX_STR=="DTH")
+        {
+            ASSIGN(TH_OPTION, 5, IMPORT);
+        }
+        else if(PREFIX_STR=="ETH")
+        {
+            ASSIGN(TH_OPTION, 6, IMPORT);
+        }
+         else if(PREFIX_STR=="FTH")
+        {
+            ASSIGN(TH_OPTION, 7, IMPORT);
+        }
+        else if(PREFIX_STR=="GTH")
+        {
+            ASSIGN(TH_OPTION, 8, IMPORT);
+        }
+        else if(PREFIX_STR=="HTH")
+        {
+            ASSIGN(TH_OPTION, 9, IMPORT);
+        }                
+        else if(PREFIX_STR=="ITH")
+        {
+            ASSIGN(TH_OPTION, 10, IMPORT);
+        }
+        
+    }
+    if(IO_FLAG == 2 )
+    {
+        if(TH_OPTION==0 || TH_OPTION == 1)
+        {
+            HEADER("/TH/TRIA/%d", _ID_); 
+        }
+        else if( TH_OPTION == 2)
+        {
+            HEADER("/ATH/TRIA/%d", _ID_); 
+        }
+        else if( TH_OPTION == 3)
+        {
+            HEADER("/BTH/TRIA/%d", _ID_); 
+        }
+        else if( TH_OPTION == 4)
+        {
+            HEADER("/CTH/TRIA/%d", _ID_); 
+        }
+        else if( TH_OPTION == 5)
+        {
+            HEADER("/DTH/TRIA/%d", _ID_); 
+        }
+        else if( TH_OPTION == 6)
+        {
+            HEADER("/ETH/TRIA/%d", _ID_); 
+        }
+        else if( TH_OPTION == 7)
+        {
+            HEADER("/FTH/TRIA/%d", _ID_); 
+        }
+        else if( TH_OPTION == 8)
+        {
+            HEADER("/GTH/TRIA/%d", _ID_); 
+        }
+        else if( TH_OPTION == 9)
+        {
+            HEADER("/HTH/TRIA/%d", _ID_); 
+        }
+        else if( TH_OPTION == 10)
+        {
+            HEADER("/ITH/TRIA/%d", _ID_); 
+        }
+    }
+    CARD("%-100s", TITLE);
+    // Card 1
+    COMMENT("#   var_ID    var_ID    var_ID    var_ID    var_ID    var_ID    var_ID    var_ID    var_ID    var_ID");
+    FREE_CELL_LIST(Number_Of_Variables,"%-10s", VAR, 100);
+
+    // Card 2
+    COMMENT("#  elem_ID          elem_name");
+    FREE_CARD_LIST(idsmax)
+    {
+        CARD("%10d%10s%-50s", ids, _BLANK_, NAME_ARRAY);
+    }
+}


### PR DESCRIPTION
#### VSTRAIN output for TRIA and ALE-multimaterial compatibility

#### Description of the changes
Volumetric strain output is now compatible with ALE-multimaterial law (hexa, quad, tria)
example : /H3D/ELEM/VSTRAIN/3 or /ANIM/ELEM/VSTRAIN/3 will output volumetric strain for submaterial 3