### PR TITLE
COMPACTION EOS : unload modulus check

### DIFF
--- a/starter/source/materials/eos/hm_read_eos.F
+++ b/starter/source/materials/eos/hm_read_eos.F
@@ -60,7 +60,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       SUBROUTINE HM_READ_EOS(
      .           MAT_PARAM   ,IPM      ,PM       ,BUFMAT   ,
      .           BUFLEN      ,IADBUF   ,EOS_TAG  ,UNITAB   ,LSUBMODEL,
-     .           MLAW_TAG    )
+     .           MLAW_TAG    ,NPC      ,TF       ,SNPC     ,NPTS     ,SBUFMAT)
 C-----------------------------------------------
 C   A n a l y s e   M o d u l e
 C-----------------------------------------------
@@ -89,9 +89,13 @@ C-----------------------------------------------
       TYPE(MLAW_TAG_) , DIMENSION(NUMMAT),INTENT(INOUT) :: MLAW_TAG
       TYPE (UNIT_TYPE_),INTENT(IN) ::UNITAB 
       INTEGER  :: BUFLEN,IADBUF
+      INTEGER,INTENT(IN) :: SBUFMAT
       INTEGER ,DIMENSION(NPROPMI,NUMMAT) ,INTENT(INOUT) :: IPM
+      INTEGER,INTENT(IN) :: SNPC, NPTS
+      INTEGER,INTENT(IN) :: NPC(SNPC)
+      my_real,INTENT(IN) :: TF(NPTS)
       my_real ,DIMENSION(NPROPM ,NUMMAT) ,INTENT(INOUT) :: PM
-      my_real ,DIMENSION(*)              ,INTENT(INOUT) :: BUFMAT
+      my_real ,DIMENSION(SBUFMAT),INTENT(INOUT) :: BUFMAT
       TYPE(MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(INOUT) :: MAT_PARAM
       TYPE(EOS_TAG_),DIMENSION(0:MAXEOS) ,INTENT(INOUT) :: EOS_TAG
       TYPE(SUBMODEL_DATA) ,DIMENSION(NSUBMOD)  ,INTENT(IN)    :: LSUBMODEL
@@ -128,7 +132,7 @@ c     Routine reading EOS models :
       !  17       !     TABULATED          ! 2022.2
       !  18       !     LINEAR             ! 2019.0
       !  19       !     EXPONENTIAL        ! 2024.1
-      !  20       !     COMPACTION2        !
+      !  20       !     COMPACTION2        ! 2025.1
       !------------------------------------!                      
 c======================================================================-       
 c     COUNT EOS MODELS USING CFG FILES
@@ -260,7 +264,7 @@ c---
           CASE ('COMPACTION2')
             IEOS = 20
             CALL HM_READ_EOS_COMPACTION2(IOUT,PM(1,IMAT),UNITAB,LSUBMODEL,IMIDEOS,EOS_TAG,IEOS,NPROPM,MAXEOS,
-     .                                   MAT_PARAM(IMAT)%EOS, IUNIT )
+     .                                   MAT_PARAM(IMAT)%EOS, IUNIT, NFUNCT, NPC, TF ,SNPC , NPTS)
 c---
           CASE DEFAULT
             IEOS = -1 

--- a/starter/source/materials/eos/hm_read_eos_compaction.F90
+++ b/starter/source/materials/eos/hm_read_eos_compaction.F90
@@ -83,7 +83,9 @@
       my_real  p0, e0, psh, rho0,rhoi,rhor
       my_real  c0,c1,c2,c3,bunl,mu,mumin,mumax
       my_real  mu0,ssp0,df, g0, bulk,bulk2, bb, pold, mu2, muold, alpha,dpdmu
+      my_real dpdmu_mumax
       integer iform, ioutp
+      integer :: jfunc !< loop
       logical :: is_encrypted, is_available, is_available_rho0
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Body
@@ -132,10 +134,25 @@
         iform=2 !default
         ioutp=0
       endif
-      
+
       mu = rho0/rhor-one
       p0 = c0+min(c1*mu,c1*mu+c2*mu*mu+c3*mu*mu*mu)
       e0 = zero
+
+      !check unload modulus regarding C1
+      if(Bunl < C1)then
+        call ancmsg(MSGID=67,MSGTYPE=msgerror,ANMODE=aninfo,I1=imideos, &
+        C1='/EOS/COMPACTION',C2='BUNL MUST BEGREATER THAN C1')
+      end if
+
+      !check unload modulus regarding point of maximum compaction
+      if(mumax > zero .and. mumax < 1000.)then
+        dpdmu_mumax = c1 + two*c2*mumax + three*c3*mumax**2
+        if(Bunl < dpdmu_mumax)  then
+          call ancmsg(MSGID=67,MSGTYPE=msgerror,ANMODE=aninfo,I1=imideos, &
+          C1='/EOS/COMPACTION',C2='BUNL MUST BEGREATER THAN DERIVATIVE OF P(MU) AT MUMAX')
+        end if
+      end if
 
       pm(49) = c0
       pm(32) = c1

--- a/starter/source/materials/read_material_models.F
+++ b/starter/source/materials/read_material_models.F
@@ -173,7 +173,8 @@ c     /EOS : Equations of State P=P(µ,E)
 c-------------------------------------------------------------------
       CALL HM_READ_EOS(MAT_ELEM%MAT_PARAM ,IPM      ,PM       ,BUFMAT   ,
      .                 BUFLEN   ,IADBUF   ,EOS_TAG  ,UNITAB   ,LSUBMODEL,
-     .                 MLAW_TAG )
+     .                 MLAW_TAG ,NPC      ,TF       ,SNPC     ,NPTS     ,
+     .                 SBUFMAT)
 
 c-------------------------------------------------------------------
 c     /FAIL : Failure Models


### PR DESCRIPTION
#### COMPACTION EOS : unload modulus check

#### Description of the changes
The compaction EoS (/EOS/COMPACTION & /EOS/COMPACTION2) enable modeling of unloading using user-defined parameter(s) (slope). This value is compared with the provided function. The unloading modulus must be greater than the slope of the curve; otherwise, the mathematical model lacks physical validity.
When situation is not exected an error message is now displayed . Here is an example of such messages :

> ERROR ID :     67
** ERROR IN EOS DEFINITION
DESCRIPTION :  
   -- EOS ID        : 1
   -- EOS TYPE      : /EOS/COMPACTION2
   BMIN MUST BEGREATER THAN DERIVATIVE OF P(MU) AT 0.0

> ERROR ID :     67
** ERROR IN EOS DEFINITION
DESCRIPTION :  
   -- EOS ID        : 1
   -- EOS TYPE      : /EOS/COMPACTION2
   BMAX MUST BEGREATER THAN DERIVATIVE OF P(MU) AT MUMAX

These new Starter checks are helping user to built a well defined EoS.

![image](https://github.com/user-attachments/assets/7a12ca78-7a1b-49ec-afec-2cd352a67d32)

