### PR TITLE
/EOS/COMPACTION2:Fscale default value is now consistent with unit system

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2025/MAT/mat_EOS.cfg
+++ b/hm_cfg_files/config/CFG/radioss2025/MAT/mat_EOS.cfg
@@ -381,7 +381,7 @@ GUI(COMMON) {
     {
         DATA(P_FUNC);
         SCALAR(XSCALE_P)        { DIMENSION="DIMENSIONLESS"; }
-        SCALAR(FSCALE_P)        { DIMENSION="DIMENSIONLESS"; }
+        SCALAR(FSCALE_P)        { DIMENSION="pressure"; }
         SCALAR(EOS_COM_Mue_min) { DIMENSION="DIMENSIONLESS"; }
         SCALAR(EOS_COM_Mue_max) { DIMENSION="DIMENSIONLESS"; }
         SCALAR(EOS_COM_BT)      { DIMENSION="pressure"; }

--- a/starter/source/materials/eos/hm_read_eos.F
+++ b/starter/source/materials/eos/hm_read_eos.F
@@ -260,7 +260,7 @@ c---
           CASE ('COMPACTION2')
             IEOS = 20
             CALL HM_READ_EOS_COMPACTION2(IOUT,PM(1,IMAT),UNITAB,LSUBMODEL,IMIDEOS,EOS_TAG,IEOS,NPROPM,MAXEOS,
-     .                                   MAT_PARAM(IMAT)%EOS )
+     .                                   MAT_PARAM(IMAT)%EOS, IUNIT )
 c---
           CASE DEFAULT
             IEOS = -1 


### PR DESCRIPTION
#### /EOS/COMPACTION2:Fscale default value is now consistent with unit system

#### Description of the changes
/EOS/COMPACTION2/[mat_ID]/**[eos_unit_ID]**
- The 'Fscale' parameter is the scale factor for the pressure function (user-defined function).
- It now has the correct dimension in the CFG file (_"pressure"_).
- Furthermore, when the default value is set to 1, this value must be converted to the working unit system (_eos_unit_ID -> working unit_).
