### PR TITLE
/LOAD/PBLAST : warning message Imodel=2

### DIFF
--- a/common_source/modules/loads/pblast_mod.F90
+++ b/common_source/modules/loads/pblast_mod.F90
@@ -3221,7 +3221,7 @@ type (pblast_) :: pblast
    subroutine pblast_parameters__free_air( pblast,z, w13, tdet,          &
    &                                       fac_p_bb, fac_i_bb, fac_t_bb, &
    &                                       is_decay_to_be_computed,      &
-   &                                       output_params )
+   &                                       output_params, nwarn )
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Modules
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -3240,6 +3240,7 @@ type (pblast_) :: pblast
       my_real,intent(in) :: z,w13,tdet
       my_real,intent(in) :: fac_p_bb, fac_i_bb, fac_t_bb
       type(friedlander_params_), intent(out) :: output_params
+      integer,intent(inout) :: nwarn !< number of segments in the warning message (for which idmodel=2 method did not converge)
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Local variables
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -3389,6 +3390,7 @@ type (pblast_) :: pblast
             endif
             res = abs(funct)   !g(x_new)
          enddo
+         if(zeta < em10) nwarn = nwarn+1
          decay_inci=max(zero,zeta)   ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
 
          iter=0
@@ -3415,6 +3417,7 @@ type (pblast_) :: pblast
             endif
             res = abs(funct)   !g(x_new)
          enddo
+         if(zeta < em10) nwarn = nwarn + 1
          decay_refl=max(zero,zeta)   ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
       endif
 
@@ -3452,7 +3455,7 @@ type (pblast_) :: pblast
    subroutine pblast_parameters__surface_burst(  pblast,z, w13, tdet,         &
    &                                            fac_p_bb, fac_i_bb, fac_t_bb, &
    &                                            is_decay_to_be_computed,      &
-   &                                            output_params)
+   &                                            output_params, nwarn)
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Modules
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -3471,6 +3474,7 @@ type (pblast_) :: pblast
       my_real,intent(in) :: z,w13,tdet
       my_real,intent(in) :: fac_p_bb, fac_i_bb, fac_t_bb
       type(friedlander_params_), intent(out) :: output_params
+      integer,intent(inout) :: nwarn !< number of segments in the warning message (for which idmodel=2 method did not converge)
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Local variables
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -3592,6 +3596,7 @@ type (pblast_) :: pblast
             endif
             res = abs(funct)   !g(x_new)
          enddo
+         if(zeta < em10) nwarn = nwarn+1
          decay_inci=max(zero,zeta)    ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
 
          iter=0
@@ -3618,6 +3623,7 @@ type (pblast_) :: pblast
             endif
             res = abs(funct)   !g(x_new)
          enddo
+         if(zeta < em10) nwarn = nwarn+1
          decay_refl=max(zero,zeta)    ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
 
       endif! is_decay_to_be_computed
@@ -3653,7 +3659,7 @@ type (pblast_) :: pblast
    &                                        fac_p_bb, fac_i_bb, fac_t_bb,                &
    &                                        is_decay_to_be_computed,                     &
    &                                        id,label,is_output_enabled,                  &
-   &                                        output_params )
+   &                                        output_params, nwarn )
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Modules
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -3677,6 +3683,7 @@ type(pblast_) :: pblast
       my_real,intent(in) :: fac_p_bb, fac_i_bb, fac_t_bb
       character*4,intent(in)::label  !'ebcs' or 'load'
       type(friedlander_params_), intent(out) :: output_params
+      integer,intent(inout) :: nwarn !< number of segments in the warning message (for which idmodel=2 method did not converge)
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Local variables
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -4054,6 +4061,7 @@ type(pblast_) :: pblast
             endif
             res = abs(funct)   !g(x_new)
          enddo
+         if(zeta < em10) nwarn = nwarn+1
          decay_inci=max(zero,zeta)    ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
 
          iter=0
@@ -4080,6 +4088,7 @@ type(pblast_) :: pblast
             endif
             res = abs(funct)   !g(x_new)
          enddo
+         if(zeta < em10) nwarn = nwarn+1
          decay_refl=max(zero,zeta)    ! lower value may have few change on positive impulse but large change to negative impulse (potential unphysical solution)
 
       endif! is_decay_to_be_computed

--- a/engine/source/loads/pblast/pblast_1.F
+++ b/engine/source/loads/pblast/pblast_1.F
@@ -46,6 +46,7 @@ C-----------------------------------------------
       USE GROUPDEF_MOD      
       USE H3D_INC_MOD 
       USE TH_SURF_MOD , ONLY : TH_SURF_
+      USE NAMES_AND_TITLES_MOD , ONLY : NCHARLINE
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -86,7 +87,8 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER :: N1, N2, N3, N4,IL,IS,IAD,I,IANIM_OR_H3D,IZ_UPDATE,ABAC_ID,ISIZ_SEG,IERR1,
      .           ID, ITA_SHIFT,IMODEL,NN(4),NS,KSURF,NDT
-     
+      INTEGER :: NWARN !< number of segment for which it is not possible to correlate the positive impulse. It may happen that for a given Pmax and dt0 value even building a triangle shape leads to a lower impulse that the targeted one.
+
       my_real :: Zx,Zy,Zz,NORM,Nx,Ny,Nz,AREA,
      .           cos_theta, alpha_inci, alpha_refl, P_inci, P_refl_,P_inci_, P_refl,Z,
      .           I_inci,I_refl,I_inci_,I_refl_, dt_0, t_a,dt_0_,
@@ -99,6 +101,8 @@ C-----------------------------------------------
       INTEGER, EXTERNAL :: OMP_GET_THREAD_NUM
 
       LOGICAL IS_UPDATED,IS_DECAY_TO_BE_COMPUTED
+
+      CHARACTER(LEN=NCHARLINE) ::  MSGOUT1,MSGOUT2
       
       DATA cst_255_div_ln_Z1_on_ZN/-38.147316611455952998/
       DATA log10_ /2.30258509299405000000/
@@ -185,6 +189,7 @@ C-----------------------------------------------
 
       IS_DECAY_TO_BE_COMPUTED = .FALSE.
       IF(IMODEL == 2)IS_DECAY_TO_BE_COMPUTED=.TRUE.
+      NWARN = 0
 
       !---------------------------------------------                                                                  
       !   LOOP ON SEGMENTS (4N or 3N)                                                                  
@@ -300,7 +305,7 @@ C-----------------------------------------------
           CALL PBLAST_PARAMETERS__FREE_AIR(PBLAST,Z, W13, TDET,
      +                                     FAC_P_bb, FAC_I_bb, FAC_T_bb,
      +                                     IS_DECAY_TO_BE_COMPUTED,
-     +                                     FRIEDLANDER_PARAMS)
+     +                                     FRIEDLANDER_PARAMS,NWARN)
 
           P_inci     = FRIEDLANDER_PARAMS%P_inci
           P_inci_    = FRIEDLANDER_PARAMS%P_inci_
@@ -402,6 +407,16 @@ C----- /TH/SURF -------
 
       ENDDO!next I                                                                                                                                                                                    
 !$OMP END DO
+
+      IF(IMODEL == 2 .AND. NWARN > 0)THEN
+        MSGOUT1=''
+        WRITE(MSGOUT1,FMT='(I0,A)') NWARN,
+     .  ' SEGMENT(S) HAS EXCESSIVE POSITIVE IMPULSE REGARDING THE PEAK PRESSURE AND POSITIVE DURATION.'
+        MSGOUT2=''
+        MSGOUT2='A TRIANGULAR WAVEFORM WILL BE USED INSTEAD TO MAXIMIZE THE IMPULSE. DEFINING A PMIN VALUE IS STRONGLY RECOMMENDED'
+        write(IOUT , FMT='(A,I10,/A,/A)') "Updated parameters for /LOAD/PBLAST id=", ID, MSGOUT1, MSGOUT2
+        write(ISTDO, FMT='(A,I10,/A,/A)') "Updated parameters for /LOAD/PBLAST id=", ID, MSGOUT1, MSGOUT2
+      ENDIF
          
       IF(IS_UPDATED)THEN
 #include "lockon.inc"

--- a/engine/source/loads/pblast/pblast_2.F
+++ b/engine/source/loads/pblast/pblast_2.F
@@ -46,6 +46,7 @@ C-----------------------------------------------
       USE GROUPDEF_MOD
       USE H3D_INC_MOD
       USE TH_SURF_MOD , ONLY : TH_SURF_
+      USE NAMES_AND_TITLES_MOD , ONLY : NCHARLINE
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -86,6 +87,7 @@ C-----------------------------------------------
       INTEGER :: N1, N2, N3, N4, IL, IS, IAD, I, IANIM_OR_H3D,IZ_UPDATE,ABAC_ID,ISIZ_SEG,IERR1,ID, ITA_SHIFT,NS,KSURF
       INTEGER :: NDT,IMODEL,NN(4)
       INTEGER :: ISHAPE
+      INTEGER :: NWARN !< number of segment for which it is not possible to correlate the positive impulse. It may happen that for a given Pmax and dt0 value even building a triangle shape leads to a lower impulse that the targeted one.
       my_real :: Zx,Zy,Zz,NORM,Nx,Ny,Nz,NNx,NNy,NNz,Hz,AREA
       my_real :: LAMBDA,cos_theta, alpha_inci, alpha_refl, P_inci,P_refl,Z
       my_real :: I_inci,I_refl,dt_0,t_a,WAVE_refl,WAVE_inci, W13
@@ -99,6 +101,8 @@ C-----------------------------------------------
       my_real :: DNORM, Dx, Dy, Dz
       TYPE(FRIEDLANDER_PARAMS_) :: FRIEDLANDER_PARAMS
       LOGICAL IS_UPDATED,IS_DECAY_TO_BE_COMPUTED
+
+      CHARACTER(LEN=NCHARLINE) ::  MSGOUT1,MSGOUT2
 
       DATA cst_255_div_ln_Z1_on_ZN/-38.147316611455952998/
       DATA log10_ /2.30258509299405000000/
@@ -190,6 +194,7 @@ C-----------------------------------------------
 
       IS_DECAY_TO_BE_COMPUTED = .FALSE.
       IF(IMODEL == 2)IS_DECAY_TO_BE_COMPUTED=.TRUE.
+      NWARN = 0
 
       !---------------------------------------------
       !   LOOP ON SEGMENTS (4N or 3N)
@@ -341,7 +346,7 @@ C-----------------------------------------------
      +                                             Z, W13, TDET,
      +                                             FAC_P_bb, FAC_I_bb, FAC_T_bb,
      +                                             IS_DECAY_TO_BE_COMPUTED,
-     +                                             FRIEDLANDER_PARAMS )
+     +                                             FRIEDLANDER_PARAMS, NWARN )
             P_inci     = FRIEDLANDER_PARAMS%P_inci
             P_refl     = FRIEDLANDER_PARAMS%P_refl
             I_inci     = FRIEDLANDER_PARAMS%I_inci
@@ -451,6 +456,16 @@ C----- /TH/SURF -------
 
       ENDDO!next I
 !$OMP END DO
+
+      IF(IMODEL == 2 .AND. NWARN > 0)THEN
+        MSGOUT1=''
+        WRITE(MSGOUT1,FMT='(I0,A)') NWARN,
+     .  ' SEGMENT(S) HAS EXCESSIVE POSITIVE IMPULSE REGARDING THE PEAK PRESSURE AND POSITIVE DURATION.'
+        MSGOUT2=''
+        MSGOUT2='A TRIANGULAR WAVEFORM WILL BE USED INSTEAD TO MAXIMIZE THE IMPULSE. DEFINING A PMIN VALUE IS STRONGLY RECOMMENDED'
+        write(IOUT , FMT='(A,I10,/A,/A)') "Updated parameters for /LOAD/PBLAST id=", ID, MSGOUT1, MSGOUT2
+        write(ISTDO, FMT='(A,I10,/A,/A)') "Updated parameters for /LOAD/PBLAST id=", ID, MSGOUT1, MSGOUT2
+      ENDIF
 
       IF(IS_UPDATED)THEN
 #include "lockon.inc"

--- a/engine/source/loads/pblast/pblast_3.F
+++ b/engine/source/loads/pblast/pblast_3.F
@@ -46,6 +46,7 @@ C-----------------------------------------------
       USE GROUPDEF_MOD
       USE H3D_INC_MOD
       USE TH_SURF_MOD , ONLY : TH_SURF_
+      USE NAMES_AND_TITLES_MOD , ONLY : NCHARLINE
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -83,12 +84,14 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
+      CHARACTER(LEN=NCHARLINE) ::  MSGOUT1,MSGOUT2
       TYPE(FRIEDLANDER_PARAMS_) :: FRIEDLANDER_PARAMS
       INTEGER N1, N2, N3, N4,IL,IS,IAD,I,IANIM_OR_H3D,IZ_UPDATE,ABAC_ID,ISIZ_SEG,IERR1
       INTEGER  ID, ITA_SHIFT,IMODEL
       INTEGER :: NS,KSURF
       INTEGER :: curve_id1, curve_id2, NN(4), NDT
       LOGICAL :: BOOL_UNDERGROUND_CURRENT_SEG, IS_UPDATED, IS_DECAY_TO_BE_COMPUTED
+      INTEGER :: NWARN !< number of segment for which it is not possible to correlate the positive impulse. It may happen that for a given Pmax and dt0 value even building a triangle shape leads to a lower impulse that the targeted one.
 
       my_real :: Zx,Zy,Zz,NORM,Nx,Ny,Nz ! target face centroid and normal vector
       my_real NNx,NNy,NNz,NORM_NN, NORM2_NN, tmp_var ! ground vector
@@ -215,6 +218,7 @@ C-----------------------------------------------
 
       IS_DECAY_TO_BE_COMPUTED = .FALSE.
       IF(IMODEL == 2)IS_DECAY_TO_BE_COMPUTED=.TRUE.
+      NWARN = 0
 
       !curve_id1+alpha_zc
       curve_id1=INT(alpha_zc)
@@ -240,7 +244,7 @@ C-----------------------------------------------
         N3=LLOADP(ILOADP(4,NL)+4*(I-1)+2)
         N4=LLOADP(ILOADP(4,NL)+4*(I-1)+3)
 
-        IF(N4==0 .OR. N3==N4)THEN
+        IF(N4 == 0 .OR. N3 == N4)THEN
           !3-NODE-SEGMENT
           PBLAST%PBLAST_TAB(IL)%NPt(I) = THREE
           NPT = THREE
@@ -394,7 +398,7 @@ C-----------------------------------------------
      +                                         FAC_P_bb, FAC_I_bb, FAC_T_bb,
      +                                         IS_DECAY_TO_BE_COMPUTED,
      +                                         ID,'LOAD',.TRUE.,
-     +                                         FRIEDLANDER_PARAMS)
+     +                                         FRIEDLANDER_PARAMS,NWARN)
             P_inci     = FRIEDLANDER_PARAMS%P_inci
             P_refl     = FRIEDLANDER_PARAMS%P_refl
             I_inci     = FRIEDLANDER_PARAMS%I_inci
@@ -491,6 +495,16 @@ C----- /TH/SURF -------
 
       ENDDO!next I
 !$OMP END DO
+
+      IF(IMODEL == 2 .AND. NWARN > 0)THEN
+        MSGOUT1=''
+        WRITE(MSGOUT1,FMT='(I0,A)') NWARN,
+     .  ' SEGMENT(S) HAS EXCESSIVE POSITIVE IMPULSE REGARDING THE PEAK PRESSURE AND POSITIVE DURATION.'
+        MSGOUT2=''
+        MSGOUT2='A TRIANGULAR WAVEFORM WILL BE USED INSTEAD TO MAXIMIZE THE IMPULSE. DEFINING A PMIN VALUE IS STRONGLY RECOMMENDED'
+        write(IOUT , FMT='(A,I10,/A,/A)') "Updated parameters for /LOAD/PBLAST id=", ID, MSGOUT1, MSGOUT2
+        write(ISTDO, FMT='(A,I10,/A,/A)') "Updated parameters for /LOAD/PBLAST id=", ID, MSGOUT1, MSGOUT2
+      ENDIF
 
       IF(IS_UPDATED)THEN
 #include "lockon.inc"

--- a/starter/source/loads/pblast/hm_read_pblast.F
+++ b/starter/source/loads/pblast/hm_read_pblast.F
@@ -127,6 +127,7 @@ C-----------------------------------------------
       INTEGER curve_id1,curve_id2,SEG_UNDERGROUND
       INTEGER, DIMENSION(:), POINTER :: INGR2USR
       INTEGER :: ISHAPE
+      INTEGER :: NWARN !< number of segment for which it is not possible to correlate the positive impulse. It may happen that for a given Pmax and dt0 value even building a triangle shape leads to a lower impulse that the targeted one.
       TYPE(FRIEDLANDER_PARAMS_) :: FRIEDLANDER_PARAMS
 C-----------------------------------------------
 C   C o n s t a n t   V a l u e s
@@ -224,6 +225,7 @@ C-----------------------------------------------
       HC = ZERO
       BOOL_SKIP_CALC = .FALSE.
       IS_ITA_SHIFT = .FALSE.
+      NWARN = 0
 
       ALLOCATE( OUTPUT_USER_PARAMS(6,PBLAST%NLOADP_B))
       OUTPUT_USER_PARAMS(:,:) = ZERO
@@ -843,7 +845,7 @@ C-----------------------------------------------
                  CALL PBLAST_PARAMETERS__FREE_AIR(PBLAST,Z, W13, TDET,
      +                                            FAC_P_bb, FAC_I_bb, FAC_T_bb,
      +                                            IS_DECAY_TO_BE_COMPUTED,
-     +                                            FRIEDLANDER_PARAMS)
+     +                                            FRIEDLANDER_PARAMS, NWARN)
 
                  P_inci     = FRIEDLANDER_PARAMS%P_inci
                  P_refl     = FRIEDLANDER_PARAMS%P_refl
@@ -950,7 +952,7 @@ C-----------------------------------------------
                   CALL PBLAST_PARAMETERS__SURFACE_BURST( PBLAST,Z, W13, TDET,
      +                                             FAC_P_bb, FAC_I_bb, FAC_T_bb,
      +                                             IS_DECAY_TO_BE_COMPUTED,
-     +                                             FRIEDLANDER_PARAMS )
+     +                                             FRIEDLANDER_PARAMS,NWARN )
                   P_inci     = FRIEDLANDER_PARAMS%P_inci
                   P_refl     = FRIEDLANDER_PARAMS%P_refl
                   I_inci     = FRIEDLANDER_PARAMS%I_inci
@@ -1052,7 +1054,7 @@ C-----------------------------------------------
      +                                            FAC_P_bb, FAC_I_bb, FAC_T_bb,
      +                                            IS_DECAY_TO_BE_COMPUTED,
      +                                            ID,'LOAD',.TRUE.,
-     +                                            FRIEDLANDER_PARAMS)
+     +                                            FRIEDLANDER_PARAMS,NWARN)
 
                  P_inci     = FRIEDLANDER_PARAMS%P_inci
                  P_refl     = FRIEDLANDER_PARAMS%P_refl
@@ -1107,6 +1109,15 @@ C-----------------------------------------------
              MSGOUT2='THERE WILL NOT BE LOADED WITH BLAST PRESSURE'
              CALL ANCMSG(MSGID=1907,MSGTYPE=MSGWARNING,ANMODE=ANINFO,C1=TRIM(TITR),I1=ID,C2=MSGOUT1,C3=MSGOUT2)
            ENDIF
+           IF(IMODEL == 2 .AND. NWARN > 0)THEN
+             MSGOUT1=''
+             WRITE(MSGOUT1,FMT='(I0,A)') NWARN,
+     .       ' SEGMENT(S) HAS EXCESSIVE POSITIVE IMPULSE REGARDING THE PEAK PRESSURE AND POSITIVE DURATION.'
+             MSGOUT2=''
+             MSGOUT2='A TRIANGULAR WAVEFORM WILL BE USED INSTEAD TO MAXIMIZE THE IMPULSE. DEFINING A PMIN VALUE IS STRONGLY RECOMMENDED'
+             CALL ANCMSG(MSGID=1907,MSGTYPE=MSGWARNING,ANMODE=ANINFO,C1=TRIM(TITR),I1=ID,C2=MSGOUT1,C3=MSGOUT2)
+           ENDIF
+
 
         ENDIF
 


### PR DESCRIPTION
#### /LOAD/PBLAST : warning message Imodel=2

#### Description of the changes
The /LOAD/PBLAST option is a loading method used to apply a time-dependent blast wave pressure on a Lagrangian surface.
The blast wave is generated using the Friedlander model, characterized by a decay parameter b:
![image](https://github.com/user-attachments/assets/d67d7a15-a271-4400-b9ed-6a05fb545207)

The parameter b is calculated so that the resulting impulse matches the target value interpolated from input data:
![image](https://github.com/user-attachments/assets/01babd4d-5336-487c-b217-eaebfc2a8e3c)

However, in some cases, the target positive impulse may be too high to construct a realistic wave using the corresponding peak pressure and positive phase duration.
In such situations, a triangular wave shape is used as a fallback (b = 0.0) to maximize the impulse magnitude. This approach may result in large negative pressures. To address this, a warning is issued, and users are strongly encouraged to define a PMIN value to limit unphysical negative pressures.
![image](https://github.com/user-attachments/assets/80cce091-e1aa-4673-b2a4-759c6784c3c9)

These cases typically arise near the boundaries of the domain covered by the experimental reference plots:
![image](https://github.com/user-attachments/assets/9b85c91c-41c4-43b9-ba99-84e1a9a9a1cf)
