### PR TITLE
Correction of strain rate calculation for h3d and anim output for law25 in solids

### DIFF
--- a/engine/source/materials/mat/mat025/m25law.F
+++ b/engine/source/materials/mat/mat025/m25law.F
@@ -42,7 +42,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      5   D6,        RX,        RY,        RZ,
      6   SX,        SY,        SZ,        TX,
      7   TY,        TZ,        GAMA,      VNEW,
-     8   SSP,       VOL,       EPSP,      WPLA,
+     8   SSP,       VOL,       EPSD,      WPLA,
      9   EPST,      SIGL,      TSAIWU,          
      A   FLAY,      NGL,       NEL,       NFT,             
      B   ILAY,      NPT,       IPG,
@@ -82,12 +82,10 @@ C-----------------------------------------------
       INTEGER, INTENT(IN) :: L_DMG
       INTEGER NGL(MVSIZ),ILAY,NEL,IPG
       INTEGER, INTENT(INOUT) :: OUTV(NEL)
-C     REAL
+      my_real ,DIMENSION(NEL) ,INTENT(INOUT) :: EPSD ! local equivalent strain rate
       my_real
      .   PM(NPROPM),OFF(*), SIG(NEL,6), WPLA(*), GAMA(MVSIZ,6), 
-     .   EINT(*), EPSP(*),
-     .   RX(*) ,RY(*),RZ(*) ,SX(*),SY(*),SZ(*),
-     .   TX(*) ,TY(*) ,TZ(*)
+     .   EINT(*),RX(*) ,RY(*),RZ(*) ,SX(*),SY(*),SZ(*),TX(*) ,TY(*) ,TZ(*)
       my_real
      .   D1(*), D2(*), D3(*), D4(*),
      .   D5(*), D6(*),
@@ -139,16 +137,15 @@ C-----------------------------------------------------------
         DMAXT(I) = ZERO
       ENDDO  
 C-----------------------------------------------------------
-C     STRAIN RATE FILTERING (EQUIVALENT EPSP)
+C     STRAIN RATE FILTERING (EQUIVALENT EPSD)
 C-----------------------------------------------------------
       ASRATE = ASRATE / (ASRATE + ONE)   
       DO I=1,NEL                                                                                                    
         DAV = -THIRD*(D1(I)+D2(I)+D3(I))                         
-        EPD = HALF*((D1(I)+DAV )**2+(D2(I)+DAV)**2          
-     .                                +(D3(I)+DAV)**2)           
-     .         + FOURTH*(D4(I)**2+D5(I)**2+D6(I)**2)              
+        EPD = HALF*((D1(I)+DAV )**2 + (D2(I)+DAV)**2 + (D3(I)+DAV)**2)           
+     .      + FOURTH*(D4(I)**2 + D5(I)**2 + D6(I)**2)
         EPD = SQRT(THREE*EPD)/THREE_HALF                        
-        EPSP(I) = ASRATE*EPD + (ONE - ASRATE)*EPSP(I)     
+        EPSD(I) = ASRATE*EPD + (ONE - ASRATE)*EPSD(I)   
       ENDDO                                                        
 C--------------------------------------------
 C     STRESS TRANSFORMATION (GLOBAL -> FIBER)
@@ -204,7 +201,7 @@ C-----------------------------------------------------------
      2                    S1     ,S2   ,S3    ,S4   ,S5   ,S6   ,
      3                    EP1    ,EP2  ,EP3   ,EP4  , EP5 ,EP6  ,
      4                    EPST   ,NFIS1,NFIS2 ,NFIS3,
-     5                    WPLAR  ,EPSP ,WPLA  ,SIGL ,ILAY ,IPG  ,
+     5                    WPLAR  ,EPSD ,WPLA  ,SIGL ,ILAY ,IPG  ,
      6                    TSAIWU ,TT   ,IMCONV,MVSIZ,IOUT ,DMG  ,
      7                    L_DMG  ,OUTV)
       
@@ -215,7 +212,7 @@ C-----------------------------------------------------------
      2             S1   ,S2   ,S3  ,S4   ,S5   ,S6    ,
      3             EP1  ,EP2  ,EP3 ,EP4  , EP5 ,EP6,
      4             EPST ,NFIS1,NFIS2,NFIS3,
-     5             WPLAR,EPSP, WPLA, SIGL, ILAY,
+     5             WPLAR,EPSD, WPLA, SIGL, ILAY,
      6             IPG  ,TSAIWU,TT,IMCONV  ,MVSIZ   ,IOUT,
      7             DMG  ,L_DMG ,OUTV)
 

--- a/engine/source/materials/mat/mat025/mat25_crasurv_s.F90
+++ b/engine/source/materials/mat/mat025/mat25_crasurv_s.F90
@@ -51,7 +51,7 @@
           s1  ,s2  ,s3, s4  ,s5  ,s6  ,                     &
           d1  ,d2  ,d3, d4  ,d5  ,d6  ,                     &
           epst,nfis1,nfis2,nfis3,                           &
-          wplar,epsp , wpla, sigl, ilay,                    &
+          wplar,epsd , wpla, sigl, ilay,                    &
           ipg,tsaiwu,time,imconv  ,mvsiz   ,iout,           &
           dmg,l_dmg ,outv)
 !-----------------------------------------------
@@ -82,7 +82,7 @@
           real(kind=WP) ,intent(in)    :: time                   !< current time
           real(kind=WP) ,intent(inout) :: off(mvsiz)             !< element activation coefficient
           real(kind=WP) ,intent(inout) :: wpla(mvsiz)            !< plastic work
-          real(kind=WP) ,intent(inout) :: epsp(mvsiz)            !< equivalent strain rate
+          real(kind=WP) ,intent(in)    :: epsd(mvsiz)            !< equivalent strain rate
           real(kind=WP) ,intent(inout) :: epst(nel,6)            !< total strain tensor
           real(kind=WP) ,intent(inout) :: wplar(mvsiz)           !< reference plastic work
           real(kind=WP) ,intent(inout) :: s1(mvsiz)              !< stress component
@@ -136,6 +136,7 @@
             epsf1(mvsiz),epsf2(mvsiz),eps(mvsiz,6),soft(3),                    &
             wplamxt1(mvsiz),wplamxt2(mvsiz),wplamxc1(mvsiz),wplamxc2(mvsiz),   &
             wplamxt12(mvsiz),beta(mvsiz)
+          real(kind=WP) :: frate(mvsiz)
 !=======================================================================
           iflag  = mat_param%iparam(1)
           ioff   = mat_param%iparam(2)
@@ -385,10 +386,10 @@
 !     strain rate
 !-------------------------------------------------------------------
           do i=1,nel
-            if(epsp(i) > epdr) then
-              epsp(i)=log(epsp(i)/epdr)
+            if(epsd(i) > epdr) then
+              frate(i)=log(epsd(i)/epdr)
             else
-              epsp(i)= zero
+              frate(i)= zero
             endif
             coef(i)=zero
           enddo
@@ -416,17 +417,17 @@
               sigyc1 = min(sigyc1 ,sigmxc1)
               sigyc2 = min(sigyc2 ,sigmxc2)
               sigyt12= min(sigyt12,sigmxt12)
-              sigyt1 = sigyt1*(one  + cc_t1 *epsp(i))
-              sigyt2 = sigyt2*(one  + cc_t2 *epsp(i))
-              sigyc1 = sigyc1*(one  + cc_c1 *epsp(i))
-              sigyc2 = sigyc2*(one  + cc_c2 *epsp(i))
-              sigyt12= sigyt12*(one + cc_t12*epsp(i))
+              sigyt1 = sigyt1*(one  + cc_t1 *frate(i))
+              sigyt2 = sigyt2*(one  + cc_t2 *frate(i))
+              sigyc1 = sigyc1*(one  + cc_c1 *frate(i))
+              sigyc2 = sigyc2*(one  + cc_c2 *frate(i))
+              sigyt12= sigyt12*(one + cc_t12*frate(i))
             else
-              sigyt1 = sigyt1*(one  + cc_t1 *epsp(i))
-              sigyt2 = sigyt2*(one  + cc_t2 *epsp(i))
-              sigyc1 = sigyc1*(one  + cc_c1 *epsp(i))
-              sigyc2 = sigyc2*(one  + cc_c2 *epsp(i))
-              sigyt12= sigyt12*(one + cc_t12*epsp(i))
+              sigyt1 = sigyt1*(one  + cc_t1 *frate(i))
+              sigyt2 = sigyt2*(one  + cc_t2 *frate(i))
+              sigyc1 = sigyc1*(one  + cc_c1 *frate(i))
+              sigyc2 = sigyc2*(one  + cc_c2 *frate(i))
+              sigyt12= sigyt12*(one + cc_t12*frate(i))
               sigyt1 = min(sigyt1 ,sigmxt1 )
               sigyt2 = min(sigyt2 ,sigmxt2 )
               sigyc1 = min(sigyc1 ,sigmxc1 )
@@ -496,9 +497,9 @@
             alpha=f12(i)
             f12(i) = -alpha/(two*sqrt(sigyt1*sigyc1*sigyt2*sigyc2))
 !
-            epsp(i)=one + cc * epsp(i)
+            frate(i) = one + cc * frate(i)
             if(icc == 3.or.icc == 4)then
-              wplamx(i) = wplamx(i)*epsp(i)
+              wplamx(i) = wplamx(i)*frate(i)
             endif
           enddo
 !-------------------------------------------------------------------

--- a/engine/source/output/anim/generate/dfunc6.F
+++ b/engine/source/output/anim/generate/dfunc6.F
@@ -2377,7 +2377,7 @@ c
                 ENDDO  
 
               ELSEIF(IFUNC == 26) THEN
-                 IF (ISRAT > 0) THEN
+                IF (GBUF%G_EPSD > 0) THEN
                    DO I=LFT,LLT
                      EVAR(I) = GBUF%EPSD(I)
                    ENDDO


### PR DESCRIPTION

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

h3d and anim output of strain rate in law25 for solids was containing strain rate coefficient instead of correct value

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

Corrected strain rate value which was overwritten by an internal variable

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
