### PR TITLE
correction of a potential issue when NODE_ID is empty in PART_INERTIA+ use of CONTRAINED_EXTRA_NODES

### DIFF
--- a/reader/source/dyna2rad/_private/convertrigids.cxx
+++ b/reader/source/dyna2rad/_private/convertrigids.cxx
@@ -299,12 +299,15 @@ void sdiD2R::ConvertRigid::ConvertConstrainedExtraNodes()
 
                     HandleRead dynaNODEIDHRead;
                     dynapartHread.GetEntityHandle(p_lsdynaModel, sdiIdentifier("NODEID"), dynaNODEIDHRead);
-                    EntityRead dynaNODEIDRead(p_lsdynaModel, dynaNODEIDHRead);
+                    
+                    EntityRead dynaNODEIDRead;
+                    dynaNODEIDRead = EntityRead(p_lsdynaModel, dynaNODEIDHRead);
 
                     if(slaveAttName == "NID")
                     {
-                        if(slaveEntityId  == dynaNODEIDRead.GetId() &&
-                           masterEntityId == dynaPIDinertiaRead.GetId())break;
+                        if(dynaNODEIDRead.IsValid() &&  dynaPIDinertiaRead.IsValid())
+                          if(slaveEntityId  == dynaNODEIDRead.GetId() &&
+                             masterEntityId == dynaPIDinertiaRead.GetId())break;
                     }
                     else if(slaveAttName == "NSID")
                     {


### PR DESCRIPTION


#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
correction of a potential issue when NODE_ID is empty in PART_INERTIA+ use of CONTRAINED_EXTRA_NODES

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
check validity of objects

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
