### PR TITLE
make change in 52abde25d3183d903003550a8590eef0cd8fa365 only for full…

### DIFF
--- a/engine/source/materials/mat_share/mulawc.F90
+++ b/engine/source/materials/mat_share/mulawc.F90
@@ -510,7 +510,7 @@
           if (flag_law25 .and. igtyp == 9 .and. npt == 1) then
             degmb(jft:jlt) = zero
             degfx(jft:jlt) = zero 
-          else
+          elseif (npg>1) then
             degmb(jft:jlt) = degmb(jft:jlt)*off(jft:jlt)
             degfx(jft:jlt) = degfx(jft:jlt)*off(jft:jlt)
           endif


### PR DESCRIPTION
…y integration shells

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
correction in 52abde25d3183d903003550a8590eef0cd8fa365 will make slight change of internal energy for 1pt integration shell, this isn't waited.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
make change of dkt18_rupture only for fully integration shell (dkt18,Qbat)

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
