### PR TITLE
Correct yield stress calculation in law128 for hourglass in case of kinematic hardening

### DIFF
--- a/engine/source/materials/mat/mat128/sigeps128c.F90
+++ b/engine/source/materials/mat/mat128/sigeps128c.F90
@@ -94,6 +94,7 @@
       my_real ,dimension(nel)     ,intent(inout) :: off    !< element activation coefficient
       my_real ,dimension(nel)     ,intent(inout) :: pla    !< plastic strain
       my_real ,dimension(nel)     ,intent(inout) :: thk    !< element thickness
+      my_real ,dimension(nel)     ,intent(inout) :: yld    !< yield stress 
       my_real ,dimension(nel)     ,intent(out)   :: signxx !< output stress component
       my_real ,dimension(nel)     ,intent(out)   :: signyy !< output stress component
       my_real ,dimension(nel)     ,intent(out)   :: signxy !< output stress component
@@ -101,7 +102,6 @@
       my_real ,dimension(nel)     ,intent(out)   :: signzx !< output stress component
       my_real ,dimension(nel)     ,intent(out)   :: dpla   !< plastic strain increment
       my_real ,dimension(nel)     ,intent(out)   :: sighl  !< hill equivalent stress 
-      my_real ,dimension(nel)     ,intent(out)   :: yld    !< yield stress 
       my_real ,dimension(nel)     ,intent(out)   :: soundsp!< sound speed
       my_real ,dimension(nel)     ,intent(out)   :: hardm  !< tangent module
       my_real ,dimension(nel)     ,intent(out)   :: epsd   !< plastic strain rate
@@ -187,10 +187,11 @@
         signxy(1:nel) = signxy(1:nel) - sigb(1:nel,3)
         !< Save the initial yield stress in case of kinematic hardening
         if (mat_param%ntable == 0) then     ! analytical yield formulation
-         yld0(1:nel) = sigy
-         h0(1:nel)   = qr1*cr1 + qr2*cr2 + qx1*cx1 + qx2*cx2
-        else 
-          if (ndim == 2) then
+          yld0(1:nel) = sigy
+          h0(1:nel)   = qr1*cr1 + qr2*cr2 + qx1*cx1 + qx2*cx2
+          if (ndim == 1) then
+            yld0(1:nel) = sigy
+          else if (ndim == 2) then
             xvec2(1:nel,1) = zero
             xvec2(1:nel,2) = epsd(1:nel)
             call table_mat_vinterp(mat_param%table(1),nel,nel,vartmp,xvec2,yld0,h0)

--- a/engine/source/materials/mat/mat128/sigeps128s.F90
+++ b/engine/source/materials/mat/mat128/sigeps128s.F90
@@ -99,10 +99,10 @@
       my_real ,dimension(nel)     ,intent(out)   :: signzx !< output stress component
       my_real ,dimension(nel)     ,intent(inout) :: off    !< element activation coefficient
       my_real ,dimension(nel)     ,intent(inout) :: pla    !< plastic strain
+      my_real ,dimension(nel)     ,intent(inout) :: yld    !< yield stress 
       my_real ,dimension(nel)     ,intent(out)   :: dpla   !< plastic strain increment
       my_real ,dimension(nel)     ,intent(out)   :: et     !< tangent module
       my_real ,dimension(nel)     ,intent(out)   :: sighl  !< Hill equivalent stress 
-      my_real ,dimension(nel)     ,intent(out)   :: yld    !< yield stress 
       my_real ,dimension(nel)     ,intent(out)   :: soundsp!< sound speed
       my_real ,dimension(nel)     ,intent(out)   :: epsd   !< plastic strain rate
       my_real ,dimension(nel,l_sigb)  ,intent(inout) :: sigb      !< backstress tensor
@@ -190,7 +190,9 @@
          yld0(1:nel) = sigy
          h0(1:nel)   = qr1*cr1 + qr2*cr2 + qx1*cx1 + qx2*cx2
         else 
-          if (ndim == 2) then
+          if (ndim == 1) then
+            yld0(1:nel) = sigy
+          else if (ndim == 2) then
             xvec2(1:nel,1) = zero
             xvec2(1:nel,2) = epsd(1:nel)
             call table_mat_vinterp(mat_param%table(1),nel,nel,vartmp,xvec2,yld0,h0)


### PR DESCRIPTION

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

possible floating point exception in hourglass striffness calculation

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Corrected yield stress initialization with kinematic hardening and tabulated input using 1D function

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
