### PR TITLE
/MAT/LAW11 : define adjacent temperature only if allocated

### DIFF
--- a/engine/source/materials/mat/mat011/m11law.F
+++ b/engine/source/materials/mat/mat011/m11law.F
@@ -145,7 +145,7 @@ C=======================================================================
         Vx0(I)    = Vx_1
         Vy0(I)    = Vy_1
         Vz0(I)    = Vz_1     
-        TV(I)     = ZERO
+        TV(I)     = T0      ! Consequently, if the adjacent material does not have an allocated temperature, it will retain its initial value.
       ENDDO
 
       DO I=1,NEL

--- a/engine/source/materials/mat/mat011/m11vs2.F
+++ b/engine/source/materials/mat/mat011/m11vs2.F
@@ -144,7 +144,9 @@ C-----------------------------------------------
               REV(I) = GBUF%RE(IS+1)
               VIS(I)=VIS(I)+PM(81,MV)*RKV(I)**2/REV(I)
             ENDIF
-            TV(I)  = GBUF%TEMP(IS+1)
+            IF (GBUF%G_TEMP > 0) THEN
+              TV(I) = GBUF%TEMP(IS+1)  ! The adjacent cell must have an allocated temperature; otherwise, TV is set to T0 as initialized.
+            END IF
             !MOMENTUM
             IF(ALEFVM_Param%IEnabled == 1)THEN          
               IS       = IVOI-MFT

--- a/engine/source/materials/mat/mat011/m11vs3.F
+++ b/engine/source/materials/mat/mat011/m11vs3.F
@@ -144,7 +144,9 @@ C-----------------------------------------------
               RKV(I) = GBUF%RK(IS+1)
               REV(I) = GBUF%RE(IS+1)
             ENDIF
-            TV(I) = GBUF%TEMP(IS+1)
+            IF (GBUF%G_TEMP > 0) THEN
+              TV(I) = GBUF%TEMP(IS+1)  ! The adjacent cell must have an allocated temperature; otherwise, TV is set to T0 as initialized.
+            END IF
             !MOMENTUM
             IF(ALEFVM_Param%IEnabled==1)THEN
             !USE INPUT VALUE, NOT THIS!


### PR DESCRIPTION
#### /MAT/LAW11 : defining adjacent temperatures only if allocated

#### Description of the changes
Adjacent temperature must be defined with boundary material law11 only if adjacent material law requires to allocate temperature.  (GBUF%TEMP( : ))