### PR TITLE
correct element temperature initialization in mulaw.F90 and mulawc.F90

### DIFF
--- a/engine/source/materials/mat_share/mulaw.F90
+++ b/engine/source/materials/mat_share/mulaw.F90
@@ -543,6 +543,7 @@
             enddo
           endif
           ! needed in mqviscb
+          vecnul(1:nel) = zero
           facq0  = one
           imat   = mat(1)
           npar   = ipm(9,imat)
@@ -610,12 +611,12 @@
           ! Save old value of OFF flag
           off_old(1:nel) = off(1:nel)
 !
-          if (mtn == 67) then
-            el_temp => uvar(nft+1:nft+nel)
-          else if (jthe /= 0) then
+          if (jthe /= 0) then
             el_temp => tempel(1:nel)     ! gbuf%temp
           elseif (elbuf_tab(ng)%bufly(ilay)%l_temp > 0) then
             el_temp => ltemp             ! lbuf%temp
+          else
+            el_temp => vecnul(1:nel)
           endif
 
           !initial scale factor for yield stress defined per ipg,npi
@@ -1093,7 +1094,6 @@
               sigbyz => lbuf%sigb(4*nel+1:5*nel)
               sigbzx => lbuf%sigb(5*nel+1:6*nel)
             else
-              vecnul(1:nel) = zero
               sigbxx => vecnul(1:nel)
               sigbyy => vecnul(1:nel)
               sigbzz => vecnul(1:nel)

--- a/engine/source/materials/mat_share/mulawc.F90
+++ b/engine/source/materials/mat_share/mulawc.F90
@@ -476,6 +476,8 @@
           if( (jhbe>=21.and.jhbe<=29).or.(impl_s>0)) flag_zcfac=.true.
           flag_etimp=.false.
           if(impl_s>0 .and. mtn==78) flag_etimp=.true.
+!
+          vecnul(1:nel) = zero
           scale1(1:nel) = one
           iflag(1) = ipla
           bidon1 = zero
@@ -726,6 +728,8 @@
                 el_temp => gbuf%temp(1:nel) ! calculated from nodal temp with /heat/mat
               else if (bufly%l_temp > 0) then
                 el_temp => lbuf%temp(1:nel) ! local temp from mat in adiabatic conditions
+              else
+                el_temp => vecnul(1:nel)
               endif
 !---------------------------------------------------
 !         initial scale factor for yield stress defined per ipg,npi
@@ -1238,7 +1242,6 @@
                   sigbyy => lbuf%sigb(nel+1  :2*nel)
                   sigbxy => lbuf%sigb(3*nel+1:4*nel)
                 else
-                  vecnul(1:nel) = zero
                   sigbxx => vecnul(1:nel)
                   sigbyy => vecnul(1:nel)
                   sigbxy => vecnul(1:nel)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->

Avoid problems with non initialized variable

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

Element temperature will point to a null vector when local or global variable in element buffer is not allocated

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
