### PR TITLE
correction missing option in datahierarchy file : DAMPING FREQUENCY RANGE & EBCS PROPERGOL

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2025/data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/radioss2025/data_hierarchy.cfg
@@ -2937,6 +2937,15 @@ HIERARCHY {
             FILE    = "DAMP/Damp_Vrel.cfg";
             USER_NAMES = (VREL);
         }       
+        HIERARCHY {
+            KEYWORD = FREQUENCY_RANGE;
+            TITLE   = "FREQUENCY_RANGE";
+            SUBTYPE = USER;
+            USER_ID = 4;
+            HM_CONFIG_TYPE = 204;
+            FILE    = "DAMP/Damp_freq_range.cfg";
+            USER_NAMES = (FREQUENCY_RANGE);
+        }
     }
 }
 
@@ -3273,6 +3282,16 @@ HIERARCHY {
             HM_TYPE = 20;
             FILE    = "LOADS/ebcs_nrf.cfg";
             USER_NAMES = (EBCS_NRF);
+        }
+        HIERARCHY {
+            KEYWORD = EBCS_PROPERGOL;
+            TITLE   = "EBCS_PROPERGOL";
+            SUBTYPE = USER;
+            USER_ID = 20;
+            HM_CONFIG_TYPE = 4;
+            HM_TYPE = 20;
+            FILE    = "LOADS/ebcs_propergol.cfg";
+            USER_NAMES = (EBCS_PROPERGOL);
         }
     }
     HIERARCHY {


### PR DESCRIPTION

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->
correction missing option in datahierachy DAMPING FREQUENCY RANGE & EBCS PROPERGOL

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
