### PR TITLE
Allow thermal dependency on hardening in law2 regardless of strain rate

### DIFF
--- a/engine/source/materials/mat/mat002/m2cplr.F
+++ b/engine/source/materials/mat/mat002/m2cplr.F
@@ -25,7 +25,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||--- called by ------------------------------------------------------
       !||    sigeps02c   ../engine/source/materials/mat/mat002/sigeps02c.F
       !||====================================================================
-      SUBROUTINE M2CPLR(JFT    ,JLT    ,EZZ      ,OFF      ,EPSEQ   ,
+      SUBROUTINE M2CPLR(JFT    ,JLT    ,EZZ      ,OFF      ,PLA   ,
      2                  IPLA   ,TEMP   ,Z3       ,Z4       ,
      3                  IRTY   ,ETSE   ,GS       ,EPSP     ,
      4                  ISRATE ,YLD    ,G        ,A1       ,A2      ,
@@ -56,7 +56,7 @@ C-----------------------------------------------
       INTEGER,INTENT(IN) :: VP
 C     REAL
       my_real
-     .   EZZ(*), OFF(*), EPSEQ(*),TEMP(*),Z3,Z4,
+     .   EZZ(*), OFF(*), PLA(*),TEMP(*),Z3,Z4,
      .   ETSE(*),GS(*),EPSP(*)
       my_real
      .   A1, A2, G, YMAX0, 
@@ -166,17 +166,29 @@ C-------------
             CA(I) = CA(I) + Q(I)
           ENDDO
         ENDIF ! IRTY
-      ENDIF ! IF (CC /= ZERO)
+      ELSE           ! CC = ZERO  , no strain rate effect
+        IF (IRTY == 0) THEN       ! J-C
+          MT = MAX(EM20,Z3)
+          DO I=JFT,JLT          
+            IF (TSTAR(I) /= ZERO) THEN
+              Q(I)  = ONE - EXP(MT*LOG(TSTAR(I)))
+              Q(I)  = MAX(Q(I),EM20)
+              CA(I) = CA(I) * Q(I)
+              CB(I) = CB(I) * Q(I)
+            END IF
+          ENDDO
+        ENDIF ! IRTY
+      ENDIF   ! IF (CC /= ZERO)
 C-----------------------------------
 C     YIELD
 C-----------------------------------
       DO I=JFT,JLT
         DPLA(I) = ZERO
-        IF (EPSEQ(I) == ZERO) THEN
+        IF (PLA(I) == ZERO) THEN
            YLD(I)= CA(I)
         ELSE
            BETA = CB(I)*(ONE-FISOKIN)
-           YLD(I)= CA(I)+BETA*EXP(CN*LOG(EPSEQ(I)))
+           YLD(I)= CA(I)+BETA*EXP(CN*LOG(PLA(I)))
         ENDIF
         YLD(I)= MIN(YLD(I),YMAX(I))
       ENDDO
@@ -204,12 +216,12 @@ C projection radiale
             DPLA(I) =  OFF(I) * MAX(ZERO,(SVM(I)-YLD(I))/YOUNG)
             S1=HALF*(SIGNXX(I)+SIGNYY(I))
             EZZ(I) = DPLA(I) * S1 /YLD(I)
-            EPSEQ(I) = EPSEQ(I) + DPLA(I)
-            EPCHK(I) = MAX(EPSEQ(I),EPCHK(I))     
+            PLA(I) = PLA(I) + DPLA(I)
+            EPCHK(I) = MAX(PLA(I),EPCHK(I))     
             IF (YLD(I) >=YMAX(I)) THEN
               H(I)=ZERO
             ELSE
-              H(I)=CN*CB(I)*EXP((CN-ONE)*LOG(EPSEQ(I)+SMALL))
+              H(I)=CN*CB(I)*EXP((CN-ONE)*LOG(PLA(I)+SMALL))
             ENDIF
             ETSE(I)= H(I)/(H(I)+YOUNG)
           ENDIF
@@ -263,7 +275,7 @@ C---------------------------
           IF (YLD(I) >= YMAX(I)) THEN
             H(I)=ZERO
           ELSE
-            H(I)=CN*CB(I)*EXP((CN-ONE)*LOG(EPSEQ(I)+SMALL))
+            H(I)=CN*CB(I)*EXP((CN-ONE)*LOG(PLA(I)+SMALL))
           ENDIF
           DPLA_J(I)=(SVM(I)-YLD(I))/(THREE*G+H(I))
           ETSE(I)= H(I)/(H(I)+YOUNG)
@@ -278,7 +290,7 @@ C-----just keep at least old performance--to update H(I) inside iteration for im
             DO J=1,NINDX
               I=INDEX(J)
               DPLA_I(I)=DPLA_J(I)
-              PLA_I =EPSEQ(I)+DPLA_I(I)
+              PLA_I =PLA(I)+DPLA_I(I)
               DPLA(I) = DPLA_J(I)
               IF (PLA_I == ZERO) THEN
                 YLD_I =MIN(YMAX(I),CA(I))
@@ -322,7 +334,7 @@ C----------kinematic&mix hardening
             DO J=1,NINDX
               I=INDEX(J)
               DPLA_I(I)=DPLA_J(I)
-              PLA_I =EPSEQ(I)+DPLA_I(I)
+              PLA_I =PLA(I)+DPLA_I(I)
               DPLA(I) = DPLA_J(I)
               BETA = ONE-FISOKIN
               IF (PLA_I == ZERO) THEN
@@ -353,8 +365,8 @@ C------------------------------------------
 #include "vectorize.inc" 
         DO J=1,NINDX
           I=INDEX(J)
-          EPSEQ(I) = EPSEQ(I) + DPLA_I(I)
-          EPCHK(I) = MAX(EPSEQ(I),EPCHK(I))
+          PLA(I) = PLA(I) + DPLA_I(I)
+          EPCHK(I) = MAX(PLA(I),EPCHK(I))
           S1=(SIGNXX(I)+SIGNYY(I))*P(I)
           S2=(SIGNXX(I)-SIGNYY(I))*Q(I)
           SIGNXX(I)=HALF*(S1+S2)
@@ -396,7 +408,7 @@ C-------------
             IF (YLD(I) >= YMAX(I)) THEN
               H(I)=ZERO
             ELSE
-              H(I)=CN*CB(I)*EXP((CN-ONE)*LOG(EPSEQ(I)+SMALL))
+              H(I)=CN*CB(I)*EXP((CN-ONE)*LOG(PLA(I)+SMALL))
             ENDIF
             ETSE(I)= H(I)/(H(I)+YOUNG)
 C
@@ -409,7 +421,7 @@ C
             SIGNYY(I)=S2
             SIGNXY(I)=S3
             DPLA(I) = OFF(I)*(SVM(I)-YLD(I))/(THREE*G+H(I))
-            EPSEQ(I) = EPSEQ(I) + DPLA(I)
+            PLA(I) = PLA(I) + DPLA(I)
 C
             YLD(I) =YLD(I)+H(I)*DPLA(I)
           END DO ! DO J=1,NINDX
@@ -437,7 +449,7 @@ C------------------------------------------
           DO I = JFT,JLT
             IF (DPLA(I) > ZERO) THEN
 c ...... Parameter d(gama)
-              PLA_I =EPSEQ(I)
+              PLA_I =PLA(I)
               BETA = ONE-FISOKIN
               YLD(I) =MIN(YMAX(I),CA(I)+BETA*CB(I)*EXP(CN*LOG(PLA_I)))
               GAMA_IMP(I)= THREE_HALF*DPLA(I)/YLD(I)
@@ -462,7 +474,7 @@ C------------------------------------------
 #include "vectorize.inc" 
           DO J=1,NINDX
             I=INDEX(J)
-            PLA_I =EPSEQ(I)
+            PLA_I =PLA(I)
             BETA = ONE-FISOKIN
 C------YLD, H(I) should not be updated----
             IF (PLA_I == ZERO) THEN

--- a/engine/source/materials/mat/mat002/m2law.F
+++ b/engine/source/materials/mat/mat002/m2law.F
@@ -108,7 +108,7 @@ C
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER :: I, J, ICC,IRTY,ISRATE,VP,IDEV,MX,IBID,IKFLG,NINDX
+      INTEGER :: I, J, ICC,IRTY,ISRATE,VP,IDEV,MX,IBID,NINDX
       INTEGER :: INDX(NEL)
       my_real RHO0, PLAP1,POLD,PSHIFT,BULK,P, EPMX,CC,CN,EPDR, CMX,
      .        Z3,Z4,RHOCP,RHOCPI,T_REF,T_MELT,ASRATE,
@@ -168,18 +168,16 @@ C
 C------------------------------------------
 C     ECROUISSAGE CINE
 C------------------------------------------
-      IKFLG=0
-      DO I=1,NEL
-        IF (FISOKIN /= ZERO ) THEN
+      IF (FISOKIN > ZERO) THEN
+        DO I=1,NEL
          SIG(I,1)=SIG(I,1)-SIGBAK(I,1)
          SIG(I,2)=SIG(I,2)-SIGBAK(I,2)
          SIG(I,3)=SIG(I,3)-SIGBAK(I,3)
          SIG(I,4)=SIG(I,4)-SIGBAK(I,4)
          SIG(I,5)=SIG(I,5)-SIGBAK(I,5)
          SIG(I,6)=SIG(I,6)-SIGBAK(I,6)
-         IKFLG = IKFLG + 1
-        ENDIF           
-      ENDDO
+        ENDDO
+      ENDIF           
 C      
       DO I=1,NEL
         P  =-THIRD*(SIG(I,1)+SIG(I,2)+SIG(I,3))
@@ -202,7 +200,7 @@ c      -- von Mises stress at elastic predictor
       ENDDO
 C
 c     --  storing elastic predictors for stiffness computation
-      IF (IMPL_S>0.OR.IKFLG>0) THEN
+      IF (IMPL_S>0 .OR. FISOKIN>ZERO) THEN
         DO I=1,NEL
          SIGEXX(I) = SIG(I,1)
          SIGEYY(I) = SIG(I,2)
@@ -220,8 +218,8 @@ C-------------
      .                  D1,      D2,      D3,      D4,       D5,      D6)
 
       EPSP(1:NEL) = EPSD(1:NEL)                   
+      EPD(1:NEL)  = ONE                 
 c
-
       IF (CC /= ZERO) THEN
         IF(VP == 1)THEN
           DO I=1,NEL
@@ -250,15 +248,14 @@ c
              EPD(I)=ONE
           ENDDO
         END IF
-      ELSE
-        DO I=1,NEL
-          EPD(I)=ONE
-        ENDDO
+      ELSEIF (IRTY == 0) THEN  
+        MT = MAX(EM15,Z3)
+        EPD(1:NEL) = ONE - TSTAR(1:NEL)**MT
       ENDIF
 C-------------
 C     CRITERE
 C-------------
-      IF (IKFLG == 0 ) THEN  ! isotropic hardening
+      IF (FISOKIN == ZERO) THEN  ! isotropic hardening
         IF(CN==ONE) THEN
           AK(1:NEL)= CA(1:NEL)+CB*EPXE(1:NEL)
           QH(1:NEL)= CB*EPD(1:NEL)
@@ -290,7 +287,7 @@ C-------------
           ENDIF
         ENDDO
 !
-      ELSE     ! IKFLG > 0 => kinematic hardening
+      ELSE     ! kinematic hardening
 !
         DO I=1,NEL
           BETA = ONE-FISOKIN
@@ -325,8 +322,8 @@ C-------------
             AK(I)=ZERO
             QH(I)=ZERO
           ENDIF
-        END DO !I=1,NEL
-      END IF !(IKFLG == 0 ) THEN
+        END DO ! I=1,NEL
+      END IF   ! (FISOKIN == 0 ) THEN
 !---------------------------------------------------------
       IF (IMPL_S==0) THEN
         DO I=1,NEL
@@ -353,7 +350,7 @@ C         actual yield stress.
 !
       END IF ! IMPL_S
 c-----------------------------------------
-      IF (IKFLG > 0 ) THEN
+      IF (FISOKIN > ZERO) THEN
        DO I=1,NEL
           DSXX = SIGEXX(I) - SIG(I,1) 
           DSYY = SIGEYY(I) - SIG(I,2)
@@ -379,7 +376,7 @@ C       ..gets stresses from shifted stresses and back stresses
           SIG(I,5)=SIG(I,5) + SIGBAK(I,5)
           SIG(I,6)=SIG(I,6) + SIGBAK(I,6)
        ENDDO
-      END IF !(IKFLG > 0 ) THEN
+      END IF !(FISOKIN > 0 ) THEN
 c-----------------------------------------
 !
       BIDMVSIZ(1:MVSIZ) = ZERO
@@ -479,20 +476,20 @@ C
 !----------------------------------------------------------------     
       IF (IMPL_S>0) THEN
         IF (IKT==0) RETURN
-        IF (IKFLG==0)THEN
+        IF (FISOKIN == ZERO) THEN
           DO I=1,NEL
            IF (DPLA(I)>0)THEN
-            IF(CN==ONE) THEN
-             QH(I)= CB*EPD(I)
-            ELSEIF(CN>ONE) THEN
-             QH(I)= (CB*CN*EPXE(I)**(CN - ONE))*EPD(I)
-            ELSE
-             QH(I)= (CB*CN/EPXE(I)**(ONE -CN))*EPD(I)
-            ENDIF
+             IF(CN==ONE) THEN
+               QH(I)= CB*EPD(I)
+             ELSEIF(CN>ONE) THEN
+               QH(I)= (CB*CN*EPXE(I)**(CN - ONE))*EPD(I)
+             ELSE
+               QH(I)= (CB*CN/EPXE(I)**(ONE -CN))*EPD(I)
+             ENDIF
            ENDIF
           ENDDO
         ENDIF
-C      -----IKT=4------------
+C
         DO I = 1,NEL
          IF (DPLA(I)>ZERO) THEN
 

--- a/engine/source/materials/mat_share/mmain.F90
+++ b/engine/source/materials/mat_share/mmain.F90
@@ -460,6 +460,7 @@
           logical_userl_avail = .false.
           l_mulaw_called=.false.
           if(userl_avail/=0) logical_userl_avail = .true.
+
           lft = 1
           if(present(opt_mtn)) then
             mtn     = opt_mtn
@@ -866,26 +867,26 @@
           elseif (mtn == 2) then
 !
             call m2law(&
-            &pm,       off,      lbuf%sig, lbuf%eint,&
-            &lbuf%rho, lbuf%qvis,lbuf%pla, lbuf%epsd,&
-            &lbuf%vol, stifn,    dt2t,     neltst,&
-            &ityptst,  lbuf%off, geo,      pid,&
-            &amu,      vol_avg,  mumax,    mat,&
-            &ngl,      cxx,      dvol,     aire,&
-            &voln,     vd2,      deltax,   vis,&
-            &dxx,      dyy,      dzz,      d4,&
-            &d5,       d6,       pnew,     psh,&
-            &qvis,     ssp_eq,   s1,       s2,&
-            &s3,       s4,       s5,       s6,&
-            &sigy,     defp,     dpla,&
-            &epsp,     tstar,    et,       mssa,&
-            &dmels,    el_temp,  lbuf%sigb,al_imp,&
-            &signor,   conde,    gbuf%dt,  gbuf%g_dt,&
-            &nel,      ipm,      rhoref,   rhosp,&
-            &ipg,      lbuf%dmg, ity,      jtur,&
-            &jthe,     jsph,     ismstr,   jsms,&
-            &lbuf%epsq,npg ,mat_elem%mat_param(imat)%ieos ,dpdm  ,fheat ,&
-             glob_therm, jlag)
+                 pm,       off,      lbuf%sig, lbuf%eint,&
+                 lbuf%rho, lbuf%qvis,lbuf%pla, lbuf%epsd,&
+                 lbuf%vol, stifn,    dt2t,     neltst,&
+                 ityptst,  lbuf%off, geo,      pid,&
+                 amu,      vol_avg,  mumax,    mat,&
+                 ngl,      cxx,      dvol,     aire,&
+                 voln,     vd2,      deltax,   vis,&
+                 dxx,      dyy,      dzz,      d4,&
+                 d5,       d6,       pnew,     psh,&
+                 qvis,     ssp_eq,   s1,       s2,&
+                 s3,       s4,       s5,       s6,&
+                 sigy,     defp,     dpla,&
+                 epsp,     tstar,    et,       mssa,&
+                 dmels,    el_temp,  lbuf%sigb,al_imp,&
+                 signor,   conde,    gbuf%dt,  gbuf%g_dt,&
+                 nel,      ipm,      rhoref,   rhosp,&
+                 ipg,      lbuf%dmg, ity,      jtur,&
+                 jthe,     jsph,     ismstr,   jsms,&
+                 lbuf%epsd,npg ,mat_elem%mat_param(imat)%ieos , &
+                 dpdm  ,fheat ,glob_therm, jlag )
 !----------------
             if (istrain > 0 .and.&
             &(h3d_strain == 1 .or. th_strain == 1 )) then

--- a/engine/source/materials/mat_share/mqviscb.F
+++ b/engine/source/materials/mat_share/mqviscb.F
@@ -42,7 +42,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||====================================================================
       SUBROUTINE MQVISCB(
      1   PM,      OFF,     RHO,     RK,
-     2   T,       SSP,     RE,      STI,
+     2   TEMP,    SSP,     RE,      STI,
      3   DT2T,    NELTST,  ITYPTST, AIRE,
      4   OFFG,    GEO,     PID,     VOL,
      5   VD2,     DELTAX,  VIS,     D1,
@@ -97,7 +97,7 @@ C-----------------------------------------------
       INTEGER, INTENT(IN) :: JSMS,NPG
       INTEGER NELTST,ITYPTST,PID(*),MAT(*), NGL(*),IGEO(NPROPGI,NUMGEO),G_DT,IPM(NPROPMI,NUMMAT)
       my_real DT2T
-      my_real PM(NPROPM,NUMMAT), OFF(*), RHO(*), RK(*), T(*), RE(*),STI(*),
+      my_real PM(NPROPM,NUMMAT), OFF(*), RHO(*), RK(*), TEMP(*), RE(*),STI(*),
      .        OFFG(*),GEO(NPROPG,NUMGEO),
      .        VOL(*), VD2(*), DELTAX(*), SSP(*), AIRE(*), VIS(*), 
      .        PSH(*), PNEW(*),QVIS(*) ,SSP_EQ(*),CONDE(*), 
@@ -286,10 +286,10 @@ C
         BK2 = PM(78,MT)
         TLI = PM(80,MT)
        DO I=1,NEL       
-        IF(T(I)<TLI)THEN
-         AKK=AK1+BK1*T(I)
+        IF(TEMP(I)<TLI)THEN
+         AKK=AK1+BK1*TEMP(I)
         ELSE
-         AKK=AK2+BK2*T(I)
+         AKK=AK2+BK2*TEMP(I)
         ENDIF
         IF(JTUR/=0)THEN
          XMU = RHO(I)*PM(24,MT)
@@ -597,10 +597,10 @@ C
           AK2 = PM(77,MT)
           BK2 = PM(78,MT)
           TLI = PM(80,MT)
-          IF(T(I)<TLI)THEN
-           AKK=AK1+BK1*T(I)
+          IF(TEMP(I)<TLI)THEN
+           AKK=AK1+BK1*TEMP(I)
           ELSE
-           AKK=AK2+BK2*T(I)
+           AKK=AK2+BK2*TEMP(I)
           ENDIF
           IF(JTUR/=0)THEN
            XMU = RHO(I)*PM(24,MT)
@@ -648,10 +648,10 @@ C--------------------------
         BK2 = PM(78,MT)
         TLI = PM(80,MT)
        DO I=1,NEL
-        IF(T(I)<TLI)THEN
-         AKK=AK1+BK1*T(I)
+        IF(TEMP(I)<TLI)THEN
+         AKK=AK1+BK1*TEMP(I)
         ELSE
-         AKK=AK2+BK2*T(I)
+         AKK=AK2+BK2*TEMP(I)
         ENDIF
         IF(JTUR/=0)THEN
          XMU = RHO(I)*PM(24,MT)


### PR DESCRIPTION
Temperature influence on hardening in law2 was conditionned by strain rate dependency parameters.
After correction, strain rate and temperature dependency are independent.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
