### PR TITLE
Add missing total strain calculation in law24 in case of 2D simulation tests

### DIFF
--- a/engine/source/materials/mat/mat024/conc24.F
+++ b/engine/source/materials/mat/mat024/conc24.F
@@ -94,14 +94,16 @@ C-----------------------------------------------
      .   SM, DSM, S1,S2,S3,S4,S5,S6,DE1,DE2, DE3, C44, C55, C66
       my_real, DIMENSION(NEL,3,3) :: CDAM
 C=======================================================================
-!      DO I=1,NEL
-!        STRAIN(I,1) = STRAIN(I,1) + D1(I)*DT1
-!        STRAIN(I,2) = STRAIN(I,2) + D2(I)*DT1
-!        STRAIN(I,3) = STRAIN(I,3) + D3(I)*DT1
-!        STRAIN(I,4) = STRAIN(I,4) + D4(I)*DT1
-!        STRAIN(I,5) = STRAIN(I,5) + D5(I)*DT1
-!        STRAIN(I,6) = STRAIN(I,6) + D6(I)*DT1
-!      ENDDO
+      IF (N2D == 1) THEN
+        DO I=1,NEL
+        STRAIN(I,1) = STRAIN(I,1) + D1(I)*DT1
+        STRAIN(I,2) = STRAIN(I,2) + D2(I)*DT1
+        STRAIN(I,3) = STRAIN(I,3) + D3(I)*DT1
+        STRAIN(I,4) = STRAIN(I,4) + D4(I)*DT1
+        STRAIN(I,5) = STRAIN(I,5) + D5(I)*DT1
+        STRAIN(I,6) = STRAIN(I,6) + D6(I)*DT1
+        ENDDO
+      END IF
 C . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 C ARMATURES
 C . . . . . . . . . . .


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

Total strain calculation was missing in 2D for law24, affecting failure criteria

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

Added total strain integration in the law in case of 2D. In 3D total strain is already calculated in element routines

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
