### PR TITLE
Fix typos in common_source

### DIFF
--- a/common_source/eos/compaction.F90
+++ b/common_source/eos/compaction.F90
@@ -48,7 +48,7 @@
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------

--- a/common_source/eos/compaction2.F90
+++ b/common_source/eos/compaction2.F90
@@ -41,7 +41,7 @@
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------

--- a/common_source/eos/eosexponential.F90
+++ b/common_source/eos/eosexponential.F90
@@ -37,7 +37,7 @@ module eosexponential_mod
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------

--- a/common_source/eos/eoslinear.F
+++ b/common_source/eos/eoslinear.F
@@ -41,7 +41,7 @@ C-----------------------------------------------
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------

--- a/common_source/eos/eospolyno.F
+++ b/common_source/eos/eospolyno.F
@@ -47,7 +47,7 @@ C-----------------------------------------------
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------

--- a/common_source/eos/gruneisen.F
+++ b/common_source/eos/gruneisen.F
@@ -42,7 +42,7 @@ C-----------------------------------------------
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------

--- a/common_source/eos/idealgas.F
+++ b/common_source/eos/idealgas.F
@@ -47,7 +47,7 @@ C of IDEAL GAS EOS
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------

--- a/common_source/eos/idealgas_vt.F
+++ b/common_source/eos/idealgas_vt.F
@@ -47,7 +47,7 @@ C of IDEAL GAS EOS with variable Cp(T) parameter
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------

--- a/common_source/eos/jwl.F
+++ b/common_source/eos/jwl.F
@@ -44,7 +44,7 @@ C of JWL EOS
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------

--- a/common_source/eos/lszk.F
+++ b/common_source/eos/lszk.F
@@ -48,7 +48,7 @@ C Landau Stanyukovich Zeldovich Kompaneet
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------

--- a/common_source/eos/murnaghan.F
+++ b/common_source/eos/murnaghan.F
@@ -47,7 +47,7 @@ C of MURNAGHAN EOS
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------

--- a/common_source/eos/nasg.F
+++ b/common_source/eos/nasg.F
@@ -49,7 +49,7 @@ C 2nd order integration in time
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------

--- a/common_source/eos/noble_abel.F
+++ b/common_source/eos/noble_abel.F
@@ -43,7 +43,7 @@ C of NOBLE-ABEL EOS
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------

--- a/common_source/eos/osborne.F
+++ b/common_source/eos/osborne.F
@@ -47,7 +47,7 @@ C of OSBORNE EOS
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------

--- a/common_source/eos/powder_burn.F
+++ b/common_source/eos/powder_burn.F
@@ -51,7 +51,7 @@ C This is a template to introduce numerical solving of Deflagration EoS (experim
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------

--- a/common_source/eos/puff.F
+++ b/common_source/eos/puff.F
@@ -45,7 +45,7 @@ C of PUFF EOS
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------

--- a/common_source/eos/sesame.F
+++ b/common_source/eos/sesame.F
@@ -47,7 +47,7 @@ C of SESAME EOS
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------C-----------------------------------------------

--- a/common_source/eos/stiffgas.F
+++ b/common_source/eos/stiffgas.F
@@ -48,7 +48,7 @@ C of STIFFENED-GAS EOS
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------

--- a/common_source/eos/tabulated.F
+++ b/common_source/eos/tabulated.F
@@ -50,7 +50,7 @@ C
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------

--- a/common_source/eos/tillotson.F
+++ b/common_source/eos/tillotson.F
@@ -42,7 +42,7 @@ C-----------------------------------------------
 !! \details     MEINT              : INTERNAL ENERGY INTEGRATION FOR E[n+1] : FIRST PART USING P[n], Q[n], and Q[n+1] CONTRIBUTIONS
 !! \details     EOSMAIN / IFLG = 1 : UPDATE P[n+1], T[N+1]
 !! \details                          INTERNAL ENERGY INTEGRATION FOR E[n+1] : LAST PART USING P[n+1] CONTRIBUTION
-!! \details                            (second order integeration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
+!! \details                            (second order integration dE = -P.dV where P = 0.5(P[n+1] + P[n]) )
 !! \details  COLLOCATED SCHEME
 !! \details     EOSMAIN / IFLG = 2 : SINGLE PASS FOR P[n+1] AND DERIVATIVES
 !----------------------------------------------------------------------------

--- a/common_source/modules/interfaces/cut-cell-buffer_mod.F
+++ b/common_source/modules/interfaces/cut-cell-buffer_mod.F
@@ -101,7 +101,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
         INTEGER                              :: Num      
         INTEGER                              :: NumSecndNodes        
         INTEGER                              :: FM(24)                  !Main face common face
-        INTEGER                              :: FV(24)                  !Secnd corresponding face        
+        INTEGER                              :: FV(24)                  !Secnd corresponding face
         INTEGER                              :: IV(24)                  !brick id which contains secnd cell
         INTEGER                              :: IBV(24)                 !cut cell address in cut cell buffer
         INTEGER                              :: ICELLv(24)              !secnd cell id
@@ -199,13 +199,13 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
         INTEGER                              :: ITASK
         INTEGER                              :: SECID_Cell(8)           !cut local id in [1,8] -> [1,52] = sec type. Each possible cut is numbered from 1 to 52 ; 8 nodes => 8 possible cut cells
         INTEGER                              :: Seg_add_LFT             !EL FIRST : first lagrangian face in CAND_E
-        INTEGER                              :: Seg_add_LLT             !EL LAST  : last lagrangian face in CAND_E        
+        INTEGER                              :: Seg_add_LLT             !EL LAST  : last lagrangian face in CAND_E
         INTEGER                              :: Adjacent_Brick(6,5)     !index2: 1:IV, 2:NGV, 3:IDLOCV, 4:IBV, 5:IFV
         INTEGER                              :: MergeTarget(3,5)        !index1 (1)=Face (2)=MCELL, (3)=IB
         INTEGER                              :: NTarget                 !number of merged location
-        INTEGER                              :: ClosedSurf(6)           !tells if brick face has a double cut (only for multiple cut, in this case cell 9 has no adjacent celle, only for contact forces to get pressure differential)
+        INTEGER                              :: ClosedSurf(6)           !tells if brick face has a double cut (only for multiple cut, in this case cell 9 has no adjacent cells, only for contact forces to get pressure differential)
         INTEGER                              :: IsMergeTarget
-        my_real                              :: N(6,3)                  !unitary normal vector on each 6 faces        
+        my_real                              :: N(6,3)                  !unitary normal vector on each 6 faces
         my_real                              :: Vnew_SCell              !SuperCell volume (if exists)
         my_real                              :: Vold_SCell              !volume main (if exists)    : need for epsdot in sigeps51, merge/demerge, link switching , srho3   
         my_real                              :: SCellCenter(3)          !SuperCell centroid

--- a/common_source/modules/mat_elem/elbufdef_mod.F90
+++ b/common_source/modules/mat_elem/elbufdef_mod.F90
@@ -1070,8 +1070,8 @@
 !--------------------------------------------------------------------------------
 !     buffer for damping frequency range
       Type buf_damp_range_
-        my_real, dimension(:), pointer :: alpha ! alpha paramter of maxwell damping components
-        my_real, dimension(:), pointer :: tau   ! tau paramter of maxwell damping components
+        my_real, dimension(:), pointer :: alpha ! alpha parameter of maxwell damping components
+        my_real, dimension(:), pointer :: tau   ! tau parameter of maxwell damping components
       end type buf_damp_range_
 !-------------------------------------------------------------------------------
 
@@ -1297,7 +1297,7 @@
         type (buf_nloc_)  , dimension(:,:) , pointer :: nloc   ! non-local thickness specific structure for shells
         type (buf_nlocts_), dimension(:,:) , pointer :: nlocts ! non-local thickness specific structure for thickshells
         type (buf_nlocs_)                            :: nlocs  ! non-local structure of brick element geometry configuration
-        type (buf_damp_range_)                       :: damp_range  ! strucutre for damping parameters of dampinf freq range
+        type (buf_damp_range_)                       :: damp_range  ! structure for damping parameters of damping freq range
 
       end type elbuf_struct_
 !

--- a/common_source/qa/qa_out_mod.F
+++ b/common_source/qa/qa_out_mod.F
@@ -717,7 +717,7 @@ C         Remove leading blank if any
 
 ! ----------------------------------------------------------------------
 !>    @purpose 
-!>    Check if a given value is the predefined array fo available qakeys
+!>    Check if a given value is the predefined array of available qakeys
 !>    Useful to check if a qakey is allowed/available
 !>    Return true or false (false = program must exit with an error)
 !>    @ingroup utl_qa 

--- a/common_source/tools/set_operation/set_graph.cpp
+++ b/common_source/tools/set_operation/set_graph.cpp
@@ -47,13 +47,13 @@ class set_graph
 
     void recur_graph(int set_id,int * dependancy_list,int current_tree,int * check)
     //  ---------------------------------------------------------------------------------
-    //  recur_graph  recursive function goes through the tree & builds dependancy array  int * check)
+    //  recur_graph  recursive function goes through the tree & builds dependency array  int * check)
     //  ---------------------------------------------------------------------------------
     //  INPUT
     //   set_id          : current set ID
-    //  dependancy_list : dependancy list to build 
-    //   current_tree    : "Root" Set to inspect need for circular dependancy check
-    //   check           : check value, if negative - gets the SET ID which has circular dependancy
+    //  dependancy_list : dependency list to build 
+    //   current_tree    : "Root" Set to inspect need for circular dependency check
+    //   check           : check value, if negative - gets the SET ID which has circular dependency
     //  OUTPUT
     //   ----------------------------------------------------------------------------
     {
@@ -64,7 +64,7 @@ class set_graph
       if (edge -> color > 0) return;                                          // Current set appears already in list
 
       if (edge->closed_tree_check == current_tree) {                         
-        // cout << "error infinite dependancy in SET found" << endl;          // if check fails this SET has been visited twice for Same Root SET.
+        // cout << "error infinite dependency in SET found" << endl;          // if check fails this SET has been visited twice for Same Root SET.
         *check = -current_tree;                                               // Do not continue
         return;
       }
@@ -80,7 +80,7 @@ class set_graph
       }
 
 
-      if (  edge->color == 0){                                                // If leave store it in dependancy list
+      if (  edge->color == 0){                                                // If leave store it in dependency list
             edge->color =edge->id;
             dependancy_list[depend_stack] = edge -> id;
             // cout << "Stack " <<  edge -> id << endl;
@@ -128,8 +128,8 @@ class set_graph
     //  when a SET depends from another SET : ensure Child SET is before.
     //  ---------------------------------------------------------------------------------
     //  INPUT
-    //   dependancy_list : dependancy list to build 
-    //   check           : check value, if negative - gets the SET ID which has circular dependancy
+    //   dependancy_list : dependency list to build 
+    //   check           : check value, if negative - gets the SET ID which has circular dependency
     //  OUTPUT
     //   ----------------------------------------------------------------------------
     {
@@ -258,7 +258,7 @@ set_graph my_set_graph;
 
  my_set_graph.print();
  cout << endl;
- cout << endl <<  "  dependancy computation " << endl  ;
+ cout << endl <<  "  dependency computation " << endl  ;
  cout <<          " ------------------------" << endl << endl ;
 
  int slist=6;


### PR DESCRIPTION
#### Description of the feature or the bug
Fixes typos in common_source/   
Note: some trailing whitespace was trimmed as well.


#### Description of the changes
Found via `codespell -q 3 -S "./.git,./extlib" -L activ,addresse,adress,adresse,adresses,agrv,alph,als,ans,bloc,bord,branche,bu,candidat,candidats,childs,classe,clos,commun,connectes,connec,connecte,contrl,crach,crypted,daa,datas,defaut,detecte,determinee,differents,divde,dum,eddge,filles,fils,fixe,flagg,fonction,fonctions,fourty,fpr,fpt,fram,frequence,globaly,groupe,groupes,hashin,idel,imform,incluse,indx,initiales,inout,interm,invers,iself,ist,itens,ivalid,iverse,lamda,lamdas,lengt,limite,marge,mater,mot,mouvement,nam,nax,nd,nin,ninty,nodel,normale,normales,parametres,parm,penality,pinter,pointeur,polygone,pres,probleme,propt,renforce,reste,rige,rin,prset,remplace,rotat,runn,sav,secnd,secnds,serie,shft,shs,sirect,siz,som,somme,sprin,substract,tabl,tage,te,thck,thet,topologie,transfert,treshold,trian,ue,unitl,varn,verifie,versio,zeroin`