### PR TITLE
Correct MDS variable allocation at the beginning of Radioss engine

### DIFF
--- a/engine/source/engine/radioss2.F
+++ b/engine/source/engine/radioss2.F
@@ -1410,12 +1410,36 @@ C-----------------------------------------------------
      .                    NODES%MS       ,NODES%IN       ,NODES%ITAB     ,IGEO     ,IPM    ,
      .                    BUFMAT   ,IPART    ,IGRNOD   ,IGRPART)
       END IF
+C-----------------------------------------------------
+      MAX_DEPVAR = 0
+#ifdef DNC
+      IF(MDS_AVAIL==1) THEN
+        NSPMD_USER = NSPMD
+        NTASK_USER = NTHREAD
+        ISPMD_USER = ISPMD
+
+        MAX_DEPVAR=0
+        DO I=1,MDS_NMAT
+           MAX_DEPVAR=MAX(MAX_DEPVAR,MDS_NDEPSVAR(I) )
+        ENDDO
+        ALLOCATE (MDS_OUTPUT_TABLE(MDS_NMAT*MAX_DEPVAR) ) 
+      ENDIF
+#endif
+      IF(.NOT.ALLOCATED(MDS_LABEL)) THEN
+        ALLOCATE( MDS_LABEL(1024,MDS_NMAT) )
+      ENDIF
+      IF(.NOT.ALLOCATED(MDS_NDEPSVAR)) THEN
+        ALLOCATE( MDS_NDEPSVAR(MDS_NMAT) )
+      ENDIF
+      IF(.NOT.ALLOCATED(MDS_OUTPUT_TABLE) ) THEN
+        ALLOCATE (MDS_OUTPUT_TABLE(MDS_NMAT*MAX_DEPVAR) ) 
+      ENDIF
 C------------------------------------------------
 C     engine file reading
 C------------------------------------------------
       CALL TRACE_IN(16,2,ZERO)
-      CALL LECTUR(  NODES%ICODE ,  NODES%ISKEW ,  ISKWN ,  IXTG  ,   IXS ,
-     2              IXQ ,    ELEMENT%SHELL%IXC ,    IXT ,    IXP ,     IXR ,
+      CALL LECTUR(  NODES%ICODE ,  NODES%ISKEW ,  ISKWN ,  IXTG  ,   IXS  ,
+     2              IXQ ,    ELEMENT%SHELL%IXC ,    IXT ,    IXP ,   IXR  ,
      3              NODES%ITAB ,   NODES%ITABM1  ,NPC,     IPARG,    IGRV ,
      4              LGRAV   ,IPARI,
      5              NPBY ,   LPBY    ,ILINK,   LLINK  ,LINALE ,
@@ -1443,32 +1467,14 @@ C------------------------------------------------
 C------------------------------------------------
 C     initializations MDS
 C------------------------------------------------
-      IF(.NOT.ALLOCATED(MDS_LABEL)) THEN
-        ALLOCATE( MDS_LABEL(1024,MDS_NMAT) )
-      ENDIF
-      IF(.NOT.ALLOCATED(MDS_NDEPSVAR)) THEN
-        ALLOCATE( MDS_NDEPSVAR(MDS_NMAT) )
-      ENDIF
-      MAX_DEPVAR = 0
+
 #ifdef DNC
-      IF(MDS_AVAIL==1) THEN
-        NSPMD_USER = NSPMD
-        NTASK_USER = NTHREAD
-        ISPMD_USER = ISPMD
-
-        MAX_DEPVAR=0
-        DO I=1,MDS_NMAT
-           MAX_DEPVAR=MAX(MAX_DEPVAR,MDS_NDEPSVAR(I) )
-        ENDDO
-        ALLOCATE (MDS_OUTPUT_TABLE(MDS_NMAT*MAX_DEPVAR) ) 
-
+      IF (MDS_AVAIL==1) THEN
         CALL MDS_ENGINE_USER_INITIALIZE(NSPMD_USER,NTASK_USER,ISPMD_USER,TSTOP,
-     *                                  MDS_NMAT,MDS_MATID,MDS_FILES,MDS_LABEL,MDS_NDEPSVAR,MAX_DEPVAR,MDS_OUTPUT_TABLE)
+     *       MDS_NMAT,MDS_MATID,MDS_FILES,MDS_LABEL,MDS_NDEPSVAR,MAX_DEPVAR,MDS_OUTPUT_TABLE)
       ENDIF
 #endif
-      IF(.NOT.ALLOCATED(MDS_OUTPUT_TABLE) ) THEN
-        ALLOCATE (MDS_OUTPUT_TABLE(MDS_NMAT*MAX_DEPVAR) ) 
-      ENDIF
+
 C------------------------------------------------
       CALL TRACE_IN(19,0,ZERO)
       CALL TRACE_OUT(19)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

some of the MDS variables used for h3d output were not correctly initialized in engine

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Moved MDS table allocations before lectur() in resol2.F

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
