### PR TITLE
correction solver names in law128 cfg file

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2025/MAT/Law128_hill_visc_plast.cfg
+++ b/hm_cfg_files/config/CFG/radioss2025/MAT/Law128_hill_visc_plast.cfg
@@ -221,10 +221,10 @@ FORMAT (radioss2025)
     
     COMMENT("#              Rho_i");
     CARD("%20lg",MAT_RHO);
-    COMMENT("#                  E                  NU                SIGY                FKIN");
+    COMMENT("#                  E                  NU                SIGY               CHARD");
     CARD("%20lg%20lg%20lg%20lg",LAW128_E,LAW128_NU,LAW128_SIGY,LAW128_KIN);
 
-    COMMENT("#     Itab                          FacX                FacY");
+    COMMENT("#   tab_ID                        Xscale              Fscale");
     CARD("%10d          %20lg%20lg",LAW128_ITAB,LAW128_FACX,LAW128_FACY);
 
     COMMENT("#                QR1                 CR1                 QR2                 CR2");


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
some solver names in law128 cfg file were wrong 
This pull request updates comments in the `Law128_hill_visc_plast.cfg` configuration file to improve clarity and consistency in naming conventions. The changes replace ambiguous terms with clearer ones.

Comment updates for improved clarity:


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
correction solver names in law128 cfg file

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
