### PR TITLE
/LOAD/PBLAST : zeroing output data structure

### DIFF
--- a/starter/source/loads/pblast/hm_read_pblast.F
+++ b/starter/source/loads/pblast/hm_read_pblast.F
@@ -227,6 +227,7 @@ C-----------------------------------------------
       IS_ITA_SHIFT = .FALSE.
 
       ALLOCATE( OUTPUT_USER_PARAMS(6,PBLAST%NLOADP_B))
+      OUTPUT_USER_PARAMS(:,:) = ZERO
 
       CALL HM_OPTION_START('/LOAD/PBLAST')
 


### PR DESCRIPTION
#### /LOAD/PBLAST : zeroing output data structure


#### Description of the changes
The data structure may not be initilized to 0 depending and compiler or compiler options.
It must be initialized to 0 when retrieving node identifier (if defined) :
`NODE_ID = INT(OUTPUT_USER_PARAMS(5,K_BLAST))`  _hm_read_pblast.F : 1126_ 
Consequently if NODE_ID is not provided in the input NODE_ID is 0 as expected.
