### PR TITLE
Issue in Law70 with unload functions : 

### DIFF
--- a/starter/source/materials/mat/mat070/law70_upd.F
+++ b/starter/source/materials/mat/mat070/law70_upd.F
@@ -73,7 +73,7 @@ C-----------------------------------------------
       my_real :: E0,EMAX,EPSMAX,STIFFMIN,STIFFMAX,STIFFINI,C1,G,NU,XMAX,
      .   S1,S2,T1,T2,X1,X2,Y1,Y2,DERI,YY,EPS0,EPST
       INTEGER ,DIMENSION(NFUNC) :: FUNC,PERM,LEN
-      my_real ,DIMENSION(NFUNC) :: RATE,YFAC
+      my_real ,DIMENSION(NFUNC*2) :: RATE,YFAC
       my_real ,DIMENSION(:)   ,ALLOCATABLE :: XF
       my_real ,DIMENSION(:,:) ,ALLOCATABLE :: XI,YI,YF
 C=======================================================================
@@ -181,7 +181,7 @@ c
         DO I = 1,NULOAD
           K  = NLOAD + I
           FUNC(I) = IFUNC (K)
-          RATE(I) = UPARAM(K + 8)
+          RATE(I+NLOAD) = UPARAM(K + 8)
           YFAC(I) = UPARAM(K + 8 + NFUNC)
           LEN(I)  = (NPC(FUNC(I)+1) - NPC(FUNC(I))) / 2
           LMAX    = MAX(LMAX,LEN(I))
@@ -244,7 +244,7 @@ c       reduce number of points if necessary
         END DO
 c--------------------------------------------------------
         CALL LAW70_TABLE(
-     .       MAT_PARAM%TABLE(UNLOAD)  ,NULOAD  ,LEN     ,LMAX   ,RATE  ,
+     .       MAT_PARAM%TABLE(UNLOAD)  ,NULOAD  ,LEN     ,LMAX   ,RATE(NLOAD+1)  ,
      .       XI    , YI     )      
       
         DEALLOCATE (YI)
@@ -416,7 +416,7 @@ c-----------
      .       5X,/'      X,              Y')
  1102 FORMAT(5X,/,'YIELD STRESS FUNCTION=',I10,
      .       5X,'STRAIN RATE = ',1PG20.13,/,
-     .       5X,'      X,              Y')
- 2000 FORMAT(2G16.9)
+     .       5X,'              X                   Y')
+ 2000 FORMAT(2G20.13)
 c------------------------------------
       END


### PR DESCRIPTION
* Used strain rate was from load functions but not unload.
Those are ignored. It can cause problems when load & unload functions are not same.

* Review printout format to simplify transfer in input deck.

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
