### PR TITLE
/BEM/DAA option: Lapack call was conditionned by MKL but can always be used 

### DIFF
--- a/starter/source/fluid/mass-fluid_qd.F
+++ b/starter/source/fluid/mass-fluid_qd.F
@@ -37,7 +37,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    message_mod     ../starter/share/message_module/message_mod.F
       !||====================================================================
       SUBROUTINE MASS_FLUID_QD(NNO, NEL, IFLOW, IBUF, ELEM, X,
-     .                         NORMAL, AF, MFLE, CBEM, RHO)
+     .                         NORMAL, AF, MFLE, CBEM, RHO,IRESP)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -55,6 +55,7 @@ C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER NNO, NEL, IFLOW(*), IBUF(*), ELEM(5,*)
       my_real X(3,*), AF(*), NORMAL(3,*), MFLE(NEL,*), CBEM(NEL,*), RHO
+      INTEGER,INTENT(IN):: IRESP
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -316,27 +317,28 @@ C         MFLE(1:NEL,1:NEL) = MATMUL(CMAT(1:NEL,1:NEL),CBEM(1:NEL,1:NEL))
 C         CMAT(1:NEL,1:NEL) = TRANSPOSE(CBEM(1:NEL,1:NEL))
 C         MFLE(1:NEL,1:NEL) = MFLE(1:NEL,1:NEL) + MATMUL(CMAT(1:NEL,1:NEL),BBEM(1:NEL,1:NEL))
 C         CMAT(1:NEL,1:NEL) = CBEM(1:NEL,1:NEL)
-#if defined(mkl)
-C #warning "MKL used: DAA will be fast"
+  
+         IF (IRESP == 0)THEN
+         ! Double Precision version : use either Lapack / MKP or ARMPL
 
-         ALPHA = 1.0D0
-         BETA = 0.0D0
-         CALL DGEMM('T','N',NEL,NEL,NEL,ALPHA,CBEM,NEL,BBEM,NEL,BETA,MFLE,NEL)
-         ALPHA = 1.0D0
-         BETA = 1.0D0
-         CALL DGEMM('N','T',NEL,NEL,NEL,ALPHA,BBEM,NEL,CBEM,NEL,BETA,MFLE,NEL)
-#else
-C #warning "MKL not used: DAA will be slow"
-         DO JN=1,NEL
-            DO IN=1,NEL
+           ALPHA = 1.0D0
+           BETA = 0.0D0
+           CALL DGEMM('T','N',NEL,NEL,NEL,ALPHA,CBEM,NEL,BBEM,NEL,BETA,MFLE,NEL)
+           ALPHA = 1.0D0
+           BETA = 1.0D0
+           CALL DGEMM('N','T',NEL,NEL,NEL,ALPHA,BBEM,NEL,CBEM,NEL,BETA,MFLE,NEL)
+         ELSE
+         ! Single Precision version / Bad performance 
+           DO JN=1,NEL
+             DO IN=1,NEL
                SUM=ZERO
                DO KN=1,NEL
                   SUM=SUM+BBEM(KN,IN)*CBEM(KN,JN)+CBEM(KN,IN)*BBEM(KN,JN)
                ENDDO
                MFLE(IN,JN)=SUM
-            ENDDO
-         ENDDO
-#endif
+             ENDDO
+           ENDDO
+         ENDIF
          RETURN
       ENDIF
 C---------------------------------------------------

--- a/starter/source/loads/bem/hm_read_bem.F
+++ b/starter/source/loads/bem/hm_read_bem.F
@@ -270,7 +270,7 @@ C
       !||====================================================================
       SUBROUTINE HM_READ_BEM(IGRSURF, IFLOW   , RFLOW  ,
      .                    NPC    , IGRNOD  , MEMFLOW,UNITAB,
-     .                    X      , NOM_OPT , LGAUGE ,IGRV, LSUBMODEL)
+     .                    X      , NOM_OPT , LGAUGE ,IGRV, LSUBMODEL,IRESP)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -302,6 +302,7 @@ C-----------------------------------------------
       INTEGER(KIND=8) MEMFLOW(*)
       my_real RFLOW(*), X(3,*)
       TYPE(SUBMODEL_DATA), DIMENSION(NSUBMOD), INTENT(IN) :: LSUBMODEL
+      INTEGER,INTENT(IN) :: IRESP
 C-----------------------------------------------
       TYPE (GROUP_)  , DIMENSION(NGRNOD)  :: IGRNOD
       TYPE (SURF_)   , DIMENSION(NSURF)   :: IGRSURF
@@ -331,7 +332,7 @@ C-----------------------------------------------
       CHARACTER(LEN=NCHARTITLE) :: TITR
       LOGICAL :: IS_AVAILABLE
       INTEGER :: HM_NDAA, HM_NFLOW
-      
+C-----------------------------------------------
       HM_NDAA = 0
       HM_NFLOW = 0
       CALL HM_OPTION_COUNT('/BEM/DAA', HM_NDAA)
@@ -1160,11 +1161,11 @@ C-------------------------------------------------------------------------------
             IF(NEL < NELMAX) THEN
                ALLOCATE(CBEM(NEL,NEL))
                CALL MASS_FLUID_QD(NNO, NEL, IFLOW(II1), IFLOW(II2), IFLOW(II3), X,
-     .              RFLOW(IR2), RFLOW(IR4), RFLOW(IR7), CBEM, RHO)
+     .              RFLOW(IR2), RFLOW(IR4), RFLOW(IR7), CBEM, RHO,IRESP)
                DEALLOCATE(CBEM)
             ELSE
                CALL MASS_FLUID_QD(NNO, NEL, IFLOW(II1), IFLOW(II2), IFLOW(II3),  X,
-     .              RFLOW(IR2), RFLOW(IR4), RFLOW(IR7), RFLOW(IR11), RHO)
+     .              RFLOW(IR2), RFLOW(IR4), RFLOW(IR7), RFLOW(IR11), RHO,IRESP)
             ENDIF
             IF(NBGAUGE > 0) THEN
                WRITE (IOUT,'(/5X,A)') 'GAUGE   ELEMENT   ELEMENT'

--- a/starter/source/starter/lectur.F
+++ b/starter/source/starter/lectur.F
@@ -9459,7 +9459,7 @@ C
 C
          CALL HM_READ_BEM(IGRSURF, IFLOW,   RFLOW,
      .                 NPC1   , IGRNOD , MEMFLOW(1,1),UNITAB,
-     .                 X, NOM_OPT(LNOPT1*INOM_OPT(12)+1),LGAUGE, IGRV, LSUBMODEL)
+     .                 X, NOM_OPT(LNOPT1*INOM_OPT(12)+1),LGAUGE, IGRV, LSUBMODEL,IRESP)
 C
       ELSE
          ALLOCATE(IFLOW(0), RFLOW(0))


### PR DESCRIPTION
/BEM/DAA option: Lapack call was conditionned by MKL but can always be used :
Lapack on gfortran
Armpl on ARM64
MKL on Windows / Linux ifx

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
