### PR TITLE
/TH/NODE (PEXT) : nodal averaged external pressure (new output)

### DIFF
--- a/common_source/modules/loads/pblast_mod.F90
+++ b/common_source/modules/loads/pblast_mod.F90
@@ -76,7 +76,7 @@
           real(kind=WP), allocatable,dimension(:)    :: pres                                      !< pressure output(workarray)
           real(kind=WP), allocatable,dimension(:)    :: cos_theta                                 !< angle on structural face
           real(kind=WP), allocatable,dimension(:)    :: p_inci,p_refl,ta,t0,decay_inci,decay_refl !< friedlander parameters
-          real(kind=WP), dimension(:)  , allocatable :: fx,fy,fz,npt                              !< working arrays (forces)
+          real(kind=WP), dimension(:)  , allocatable :: fx,fy,fz,npt,surf_patch                         !< working arrays (forces)
           integer, dimension(:,:), allocatable :: n                                         !< working array (normal vectors)
           integer, allocatable,dimension(:)    :: tagmsg
         end type pblast_struct_
@@ -164,6 +164,7 @@
 ! ----------------------------------------------------------------------------------------------------------------------
           use message_mod
           use precision_mod, only : WP
+          use constant_mod , only : zero
           implicit none
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Arguments
@@ -216,9 +217,12 @@
             allocate ( pblast%pblast_tab(i)%fx(siz),stat=ierr1); if (ierr1/=0) call pblast_alloc_error()
             allocate ( pblast%pblast_tab(i)%fy(siz),stat=ierr1); if (ierr1/=0) call pblast_alloc_error()
             allocate ( pblast%pblast_tab(i)%fz(siz),stat=ierr1); if (ierr1/=0) call pblast_alloc_error()
+            allocate ( pblast%pblast_tab(i)%pres(siz),stat=ierr1); if (ierr1/=0) call pblast_alloc_error()
+            allocate ( pblast%pblast_tab(i)%surf_patch(siz),stat=ierr1); if (ierr1/=0) call pblast_alloc_error()
             allocate ( pblast%pblast_tab(i)%n(4,siz),stat=ierr1); if (ierr1/=0) call pblast_alloc_error()
             allocate ( pblast%pblast_tab(i)%npt(siz),stat=ierr1); if (ierr1/=0) call pblast_alloc_error()
             allocate ( pblast%pblast_tab(i)%tagmsg(siz),stat=ierr1); if (ierr1/=0) call pblast_alloc_error()
+            pblast%pblast_tab(i)%pres(1:siz) = zero
             allocate(rtmp(8*siz))
             call read_db(rtmp,8*siz)
             iad = 0
@@ -317,6 +321,7 @@
             if(allocated( pblast%pblast_tab(ii)%fx ))         deallocate ( pblast%pblast_tab(ii)%fx )
             if(allocated( pblast%pblast_tab(ii)%fy ))         deallocate ( pblast%pblast_tab(ii)%fy )
             if(allocated( pblast%pblast_tab(ii)%fz ))         deallocate ( pblast%pblast_tab(ii)%fz )
+            if(allocated( pblast%pblast_tab(ii)%surf_patch )) deallocate ( pblast%pblast_tab(ii)%surf_patch )
             if(allocated( pblast%pblast_tab(ii)%n ))          deallocate ( pblast%pblast_tab(ii)%n )
             if(allocated( pblast%pblast_tab(ii)%npt ))        deallocate ( pblast%pblast_tab(ii)%npt )
           enddo

--- a/common_source/modules/output/output_mod.F90
+++ b/common_source/modules/output/output_mod.F90
@@ -88,6 +88,7 @@
         use time_history_mod
         use state_file_mod
         use checksum_output_option_mod
+        use precision_mod, only : WP
 
         type output_
            type (th_) :: th
@@ -100,6 +101,8 @@
 
         double precision, pointer :: wfext
         double precision, pointer :: wfext_md
+
+        real(kind=WP), dimension(:), allocatable :: NODA_SURF, NODA_PEXT
 
         type(output_),pointer :: output_ptr      ! pointer to output structure (need for arret)
       end module output_mod

--- a/engine/share/modules/th_mod.F
+++ b/engine/share/modules/th_mod.F
@@ -108,5 +108,7 @@ C-----------------------------------------------
         TYPE(TH_PROC_TYPE), DIMENSION(10), TARGET :: NST_STRUCT       
         TYPE(TH_COMM), DIMENSION(10), TARGET :: WA_NST_COMM
         TYPE(TH_WA_REAL), DIMENSION(10), TARGET :: WA_NST_P0,WA_NST
+
+        INTEGER :: TH_HAS_NODA_PEXT
 C
         END MODULE TH_MOD

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -681,7 +681,7 @@ C-----------------------------------------------
               USE STATE_MOD
               USE USER_WINDOWS_MOD
               USE ALE_MOD
-              USE OUTPUT_MOD , ONLY : OUTPUT_, WFEXT, WFEXT_MD
+              USE OUTPUT_MOD , ONLY : OUTPUT_, WFEXT, WFEXT_MD, NODA_SURF, NODA_PEXT
               USE INTERFACES_MOD
               USE DEBUG_CHKSM_MOD ,  ONLY : SPMD_FLUSH_ACCEL
               USE DT_MOD
@@ -718,6 +718,8 @@ C-----------------------------------------------
               USE UPDATE_PON_MOD
               USE DEBUG_MOD
               use inter_init_component_mod , only : inter_init_component
+              use th_mod , only : th_has_noda_pext
+              use output_mod
               use damping_vref_compute_dampa_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
@@ -1100,7 +1102,8 @@ C End Parith/ON specific
               INTEGER, POINTER, DIMENSION(:) :: PTR_SMS
               INTEGER NMT0
               INTEGER, DIMENSION(:), ALLOCATABLE :: IKINE
-              my_real, DIMENSION(:), ALLOCATABLE :: STK_SN,STK_SR,FEXT,FCLUSTER,MCLUSTER
+              my_real, DIMENSION(:), ALLOCATABLE :: STK_SN,STK_SR,FCLUSTER,MCLUSTER
+              my_real, DIMENSION(:), ALLOCATABLE :: NODA_FEXT
               INTEGER LNZM
               INTEGER, DIMENSION(:),ALLOCATABLE :: INT18ADD,TAGPENE
               INTEGER, DIMENSION(:),ALLOCATABLE :: IDAMP_RDOF_TAB
@@ -2365,13 +2368,26 @@ C ---------------------
 C ---------------------
 C Allocating FEXT Array
 C ---------------------
-              IF(ANIM_V(5)+OUTP_V(5)+H3D_DATA%N_VECT_FINT+
-     .           ANIM_V(6)+OUTP_V(6)+H3D_DATA%N_VECT_FEXT >0) THEN
-                ALLOCATE(FEXT(3*NUMNOD))
-                FEXT(1:3*NUMNOD)=ZERO
+              IF(ANIM_V(5)+OUTP_V(5)+H3D_DATA%N_VECT_FINT+ANIM_V(6)+OUTP_V(6)+H3D_DATA%N_VECT_FEXT > 0 .OR. TH_HAS_NODA_PEXT> 0) THEN
+                ALLOCATE(NODA_FEXT(3*NUMNOD))
+                NODA_FEXT(1:3*NUMNOD)=ZERO
               ELSE
-                ALLOCATE(FEXT(3))
-                FEXT(1:3)=ZERO
+                ALLOCATE(NODA_FEXT(3))
+                NODA_FEXT(1:3)=ZERO
+              ENDIF
+C ---------------------
+C Allocating PEXT Array
+C ---------------------
+              IF(TH_HAS_NODA_PEXT > 0) THEN
+                ALLOCATE(NODA_SURF(NUMNOD))
+                ALLOCATE(NODA_PEXT(NUMNOD))
+                NODA_SURF(1:NUMNOD)=ZERO
+                NODA_PEXT(1:NUMNOD)=ZERO
+              ELSE
+                ALLOCATE(NODA_SURF(3))
+                ALLOCATE(NODA_PEXT(3))
+                NODA_SURF(1:3)=ZERO
+                NODA_PEXT(1:3)=ZERO
               ENDIF
 C ---------------------
               IF (ANIM_V(19) + H3D_DATA%N_VECT_CLUST_FORCE > 0) THEN
@@ -3447,7 +3463,7 @@ C-------------------------------------------------------------------
      2                     NPC     ,STF      ,TF       ,NODES%A        ,NODES%V                         ,
      3                     NODES%X       ,SKEWS    ,NODES%AR                        ,
      4                     NODES%VR      ,NSENSOR  ,SENSORS%SENSOR_TAB ,WFEXC          ,ELEMENT%PON%IAD_CONLD ,
-     5                     LSKY    ,ELEMENT%PON%FSKY     ,FEXT     ,H3D_DATA ,CPTREAC                   ,
+     5                     LSKY    ,ELEMENT%PON%FSKY     ,NODA_FEXT     ,H3D_DATA ,CPTREAC                   ,
      6                     FTHREAC ,NODREAC  ,OUTPUT%TH%TH_SURF  ,
      7                     DPL0CLD ,VEL0CLD  ,NODES%D        ,NODES%DR       ,NCONLD                    ,
      8                     NUMNOD  ,NFUNCT   ,ANIM_V   ,OUTP_V                    ,
@@ -3458,7 +3474,7 @@ C
                   CALL FORCEPINCH(IBCL   ,FORC    ,NPC    ,TF      ,NODES%A         ,
      2                            NODES%V      ,NODES%X       ,SKEWS%SKEW   ,NODES%AR      ,NODES%VR        ,
      3                            NSENSOR,SENSORS%SENSOR_TAB ,NODES%WEIGHT ,WFEXC   ,ELEMENT%PON%IAD_CONLD,
-     4                            ELEMENT%PON%FSKY   , ELEMENT%PON%FSKY   ,FEXT   ,H3D_DATA,
+     4                            ELEMENT%PON%FSKY   , ELEMENT%PON%FSKY   ,NODA_FEXT   ,H3D_DATA,
      5                            PINCH_DATA%APINCH, PINCH_DATA%VPINCH, PYTHON, OUTPUT%WFEXT)
                 ENDIF
 C
@@ -3474,7 +3490,7 @@ C
                   IF(IMONM > 0) CALL STARTIME(TIMERS,44)
                 ENDIF
                 CALL FORCEFINGEO(IBFV ,NPC    ,TF      ,NODES%A    ,NODES%V    ,NODES%X     ,
-     2                           VEL  ,SENSORS%SENSOR_TAB ,ELEMENT%PON%FSKY ,FEXT ,NODES%ITABM1,
+     2                           VEL  ,SENSORS%SENSOR_TAB ,ELEMENT%PON%FSKY ,NODA_FEXT ,NODES%ITABM1,
      3                           H3D_DATA,NSENSOR,PYTHON,WFEXT)
                 IF(IMON>0) THEN
                   IF(IMONM > 0) CALL STOPTIME(TIMERS,44)
@@ -3493,7 +3509,7 @@ C-------------------------------------------------------------------
                 CALL PFLUID(ILOADP  ,LOADP             ,NPC        ,TF          ,NODES%A               ,
      2                      NODES%V       ,NODES%X                 ,XFRAME      ,NODES%MS              ,
      3                      NSENSOR ,SENSORS%SENSOR_TAB,WFEXC      ,OUTPUT%WFEXT,ELEMENT%PON%IAD_LOADP ,
-     4                      ELEMENT%PON%FSKY , ELEMENT%PON%FSKY                 ,LLOADP                ,FEXT       ,H3D_DATA  ,
+     4                      ELEMENT%PON%FSKY , ELEMENT%PON%FSKY                 ,LLOADP                ,NODA_FEXT   ,H3D_DATA  ,
      5                      OUTPUT%TH%TH_SURF, PYTHON)
 !$OMP END PARALLEL
                 IF (IMONM > 0) CALL STOPTIME(TIMERS,41)
@@ -3510,7 +3526,7 @@ C----------------------------------
                 IF (IMONM > 0) CALL STARTIME(TIMERS,41)
                 CALL PBLAST_LOAD_COMPUTATION(
      1                      PBLAST                ,ILOADP           ,LOADP             ,NODES%A      ,NODES%V   ,NODES%X,
-     2                      ELEMENT%PON%IAD_LOADP ,ELEMENT%PON%FSKY ,LLOADP            ,FEXT         ,
+     2                      ELEMENT%PON%IAD_LOADP ,ELEMENT%PON%FSKY ,LLOADP            ,NODA_FEXT    ,NODA_SURF ,NODA_PEXT,
      3                      NODES%ITAB            ,H3D_DATA         ,OUTPUT%TH%TH_SURF ,OUTPUT%WFEXT)
                 IF (IMONM > 0) CALL STOPTIME(TIMERS,41)
                 IF (IMON>0) CALL STOPTIME(TIMERS,TIMER_KIN)
@@ -3528,8 +3544,8 @@ C       LOAD PCYL
 C----------------------------------
               IF (LOADS%NLOAD_CYL > 0) THEN
                 CALL PRESSURE_CYL(
-     .               LOADS     ,TABLE     ,SENSORS%NSENSOR,SENSORS%SENSOR_TAB,IFRAME    ,
-     .               DT1       ,NODES%X         ,NODES%V         ,NODES%A         ,FEXT      ,
+     .               LOADS     ,TABLE     ,SENSORS%NSENSOR,SENSORS%SENSOR_TAB,IFRAME         ,
+     .               DT1       ,NODES%X         ,NODES%V         ,NODES%A         ,NODA_FEXT ,
      .               H3D_DATA  ,CPTREAC   ,FTHREAC   ,NODREAC   ,ELEMENT%PON%FSKY ,OUTPUT%WFEXT     )
               ENDIF
 !-------------------------------------------------------------------
@@ -3619,7 +3635,7 @@ C
      5            ELEMENT%PON%FSKY,ICONTACT           ,WA(N0)             ,IPARG     ,
      6            ELBUF_TAB       ,GEO                ,IGEO               ,
      7            PM              ,IPM                ,IPART              ,IPART(K3) ,
-     8            IPART(K8)       ,IGROUPC            ,IGROUPTG           ,FEXT      ,
+     8            IPART(K8)       ,IGROUPC            ,IGROUPTG           ,NODA_FEXT ,
      9            1               ,H3D_DATA           ,T_MONVOL           ,frontier_global_mv,
      A            OUTPUT )
                 CALL TRACE_OUT(11)
@@ -3950,7 +3966,7 @@ C-----------------------------------------------
                 ITSK = OMP_GET_THREAD_NUM()
                 NODFTSK   = 1+ITSK*NUMNOD/ NTHREAD
                 NODLTSK   = (ITSK+1)*NUMNOD/NTHREAD
-                CALL FORANI1(FANI,NODES%A ,NFIA,NFEA,NFOA,NODFTSK,NODLTSK,FEXT,H3D_DATA)
+                CALL FORANI1(FANI,NODES%A ,NFIA,NFEA,NFOA,NODFTSK,NODLTSK,NODA_FEXT,H3D_DATA)
 !$OMP END PARALLEL
 C
               ENDIF
@@ -4521,7 +4537,7 @@ C
      .                      NODES%A        , NPC,      TF,           NSENSOR           ,
      .                      FSAV(1,N), IFVMESH,  ICONTACT_OLD, LGAUGE            ,
      .                      GAUGE    , IGEO,     GEO,          PM                , IPM ,
-     .                      IPARG    , IGROUPTG, IGROUPC,      ELBUF_TAB         , FEXT,
+     .                      IPARG    , IGROUPTG, IGROUPC,      ELBUF_TAB         , NODA_FEXT,
      .                      1        , H3D_DATA, NODES%ITAB,   NODES%WEIGHT      , OUTPUT%WFEXT)
 C
                 CALL TRACE_OUT(11)
@@ -4860,7 +4876,7 @@ C
      .                      NODES%A,      NPC,     TF,     NSENSOR           ,
      .                      FSAV(1,N), IFVMESH, ICONTACT_OLD,LGAUGE,
      .                      GAUGE    , IGEO,    GEO,         PM,                  IPM,
-     .                      IPARG    , IGROUPTG,IGROUPC,     ELBUF_TAB,           FEXT,
+     .                      IPARG    , IGROUPTG,IGROUPC,     ELBUF_TAB,           NODA_FEXT,
      .                      2        , H3D_DATA,NODES%ITAB, NODES%WEIGHT, OUTPUT%WFEXT)
                 IF (IMPL_S > 0 .AND. ISMDISP >0) THEN
                   CALL ASSIGN_PTRX(ptrx,IMPBUF_TAB%X_A,NUMNOD)
@@ -4875,7 +4891,7 @@ C
      5            ELEMENT%PON%FSKY  ,ICONTACT           ,WA(N0)             ,IPARG     ,
      6            ELBUF_TAB         ,GEO                ,IGEO               ,
      7            PM                ,IPM                ,IPART              ,IPART(K3) ,
-     8            IPART(K8)         ,IGROUPC            ,IGROUPTG           ,FEXT      ,
+     8            IPART(K8)         ,IGROUPC            ,IGROUPTG           ,NODA_FEXT      ,
      9            2                 ,H3D_DATA           ,T_MONVOL           ,frontier_global_mv,
      A            OUTPUT)
 
@@ -4966,7 +4982,7 @@ C
 !   ----------------------------------
 
               IF(NLOADP_HYD/=0.AND.IMPL_S/=1) THEN
-                FEXT = ZERO
+                NODA_FEXT = ZERO
                 CALL TRACE_IN(10,0,ZERO)
                 IF (IMON>0) CALL STARTIME(TIMERS,TIMER_KIN)
                 IF (IMONM > 0) CALL STARTIME(TIMERS,41)
@@ -6530,7 +6546,7 @@ C--                   /DAMP/VREL - recompute damping parameters at current time
                         call damping_vref_compute_dampa(i,ndamp,nrdamp,dampr,dt1,tt,damp_a)
                         DAMPA = MAX(DAMP_A(1),DAMP_A(2),DAMP_A(3))
                         DAMPB = ZERO
-                      ENDIF 
+                      ENDIF
                       FACTB = DAMPR(16,I)
                       D_TSTART = DAMPR(17,I)
                       D_TSTOP  = DAMPR(18,I)
@@ -9957,7 +9973,9 @@ C
                 ENDIF
                 IF(INTPLYXFEM > 0)DEALLOCATE(PLYSKYI%FSKYI)
                 DEALLOCATE(PLY, PLYSKY)
-                DEALLOCATE(FEXT)
+                IF(ALLOCATED(NODA_FEXT))DEALLOCATE(NODA_FEXT)
+                IF(ALLOCATED(NODA_SURF))DEALLOCATE(NODA_SURF)
+                IF(ALLOCATED(NODA_PEXT))DEALLOCATE(NODA_PEXT)
                 DEALLOCATE(NPCONT2)
 C
 C Deallocte AMS / POFF

--- a/engine/source/engine/resol_init.F
+++ b/engine/source/engine/resol_init.F
@@ -1128,11 +1128,11 @@ C-----------------------
        IF (ITASK == 0) 
      .   CALL TMAX_IPART(IPARG   ,IPART   ,IPART(I15A),IPART(I15C),
      .                 IPART(I15I),H3D_DATA)
-       CALL INI_TMAX(ELBUF_TAB,IPARG   ,GEO     ,PM   ,
-     .           IXS  ,IXS10   ,IXS16   ,IXS20   ,IXQ     ,
-     .           IXC  ,IXTG   ,IXT    ,IXP     ,IXR     ,
-     .           X  ,D       ,V       ,IAD_ELEM,FR_ELEM ,
-     .             WEIGHT ,IPM   ,IGEO    ,STACK   ,ITASK   )
+       CALL INI_TMAX(ELBUF_TAB ,IPARG   ,GEO     ,PM       ,
+     .                IXS      ,IXS10   ,IXS16   ,IXS20    ,IXQ     ,
+     .                IXC      ,IXTG    ,IXT     ,IXP      ,IXR     ,
+     .                X        ,D       ,V       ,IAD_ELEM ,FR_ELEM ,
+     .                WEIGHT   ,IPM     ,IGEO    ,STACK    ,ITASK   )
 !$OMP SINGLE
        IF (FAILWAVE%WAVE_MOD > 0) THEN
          CALL SPMD_FAILWAVE_BOUNDARIES(FAILWAVE,IAD_ELEM,FR_ELEM)
@@ -1140,15 +1140,8 @@ C-----------------------
        ! Non-local regularization is activated
        IF (NLOC_DMG%IMOD > 0) THEN
          CALL SPMD_SUB_BOUNDARIES(NLOC_DMG,IAD_ELEM,FR_ELEM)
-         CALL NLOC_COUNT_SOLNOD(NGROUP   ,NPARG    ,IPARG    ,
-     .                ELBUF_TAB,IXS      ,NIXS     ,NUMELS   )
+         CALL NLOC_COUNT_SOLNOD(NGROUP, NPARG, IPARG, ELBUF_TAB, IXS, NIXS, NUMELS)
        ENDIF
-C       
-       DO I=1,PBLAST%NLOADP_B
-         NBS = PBLAST%PBLAST_TAB(I)%SIZ
-         ALLOCATE (PBLAST%PBLAST_TAB(I)%PRES(NBS))
-         PBLAST%PBLAST_TAB(I)%PRES(1:NBS)=ZERO
-       ENDDO
 C-----------------------
 C DT_DC OF TSH
 C-----------------------

--- a/engine/source/loads/pblast/pblast.F
+++ b/engine/source/loads/pblast/pblast.F
@@ -35,8 +35,8 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    pblast_mod                ../common_source/modules/loads/pblast_mod.F90
       !||    th_surf_mod               ../common_source/modules/interfaces/th_surf_mod.F
       !||====================================================================
-      SUBROUTINE PBLAST_LOAD_COMPUTATION (PBLAST,ILOADP  ,FAC   ,A  , V   ,X ,
-     1                        IADC    ,FSKY    ,LLOADP   ,FEXT    ,
+      SUBROUTINE PBLAST_LOAD_COMPUTATION (PBLAST,ILOADP  ,FAC   ,A  , V   , X        ,
+     1                        IADC    ,FSKY    ,LLOADP   ,FEXT  ,NODA_SURF, NODA_PEXT,
      2                        ITAB    ,H3D_DATA,TH_SURF  ,WFEXT)
 C-----------------------------------------------
 C   M o d u l e s
@@ -70,6 +70,8 @@ C-----------------------------------------------
       my_real,INTENT(INOUT) :: FAC(LFACLOAD,NLOADP)
       my_real,INTENT(IN) :: V(3,NUMNOD),X(3,NUMNOD)
       my_real,INTENT(INOUT) :: A(3,NUMNOD),FSKY(8,SFSKY/8), FEXT(3,NUMNOD)
+      my_real,INTENT(INOUT) :: NODA_SURF(NUMNOD)
+      my_real,INTENT(INOUT) :: NODA_PEXT(NUMNOD)
       TYPE(H3D_DATABASE),INTENT(IN) :: H3D_DATA
       TYPE (TH_SURF_) , INTENT(INOUT) :: TH_SURF
       DOUBLE PRECISION,INTENT(INOUT) :: WFEXT
@@ -129,7 +131,7 @@ C-----------------------------------------------
                !--- LOADING MODEL : FREE AIR, SPHERICAL CHARGE
                CALL PBLAST_1(PBLAST,
      1                       ILOADP  ,FAC      ,A        ,V         ,X        ,
-     2                       IADC    ,FSKY     ,LLOADP   ,FEXT      ,
+     2                       IADC    ,FSKY     ,LLOADP   ,FEXT      ,NODA_SURF, NODA_PEXT,
      3                       ITAB    ,H3D_DATA ,NL       ,DTMIN_LOC ,WFEXT_LOC,
      4                       TH_SURF ,NSEGPL   )
      
@@ -137,14 +139,14 @@ C-----------------------------------------------
                !--- LOADING MODEL : GROUND REFLECTION, HEMISPHERICAL CHARGE
                CALL PBLAST_2(PBLAST,
      1                       ILOADP  ,FAC      ,A        ,V         ,X        ,
-     2                       IADC    ,FSKY     ,LLOADP   ,FEXT      ,
+     2                       IADC    ,FSKY     ,LLOADP   ,FEXT      ,NODA_SURF, NODA_PEXT,
      3                       ITAB    ,H3D_DATA ,NL       ,DTMIN_LOC ,WFEXT_LOC,
      4                       TH_SURF ,NSEGPL   )
              CASE(3)
                !--- LOADING MODEL : SURFACE BURST, SPHERICAL CHARGE
                CALL PBLAST_3(PBLAST,
      1                       ILOADP  ,FAC      ,A        ,V         ,X        ,
-     2                       IADC    ,FSKY     ,LLOADP   ,FEXT      ,
+     2                       IADC    ,FSKY     ,LLOADP   ,FEXT      ,NODA_SURF, NODA_PEXT,
      3                       ITAB    ,H3D_DATA ,NL       ,DTMIN_LOC ,WFEXT_LOC,
      4                       TH_SURF ,NSEGPL   )
      

--- a/engine/source/loads/pblast/pblast_1.F
+++ b/engine/source/loads/pblast/pblast_1.F
@@ -37,9 +37,9 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    pblast_mod                    ../common_source/modules/loads/pblast_mod.F90
       !||    th_surf_mod                   ../common_source/modules/interfaces/th_surf_mod.F
       !||====================================================================
-      SUBROUTINE PBLAST_1(PBLAST,ILOADP  ,FAC      ,A       ,V         ,X       ,
-     1                    IADC    ,FSKY     ,LLOADP  ,FEXT      ,
-     2                    ITAB    ,H3D_DATA ,NL      ,DTMIN_LOC ,WFEXT_LOC,
+      SUBROUTINE PBLAST_1(PBLAST  ,ILOADP   ,FAC     ,A         ,V         ,X        ,
+     1                    IADC    ,FSKY     ,LLOADP  ,FEXT      ,NODA_SURF ,NODA_PEXT,
+     2                    ITAB    ,H3D_DATA ,NL      ,DTMIN_LOC ,WFEXT_LOC ,
      3                    TH_SURF ,NSEGPL)
 C-----------------------------------------------
 C   M o d u l e s
@@ -50,6 +50,7 @@ C-----------------------------------------------
       USE H3D_INC_MOD 
       USE TH_SURF_MOD , ONLY : TH_SURF_
       USE NAMES_AND_TITLES_MOD , ONLY : NCHARLINE
+      USE TH_MOD ,ONLY : TH_HAS_NODA_PEXT
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -79,7 +80,10 @@ C-----------------------------------------------
       DOUBLE PRECISION,INTENT(INOUT) :: WFEXT_LOC
       my_real,INTENT(IN) :: V(3,NUMNOD),X(3,NUMNOD)
       my_real,INTENT(INOUT) :: FAC(LFACLOAD,NLOADP)
-      my_real,INTENT(INOUT) :: A(3,NUMNOD),FSKY(8,SFSKY/8),FEXT(3,NUMNOD)
+      my_real,INTENT(INOUT) :: A(3,NUMNOD),FSKY(8,SFSKY/8)
+      my_real,INTENT(INOUT) :: FEXT(3,NUMNOD)
+      my_real,INTENT(INOUT) :: NODA_SURF(NUMNOD)
+      my_real,INTENT(INOUT) :: NODA_PEXT(NUMNOD)
       TYPE(H3D_DATABASE),INTENT(IN) :: H3D_DATA
       TYPE (TH_SURF_) , INTENT(INOUT) :: TH_SURF
       INTEGER, INTENT(INOUT) :: NSEGPL
@@ -99,7 +103,8 @@ C-----------------------------------------------
      .           DNORM, Xdet,Ydet,Zdet,Tdet,Wtnt,PMIN,T_STOP,Dx,Dy,Dz,P,
      .           FAC_M_bb, FAC_L_bb, FAC_T_bb, FAC_P_bb, FAC_I_bb, TA_FIRST, TT_STAR, Z1_,
      .           DECAY_inci,DECAY_refl,ZETA,
-     .           cst_255_div_ln_Z1_on_ZN,  log10_, NPT, FF(3), TA_INF_LOC
+     .           cst_255_div_ln_Z1_on_ZN,  log10_, NPT, FF(3), TA_INF_LOC,
+     .           SURF_PATCH
       
       INTEGER, EXTERNAL :: OMP_GET_THREAD_NUM
 
@@ -379,12 +384,13 @@ C-----------------------------------------------
         ENDIF                                                                                                                                                                                         
         P = alpha_refl * WAVE_REFL + alpha_inci * WAVE_INCI
         P = MAX(P,PMIN)                                                                                                                                                                               
-        IF (NUMSKINP > 0) PBLAST%PBLAST_TAB(IL)%PRES(I) = P                                                                                                                                                  
+        PBLAST%PBLAST_TAB(IL)%PRES(I) = P
 
         !!Expand Pressure load to nodes
         ! FF is nodal force which applied on each node N1,N2,N3, and also N4 if relevant
         ! FF = FF_elem / NPT = Pload.S.n / NPT  where n is the unitary normal vector
         ! NX,NY,NZ = 2S.n (in all cases:quadrangles & triangles)
+        SURF_PATCH = HALF*SQRT(NX*NX+NY*NY+NZ*NZ) / NPT
         FF(1) = -P * HALF*NX / NPT       !  -P*S/NPT . nx
         FF(2) = -P * HALF*NY / NPT       !  -P*S/NPT . ny
         FF(3) = -P * HALF*NZ / NPT       !  -P*S/NPT . nz
@@ -392,6 +398,7 @@ C-----------------------------------------------
         PBLAST%PBLAST_TAB(IL)%FX(I) = FF(1)
         PBLAST%PBLAST_TAB(IL)%FY(I) = FF(2)
         PBLAST%PBLAST_TAB(IL)%FZ(I) = FF(3)
+        PBLAST%PBLAST_TAB(IL)%SURF_PATCH(I) = SURF_PATCH
 
         !External Force work
         ! on a given node : DW = <F,V>*dt
@@ -401,7 +408,7 @@ C-----------------------------------------------
 C----- /TH/SURF -------
         IF(TH_SURF%LOADP_FLAG > 0 ) THEN
           NSEGPL = NSEGPL + 1
-          AREA = HALF*SQRT(NX*NX+NY*NY+NZ*NZ)
+          AREA = SURF_PATCH * NPT
           DO NS=TH_SURF%LOADP_KSEGS(NSEGPL) +1,TH_SURF%LOADP_KSEGS(NSEGPL+1)
              KSURF = TH_SURF%LOADP_SEGS(NS)
              th_surf%channels(4,KSURF)= th_surf%channels(4,KSURF) + AREA*P ! mean pressure
@@ -505,28 +512,48 @@ C----- /TH/SURF -------
       !   H3D FILE         /H3D/NODA/FEXT         !
       !-------------------------------------------!                                                                                                                       
 !$OMP SINGLE
-      IF(IANIM_OR_H3D>0) THEN
+      IF(IANIM_OR_H3D > 0) THEN
         DO I = 1,ISIZ_SEG                                                                        
-          N1=PBLAST%PBLAST_TAB(IL)%N(1,I)                                                                              
-          N2=PBLAST%PBLAST_TAB(IL)%N(2,I)                                                                              
-          N3=PBLAST%PBLAST_TAB(IL)%N(3,I)                                                                              
-          N4=PBLAST%PBLAST_TAB(IL)%N(4,I)                                                                              
-          FEXT(1,N1) = FEXT(1,N1)+PBLAST%PBLAST_TAB(IL)%FX(I)                                                          
-          FEXT(2,N1) = FEXT(2,N1)+PBLAST%PBLAST_TAB(IL)%FY(I)                                                          
-          FEXT(3,N1) = FEXT(3,N1)+PBLAST%PBLAST_TAB(IL)%FZ(I)                                                          
-          FEXT(1,N2) = FEXT(1,N2)+PBLAST%PBLAST_TAB(IL)%FX(I)                                                          
-          FEXT(2,N2) = FEXT(2,N2)+PBLAST%PBLAST_TAB(IL)%FY(I)                                                          
-          FEXT(3,N2) = FEXT(3,N2)+PBLAST%PBLAST_TAB(IL)%FZ(I)                                                          
-          FEXT(1,N3) = FEXT(1,N3)+PBLAST%PBLAST_TAB(IL)%FX(I)                                                          
-          FEXT(2,N3) = FEXT(2,N3)+PBLAST%PBLAST_TAB(IL)%FY(I)                                                          
-          FEXT(3,N3) = FEXT(3,N3)+PBLAST%PBLAST_TAB(IL)%FZ(I)                                                          
-          IF(PBLAST%PBLAST_TAB(IL)%NPt(I)==FOUR)THEN                                                                   
-            FEXT(1,N4) = FEXT(1,N4)+PBLAST%PBLAST_TAB(IL)%FX(I)                                                        
-            FEXT(2,N4) = FEXT(2,N4)+PBLAST%PBLAST_TAB(IL)%FY(I)                                                        
-            FEXT(3,N4) = FEXT(3,N4)+PBLAST%PBLAST_TAB(IL)%FZ(I)                                                        
+          N1 = PBLAST%PBLAST_TAB(IL)%N(1,I)
+          N2 = PBLAST%PBLAST_TAB(IL)%N(2,I)
+          N3 = PBLAST%PBLAST_TAB(IL)%N(3,I)
+          N4 = PBLAST%PBLAST_TAB(IL)%N(4,I)
+          FEXT(1,N1) = FEXT(1,N1) + PBLAST%PBLAST_TAB(IL)%FX(I)
+          FEXT(2,N1) = FEXT(2,N1) + PBLAST%PBLAST_TAB(IL)%FY(I)
+          FEXT(3,N1) = FEXT(3,N1) + PBLAST%PBLAST_TAB(IL)%FZ(I)
+          FEXT(1,N2) = FEXT(1,N2) + PBLAST%PBLAST_TAB(IL)%FX(I)
+          FEXT(2,N2) = FEXT(2,N2) + PBLAST%PBLAST_TAB(IL)%FY(I)
+          FEXT(3,N2) = FEXT(3,N2) + PBLAST%PBLAST_TAB(IL)%FZ(I)
+          FEXT(1,N3) = FEXT(1,N3) + PBLAST%PBLAST_TAB(IL)%FX(I)
+          FEXT(2,N3) = FEXT(2,N3) + PBLAST%PBLAST_TAB(IL)%FY(I)
+          FEXT(3,N3) = FEXT(3,N3) + PBLAST%PBLAST_TAB(IL)%FZ(I)
+          IF(PBLAST%PBLAST_TAB(IL)%NPt(I) == FOUR)THEN
+            FEXT(1,N4) = FEXT(1,N4) + PBLAST%PBLAST_TAB(IL)%FX(I)
+            FEXT(2,N4) = FEXT(2,N4) + PBLAST%PBLAST_TAB(IL)%FY(I)
+            FEXT(3,N4) = FEXT(3,N4) + PBLAST%PBLAST_TAB(IL)%FZ(I)
           ENDIF                                                                                  
         ENDDO                                                                                           
-      ENDIF  
+      ENDIF
+      IF(TH_HAS_NODA_PEXT > 0) THEN
+        DO I = 1,ISIZ_SEG
+          N1 = PBLAST%PBLAST_TAB(IL)%N(1,I)
+          N2 = PBLAST%PBLAST_TAB(IL)%N(2,I)
+          N3 = PBLAST%PBLAST_TAB(IL)%N(3,I)
+          N4 = PBLAST%PBLAST_TAB(IL)%N(4,I)
+          SURF_PATCH = PBLAST%PBLAST_TAB(IL)%SURF_PATCH(I)
+          NODA_SURF(N1) = NODA_SURF(N1) + SURF_PATCH
+          NODA_SURF(N2) = NODA_SURF(N2) + SURF_PATCH
+          NODA_SURF(N3) = NODA_SURF(N3) + SURF_PATCH
+          P = PBLAST%PBLAST_TAB(IL)%PRES(I) * SURF_PATCH
+          NODA_PEXT(N1) = NODA_PEXT(N1) + P
+          NODA_PEXT(N2) = NODA_PEXT(N2) + P
+          NODA_PEXT(N3) = NODA_PEXT(N3) + P
+          IF(PBLAST%PBLAST_TAB(IL)%NPT(I) == FOUR)THEN
+            NODA_SURF(N4) = NODA_SURF(N4) + SURF_PATCH
+            NODA_PEXT(N4) = NODA_PEXT(N4) + P
+          ENDIF
+        ENDDO
+      ENDIF
 !$OMP END SINGLE    
 
       RETURN
@@ -538,5 +565,4 @@ C-----------------------------------------------
          CALL ARRET(2)
        END IF
 C-----------------------------------------------
-       
-      END SUBROUTINE
+      END SUBROUTINE PBLAST_1

--- a/engine/source/loads/pblast/pblast_2.F
+++ b/engine/source/loads/pblast/pblast_2.F
@@ -37,8 +37,8 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    th_surf_mod                        ../common_source/modules/interfaces/th_surf_mod.F
       !||====================================================================
       SUBROUTINE PBLAST_2(PBLAST,
-     *                    ILOADP  ,FAC      ,A       ,V         ,X       ,
-     1                    IADC    ,FSKY     ,LLOADP  ,FEXT      ,
+     *                    ILOADP  ,FAC      ,A       ,V         ,X        ,
+     1                    IADC    ,FSKY     ,LLOADP  ,FEXT      ,NODA_SURF,NODA_PEXT,
      2                    ITAB    ,H3D_DATA ,NL      ,DTMIN_LOC ,WFEXT_LOC,
      3                    TH_SURF ,NSEGPL)
 C-----------------------------------------------
@@ -50,6 +50,7 @@ C-----------------------------------------------
       USE H3D_INC_MOD
       USE TH_SURF_MOD , ONLY : TH_SURF_
       USE NAMES_AND_TITLES_MOD , ONLY : NCHARLINE
+      USE TH_MOD ,ONLY : TH_HAS_NODA_PEXT
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -79,7 +80,10 @@ C-----------------------------------------------
       DOUBLE PRECISION,INTENT(INOUT) :: WFEXT_LOC
       my_real,INTENT(IN) :: V(3,NUMNOD),X(3,NUMNOD)
       my_real,INTENT(INOUT) :: FAC(LFACLOAD,NLOADP)
-      my_real,INTENT(INOUT) :: A(3,NUMNOD),FSKY(8,SFSKY/8), FEXT(3,NUMNOD)
+      my_real,INTENT(INOUT) :: A(3,NUMNOD),FSKY(8,SFSKY/8)
+      my_real,INTENT(INOUT) :: FEXT(3,NUMNOD)
+      my_real,INTENT(INOUT) :: NODA_SURF(NUMNOD)
+      my_real,INTENT(INOUT) :: NODA_PEXT(NUMNOD)
       TYPE(H3D_DATABASE),INTENT(IN) :: H3D_DATA
       TYPE (TH_SURF_) , INTENT(INOUT) :: TH_SURF
       INTEGER, INTENT(INOUT) :: NSEGPL
@@ -102,6 +106,7 @@ C-----------------------------------------------
       my_real :: Base_x,Base_y,Base_z
       my_real :: TA_INF_LOC,ZETA
       my_real :: DNORM, Dx, Dy, Dz
+      my_real :: SURF_PATCH
       TYPE(FRIEDLANDER_PARAMS_) :: FRIEDLANDER_PARAMS
       LOGICAL,SAVE :: IS_UPDATED
       LOGICAL :: IS_DECAY_TO_BE_COMPUTED
@@ -428,12 +433,13 @@ C-----------------------------------------------
         ENDIF
         P = alpha_refl * WAVE_REFL + alpha_inci * WAVE_INCI
         P = MAX(P,PMIN)
-        IF (NUMSKINP > 0) PBLAST%PBLAST_TAB(IL)%PRES(I) = P
+        PBLAST%PBLAST_TAB(IL)%PRES(I) = P
 
         !!Expand Pressure load to nodes
         ! FF is nodal force which applied on each node N1,N2,N3, and also N4 if relevant
         ! FF = FF_elem / NPT = Pload.S.n / NPT  where n is the unitary normal vector
         ! NX,NY,NZ = 2S.n (in all cases:quadrangles & triangles)
+        SURF_PATCH = HALF*SQRT(NX*NX+NY*NY+NZ*NZ) / NPT
         FF(1) = -P * HALF*NX / NPT       !  -P*S/NPT . nx
         FF(2) = -P * HALF*NY / NPT       !  -P*S/NPT . ny
         FF(3) = -P * HALF*NZ / NPT       !  -P*S/NPT . nz
@@ -441,6 +447,7 @@ C-----------------------------------------------
         PBLAST%PBLAST_TAB(IL)%FX(I) = FF(1)
         PBLAST%PBLAST_TAB(IL)%FY(I) = FF(2)
         PBLAST%PBLAST_TAB(IL)%FZ(I) = FF(3)
+        PBLAST%PBLAST_TAB(IL)%SURF_PATCH(I) = SURF_PATCH
 
         !External Force work
         ! on a given node : DW = <F,V>*dt
@@ -450,7 +457,7 @@ C-----------------------------------------------
 C----- /TH/SURF -------
         IF(TH_SURF%LOADP_FLAG > 0 ) THEN
           NSEGPL = NSEGPL + 1
-          AREA = HALF*SQRT(NX*NX+NY*NY+NZ*NZ)
+          AREA = SURF_PATCH*NPT
           DO NS=TH_SURF%LOADP_KSEGS(NSEGPL) +1,TH_SURF%LOADP_KSEGS(NSEGPL+1)
              KSURF = TH_SURF%LOADP_SEGS(NS)
              th_surf%channels(4,KSURF)= th_surf%channels(4,KSURF) + AREA*P ! mean pressure
@@ -552,7 +559,7 @@ C----- /TH/SURF -------
       !   H3D FILE         /H3D/NODA/FEXT         !
       !-------------------------------------------!
 !$OMP SINGLE
-      IF(IANIM_OR_H3D>0) THEN
+      IF(IANIM_OR_H3D > 0) THEN
         DO I = 1,ISIZ_SEG
           N1=PBLAST%PBLAST_TAB(IL)%N(1,I)
           N2=PBLAST%PBLAST_TAB(IL)%N(2,I)
@@ -571,6 +578,26 @@ C----- /TH/SURF -------
             FEXT(1,N4) = FEXT(1,N4)+PBLAST%PBLAST_TAB(IL)%FX(I)
             FEXT(2,N4) = FEXT(2,N4)+PBLAST%PBLAST_TAB(IL)%FY(I)
             FEXT(3,N4) = FEXT(3,N4)+PBLAST%PBLAST_TAB(IL)%FZ(I)
+          ENDIF
+        ENDDO
+      ENDIF
+      IF(TH_HAS_NODA_PEXT > 0) THEN
+        DO I = 1,ISIZ_SEG
+          N1 = PBLAST%PBLAST_TAB(IL)%N(1,I)
+          N2 = PBLAST%PBLAST_TAB(IL)%N(2,I)
+          N3 = PBLAST%PBLAST_TAB(IL)%N(3,I)
+          N4 = PBLAST%PBLAST_TAB(IL)%N(4,I)
+          SURF_PATCH = PBLAST%PBLAST_TAB(IL)%SURF_PATCH(I)
+          NODA_SURF(N1) = NODA_SURF(N1) + SURF_PATCH
+          NODA_SURF(N2) = NODA_SURF(N2) + SURF_PATCH
+          NODA_SURF(N3) = NODA_SURF(N3) + SURF_PATCH
+          P = PBLAST%PBLAST_TAB(IL)%PRES(I) * SURF_PATCH
+          NODA_PEXT(N1) = NODA_PEXT(N1) + P
+          NODA_PEXT(N2) = NODA_PEXT(N2) + P
+          NODA_PEXT(N3) = NODA_PEXT(N3) + P
+          IF(PBLAST%PBLAST_TAB(IL)%NPT(I) == FOUR)THEN
+            NODA_SURF(N4) = NODA_SURF(N4) + SURF_PATCH
+            NODA_PEXT(N4) = NODA_PEXT(N4) + P
           ENDIF
         ENDDO
       ENDIF

--- a/engine/source/loads/pblast/pblast_3.F
+++ b/engine/source/loads/pblast/pblast_3.F
@@ -38,7 +38,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||====================================================================
       SUBROUTINE PBLAST_3(PBLAST,
      *                    ILOADP  ,FAC      ,A       ,V         ,X       ,
-     1                    IADC    ,FSKY     ,LLOADP  ,FEXT      ,
+     1                    IADC    ,FSKY     ,LLOADP  ,FEXT      ,NODA_SURF,NODA_PEXT,
      2                    ITAB    ,H3D_DATA ,NL      ,DTMIN_LOC ,WFEXT_LOC,
      4                    TH_SURF ,NSEGPL)
 C-----------------------------------------------
@@ -50,6 +50,7 @@ C-----------------------------------------------
       USE H3D_INC_MOD
       USE TH_SURF_MOD , ONLY : TH_SURF_
       USE NAMES_AND_TITLES_MOD , ONLY : NCHARLINE
+      USE TH_MOD ,ONLY : TH_HAS_NODA_PEXT
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -79,7 +80,10 @@ C-----------------------------------------------
       DOUBLE PRECISION,INTENT(INOUT) :: WFEXT_LOC
       my_real,INTENT(IN) :: V(3,NUMNOD),X(3,NUMNOD)
       my_real,INTENT(INOUT) :: FAC(LFACLOAD,NLOADP)
-      my_real,INTENT(INOUT) :: A(3,NUMNOD),FSKY(8,SFSKY/8), FEXT(3,NUMNOD)
+      my_real,INTENT(INOUT) :: A(3,NUMNOD),FSKY(8,SFSKY/8)
+      my_real,INTENT(INOUT) :: FEXT(3,NUMNOD)
+      my_real,INTENT(INOUT) :: NODA_SURF(NUMNOD)
+      my_real,INTENT(INOUT) :: NODA_PEXT(NUMNOD)
       TYPE(H3D_DATABASE),INTENT(IN) :: H3D_DATA
       TYPE (TH_SURF_) , INTENT(INOUT) :: TH_SURF
       INTEGER, INTENT(INOUT) :: NSEGPL
@@ -116,6 +120,7 @@ C-----------------------------------------------
       my_real DECAY_inci,DECAY_refl,AREA
       my_real NPT
       my_real :: TA_INF_LOC, ZETA
+      my_real :: SURF_PATCH
 
       my_real PI_
       DATA PI_/3.141592653589793238462643D0/
@@ -471,12 +476,14 @@ C-----------------------------------------------
         ENDIF
         P = alpha_refl * WAVE_REFL + alpha_inci * WAVE_INCI
         P = MAX(P,PMIN)
-        IF (NUMSKINP > 0) PBLAST%PBLAST_TAB(IL)%PRES(I) = P
+        PBLAST%PBLAST_TAB(IL)%PRES(I) = P
 
         !Expand Pressure load to nodes
+        SURF_PATCH = HALF*SQRT(NX*NX+NY*NY+NZ*NZ) / NPT
         PBLAST%PBLAST_TAB(IL)%FX(I)= -P * HALF*NX / NPT
         PBLAST%PBLAST_TAB(IL)%FY(I)= -P * HALF*NY / NPT
         PBLAST%PBLAST_TAB(IL)%FZ(I)= -P * HALF*NZ / NPT
+        PBLAST%PBLAST_TAB(IL)%SURF_PATCH(I) = SURF_PATCH
 
         !External Force work
         ! on a given node : DW = <F,V>*dt
@@ -489,7 +496,7 @@ C-----------------------------------------------
 C----- /TH/SURF -------
         IF(TH_SURF%LOADP_FLAG > 0 ) THEN
           NSEGPL = NSEGPL + 1
-          AREA = HALF*SQRT(NX*NX+NY*NY+NZ*NZ)
+          AREA = SURF_PATCH*NPT
           DO NS=TH_SURF%LOADP_KSEGS(NSEGPL) +1,TH_SURF%LOADP_KSEGS(NSEGPL+1)
              KSURF = TH_SURF%LOADP_SEGS(NS)
              th_surf%channels(4,KSURF)= th_surf%channels(4,KSURF) + AREA*P ! mean pressure
@@ -595,7 +602,7 @@ C----- /TH/SURF -------
       !-------------------------------------------!
 
 !$OMP SINGLE
-      IF(IANIM_OR_H3D>0) THEN
+      IF(IANIM_OR_H3D > 0) THEN
         DO I = 1,ISIZ_SEG
           N1=PBLAST%PBLAST_TAB(IL)%N(1,I)
           N2=PBLAST%PBLAST_TAB(IL)%N(2,I)
@@ -617,6 +624,26 @@ C----- /TH/SURF -------
           ENDIF
         ENDDO
        ENDIF
+      IF(TH_HAS_NODA_PEXT > 0) THEN
+        DO I = 1,ISIZ_SEG
+          N1 = PBLAST%PBLAST_TAB(IL)%N(1,I)
+          N2 = PBLAST%PBLAST_TAB(IL)%N(2,I)
+          N3 = PBLAST%PBLAST_TAB(IL)%N(3,I)
+          N4 = PBLAST%PBLAST_TAB(IL)%N(4,I)
+          SURF_PATCH = PBLAST%PBLAST_TAB(IL)%SURF_PATCH(I)
+          NODA_SURF(N1) = NODA_SURF(N1) + SURF_PATCH
+          NODA_SURF(N2) = NODA_SURF(N2) + SURF_PATCH
+          NODA_SURF(N3) = NODA_SURF(N3) + SURF_PATCH
+          P = PBLAST%PBLAST_TAB(IL)%PRES(I) * SURF_PATCH
+          NODA_PEXT(N1) = NODA_PEXT(N1) + P
+          NODA_PEXT(N2) = NODA_PEXT(N2) + P
+          NODA_PEXT(N3) = NODA_PEXT(N3) + P
+          IF(PBLAST%PBLAST_TAB(IL)%NPT(I) == FOUR)THEN
+            NODA_SURF(N4) = NODA_SURF(N4) + SURF_PATCH
+            NODA_PEXT(N4) = NODA_PEXT(N4) + P
+          ENDIF
+        ENDDO
+      ENDIF
 !$OMP END SINGLE
 
       RETURN

--- a/engine/source/output/restart/rdcomm.F
+++ b/engine/source/output/restart/rdcomm.F
@@ -78,6 +78,7 @@ C-----------------------------------------------
       USE glob_therm_mod
       USE PBLAST_MOD
       USE RBE3_MOD
+      USE TH_MOD , ONLY : TH_HAS_NODA_PEXT
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -175,7 +176,7 @@ C-----------------------------------------------
       NSPMD   =TABVINT(23)
       LENWA   =TABVINT(24)
       ISGIFL  =TABVINT(25)
-      !       =TABVINT(26)
+      TH_HAS_NODA_PEXT = TABVINT(26)
       NNODS   =TABVINT(27)
       NCNOIS  =TABVINT(28)
       LCNE0   =TABVINT(29)

--- a/engine/source/output/restart/wrcomm.F
+++ b/engine/source/output/restart/wrcomm.F
@@ -69,6 +69,7 @@ C-----------------------------------------------
       USE DAMP_MOD
       USE glob_therm_mod
       USE PBLAST_MOD
+      USE TH_MOD , ONLY : TH_HAS_NODA_PEXT
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -167,7 +168,7 @@ C-----
       TABVINT(23) =NSPMD
       TABVINT(24) =LENWA
       TABVINT(25) =ISGIFL
-      TABVINT(26) =0 !no longer used
+      TABVINT(26) = TH_HAS_NODA_PEXT
       TABVINT(27) =NNODS
       TABVINT(28) =NCNOIS
       TABVINT(29) =LCNE0

--- a/engine/source/output/sortie_main.F
+++ b/engine/source/output/sortie_main.F
@@ -165,7 +165,7 @@ C-----------------------------------------------
       USE MESSAGE_MOD
       USE STATE_MOD
       USE USER_WINDOWS_MOD
-      USE OUTPUT_MOD , ONLY : OUTPUT_
+      USE OUTPUT_MOD , ONLY : OUTPUT_, NODA_SURF, NODA_PEXT
       USE DT_MOD
       USE TABLE_MOD
       USE LOADS_MOD
@@ -176,6 +176,7 @@ C-----------------------------------------------
       use FPCONT2_MIN_OUTPUT_MOD
       use glob_therm_mod
       use PBLAST_MOD
+      use th_mod , only : TH_HAS_NODA_PEXT
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -1702,9 +1703,7 @@ C
      N                ITHFLAG,PINCH_DATA,MULTI_FVM,W,OUTPUT%TH%ITHBUFH,
      Q                FSAVSURF,NEED_TO_REINIT_FSAV,GLOB_THERM,OUTPUT)
 
-        IF(SIZE_MES==1 .AND.
-     *     AFORM(8)==3   .AND.
-     *     ISPMD==0 ) CALL file_size(MULTITHFILESIZE(8))
+        IF(SIZE_MES==1 .AND. AFORM(8)==3 .AND.ISPMD==0 ) CALL file_size(MULTITHFILESIZE(8))
 
        IF(ABFILE(9) /= 0) THEN
 #ifdef DNC
@@ -1748,9 +1747,7 @@ C
               DO I=1,LEN_TMP_NAME!ROOTLEN+LONG_TMP
                 IFILNAM_TMP(I)=ICHAR(TMP_NAME(I:I))!(FILNAMABF_TMP(I:I))
               ENDDO
-               CALL ABFFILE_UPDATE(ABINP,ABOUT,NABFWR(9),IFILNAM,
-     .                      LEN_TMP_NAME2,IFILNAM_TMP,LEN_TMP_NAME,
-     .                      CPTFILE)
+               CALL ABFFILE_UPDATE(ABINP,ABOUT,NABFWR(9),IFILNAM,LEN_TMP_NAME2,IFILNAM_TMP,LEN_TMP_NAME, CPTFILE)
                NABFWR(9) = 0
              ENDIF
 #endif
@@ -1793,9 +1790,7 @@ C
      N                ITHFLAG,PINCH_DATA,MULTI_FVM,W,OUTPUT%TH%ITHBUFI,
      Q                FSAVSURF,NEED_TO_REINIT_FSAV,GLOB_THERM,OUTPUT)
 
-        IF(SIZE_MES==1 .AND.
-     *     AFORM(9)==3   .AND.
-     *     ISPMD==0 ) CALL file_size(MULTITHFILESIZE(9))
+        IF(SIZE_MES==1 .AND. AFORM(9)==3 .AND. ISPMD==0 ) CALL file_size(MULTITHFILESIZE(9))
             IF(ABFILE(10) /= 0) THEN
 #ifdef DNC
             IFILABF = 20
@@ -1882,9 +1877,7 @@ C
      N                ITHFLAG,PINCH_DATA,MULTI_FVM,W,OUTPUT%TH%SITHBUF,
      Q                FSAVSURF,NEED_TO_REINIT_FSAV,GLOB_THERM,OUTPUT)
 
-        IF(SIZE_MES==1 .AND.
-     *     ITFORM==3   .AND.
-     *     ISPMD==0 )CALL file_size(THFILESIZE)
+        IF(SIZE_MES==1 .AND. ITFORM==3 .AND. ISPMD==0 )CALL file_size(THFILESIZE)
 
         IF(ABFILE(1) /= 0) THEN
 #ifdef DNC
@@ -1928,8 +1921,7 @@ C
             IFILNAM_TMP(I)=ICHAR(TMP_NAME(I:I))!(FILNAMABF_TMP(I:I))
           ENDDO
 
-         CALL ABFFILE_UPDATE(ABINP,ABOUT,NABFWR(1),IFILNAM,LEN_TMP_NAME2,
-     .                      IFILNAM_TMP,LEN_TMP_NAME,0)
+         CALL ABFFILE_UPDATE(ABINP,ABOUT,NABFWR(1),IFILNAM,LEN_TMP_NAME2,IFILNAM_TMP,LEN_TMP_NAME,0)
 
            NABFWR(1) = 0
          ENDIF
@@ -1948,7 +1940,7 @@ C----------------------------------------------
 C-------------------------------------------------------
 C     TRAITEMENT SUR FSAV NON CUMULE
 C-------------------------------------------------------
-      IF(ISPMD==0.AND.THUPDT==1) THEN
+      IF(ISPMD == 0 .AND. THUPDT == 1) THEN
 C en SPMD il faut remettre FSAV a 0 sur P0, la ou FSAV n est pas cumule
         IF(NVOLU>0)THEN
          IAD = NINTER+NRWALL+NRBODY+NSECT+NJOINT
@@ -1961,7 +1953,7 @@ C en SPMD il faut remettre FSAV a 0 sur P0, la ou FSAV n est pas cumule
       ENDIF
 
 C  FSAV(26) : contact elastic energy is not cumulated : only for int10 and int18 for the moment
-      IF(NINTER>0)THEN
+      IF(NINTER > 0)THEN
           DO I=1,NINTER
             ITY = IPARI(7,I)
             IF(ITY /= 10.AND.(ITY /= 7.OR.IPARI(22,I) /= 7)) THEN 
@@ -1989,10 +1981,10 @@ C /TH/SURF quantities reset to 0 expect for massflow (airbags)
       
       ! -----------------------
       ! need to re-initialize PARTSAV array after any th/abf file writing
-      IF(ISPMD==0) THEN
+      IF(ISPMD == 0) THEN
         ! ---------
         ! check if an abf file was written
-        IF(NABFILE/=0) THEN
+        IF(NABFILE /= 0) THEN
             DO I=1,10
                 IF(TT>TABFWR0(I)) NEED_TO_REINIT_FSAV = .TRUE.
             ENDDO
@@ -2014,7 +2006,14 @@ C /TH/SURF quantities reset to 0 expect for massflow (airbags)
       ENDIF
       ! -----------------------
 
-      IF (ISPMD==0.AND.IFLAG==1) WFEXT  = WFEXT- WFEXTH
+      IF (ISPMD == 0 .AND. IFLAG == 1) WFEXT  = WFEXT- WFEXTH
+
+      ! /TH/NODE (PEXT) or /H3D/NODA/PEXT or /ANIM/NODA/PEXT
+      ! reset for next cycle
+      IF(TH_HAS_NODA_PEXT == 1)THEN
+        NODA_SURF(1:NUMNOD) = ZERO
+        NODA_PEXT(1:NUMNOD) = ZERO
+      ENDIF
 C-----------
       RETURN
       END

--- a/engine/source/output/th/thnod.F
+++ b/engine/source/output/th/thnod.F
@@ -43,6 +43,7 @@ C   M o d u l e s
 C-----------------------------------------------
       USE PLYXFEM_MOD
       USE PINCHTYPE_MOD
+      USE OUTPUT_MOD , ONLY : NODA_SURF, NODA_PEXT
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -81,9 +82,7 @@ C-----------------------------------------------
       INTEGER I, J, ISK, II, L, K, IUN, IFRA, N1,IPLY,IDIR,N
       INTEGER :: II_SAVE,IJK, ITYP
       INTEGER :: IAD,NN,IADV,NVAR
-      my_real
-     .   XL(3),DL(3),VL(3),AL(3),VRL(3),ARL(3),OD(3),VO(3),AO(3),
-     .   VRG(3),ARG(3)
+      my_real :: XL(3),DL(3),VL(3),AL(3),VRL(3),ARL(3),OD(3),VO(3),AO(3),VRG(3),ARG(3)
       DATA IUN/1/
 C-------------------------
 C     NODES
@@ -208,76 +207,79 @@ C workaround for possible PGI bug
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 626) THEN
-                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND.
-     .                  IRODDL/=0 )THEN
+                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND. IRODDL/=0 )THEN
                       WA(IJK) = DR(1,I)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 627) THEN
-                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND.
-     .                   IRODDL/=0 )THEN
+                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND. IRODDL/=0 )THEN
                       WA(IJK) = DR(2,I)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 628) THEN
-                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND.
-     .                   IRODDL/=0 )THEN
+                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND. IRODDL/=0 )THEN
                       WA(IJK) = DR(3,I)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
-C start of pinching information
                   ELSEIF(K == 629) THEN
+                    IF(NODA_SURF(I) > ZERO)THEN
+                      WA(IJK) = NODA_PEXT(I) / NODA_SURF(I)
+                    ELSE
+                      WA(IJK) = ZERO
+                    ENDIF
+C start of pinching information
+                  ELSEIF(K == 630) THEN
                     IF (NPINCH > 0 )THEN
                       WA(IJK) = PINCH_DATA%APINCH(1,I)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
-                  ELSEIF(K == 630) THEN
+                  ELSEIF(K == 631) THEN
                     IF (NPINCH > 0 )THEN
                       WA(IJK) = PINCH_DATA%APINCH(2,I)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
-                  ELSEIF(K == 631) THEN
+                  ELSEIF(K == 632) THEN
                     IF (NPINCH > 0 )THEN
                       WA(IJK) = PINCH_DATA%APINCH(3,I)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
-                  ELSEIF(K == 632) THEN
+                  ELSEIF(K == 633) THEN
                     IF (NPINCH > 0 )THEN
                       WA(IJK) = PINCH_DATA%VPINCH(1,I)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
-                  ELSEIF(K == 633) THEN
+                  ELSEIF(K == 634) THEN
                     IF (NPINCH > 0 )THEN
                       WA(IJK) = PINCH_DATA%VPINCH(2,I)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
-                  ELSEIF(K == 634) THEN
+                  ELSEIF(K == 635) THEN
                     IF (NPINCH > 0 )THEN
                       WA(IJK) = PINCH_DATA%VPINCH(3,I)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
-                  ELSEIF(K == 635) THEN
+                  ELSEIF(K == 636) THEN
                     IF (NPINCH > 0 )THEN
                       WA(IJK) = PINCH_DATA%DPINCH(1,I)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
-                  ELSEIF(K == 636) THEN
+                  ELSEIF(K == 637) THEN
                     IF (NPINCH > 0 )THEN
                       WA(IJK) = PINCH_DATA%DPINCH(2,I)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
-                  ELSEIF(K == 637) THEN
+                  ELSEIF(K == 638) THEN
                     IF (NPINCH > 0 )THEN
                       WA(IJK) = PINCH_DATA%DPINCH(3,I)
                     ELSE
@@ -296,77 +298,41 @@ C end of pinching information
                   II=II+1
                   IJK=IJK+1
                   IF(K==1)THEN
-                    WA(IJK) = D(1,I)*SKEW(1,ISK)
-     .                     + D(2,I)*SKEW(2,ISK)
-     .                     + D(3,I)*SKEW(3,ISK)
+                    WA(IJK) = D(1,I)*SKEW(1,ISK) + D(2,I)*SKEW(2,ISK) + D(3,I)*SKEW(3,ISK)
                   ELSEIF(K==2)THEN
-                    WA(IJK) = D(1,I)*SKEW(4,ISK)
-     .                     + D(2,I)*SKEW(5,ISK)
-     .                     + D(3,I)*SKEW(6,ISK)
+                    WA(IJK) = D(1,I)*SKEW(4,ISK) + D(2,I)*SKEW(5,ISK) + D(3,I)*SKEW(6,ISK)
                   ELSEIF(K==3)THEN
-                    WA(IJK) = D(1,I)*SKEW(7,ISK)
-     .                     + D(2,I)*SKEW(8,ISK)
-     .                     + D(3,I)*SKEW(9,ISK)
+                    WA(IJK) = D(1,I)*SKEW(7,ISK) + D(2,I)*SKEW(8,ISK) + D(3,I)*SKEW(9,ISK)
                   ELSEIF(K==4)THEN
-                    WA(IJK) = V(1,I)*SKEW(1,ISK)
-     .                     + V(2,I)*SKEW(2,ISK)
-     .                     + V(3,I)*SKEW(3,ISK)
+                    WA(IJK) = V(1,I)*SKEW(1,ISK) + V(2,I)*SKEW(2,ISK) + V(3,I)*SKEW(3,ISK)
                   ELSEIF(K==5)THEN
-                    WA(IJK) = V(1,I)*SKEW(4,ISK)
-     .                     + V(2,I)*SKEW(5,ISK)
-     .                     + V(3,I)*SKEW(6,ISK)
+                    WA(IJK) = V(1,I)*SKEW(4,ISK) + V(2,I)*SKEW(5,ISK) + V(3,I)*SKEW(6,ISK)
                   ELSEIF(K==6)THEN
-                    WA(IJK) = V(1,I)*SKEW(7,ISK)
-     .                     + V(2,I)*SKEW(8,ISK)
-     .                     + V(3,I)*SKEW(9,ISK)
+                    WA(IJK) = V(1,I)*SKEW(7,ISK) + V(2,I)*SKEW(8,ISK) + V(3,I)*SKEW(9,ISK)
                   ELSEIF(K==7)THEN
-                    WA(IJK) = A(1,I)*SKEW(1,ISK)
-     .                     + A(2,I)*SKEW(2,ISK)
-     .                     + A(3,I)*SKEW(3,ISK)
+                    WA(IJK) = A(1,I)*SKEW(1,ISK) + A(2,I)*SKEW(2,ISK) + A(3,I)*SKEW(3,ISK)
                   ELSEIF(K==8)THEN
-                    WA(IJK) = A(1,I)*SKEW(4,ISK)
-     .                     + A(2,I)*SKEW(5,ISK)
-     .                     + A(3,I)*SKEW(6,ISK)
+                    WA(IJK) = A(1,I)*SKEW(4,ISK) + A(2,I)*SKEW(5,ISK) + A(3,I)*SKEW(6,ISK)
                   ELSEIF(K==9)THEN
-                    WA(IJK) = A(1,I)*SKEW(7,ISK)
-     .                     + A(2,I)*SKEW(8,ISK)
-     .                     + A(3,I)*SKEW(9,ISK)
+                    WA(IJK) = A(1,I)*SKEW(7,ISK) + A(2,I)*SKEW(8,ISK) + A(3,I)*SKEW(9,ISK)
                   ELSEIF(K==10)THEN
-                    WA(IJK) = VR(1,I)*SKEW(1,ISK)
-     .                     + VR(2,I)*SKEW(2,ISK)
-     .                     + VR(3,I)*SKEW(3,ISK)
+                    WA(IJK) = VR(1,I)*SKEW(1,ISK) + VR(2,I)*SKEW(2,ISK) + VR(3,I)*SKEW(3,ISK)
                   ELSEIF(K==11)THEN
-                    WA(IJK) = VR(1,I)*SKEW(4,ISK)
-     .                     + VR(2,I)*SKEW(5,ISK)
-     .                     + VR(3,I)*SKEW(6,ISK)
+                    WA(IJK) = VR(1,I)*SKEW(4,ISK) + VR(2,I)*SKEW(5,ISK) + VR(3,I)*SKEW(6,ISK)
                   ELSEIF(K==12)THEN
-                    WA(IJK) = VR(1,I)*SKEW(7,ISK)
-     .                     + VR(2,I)*SKEW(8,ISK)
-     .                     + VR(3,I)*SKEW(9,ISK)
+                    WA(IJK) = VR(1,I)*SKEW(7,ISK) + VR(2,I)*SKEW(8,ISK) + VR(3,I)*SKEW(9,ISK)
                   ELSEIF(K==13)THEN
-                    WA(IJK) = AR(1,I)*SKEW(1,ISK)
-     .                     + AR(2,I)*SKEW(2,ISK)
-     .                     + AR(3,I)*SKEW(3,ISK)
+                    WA(IJK) = AR(1,I)*SKEW(1,ISK) + AR(2,I)*SKEW(2,ISK) + AR(3,I)*SKEW(3,ISK)
                   ELSEIF(K==14)THEN
-                    WA(IJK) = AR(1,I)*SKEW(4,ISK)
-     .                     + AR(2,I)*SKEW(5,ISK)
-     .                     + AR(3,I)*SKEW(6,ISK)
+                    WA(IJK) = AR(1,I)*SKEW(4,ISK) + AR(2,I)*SKEW(5,ISK) + AR(3,I)*SKEW(6,ISK)
                   ELSEIF(K==15)THEN
-                    WA(IJK) = AR(1,I)*SKEW(7,ISK)
-     .                     + AR(2,I)*SKEW(8,ISK)
-     .                     + AR(3,I)*SKEW(9,ISK)
+                    WA(IJK) = AR(1,I)*SKEW(7,ISK) + AR(2,I)*SKEW(8,ISK) + AR(3,I)*SKEW(9,ISK)
                   ELSEIF(K==16)THEN
-                    WA(IJK) = X(1,I)*SKEW(1,ISK)
-     .                     + X(2,I)*SKEW(2,ISK)
-     .                     + X(3,I)*SKEW(3,ISK)
+                    WA(IJK) = X(1,I)*SKEW(1,ISK) + X(2,I)*SKEW(2,ISK) + X(3,I)*SKEW(3,ISK)
                   ELSEIF(K==17)THEN
-                    WA(IJK) = X(1,I)*SKEW(4,ISK)
-     .                     + X(2,I)*SKEW(5,ISK)
-     .                     + X(3,I)*SKEW(6,ISK)
+                    WA(IJK) = X(1,I)*SKEW(4,ISK) + X(2,I)*SKEW(5,ISK) + X(3,I)*SKEW(6,ISK)
                   ELSEIF(K==18)THEN
-                    WA(IJK) = X(1,I)*SKEW(7,ISK)
-     .                     + X(2,I)*SKEW(8,ISK)
-     .                     + X(3,I)*SKEW(9,ISK)
+                    WA(IJK) = X(1,I)*SKEW(7,ISK) + X(2,I)*SKEW(8,ISK) + X(3,I)*SKEW(9,ISK)
                   ELSEIF(K==19)THEN
 C workaround for possible PGI bug
                     call sync_data(I)
@@ -419,102 +385,81 @@ C workaround for possible PGI bug
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 626) THEN
-                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND.
-     .                   IRODDL/=0 )THEN
-                      WA(IJK) = DR(1,I)*SKEW(1,ISK)
-     .                       + DR(2,I)*SKEW(2,ISK)
-     .                       + DR(3,I)*SKEW(3,ISK)
+                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND. IRODDL/=0 )THEN
+                      WA(IJK) = DR(1,I)*SKEW(1,ISK) + DR(2,I)*SKEW(2,ISK) + DR(3,I)*SKEW(3,ISK)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 627) THEN
-                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND.
-     .                   IRODDL/=0 )THEN
-                      WA(IJK) = DR(1,I)*SKEW(4,ISK)
-     .                       + DR(2,I)*SKEW(5,ISK)
-     .                       + DR(3,I)*SKEW(6,ISK)
+                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND. IRODDL/=0 )THEN
+                      WA(IJK) = DR(1,I)*SKEW(4,ISK) + DR(2,I)*SKEW(5,ISK) + DR(3,I)*SKEW(6,ISK)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 628) THEN
-                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND.
-     .                   IRODDL/=0 )THEN
-                      WA(IJK) = DR(1,I)*SKEW(7,ISK)
-     .                       + DR(2,I)*SKEW(8,ISK)
-     .                       + DR(3,I)*SKEW(9,ISK)
+                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND. IRODDL/=0 )THEN
+                      WA(IJK) = DR(1,I)*SKEW(7,ISK) + DR(2,I)*SKEW(8,ISK) + DR(3,I)*SKEW(9,ISK)
+                    ELSE
+                      WA(IJK) = ZERO
+                    ENDIF
+                  ELSEIF(K == 629) THEN
+                    IF(NODA_SURF(I) > ZERO)THEN
+                      WA(IJK) = NODA_PEXT(I) / NODA_SURF(I)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
 C start of pinching information
-                  ELSEIF(K == 629) THEN
-                    IF (NPINCH > 0 )THEN
-                      WA(IJK) = PINCH_DATA%APINCH(1,I)*SKEW(1,ISK)
-     .                         +PINCH_DATA%APINCH(2,I)*SKEW(2,ISK)
-     .                         +PINCH_DATA%APINCH(3,I)*SKEW(3,ISK)
-                    ELSE
-                      WA(IJK) = ZERO
-                    ENDIF
                   ELSEIF(K == 630) THEN
                     IF (NPINCH > 0 )THEN
-                      WA(IJK) = PINCH_DATA%APINCH(1,I)*SKEW(4,ISK)
-     .                         +PINCH_DATA%APINCH(2,I)*SKEW(5,ISK)
-     .                         +PINCH_DATA%APINCH(3,I)*SKEW(6,ISK)
+                      WA(IJK) = PINCH_DATA%APINCH(1,I)*SKEW(1,ISK) +PINCH_DATA%APINCH(2,I)*SKEW(2,ISK) +PINCH_DATA%APINCH(3,I)*SKEW(3,ISK)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 631) THEN
                     IF (NPINCH > 0 )THEN
-                      WA(IJK) = PINCH_DATA%APINCH(1,I)*SKEW(7,ISK)
-     .                         +PINCH_DATA%APINCH(2,I)*SKEW(8,ISK)
-     .                         +PINCH_DATA%APINCH(3,I)*SKEW(9,ISK)
+                      WA(IJK) = PINCH_DATA%APINCH(1,I)*SKEW(4,ISK) +PINCH_DATA%APINCH(2,I)*SKEW(5,ISK) +PINCH_DATA%APINCH(3,I)*SKEW(6,ISK)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 632) THEN
                     IF (NPINCH > 0 )THEN
-                      WA(IJK) = PINCH_DATA%VPINCH(1,I)*SKEW(1,ISK)
-     .                         +PINCH_DATA%VPINCH(2,I)*SKEW(2,ISK)
-     .                         +PINCH_DATA%VPINCH(3,I)*SKEW(3,ISK)
+                      WA(IJK) = PINCH_DATA%APINCH(1,I)*SKEW(7,ISK) +PINCH_DATA%APINCH(2,I)*SKEW(8,ISK) +PINCH_DATA%APINCH(3,I)*SKEW(9,ISK)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 633) THEN
                     IF (NPINCH > 0 )THEN
-                      WA(IJK) = PINCH_DATA%VPINCH(1,I)*SKEW(4,ISK)
-     .                         +PINCH_DATA%VPINCH(2,I)*SKEW(5,ISK)
-     .                         +PINCH_DATA%VPINCH(3,I)*SKEW(6,ISK)
+                      WA(IJK) = PINCH_DATA%VPINCH(1,I)*SKEW(1,ISK) +PINCH_DATA%VPINCH(2,I)*SKEW(2,ISK) +PINCH_DATA%VPINCH(3,I)*SKEW(3,ISK)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 634) THEN
                     IF (NPINCH > 0 )THEN
-                      WA(IJK) = PINCH_DATA%VPINCH(1,I)*SKEW(7,ISK)
-     .                         +PINCH_DATA%VPINCH(2,I)*SKEW(8,ISK)
-     .                         +PINCH_DATA%VPINCH(3,I)*SKEW(9,ISK)
+                      WA(IJK) = PINCH_DATA%VPINCH(1,I)*SKEW(4,ISK) +PINCH_DATA%VPINCH(2,I)*SKEW(5,ISK) +PINCH_DATA%VPINCH(3,I)*SKEW(6,ISK)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 635) THEN
                     IF (NPINCH > 0 )THEN
-                      WA(IJK) = PINCH_DATA%DPINCH(1,I)*SKEW(1,ISK)
-     .                         +PINCH_DATA%DPINCH(2,I)*SKEW(2,ISK)
-     .                         +PINCH_DATA%DPINCH(3,I)*SKEW(3,ISK)
+                      WA(IJK) = PINCH_DATA%VPINCH(1,I)*SKEW(7,ISK) +PINCH_DATA%VPINCH(2,I)*SKEW(8,ISK) +PINCH_DATA%VPINCH(3,I)*SKEW(9,ISK)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 636) THEN
                     IF (NPINCH > 0 )THEN
-                      WA(IJK) = PINCH_DATA%DPINCH(1,I)*SKEW(4,ISK)
-     .                         +PINCH_DATA%DPINCH(2,I)*SKEW(5,ISK)
-     .                         +PINCH_DATA%DPINCH(3,I)*SKEW(6,ISK)
+                      WA(IJK) = PINCH_DATA%DPINCH(1,I)*SKEW(1,ISK) +PINCH_DATA%DPINCH(2,I)*SKEW(2,ISK) +PINCH_DATA%DPINCH(3,I)*SKEW(3,ISK)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 637) THEN
                     IF (NPINCH > 0 )THEN
-                      WA(IJK) = PINCH_DATA%DPINCH(1,I)*SKEW(7,ISK)
-     .                         +PINCH_DATA%DPINCH(2,I)*SKEW(8,ISK)
-     .                         +PINCH_DATA%DPINCH(3,I)*SKEW(9,ISK)
+                      WA(IJK) = PINCH_DATA%DPINCH(1,I)*SKEW(4,ISK) +PINCH_DATA%DPINCH(2,I)*SKEW(5,ISK) +PINCH_DATA%DPINCH(3,I)*SKEW(6,ISK)
+                    ELSE
+                      WA(IJK) = ZERO
+                    ENDIF
+                  ELSEIF(K == 638) THEN
+                    IF (NPINCH > 0 )THEN
+                      WA(IJK) = PINCH_DATA%DPINCH(1,I)*SKEW(7,ISK) +PINCH_DATA%DPINCH(2,I)*SKEW(8,ISK) +PINCH_DATA%DPINCH(3,I)*SKEW(9,ISK)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
@@ -682,28 +627,31 @@ C workaround for possible PGI bug
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 626) THEN
-                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND.
-     .                   IRODDL/=0 )THEN
+                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND.IRODDL/=0 )THEN
                       WA(IJK) = DR(1,I)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 627) THEN
-                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND.
-     .                   IRODDL/=0 )THEN
+                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND. IRODDL/=0 )THEN
                       WA(IJK) = DR(2,I)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 628) THEN
-                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND.
-     .                   IRODDL/=0 )THEN
+                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND. IRODDL/=0 )THEN
                       WA(IJK) = DR(3,I)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
+                  ELSEIF(K == 629) THEN
+                    IF(NODA_SURF(I) > ZERO)THEN
+                      WA(IJK) = NODA_PEXT(I) / NODA_SURF(I)
+                    ELSE
+                      WA(IJK) = ZERO
+                    ENDIF
                   ELSE
-                    WA(IJK)=0.
+                    WA(IJK)=ZERO
                   ENDIF
                 ENDDO ! L=IADV,IADV+NVAR-1
                 IJK=IJK+1
@@ -717,53 +665,29 @@ C               output with respect to a (non global) SKEW.
                   II=II+1
                   IJK=IJK+1
                   IF(K==1)THEN
-                    WA(IJK) = D(1,I)*SKEW(1,ISK)
-     .                     + D(2,I)*SKEW(2,ISK)
-     .                     + D(3,I)*SKEW(3,ISK)
+                    WA(IJK) = D(1,I)*SKEW(1,ISK) + D(2,I)*SKEW(2,ISK) + D(3,I)*SKEW(3,ISK)
                   ELSEIF(K==2)THEN
-                    WA(IJK) = D(1,I)*SKEW(4,ISK)
-     .                     + D(2,I)*SKEW(5,ISK)
-     .                     + D(3,I)*SKEW(6,ISK)
+                    WA(IJK) = D(1,I)*SKEW(4,ISK) + D(2,I)*SKEW(5,ISK) + D(3,I)*SKEW(6,ISK)
                   ELSEIF(K==3)THEN
-                    WA(IJK) = D(1,I)*SKEW(7,ISK)
-     .                     + D(2,I)*SKEW(8,ISK)
-     .                     + D(3,I)*SKEW(9,ISK)
+                    WA(IJK) = D(1,I)*SKEW(7,ISK) + D(2,I)*SKEW(8,ISK) + D(3,I)*SKEW(9,ISK)
                   ELSEIF(K==4)THEN
-                    WA(IJK) = V(1,I)*SKEW(1,ISK)
-     .                     + V(2,I)*SKEW(2,ISK)
-     .                     + V(3,I)*SKEW(3,ISK)
+                    WA(IJK) = V(1,I)*SKEW(1,ISK) + V(2,I)*SKEW(2,ISK) + V(3,I)*SKEW(3,ISK)
                   ELSEIF(K==5)THEN
-                    WA(IJK) = V(1,I)*SKEW(4,ISK)
-     .                     + V(2,I)*SKEW(5,ISK)
-     .                     + V(3,I)*SKEW(6,ISK)
+                    WA(IJK) = V(1,I)*SKEW(4,ISK) + V(2,I)*SKEW(5,ISK) + V(3,I)*SKEW(6,ISK)
                   ELSEIF(K==6)THEN
-                    WA(IJK) = V(1,I)*SKEW(7,ISK)
-     .                     + V(2,I)*SKEW(8,ISK)
-     .                     + V(3,I)*SKEW(9,ISK)
+                    WA(IJK) = V(1,I)*SKEW(7,ISK) + V(2,I)*SKEW(8,ISK) + V(3,I)*SKEW(9,ISK)
                   ELSEIF(K==7)THEN
-                    WA(IJK) = A(1,I)*SKEW(1,ISK)
-     .                     + A(2,I)*SKEW(2,ISK)
-     .                     + A(3,I)*SKEW(3,ISK)
+                    WA(IJK) = A(1,I)*SKEW(1,ISK) + A(2,I)*SKEW(2,ISK) + A(3,I)*SKEW(3,ISK)
                   ELSEIF(K==8)THEN
-                    WA(IJK) = A(1,I)*SKEW(4,ISK)
-     .                     + A(2,I)*SKEW(5,ISK)
-     .                     + A(3,I)*SKEW(6,ISK)
+                    WA(IJK) = A(1,I)*SKEW(4,ISK) + A(2,I)*SKEW(5,ISK) + A(3,I)*SKEW(6,ISK)
                   ELSEIF(K==9)THEN
-                    WA(IJK) = A(1,I)*SKEW(7,ISK)
-     .                     + A(2,I)*SKEW(8,ISK)
-     .                     + A(3,I)*SKEW(9,ISK)
+                    WA(IJK) = A(1,I)*SKEW(7,ISK) + A(2,I)*SKEW(8,ISK) + A(3,I)*SKEW(9,ISK)
                   ELSEIF(K==16)THEN
-                    WA(IJK) = X(1,I)*SKEW(1,ISK)
-     .                     + X(2,I)*SKEW(2,ISK)
-     .                     + X(3,I)*SKEW(3,ISK)
+                    WA(IJK) = X(1,I)*SKEW(1,ISK) + X(2,I)*SKEW(2,ISK) + X(3,I)*SKEW(3,ISK)
                   ELSEIF(K==17)THEN
-                    WA(IJK) = X(1,I)*SKEW(4,ISK)
-     .                     + X(2,I)*SKEW(5,ISK)
-     .                     + X(3,I)*SKEW(6,ISK)
+                    WA(IJK) = X(1,I)*SKEW(4,ISK) + X(2,I)*SKEW(5,ISK) + X(3,I)*SKEW(6,ISK)
                   ELSEIF(K==18)THEN
-                    WA(IJK) = X(1,I)*SKEW(7,ISK)
-     .                     + X(2,I)*SKEW(8,ISK)
-     .                     + X(3,I)*SKEW(9,ISK)
+                    WA(IJK) = X(1,I)*SKEW(7,ISK) + X(2,I)*SKEW(8,ISK) + X(3,I)*SKEW(9,ISK)
                   ELSEIF(K==19)THEN
 C workaround for possible PGI bug
                     call sync_data(I)
@@ -774,81 +698,66 @@ C workaround for possible PGI bug
                     ENDIF
                   ELSEIF(K == 620) THEN
                     IF (NODREAC(I) /= 0) THEN
-                      WA(IJK) = FTHREAC(1,NODREAC(I))*SKEW(1,ISK)
-     .                       + FTHREAC(2,NODREAC(I))*SKEW(2,ISK)
-     .                       + FTHREAC(3,NODREAC(I))*SKEW(3,ISK)
+                      WA(IJK) = FTHREAC(1,NODREAC(I))*SKEW(1,ISK) + FTHREAC(2,NODREAC(I))*SKEW(2,ISK) + FTHREAC(3,NODREAC(I))*SKEW(3,ISK)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 621) THEN
                     IF (NODREAC(I) /= 0) THEN
-                      WA(IJK) = FTHREAC(1,NODREAC(I))*SKEW(4,ISK)
-     .                       + FTHREAC(2,NODREAC(I))*SKEW(5,ISK)
-     .                       + FTHREAC(3,NODREAC(I))*SKEW(6,ISK)
+                      WA(IJK) = FTHREAC(1,NODREAC(I))*SKEW(4,ISK) + FTHREAC(2,NODREAC(I))*SKEW(5,ISK) + FTHREAC(3,NODREAC(I))*SKEW(6,ISK)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 622) THEN
                     IF (NODREAC(I) /= 0) THEN
-                      WA(IJK) = FTHREAC(1,NODREAC(I))*SKEW(7,ISK)
-     .                       + FTHREAC(2,NODREAC(I))*SKEW(8,ISK)
-     .                       + FTHREAC(3,NODREAC(I))*SKEW(9,ISK)
+                      WA(IJK) = FTHREAC(1,NODREAC(I))*SKEW(7,ISK) + FTHREAC(2,NODREAC(I))*SKEW(8,ISK) + FTHREAC(3,NODREAC(I))*SKEW(9,ISK)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 623) THEN
                     IF (NODREAC(I) /= 0) THEN
-                      WA(IJK) = FTHREAC(4,NODREAC(I))*SKEW(1,ISK)
-     .                       + FTHREAC(5,NODREAC(I))*SKEW(2,ISK)
-     .                       + FTHREAC(6,NODREAC(I))*SKEW(3,ISK)
+                      WA(IJK) = FTHREAC(4,NODREAC(I))*SKEW(1,ISK) + FTHREAC(5,NODREAC(I))*SKEW(2,ISK) + FTHREAC(6,NODREAC(I))*SKEW(3,ISK)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 624) THEN
                     IF (NODREAC(I) /= 0) THEN
-                      WA(IJK) = FTHREAC(4,NODREAC(I))*SKEW(4,ISK)
-     .                       + FTHREAC(5,NODREAC(I))*SKEW(5,ISK)
-     .                       + FTHREAC(6,NODREAC(I))*SKEW(6,ISK)
+                      WA(IJK) = FTHREAC(4,NODREAC(I))*SKEW(4,ISK) + FTHREAC(5,NODREAC(I))*SKEW(5,ISK) + FTHREAC(6,NODREAC(I))*SKEW(6,ISK)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 625) THEN
                     IF (NODREAC(I) /= 0) THEN
-                      WA(IJK) = FTHREAC(4,NODREAC(I))*SKEW(7,ISK)
-     .                     + FTHREAC(5,NODREAC(I))*SKEW(8,ISK)
-     .                     + FTHREAC(6,NODREAC(I))*SKEW(9,ISK)
+                      WA(IJK) = FTHREAC(4,NODREAC(I))*SKEW(7,ISK) + FTHREAC(5,NODREAC(I))*SKEW(8,ISK) + FTHREAC(6,NODREAC(I))*SKEW(9,ISK)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 626) THEN
-                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND.
-     .                  IRODDL/=0 )THEN
-                      WA(IJK) = DR(1,I)*SKEW(1,ISK)
-     .                + DR(2,I)*SKEW(2,ISK)
-     .                + DR(3,I)*SKEW(3,ISK)
+                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND. IRODDL/=0 )THEN
+                      WA(IJK) = DR(1,I)*SKEW(1,ISK) + DR(2,I)*SKEW(2,ISK) + DR(3,I)*SKEW(3,ISK)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 627) THEN
-                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND.
-     .                   IRODDL/=0 )THEN
-                      WA(IJK) = DR(1,I)*SKEW(4,ISK)
-     .                       + DR(2,I)*SKEW(5,ISK)
-     .                       + DR(3,I)*SKEW(6,ISK)
+                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND. IRODDL/=0 )THEN
+                      WA(IJK) = DR(1,I)*SKEW(4,ISK) + DR(2,I)*SKEW(5,ISK) + DR(3,I)*SKEW(6,ISK)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSEIF(K == 628) THEN
-                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND.
-     .                  IRODDL/=0 )THEN
-                      WA(IJK) = DR(1,I)*SKEW(7,ISK)
-     .                       + DR(2,I)*SKEW(8,ISK)
-     .                     + DR(3,I)*SKEW(9,ISK)
+                    IF ((IDROT == 1 .OR. ISECUT>0 .OR. IISROT>0 .OR. IMPOSE_DR>0) .AND.IRODDL/=0 )THEN
+                      WA(IJK) = DR(1,I)*SKEW(7,ISK) + DR(2,I)*SKEW(8,ISK) + DR(3,I)*SKEW(9,ISK)
+                    ELSE
+                      WA(IJK) = ZERO
+                    ENDIF
+                  ELSEIF(K == 629) THEN
+                    IF(NODA_SURF(I) > ZERO)THEN
+                      WA(IJK) = NODA_PEXT(I) / NODA_SURF(I)
                     ELSE
                       WA(IJK) = ZERO
                     ENDIF
                   ELSE
-                    WA(IJK)=0.
+                    WA(IJK)=ZERO
                   ENDIF
                 ENDDO
                 IJK=IJK+1
@@ -901,7 +810,7 @@ C workaround for possible PGI bug
                       WA(IJK) = ZERO
                     ENDIF
                   ELSE
-                    WA(IJK)=0.
+                    WA(IJK)=ZERO
                   ENDIF
                 ENDDO
                 IJK=IJK+1

--- a/starter/share/modules1/th_mod.F90
+++ b/starter/share/modules1/th_mod.F90
@@ -1,0 +1,29 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 1986-2025 Altair Engineering Inc.
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Altair Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+!Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+!Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+      module th_mod
+
+        integer :: TH_HAS_NODA_PEXT
+
+
+
+      end module th_mod

--- a/starter/source/output/th/hm_read_thgrne.F
+++ b/starter/source/output/th/hm_read_thgrne.F
@@ -225,13 +225,7 @@ C
                IF (ITHBUF(I) == 627)DIRMSG='DRY'               
                IF (ITHBUF(I) == 628)DIRMSG='DRZ'            
                CALL FRETITL2(TITR,ITHGRP(NITHGR-LTITR+1),LTITR)
-               CALL ANCMSG(MSGID=774,
-     .                     MSGTYPE=MSGWARNING,
-     .                     ANMODE=ANINFO_BLIND_1,
-     .                     I1=ITHGRP(1),
-     .                     C1=TITR,
-     .                     I2=ITHGRP(1),
-     .                     C2=DIRMSG)
+               CALL ANCMSG(MSGID=774, MSGTYPE=MSGWARNING, ANMODE=ANINFO_BLIND_1, I1=ITHGRP(1), C1=TITR, I2=ITHGRP(1), C2=DIRMSG)
          ENDIF   
          IF(ITHBUF(I) == 19 .AND. ITHERM_FE == 0 ) THEN
                CALL FRETITL2(TITR,ITHGRP(NITHGR-LTITR+1),LTITR)

--- a/starter/source/output/th/hm_read_thgrou.F
+++ b/starter/source/output/th/hm_read_thgrou.F
@@ -171,7 +171,7 @@ C-----------------------------------------------
       INTEGER IVARRIV(18,NVARRIVG)
       CHARACTER*10 VARRIV(NVARRIV),VARRIVG(NVARRIVG)
 C-----------------------------------------------
-      PARAMETER (NVARN = 637,NVARN1 = 19,NVARN1A = 600,NVARN2 = 9 ,NVARNPINCH = 9)
+      PARAMETER (NVARN1 = 19,NVARN1A = 600,NVARN2 = 10 ,NVARNPINCH = 9)
       PARAMETER (NVARS1 = 196,NVARS2 = 567,NVARS3 = 369,NVARS4 = 492,NVARS5 = 22)
       PARAMETER (NVARS6 = 97200,NVARS7 = 97200,NVARS8 = 516,NVARS9 = 6,NVARS10 = 1,NVARSNLOC = 2)
       PARAMETER (NVARS =239555 ,NVARC = 37856,NVART = 6)
@@ -182,9 +182,9 @@ C-----------------------------------------------
       PARAMETER (NVARAC = 6,NVARSE =39,NVARJO = 6)
       PARAMETER (NVARAB = 7,NVARMV4= 9,NVARMV = 19,NVARMVENT = 150)
       PARAMETER (NVARPA = 32)
-      PARAMETER (NVARF1 = 18,NVARFR = 24,NVARGAU = 8,NVARCLUS=11,NVARFLOW=1,
-     .           NVARSURF = 6,NVARSLIP=6,NVARRET=3)
-      CHARACTER*10 VARN(NVARN),VART(NVART)
+      PARAMETER (NVARF1 = 18,NVARFR = 24,NVARGAU = 8,NVARCLUS=11,NVARFLOW=1,NVARSURF = 6,NVARSLIP=6,NVARRET=3)
+      CHARACTER*10, DIMENSION(:), ALLOCATABLE :: VARN
+      CHARACTER*10 :: VART(NVART)
       CHARACTER*10 VARP(NVARP),VARR(NVARR),VARUR(NVARUR)
       CHARACTER(LEN=10),DIMENSION(:),ALLOCATABLE::VARS
       CHARACTER(LEN=10),DIMENSION(:),ALLOCATABLE::VARC
@@ -310,6 +310,11 @@ C-----------------------------------------------
 C   TH TITLES
 C   DON T MISS TO ADD TH TITLES FOR NEW TH OPTIONS 
 C-----------------------------------------------
+
+      NVARN = NVARN1 + NVARN1A + NVARN2 + NVARNPINCH
+      ALLOCATE(VARN(NVARN))
+
+
       ALLOCATE(VARN1_TITLE(NVARN1),VARN1A_TITLE(NVARN1A),VARN2_TITLE(NVARN2),VARNPINCH_TITLE(NVARNPINCH),
      .         VARP_TITLE(NVARP),VARR_TITLE(NVARR),VART_TITLE(NVART),
      .         VARS1_TITLE(NVARS1),VARS2_TITLE(NVARS2),VARS3_TITLE(NVARS3),VARS4_TITLE(NVARS4),
@@ -378,7 +383,8 @@ C   nodes
      .           'TEMP    '/
       DATA VARN2/'REACX   ','REACY   ','REACZ   ',
      .           'REACXX  ','REACYY  ','REACZZ  ',
-     .           'DRX     ','DRY     ','DRZ     '/
+     .           'DRX     ','DRY     ','DRZ     ',
+     .           'PEXT    '/
       DATA VARNPINCH/
      .          'APINCHX ','APINCHY ','APINCHZ ',
      .          'VPINCHX ','VPINCHY ','VPINCHZ ',
@@ -2206,10 +2212,10 @@ C  ---- node + displacement by ply for shell
           VARN1A((J-1)*3  + 3 )= VAR
        ENDDO
       DO I=1,NVARN2
-       VARN(619+I) = VARN2(I)
+       VARN(NVARN1+NVARN1A+I) = VARN2(I)
       ENDDO
-      DO I=1,NVARNPINCH 
-       VARN(628+I) = VARNPINCH(I)
+      DO I=1,NVARNPINCH
+       VARN(NVARN1+NVARN1A+NVARN2+I) = VARNPINCH(I)
       ENDDO
       NNOD = 0
       CHNOD = 78
@@ -3301,6 +3307,8 @@ C-------------------------------------
      .           VARSLIP_TITLE,VARRET_TITLE,
      .           VARCLUS_TITLE,VARFLOW_TITLE,
      .           VARSURF_TITLE,VARSENS_TITLE)
+
+      DEALLOCATE(VARN)
       
 
       RETURN

--- a/starter/source/output/th/hm_read_thvarc.F
+++ b/starter/source/output/th/hm_read_thvarc.F
@@ -49,6 +49,7 @@ C-----------------------------------------------
       USE SUBMODEL_MOD
       USE HM_OPTION_READ_MOD
       USE NAMES_AND_TITLES_MOD , ONLY : NCHARTITLE
+      USE TH_MOD , ONLY : TH_HAS_NODA_PEXT
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -116,7 +117,10 @@ c
 c                                                     
           IF(OK==0)THEN                                       
             DO I=1,NV                                                             
-              IF(VAR == VARE(I))THEN                                          
+              IF(VAR == VARE(I))THEN
+                IF(VAR(1:4) == 'PEXT ')THEN
+                  TH_HAS_NODA_PEXT = 1
+                ENDIF
                 TAG(I)=1                             
                 OK=1                                 
 C---------Multidomaines : pour les subsets, on stocke des infos en plus dans le th pour merge---------                      

--- a/starter/source/output/th/th_titles.F90
+++ b/starter/source/output/th/th_titles.F90
@@ -208,7 +208,8 @@
             'ZZ REACTION IMPULSE ON NODE',&
             'X-ROT DISPLACEMENT',&
             'Y-ROT DISPLACEMENT',&
-            'Z-ROT DISPLACEMENT'/)
+            'Z-ROT DISPLACEMENT',&
+            'EXTERNAL PRESSURE (MEAN)'/)
 
           varnpinch_title = (/&
             character(len=100) ::&

--- a/starter/source/restart/ddsplit/wrcommp.F
+++ b/starter/source/restart/ddsplit/wrcommp.F
@@ -90,6 +90,7 @@ C-----------------------------------------------
       USE UNITAB_MOD
       use glob_therm_mod
       USE PBLAST_MOD
+      USE TH_MOD , ONLY : TH_HAS_NODA_PEXT
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -213,7 +214,7 @@ C-----
       TABVINT(23) =NSPMD
       TABVINT(24) =LENWA_L
       TABVINT(25) =ISGIFL
-      TABVINT(26) = 0 !no longer used
+      TABVINT(26) = TH_HAS_NODA_PEXT
       TABVINT(27) =NNODS
       TABVINT(28) =NCNOIS
       TABVINT(29) =LCNE_L

--- a/starter/source/starter/starter0.F
+++ b/starter/source/starter/starter0.F
@@ -98,6 +98,7 @@ C-----------------------------------------------
       USE PBLAST_MOD
       use checksum_starter_option_mod
       use checksum_check_mod
+      use th_mod , only : TH_HAS_NODA_PEXT
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -196,8 +197,7 @@ c      TYPE(SENSORS_) :: SENSORS    ! declared as global in USER_SENSOR_MOD
 C-----------------------------------------------
 C   E x t e r n a l   F u n c t i o n s
 C-----------------------------------------------
-      INTEGER  ANEND
-      EXTERNAL ANEND
+      INTEGER,EXTERNAL ::  ANEND
 C--------------------------------------------------------
 C     LAM MAX LENGTH REAL ARRAY
 C     LMA MAX LENGTH INTEGER ARRAY
@@ -336,6 +336,8 @@ C MUSCL compression coefficient, default value set to 1.
       RADIOSSV = 100090402
       IFLEXPIPE = 1
       LEN = ncharfield*2
+C
+      TH_HAS_NODA_PEXT = 0
 C
 C No Decay for Starter
       TAGLEN      = 0


### PR DESCRIPTION
#### /TH/NODE (PEXT) : nodal averaged external pressure

#### Description of the changes
External pressure (e.g., blast loading from the /LOAD/PBLAST option) can now be post-processed using the /TH/NODE option with the label PEXT.

```
#---1----|----2----|----3----|----4----|----5----|----6----|----7----|----8----|----9----|---10----|
/TH/NODE/3
MY_PEXT_TIME_HISTORY
#LABEL1
PEXT
#node list          title
         1          pext_at_node_id1
         2          pext_at_node_id2
         3          pext_at_node_id3
         4          pext_at_node_id4
         5          pext_at_node_id5                                   
#---1----|----2----|----3----|----4----|----5----|----6----|----7----|----8----|----9----|---10----|
```
Expected result with 2 element and a single load
![image](https://github.com/user-attachments/assets/fa4c23aa-21ca-4aaf-9cbf-0ae951a18a0b)

General case (superposition of load case. Several blast loading may occur)
![image](https://github.com/user-attachments/assets/32c6c788-790f-45ad-bd10-87ff6222e383)

Verification Test : 
![image](https://github.com/user-attachments/assets/59659cbb-dabb-4151-82a3-b0b60c314602)
[Test-Case.zip](https://github.com/user-attachments/files/21115046/Test-Case.zip)


