### PR TITLE
Add missing starter output in law88

### DIFF
--- a/starter/source/materials/mat/mat088/hm_read_mat88.F
+++ b/starter/source/materials/mat/mat088/hm_read_mat88.F
@@ -275,7 +275,8 @@ c-----------------
       ELSE     
         WRITE(IOUT,1020)RHO0 
         WRITE(IOUT,1100)NU,BULK,ITENS,NL-IADD
-        WRITE(IOUT,1200)(IFUNC(I),YFAC(I),RATE(I),I=1+IADD,NL)     
+        WRITE(IOUT,1200)(IFUNC(I),YFAC(I),RATE(I),I=1+IADD,NL)   
+        WRITE(IOUT,1250) ISRATE,FCUT
         IF(IUNL_FOR == 1) THEN
          II = NL
          WRITE(IOUT,1300)IFUNC(NFUNC),YFAC_UNL 
@@ -304,7 +305,10 @@ C-----------------
  1200 FORMAT(
      & 5X,'LOADING STRESS-STRAIN FUNCTION NUMBER. . .=',I10/
      & 5X,'STRESS SCALE FACTOR. . . . . . . . . . . .=',1PG20.13/
-     & 5X,'STRAIN RATE . . . . . . . . . . . . . . . =',1PG20.13/)   
+     & 5X,'STRAIN RATE . . . . . . . . . . . . . . . =',1PG20.13)   
+ 1250 FORMAT(
+     & 5X,'STRAIN RATE FILTERING FLAG. . . . . . . . =',I10/  
+     & 5X,'STRAIN RATE FILTERING CUTOFF FREQUENCY. . =',1PG20.13/)   
  1300 FORMAT(
      & 5X,'UNLOADING STRESS-STRAIN FUNCTION NUMBER. .=',I10/
      & 5X,'STRESS SCALE FACTOR. . . . . . . . . . . .=',1PG20.13/)    


### PR DESCRIPTION
Strain rate filtering flag and cutoff frequency was not written to stater output file

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
