### PR TITLE
close IOUT unit in case ARRET(2)

### DIFF
--- a/engine/source/system/arret.F
+++ b/engine/source/system/arret.F
@@ -648,6 +648,8 @@ C
               WRITE(IOUT,1100)
               WRITE(ISTDO,1150)
 
+              IF(ISPMD == 0 .AND. IOUT/= 0)  CLOSE(UNIT=IOUT)
+
               CALL SPMD_KILL(2)
               CALL MY_EXIT(2)
 


### PR DESCRIPTION
This pull request includes a small change to the `engine/source/system/arret.F` file. The change ensures that the output unit (`IOUT`) is closed properly when specific conditions are met, improving resource management.#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
