### PR TITLE
group creation issue when referencing engine keywords with comments

### DIFF
--- a/starter/source/model/sets/fill_igr.F
+++ b/starter/source/model/sets/fill_igr.F
@@ -121,7 +121,7 @@ C
             IF (IO_ERR2 == 0) THEN
       ! Process the line stored in KEYA here if needed
               IF(KEYA(1:14) == '/DT/NODA/CST/1' .OR. KEYA(1:8) == '/DYREL/1' .OR. KEYA(1:8) == '/KEREL/1' .OR.
-     .           KEYA(1:14) == '/INIV/AXIS/X/2' .OR. KEYA(1:14) == '/INIV/AXIS/X/2' .OR.
+     .           KEYA(1:14) == '/INIV/AXIS/X/2' .OR. KEYA(1:14) == '/INIV/AXIS/Y/2' .OR.
      .           KEYA(1:14) == '/INIV/AXIS/Z/2')  THEN
                 NB_GRNODE = NB_GRNODE + 1
               ELSE IF(KEYA(1:6) == '/BEGIN') THEN
@@ -153,23 +153,60 @@ C
       ! Process the line stored in KEYA here if needed
               IF(KEYA(1:14) == '/DT/NODA/CST/1') THEN
                 NB_GRNODE = NB_GRNODE + 1
+                
+                DO WHILE (CARTE(1:1) == '#' .AND. IO_ERR2 == 0)
+                  READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
+                END DO
                 READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
+                DO WHILE (CARTE(1:1) == '#' .AND. IO_ERR2 == 0)
+                  READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
+                END DO
                 READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
+                DO WHILE (CARTE(1:1) == '#' .AND. IO_ERR2 == 0)
+                  READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
+                END DO
                 READ(CARTE, FMT=*) GRNODE(NB_GRNODE)
               ELSEIF(KEYA(1:8) == '/DYREL/1') THEN
                 NB_GRNODE = NB_GRNODE + 1
+
+                DO WHILE (CARTE(1:1) == '#' .AND. IO_ERR2 == 0)
+                  READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
+                END DO
                 READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
+                DO WHILE (CARTE(1:1) == '#' .AND. IO_ERR2 == 0)
+                  READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
+                END DO
                 READ(CARTE, FMT=*) GRNODE(NB_GRNODE)
               ELSEIF(KEYA(1:8) == '/KEREL/1') THEN
                 NB_GRNODE = NB_GRNODE + 1
+
+                DO WHILE (CARTE(1:1) == '#' .AND. IO_ERR2 == 0)
+                  READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
+                END DO
                 READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
+                DO WHILE (CARTE(1:1) == '#' .AND. IO_ERR2 == 0)
+                  READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
+                END DO
                 READ(CARTE, FMT=*) GRNODE(NB_GRNODE)
               ELSEIF(KEYA(1:14) == '/INIV/AXIS/X/2' .OR. KEYA(1:14) == '/INIV/AXIS/Y/2' .OR. 
      .               KEYA(1:14) == '/INIV/AXIS/Z/2') THEN
                 NB_GRNODE = NB_GRNODE + 1
+                
+                DO WHILE (CARTE(1:1) == '#' .AND. IO_ERR2 == 0)
+                  READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
+                END DO
                 READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
+                DO WHILE (CARTE(1:1) == '#' .AND. IO_ERR2 == 0)
+                  READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
+                END DO
                 READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
+                DO WHILE (CARTE(1:1) == '#' .AND. IO_ERR2 == 0)
+                  READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
+                END DO
                 READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
+                DO WHILE (CARTE(1:1) == '#' .AND. IO_ERR2 == 0)
+                  READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
+                END DO
                 READ(CARTE, FMT=*) GRNODE(NB_GRNODE)
               ELSE IF(KEYA(1:6) == '/BEGIN') THEN
                 IO_ERR2 = 1


### PR DESCRIPTION
This pull request introduces enhancements to the `SUBROUTINE FILL_IGR` in the file `starter/source/model/sets/fill_igr.F`. The changes improve the handling of specific key patterns and refine the reading logic to better process lines starting with a `#` character. These modifications aim to increase the robustness and accuracy of the subroutine.

### Key Pattern Updates:
* Added support for the `/INIV/AXIS/Y/2` key pattern in the conditional checks, ensuring it is processed alongside `/INIV/AXIS/X/2` and `/INIV/AXIS/Z/2`.

### Line Reading Logic Enhancements:
* Introduced multiple `DO WHILE` loops to handle lines starting with `#` during the reading process. This ensures that such lines are skipped appropriately before processing the next meaningful line. These loops were added for various key patterns, including `/DT/NODA/CST/1`, `/DYREL/1`, `/KEREL/1`, and `/INIV/AXIS/*`.#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
