### PR TITLE
Correction of MDS initialization in Radioss engine

### DIFF
--- a/engine/source/engine/radioss2.F
+++ b/engine/source/engine/radioss2.F
@@ -1412,35 +1412,6 @@ C-----------------------------------------------------
      .                    BUFMAT   ,IPART    ,IGRNOD   ,IGRPART)
       END IF
 C------------------------------------------------
-C     initializations MDS
-C------------------------------------------------
-      IF(.NOT.ALLOCATED(MDS_LABEL)) THEN
-        ALLOCATE( MDS_LABEL(1024,MDS_NMAT) )
-      ENDIF
-      IF(.NOT.ALLOCATED(MDS_NDEPSVAR)) THEN
-        ALLOCATE( MDS_NDEPSVAR(MDS_NMAT) )
-      ENDIF
-      MAX_DEPVAR = 0
-#ifdef DNC
-      IF(MDS_AVAIL==1) THEN
-        NSPMD_USER = NSPMD
-        NTASK_USER = NTHREAD
-        ISPMD_USER = ISPMD
-
-        MAX_DEPVAR=0
-        DO I=1,MDS_NMAT
-           MAX_DEPVAR=MAX(MAX_DEPVAR,MDS_NDEPSVAR(I) )
-        ENDDO
-        ALLOCATE (MDS_OUTPUT_TABLE(MDS_NMAT*MAX_DEPVAR) ) 
-
-        CALL MDS_ENGINE_USER_INITIALIZE(NSPMD_USER,NTASK_USER,ISPMD_USER,TSTOP,
-     *                                  MDS_NMAT,MDS_MATID,MDS_FILES,MDS_LABEL,MDS_NDEPSVAR,MAX_DEPVAR,MDS_OUTPUT_TABLE)
-      ENDIF
-#endif
-      IF(.NOT.ALLOCATED(MDS_OUTPUT_TABLE) ) THEN
-        ALLOCATE (MDS_OUTPUT_TABLE(MDS_NMAT*MAX_DEPVAR) ) 
-      ENDIF
-C------------------------------------------------
 C     engine file reading
 C------------------------------------------------
       CALL TRACE_IN(16,2,ZERO)
@@ -1470,6 +1441,35 @@ C Close & Delete scratch file
       CALL DELETE_USER_FILE(IINFNA,LEN_IINFNA)
 C------------------------------------------------
       CALL TRACE_OUT(16)
+C------------------------------------------------
+C     initializations MDS
+C------------------------------------------------
+      IF(.NOT.ALLOCATED(MDS_LABEL)) THEN
+        ALLOCATE( MDS_LABEL(1024,MDS_NMAT) )
+      ENDIF
+      IF(.NOT.ALLOCATED(MDS_NDEPSVAR)) THEN
+        ALLOCATE( MDS_NDEPSVAR(MDS_NMAT) )
+      ENDIF
+      MAX_DEPVAR = 0
+#ifdef DNC
+      IF(MDS_AVAIL==1) THEN
+        NSPMD_USER = NSPMD
+        NTASK_USER = NTHREAD
+        ISPMD_USER = ISPMD
+
+        MAX_DEPVAR=0
+        DO I=1,MDS_NMAT
+           MAX_DEPVAR=MAX(MAX_DEPVAR,MDS_NDEPSVAR(I) )
+        ENDDO
+        ALLOCATE (MDS_OUTPUT_TABLE(MDS_NMAT*MAX_DEPVAR) ) 
+
+        CALL MDS_ENGINE_USER_INITIALIZE(NSPMD_USER,NTASK_USER,ISPMD_USER,TSTOP,
+     *                                  MDS_NMAT,MDS_MATID,MDS_FILES,MDS_LABEL,MDS_NDEPSVAR,MAX_DEPVAR,MDS_OUTPUT_TABLE)
+      ENDIF
+#endif
+      IF(.NOT.ALLOCATED(MDS_OUTPUT_TABLE) ) THEN
+        ALLOCATE (MDS_OUTPUT_TABLE(MDS_NMAT*MAX_DEPVAR) ) 
+      ENDIF
 C------------------------------------------------
       CALL TRACE_IN(19,0,ZERO)
       CALL TRACE_OUT(19)

--- a/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
@@ -1136,6 +1136,7 @@ c ILAYER=NULL NPT=NULL (mid-layer)
 c
                   IF (NLAY > 1) THEN
                     IL  = IABS(NLAY)/2 + 1
+                    NPT = ELBUF_TAB(NG)%BUFLY(IL)%NPTT
                     IPT = IABS(NPT)/2 + 1
                   ELSE
                     IL  = 1

--- a/starter/source/user_interface/uaccess.F
+++ b/starter/source/user_interface/uaccess.F
@@ -1236,14 +1236,10 @@ C   C o m m o n   B l o c k s
 C-----------------------------------------------
 #include "units_c.inc"
 C-----------------------------------------------
-#ifndef ncharline
-#define ncharline 500
-#endif
-C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      CHARACTER(len=ncharline)  LINE
       INTEGER LEN1
+      CHARACTER(len=LEN1)  LINE
 C-----------------------------------------------
 
         WRITE(IOUT,'(A)') LINE(1:LEN1)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

MDS crashing at the beginning of engine

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Mds initialization routine must be called after engine input file is read. It uses input parameters which are not initialized otherwise.
Corrected h3d output of mds user variables in composite shells.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
