### PR TITLE
OpenMP fix for /LOAD/PBLAST option

### DIFF
--- a/engine/source/loads/pblast/pblast_1.F
+++ b/engine/source/loads/pblast/pblast_1.F
@@ -103,7 +103,8 @@ C-----------------------------------------------
       
       INTEGER, EXTERNAL :: OMP_GET_THREAD_NUM
 
-      LOGICAL IS_UPDATED,IS_DECAY_TO_BE_COMPUTED
+      LOGICAL,SAVE ::  IS_UPDATED
+      LOGICAL :: IS_DECAY_TO_BE_COMPUTED
 
       CHARACTER(LEN=NCHARLINE) ::  MSGOUT1,MSGOUT2
       
@@ -164,6 +165,7 @@ C-----------------------------------------------
       FAC_I_bb = FAC_M_bb/FAC_L_bb/FAC_T_bb
 
       IS_UPDATED=.FALSE.
+      CALL MY_BARRIER
 
       !-----------------------------------------------,                                                 
       !   FREE AIR BURST                                                                                
@@ -339,7 +341,6 @@ C-----------------------------------------------
           DTMIN_LOC = MIN(DTMIN_LOC,DT_0/NDT)
           IS_UPDATED = .TRUE.
 
-                                                                                                                                                                                                      
         ELSE! => IZ_UPDATE=1
                                                                                                                                                                                                       
           !use wave parameters from Starter
@@ -420,7 +421,8 @@ C----- /TH/SURF -------
         write(IOUT , FMT='(A,I10,/A,/A)') "Updated parameters for /LOAD/PBLAST id=", ID, MSGOUT1, MSGOUT2
         write(ISTDO, FMT='(A,I10,/A,/A)') "Updated parameters for /LOAD/PBLAST id=", ID, MSGOUT1, MSGOUT2
       ENDIF
-         
+
+      CALL MY_BARRIER
       IF(IS_UPDATED)THEN
 #include "lockon.inc"
         !---arrival time
@@ -433,7 +435,6 @@ C----- /TH/SURF -------
         IZ_UPDATE = 1 !update done
         ILOADP(06,NL) = IZ_UPDATE
 #include "lockoff.inc"
-        CALL MY_BARRIER()
 !$OMP SINGLE
         write(IOUT,FMT='(A,I10,A,E16.8,A,E16.8)') "Updated parameters for /LOAD/PBLAST id=",
      .                                         ID,' previous first arrival time :',ZETA,

--- a/engine/source/loads/pblast/pblast_2.F
+++ b/engine/source/loads/pblast/pblast_2.F
@@ -103,7 +103,8 @@ C-----------------------------------------------
       my_real :: TA_INF_LOC,ZETA
       my_real :: DNORM, Dx, Dy, Dz
       TYPE(FRIEDLANDER_PARAMS_) :: FRIEDLANDER_PARAMS
-      LOGICAL IS_UPDATED,IS_DECAY_TO_BE_COMPUTED
+      LOGICAL,SAVE :: IS_UPDATED
+      LOGICAL :: IS_DECAY_TO_BE_COMPUTED
 
       CHARACTER(LEN=NCHARLINE) ::  MSGOUT1,MSGOUT2
 
@@ -163,7 +164,8 @@ C-----------------------------------------------
       FAC_I_bb = FAC_P_bb*FAC_T_bb
       FAC_I_bb = FAC_M_bb/FAC_L_bb/FAC_T_bb
 
-      IS_UPDATED=.FALSE.
+      IS_UPDATED = .FALSE.
+      CALL MY_BARRIER
 
       !-----------------------------------------------
       !   FREE AIR BURST
@@ -470,6 +472,7 @@ C----- /TH/SURF -------
         write(ISTDO, FMT='(A,I10,/A,/A)') "Updated parameters for /LOAD/PBLAST id=", ID, MSGOUT1, MSGOUT2
       ENDIF
 
+      CALL MY_BARRIER
       IF(IS_UPDATED)THEN
 #include "lockon.inc"
         !---arrival time
@@ -482,7 +485,6 @@ C----- /TH/SURF -------
         IZ_UPDATE = 1 !update done
         ILOADP(06,NL) = IZ_UPDATE
 #include "lockoff.inc"
-        CALL MY_BARRIER()
 !$OMP SINGLE
         write(*,FMT='(A,I10,A,E16.8,A,E16.8)') "Updated parameters for /LOAD/PBLAST id=",
      .                                         ID,' previous first arrival time :',ZETA,

--- a/engine/source/loads/pblast/pblast_3.F
+++ b/engine/source/loads/pblast/pblast_3.F
@@ -93,7 +93,8 @@ C-----------------------------------------------
       INTEGER  ID, ITA_SHIFT,IMODEL
       INTEGER :: NS,KSURF
       INTEGER :: curve_id1, curve_id2, NN(4), NDT
-      LOGICAL :: BOOL_UNDERGROUND_CURRENT_SEG, IS_UPDATED, IS_DECAY_TO_BE_COMPUTED
+      LOGICAL :: BOOL_UNDERGROUND_CURRENT_SEG, IS_DECAY_TO_BE_COMPUTED
+      LOGICAL,SAVE :: IS_UPDATED
       INTEGER :: NWARN !< number of segment for which it is not possible to correlate the positive impulse. It may happen that for a given Pmax and dt0 value even building a triangle shape leads to a lower impulse that the targeted one.
 
       my_real :: Zx,Zy,Zz,NORM,Nx,Ny,Nz ! target face centroid and normal vector
@@ -191,6 +192,7 @@ C-----------------------------------------------
       FAC_I_bb = FAC_P_bb*FAC_T_bb !/FAC_M_bb**THIRD
 
       IS_UPDATED=.FALSE.
+      CALL MY_BARRIER
 
       !-----------------------------------------------,
       !    AIR BURST
@@ -509,6 +511,7 @@ C----- /TH/SURF -------
         write(ISTDO, FMT='(A,I10,/A,/A)') "Updated parameters for /LOAD/PBLAST id=", ID, MSGOUT1, MSGOUT2
       ENDIF
 
+      CALL MY_BARRIER
       IF(IS_UPDATED)THEN
 #include "lockon.inc"
         !---arrival time
@@ -521,7 +524,6 @@ C----- /TH/SURF -------
         IZ_UPDATE = 1 !update done
         ILOADP(06,NL) = IZ_UPDATE
 #include "lockoff.inc"
-        CALL MY_BARRIER()
 !$OMP SINGLE
         write(IOUT ,FMT='(A,I10,A,E16.8,A,E16.8)') "Updated parameters for /LOAD/PBLAST id=",
      .                                             ID,' previous first arrival time :',ZETA,


### PR DESCRIPTION
#### OpenMP fix for /LOAD/PBLAST option

#### Description of the changes
Resolved an issue where parallel execution using multiple threads could cause incorrect behavior when processing a single element. The problem was more likely to occur with more than one OpenMP thread active.