### PR TITLE
correct non initialized element temperature in 16 and 20 node solids …and thickshells

### DIFF
--- a/starter/source/elements/solid/solide20/s20init3.F
+++ b/starter/source/elements/solid/solide20/s20init3.F
@@ -250,6 +250,8 @@ c
 C
           IF (JTHE == 0 .and. GLOB_THERM%NINTEMP > 0) THEN
             CALL S20TEMP(NEL,NUMNOD,MVSIZ,NPE, NC,NI(1,IP),TEMP,TEMPEL)
+          ELSE
+            TEMPEL(1:NEL) = TEMP0(1:NEL)
           ENDIF             
 !
           CALL MATINI(PM      ,IXS      ,NIXS      ,X         ,

--- a/starter/source/elements/thickshell/solide16/s16init3.F
+++ b/starter/source/elements/thickshell/solide16/s16init3.F
@@ -395,6 +395,8 @@ c
 c
          IF (JTHE == 0 .and. GLOB_THERM%NINTEMP > 0) THEN
            CALL S20TEMP(NEL,NUMNOD,MVSIZ,NPE, NC,NI(1,IP),TEMP,TEMPEL)
+         ELSE
+           TEMPEL(1:NEL) = TEMP0(1:NEL)
          ENDIF             
 !
          CALL MATINI(PM       ,IXS    ,NIXS        ,X          ,


### PR DESCRIPTION
Corrected missing element temperature initialization in solid and thickshell elements when /heat/mat ot /initemp is absent

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
