### PR TITLE
/LOAD/PBLAST:cosinus update for Ishape=1,2

### DIFF
--- a/engine/source/loads/pblast/pblast_2.F
+++ b/engine/source/loads/pblast/pblast_2.F
@@ -282,8 +282,6 @@ C-----------------------------------------------
             LG = SQRT(TMP(1)*TMP(1)+TMP(2)*TMP(2)+TMP(3)*TMP(3))
             ZG = LG*FAC_L_bb/W13     !scaled horizontal distance (ground)  {g,cm,mus}
 
-            cos_theta = (Xdet-ProjZ(1))*Nx +  (Ydet-ProjZ(2))*Ny + (Zdet-ProjZ(3))*Nz
-            cos_theta = cos_theta/MAX(EM20,LG*NORM)
 
             ! scaled distance
             SELECT CASE(ISHAPE)
@@ -294,8 +292,14 @@ C-----------------------------------------------
                 Dz = (Zdet - Zz)*FAC_L_bb
                 DNORM = SQRT(Dx*Dx+Dy*Dy+Dz*Dz) ! *FAC_L_bb  cm->work unit    /FAC_L_bb : WORK_UNIT -> cm
                 Z = DNORM / W13    !spherical
+                !Angle from detonation point
+                cos_theta = Dx*Nx + Dy*Ny + Dz*Nz
+                cos_theta = cos_theta/MAX(EM20,NORM*DNORM)
              CASE(3)
                 Z = ZG             !cylindrical - in abac unit ID  g,cm,mus
+                ! Angle from detonation point
+                cos_theta = (Xdet-ProjZ(1))*Nx +  (Ydet-ProjZ(2))*Ny + (Zdet-ProjZ(3))*Nz
+                cos_theta = cos_theta/MAX(EM20,LG*NORM)
             END SELECT
 
            !checking bounds

--- a/starter/source/loads/pblast/hm_read_pblast.F
+++ b/starter/source/loads/pblast/hm_read_pblast.F
@@ -897,16 +897,21 @@ C-----------------------------------------------
                   tmp(2) = (ProjZ(2)-ProjDet(2))
                   tmp(3) = (ProjZ(3)-ProjDet(3))
                   LG = SQRT(TMP(1)*TMP(1)+TMP(2)*TMP(2)+TMP(3)*TMP(3))
-                  cos_theta = (ProjDet(1)-ProjZ(1))*Nx_SEG + (ProjDet(2)-ProjZ(2))*Ny_SEG + (ProjDet(3)-ProjZ(3))*Nz_SEG
-                  cos_theta = cos_theta/MAX(EM20,LG*NORM_)
-                  ZG = LG*FAC_L_bb/W13     !scaled horizontal distance (ground)
+                  ZG = LG*FAC_L_bb/W13
 
                   ! scaled distance
                   SELECT CASE(ISHAPE)
                     CASE (1,2)
                       Z = DNORM / W13    !spherical
+                      !Angle from detonation point
+                      cos_theta = Dx*Nx_SEG + Dy*Ny_SEG + Dz*Nz_SEG
+                      cos_theta = cos_theta/MAX(EM20,NORM_*DNORM)
                    CASE(3)
                       Z = ZG             !cylindrical - in abac unit ID  g,cm,mus
+                      !Angle from detonation point
+                      !   is here cos between (Det-ProjZ) and normal
+                      cos_theta = (ProjDet(1)-ProjZ(1))*Nx_SEG + (ProjDet(2)-ProjZ(2))*Ny_SEG + (ProjDet(3)-ProjZ(3))*Nz_SEG
+                      cos_theta = cos_theta/MAX(EM20,LG*NORM_)
                   END SELECT
 
                   !finding index for TM5-1300 abacuses from bijection.


### PR DESCRIPTION
#### /LOAD/PBLAST:cosinus update for Ishape=1,2


#### Description of the changes
/LOAD/PBLAST is a loading option which model a blast wave hiting a structure. It depends on the angle of the structure. This angle must be updated in the specific cases of the Surface Burst model with Ishape=1 or 2 (spherical propagation).

This update is missing in commit : bfe0dd22269795d6db2856f399f74378ebf2de83
![image](https://github.com/user-attachments/assets/cdbbe278-9957-4b24-a021-13258a043e60)
