### PR TITLE
Change checksum routine algorithm for input error detection in /TABLE/1

### DIFF
--- a/common_source/tools/sort/myqsort_d.F90
+++ b/common_source/tools/sort/myqsort_d.F90
@@ -1,0 +1,222 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 1986-2025 Altair Engineering Inc.
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Altair Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+!Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+!Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+! ----------------------------------------------------------------------------------------------------------------------
+      module myqsort_d_mod
+      
+      contains
+!
+      !||====================================================================
+      !||    myqsort_d                           ../common_source/tools/sort/myqsort_d.F
+      !||--- called by ------------------------------------------------------
+      !||====================================================================
+
+      subroutine myqsort_d(n, a, perm, error)
+!-----------------------------------------------
+!!< brief      q u i c k s o r t algorithm using double precision input vector
+!< sedgewick algorithm from "implementing quicksort programs"
+!<     a: data
+!<     n: len
+!<     perm: permutations
+!-----------------------------------------------
+!   i m p l i c i t   t y p e s
+!-----------------------------------------------
+       implicit none
+!-----------------------------------------------
+!   d u m m y   a r g u m e n t s
+!-----------------------------------------------
+      integer n,error,perm(n)
+      double precision a(n)
+!-----------------------------------------------
+!   l o c a l   v a r i a b l e s
+!-----------------------------------------------
+      integer :: stacklen
+      integer :: treshold
+      integer :: done
+! the max stacklen <= 1 + 2 x log2 (n+1)/(treshold + 2)
+      parameter( stacklen = 128 , treshold   =  9 )
+!
+      integer :: i 
+      integer :: iplus1
+      integer :: j
+      integer :: jminus1
+      integer :: k 
+      integer :: left
+      integer :: llen
+      integer :: right 
+      integer :: rlen
+      integer :: top  
+      integer :: stack(stacklen)
+      double precision :: rk, rv
+!===============================================================================
+      error = 0
+!
+      if  (n < 1)  then
+        error = -1
+        return
+      endif
+
+      if  (n == 1)  then
+         perm(1)=1
+         return
+      endif
+
+      do  i = 1, n
+         perm(i) = i
+      enddo
+!
+      top = 1
+      left = 1
+      right = n
+      if (n <= treshold) then
+        done = 1
+      else
+        done = 0
+      endif
+
+!     quicksort                                                              
+!
+       do while (done /= 1)
+         rk = a((left+right)/2)
+         a((left+right)/2) = a(left)
+         a(left) = rk
+!
+         k = perm((left+right)/2)
+         perm((left+right)/2) = perm(left)
+         perm(left) = k
+
+         if( a(left+1) > a(right) ) then
+           rk = a(left+1)
+           a(left+1) = a(right)
+           a(right) = rk
+           k = perm(left+1)
+           perm(left+1) = perm(right)
+           perm(right) = k
+         endif
+         if( a(left) > a(right) ) then
+           rk = a(left)
+           a(left) = a(right)
+           a(right) = rk
+           k = perm(left)
+           perm(left) = perm(right)
+           perm(right) = k
+         endif
+         if( a(left+1) >  a(left) ) then
+           rk = a(left+1)
+           a(left+1) = a(left)
+           a(left) = rk
+           k = perm(left+1)
+           perm(left+1) = perm(left)
+           perm(left) = k
+         endif
+
+         rv = a(left)
+         i = left+1
+         j = right
+
+         do while(j >= i)
+           i  = i + 1
+           do while(a(i) <  rv) 
+             i = i +1
+           enddo
+           j = j - 1
+           do while(a(j) > rv)
+             j = j - 1  
+           enddo
+           if (j >= i) then 
+             rk = a(i)
+             a(i) = a(j)
+             a(j) = rk
+             k = perm(i)
+             perm(i) = perm(j)
+             perm(j) = k
+           endif
+         enddo
+!
+         rk = a(left)
+         a(left) = a(j)
+         a(j) = rk
+!
+         k = perm(left)
+         perm(left) = perm(j)
+         perm(j) = k
+!
+         llen = j-left
+         rlen = right - i + 1
+
+         if(max(llen, rlen) <= treshold ) then
+             if  (top == 1) then
+               done = 1
+             else
+               top = top - 2
+               left = stack(top)
+               right = stack(top+1)
+             endif
+         else if(min(llen, rlen) <=  treshold) then 
+             if( llen > rlen ) then 
+               right = j - 1
+             else
+               left = i
+             endif
+         else
+           if( llen > rlen ) then 
+              stack(top) = left
+              stack(top+1) = j-1
+              left = i
+            else
+              stack(top) = i
+              stack(top+1) = right
+              right = j-1
+            endif
+            top = top + 2
+         endif
+       end do
+!
+!     insertion sort 
+!
+      i = n - 1
+      iplus1 = n
+      do while (i > 0) 
+        if( a(i) > a(iplus1) ) then 
+          rk = a(i)
+          k  = perm(i)
+          j = iplus1
+          jminus1 = i
+          do while(a(j) <  rk)
+            a(jminus1) = a(j) 
+            perm(jminus1) = perm(j)
+            jminus1 = j
+            j = j + 1
+            if  ( j > n )  exit
+          enddo
+          a(jminus1) = rk
+          perm(jminus1) = k
+        endif
+!
+        iplus1 = i
+        i = i - 1
+      enddo
+!-----------
+      return
+      end subroutine
+
+      end module myqsort_d_mod

--- a/starter/source/tools/curve/hm_read_table2_1.F
+++ b/starter/source/tools/curve/hm_read_table2_1.F
@@ -50,6 +50,7 @@ C-----------------------------------------------
       USE UNITAB_MOD
       USE NAMES_AND_TITLES_MOD , ONLY : NCHARTITLE, NCHARFIELD
       use simple_checksum_mod
+      use myqsort_d_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -78,16 +79,16 @@ C-----------------------------------------------
       integer :: i1,i2,countx
       integer :: ierror,errorstop
       integer :: nx1,nx2,nx3,nx4,ny
-      integer :: h1,h2
-      integer :: chksum
       integer :: NX(4),NOK(4)
       my_real :: X0,X1,X2,X3,YY,Y1,Y2,R,XMIN,XMAX,SCALEY
       my_real :: X234(3)
+      double precision :: h1,h2
+      double precision :: chksum
       double precision :: hasht(5)
+      double precision ,dimension(:) ,allocatable :: hash
       integer ,dimension(:)   ,allocatable :: jperm1,jperm2
       integer ,dimension(:)   ,allocatable :: idfun,lenx,idxtab
       integer ,dimension(:)   ,allocatable :: nv1,nv2,nv3
-      integer ,dimension(:)   ,allocatable :: hash
       my_real ,dimension(:)   ,allocatable :: xx1,xx2,xx3,xx4,yfac
       integer ,dimension(:,:) ,allocatable :: itag
       character(LEN=NCHARTITLE) :: TITR
@@ -192,7 +193,7 @@ C-----------------------------------------------
 !-----------------------------------------------------------------------------------------
         ! check duplicated input lines
 !
-        call myqsort_int(nfun,hash,jperm2,ierror)
+        call myqsort_d(nfun,hash,jperm2,ierror)
         h1 = hash(1)
         do ifun = 2,nfun
           h2 = hash(ifun)
@@ -217,7 +218,7 @@ C-----------------------------------------------
         end do  
         ! hash of all abscissa combinations
 !
-        call myqsort_int(nfun,hash,jperm2,ierror)
+        call myqsort_d(nfun,hash,jperm2,ierror)
         h1 = hash(1)
         do ifun = 2,nfun
           h2 = hash(ifun)

--- a/starter/source/tools/curve/simple_checksum_mod.F90
+++ b/starter/source/tools/curve/simple_checksum_mod.F90
@@ -31,7 +31,7 @@ module simple_checksum_mod
         import :: c_int, c_double
         real(c_double), intent(in) ,dimension(length) :: vector
         integer(c_int), intent(in)  :: length
-        integer(c_int), intent(out) :: hash
+        real(c_double), intent(out) :: hash
       end subroutine simple_checksum
    end interface
 


### PR DESCRIPTION
Starter routine of /TABLE1 uses a simple checksum routine to detect multiple type of input errors.
Previous version showed conflicts in several correctly defined models. The algorithm was changed, the new routine uses more stable crc32 algorithm.
To avoid C uint32_t data type to fortran integer conversion problems, the hash value is now defined as double precision.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
