### PR TITLE
Erosion solid Inter25 : take into account elemets defined in surface

### DIFF
--- a/engine/source/interfaces/int25/i25dst3_e2s.F
+++ b/engine/source/interfaces/int25/i25dst3_e2s.F
@@ -289,9 +289,9 @@ C---------------------------------------
 C         Solid on secnd side !
 C---------------------------------------
 
-          IF(IAS(I)==0 .OR. IBS(I)==0) THEN
-            print *,' internal error - i25dst3_e2s'
-          END IF
+c          IF(IAS(I)==0 .OR. IBS(I)==0) THEN
+c            print *,' internal error - i25dst3_e2s'   ! This error message is desactivated : E2E solid erosion will be taken into account
+c          END IF
 
 
           DO EJ=1,4

--- a/engine/source/interfaces/interf/check_surface_state.F
+++ b/engine/source/interfaces/interf/check_surface_state.F
@@ -167,12 +167,13 @@ C-----------------------------------------------
           ELSEIF(TYPE_INTER.AND.IDEL==2) THEN
               DEACTIVATION = .TRUE.
           ENDIF
+
           IF(.NOT.DEACTIVATION.AND.(IPARI(100,NIN)/=0.AND.ITY==25)) THEN
             NB_CONNECTED_ELM = SHOOT_STRUCT%INTER(NIN)%NB_ELM_M(K)
             ! ---------
-            IF((NB_CONNECTED_ELM<1).AND.(INTBUF_TAB(NIN)%STFM(k)>ZERO)) THEN
-              DEACTIVATION=.TRUE.
-            ELSEIF(NB_CONNECTED_ELM==1.AND.(INTBUF_TAB(NIN)%STFM(k)<ZERO)) THEN
+c            IF((NB_CONNECTED_ELM<1).AND.(INTBUF_TAB(NIN)%STFM(k)>ZERO)) THEN
+c              DEACTIVATION=.TRUE.
+            IF(NB_CONNECTED_ELM==1.AND.(INTBUF_TAB(NIN)%STFM(k)<ZERO)) THEN
               ACTIVATION = .TRUE.
             ENDIF
             ! ---------

--- a/starter/source/interfaces/inter3d1/i24sti3.F
+++ b/starter/source/interfaces/inter3d1/i24sti3.F
@@ -51,7 +51,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      G IPARTFRICM,INTBUF_FRIC_TAB ,INTNITSCHE,NRTS,IRECTS,
      I IELNRTS ,ADRECTS ,FACNRTS  ,NMN       ,MSR ,
      J IPARTT ,IPARTP   ,IPARTR   ,ELEM_LINKED_TO_SEGMENT,
-     K IGSTI  )
+     K IGSTI  ,FLAG_ELEM_INTER25  ) 
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -105,6 +105,7 @@ C     REAL
       TYPE(INTBUF_FRIC_STRUCT_) INTBUF_FRIC_TAB(*)
       TYPE (SURF_) :: IGRSURF
       TYPE (SURF_) :: IGRSURF2
+      INTEGER, INTENT(IN) :: FLAG_ELEM_INTER25(NINTER25,NUMELS)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -745,7 +746,8 @@ C------------ISU1 first
      F GAPMX  , GAPMN  ,GAPSCALE  ,NSHIF   ,GAPMAX_M,
      G ID     ,TITR    ,IGEO      ,FILLSOL ,NRTT    ,
      H PM_STACK, IWORKSH,INTFRIC ,TAGPRT_FRIC,IPARTFRICS,
-     I IPARTFRICM,IPARTS,INTBUF_FRIC_TAB ,ELEM_LINKED_TO_SEGMENT,IGSTI)
+     I IPARTFRICM,IPARTS,INTBUF_FRIC_TAB ,ELEM_LINKED_TO_SEGMENT,
+     J IGSTI  , FLAG_ELEM_INTER25)
        NRT2=IGRSURF%NSEG
        NSHIF = NRT1
        CALL I24GAPM(
@@ -764,7 +766,8 @@ C------------ISU1 first
      F GAPMX  , GAPMN  ,GAPSCALE  ,NSHIF   ,GAPMAX_M,
      G ID     ,TITR    ,IGEO      ,FILLSOL ,NRTT  ,
      H PM_STACK , IWORKSH,INTFRIC,TAGPRT_FRIC,IPARTFRICS,
-     I IPARTFRICM,IPARTS,INTBUF_FRIC_TAB ,ELEM_LINKED_TO_SEGMENT,IGSTI)
+     I IPARTFRICM,IPARTS,INTBUF_FRIC_TAB ,ELEM_LINKED_TO_SEGMENT,
+     J IGSTI  , FLAG_ELEM_INTER25)
       ELSE
        CALL I24GAPM(
      1 X     ,IRECT ,STF   ,IXS   ,PM    ,
@@ -781,7 +784,8 @@ C------------ISU1 first
      F GAPMX  , GAPMN  ,GAPSCALE  ,NSHIF   ,GAPMAX_M,
      G ID     ,TITR    ,IGEO      ,FILLSOL ,NRTT ,
      H PM_STACK , IWORKSH,INTFRIC,TAGPRT_FRIC,IPARTFRICS,
-     I IPARTFRICM,IPARTS,INTBUF_FRIC_TAB ,ELEM_LINKED_TO_SEGMENT,IGSTI)
+     I IPARTFRICM,IPARTS,INTBUF_FRIC_TAB ,ELEM_LINKED_TO_SEGMENT,
+     J IGSTI  , FLAG_ELEM_INTER25)
       END IF
 
 
@@ -1095,7 +1099,8 @@ C-----------------------------------------------
      F GAPMX  , GAPMN  ,GAPSCALE  ,NSHIFT  ,GAPMAX_M,
      G ID     ,TITR    ,IGEO      ,FILLSOL ,NRTT    ,
      H PM_STACK , IWORKSH ,INTFRIC,TAGPRT_FRIC,IPARTFRICS,
-     I IPARTFRICM,IPARTS,INTBUF_FRIC_TAB,ELEM_LINKED_TO_SEGMENT,IGSTI)
+     I IPARTFRICM,IPARTS,INTBUF_FRIC_TAB,ELEM_LINKED_TO_SEGMENT,IGSTI,
+     J FLAG_ELEM_INTER25 ) 
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -1143,13 +1148,14 @@ C     REAL
       CHARACTER(LEN=NCHARTITLE) :: TITR
       TYPE(INTBUF_FRIC_STRUCT_) INTBUF_FRIC_TAB(*) 
       TYPE (SURF_) :: IGRSURF
+      INTEGER, INTENT(IN) :: FLAG_ELEM_INTER25(NINTER25,NUMELS)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I, J, INRT, NELS, MT, JJ, JJJ, NELC,
      .   MG, NUM, NPT, LL, L, NN, NELTG,N1,N2,N3,N4,IE,
      .   IP, NLEV, MYLEV, K, P, R, T,IAD,NREV,IGTYP,IPGMAT,IGMAT,
-     .   ISUBSTACK,IPL,IPG,NINV,ICONTR
+     .   ISUBSTACK,IPL,IPG,NINV,ICONTR,NIN25
       INTEGER, DIMENSION(:),ALLOCATABLE  :: TAGELEMS,INDEXE
 C     REAL
       my_real
@@ -1316,10 +1322,12 @@ C ----Friction model ------
 C-------coating shell  stif=max(sol,shell)         
           IF (MSEGTYP(I)>NRTT) THEN
              PRINT_ERROR = .FALSE.
+             NIN25 = 0
              CALL INSOL3D(X,IRECT,IXS,NINT,NELS,I   ,
      .            AREA,NOINT,KNOD2ELS ,NOD2ELS ,0,
      .            IXS10,IXS16,IXS20,TAGELEMS,INDEXE,
-     .            NINV,IELEM,ELEM_LINKED_TO_SEGMENT,PRINT_ERROR)
+     .            NINV,IELEM,ELEM_LINKED_TO_SEGMENT,PRINT_ERROR,
+     .            NIN25,NTY, FLAG_ELEM_INTER25 )
              IF(PRINT_ERROR) THEN
                 NODE_ID(1:4) = ITAB(IRECT(1:4,I))
           
@@ -1441,10 +1449,12 @@ C------------------------------------
 C-------coating shell  stif=max(sol,shell)         
           IF (MSEGTYP(I)>NRTT) THEN
              PRINT_ERROR = .FALSE.
+             NIN25 = 0
              CALL INSOL3D(X,IRECT,IXS,NINT,NELS,I   ,
      .            AREA,NOINT,KNOD2ELS ,NOD2ELS ,0,
      .            IXS10,IXS16,IXS20,TAGELEMS,INDEXE ,
-     .            NINV,IELEM,ELEM_LINKED_TO_SEGMENT,PRINT_ERROR)
+     .            NINV,IELEM,ELEM_LINKED_TO_SEGMENT,PRINT_ERROR,
+     .            NIN25,NTY, FLAG_ELEM_INTER25 ,NINTER25)
              IF(PRINT_ERROR) THEN
                 NODE_ID(1:4) = ITAB(IRECT(1:4,I))
           
@@ -1493,10 +1503,12 @@ C----------------------
 C     ELEMENTS SOLIDES
 C----------------------
        PRINT_ERROR = .FALSE.
+       NIN25 = 0
        CALL INSOL3D(X,IRECT,IXS,NINT,NELS,I   ,
      .            AREA,NOINT,KNOD2ELS ,NOD2ELS ,0,
      .            IXS10,IXS16,IXS20,TAGELEMS,INDEXE,
-     .            NINV ,IELEM,ELEM_LINKED_TO_SEGMENT,PRINT_ERROR)
+     .            NINV ,IELEM,ELEM_LINKED_TO_SEGMENT,PRINT_ERROR,
+     .            NIN25,NTY, FLAG_ELEM_INTER25 ,NINTER25)
        IF(PRINT_ERROR) THEN
             NODE_ID(1:4) = ITAB(IRECT(1:4,I))
           

--- a/starter/source/interfaces/inter3d1/i25sti3.F
+++ b/starter/source/interfaces/inter3d1/i25sti3.F
@@ -53,7 +53,8 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      I KNOD2EL1D ,NOD2EL1D   ,INTFRIC   ,TAGPRT_FRIC,IPARTFRICS,
      J IPARTFRICM,INTBUF_FRIC_TAB,IVIS2 ,GAPM_MX   ,GAPS_MX    ,
      K GAPM_L_MX ,GAPS_L_MX  ,IPARTSM   ,DRAD      ,IPARTT     ,
-     J IPARTP    ,IPARTR     ,IELEM_M   ,IDEL_SOLID,ELEM_LINKED_TO_SEGMENT)
+     J IPARTP    ,IPARTR     ,IELEM_M   ,IDEL_SOLID,ELEM_LINKED_TO_SEGMENT,
+     K NIN25     , FLAG_ELEM_INTER25)
 C-----------------------------------------------
       USE MY_ALLOC_MOD
       USE INTBUF_FRIC_MOD
@@ -106,6 +107,8 @@ C     REAL
       INTEGER  , INTENT(INOUT) :: IDEL_SOLID
       INTEGER  , INTENT(INOUT) :: IELEM_M(2,NRT+NRT_SH)
       INTEGER, DIMENSION(NUMELS), INTENT(INOUT):: ELEM_LINKED_TO_SEGMENT !< working array, dim=numels
+      INTEGER, INTENT(IN) :: NIN25
+      INTEGER, INTENT(IN) :: FLAG_ELEM_INTER25(NINTER25,NUMELS)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -424,7 +427,8 @@ C------------------------------------
      G ID     ,TITR    ,IGEO      ,FILLSOL ,NRTT ,
      H PM_STACK, IWORKSH,INTFRIC,TAGPRT_FRIC,IPARTFRICS,
      I IPARTFRICM,IPARTS,INTBUF_FRIC_TAB,IPARTSM,INRTIE,
-     J IVIS2  ,IELEM_M  ,IDEL_SOLID,ELEM_LINKED_TO_SEGMENT)
+     J IVIS2  ,IELEM_M  ,IDEL_SOLID,ELEM_LINKED_TO_SEGMENT,
+     K NIN25  ,FLAG_ELEM_INTER25  )
 C---------------------------
 C     GAP
 C---------------------------
@@ -727,7 +731,8 @@ C
      G ID     ,TITR    ,IGEO      ,FILLSOL ,NRTT ,
      H PM_STACK, IWORKSH,INTFRIC,TAGPRT_FRIC,IPARTFRICS,
      I IPARTFRICM,IPARTS,INTBUF_FRIC_TAB,IPARTSM,INRTIE,
-     J IVIS2  ,IELEM_M  ,IDEL_SOLID,ELEM_LINKED_TO_SEGMENT)
+     J IVIS2  ,IELEM_M  ,IDEL_SOLID,ELEM_LINKED_TO_SEGMENT,
+     F NIN25  ,FLAG_ELEM_INTER25)
 C-----------------------------------------------
       USE MESSAGE_MOD
       USE INTBUF_FRIC_MOD
@@ -772,6 +777,8 @@ C-----------------------------------------------
       INTEGER  , INTENT(INOUT) :: IELEM_M(2,NRTT)
       INTEGER  , INTENT(INOUT) :: IDEL_SOLID
       INTEGER, DIMENSION(NUMELS), INTENT(INOUT):: ELEM_LINKED_TO_SEGMENT !< working array, dim=numels
+      INTEGER, INTENT(IN) :: NIN25
+      INTEGER, INTENT(INOUT) :: FLAG_ELEM_INTER25(NINTER25,NUMELS)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -821,7 +828,8 @@ C----------------------
      .             AREA,NOINT,KNOD2ELS ,NOD2ELS ,0,
      .             IXS10,IXS16,IXS20,TAGELEMS,INDEXE,
      .             NINV ,IELEM_M(1,I),
-     .             ELEM_LINKED_TO_SEGMENT ,PRINT_ERROR)
+     .             ELEM_LINKED_TO_SEGMENT ,PRINT_ERROR,
+     .             NIN25,NTY, FLAG_ELEM_INTER25 )
 
         IF(PRINT_ERROR) THEN
           NODE_ID(1:4) = ITAB(IRECT(1:4,I))

--- a/starter/source/interfaces/inter3d1/i25surfi.F
+++ b/starter/source/interfaces/inter3d1/i25surfi.F
@@ -42,7 +42,8 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      5                    IXTG    ,KNOD2ELC,KNOD2ELTG,NOD2ELC,
      6                    NOD2ELTG,KNOD2ELS,NOD2ELS  ,IXS    ,
      7                    IXS10   ,IXS16   ,IXS20    ,IRTSE  ,
-     8                    IS2SE   ,IS2PT   ,IS2ID    ,PARAMETERS)
+     8                    IS2SE   ,IS2PT   ,IS2ID    ,PARAMETERS,
+     A                    NIN25   ,FLAG_ELEM_INTER25      )
 C============================================================================
 C-----------------------------------------------
 C   M o d u l e s
@@ -78,6 +79,8 @@ C-----------------------------------------------
       INTEGER, DIMENSION(:),ALLOCATABLE :: INDEX
       INTEGER, DIMENSION(:,:),ALLOCATABLE :: IRECTMP
       INTEGER, DIMENSION(:,:),ALLOCATABLE :: IRECTMP_SAV
+      INTEGER, INTENT(IN) ::  NIN25
+      INTEGER, INTENT(INOUT) :: FLAG_ELEM_INTER25(NINTER25,NUMELS)
       my_real
      .   X(3,*),FRIGAP(*)
 C-----------------------------------------------
@@ -94,7 +97,7 @@ C-----------------------------------------------
       INTEGER NSU1,NLS1,NLS2,NRTM_SH,ETYP,NRTM0,
      .        IMBIN,IM,IDEB,ISN
       LOGICAL :: NEED_SOLID_EROSION
-      INTEGER :: IDEL,SOLID_SEGMENT  
+      INTEGER :: IDEL,SOLID_SEGMENT,ELEM
 C-----------------------------------------------
 C   E x t e r n a l   F u n c t i o n s
 C-----------------------------------------------
@@ -163,7 +166,10 @@ c---------------------------------------
      .                 KNOD2ELC ,KNOD2ELTG ,NOD2ELC ,NOD2ELTG,
      .                 KNOD2ELS,NOD2ELS,IXS ,IXS10 ,IXS16 ,IXS20 )
           IF(IMBIN /= 0)IRECTMP(6,L) = BITSET(IRECTMP(6,L),0) ! MBINFLG
-
+          IF(ILEV==1.OR.ILEV==2) THEN
+             ELEM = IGRSURF(ISU1)%ELEM(J)
+             IF(ELEM/=0.AND.IGRSURF(ISU1)%ELTYP(J)==1) FLAG_ELEM_INTER25(NIN25,ELEM) = 1 ! tag solid elements included in surface 
+          ENDIF
         ENDDO
       ENDIF
       NSU1 = L
@@ -180,7 +186,8 @@ c---------------------------------------
      .                 KNOD2ELC ,KNOD2ELTG ,NOD2ELC ,NOD2ELTG,
      .                 KNOD2ELS,NOD2ELS,IXS ,IXS10 ,IXS16 ,IXS20 )
           IF(IMBIN /= 0) IRECTMP(6,L) = BITSET(IRECTMP(6,L),1) ! MBINFLG
-
+          ELEM = IGRSURF(ISU2)%ELEM(J)
+          IF(ELEM/=0.AND.IGRSURF(ISU2)%ELTYP(J)==1) FLAG_ELEM_INTER25(NIN25,ELEM) = 1 ! tag solid elements included in surface 
         ENDDO
       ENDIF
 C=======================================================================

--- a/starter/source/interfaces/inter3d1/i7sti3.F
+++ b/starter/source/interfaces/inter3d1/i7sti3.F
@@ -55,7 +55,8 @@ C
      F              IT19       ,KXIG3D ,IXIG3D        ,INTFRIC  ,IPARTS   ,
      G              TAGPRT_FRIC,IPARTFRICS,IPARTFRICM ,INTBUF_FRIC_TAB,NRT_IGE,
      I              IREM_GAP   ,GAPM_MX,GAPS_MX       ,GAPM_L_MX,GAPS_L_MX,
-     J              IPARTT     ,IPARTP ,IPARTR        ,ELEM_LINKED_TO_SEGMENT)
+     J              IPARTT     ,IPARTP ,IPARTR        ,ELEM_LINKED_TO_SEGMENT,
+     K              FLAG_ELEM_INTER25     ) 
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -109,6 +110,7 @@ C-----------------------------------------------
       TYPE(INTBUF_FRIC_STRUCT_) INTBUF_FRIC_TAB(*)
       TYPE (SURF_) :: IGRSURF
       INTEGER, DIMENSION(NUMELS), INTENT(INOUT):: ELEM_LINKED_TO_SEGMENT !< working array, dim=numels
+      INTEGER, INTENT(IN) :: FLAG_ELEM_INTER25(NINTER25,NUMELS)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -116,7 +118,7 @@ C-----------------------------------------------
      .   MG, NUM, NPT, LL, L, NN, NELTG,N1,N2,N3,N4,IE,
      .   IP, NLEV, MYLEV, K, P, R, T,IGTYP,IPGMAT,IGMAT,
      .   ISUBSTACK,NELIG3D, COIN_IGE(8), IPID, PX, PY, PZ, IAD ,IPFMAX,IPL,
-     .   IPFLMAX,IPG,NINV,ICONTR
+     .   IPFLMAX,IPG,NINV,ICONTR,NIN25
       INTEGER JPERM(4)
       LOGICAL TYPE18
       my_real
@@ -652,10 +654,12 @@ C----------------------
 C       SOLID ELEMENTS
 C----------------------
         PRINT_ERROR = .FALSE.
+        NIN25 = 0
         CALL INSOL3D(X     ,IRECT ,IXS      ,NINT    ,NELS,INRT,
      .               AREA  ,NOINT ,KNOD2ELS ,NOD2ELS ,0   ,
      .               IXS10 ,IXS16 ,IXS20    ,TAGELEMS,INDEXE,NINV,IELEM,
-     .               ELEM_LINKED_TO_SEGMENT ,PRINT_ERROR)
+     .               ELEM_LINKED_TO_SEGMENT ,PRINT_ERROR,
+     .               NIN25,NTY, FLAG_ELEM_INTER25 )
         IF(PRINT_ERROR) THEN
           NODE_ID(1:4) = ITAB(IRECT(1:4,INRT))
           

--- a/starter/source/interfaces/inter3d1/inint3.F
+++ b/starter/source/interfaces/inter3d1/inint3.F
@@ -140,7 +140,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      G                  T2_CONNEC     ,NOM_OPT             ,ICODE                 ,ISKEW        ,IREMNODE_EDG,
      H                  S_APPEND_ARRAY,X_APPEND            ,MASS_APPEND           ,N2D          ,FLAG_REMOVED_NODE,
      I                  NSPMD         ,INTER_TYPE2_NUMBER  ,ELEM_LINKED_TO_SEGMENT,SINSCR       ,SICODE  ,
-     J                  SITAB)
+     J                  SITAB         ,NIN25               ,FLAG_ELEM_INTER25     )
 C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
@@ -225,6 +225,8 @@ C-----------------------------------------------
       LOGICAL, INTENT(in) :: FLAG_REMOVED_NODE !< flag to remove some S node from the list of candidates
       TYPE(INTER_CAND_), iNTENT(inout) :: INTER_CAND
       INTEGER, DIMENSION(NUMELS), INTENT(INOUT):: ELEM_LINKED_TO_SEGMENT
+      INTEGER, INTENT(IN) ::  NIN25
+      INTEGER, INTENT(IN) :: FLAG_ELEM_INTER25(NINTER25,NUMELS)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -701,7 +703,8 @@ C----------------
      G    IT19             ,KXIG3D                  ,IXIG3D           ,IPARI(72,NIN)    , IPARTS          ,
      H    TAGPRT_FRIC      ,INTBUF_TAB(NIN)%IPARTFRICS   ,INTBUF_TAB(NIN)%IPARTFRICM ,INTBUF_FRIC_TAB,NRTM_IGE      ,
      I    IPARI(63,NIN)    ,GAPM_MX                 ,GAPS_MX          ,GAPM_L_MX        ,GAPS_L_MX        ,
-     J    IPARTT           ,IPARTP                  ,IPARTR           ,ELEM_LINKED_TO_SEGMENT)
+     J    IPARTT           ,IPARTP                  ,IPARTR           ,ELEM_LINKED_TO_SEGMENT,
+     K    FLAG_ELEM_INTER25       ) 
        IPARI(21,NIN) = IGAP 
 C
 C----------------
@@ -1489,7 +1492,7 @@ C----  INTBUF_TAB(NIN)%CRIT V/A is used temporarily for sorting and Pen-max
      H PM_STACK  ,IWORKSH    ,IPARI(72,NIN)  ,TAGPRT_FRIC   , INTBUF_TAB(NIN)%IPARTFRICS,
      G INTBUF_TAB(NIN)%IPARTFRICM,INTBUF_FRIC_TAB,IPARI(86,NIN) , NRTS   ,INTBUF_TAB(NIN)%IRECTS ,
      I INTBUF_TAB(NIN)%IELNRTS,INTBUF_TAB(NIN)%ADRECTS,INTBUF_TAB(NIN)%FACNRTS,NMN,INTBUF_TAB(NIN)%MSR ,
-     J IPARTT   ,IPARTP   ,IPARTR  ,ELEM_LINKED_TO_SEGMENT,IGSTI)  
+     J IPARTT   ,IPARTP   ,IPARTR  ,ELEM_LINKED_TO_SEGMENT,IGSTI, FLAG_ELEM_INTER25 )  
        IPARI(21,NIN) = IGAP
 C---------GAP_S for fictive nodes       
         IF (NSNE >0) THEN
@@ -1906,7 +1909,8 @@ C-----------------------------------------------------------
      I KNOD2EL1D  ,NOD2EL1D         ,IPARI(72,NIN)       ,TAGPRT_FRIC    ,INTBUF_TAB(NIN)%IPARTFRICS   ,
      J INTBUF_TAB(NIN)%IPARTFRICM,INTBUF_FRIC_TAB,IVIS2   ,GAPM_MX       , GAPS_MX               ,
      K GAPM_L_MX  ,GAPS_L_MX        ,IPARTSM         ,DRAD          ,IPARTT                 ,
-     J IPARTP     ,IPARTR           ,INTBUF_TAB(NIN)%IELEM_M , IPARI(100,NIN),ELEM_LINKED_TO_SEGMENT)
+     J IPARTP     ,IPARTR           ,INTBUF_TAB(NIN)%IELEM_M , IPARI(100,NIN),ELEM_LINKED_TO_SEGMENT,
+     K NIN25      , FLAG_ELEM_INTER25)
        IPARI(21,NIN) = IGAP
 C-----------------------------------------------------------
 C      ELEMENT NEIGHBROURS & FREE EDGES

--- a/starter/source/interfaces/inter3d1/insol3.F
+++ b/starter/source/interfaces/inter3d1/insol3.F
@@ -188,7 +188,8 @@ C
       SUBROUTINE INSOL3D(X   ,IRECT ,IXS     ,NINT   ,NEL,I ,
      .                  AREA ,NOINT ,KNOD2ELS,NOD2ELS,IR ,
      .                  IXS10,IXS16,IXS20    ,TAGELEMS,INDEXE,
-     .                  NINV ,IELEM_M ,ELEM_LINKED_TO_SEGMENT,PRINT_ERROR)
+     .                  NINV ,IELEM_M ,ELEM_LINKED_TO_SEGMENT,PRINT_ERROR,
+     .                  NIN25,NTY     , FLAG_ELEM_INTER25 )
 C-----------------------------------------------
 C   M o d u l e s
 C----------------------------------------------- 
@@ -216,6 +217,8 @@ C-----------------------------------------------
       INTEGER  , INTENT(INOUT) :: IELEM_M(2) ! ID of 1 or 2 solid elements attached to main segment
       INTEGER, DIMENSION(NUMELS), INTENT(INOUT) :: ELEM_LINKED_TO_SEGMENT !< working array, dim=numels
       LOGICAL, INTENT(INOUT) :: PRINT_ERROR !< flag : true if several elements seem to be duplicated
+      INTEGER, INTENT(IN) :: NIN25, NTY
+      INTEGER, INTENT(IN) :: FLAG_ELEM_INTER25(NINTER25,NUMELS)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -351,6 +354,17 @@ C
             IELEM_M(1) = IELEM_M(2)
             IELEM_M(2) = IELS
           ENDIF
+          IF(NTY==25) THEN
+            IF(FLAG_ELEM_INTER25(NIN25,IELEM_M(1)) ==1.AND.FLAG_ELEM_INTER25(NIN25,IELEM_M(2)) ==0) THEN
+              IC = 1  
+            ELSEIF(FLAG_ELEM_INTER25(NIN25,IELEM_M(1)) ==0.AND.FLAG_ELEM_INTER25(NIN25,IELEM_M(2)) ==1) THEN
+              IC = 1
+              NEL = IELEM_M(2)
+              IELEM_M(1) = IELEM_M(2)
+              IELEM_M(2) = 0
+            ENDIF
+          ENDIF
+          
        ELSE
           IELEM_M(1:2) = ELEM_LINKED_TO_SEGMENT(1:2)
           PRINT_ERROR = .TRUE.

--- a/starter/source/interfaces/interf1/inintr.F
+++ b/starter/source/interfaces/interf1/inintr.F
@@ -60,7 +60,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      F                  SEGQUADFR,TAGPRT_FRIC,INTBUF_FRIC_TAB   ,IPARTT          ,
      G                  IPARTP    ,IPARTX    ,IPARTR            ,NSN_MULTI_CONNEC,T2_NB_CONNEC,
      H                  SICODE    ,ICODE     ,ISKEW             ,MULTI_FVM       ,S_NOD2ELS   ,
-     I                  SITAB     ,SITABM1)
+     I                  SITAB     ,SITABM1   ,FLAG_ELEM_INTER25 ,LIST_NIN25      )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -115,6 +115,8 @@ C-----------------------------------------------
      .        THK(*),THK_PART(*),FRIGAP(NPARIR,NINTER),
      .        LELX(*), FILLSOL(*),PM_STACK(*)
       INTEGER NOM_OPT(LNOPT1,*),KXX(*),IXX(*)
+      INTEGER, INTENT(IN) :: LIST_NIN25(NINTER)
+      INTEGER, INTENT(IN) :: FLAG_ELEM_INTER25(NINTER25,NUMELS)   
       TYPE(INTERSURFP) :: INTERCEP(3,NINTER)
       TYPE(INTBUF_STRUCT_) INTBUF_TAB(*)
       TYPE(SCRATCH_STRUCT_) INSCR(*)
@@ -133,7 +135,7 @@ C-----------------------------------------------
       INTEGER NTY, NSN2T, NMN2T,ID,
      .        NSNET  ,NMNET  ,MULTIMP, IREMNODE, NREMNODE,
      .        NREMN(NINTER),NREMN_OLD(NINTER),IEDG,IEDGN,ST2_CONNEC,
-     .        REMNODE_SIZE,LEN_FILNAM,REMNODE_SIZE_EDG,IREMNODE_EDG
+     .        REMNODE_SIZE,LEN_FILNAM,REMNODE_SIZE_EDG,IREMNODE_EDG,NIN25
       CHARACTER*(2148) FILNAM
       CHARACTER(LEN=NCHARTITLE) :: TITR
       INTEGER, DIMENSION(:),ALLOCATABLE :: REMNODE,KREMNODE,T2_ADD_CONNEC,T2_CONNEC,IKINE1
@@ -332,6 +334,7 @@ C---     Initial dimension of REMNODE arrays
             NIN=N
             ID=NOM_OPT(1,NIN)
             CALL FRETITL2(TITR,NOM_OPT(LNOPT1-LTITR+1,NIN),LTITR)
+            NIN25 = LIST_NIN25(NIN)
 
             IF(N2D == 0)THEN
 
@@ -355,7 +358,7 @@ C---     Initial dimension of REMNODE arrays
      G               T2_CONNEC               , NOM_OPT               , ICODE                 , ISKEW          , IREMNODE_EDG     ,
      H               MULTI_FVM%S_APPEND_ARRAY, MULTI_FVM%X_APPEND    , MULTI_FVM%MASS_APPEND , N2D            , FLAG_REMOVED_NODE,
      I               NSPMD                   ,INTER_TYPE2_NUMBER     , ELEM_LINKED_TO_SEGMENT, INSCR(N)%SINSCR, SICODE           ,
-     J               SITAB )
+     J               SITAB                   ,NIN25                  , FLAG_ELEM_INTER25      )
 
               IF (I_MEM /= 0) GOTO 200
             ELSE

--- a/starter/source/interfaces/interf1/lecins.F
+++ b/starter/source/interfaces/interf1/lecins.F
@@ -54,7 +54,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .                  NOD2ELTG,INTBUF_TAB ,KNOD2ELS ,NOD2ELS   ,IXS10   ,
      .                  IXS16   ,IXS20      ,NIGE,RIGE,XIGE      ,VIGE    ,
      .                  IGRBRIC ,MULTI_FVM  ,NALE     ,IGEO      ,INTERFACES,
-     .                  S_NOD2ELS,S_NOD2ELTG)
+     .                  S_NOD2ELS,S_NOD2ELTG,FLAG_ELEM_INTER25   ,LIST_NIN25)
 C============================================================================
 C-----------------------------------------------
 C   M o d u l e s
@@ -95,7 +95,9 @@ C-----------------------------------------------
       my_real, INTENT(IN) :: PM(*)
       INTEGER NOM_OPT(LNOPT1,*)
       TYPE(INTBUF_STRUCT_) INTBUF_TAB(*)
-      INTEGER, INTENT(IN) :: NALE(NUMNOD)      
+      INTEGER, INTENT(IN) :: NALE(NUMNOD)   
+      INTEGER, INTENT(INOUT) :: LIST_NIN25(NINTER)
+      INTEGER, INTENT(INOUT) :: FLAG_ELEM_INTER25(NINTER25,NUMELS)   
 C-----------------------------------------------
       TYPE (GROUP_)  , DIMENSION(NGRNOD)  :: IGRNOD
       TYPE (GROUP_)  , DIMENSION(NGRBRIC) :: IGRBRIC
@@ -112,7 +114,7 @@ C-----------------------------------------------
      .   ISU1,ISU2,NRTM0,NRTM_SH,
      .   NRTS_NEW, NRTM_NEW,IBID,INTTH,
      .   NRTM_IGE,NRTM_FE,NRTS_IGE,NRTS_FE,
-     .   NMN_IGE,NMN_FE,NSN_IGE,NSN_FE,INTNITSCHE,IAD_IGE,GRBRIC_ID
+     .   NMN_IGE,NMN_FE,NSN_IGE,NSN_FE,INTNITSCHE,IAD_IGE,GRBRIC_ID,NIN25
 
       INTEGER :: STAT
       INTEGER, DIMENSION(:), ALLOCATABLE, TARGET ::  NTAG_TARGET
@@ -132,6 +134,7 @@ C=======================================================================
         NTAG(K) = 0
        ENDDO
       LIXINT = 0
+      NIN25 = 0
 C---------------------
       DO NI = 1,LINTER
 C
@@ -617,6 +620,8 @@ C           necessaire au 2eme passage (cf IDDLEVEL)
             INTBUF_TAB(NI)%NBINFLG(1:INTBUF_TAB(NI)%S_NBINFLG)=0
             INTBUF_TAB(NI)%MBINFLG(1:INTBUF_TAB(NI)%S_MBINFLG)=0
           END IF
+          NIN25 = NIN25 + 1
+          LIST_NIN25(NI) = NIN25
           CALL I25SURFI(
      1      IALLO                  ,IPARI(1,NI)            ,IGRNOD                   , IGRSURF               ,
      2      INTBUF_TAB(NI)%IRECTM  , FRIGAP(1,NI)          ,
@@ -626,7 +631,8 @@ C           necessaire au 2eme passage (cf IDDLEVEL)
      6      IXTG                   ,KNOD2ELC               ,KNOD2ELTG                ,NOD2ELC                ,
      7      NOD2ELTG               ,KNOD2ELS               ,NOD2ELS                  ,IXS                    ,
      8      IXS10                  ,IXS16                  ,IXS20                    ,INTBUF_TAB(NI)%IRTSE   ,
-     9      INTBUF_TAB(NI)%IS2SE   ,INTBUF_TAB(NI)%IS2PT   ,INTBUF_TAB(NI)%IS2ID     ,INTERFACES%PARAMETERS  )
+     9      INTBUF_TAB(NI)%IS2SE   ,INTBUF_TAB(NI)%IS2PT   ,INTBUF_TAB(NI)%IS2ID     ,INTERFACES%PARAMETERS  ,
+     A      NIN25                  ,FLAG_ELEM_INTER25      )
 C------initialization of doubler M_seg pour shells ---> move inside I24SURFI
         ENDIF
 C

--- a/starter/source/interfaces/interf1/lecint.F
+++ b/starter/source/interfaces/interf1/lecint.F
@@ -61,7 +61,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .                  IXS16   ,IXS20   ,DEF_INTER,MAXNSNE,
      .                  NPC1    ,MULTI_FVM,NOM_OPTFRIC,INTBUF_FRIC_TAB,
      .                  IGRBRIC,IGRSH3N ,IGRTRUSS ,MAXRTM_T2,NSN_MULTI_CONNEC,T2_NB_CONNEC,
-     .                  IDDLEVEL,NALE   ,INTERFACES,SNPC1)
+     .                  IDDLEVEL,NALE   ,INTERFACES,SNPC1  ,FLAG_ELEM_INTER25,LIST_NIN25)
 C============================================================================
 C   M o d u l e s
 C-----------------------------------------------
@@ -106,6 +106,8 @@ C-----------------------------------------------
      .        NPC1(SNPC1),NOM_OPTFRIC(LNOPT1,*),MAXRTM_T2,
      .        T2_NB_CONNEC(*),NSN_MULTI_CONNEC
       INTEGER, INTENT(IN) :: NALE(NUMNOD)
+      INTEGER, INTENT(INOUT) :: LIST_NIN25(NINTER)
+      INTEGER, INTENT(INOUT) :: FLAG_ELEM_INTER25(NINTER25,NUMELS)
       my_real
      .   GEO(NPROPG,NUMGEO), PM(*), XFILTR(*),STFAC(*),
      .   FRIC_P(10,NINTER),I2RUPT(6,NINTER),FRIGAP(NPARIR,NINTER),AREASL(*)
@@ -136,7 +138,7 @@ C-----------------------------------------------
      .        NRTM_IGE,NRTMM_IGE,
      .        NRTS_IGE,NRTMS_IGE,NRTS_FE,
      .        NMN_IGE,NMN_FE,NSN_IGE,NSN_FE,IAD_IGE,
-     .        IEDGE,NCONTE,MULTIMPE,MULTIMPS,ISTIFF
+     .        IEDGE,NCONTE,MULTIMPE,MULTIMPS,ISTIFF,NIN25
       INTEGER KD(50),JD(50),IBID,NRTM_SH,ETYP,INTPLY
       INTEGER, DIMENSION(:), ALLOCATABLE :: IRECTS,IRECTM,NSV,MSR
       INTEGER ID,ISL, GRBRIC_ID
@@ -270,6 +272,7 @@ C-----------------------------------------------
       NRTMM_IGE = 0
       NRTMS_IGE = 0
       STIFF_STAT = ZERO
+      NIN25 = 0
       
       DO NI=1,LINTER
 C
@@ -439,6 +442,8 @@ C
         ELSEIF(NTYP == 25)THEN
           IALLO = 1  ! memory evaluation
           INTPLY = 0
+          NIN25 = NIN25 + 1
+          LIST_NIN25(NI) = NIN25
           CALL I25SURFI(
      1      IALLO        ,IPARI(1,NI)  ,IGRNOD     ,IGRSURF      ,
      2      IBID         ,FRIGAP(1,NI) ,
@@ -448,7 +453,8 @@ C
      6      IXTG         ,KNOD2ELC     ,KNOD2ELTG   ,NOD2ELC      ,
      7      NOD2ELTG     ,KNOD2ELS     ,NOD2ELS     ,IXS          ,
      8      IXS10        ,IXS16        ,IXS20       ,IBID         ,
-     9      IBID         ,IBID         ,IBID        ,INTERFACES%PARAMETERS)
+     9      IBID         ,IBID         ,IBID        ,INTERFACES%PARAMETERS,
+     A      NIN25        ,FLAG_ELEM_INTER25)
             IPARI(66,NI) = INTPLY
             IF(INTPLY > 0) INTPLYXFEM = 1          
 C----------NRTS,NRTM is calculated in I25SURFI     

--- a/starter/source/starter/lectur.F
+++ b/starter/source/starter/lectur.F
@@ -915,6 +915,8 @@ C-----------------------------------------------
       INTEGER NUSPHCEL
       INTEGER, DIMENSION(:,:), ALLOCATABLE :: IXSPS
       LOGICAL MAT20_DISCRETE_FILL
+      INTEGER, DIMENSION(:,:), ALLOCATABLE :: FLAG_ELEM_INTER25     
+      INTEGER, DIMENSION(:), ALLOCATABLE :: LIST_NIN25
 C-----------------------------------------------
 C Model Checker Memory
       DATA IUN/1/
@@ -7437,6 +7439,17 @@ C--------------------------------------------------------------
 C
        IF(.NOT. ALLOCATED(ALE_CONNECTIVITY%NALE)) ALLOCATE(ALE_CONNECTIVITY%NALE(0))
 
+       IF(NINTER > 0) THEN 
+         ALLOCATE(LIST_NIN25(NINTER))
+         LIST_NIN25(1:NINTER) = 0
+       ENDIF
+       IF(NINTER25 >0.AND.NUMELS > 0)  THEN
+         ALLOCATE(FLAG_ELEM_INTER25(NINTER25,NUMELS))
+         FLAG_ELEM_INTER25 (1:NINTER25,1:NUMELS) = 0
+       ELSE
+         ALLOCATE(FLAG_ELEM_INTER25(0,0))
+       ENDIF
+
        CALL LECINT (IPARI       ,NINTER    ,IPM                           ,BUFMAT         ,
      .              NMNT        ,ITAB      ,ITABM1                        ,GEO            ,
      .              PM          ,X         ,IGRNOD                        ,IGRSURF        ,IGRSLIN  ,
@@ -7450,7 +7463,8 @@ C
      .              IXS16       ,IXS20     ,DEF_INTER                     ,MAXNSNE        ,
      .              NPC1        ,MULTI_FVM ,NOM_OPT(LNOPT1*INOM_OPT(29)+1),INTBUF_FRIC_TAB,            
      .              IGRBRIC     ,IGRSH3N   ,IGRTRUSS                      ,MAXRTM_T2      ,NSN_MULTI_CONNEC,
-     .              T2_NB_CONNEC,IDDLEVEL  ,ALE_CONNECTIVITY%NALE         ,INTERFACES     ,SNPC1)
+     .              T2_NB_CONNEC,IDDLEVEL  ,ALE_CONNECTIVITY%NALE         ,INTERFACES     ,SNPC1   ,
+     .              FLAG_ELEM_INTER25      ,LIST_NIN25)
 
        !need to allocate only once at first passage in lectur
        FLAG_ALLOCATE = 1
@@ -7512,7 +7526,7 @@ C
      .             NOD2ELTG ,INTBUF_TAB,KNOD2ELS ,NOD2ELS                      ,IXS10  ,
      .             IXS16    ,IXS20     ,NIGE     ,RIGE                         ,XIGE   ,
      .             VIGE     ,IGRBRIC   ,MULTI_FVM,ALE_CONNECTIVITY%NALE        ,IGEO   ,
-     .             INTERFACES,S_NOD2ELS,S_NOD2ELTG)
+     .             INTERFACES,S_NOD2ELS,S_NOD2ELTG,FLAG_ELEM_INTER25           ,LIST_NIN25)
 C
 cc     DEALLOCATE(XFILTR)
 cc     DEALLOCATE(STFAC)
@@ -7640,7 +7654,7 @@ C
      F               SEGQUADFR ,TAGPRT_FRIC,INTBUF_FRIC_TAB              ,IPARTT           ,
      G               IPARTP    ,IPARTX     ,IPARTR                       ,NSN_MULTI_CONNEC ,T2_NB_CONNEC,
      H               SICODE    ,ICODE      ,ISKEW                        ,MULTI_FVM        ,S_NOD2ELS   ,
-     I               SITAB     ,SITABM1)
+     I               SITAB     ,SITABM1    ,FLAG_ELEM_INTER25            ,LIST_NIN25  )
       IF(IDDLEVEL == 0) CALL STOPTIME(12,1)
       IF(IDDLEVEL == 1) CALL STOPTIME(13,1)
 
@@ -7651,7 +7665,10 @@ C
          ENDIF
       ENDDO
       IF(IDEL_SOLID == 0) INTERFACES%PARAMETERS%INT25_EROSION_SOLID = 0
-         
+ 
+        DEALLOCATE (FLAG_ELEM_INTER25)  
+        DEALLOCATE (LIST_NIN25)  
+      
         DEALLOCATE (T2_NB_CONNEC)
         DEALLOCATE (RWORK)
         DEALLOCATE (IWORK)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
Taking into account elements defined in contact for defining activated surface for /SURF/PART and SURF/GRBRIC.
Desactivating error message when E2E solid is used with Idel

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
- tagging elements defined in Contact surface
- When searching element for segments check which one is in contact surface. If just 1 element surface is external and if both of them segment is internal

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
