### PR TITLE
Fix solid element connectivity issue for total Lagrangian cases

### DIFF
--- a/starter/source/elements/reader/hm_read_solid.F
+++ b/starter/source/elements/reader/hm_read_solid.F
@@ -103,7 +103,8 @@ C-----------------------------------------------
       INTEGER I, J, MT, MLAW, JTUR, I1, I2, INEW,I10,I20,I16
       INTEGER IC,IC1,IC2,IC3,IC4,IPID,ID,IDS,N,JC,NSPHDIR,STAT
       INTEGER FLAG_FMT,FLAG_FMT_TMP,IFIX_TMP,NUMELS_READ,
-     .        IOUTN, IERROR, INDEX_PART,IXS10_SAV(6)
+     .        IOUTN, IERROR, INDEX_PART,IXS10_SAV(6),IC5,IC6,
+     .        IC7,IC8
       my_real BID
       CHARACTER MESS*40, MESS2*40
       INTEGER, DIMENSION(:), ALLOCATABLE :: SUB_SOL
@@ -111,7 +112,7 @@ C-----------------------------------------------
 C   E x t e r n a l  F u n c t i o n s
 C-----------------------------------------------
       my_real
-     .   CHECKVOLUME_4N
+     .   CHECKVOLUME_4N,CHECKVOLUME_6N,CHECKVOLUME_8N
 C-----------------------------------------------
 C   E x t e r n a l   F u n c t i o n s
 C-----------------------------------------------
@@ -171,12 +172,46 @@ C--------------------------------------------------
           IXS(6,I)=IXS(5,I)
           IXS(5,I)=IXS(2,I)
           ISOLNOD(I)=6
+          IF (CHECKVOLUME_6N(X ,IXS(1,I)) < ZERO) THEN
+C           renumber connectivity
+            IC1 = IXS(6,I)
+            IC2 = IXS(7,I)
+            IC3 = IXS(8,I)
+            IC4 = IXS(2,I)
+            IC5 = IXS(3,I)
+            IC6 = IXS(4,I)
+            IXS(2,I) = IC1
+            IXS(3,I) = IC2
+            IXS(4,I) = IC3
+            IXS(6,I) = IC4
+            IXS(7,I) = IC5
+            IXS(8,I) = IC6
+          ENDIF 
         ELSE
           DO J=2,9  
             IXS(J,I)=USR2SYS(IXS(J,I),ITABM1,MESS,IXS(11,I))
             CALL ANODSET(IXS(J,I), CHECK_VOLU)
           ENDDO  
           ISOLNOD(I)=8
+          IF (CHECKVOLUME_8N(X ,IXS(1,I)) < ZERO) THEN
+C         renumber connectivity
+            IC1 = IXS(6,I)
+            IC2 = IXS(7,I)
+            IC3 = IXS(8,I)
+            IC4 = IXS(9,I)
+            IC5 = IXS(2,I)
+            IC6 = IXS(3,I)
+            IC7 = IXS(4,I)
+            IC8 = IXS(5,I)
+            IXS(2,I) = IC1
+            IXS(3,I) = IC2
+            IXS(4,I) = IC3
+            IXS(5,I) = IC4
+            IXS(6,I) = IC5
+            IXS(7,I) = IC6
+            IXS(8,I) = IC7
+            IXS(9,I) = IC8
+          ENDIF
         ENDIF
 C--------------------------------------------------
 C      INTERNAL PART ID

--- a/starter/source/materials/fail/composite/hm_read_fail_composite.F90
+++ b/starter/source/materials/fail/composite/hm_read_fail_composite.F90
@@ -150,15 +150,15 @@
       ! Modes of failure
       fail_tag%lf_dammx = fail_tag%lf_dammx + fail%nmod
       allocate (fail%mode(fail%nmod))
-      fail%mode(1) = "Tensile failure index in dir. 1"
-      fail%mode(2) = "Compression failure index in dir. 1"
-      fail%mode(3) = "Tensile failure index in dir. 2"
-      fail%mode(4) = "Compression failure index in dir. 2"
-      fail%mode(5) = "Shear failure index in plane 1-2"
-      fail%mode(6) = "Tensile failure index in dir. 3"
-      fail%mode(7) = "Compression failure index in dir. 3"
-      fail%mode(8) = "Shear failure index in plane 2-3"
-      fail%mode(9) = "Shear failure index in plane 3-1"
+      fail%mode(1) = "Tensile index in dir. 1"
+      fail%mode(2) = "Compression index in dir. 1"
+      fail%mode(3) = "Tensile index in dir. 2"
+      fail%mode(4) = "Compression index in dir. 2"
+      fail%mode(5) = "Shear index in plane 1-2"
+      fail%mode(6) = "Tensile index in dir. 3"
+      fail%mode(7) = "Compression index in dir. 3"
+      fail%mode(8) = "Shear index in plane 2-3"
+      fail%mode(9) = "Shear index in plane 3-1"
 !
       !< Integer material parameters
       fail%iparam(1) = ifail_sh


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

A very critical bug was found regarding the Total Lagrangian cases. In fact the connectivity of solid elements might be changed in some cases due to negative volume detected in the starter. However, this automatic correction was done before the storage of some initial values that are critical for total lagragian approach, leading to inconsistencies and crashes in the engine.  

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

Move the connectivity check/correction to the solid element reading routine (very early stage) + fix some failure mode typo. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
