### PR TITLE
bug fixing for auto stiffness option of interface type24 +iedge=1

### DIFF
--- a/starter/source/interfaces/interf1/stifint_icontrol.F90
+++ b/starter/source/interfaces/interf1/stifint_icontrol.F90
@@ -190,6 +190,7 @@
               nsn=ipari(5,n)
               do j = 1, nsn
                 ns = intbuf_tab(n)%nsv(j)
+                if (ns>numnod) cycle
                 if (itag(ns)==0) stifint(ns) =  sfac_max*stifint(ns)
               end do
             endif


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
correction to avoid buffer overflow in case using istif=-1,iedge=1 of interface type24

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
