### PR TITLE
Correction of thermal options problem with adaptative meshing

### DIFF
--- a/engine/source/model/remesh/admdiv.F
+++ b/engine/source/model/remesh/admdiv.F
@@ -72,7 +72,7 @@ C-----------------------------------------------
      .        IPART(LIPART1,*),ITASK,ICONTACT(*),IPARG(NPARG,*),
      .        NODFT, NODLT, IGEO(NPROPGI,*), IPM(NPROPMI,*),
      .        SH4TREE(KSH4TREE,*), SH3TREE(KSH3TREE,*)
-      my_real ,INTENT(IN) :: ITHERM_FE
+      INTEGER ,INTENT(IN) :: ITHERM_FE
       my_real
      .        X(3,*),MS(*),IN(*),RCONTACT(*),
      .        PADMESH(KPADMESH,*), MSC(*), INC(*), 

--- a/engine/source/model/remesh/admfor0.F
+++ b/engine/source/model/remesh/admfor0.F
@@ -58,7 +58,7 @@ C-----------------------------------------------
       INTEGER IXC(NIXC,*), IPARTC(*), IXTG(NIXTG,*), IPARTTG(*),
      .        IPART(LIPART1,*), SH4TREE(KSH4TREE,*), SH3TREE(KSH3TREE,*)
       INTEGER ,INTENT(IN) :: NODADT_THERM
-      my_real ,INTENT(IN) :: ITHERM_FE
+      INTEGER ,INTENT(IN) :: ITHERM_FE
       my_real A(3,*), STIFN(*), AR(3,*), STIFR(*), X(3,*),
      .        STCONT(*), FTHE(*),CONDN(*)
 C-----------------------------------------------

--- a/engine/source/model/remesh/admregul.F
+++ b/engine/source/model/remesh/admregul.F
@@ -69,7 +69,7 @@ C-----------------------------------------------
      .        IPART(LIPART1,*),ITASK,IPARG(NPARG,*),
      .        NODFT, NODLT, IGEO(NPROPGI,*), IPM(NPROPMI,*),
      .        SH4TREE(KSH4TREE,*),SH3TREE(KSH3TREE,*)
-      my_real ,INTENT(IN) :: ITHERM_FE
+      integer ,INTENT(IN) :: ITHERM_FE
       my_real
      .        X(3,*),MS(*),IN(*),MSC(*), INC(*),
      .        MSTG(*), INTG(*), PTG(3,*), MSCND(*), INCND(*),

--- a/engine/source/model/remesh/admvit.F
+++ b/engine/source/model/remesh/admvit.F
@@ -64,9 +64,8 @@ C-----------------------------------------------
       INTEGER SH4FT, SH4LT, SH3FT, SH3LT
       INTEGER N, NN, LEVEL, IP, NLEV, LL, IERR
       INTEGER SON,M(4),MC,N1,N2,N3,N4,J,NA,NB
-      my_real ,INTENT(IN) :: ITHERM_FE
-      my_real
-     .        VV, USDT
+      integer ,INTENT(IN) :: ITHERM_FE
+      my_real :: VV, USDT
 C-----------------------------------------------
       USDT=ONE/DT12
 C


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Temperature distribution was wrong with adaptative mesh.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Corrected thermal flag declaration in arguments passed to remesh routines: they were declared as my_real instead of integer

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
