### PR TITLE
correction of impuse value derivation for section

### DIFF
--- a/tools/th_to_csv/src/th_to_csv.c
+++ b/tools/th_to_csv/src/th_to_csv.c
@@ -1277,7 +1277,7 @@ void csvFileWrite(char* csvFilename,char* titleFilename,int *nbglobVar,int *nbPa
                 outpuType != 6) ||
                 ((strcmp(buffer,"F1        ")==0 || strcmp(buffer,"F2        ")==0 || strcmp(buffer,"F3        ")==0 ||
                     strcmp(buffer,"M1        ")==0 || strcmp(buffer,"M2        ")==0 || strcmp(buffer,"M3        ")==0 ) &&
-                outpuType == 102) )
+                outpuType == 104) )
             {
                 isImpulse[i]=1;
             }


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
F1/F2/F3 M1/M2/M3 are not valid for outpuType=102 ( RBODY) but, it is for sectionx (outpuType = 104)
No need to add MX/MY/MZ ,, it is already well handle

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
