### PR TITLE
/FAIL possible NaN in fail_gene1_s.F

### DIFF
--- a/engine/source/materials/fail/gene1/fail_gene1_s.F
+++ b/engine/source/materials/fail/gene1/fail_gene1_s.F
@@ -252,9 +252,9 @@ c
           R   = (TWO*I1*I1*I1-NINE*I1*I2+TWENTY7*I3)/CINQUANTE4     ! (2*I3^3-9*I1*I2+27*I3)/54  
           R_INTER = MIN(R/SQRT(MAX(EM20,(-Q**3))),ONE)
           PHI = ACOS(MAX(R_INTER,-ONE))
-          E11(I) = TWO*SQRT(-Q)*COS(PHI/THREE)+THIRD*I1
-          E22(I) = TWO*SQRT(-Q)*COS((PHI+TWO*PI)/THREE)+THIRD*I1
-          E33(I) = TWO*SQRT(-Q)*COS((PHI+FOUR*PI)/THREE)+THIRD*I1
+          E11(I) = TWO*SQRT(MAX(ZERO,-Q))*COS(PHI/THREE)+THIRD*I1
+          E22(I) = TWO*SQRT(MAX(ZERO,-Q))*COS((PHI+TWO*PI)/THREE)+THIRD*I1
+          E33(I) = TWO*SQRT(MAX(ZERO,-Q))*COS((PHI+FOUR*PI)/THREE)+THIRD*I1
           IF (E11(I) < E22(I)) THEN 
             R_INTER = E11(I)
             E11(I)  = E22(I)
@@ -308,9 +308,9 @@ c
           R  = (TWO*I1*I1*I1-NINE*I1*I2+TWENTY7*I3)/CINQUANTE4     ! (2*I3^3-9*I1*I2+27*I3)/54
           R_INTER = MIN(R/SQRT(MAX(EM20,(-Q**3))),ONE)
           PSI = ACOS(MAX(R_INTER,-ONE))
-          S11(I) = TWO*SQRT(-Q)*COS(PSI/THREE)+THIRD*I1
-          S22(I) = TWO*SQRT(-Q)*COS((PSI+TWO*PI)/THREE)+THIRD*I1
-          S33(I) = TWO*SQRT(-Q)*COS((PSI+FOUR*PI)/THREE)+THIRD*I1
+          S11(I) = TWO*SQRT(MAX(ZERO,-Q))*COS(PSI/THREE)+THIRD*I1
+          S22(I) = TWO*SQRT(MAX(ZERO,-Q))*COS((PSI+TWO*PI)/THREE)+THIRD*I1
+          S33(I) = TWO*SQRT(MAX(ZERO,-Q))*COS((PSI+FOUR*PI)/THREE)+THIRD*I1
           IF (S11(I) < S22(I)) THEN 
             R_INTER = S11(I)
             S11(I)  = S22(I)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
This pull request makes updates to the `engine/source/materials/fail/gene1/fail_gene1_s.F` file to ensure numerical stability by replacing direct calculations with the `SQRT` function to use `MAX(ZERO, -Q)`. This change prevents potential issues when `Q` is negative, which could lead to undefined behavior or errors.

Numerical stability improvements:

* Modified the calculation of `E11(I)`, `E22(I)`, and `E33(I)` to use `SQRT(MAX(ZERO, -Q))` instead of `SQRT(-Q)` in the `FAIL_GENE1_S` subroutine. This ensures that the square root operation does not encounter negative values, improving robustness.
* Updated the computation of `S11(I)`, `S22(I)`, and `S33(I)` to use `SQRT(MAX(ZERO, -Q))` instead of `SQRT(-Q)` in the `FAIL_GENE1_S` subroutine for similar stability improvements.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
