### PR TITLE
remove anti-buckling treatment w/ small Poisson ratio for law42,69

### DIFF
--- a/engine/source/materials/mat/mat042/sigeps42.F
+++ b/engine/source/materials/mat/mat042/sigeps42.F
@@ -239,12 +239,13 @@ c
       ENDIF
 c--- avoid buckling
       P_FAC(1:NEL) = ONE
-      NU_1 = FOURTY*(HALF-(3*RBULK-GMAX)/(6*RBULK+GMAX))
-      DO I=1,NEL
-        AMIN = MIN(EV(I,1),EV(I,2),EV(I,3))
-        IF (AMIN<ZEP2) P_FAC(I) = MAX(ONE,NU_1/MAX(EM20,AMIN))
-      ENDDO
-!        
+      IF (RBULK > 90*GMAX) THEN
+        NU_1 = FOURTY*(HALF-(3*RBULK-GMAX)/(6*RBULK+GMAX))
+        DO I=1,NEL
+          AMIN = MIN(EV(I,1),EV(I,2),EV(I,3))
+          IF (AMIN<ZEP2) P_FAC(I) = MAX(ONE,NU_1/MAX(EM20,AMIN))
+        ENDDO
+      END IF 
 c 
       ! Compute normalized (deviatoric) stretches and bulk modulus
       ! (Deviatoric principal stretches = lambda_bar_i)

--- a/engine/source/materials/mat/mat069/sigeps69.F
+++ b/engine/source/materials/mat/mat069/sigeps69.F
@@ -202,11 +202,13 @@ C        ET(I) = ZERO
       ENDIF
 c--- avoid buckling
       P_FAC(1:NEL) = ONE
-      NU_1 = FOURTY*(HALF-(3*RBULK-GMAX)/(6*RBULK+GMAX))
-      DO I=1,NEL
-        AMIN = MIN(EV(I,1),EV(I,2),EV(I,3))
-        IF (AMIN<ZEP2) P_FAC(I) = MAX(ONE,NU_1/MAX(EM20,AMIN))
-      ENDDO
+      IF (RBULK > 90*GMAX) THEN
+        NU_1 = FOURTY*(HALF-(3*RBULK-GMAX)/(6*RBULK+GMAX))
+        DO I=1,NEL
+          AMIN = MIN(EV(I,1),EV(I,2),EV(I,3))
+          IF (AMIN<ZEP2) P_FAC(I) = MAX(ONE,NU_1/MAX(EM20,AMIN))
+        ENDDO
+      END IF 
 C----------------
       DO I=1,NEL
         RV(I) = EV(I,1)*EV(I,2)*EV(I,3)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
it's observed that when law42,62 w/ low Poisson ratio used (nu<0.49), the anti-buckling treatment isn't efficient with distortion control. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
remove anti-buckling treatment w/ low Poisson ratio for law42,69

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
