### PR TITLE
Compatibility with Armflang 24.10.1, fix issue in Starter link

### DIFF
--- a/engine/CMake_Compilers/cmake_linuxa64.txt
+++ b/engine/CMake_Compilers/cmake_linuxa64.txt
@@ -95,14 +95,8 @@ if ( NOT DEFINED WITH_LINEAR_ALGEBRA)
 set ( wo_linalg "-DWITHOUT_LINALG" )
 endif()
 
-if ( CMAKE_C_COMPILER_VERSION  VERSION_GREATER 18)
- set (veclib "-fveclib=none")
-else()
- set (veclib "-fno-simdmath")
-endif()
-
 set(Vect_opt "-march=armv8-a  -D COMP_ARMFLANG=1 -D ARCH_CPU=ARM -fopenmp")
-set(Vect_precise "-nofma -ffp-contract=off -fno-unsafe-math-optimizations -fno-fast-math ${veclib}")
+set(Vect_precise "-nofma -ffp-contract=off -fno-unsafe-math-optimizations -fno-fast-math -fveclib=none")
 set(Fortran "-ffixed-line-length-none")
 
 if ( debug STREQUAL "1" )

--- a/starter/CMake_Compilers/cmake_linuxa64.txt
+++ b/starter/CMake_Compilers/cmake_linuxa64.txt
@@ -21,7 +21,7 @@ set ( cpprel  "-DCPP_rel=70" )
 if ( USE_OPEN_READER STREQUAL 1 )
        set ( reader_lib "-L${source_directory}/../exec -lopen_reader_linuxa64")
 else ()
-       set ( reader_lib "-L${source_directory}/../extlib/hm_reader/linuxa64/ -lhm_reader_linux64 -lapr-1 " )
+       set ( reader_lib "-L${source_directory}/../extlib/hm_reader/linuxa64/ -lhm_reader_linuxa64 -lapr-1 " )
 endif()
 
 #Lapack
@@ -62,7 +62,7 @@ message (STATUS "modules: ${CMAKE_Fortran_MODULE_DIRECTORY}")
 
 #Generic Compilation flags
 ###########################
-set(ARCH_OPT "-O2 -march=armv8-a  -DCOMP_ARMFLANG=1 -DARCH_CPU=ARM  -nofma -fopenmp")
+set(ARCH_OPT "-O2 -march=armv8-a  -DCOMP_ARMFLANG=1 -DARCH_CPU=ARM  -nofma -fopenmp -fveclib=none")
 set(FLAG_PRECISE "-ffp-contract=off -fno-unsafe-math-optimizations -fno-fast-math")
 set(Fortran "-DCPP_comp=f90 -ffixed-line-length-none -fno-backslash ")
 


### PR DESCRIPTION
This pull request updates compiler flags and library paths in Armflang configuration files, adding a consistent `-fveclib=none` flag.