### PR TITLE
correct bug of temperature initialization with /heat/mat in shells

### DIFF
--- a/starter/source/elements/shell/coque/cinmas.F
+++ b/starter/source/elements/shell/coque/cinmas.F
@@ -886,7 +886,7 @@ cc                ZJ = ZI_LAYERC(II,IP)
          ENDDO 
       ENDIF
 C
-      IF (JTHE < 0 .or. NINTEMP > 0) THEN             
+      IF (JTHE > 0 .or. NINTEMP > 0) THEN             
         IF (NINTEMP > 0 ) THEN                                   
           DO I= LFT,LLT                                          
             IF(TEMP(IX1(I))== ZERO) TEMP(IX1(I)) = PM(79,IMID)   


### PR DESCRIPTION
Correction of temperature initialization in shells when /heat/mat is defined


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

Corrected the check if /heat/mat is defined in input deck, bug introduced in previous PR

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
