### PR TITLE
/TABLE : slope calculation fixed

### DIFF
--- a/starter/source/materials/mat/mat163/law163_upd.F90
+++ b/starter/source/materials/mat/mat163/law163_upd.F90
@@ -57,37 +57,23 @@
           !< Integer variables
           integer :: i,j                                  !< iterators
           integer :: ndim                                 !< dimension
-          integer :: npt                                  !< number of integration points / max number of integration points
+          integer :: npt                                  !< number ofintegration points / max number of integration points
+          integer :: nf                                   !< number of functions
 !
           !< Real variables
           my_real :: x_i,y_i
-          my_real :: ener,dx,dy,dydx,youngmax,nu,g,bulk,lam
+          my_real :: ener,dx,dy,dydx,nu,g,bulk,lam
+          my_real :: youngmin,youngini,youngmax
+          my_real :: xmax
           type(table_4d_), dimension(:) ,pointer :: table_mat
 !
 !--------------------------------------------------------------------------
 !     copy global functions/tables to matparam data structure
 !--------------------------------------------------------------------------
 !
-          !< Loading table
-          table_mat => matparam%table(1:matparam%ntable) ! material table pointer
-          ndim = table_mat(1)%ndim               ! number of dimensions
-          npt  = size(table_mat(1)%x(1)%values)  ! number of points
-!
-          !< Compute the maximum tabulated slope
+          !< Get the maximum tabulated slope
           youngmax = zero
-          do i = 1,npt-1
-            dx = table_mat(1)%x(1)%values(i+1) - table_mat(1)%x(1)%values(i)
-            dy = zero
-            if (ndim == 1) then
-              dy = table_mat(1)%y1d(i+1) - table_mat(1)%y1d(i)
-            elseif (ndim == 2) then
-              do j = 1,ndim
-                dy = max(dy,table_mat(1)%y2d(i+1,j) - table_mat(1)%y2d(i,j))
-              enddo
-            endif
-            dydx = dy/dx
-            youngmax = max(youngmax, dy/dx)
-          enddo
+          call table_slope(matparam%table(1),youngini,youngmin,youngmax,xmax)
 !
           !< Update material parameters
           ! -> Young's modulus

--- a/starter/source/materials/tools/table_slope.F
+++ b/starter/source/materials/tools/table_slope.F
@@ -103,8 +103,8 @@ c
             IF (X1 == ZERO .or. X2 == ZERO) THEN
               STIFFINI = MAX(STIFFINI, DYDX)
             ENDIF
-            Y1 = Y2
-          ENDDO      
+          ENDDO
+          Y1 = Y2
           X1 = X2
         ENDDO
 c        


### PR DESCRIPTION
#### /TABLE : slope calculation fixed

#### Description of the changes
A bug is fixed in table_slope subroutine for case ndim=2
The slope calculation was incorrect.

/MAT/LAW163 is now calculating youngmax using table_slope subroutine for better readability and maintenance