### PR TITLE
fix old regression of QEPH+law19 (119)

### DIFF
--- a/engine/source/materials/mat_share/mulawc.F90
+++ b/engine/source/materials/mat_share/mulawc.F90
@@ -2778,8 +2778,9 @@
 !-----------------------------------------------
 !         facteurs pour coques b.l. (zeng&combescure)
 !-----------------------------------------------
-              if (ilaw /= 2  .and. ilaw /= 15 .and. ilaw /= 22 .and.&
-              &             ilaw /= 25 .and. ilaw /= 27 .and. ilaw /= 32) then  ! for law25 it is done inside sigeps25c.f
+              if (ilaw /= 2  .and. ilaw /= 15 .and. ilaw /= 22 .and.    &
+                           ilaw /= 25 .and. ilaw /= 27 .and. ilaw /= 32 &
+                     .and. ilaw /= 19 .and. ilaw /= 119) then  ! for law25,27 it is done inside sigeps25c.f...
                 if(flag_zcfac) then
                   zcfac(jft:jlt,1) = zcfac(jft:jlt,1) + etse(jft:jlt) * thkly(jpos:jpos+jlt-1)
                   zcfac(jft:jlt,2) = min(etse(jft:jlt),zcfac(jft:jlt,2))


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
hourglass stiffness of QEPH with law19 was over-estimated due to old regression

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
correction to fix old regression on QEPH+law19

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
