### PR TITLE
Add failure modes output for ORTHSTRAIN

### DIFF
--- a/engine/source/materials/fail/orthstrain/fail_orthstrain_c.F
+++ b/engine/source/materials/fail/orthstrain/fail_orthstrain_c.F
@@ -35,7 +35,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      3     TIME     ,TIMESTEP ,IPG      ,ILAY     ,IPT      ,   
      4     EPSXX    ,EPSYY    ,EPSXY    ,DMG_FLAG ,DMG_SCALE,
      5     EPSPXX   ,EPSPYY   ,EPSPXY   ,ALDT     ,ISMSTR   ,
-     6     SIGNXX   ,SIGNYY   ,SIGNXY   ,
+     6     SIGNXX   ,SIGNYY   ,SIGNXY   ,LF_DAMMX ,
      7     OFF      ,OFFLY    ,FOFF     ,DFMAX    ,TDEL     )
 C-----------------------------------------------
 C    Orthotropic strain failure model
@@ -85,6 +85,7 @@ C-----------------------------------------------
 C   I N P U T   A r g u m e n t s
 C-----------------------------------------------
       INTEGER ,INTENT(IN) :: NEL,NUPARAM,NUVAR,IPG,ILAY,IPT,ISMSTR
+      INTEGER ,INTENT(IN) :: LF_DAMMX
       INTEGER ,DIMENSION(NEL) ,INTENT(IN) :: NGL
       my_real ,INTENT(IN) :: TIME,TIMESTEP
       my_real ,DIMENSION(NEL) ,INTENT(IN) :: OFF,EPSXX,EPSYY,EPSXY,
@@ -96,7 +97,8 @@ C   I N P U T   O U T P U T   A r g u m e n t s
 C-----------------------------------------------
       INTEGER ,INTENT(OUT) :: DMG_FLAG
       INTEGER ,DIMENSION(NEL) ,INTENT(INOUT) :: OFFLY,FOFF
-      my_real ,DIMENSION(NEL) ,INTENT(INOUT) :: DFMAX,SIGNXX,SIGNYY,SIGNXY
+      my_real ,DIMENSION(NEL) ,INTENT(INOUT) :: SIGNXX,SIGNYY,SIGNXY
+      my_real ,DIMENSION(NEL,LF_DAMMX), INTENT(INOUT) :: DFMAX
       my_real ,DIMENSION(NEL) ,INTENT(OUT)   :: TDEL,DMG_SCALE
       my_real ,DIMENSION(NEL,NUVAR) ,INTENT(INOUT) :: UVAR
 C-----------------------------------------------
@@ -119,7 +121,7 @@ C-----------------------------------------------
       INTEGER I,J,NINDX,FAILI,MODE,XX,XY,YY,IFUNC_SIZ,STRDEF,STRFLAG
       INTEGER ,DIMENSION(NEL)   :: INDX,IPOSP,IADP,ILENP
       INTEGER ,DIMENSION(NEL,6) :: FMODE
-      my_real DAM(NEL,6),ODAM(NEL,6),EPSP(NEL,6),
+      my_real ODAM(NEL,6),EPSP(NEL,6),
      .  SIGOXX(NEL),SIGOYY(NEL),SIGOXY(NEL),ESCAL(NEL),DYDXE(NEL)
       my_real DYDX,FRATE,ET1,ET2,ET12,EC1,EC2,EC12,ET3,EC3,EC23,ET23,EC31,
      .  ET31,ET1M,ET2M,ET12M,EC1M,EC2M,EC12M,ET3M,EC3M,EC23M,ET23M,EC31M,
@@ -232,18 +234,18 @@ c
       END SELECT 
 c----------------------------------------------
 c     Element size scale factor
-      FSIZE => UVAR(1:NEL,32)
+      FSIZE => UVAR(1:NEL,13)
 c
       IF (FSIZE(1)==ZERO) THEN
         IF (IFUNC_SIZ > 0) THEN
-                  ESCAL(1:NEL) = ALDT(1:NEL) / REF_SIZ
+          ESCAL(1:NEL) = ALDT(1:NEL) / REF_SIZ
           IPOSP(1:NEL) = 0
           IADP (1:NEL) = NPF(IFUNC_SIZ) / 2 + 1
           ILENP(1:NEL) = NPF(IFUNC_SIZ  + 1) / 2 - IADP(1:NEL)
           CALL VINTER2(TF,IADP,IPOSP,ILENP,NEL,ESCAL,DYDXE,FSIZE)
           FSIZE(1:NEL) = FSCALE_SIZ * FSIZE(1:NEL)
         ELSE
-                  FSIZE(1:NEL) = ONE
+          FSIZE(1:NEL) = ONE
         ENDIF
       ENDIF
 c
@@ -253,15 +255,14 @@ c
 c     variable initialisation, current time
       DO  J=1 ,6
         DO I=1, NEL
-          DAM(I,J)  = UVAR(I,J)
-          ODAM(I,J) = MIN(DAM(I,J),ONE-EM3)
-          EPSP(I,J) = UVAR(I,J+6)
+          ODAM(I,J) = MIN(DFMAX(I,1+J),ONE-EM3)
+          EPSP(I,J) = UVAR(I,J)
         ENDDO
       ENDDO  
       DO I =1, NEL 
-       SIGOXX(I) = UVAR(I,12+XX)
-       SIGOYY(I) = UVAR(I,12+YY)
-       SIGOXY(I) = UVAR(I,12+XY)
+        SIGOXX(I) = UVAR(I,6+XX)
+        SIGOYY(I) = UVAR(I,6+YY)
+        SIGOXY(I) = UVAR(I,6+XY)
       ENDDO
 c      
 c     strain rate filtering
@@ -275,7 +276,7 @@ c     failure and damage calculation in each mode (dir)
 c
       NINDX = 0  
       DO I=1, NEL
-        IF (OFF(I) == ONE .and. OFFLY(I) == 1 .and. FOFF(I) == 1) THEN
+        IF (OFF(I) == ONE .AND. OFFLY(I) == 1 .AND. FOFF(I) == 1) THEN
           ET1    = UPARAM(4)
           ET1M   = UPARAM(5)
           ET2    = UPARAM(6)
@@ -311,19 +312,19 @@ c
           ELSE
             FRATE = ONE
           ENDIF
-                FRATE = FRATE*FSIZE(I)
+          FRATE = FRATE*FSIZE(I)
           ET1M = FRATE * ET1M
           ET1  = FRATE * ET1
           DEPS = EPS11(I) - ET1 
-          IF (DEPS > ZERO .and. DAM(I,MODE) < ONE) THEN
+          IF (DEPS > ZERO .AND. DFMAX(I,1+MODE) < ONE) THEN
             DEPSM = ET1M - ET1
             FACT  = ET1M / EPS11(I)
             DI    = FACT * DEPS / DEPSM 
-            DAM(I,MODE) = MAX(DAM(I,MODE), DI)
-            IF (DAM(I,MODE) >= ONE) THEN
+            DFMAX(I,1+MODE) = MAX(DFMAX(I,1+MODE), DI)
+            IF (DFMAX(I,1+MODE) >= ONE) THEN
               FAILI = 1
               FMODE(I,MODE) = 1
-              DAM(I,MODE) = ONE
+              DFMAX(I,1+MODE) = ONE
               EPSM1(I) = ET1M
             ENDIF
           ENDIF
@@ -335,19 +336,19 @@ c
           ELSE
             FRATE = ONE
           ENDIF
-                  FRATE = FRATE*FSIZE(I)
+          FRATE = FRATE*FSIZE(I)
           ET2M = FRATE * ET2M
           ET2  = FRATE * ET2
           DEPS = MAX(EPS22(I) - ET2, ZERO)
-          IF (DEPS > ZERO .and. DAM(I,MODE) < ONE) THEN
+          IF (DEPS > ZERO .AND. DFMAX(I,1+MODE) < ONE) THEN
             DEPSM = (ET2M - ET2)
             FACT  = ET2M / EPS22(I)
             DI    = FACT * DEPS / DEPSM 
-            DAM(I,MODE) = MAX(DAM(I,MODE), DI)
-            IF (DAM(I,MODE) >= ONE) THEN
+            DFMAX(I,1+MODE) = MAX(DFMAX(I,1+MODE), DI)
+            IF (DFMAX(I,1+MODE) >= ONE) THEN
               FAILI = 1
               FMODE(I,MODE) = 1
-              DAM(I,MODE) = ONE
+              DFMAX(I,1+MODE) = ONE
               EPSM2(I) = ET2M
             ENDIF
           ENDIF
@@ -359,19 +360,19 @@ c
           ELSE
             FRATE = ONE
           ENDIF
-                  FRATE = FRATE*FSIZE(I)
+          FRATE = FRATE*FSIZE(I)
           ET12M = FRATE * ET12M
           ET12  = FRATE * ET12
           DEPS  = MAX(EPS12(I) - ET12, ZERO)
-          IF (DEPS > ZERO .and. DAM(I,MODE) < ONE) THEN
+          IF (DEPS > ZERO .AND. DFMAX(I,1+MODE) < ONE) THEN
             DEPSM = (ET12M - ET12)
             FACT  = ET12M / EPS12(I)
             DI    = FACT * DEPS / DEPSM
-            DAM(I,MODE) = MAX(DAM(I,MODE), DI)
-            IF (DAM(I,MODE) >= ONE) THEN
+            DFMAX(I,1+MODE) = MAX(DFMAX(I,1+MODE), DI)
+            IF (DFMAX(I,1+MODE) >= ONE) THEN
               FAILI = 1
               FMODE(I,MODE) = 1
-              DAM(I,MODE) = ONE
+              DFMAX(I,1+MODE) = ONE
               EPSM3(I) = ET12M
             ENDIF
           ENDIF
@@ -383,19 +384,19 @@ c
           ELSE
             FRATE = ONE
           ENDIF
-                  FRATE = FRATE*FSIZE(I)
+          FRATE = FRATE*FSIZE(I)
           EC1M = FRATE * EC1M
           EC1  = FRATE * EC1
           DEPS = -EPS11(I) - EC1
-          IF (DEPS > ZERO .and. DAM(I,MODE) < ONE) THEN
+          IF (DEPS > ZERO .AND. DFMAX(I,1+MODE) < ONE) THEN
             DEPSM = (EC1M - EC1)
             FACT = EC1M / ABS(EPS11(I))
             DI = FACT * DEPS / DEPSM
-            DAM(I,MODE) = MAX(DAM(I,MODE), DI)
-            IF (DAM(I,MODE) >= ONE) THEN
+            DFMAX(I,1+MODE) = MAX(DFMAX(I,1+MODE), DI)
+            IF (DFMAX(I,1+MODE) >= ONE) THEN
               FAILI = 1
               FMODE(I,MODE) = 1
-              DAM(I,MODE) = ONE
+              DFMAX(I,1+MODE) = ONE
               EPSM4(I) = -EC1M
             ENDIF
           ENDIF
@@ -407,19 +408,19 @@ c
           ELSE
             FRATE = ONE
           ENDIF
-                  FRATE = FRATE*FSIZE(I)
+          FRATE = FRATE*FSIZE(I)
           EC2M = FRATE * EC2M
           EC2  = FRATE * EC2
           DEPS = MAX(-EPS22(I) - EC2, ZERO)
-          IF (DEPS > ZERO .and. DAM(I,MODE) < ONE) THEN
+          IF (DEPS > ZERO .AND. DFMAX(I,1+MODE) < ONE) THEN
             DEPSM = (EC2M - EC2)
             FACT  = EC2M / ABS(EPS22(I))
             DI = FACT * DEPS / DEPSM
-            DAM(I,MODE) = MAX(DAM(I,MODE), DI)
-            IF (DAM(I,MODE) >= ONE) THEN
+            DFMAX(I,1+MODE) = MAX(DFMAX(I,1+MODE), DI)
+            IF (DFMAX(I,1+MODE) >= ONE) THEN
               FAILI = 1
               FMODE(I,MODE) = 1
-              DAM(I,MODE) = ONE
+              DFMAX(I,1+MODE) = ONE
               EPSM5(I) = -EC2M
             ENDIF
           ENDIF
@@ -431,19 +432,19 @@ c
           ELSE
             FRATE = ONE
           ENDIF
-                  FRATE = FRATE*FSIZE(I)
+          FRATE = FRATE*FSIZE(I)
           EC12M = FRATE * EC12M
           EC12  = FRATE * EC12
           DEPS  = MAX(-EPS12(I) - EC12, ZERO)
-          IF (DEPS > ZERO .and. DAM(I,MODE) < ONE) THEN
+          IF (DEPS > ZERO .AND. DFMAX(I,1+MODE) < ONE) THEN
             DEPSM = (EC12M - EC12)
             FACT  = EC12M / ABS(EPS12(I))
             DI = FACT * DEPS / DEPSM
-            DAM(I,MODE) = MAX(DAM(I,MODE), DI)
-            IF (DAM(I,MODE) >= ONE) THEN
+            DFMAX(I,1+MODE) = MAX(DFMAX(I,1+MODE), DI)
+            IF (DFMAX(I,1+MODE) >= ONE) THEN
               FAILI = 1
               FMODE(I,MODE) = 1
-              DAM(I,MODE) = ONE
+              DFMAX(I,1+MODE) = ONE
               EPSM6(I) = -EC12M
             ENDIF
           ENDIF
@@ -461,7 +462,6 @@ c------------------------
         DO J=1,NINDX    
           I = INDX(J)
 #include  "lockon.inc"
-          
           WRITE(IOUT, 1000) NGL(I),IPG,ILAY,IPT
           WRITE(ISTDO,1000) NGL(I),IPG,ILAY,IPT
           IF (FMODE(I,1)==1) WRITE(IOUT, 2000) '1 - TRACTION XX',EPS11(I),EPSM1(I),EPSP(I,XX)
@@ -479,24 +479,24 @@ c     damage / direction is equal to the max of damages par mode in the same dir
 c-----------------------------------------------------------------------
       IF (DMG_FLAG == 1) THEN   ! scalar damage applied to nodal force contribution
         DO I=1, NEL
-          DAMXX  = MAX(DAM(I,1),DAM(I,4))
-          DAMYY  = MAX(DAM(I,2),DAM(I,5))
-          DAMXY  = MAX(DAM(I,3),DAM(I,6))
-          DFMAX(I) = MAX(DFMAX(I), DAMXX)
-          DFMAX(I) = MAX(DFMAX(I), DAMYY)
-          DFMAX(I) = MAX(DFMAX(I), DAMXY)
-          DFMAX(I) = MIN(ONE,DFMAX(I))
-          DMG_SCALE(I) = ONE - DFMAX(I)
+          DAMXX  = MAX(DFMAX(I,2),DFMAX(I,5))
+          DAMYY  = MAX(DFMAX(I,3),DFMAX(I,6))
+          DAMXY  = MAX(DFMAX(I,4),DFMAX(I,7))
+          DFMAX(I,1) = MAX(DFMAX(I,1), DAMXX)
+          DFMAX(I,1) = MAX(DFMAX(I,1), DAMYY)
+          DFMAX(I,1) = MAX(DFMAX(I,1), DAMXY)
+          DFMAX(I,1) = MIN(ONE,DFMAX(I,1))
+          DMG_SCALE(I) = ONE - DFMAX(I,1)
         ENDDO
       ELSE                      ! directional damage applied to stress
         DO I=1, NEL
-          DAMXX  = MAX(DAM(I,1),DAM(I,4))
-          DAMYY  = MAX(DAM(I,2),DAM(I,5))
-          DAMXY  = MAX(DAM(I,3),DAM(I,6))
-          DFMAX(I) = MAX(DFMAX(I), DAMXX)
-          DFMAX(I) = MAX(DFMAX(I), DAMYY)
-          DFMAX(I) = MAX(DFMAX(I), DAMXY)
-          DFMAX(I) = MIN(ONE,DFMAX(I))
+          DAMXX  = MAX(DFMAX(I,2),DFMAX(I,5))
+          DAMYY  = MAX(DFMAX(I,3),DFMAX(I,6))
+          DAMXY  = MAX(DFMAX(I,4),DFMAX(I,7))
+          DFMAX(I,1) = MAX(DFMAX(I,1), DAMXX)
+          DFMAX(I,1) = MAX(DFMAX(I,1), DAMYY)
+          DFMAX(I,1) = MAX(DFMAX(I,1), DAMXY)
+          DFMAX(I,1) = MIN(ONE,DFMAX(I,1))
           ODAMXX = MAX(ODAM(I,1),ODAM(I,4))
           ODAMYY = MAX(ODAM(I,2),ODAM(I,5))
           ODAMXY = MAX(ODAM(I,3),ODAM(I,6))
@@ -508,16 +508,15 @@ c         Damaged stress
           SIGNXX(I) = SIGNXX(I)* (ONE-DAMXX)
           SIGNYY(I) = SIGNYY(I)* (ONE-DAMYY)
           SIGNXY(I) = SIGNXY(I)* (ONE-DAMXY)
-          UVAR(I,13) = SIGNXX(I)
-          UVAR(I,14) = SIGNYY(I)
-          UVAR(I,15) = SIGNXY(I)
+          UVAR(I,7) = SIGNXX(I)
+          UVAR(I,8) = SIGNYY(I)
+          UVAR(I,9) = SIGNXY(I)
         ENDDO
       ENDIF
 c     Update state variables
       DO  J=1 ,6
         DO I=1, NEL
-          UVAR(I,J)   = DAM(I,J)
-          UVAR(I,J+6) = EPSP(I,J)
+          UVAR(I,J) = EPSP(I,J)
         ENDDO
       ENDDO  
 c-----------------------------------------------------------------------

--- a/engine/source/materials/fail/orthstrain/fail_orthstrain_s.F
+++ b/engine/source/materials/fail/orthstrain/fail_orthstrain_s.F
@@ -38,7 +38,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      4        EPSXX    ,EPSYY  ,EPSZZ  ,EPSXY   ,EPSYZ  ,EPSZX    ,
      5        SIGNXX   ,SIGNYY ,SIGNZZ ,SIGNXY  ,SIGNYZ ,SIGNZX   ,
      6        UVAR     ,OFF    ,IPT    ,NGL     ,DFMAX  ,TDEL     ,
-     7        UELR     ,NPT    ,DELTAX )
+     7        UELR     ,NPT    ,DELTAX ,LF_DAMMX)
 C-----------------------------------------------
 c    Orthotropic strain failure model
 C-----------------------------------------------
@@ -81,7 +81,7 @@ C OFF     | NEL     | F |R/W| DELETED ELEMENT FLAG (=1. ON, =0. OFF)
 C---------+---------+---+---+--------------------------------------------
 C   I N P U T   A r g u m e n t s
 C--------------------------------------------
-      INTEGER :: NEL,NUPARAM,NUVAR,IPT,NPT,ISMSTR
+      INTEGER :: NEL,NUPARAM,NUVAR,IPT,NPT,ISMSTR,LF_DAMMX
       INTEGER ,DIMENSION(NEL) :: NGL
       my_real :: TIME,TIMESTEP
       my_real ,DIMENSION(NUPARAM) :: UPARAM
@@ -92,7 +92,8 @@ C--------------------------------------------
 C-----------------------------------------------
 C   I N P U T   O U T P U T   A r g u m e n t s 
 C-----------------------------------------------
-      my_real UVAR(NEL,NUVAR),OFF(NEL),DFMAX(NEL),TDEL(NEL)
+      my_real UVAR(NEL,NUVAR),OFF(NEL),TDEL(NEL)
+      my_real, DIMENSION(NEL,LF_DAMMX), INTENT(INOUT) :: DFMAX
 C-----------------------------------------------
 C   VARIABLES FOR FUNCTION INTERPOLATION 
 C-----------------------------------------------
@@ -114,7 +115,7 @@ C-----------------------------------------------
      .    M11T, M11C,M22T,M22C,M33T,M33C,M12T,M12C,M23T,M23C,M31T,M31C
       INTEGER ,DIMENSION(NEL)    :: INDX,IPOSP,IADP,ILENP
       INTEGER ,DIMENSION(NEL,12) :: FMODE
-      my_real  DAM(NEL,12),ODAM(NEL,12),EPSP(NEL,6),SIGO(NEL,6),FSIZE(NEL),
+      my_real  ODAM(NEL,12),EPSP(NEL,6),SIGO(NEL,6),FSIZE(NEL),
      .   ESCAL(NEL),DYDX(NEL)
       my_real ,DIMENSION(NEL)  :: EPS11,EPS22,EPS33,EPS12,EPS23,EPS31,
      .     EPSP11,EPSP22,EPSP33,EPSP12,EPSP23,EPSP31,
@@ -361,16 +362,16 @@ c
 c------------------------------
 c     Element size scale factor
       IF (IFUNC_SIZ > 0) THEN
-        IF (UVAR(1,32)==ZERO) THEN 
+        IF (UVAR(1,13)==ZERO) THEN 
           ESCAL(1:NEL) = DELTAX(1:NEL) / REF_SIZ
           IPOSP(1:NEL) = 0
           IADP (1:NEL) = NPF(IFUNC_SIZ) / 2 + 1
           ILENP(1:NEL) = NPF(IFUNC_SIZ  + 1) / 2 - IADP(1:NEL) - IPOSP(1:NEL)
           CALL VINTER2(TF,IADP,IPOSP,ILENP,NEL,ESCAL,DYDX,FSIZE)
           FSIZE(1:NEL) = FSCALE_SIZ * FSIZE(1:NEL)
-          UVAR(1:NEL,32) = FSIZE(1:NEL)
+          UVAR(1:NEL,13) = FSIZE(1:NEL)
         ELSE
-          FSIZE(1:NEL) = UVAR(1:NEL,32)
+          FSIZE(1:NEL) = UVAR(1:NEL,13)
         ENDIF
       ELSE
         FSIZE(1:NEL) = ONE
@@ -399,8 +400,7 @@ c     current variable initialisation
       DO I=1, NEL
         IF (OFF(I) == ONE) THEN 
           DO J=1 ,12
-            DAM(I,J)  = UVAR(I,J+12)
-            ODAM(I,J) = MIN(DAM(I,J),ONE-EM3)
+            ODAM(I,J) = MIN(DFMAX(I,J+1),ONE-EM3)
           ENDDO
           DO J=1 ,6
             SIGO(I,J) = UVAR(I,J)
@@ -475,15 +475,15 @@ c
           ET1M = FRATE * ET1M
           ET1  = FRATE * ET1
           DEPS = MAX(EPS11(I) - ET1, ZERO)
-          IF (DEPS > ZERO .and. DAM(I,MODE) < ONE) THEN
+          IF (DEPS > ZERO .AND. DFMAX(I,1+MODE) < ONE) THEN
             DEPSM = (ET1M - ET1)
             FACT  = ET1M / MAX(EPS11(I),EM20)
             DI = FACT*DEPS/MAX(DEPSM,EM20)
-            DAM(I,MODE) = MAX(DAM(I,MODE), DI)
-            IF (DAM(I,MODE) >= ONE) THEN
+            DFMAX(I,1+MODE) = MAX(DFMAX(I,1+MODE), DI)
+            IF (DFMAX(I,1+MODE) >= ONE) THEN
               FAILI = 1
               FMODE(I,MODE) = 1
-              DAM(I,MODE) = ONE
+              DFMAX(I,1+MODE) = ONE
               EPSM1(I) = ET1M
             ENDIF
           ENDIF
@@ -501,15 +501,15 @@ c
           ET2M = FRATE * ET2M
           ET2  = FRATE * ET2
           DEPS = MAX(EPS22(I) - ET2, ZERO)
-          IF (DEPS > ZERO .and. DAM(I,MODE) < ONE) THEN
+          IF (DEPS > ZERO .AND. DFMAX(I,1+MODE) < ONE) THEN
             DEPSM = (ET2M - ET2)
             FACT  = ET2M / MAX(EPS22(I),EM20)
             DI    = FACT * DEPS / MAX(DEPSM,EM20) 
-            DAM(I,MODE) = MAX(DAM(I,MODE), DI)
-            IF (DAM(I,MODE) >= ONE) THEN
+            DFMAX(I,1+MODE) = MAX(DFMAX(I,1+MODE), DI)
+            IF (DFMAX(I,1+MODE) >= ONE) THEN
               FAILI = 1
               FMODE(I,MODE) = 1
-              DAM(I,MODE) = ONE
+              DFMAX(I,1+MODE) = ONE
               EPSM2(I) = ET2M
             ENDIF
           ENDIF
@@ -527,15 +527,15 @@ c
           ET12M = FRATE * ET12M
           ET12  = FRATE * ET12
           DEPS  = MAX(EPS12(I) - ET12, ZERO)
-          IF (DEPS > ZERO .and. DAM(I,MODE) < ONE) THEN
+          IF (DEPS > ZERO .AND. DFMAX(I,1+MODE) < ONE) THEN
             DEPSM = (ET12M - ET12)
             FACT  = ET12M / MAX(EPS12(I),EM20)
             DI    = FACT * DEPS / MAX(DEPSM,EM20)
-            DAM(I,MODE) = MAX(DAM(I,MODE), DI)
-            IF (DAM(I,MODE) >= ONE) THEN
+            DFMAX(I,1+MODE) = MAX(DFMAX(I,1+MODE), DI)
+            IF (DFMAX(I,1+MODE) >= ONE) THEN
               FAILI = 1
               FMODE(I,MODE) = 1
-              DAM(I,MODE) = ONE
+              DFMAX(I,1+MODE) = ONE
               EPSM3(I) = ET12M
             ENDIF
           ENDIF
@@ -553,15 +553,15 @@ c
           EC1M = FRATE * EC1M
           EC1  = FRATE * EC1
           DEPS = MAX(-EPS11(I) - EC1, ZERO)
-          IF (DEPS > ZERO .and. DAM(I,MODE) < ONE) THEN
+          IF (DEPS > ZERO .AND. DFMAX(I,1+MODE) < ONE) THEN
             DEPSM = (EC1M - EC1)
             FACT = EC1M / MAX(ABS(EPS11(I)),EM20)
             DI = FACT * DEPS / MAX(DEPSM,EM20)
-            DAM(I,MODE) = MAX(DAM(I,MODE), DI)
-            IF (DAM(I,MODE) >= ONE) THEN
+            DFMAX(I,1+MODE) = MAX(DFMAX(I,1+MODE), DI)
+            IF (DFMAX(I,1+MODE) >= ONE) THEN
               FAILI = 1
               FMODE(I,MODE) = 1
-              DAM(I,MODE) = ONE
+              DFMAX(I,1+MODE) = ONE
               EPSM4(I) = -EC1M
             ENDIF
           ENDIF
@@ -579,15 +579,15 @@ c
           EC2M = FRATE * EC2M
           EC2  = FRATE * EC2
           DEPS = MAX(-EPS22(I) - EC2, ZERO)
-          IF (DEPS > ZERO .and. DAM(I,MODE) < ONE) THEN
+          IF (DEPS > ZERO .AND. DFMAX(I,1+MODE) < ONE) THEN
             DEPSM = (EC2M - EC2)
             FACT  = EC2M / MAX(ABS(EPS22(I)),EM20)
             DI = FACT * DEPS / MAX(DEPSM,EM20)
-            DAM(I,MODE) = MAX(DAM(I,MODE), DI)
-            IF (DAM(I,MODE) >= ONE) THEN
+            DFMAX(I,1+MODE) = MAX(DFMAX(I,1+MODE), DI)
+            IF (DFMAX(I,1+MODE) >= ONE) THEN
               FAILI = 1
               FMODE(I,MODE) = 1
-              DAM(I,MODE) = ONE
+              DFMAX(I,1+MODE) = ONE
               EPSM5(I) = -EC2M
             ENDIF
           ENDIF
@@ -605,15 +605,15 @@ c
           EC12M = FRATE * EC12M
           EC12  = FRATE * EC12
           DEPS  = MAX(-EPS12(I) - EC12, ZERO)
-          IF (DEPS > ZERO .and. DAM(I,MODE) < ONE) THEN
+          IF (DEPS > ZERO .AND. DFMAX(I,1+MODE) < ONE) THEN
             DEPSM = (EC12M - EC12)
             FACT  = EC12M / MAX(ABS(EPS12(I)),EM20)
             DI = FACT * DEPS / MAX(DEPSM,EM20)
-            DAM(I,MODE) = MAX(DAM(I,MODE), DI)
-            IF (DAM(I,MODE) >= ONE) THEN
+            DFMAX(I,1+MODE) = MAX(DFMAX(I,1+MODE), DI)
+            IF (DFMAX(I,1+MODE) >= ONE) THEN
               FAILI = 1
               FMODE(I,MODE) = 1
-              DAM(I,MODE) = ONE
+              DFMAX(I,1+MODE) = ONE
               EPSM6(I) = -EC12M
             ENDIF
           ENDIF
@@ -631,15 +631,15 @@ c
           ET3M = FRATE * ET3M
           ET3  = FRATE * ET3
           DEPS = MAX(EPS33(I) - ET3, ZERO)
-          IF (DEPS > ZERO .and. DAM(I,MODE) < ONE) THEN
+          IF (DEPS > ZERO .AND. DFMAX(I,1+MODE) < ONE) THEN
             DEPSM = (ET3M - ET3)
             FACT = ET3M / MAX(EPS33(I),EM20)
             DI = FACT * DEPS / MAX(DEPSM,EM20)
-            DAM(I,MODE) = MAX(DAM(I,MODE), DI)
-            IF (DAM(I,MODE) >= ONE) THEN
+            DFMAX(I,1+MODE) = MAX(DFMAX(I,1+MODE), DI)
+            IF (DFMAX(I,1+MODE) >= ONE) THEN
               FAILI = 1
               FMODE(I,MODE) = 1
-              DAM(I,MODE) = ONE
+              DFMAX(I,1+MODE) = ONE
               EPSM7(I) = ET3M
             ENDIF
           ENDIF
@@ -657,15 +657,15 @@ c
           EC3M = FRATE * EC3M
           EC3  = FRATE * EC3
           DEPS = MAX(-EPS33(I) - EC3, ZERO)
-          IF (DEPS > ZERO .and. DAM(I,MODE) < ONE) THEN
+          IF (DEPS > ZERO .AND. DFMAX(I,1+MODE) < ONE) THEN
             DEPSM = (EC3M - EC3)
             FACT = EC3M / MAX(ABS(EPS33(I)),EM20)
             DI = FACT * DEPS / MAX(DEPSM,EM20)
-            DAM(I,MODE) = MAX(DAM(I,MODE), DI)
-            IF (DAM(I,MODE) >= ONE) THEN
+            DFMAX(I,1+MODE) = MAX(DFMAX(I,1+MODE), DI)
+            IF (DFMAX(I,1+MODE) >= ONE) THEN
               FAILI = 1
               FMODE(I,MODE) = 1
-              DAM(I,MODE) = ONE
+              DFMAX(I,1+MODE) = ONE
               EPSM8(I) = -EC3M
             ENDIF
           ENDIF
@@ -683,15 +683,15 @@ c
           ET23M = FRATE * ET23M
           ET23  = FRATE * ET23
           DEPS  = MAX(EPS23(I) - ET23, ZERO)
-          IF (DEPS > ZERO .and. DAM(I,MODE) < ONE) THEN
+          IF (DEPS > ZERO .AND. DFMAX(I,1+MODE) < ONE) THEN
             DEPSM = (ET23M - ET23)
             FACT = ET23M / MAX(EPS23(I),EM20)
             DI = FACT * DEPS / MAX(DEPSM,EM20)
-            DAM(I,MODE) = MAX(DAM(I,MODE), DI)
-            IF (DAM(I,MODE) >= ONE) THEN
+            DFMAX(I,1+MODE) = MAX(DFMAX(I,1+MODE), DI)
+            IF (DFMAX(I,1+MODE) >= ONE) THEN
               FAILI = 1
               FMODE(I,MODE) = 1
-              DAM(I,MODE) = ONE
+              DFMAX(I,1+MODE) = ONE
               EPSM9(I) = ET23M
             ENDIF
           ENDIF
@@ -709,15 +709,15 @@ c
           EC23M = FRATE * EC23M
           EC23  = FRATE * EC23
           DEPS  = MAX(-EPS23(I) - EC23, ZERO)
-          IF (DEPS > ZERO .and. DAM(I,MODE) < ONE) THEN
+          IF (DEPS > ZERO .AND. DFMAX(I,1+MODE) < ONE) THEN
             DEPSM = (EC23M - EC23)
             FACT  = EC23M / MAX(ABS(EPS23(I)),EM20)
             DI = FACT * DEPS / MAX(DEPSM,EM20)
-            DAM(I,MODE) = MAX(DAM(I,MODE), DI)
-            IF (DAM(I,MODE) >= ONE) THEN
+            DFMAX(I,1+MODE) = MAX(DFMAX(I,1+MODE), DI)
+            IF (DFMAX(I,1+MODE) >= ONE) THEN
               FAILI = 1
               FMODE(I,MODE) = 1
-              DAM(I,MODE) = ONE
+              DFMAX(I,1+MODE) = ONE
               EPSM10(I) = -EC23M
             ENDIF
           ENDIF
@@ -735,15 +735,15 @@ c
           ET31M = FRATE * ET31M
           ET31  = FRATE * ET31
           DEPS  = MAX(EPS31(I) - ET31, ZERO)
-          IF (DEPS > ZERO .and. DAM(I,MODE) < ONE) THEN
+          IF (DEPS > ZERO .AND. DFMAX(I,1+MODE) < ONE) THEN
             DEPSM = (ET31M - ET31)
             FACT  = ET31M / MAX(EPS31(I),EM20)
             DI = FACT * DEPS / MAX(DEPSM,EM20)
-            DAM(I,MODE) = MAX(DAM(I,MODE), DI)
-            IF (DAM(I,MODE) >= ONE) THEN
+            DFMAX(I,1+MODE) = MAX(DFMAX(I,1+MODE), DI)
+            IF (DFMAX(I,1+MODE) >= ONE) THEN
               FAILI = 1
               FMODE(I,MODE) = 1
-              DAM(I,MODE) = ONE
+              DFMAX(I,1+MODE) = ONE
               EPSM11(I) = ET31M
             ENDIF
           ENDIF
@@ -761,15 +761,15 @@ c
           EC31M = FRATE * EC31M
           EC31  = FRATE * EC31
           DEPS  = MAX(-EPS31(I) - EC31, ZERO)
-          IF (DEPS > ZERO .and. DAM(I,MODE) < ONE) THEN
+          IF (DEPS > ZERO .AND. DFMAX(I,1+MODE) < ONE) THEN
             DEPSM = (EC31M - EC31)
             FACT  = EC31M / MAX(ABS(EPS31(I)),EM20)
             DI = FACT * DEPS / MAX(DEPSM,EM20)
-            DAM(I,MODE) = MAX(DAM(I,MODE), DI)
-            IF (DAM(I,MODE) >= ONE) THEN
+            DFMAX(I,1+MODE) = MAX(DFMAX(I,1+MODE), DI)
+            IF (DFMAX(I,1+MODE) >= ONE) THEN
               FAILI = 1
               FMODE(I,MODE) = 1
-              DAM(I,MODE) = ONE
+              DFMAX(I,1+MODE) = ONE
               EPSM12(I) = -EC31M
             ENDIF
           ENDIF
@@ -793,25 +793,25 @@ c------------------------
       DO I=1, NEL
         IF (OFF(I) == ONE) THEN 
 c damage / direction is equal to the max of damages par mode in the same direction
-          DAMXX  = MAX(DAM(I,1),DAM(I,4))
-          DAMYY  = MAX(DAM(I,2),DAM(I,5))
-          DAMZZ  = MAX(DAM(I,7),DAM(I,8))
-          DAMXY  = MAX(DAM(I,3),DAM(I,6))
-          DAMYZ  = MAX(DAM(I,9),DAM(I,10))
-          DAMZX  = MAX(DAM(I,11),DAM(I,12))
+          DAMXX  = MAX(DFMAX(I,2) ,DFMAX(I,5) )
+          DAMYY  = MAX(DFMAX(I,3) ,DFMAX(I,6) )
+          DAMZZ  = MAX(DFMAX(I,8) ,DFMAX(I,9) )
+          DAMXY  = MAX(DFMAX(I,4) ,DFMAX(I,7) )
+          DAMYZ  = MAX(DFMAX(I,10),DFMAX(I,11))
+          DAMZX  = MAX(DFMAX(I,12),DFMAX(I,13))
 c
-          ODAMXX = MAX(ODAM(I,1),ODAM(I,4))
-          ODAMYY = MAX(ODAM(I,2),ODAM(I,5))
-          ODAMZZ = MAX(ODAM(I,7),ODAM(I,8))
-          ODAMXY = MAX(ODAM(I,3),ODAM(I,6))
-          ODAMYZ = MAX(ODAM(I,9),ODAM(I,10))
+          ODAMXX = MAX(ODAM(I,1) ,ODAM(I,4) )
+          ODAMYY = MAX(ODAM(I,2) ,ODAM(I,5) )
+          ODAMZZ = MAX(ODAM(I,7) ,ODAM(I,8) )
+          ODAMXY = MAX(ODAM(I,3) ,ODAM(I,6) )
+          ODAMYZ = MAX(ODAM(I,9) ,ODAM(I,10))
           ODAMZX = MAX(ODAM(I,11),ODAM(I,12))
 c
-          DFMAX(I) = MAX(DAMXX,DAMYY)
-          DFMAX(I) = MAX(DAMZZ,DFMAX(I))
-          DFMAX(I) = MAX(DAMXY,DFMAX(I))
-          DFMAX(I) = MAX(DAMYZ,DFMAX(I))
-          DFMAX(I) = MAX(DAMZX,DFMAX(I))
+          DFMAX(I,1) = MAX(DAMXX,DAMYY)
+          DFMAX(I,1) = MAX(DAMZZ,DFMAX(I,1))
+          DFMAX(I,1) = MAX(DAMXY,DFMAX(I,1))
+          DFMAX(I,1) = MAX(DAMYZ,DFMAX(I,1))
+          DFMAX(I,1) = MAX(DAMZX,DFMAX(I,1))
 c Undamaged sign estimate
           SIGNXX(I) = SIGO(I,XX)/MAX(ONE-ODAMXX,EM20) + (SIGNXX(I) - SIGO(I,XX))
           SIGNYY(I) = SIGO(I,YY)/MAX(ONE-ODAMYY,EM20) + (SIGNYY(I) - SIGO(I,YY))
@@ -840,9 +840,6 @@ c     Update UVAR
 c------------------------
       DO I=1, NEL
         IF (OFF(I) == ONE) THEN 
-          DO  J=1,12
-            UVAR(I,J+12) = DAM(I,J)
-          ENDDO 
           DO  J=1,6
             UVAR(I,J+6)  = EPSP(I,J)
           ENDDO

--- a/engine/source/materials/mat_share/mmain.F90
+++ b/engine/source/materials/mat_share/mmain.F90
@@ -2415,7 +2415,7 @@
                 &es1      ,es2      ,es3      ,es4      ,es5      ,es6     ,&
                 &ss1      ,ss2      ,ss3      ,ss4      ,ss5      ,ss6     ,&
                 &uvarf    ,off      ,ipg      ,ngl      ,dfmax    ,tdel    ,&
-                &gbuf%uelr,npg      ,deltax   )
+                &gbuf%uelr,npg      ,deltax   ,lf_dammx )
               elseif (irupt == 27) then
 ! ---   extended mohr coulomb failure model
                 call fail_emc(&

--- a/engine/source/materials/mat_share/mulaw.F90
+++ b/engine/source/materials/mat_share/mulaw.F90
@@ -2312,7 +2312,7 @@
                 &es1      ,es2      ,es3      ,es4      ,es5      ,es6      ,&
                 &s1       ,s2       ,s3       ,s4       ,s5       ,s6       ,&
                 &uvarf    ,off      ,ipg      ,ngl      ,dfmax    ,tdel     ,&
-                &gbuf%uelr,npg      ,deltax   )
+                &gbuf%uelr,npg      ,deltax   ,lf_dammx )
               elseif (irupt == 27) then
 ! ---   extended mohr coulomb failure model
                 call fail_emc(&

--- a/engine/source/materials/mat_share/mulawc.F90
+++ b/engine/source/materials/mat_share/mulawc.F90
@@ -2243,7 +2243,7 @@
                     &tt        ,dt1       ,ipg       ,ilayer    ,it        ,&
                     &epsxx     ,epsyy     ,epsxy     ,dmg_flag  ,dmg_loc_scale ,&
                     &epspxx    ,epspyy    ,epspxy    ,aldt      ,ismstr    ,&
-                    &signxx    ,signyy    ,signxy    ,&
+                    &signxx    ,signyy    ,signxy    ,lf_dammx  ,&
                     &off       ,offly     ,foff      ,dfmax     ,tdel      )
 !
                    case (25)     !    nxt failure

--- a/engine/source/materials/mat_share/usermat_shell.F
+++ b/engine/source/materials/mat_share/usermat_shell.F
@@ -1565,7 +1565,7 @@ c
      3              TT        ,DT1       ,IPG       ,ILAYER    ,IT        , 
      4              EPSXX     ,EPSYY     ,EPSXY     ,DMG_FLAG  ,DMG_LOC_SCALE ,
      5              EPSPXX    ,EPSPYY    ,EPSPXY    ,ALDT      ,ISMSTR    ,
-     6              SIGNXX    ,SIGNYY    ,SIGNXY    ,   
+     6              SIGNXX    ,SIGNYY    ,SIGNXY    ,LF_DAMMX  ,   
      7              OFF       ,OFFLY     ,FOFF      ,DFMAX     ,TDEL      )
 c
               CASE (25)     !    NXT Failure

--- a/engine/source/materials/mat_share/usermat_solid.F
+++ b/engine/source/materials/mat_share/usermat_solid.F
@@ -1344,7 +1344,7 @@ c   --- Orthotropic strain failure
      4        ES1      ,ES2      ,ES3      ,ES4      ,ES5      ,ES6     ,
      5        S1       ,S2       ,S3       ,S4       ,S5       ,S6      ,
      6        UVARF    ,OFF      ,IPG      ,NGL      ,DFMAX    ,TDEL    ,
-     7        GBUF%UELR,NPG      ,DELTAX   )
+     7        GBUF%UELR,NPG      ,DELTAX   ,LF_DAMMX )
           ELSEIF (IRUPT == 27) THEN                                      
 c ---   extended mohr coulomb failure model                                             
               CALL FAIL_EMC(

--- a/starter/source/materials/fail/hm_read_fail.F
+++ b/starter/source/materials/fail/hm_read_fail.F
@@ -411,7 +411,8 @@ c
             ELSEIF (KEY(1:10) == 'ORTHSTRAIN') THEN
               IRUPT = 24 
               CALL HM_READ_FAIL_ORTHSTRAIN(MAT_PARAM(IMAT)%FAIL(IFL),
-     .             MAT_ID   ,IRUPT    ,LSUBMODEL,UNITAB   )
+     .             FAIL_ID   ,IRUPT    ,LSUBMODEL,UNITAB   ,   
+     .             FAIL_TAG(IRUPT))
 c     
             ELSEIF (KEY(1:3) == 'NXT') THEN
               IRUPT = 25   

--- a/starter/source/materials/fail/orthstrain/hm_read_fail_orthstrain.F
+++ b/starter/source/materials/fail/orthstrain/hm_read_fail_orthstrain.F
@@ -34,7 +34,8 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    submodel_mod              ../starter/share/modules1/submodel_mod.F
       !||====================================================================
        SUBROUTINE HM_READ_FAIL_ORTHSTRAIN(
-     .            FAIL     ,FAIL_ID  ,IRUPT    ,LSUBMODEL,UNITAB   )
+     .            FAIL     ,FAIL_ID  ,IRUPT    ,LSUBMODEL,UNITAB   ,
+     .            FAIL_TAG )
 C-----------------------------------------------
 c    ROUTINE DESCRIPTION :
 c    Read orthotropic strain  failure model parameters
@@ -45,6 +46,7 @@ C-----------------------------------------------
       USE UNITAB_MOD
       USE SUBMODEL_MOD
       USE HM_OPTION_READ_MOD
+      USE ELBUFTAG_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -61,6 +63,7 @@ C-----------------------------------------------
       TYPE(UNIT_TYPE_)   ,INTENT(IN) :: UNITAB        ! table of input units
       TYPE(SUBMODEL_DATA),INTENT(IN) :: LSUBMODEL(*)  ! submodel table
       TYPE(FAIL_PARAM_)  ,INTENT(INOUT) :: FAIL       ! failure model data structure
+      TYPE(FAIL_TAG_)    ,INTENT(INOUT) :: FAIL_TAG   ! failure model data structure
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -187,17 +190,33 @@ c-----------------------------------------------------
       FAIL%FAIL_ID = FAIL_ID 
       FAIL%NUPARAM = 28
       FAIL%NIPARAM = 0
-      FAIL%NUVAR   = 32
+      FAIL%NUVAR   = 13
       FAIL%NFUNC   = NFUNC
       FAIL%NTABLE  = 0
-      FAIL%NMOD    = 0
+      FAIL%NMOD    = 12
       FAIL%PTHK    = PTHKF
 c            
       ALLOCATE (FAIL%UPARAM(FAIL%NUPARAM))
       ALLOCATE (FAIL%IPARAM(FAIL%NIPARAM))
       ALLOCATE (FAIL%IFUNC (FAIL%NFUNC))
       ALLOCATE (FAIL%TABLE (FAIL%NTABLE))
-      
+      ALLOCATE (FAIL%MODE  (FAIL%NMOD))
+c
+      ! Modes of failure
+      FAIL_TAG%LF_DAMMX = FAIL_TAG%LF_DAMMX + FAIL%NMOD
+      FAIL%MODE(1)  = "Failure traction XX"
+      FAIL%MODE(2)  = "Failure traction YY"
+      FAIL%MODE(3)  = "Failure positive shear XY"
+      FAIL%MODE(4)  = "Failure compression XX"
+      FAIL%MODE(5)  = "Failure compression YY"
+      FAIL%MODE(6)  = "Failure negative shear XY"
+      FAIL%MODE(7)  = "Failure traction ZZ"
+      FAIL%MODE(8)  = "Failure compression ZZ"
+      FAIL%MODE(9)  = "Failure positive shear YZ"
+      FAIL%MODE(10) = "Failure negative shear YZ"
+      FAIL%MODE(11) = "Failure positive shear ZX"
+      FAIL%MODE(12) = "Failure negative shear ZX"
+c
       FAIL%IFUNC(1:NFUNC) = IFUNC(1:NFUNC)
 c
       FAIL%UPARAM(1)  = IDAM    


### PR DESCRIPTION
Change modes name

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

There is a need to get a precise post processing of /FAIL/ORHTSTRAIN failure (per orthotropic direction). 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Add failure modes into new matparam data structure for /FAIL/ORTHSTRAIN and compute them into the engine. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
