### PR TITLE
Share direct pointers with /FUNCT_PYTHON sync

### DIFF
--- a/common_source/modules/cpp_python_funct.h
+++ b/common_source/modules/cpp_python_funct.h
@@ -66,7 +66,9 @@ typedef PyObject *(*T_PyImport_AddModule)(const char *);
 typedef PyObject *(*T_PyModule_GetDict)(PyObject *);
 typedef int (*T_PyRun_SimpleString)(const char *);
 typedef int (*T_PyTuple_SetItem)(PyObject *, My_ssize_t, PyObject *);  // Use Py_ssize_t for index
+typedef int (*T_PyList_SetItem)(PyObject* , My_ssize_t , PyObject* );
 typedef void (*T_Py_DecRef)(PyObject *);
+typedef void (*T_Py_IncRef)(PyObject *);
 typedef double (*T_PyFloat_AsDouble)(PyObject *);
 typedef int (*T_PyDict_SetItemString)(PyObject *, const char *, PyObject *);
 typedef void (*T_PyErr_Fetch)(PyObject **, PyObject **, PyObject **);
@@ -77,8 +79,10 @@ typedef PyObject *(*T_PyObject_Str)(PyObject *);
 typedef const char *(*T_PyUnicode_AsUTF8)(PyObject *);
 typedef PyObject *(*T_PyDict_New)();
 typedef PyObject *(*T_PyList_New)(My_ssize_t);  // Use Py_ssize_t for size
-typedef int (*T_PyList_SetItem)(PyObject *, My_ssize_t, PyObject *);
 typedef void (*T_PyErr_Clear)();
+typedef PyObject *(*T_PyLong_FromLong)(long int);
+typedef PyObject *(*T_PyLong_FromVoidPtr)(void *); 
+typedef PyObject *(*T_PyUnicode_FromString)(const char *); // Added this line to declare the function pointer
 
 
 // Python library handle
@@ -120,7 +124,9 @@ T_PyImport_AddModule MyImport_AddModule;
 T_PyModule_GetDict MyModule_GetDict;
 T_PyRun_SimpleString MyRun_SimpleString;
 T_PyTuple_SetItem MyTuple_SetItem;
+T_PyList_SetItem MyList_SetItem;
 T_Py_DecRef My_DecRef;
+T_Py_IncRef My_IncRef;
 T_PyFloat_AsDouble MyFloat_AsDouble;
 T_PyDict_SetItemString MyDict_SetItemString;
 T_PyErr_Fetch MyErr_Fetch;
@@ -131,9 +137,10 @@ T_PyObject_Str MyObject_Str;
 T_PyUnicode_AsUTF8 MyUnicode_AsUTF8;
 T_PyDict_New MyDict_New;
 T_PyList_New MyList_New;
-T_PyList_SetItem MyList_SetItem;
 T_PyErr_Clear MyErr_Clear;
-
+T_PyLong_FromLong MyLong_FromLong;
+T_PyLong_FromVoidPtr MyLong_FromVoidPtr; // Added this line to declare the function pointer
+T_PyUnicode_FromString MyUnicode_FromString; // Added this line to declare the function pointer
 
 constexpr std::array<const char*, 89> ELEMENT_KEYWORDS = {
 "ALPHA",
@@ -248,3 +255,26 @@ KeywordPair get_keyword_pair(const KeywordPairs& keywordPairs, size_t n) {
     auto it = std::next(keywordPairs.begin(), n);
     return *it;
 }
+
+
+// Utility function to add a key-value pair to a dictionary with proper reference counting
+//static int add_to_dict(PyObject* dict, PyObject* key, PyObject* value) {
+//    int result = MyDict_SetItem(dict, key, value);
+//    My_DecRef(key);    // PyDict_SetItem doesn't steal references
+//    My_DecRef(value);  // so we need to decrease them ourselves
+//    return result;
+//}
+
+// Utility function to format a key with the array name
+//static PyObject* create_key(const char* array_name, const char* suffix) {
+//    return MyUnicode_FromFormat("%s_%s", array_name, suffix);
+//}
+
+// Utility function to check if a Python object is a valid dictionary
+//static int check_context(PyObject* context) {
+//    if (!context || !MyDict_Check(context)) {
+//        std::cerr << "Error: Invalid context pointer" << std::endl;
+//        return -1;
+//    }
+//    return 0;
+//}

--- a/engine/source/coupling/python/python_share_memory.F90
+++ b/engine/source/coupling/python/python_share_memory.F90
@@ -1,0 +1,129 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 1986-2025 Altair Engineering Inc.
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Altair Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+!Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+!Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+      module python_share_memory_mod
+      contains
+        subroutine python_share_memory(py, nodes, numnod,&
+        & ixs, nixs, numels, &
+        & ixc, nixc, numelc, &
+        & ixp, nixp, numelp, &
+        & ixt, nixt, numelt, &
+        & ixq, nixq, numelq, &
+        & ixtg, nixtg, numeltg, &
+        & ixr, nixr, numelr, &
+        & iparg, ngroup, nparg )
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                     Module
+! ----------------------------------------------------------------------------------------------------------------------
+          use iso_c_binding, only : c_char, c_null_char, c_loc
+          use nodal_arrays_mod
+          use python_funct_mod 
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                     Implicit None
+! ----------------------------------------------------------------------------------------------------------------------
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                     Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          type(python_),intent(inout) :: py          !< the Fortran structure that holds the python function
+          integer,      intent(in) :: numnod         !< the global number of nodes
+          type(nodal_arrays_), target, intent(in) :: nodes  !< the nodal arrays
+          integer, intent(in) :: nixs                !< number of integers in the solid data structure
+          integer, intent(in) :: numels              !< number of solids
+          integer, target, intent(in) :: ixs(nixs,numels)    !< solid data structure
+          integer, intent(in) :: nixc                !< number of integers in the shell data structure
+          integer, intent(in) :: numelc              !< number of shells
+          integer, target, intent(in) :: ixc(nixc,numelc)    !< shell data structure
+          integer, intent(in) :: nixp                !< number of integers in the beam data structure
+          integer, intent(in) :: numelp              !< number of beams
+          integer, target, intent(in) :: ixp(nixp,numelp)    !< beam data structure
+          integer, intent(in) :: nixt                !< number of integers in the truss data structure
+          integer, intent(in) :: numelt              !< number of trusses
+          integer, target, intent(in) :: ixt(nixt,numelt)    !< truss data structure
+          integer, intent(in) :: nixtg               !< number of integers in the triangle data structure
+          integer, intent(in) :: numeltg             !< number of triangles
+          integer, target, intent(in) :: ixtg(nixtg,numeltg) !< triangle data structure
+          integer, intent(in) :: nixr                !< number of integers in the spring data structure
+          integer, intent(in) :: numelr              !< number of springs
+          integer, target, intent(in) :: ixr(nixr,numelr)    !< spring data structure
+          integer, intent(in) :: nixq                !< number of integers in the quad data structure
+          integer, intent(in) :: numelq              !< number of quads
+          integer, target, intent(in) :: ixq(nixq,numelq)    !< quad data structure
+          integer, intent(in) :: ngroup              !< number of groups
+          integer, intent(in) :: nparg               !< number of integers in the group data structure
+          integer, target, intent(in) :: iparg(nparg,ngroup) !< group data structure
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Local variables
+! ----------------------------------------------------------------------------------------------------------------------
+          character(len=max_line_length)             :: name
+          character(kind=c_char, len=:), allocatable :: code
+          integer                                    :: i,j,n,ierror
+          integer                                    :: nelem
+          integer, dimension(:), allocatable         :: user_id
+          integer, dimension(:), allocatable         :: local_id
+          integer, dimension(:), allocatable         :: group_id
+          integer :: ierr
+          character(kind=c_char), dimension(name_len+1)        :: temp_name
+          integer :: len
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                      Body
+! ----------------------------------------------------------------------------------------------------------------------
+          if (numnod > 0) then
+            py%context = python_create_context()
+            if (allocated(nodes%ITAB))    call python_expose_ints(py, "ITAB", 4, c_loc(nodes%ITAB),     size(nodes%ITAB))
+            if (allocated(nodes%ITABM1))  call python_expose_ints(py, "ITABM1", 6, c_loc(nodes%ITABM1),   size(nodes%ITABM1))
+            if (allocated(nodes%IKINE))   call python_expose_ints(py, "IKINE", 5, c_loc(nodes%IKINE),    size(nodes%IKINE))
+            if (allocated(nodes%MAIN_PROC)) then
+              call python_expose_ints(py, "MAIN_PROC", 9, c_loc(nodes%MAIN_PROC),size(nodes%MAIN_PROC))
+            endif
+            if (allocated(nodes%WEIGHT)) then
+              call python_expose_ints(py, "WEIGHT", 6, c_loc(nodes%WEIGHT),   size(nodes%WEIGHT))
+            endif
+            if (allocated(nodes%A))       call python_expose_doubles(py, "A", 1, c_loc(nodes%A),     3*numnod)
+            if (allocated(nodes%AR))      call python_expose_doubles(py, "AR", 2, c_loc(nodes%AR),    3*numnod)
+            if (allocated(nodes%V))       call python_expose_doubles(py, "V", 1, c_loc(nodes%V),     3*numnod)
+            if (allocated(nodes%X))       call python_expose_doubles(py, "X", 1, c_loc(nodes%X),     3*numnod)
+            if (allocated(nodes%D))       call python_expose_doubles(py, "D", 1, c_loc(nodes%D),     3*numnod)
+            if (allocated(nodes%VR))      call python_expose_doubles(py, "VR", 2, c_loc(nodes%VR),    3*numnod)
+            if (allocated(nodes%DR))      call python_expose_doubles(py, "DR", 2, c_loc(nodes%DR),    3*numnod)
+            if (allocated(nodes%MS))      call python_expose_doubles(py, "MS", 2, c_loc(nodes%MS),    numnod)
+            if (allocated(nodes%IN))      call python_expose_doubles(py, "IN", 2, c_loc(nodes%IN),    size(nodes%IN))
+            if (allocated(nodes%STIFN))   call python_expose_doubles(py, "STIFN", 5, c_loc(nodes%STIFN), size(nodes%STIFN))
+            if (allocated(nodes%MS0))     call python_expose_doubles(py, "MS0", 3, c_loc(nodes%MS0),   size(nodes%MS0))
+            if (allocated(nodes%IN0))     call python_expose_doubles(py, "IN0", 3, c_loc(nodes%IN0),   size(nodes%IN0))
+            if (allocated(nodes%MCP))     call python_expose_doubles(py, "MCP", 3, c_loc(nodes%MCP),   size(nodes%MCP))
+            if (allocated(nodes%VISCN))   call python_expose_doubles(py, "VISCN", 5, c_loc(nodes%VISCN), size(nodes%VISCN))
+            if (allocated(nodes%TEMP))    call python_expose_doubles(py, "TEMP", 4, c_loc(nodes%TEMP),  size(nodes%TEMP))
+          endif
+
+          if(numelc > 0)  call python_expose_ints(py, "IXC", 3, c_loc(ixc), numelc*nixc)
+          if(numels > 0)  call python_expose_ints(py, "IXS", 3, c_loc(ixs), numels*nixs)
+          if(numelp > 0)  call python_expose_ints(py, "IXP", 3, c_loc(ixp), numelp*nixp)
+          if(numelt > 0)  call python_expose_ints(py, "IXT", 3, c_loc(ixt), numelt*nixt)
+          if(numeltg > 0) call python_expose_ints(py, "IXTG", 4, c_loc(ixtg), numeltg*nixtg)
+          if(numelr > 0)  call python_expose_ints(py, "IXR", 3, c_loc(ixr), numelr*nixr)
+          if(numelq > 0)  call python_expose_ints(py, "IXQ", 3, c_loc(ixq), numelq*nixq)
+          if(ngroup > 0)  call python_expose_ints(py, "IPARG", 5, c_loc(iparg), ngroup*nparg)
+            
+        end subroutine
+
+      end module python_share_memory_mod

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -674,6 +674,7 @@ C-----------------------------------------------
               USE DEBUG_CHKSM_MOD ,  ONLY : SPMD_FLUSH_ACCEL
               USE DT_MOD
               USE PYTHON_FUNCT_MOD
+              USE PYTHON_SHARE_MEMORY_MOD
               USE PYTHON_REGISTER_MOD, ONLY : PYTHON_REGISTER
               USE FUNCT_PYTHON_UPDATE_ELEMENTS_MOD, ONLY : FUNCT_PYTHON_UPDATE_ELEMENTS
               USE OUTMAX_MOD
@@ -2068,7 +2069,7 @@ c  Equivalent nodal force
 C========================================================================================
 
 C save the Python functions into the Python interpreter dictionarry
-              CALL PYTHON_REGISTER(PYTHON,NODES%ITAB,NUMNOD,
+              CALL PYTHON_REGISTER(PYTHON,NODES,NUMNOD,
      .                             IXS, NIXS, NUMELS,
      .                             ELEMENT%SHELL%IXC, NIXC, NUMELC,
      .                             IXP, NIXP, NUMELP,
@@ -2077,6 +2078,18 @@ C save the Python functions into the Python interpreter dictionarry
      .                             IXTG, NIXTG, NUMELTG,
      .                             IXR, NIXR, NUMELR,
      .                             IPARG, NGROUP, NPARG, MVSIZ)
+
+             IF(PYTHON%NB_FUNCTS > 0) CALL PYTHON_SHARE_MEMORY(PYTHON,NODES,NUMNOD,
+     .                             IXS, NIXS, NUMELS,
+     .                             ELEMENT%SHELL%IXC, NIXC, NUMELC,
+     .                             IXP, NIXP, NUMELP,
+     .                             IXT, NIXT, NUMELT,
+     .                             IXQ, NIXQ, NUMELQ,
+     .                             IXTG, NIXTG, NUMELTG,
+     .                             IXR, NIXR, NUMELR,
+     .                             IPARG, NGROUP, NPARG)
+ 
+
 
               K1=1+LIPART1*(NPART+NTHPART)+2*9*(NPART+NTHPART)
               K2=K1+NUMELS
@@ -3137,11 +3150,10 @@ C First: try with reduced bounding box
               ! ----------------------
               CALL PYTHON_UPDATE_TIME(TT,DT2)
               CALL PYTHON_UPDATE_NODAL_ENTITIES(NUMNOD, X=NODES%X,A=NODES%A,V=NODES%V,D=NODES%D,DR=NODES%DR,VR=NODES%VR)
-C=======================================================================
-C----------------------------------------
-C     BEGINNING OF EXPLICIT ITERATION LOOP
-C----------------------------------------
-
+              CALL PYTHON_SYNC(PYTHON%CONTEXT)
+C===========================================================================
+C                 BEGINNING OF EXPLICIT ITERATION LOOP
+C===========================================================================                                        
  100          CONTINUE
 
               NC_DEBUG = NCYCLE
@@ -9215,8 +9227,8 @@ C===============================================================================
                   IF(IMON>0) CALL STOPTIME(TIMERS,TIMER_INTEG)
                 ENDIF
               ENDIF
-
-              CALL PYTHON_UPDATE_NODAL_ENTITIES(NUMNOD,X= NODES%X, D=NODES%D, DR=NODES%DR)
+              CALL PYTHON_SYNC(PYTHON%CONTEXT)
+              CALL PYTHON_UPDATE_NODAL_ENTITIES(NUMNOD,X=NODES%X, D=NODES%D, DR=NODES%DR)
 C========================================================================================
 C                                   NON PARALLEL SECTION (SMP)
 C========================================================================================

--- a/engine/source/loads/general/python_call_funct_cload.F90
+++ b/engine/source/loads/general/python_call_funct_cload.F90
@@ -72,6 +72,7 @@
           if(n <= size(nodes%x,2) .and. n > 0) then
             tmp = nodes%X(:,n)
             call python_set_active_node_values(1,"C",tmp)
+            call python_set_active_node_ids(n,nodes%itab(n))
           else
             tmp(1:3) = 0.0d0
             call python_set_active_node_values(1,"C",tmp)

--- a/engine/source/tools/curve/python_register.F90
+++ b/engine/source/tools/curve/python_register.F90
@@ -42,7 +42,7 @@
       !||    python_spmd_mod                        ../engine/source/mpi/python_spmd_mod.F90
       !||    user_id_mod                            ../common_source/modules/element_user_id.F90
       !||====================================================================
-        subroutine python_register(py, itab, numnod,&
+        subroutine python_register(py, nodes, numnod,&
         & ixs, nixs, numels, &
         & ixc, nixc, numelc, &
         & ixp, nixp, numelp, &
@@ -55,6 +55,7 @@
 !                                                     Module
 ! ----------------------------------------------------------------------------------------------------------------------
           use iso_c_binding, only : c_char, c_null_char
+          use nodal_arrays_mod
           use python_spmd_mod, only : python_element_init
           use python_element_mod, only : python_get_number_elemental_entities, python_get_elemental_entity
           use python_funct_mod, only : python_, max_code_length, max_line_length, NAME_LEN, python_create_node_mapping, &
@@ -69,7 +70,7 @@
 ! ----------------------------------------------------------------------------------------------------------------------
           type(python_),intent(inout) :: py          !< the Fortran structure that holds the python function
           integer,      intent(in) :: numnod         !< the global number of nodes
-          integer,      intent(in) :: itab(numnod)   !< the global node ids
+          type(nodal_arrays_), intent(in) :: nodes   !< the nodal arrays
           integer, intent(in) :: nixs                !< number of integers in the solid data structure
           integer, intent(in) :: numels              !< number of solids
           integer, intent(in) :: ixs(nixs,numels)    !< solid data structure
@@ -132,7 +133,7 @@
           end do
 
           ! creates a mapping between the global node ids and the local node ids
-          call python_create_node_mapping(itab, numnod)
+          call python_create_node_mapping(nodes%itab, numnod)
           call element_user_id(user_id, group_id, local_id, nelem, &
             ixs, nixs, numels, &
             ixc, nixc, numelc, &
@@ -168,7 +169,7 @@
           enddo
 
           call python_element_init(py%elements, n, group_id, local_id, user_id)
-          if(py%nb_functs >0 )  call python_load_environment()
+          if(py%nb_functs >0 ) call python_load_environment()
           deallocate(code)
           deallocate(user_id)
           deallocate(local_id)


### PR DESCRIPTION


#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
A special /FUNCT/PYTHON function can be defined, with the name sync. This function takes a dictionary context, which contains pointers to the nodal values, and element connectivity.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
