### PR TITLE
Correct the total strain calculation in law24

### DIFF
--- a/engine/source/materials/mat/mat024/conc24.F
+++ b/engine/source/materials/mat/mat024/conc24.F
@@ -94,14 +94,14 @@ C-----------------------------------------------
      .   SM, DSM, S1,S2,S3,S4,S5,S6,DE1,DE2, DE3, C44, C55, C66
       my_real, DIMENSION(NEL,3,3) :: CDAM
 C=======================================================================
-      DO I=1,NEL
-        STRAIN(I,1) = STRAIN(I,1) + D1(I)*DT1
-        STRAIN(I,2) = STRAIN(I,2) + D2(I)*DT1
-        STRAIN(I,3) = STRAIN(I,3) + D3(I)*DT1
-        STRAIN(I,4) = STRAIN(I,4) + D4(I)*DT1
-        STRAIN(I,5) = STRAIN(I,5) + D5(I)*DT1
-        STRAIN(I,6) = STRAIN(I,6) + D6(I)*DT1
-      ENDDO
+!      DO I=1,NEL
+!        STRAIN(I,1) = STRAIN(I,1) + D1(I)*DT1
+!        STRAIN(I,2) = STRAIN(I,2) + D2(I)*DT1
+!        STRAIN(I,3) = STRAIN(I,3) + D3(I)*DT1
+!        STRAIN(I,4) = STRAIN(I,4) + D4(I)*DT1
+!        STRAIN(I,5) = STRAIN(I,5) + D5(I)*DT1
+!        STRAIN(I,6) = STRAIN(I,6) + D6(I)*DT1
+!      ENDDO
 C . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 C ARMATURES
 C . . . . . . . . . . .

--- a/starter/source/elements/solid/solide/sgrtails.F
+++ b/starter/source/elements/solid/solide/sgrtails.F
@@ -648,7 +648,7 @@ C
 c
           IF (NFAIL > 0)THEN
             IFAIL = 1
-            IF(MLN /= 24 .AND. MLN /= 25 .AND. MLN < 28) THEN
+            IF(MLN /= 25 .AND. MLN < 28) THEN
                DO J=1,NFAIL  
                   IFAILMODEL = IPM(111 + 15*(J - 1) ,MID)
                   IF  (IFAILMODEL == 10 .OR. IFAILMODEL == 4 
@@ -1463,7 +1463,7 @@ C reperage groupe/processeur
             IPARG(41,NGROUP)=ITET4
           ENDIF
           IF(MLN/=25.AND.MLN<28)THEN
-          IPARG(44,NGROUP)= ISTRAIN
+            IPARG(44,NGROUP)= ISTRAIN
           ELSEIF(MLN>=28)THEN
            ISTRAIN=2
            IPARG(44,NGROUP)=ISTRAIN


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

total strain was twice the correct value in law24

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

Corrected total strain calcutation which was performed in both element routines and material law. The second calculation is deleted.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
