### PR TITLE
compilation error in GCC14 due to icompatible types in SP

### DIFF
--- a/engine/source/user_interface/eng_callback_c.c
+++ b/engine/source/user_interface/eng_callback_c.c
@@ -367,7 +367,7 @@ void u_vinter2__(int *jad,int *jpos,int *jlen,int *llt,my_real_c *xx,my_real_c *
 {u_vinter2_(jad,jpos,jlen,llt,xx,dydx,yy);}
 
 
-void u_vinter2dp_(int *jad,int *jpos,int *jlen,int *llt,my_real_c *xx,my_real_c *dydx,my_real_c *yy)
+void u_vinter2dp_(int *jad,int *jpos,int *jlen,int *llt,double *xx,double *dydx,double *yy)
 {
  double *tf;
  tf= (double*)sav_buf[6];
@@ -380,15 +380,15 @@ void u_vinter2dp_(int *jad,int *jpos,int *jlen,int *llt,my_real_c *xx,my_real_c 
 #endif
 }
 
-void u_vinter2dp(int *jad,int *jpos,int *jlen,int *llt,my_real_c *xx,my_real_c *dydx,my_real_c *yy)
+void u_vinter2dp(int *jad,int *jpos,int *jlen,int *llt,double *xx,double *dydx,double *yy)
 {u_vinter2dp_(jad,jpos,jlen,llt,xx,dydx,yy);}
 
 
-void _FCALL U_VINTER2DP(int *jad,int *jpos,int *jlen,int *llt,my_real_c *xx,my_real_c *dydx,my_real_c *yy)
+void _FCALL U_VINTER2DP(int *jad,int *jpos,int *jlen,int *llt,double *xx,double *dydx,double *yy)
 {u_vinter2dp_(jad,jpos,jlen,llt,xx,dydx,yy);}
 
 
-void u_vinter2dp__(int *jad,int *jpos,int *jlen,int *llt,my_real_c *xx,my_real_c *dydx,my_real_c *yy)
+void u_vinter2dp__(int *jad,int *jpos,int *jlen,int *llt,double *xx,double *dydx,double *yy)
 {u_vinter2dp_(jad,jpos,jlen,llt,xx,dydx,yy);}
 
 


### PR DESCRIPTION
This pull request includes changes to the `engine/source/user_interface/eng_callback_c.c` file to update the data type of several function parameters from `my_real_c` to `double`.

Data type updates:

* Updated the parameter types in the `u_vinter2dp_` function from `my_real_c` to `double`.
* Updated the parameter types in the `u_vinter2dp` function from `my_real_c` to `double`.
* Updated the parameter types in the `_FCALL U_VINTER2DP` function from `my_real_c` to `double`.
* Updated the parameter types in the `u_vinter2dp__` function from `my_real_c` to `double`.