### PR TITLE
Correct wrong test of lagrangian formulation in law2 for shells

### DIFF
--- a/engine/source/materials/mat/mat002/sigeps02c.F
+++ b/engine/source/materials/mat/mat002/sigeps02c.F
@@ -40,7 +40,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      A                  EPSPXX   ,EPSPYY   ,EPSPXY   ,EPSPYZ   ,EPSPZX   ,
      B                  SIGBAKXX ,SIGBAKYY ,SIGBAKXY ,INLOC    ,DPLANL   ,
      C                  VP       ,ASRATE   ,LOFF     ,EPSD     ,
-     D                  TEMPEL   ,FHEAT    ,JLAG)
+     D                  TEMPEL   ,FHEAT    )
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -60,7 +60,6 @@ C-----------------------------------------------
       INTEGER JFT,JLT,IPLA,NEL,IOFC,JTHE,IPT,NPTT,IMAT,ISRATE
       INTEGER NGL(MVSIZ),IOFF_DUCT(*),INLOC
       INTEGER, INTENT(IN) :: VP
-      INTEGER,INTENT(IN) :: JLAG
       my_real ,DIMENSION(NEL),INTENT(IN) :: EPSPXX,EPSPYY,EPSPXY,EPSPYZ,EPSPZX
       my_real ,INTENT(IN) :: ASRATE
       my_real, DIMENSION(NEL), INTENT(IN) :: LOFF
@@ -225,7 +224,7 @@ c------------------------------------
 C-----------------
 C     TEMPERATURE
 C-----------------
-      IF (JTHE /= 0 .AND. JLAG /= 0) THEN
+      IF (JTHE /= 0) THEN
         ! heat increment due to plastic work for /heat/mat
         DO I=1,NEL
           FHEAT(I) = FHEAT(I) + SIGY(I)*DPLA(I)*VOL(I)

--- a/engine/source/materials/mat_share/mulawc.F90
+++ b/engine/source/materials/mat_share/mulawc.F90
@@ -430,7 +430,7 @@
           igtyp = igeo(11,pid(1))
           igmat = igeo(98,pid(1))
           inloc = iparg(78)
-          jlag = iparg(14)                     ! flag for non-local regularization
+ !         jlag = iparg(14)        ! not initialized for shells, but should be always = 1
           nsensor = sensors%nsensor
 !
           idrape = elbuf_str%idrape
@@ -1119,7 +1119,7 @@
                 &epspxx     ,epspyy    ,epspxy   ,epspyz   ,epspzx ,&
                 &lbuf%sigb(ij1),lbuf%sigb(ij2),lbuf%sigb(ij3),inloc  ,varnl(1,it),&
                 &vp         ,asrate    ,lbuf%off ,lbuf%epsd  ,&
-                &el_temp   ,fheat      ,jlag)
+                &el_temp   ,fheat      )
 !
               elseif (ilaw == 15) then
                 call sigeps15c(&


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

there were no temperature update in law2 for shells with /heat mat 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

Deleted test on lagrangian model type in law2 for shells. Radioss shells are not compatibles wit ALE or EULER, JLAG flag was never initialized. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
