### PR TITLE
remove the limitation of MUMPS solver for /IMPL/CHECK

### DIFF
--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -8825,7 +8825,6 @@ C                                     PARALLEL SECTION (SMP)
 C========================================================================================
 
                 IF (IMP_CHK > 0) THEN
-#if defined(MUMPS5)
                   CALL IMP_CHKM(TIMERS,
      1     NODES%ICODE      ,NODES%ISKEW          ,ISKWN       ,IPART             ,IXTG       ,IXS              ,IXQ         ,
      2     ELEMENT%SHELL%IXC,IXT                  ,IXP         ,IXR               ,IXTG1      ,NODES%ITAB       ,NODES%ITABM1,
@@ -8846,13 +8845,8 @@ C===============================================================================
      O     FRWL6            ,IRBE2                ,LRBE2       ,ICFIELD           ,LCFIELD    ,CFIELD           ,ELBUF_TAB,
      P     NODES%WEIGHT_MD  ,STACK,SENSORS%SFSAV  ,SENSORS%FSAV,SENSORS%STABSEN   ,SENSORS%TABSENSOR            ,DRAPE_SH4N  ,
      Q     DRAPE_SH3N       ,H3D_DATA             ,NDDL0       ,NNZK0             ,IMPBUF_TAB ,CPTREAC,FTHREAC,NODREAC ,
-     R     DRAPEG           ,OUTPUT%TH%TH_SURF    ,DPL0CLD     ,VEL0CLD           ,SNPC       ,STF , OUTPUT%WFEXT_MD)
+     R     DRAPEG           ,OUTPUT%TH%TH_SURF    ,DPL0CLD     ,VEL0CLD           ,SNPC       ,STF , OUTPUT%WFEXT_MD,IGRSURF)
                   MSTOP=2
-#else
-                  WRITE(6,*) __LINE__,"Fatal error: MUMPS required"
-                  CALL FLUSH(6)
-                  CALL ARRET(5)
-#endif
                 ELSEIF ((TT<=TSTOP.OR.(TT-TSTOP)<EM10).AND.IBUCK==0) THEN
 C-----integer : 1:IKC,2:IKUD,3:W_DDL,4:IADM,5:JDIM,6:NDOFI,7:IDDLI
 C-----reel : 1,2,3,4:DIAG_K,LT_K,DIAG_M,LT_M,5,6:LB,DB,7:BKUD,8,9:D_IMP,DR_IMP

--- a/engine/source/implicit/imp_solv.F
+++ b/engine/source/implicit/imp_solv.F
@@ -3140,7 +3140,7 @@ C------------------------------------------
      N  FRWL6  ,IRBE2  ,LRBE2  ,ICFIELD,LCFIELD,CFIELD,ELBUF_TAB,WEIGHT_MD,
      O  STACK  ,DIMFB  ,FBSAV6 ,STABSEN,TABSENSOR,DRAPE_SH4N,DRAPE_SH3N,H3D_DATA,
      P  NDDL0  ,NNZK0  ,IMPBUF_TAB,CPTREAC,FTHREAC,NODREAC,DRAPEG,TH_SURF ,
-     Q  DPL0CLD,VEL0CLD,SNPC,STF, WFEXT_MD)
+     Q  DPL0CLD,VEL0CLD,SNPC,STF, WFEXT_MD,IGRSURF)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -3156,6 +3156,7 @@ C-----------------------------------------------
         USE DRAPE_MOD
         USE TH_SURF_MOD , ONLY : TH_SURF_
         USE SKEW_MOD , ONLY : SKEW_
+        USE GROUPDEF_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -3163,9 +3164,6 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   C o m m o n   B l o c k s
 C-----------------------------------------------
-#if defined(MUMPS5)
-#include "dmumps_struc.h"
-#endif
 #include "timeri_c.inc"
 #include "impl1_c.inc"
 #include "impl2_c.inc"
@@ -3221,7 +3219,7 @@ C-----------------------------------------------
         TYPE (TH_SURF_) , INTENT(INOUT) :: TH_SURF
         TYPE(SKEW_),INTENT(INOUT) :: SKEWS
         DOUBLE PRECISION,INTENT(INOUT) :: WFEXT, WFEXT_MD
-#if defined(MUMPS5)
+        TYPE (GROUP_)  , DIMENSION(NSURF)   :: IGRSURF
 C----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -3315,6 +3313,7 @@ C-----------------------------------------------
         IMP_IW = 0
         IMP_IR = 0
         RBID=ZERO
+        IBID= 0
 C
         IF (IRREF>0.AND.IMCONV==1.AND.ILINE/=1) THEN
           IRFLAG=IRREF
@@ -3608,7 +3607,7 @@ C----------------------------------
      9    JDIK      ,IKC       ,DIAG_K     ,LT_K      ,IDDL      ,
      A    NUM_IMP   ,NS_IMP    ,NE_IMP     ,IND_IMP   ,NDOFI     ,
      B    ITOK      ,D_IMP     ,LB         ,GAP       ,DIRUL     ,
-     C    NT_RW     ,RBID      ,IRBE3      ,LRBE3     ,FRBE3     ,
+     C    NT_RW     ,IBID      ,IRBE3      ,LRBE3     ,FRBE3     ,
      D    NSS3      ,ISS3      ,IRBE2      ,LRBE2     ,NSB2      ,
      E    ISB2      )
 C
@@ -3707,7 +3706,7 @@ C    /---------------/
      7                MS    ,X     ,IPARI ,INTBUF_TAB   ,
      8                NUM_IMP,NS_IMP,NE_IMP,NSREM       ,NSL  ,
      9                NTMP  ,GRAPHE, ITAB  ,RBID        ,IBID ,
-     A                IBID  ,NTMP  ,IBID   ,IBID        ,IBID ,
+     A                IBID  ,NTMP  ,IBID   ,IBID        ,IGRSURF ,
      B                IBID  ,RBID   ,IBFV  ,SKEWS%SKEW  ,
      C                XFRAME,MUMPS_PAR,IBID,IBID  ,RBID ,
      D                IRBE3 ,LRBE3 ,IRBE2  ,LRBE2 )
@@ -3737,7 +3736,6 @@ C    /---------------/
      .         5X,'TERMINATION WITH '/,I8,' ERRORS '/,I8,' WARNINGS'/
      .         5X,'** DETAILS REPORTED IN LISTING FILE **'/)
         RETURN
-#endif
       END
       !||====================================================================
       !||    imp_compab      ../engine/source/implicit/imp_solv.F

--- a/engine/source/input/lectur.F
+++ b/engine/source/input/lectur.F
@@ -3288,6 +3288,13 @@ C-----------------------------------------------
        IPRINT=0
 C       IMPMV>0 isolv/=1 --> IMPMV=0
        IF (ISPMD == 0) IPRINT=1
+       IF (IMP_CHK > 0) THEN
+          NTY = 5
+          IF (IPREC /= 5) IPREC=5
+          IF (ILINE /= 1) ILINE=1
+          IF (ISOLV /= 1) ISOLV=1
+          IF (D_TOL /= ZERO) D_TOL = ZERO
+       ENDIF
        IF(ISOLV >= 3 ) THEN
           CALL ANCMSG(MSGID=296,ANMODE=ANINFO,I1=ISOLV)
           ISOLV = 2
@@ -3372,13 +3379,6 @@ C------case /IMPL/PROJV/n w/o /SOLV/9
        ENDIF
 
        IF (IPREC == 0.OR.IPREC > 6)IPREC=5
-       IF (IMP_CHK > 0) THEN
-          NTY = 5
-          IF (IPREC /= 5) IPREC=5
-          IF (ILINE /= 1) ILINE=1
-          IF (ISOLV /= 1) ISOLV=1
-          IF (D_TOL /= ZERO) D_TOL = ZERO
-       ENDIF
 
        IF (ISOLV == 2) THEN
         IF (ITOL == 0.OR.ITOL > 1) ITOL=2


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
when /IMPL/CHECK is defined to run implicit check, run was stopped due to MUMPS solver which isn't used by implicit check

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
correction to run /IMPL/CHECK w/o MUMPS 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
