### PR TITLE
Correct division by zero in materials when thermal parameters are not defined

### DIFF
--- a/engine/source/materials/mat_share/mulawc.F90
+++ b/engine/source/materials/mat_share/mulawc.F90
@@ -1090,7 +1090,7 @@
               ! case of temp calculated locally in material
               t0 = pm(79, imat)
               tm = pm(80, imat)
-              tstar(1:nel) = max(zero, (el_temp(1:nel) - t0) / (tm - t0))
+              tstar(1:nel) = max(zero, (el_temp(1:nel) - t0) / max(tm - t0, em20))
             else
               tstar(1:nel) = zero
             end if


### PR DESCRIPTION
Division by zero in some materials depending on temperature but without defining initial and reference temp

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do contains merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DONTS of the CONTRIBUTING.md file -->
