### PR TITLE
open_reader : read xelem using cfg file

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2026/data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/radioss2026/data_hierarchy.cfg
@@ -158,6 +158,15 @@ HIERARCHY {
         FILE        = "ELEM/sphcel.cfg";
         USER_NAMES = (SPHCEL);
     }
+    HIERARCHY 
+    {
+        TITLE      = "XELEM";
+        KEYWORD    = XELEM;
+        SUBTYPE = USER;
+        //ID_POOL    = 10;
+        FILE        = "ELEM/xelem.cfg";
+        USER_NAMES = (XELEM);
+    }
 }
 
 HIERARCHY {

--- a/hm_cfg_files/config/CFG/radioss41/ELEM/xelem.cfg
+++ b/hm_cfg_files/config/CFG/radioss41/ELEM/xelem.cfg
@@ -1,0 +1,47 @@
+//Copyright>    CFG Files and Library ("CFG")
+//Copyright>    Copyright (C) 1986-2025 Altair Engineering Inc.
+//Copyright>
+//Copyright>    Altair Engineering Inc. grants to third parties limited permission to
+//Copyright>    use and modify CFG solely in connection with OpenRadioss software, provided
+//Copyright>    that any modification to CFG by a third party must be provided back to
+//Copyright>    Altair Engineering Inc. and shall be deemed a Contribution under and therefore
+//Copyright>    subject to the CONTRIBUTOR LICENSE AGREEMENT for OpenRadioss software.
+//Copyright>
+//Copyright>    CFG IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//Copyright>    INCLUDING, BUT NOT LIMITED TO, THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+//Copyright>    A PARTICULAR PURPOSE, AND NONINFRINGEMENT.  IN NO EVENT SHALL ALTAIR ENGINEERING
+//Copyright>    INC. OR ITS AFFILIATES BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY,
+//Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
+//Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
+//
+// Xelem element Setup File
+// 
+
+ATTRIBUTES(COMMON) {
+  // Common attributes
+  PART      = VALUE(COMPONENT,"Part","part_ID");
+  COUNT     = SIZE("Number of elements");
+  id        = ARRAY[COUNT](INT, "Element identifier"); /* { SUBTYPES = (/ELEMENT/XELEM_IDPOOL) ; } */
+  grnod_ID   = ARRAY[COUNT](SETS, "Ordered node group identifier") { SUBTYPES = (/SETS/GRNOD_IDPOOL); }
+}
+
+GUI(COMMON) {
+mandatory:
+    SIZE(COUNT) ;
+    DATA(PART);
+    ARRAY(COUNT, "element data")
+    {
+        SCALAR(id);
+        SCALAR(grnod_ID);
+    }
+}
+
+FORMAT(radioss110) 
+{
+    HEADER("/XELEM/%d", PART);
+    COMMENT("#  elem_ID  grnod_ID");
+    FREE_CARD_LIST(COUNT)
+    {
+        CARD("%10d%10d", id, grnod_ID);
+    }
+}


### PR DESCRIPTION


#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
read xelem element using open_reader lib

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

This pull request introduces a new hierarchy and configuration file to support the `XELEM` element type in the Radioss software. The changes include the addition of a new hierarchy block in the data hierarchy configuration and the creation of a dedicated configuration file for `XELEM` elements.

### Additions to hierarchy configuration:

* [`hm_cfg_files/config/CFG/radioss2026/data_hierarchy.cfg`](diffhunk://#diff-a363c0d8a651ff98903e29e2017b1b7de6bec2b0f30a751e6e3c427dc5495302R161-R169): Added a new hierarchy block for `XELEM` with attributes such as `TITLE`, `KEYWORD`, `SUBTYPE`, and `FILE`. This establishes the structure for the `XELEM` element type.

### Creation of `XELEM` configuration file:

* [`hm_cfg_files/config/CFG/radioss41/ELEM/xelem.cfg`](diffhunk://#diff-c5376c69e9b1875f62cdf5725bbffd637bf3f6916a87eb00da9d85f0a33a039aR1-R47): Created a new configuration file for `XELEM` elements. This file includes copyright information, common attributes (e.g., `PART`, `COUNT`, `id`, `grnod_ID`), GUI definitions for mandatory fields, and a format for Radioss 110 with headers, comments, and free card lists.


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
