### PR TITLE
/EOS/COMPACTION_TAB : automatic C_SOLID parameter

### DIFF
--- a/common_source/eos/eosmain.F
+++ b/common_source/eos/eosmain.F
@@ -295,7 +295,7 @@ C-----------------------------------------------
      1                  IFLAG ,NEL  ,PM   ,OFF   ,EINT  ,MU  ,MU2,
      2                  DVOL  ,MAT  ,PSH  ,
      3                  PNEW  ,DPDM ,DPDE ,MU_BAK,
-     4                  NPROPM,NUMMAT)
+     4                  NPROPM,NUMMAT,MAT_PARAM%EOS)
 
        CASE(14)
          !--------------------------------------------------!

--- a/hm_cfg_files/config/CFG/radioss2026/MAT/mat_EOS.cfg
+++ b/hm_cfg_files/config/CFG/radioss2026/MAT/mat_EOS.cfg
@@ -118,7 +118,6 @@ ATTRIBUTES(COMMON)
     cSCALE              = VALUE(FLOAT,"Scale Factor for c");
     GSCALE              = VALUE(FLOAT,"Scale Factor for Gamma");
     RHO_TMD             = VALUE(FLOAT,"Density TMD");
-    C_SOLID             = VALUE(FLOAT,"Solid Sound Speed");
 }
 
 SKEYWORDS_IDENTIFIER(COMMON)
@@ -409,7 +408,6 @@ GUI(COMMON) {
         SCALAR(cSCALE)          { DIMENSION="velocity"; }
         SCALAR(GSCALE)          { DIMENSION="DIMENSIONLESS"; }
         SCALAR(RHO_TMD)         { DIMENSION="density"; }
-        SCALAR(C_SOLID)         { DIMENSION="velocity"; }
     }    
 
 }
@@ -738,8 +736,8 @@ FORMAT(radioss2026) {
     }
     else if(EOS_Options == 22)
     {
-        COMMENT("#            RHO_TMD             C_SOLID                                                      I_PLAS");
-        CARD("%20lg%20lg%40s%10s%10d",RHO_TMD,C_SOLID,_BLANK_,_BLANK_,IPLAS);
+        COMMENT("#            RHO_TMD                                                                          I_PLAS");
+        CARD("%20lg%70s%10d",RHO_TMD,_BLANK_,IPLAS);
         COMMENT("#  fct_IDp                       P-scale");
         CARD("%10d%10s%20lg",P_FUNC,_BLANK_,PSCALE);
         COMMENT("#  fct_IDc                       c-scale");

--- a/starter/source/materials/eos/hm_read_eos.F
+++ b/starter/source/materials/eos/hm_read_eos.F
@@ -252,7 +252,8 @@ c---
 c---
           CASE ('COMPACTION')
             IEOS = 13                          
-            CALL HM_READ_EOS_COMPACTION(IOUT,PM(1,IMAT),UNITAB,LSUBMODEL,EOS_uid,EOS_TAG,IEOS,NPROPM,MAXEOS)
+            CALL HM_READ_EOS_COMPACTION(IOUT,PM(1,IMAT),UNITAB,LSUBMODEL,EOS_uid,EOS_TAG,IEOS,NPROPM,MAXEOS,
+     .                                  MAT_PARAM(IMAT)%EOS )
 c---
           CASE ('NASG')
             IEOS = 14                          

--- a/starter/source/materials/eos/hm_read_eos_compaction.F90
+++ b/starter/source/materials/eos/hm_read_eos_compaction.F90
@@ -49,7 +49,7 @@
       !||    message_mod              ../starter/share/message_module/message_mod.F
       !||    submodel_mod             ../starter/share/modules1/submodel_mod.F
       !||====================================================================
-      subroutine hm_read_eos_compaction(iout,pm,unitab,lsubmodel,imideos,eos_tag,ieos,npropm,maxeos)
+      subroutine hm_read_eos_compaction(iout,pm,unitab,lsubmodel,imideos,eos_tag,ieos,npropm,maxeos,eos_param)
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Modules
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -58,6 +58,7 @@
       use submodel_mod , only : nsubmod, submodel_data
       use elbuftag_mod , only : eos_tag_
       use constant_mod , only : zero, two_third, one, two, three, three100
+      use eos_param_mod , only : eos_param_
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Implicit none
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -77,6 +78,7 @@
       integer,intent(in) :: imideos
       type(eos_tag_),dimension(0:maxeos) ,intent(inout) :: eos_tag !< data structure for EoS
       integer,intent(in) :: ieos !< EoS (internal) identifier
+      type(eos_param_), intent(inout) :: eos_param !< eos data structure (specific parameters)
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Local variables
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -152,6 +154,18 @@
           C1='/EOS/COMPACTION',C2='BUNL MUST BE GREATER THAN DERIVATIVE OF P(MU) AT MUMAX')
         end if
       end if
+
+      eos_param%nuparam = 3
+      eos_param%niparam = 1
+      eos_param%nfunc = 0
+      eos_param%ntable = 0
+      call eos_param%construct() !allocations
+
+      eos_param%uparam(1) = mumax
+      eos_param%uparam(2) = mumin
+      eos_param%uparam(3) = bunl
+
+      eos_param%iparam(1) = iform
 
       pm(49) = c0
       pm(32) = c1

--- a/starter/source/materials/mat/mat133/hm_read_mat133.F90
+++ b/starter/source/materials/mat/mat133/hm_read_mat133.F90
@@ -254,7 +254,7 @@
         5X,'INITIAL DENSITY. . . . . . . . . . . . . .  =',1PG20.13/)
   400 format(/                                                        &
         5X,'POISSON''S RATIO  . . . . . . . . . . . . .  =',1PG20.13/, &
-        5X,'YOUNG MODULUS E (COMPUTED) . . . . . . . .  =',1PG20.13/, &
+        5X,'INITIAL YOUNG MODULUS E (COMPUTED) . . . .  =',1PG20.13/, &
         5X,"MINIMUM PRESSURE (FRACTURE). . . . . . . .  =",1PG20.13/)
   500 format(/                                                        &
         5X,'SHEAR MODULUS FUNCTION ID - G(RHO) . . . .  =',I10/,      &


### PR DESCRIPTION
#### /EOS/COMPACTION_TAB : automatic C_SOLID parameter

#### Description of the changes
The C_SOLID parameter can be automatically retrieved from the input function using the C_unload function at the point where rho = 'RHO_TMD'. It is then removed from input format to simplify user experience.

Additionally:

- The starter checks that the C_unload function is monotonic.

- /MAT/LAW133 computes bulk_mak at the maximum compaction density for all families of compaction EoS (COMPACTION, COMPACTION2, COMPACTION_TAB). Using the maximum shear modulus : G=G(RHO_TMD) or G=G( RHO0*(1+MU_MAX) )
