### PR TITLE
Enable preCICE coupling by using -preCICE at compile time

### DIFF
--- a/common_source/modules/nodal_arrays.F90
+++ b/common_source/modules/nodal_arrays.F90
@@ -115,6 +115,7 @@
             my_real, dimension(:), allocatable :: VISCN !< nodal 
             my_real, dimension(:), allocatable :: MCP !< thermal
             my_real, dimension(:), allocatable :: TEMP !< temperature
+            my_real, dimension(:,:), allocatable :: FORCES
           
             ! 3*NUMNOD if IRESP == 1, else 3
             double precision, dimension(:,:), allocatable :: DDP !< double precision D 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -221,6 +221,7 @@ message (STATUS "Flags release: ${CMAKE_Fortran_FLAGS_RELEASE} ")
 message (STATUS "Precision: ${precision} ")
 message (STATUS "Runtime Static link : ${static_link} ")
 message (STATUS "debug: ${debug} ")
+message (STATUS "PreCICE coupling: ${precice} ")
 if ( DEFINED ADF )
    message (STATUS "Addflag : ${ADF} ")
 endif()
@@ -302,7 +303,10 @@ if (NOT CMAKE_BUILD_TYPE)
       FORCE)
 endif (NOT CMAKE_BUILD_TYPE)
 
-
+if(precice STREQUAL "1")
+  message(STATUS "Coupling with preCICE")
+  find_package(precice REQUIRED CONFIG)
+endif()
 
 
 add_executable (${EXEC_NAME} ${source_files} ${source_files_common} ${c_source_files} ${cpp_source_files} ${Build_includes_directory}/engine_message_description.inc ${Build_includes_directory}/__foo.inc )
@@ -316,7 +320,14 @@ add_custom_command(TARGET ${EXEC_NAME}
                   )
 
 target_include_directories(${EXEC_NAME} PRIVATE ${include_dir_list}  )
-target_link_libraries(${EXEC_NAME} ${LINK} )
+
+if(precice STREQUAL "1")
+  message(STATUS "Linking with preCICE libraries")
+  target_link_libraries(${EXEC_NAME} PRIVATE precice::precice ${LINK} )
+else()
+  target_link_libraries(${EXEC_NAME} ${LINK} )
+endif()
+
 
 # Fortran to link
 set_property(TARGET ${EXEC_NAME} PROPERTY LINKER_LANGUAGE Fortran)

--- a/engine/CMake_Compilers/cmake_linux64_gf.txt
+++ b/engine/CMake_Compilers/cmake_linux64_gf.txt
@@ -167,6 +167,13 @@ set( FSANITIZE "-fsanitize=address -fsanitize=undefined  -fsanitize=bounds-stric
 endif()
 
 set(opt_flag "${opt_flag} ${mumps_flag} ${mumps_inc}")
+
+if( precice STREQUAL "1")
+set(opt_flag "${opt_flag} -DWITH_PRECICE ")
+set(coupling " -DWITH_PRECICE -I/usr/include/precice/")
+else()
+endif()
+
 #set( strict "-fallow-argument-mismatch -Waliasing -Wunused-dummy-argument -Werror=unused-dummy-argument -Wdo-subscript -Warray-bounds -Wtabs -Werror=tabs -pedantic-errors -Wsurprising -Wuse-without-only -Werror=use-without-only") 
 set( strict " -Werror=aliasing  -Werror=unused-dummy-argument  -Werror=do-subscript -Werror=array-bounds -Werror=tabs -Werror=surprising ")
 set( strict_wo_mpi " -Werror=aliasing ${unused_dummy_arg} -Werror=do-subscript -Werror=array-bounds -Werror=tabs -Werror=surprising ") 
@@ -185,7 +192,7 @@ set_source_files_properties(${source_files}  PROPERTIES COMPILE_FLAGS "${FSANITI
 set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${h3d_inc} ${zlib_inc} ${md5_inc} ${precision_flag}  ${cppmach} ${cpprel} -O0 -g  ${OPENMP} " )
 
 # CXX source files
-set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${h3d_inc} ${zlib_inc} ${md5_inc} ${precision_flag} ${cppmach} ${cpprel}  -O0 -g ${OPENMP} -std=c++11  " )
+set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${h3d_inc} ${zlib_inc} ${md5_inc} ${precision_flag} ${cppmach} ${cpprel}  -O0 -g ${OPENMP} -std=c++14 ${coupling} " )
 
 elseif ( debug STREQUAL "analysis" )
 # Fortran
@@ -200,7 +207,7 @@ set_source_files_properties(${source_files}  PROPERTIES COMPILE_FLAGS " -fplugin
 set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS " ${FSANITIZE} ${h3d_inc} ${zlib_inc} ${md5_inc} ${precision_flag}  ${cppmach} ${cpprel} -O0 -g  ${OPENMP} " )
 
 # CXX source files
-set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${h3d_inc} ${zlib_inc} ${md5_inc} ${precision_flag} ${cppmach} ${cpprel}  -O0 -g ${OPENMP} -std=c++11  " )
+set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${h3d_inc} ${zlib_inc} ${md5_inc} ${precision_flag} ${cppmach} ${cpprel}  -O0 -g ${OPENMP} ${coupling} -std=c++14  " )
 
 
 elseif ( debug STREQUAL "asan" )
@@ -218,8 +225,7 @@ set_source_files_properties(${source_files}  PROPERTIES COMPILE_FLAGS "${FSANITI
 set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${h3d_inc} ${precision_flag}  ${cppmach} ${cpprel} -O0 -g  ${OPENMP}  ${zlib_inc} ${md5_inc}" )
 
 # CXX source files
-set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${h3d_inc} ${precision_flag} ${cppmach} ${cpprel}  -O0 -g ${OPENMP}  ${zlib_inc} ${md5_inc} -std=c++11" )
-
+set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${h3d_inc} ${precision_flag} ${cppmach} ${cpprel}  -O0 -g ${OPENMP}  ${zlib_inc} ${md5_inc} ${coupling} -std=c++14" )
 
 else ()
 
@@ -235,7 +241,7 @@ set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS " -nostdi
 set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS " -w -O2 ${h3d_inc} ${zlib_inc} ${md5_inc} ${opt_flag} ${precision_flag} ${cppmach} ${cpprel} " )
 
 # CXX source files
-set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "-w -O2 ${h3d_inc} ${zlib_inc} ${md5_inc} ${opt_flag} ${precision_flag} ${cppmach} ${cpprel} -std=c++11  " )
+set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "-w -O2 ${h3d_inc} ${zlib_inc} ${md5_inc} ${opt_flag} ${precision_flag} ${cppmach} ${cpprel} ${coupling} -std=c++14 ${coupling}  " )
 
 endif()
 

--- a/engine/build_script.sh
+++ b/engine/build_script.sh
@@ -58,6 +58,7 @@ function my_help()
   echo "    Linux64 Intel compilers"
   echo "      download MUMPS_5.5.1 at http://ftp.mcs.anl.gov/pub/petsc/externalpackages/MUMPS_5.5.1.tar.gz"
   echo "      and uncompress it in extlib directory such that engine/extlib/MUMPS_5.5.1 exists"
+  echo " -preCICE : enable preCICE coupling"
   echo " "
   echo " -no-python : do not link with python"
   echo " " 
@@ -98,6 +99,8 @@ eng_vers="engine"
 mumps_root=""
 scalapack_root=""
 lapack_root=""
+precice="0"
+precice_exe=""
 com=0
 release=0
 ad=none
@@ -191,6 +194,12 @@ else
         scalapack_root="-Dscalapack_root=${scalapack_root}"
        fi
 
+       if [ "$arg" == "-preCICE" ]
+       then
+        precice="1"
+        precice_exe="_precice"
+       fi
+
        if [ "$arg" == "-addflag" ]
        then
          ad=`echo $var|awk -F '-addflag=' '{ print $2}'`
@@ -277,7 +286,7 @@ else
      ddebug=""
    fi 
 
-engine_exec=${eng_vers}_${arch}${dmpi}${suffix}${ddebug}
+engine_exec=${eng_vers}_${arch}${dmpi}${suffix}${precice_exe}${ddebug}
 build_directory=cbuild_${engine_exec}${cf}
 
 
@@ -386,7 +395,7 @@ then
   CXX_path_w=`cygpath.exe -m "${CXX_path}"`
   cmake.exe .. -G "Unix Makefiles" -Darch=${arch} -Dprecision=${prec} ${MPI} -Ddebug=${debug} -DEXEC_NAME=${engine_exec} -Dstatic_link=$static_link -Dmpi_os=${mpi_os} ${mpi_root} ${mpi_libdir} ${mpi_incdir} ${dc} ${mumps_root} ${scalapack_root} ${lapack_root} -DCMAKE_BUILD_TYPE=Release -Dno_python=${no_python}  -Dstatic_link=$static_link -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_COMPILER="${Fortran_path_w}" -DCMAKE_C_COMPILER="${C_path_w}" -DCMAKE_CPP_COMPILER="${CPP_path_w}" -DCMAKE_CXX_COMPILER="${CXX_path_w}" ${la}
 else
-  cmake .. -Darch=${arch} -Dprecision=${prec} ${MPI} -Ddebug=${debug} -DEXEC_NAME=${engine_exec} -Dstatic_link=$static_link -Dmpi_os=${mpi_os} -Dsanitize=${sanitize} ${mpi_root} ${mpi_libdir} ${mpi_incdir} ${dc} ${mumps_root} ${scalapack_root} ${lapack_root} -Dno_python=${no_python} -Dstatic_link=$static_link -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_COMPILER=${Fortran_path} -DCMAKE_C_COMPILER=${C_path} -DCMAKE_CPP_COMPILER=${CPP_path} -DCMAKE_CXX_COMPILER=${CXX_path}  ${la}
+  cmake .. -Darch=${arch} -Dprecision=${prec} ${MPI} -Ddebug=${debug} -DEXEC_NAME=${engine_exec} -Dstatic_link=$static_link -Dmpi_os=${mpi_os} -Dsanitize=${sanitize} ${mpi_root} ${mpi_libdir} ${mpi_incdir} ${dc} ${mumps_root} ${scalapack_root} ${lapack_root} -Dno_python=${no_python} -Dstatic_link=$static_link -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_COMPILER=${Fortran_path} -DCMAKE_C_COMPILER=${C_path} -DCMAKE_CPP_COMPILER=${CPP_path} -DCMAKE_CXX_COMPILER=${CXX_path}  ${la} -Dprecice=${precice}
 
 fi
 

--- a/engine/source/coupling/coupling.cpp
+++ b/engine/source/coupling/coupling.cpp
@@ -1,0 +1,525 @@
+#include "coupling.h"
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <algorithm>
+#include <cstring>
+
+// =============================================================================
+// Dummy Coupling Adapter Implementation (always available)
+// =============================================================================
+
+bool DummyCouplingAdapter::configure(const std::string& configFile) {
+    std::cout << "No coupling library available - coupling disabled" << std::endl;
+    return true;
+}
+
+void DummyCouplingAdapter::setNodes(const std::vector<int>& nodeIds) {
+    // Do nothing
+}
+
+bool DummyCouplingAdapter::initialize(const double* coordinates, int totalNodes, int mpiRank, int mpiSize) {
+    std::cout << "Dummy coupling adapter initialized (no actual coupling)" << std::endl;
+    return true;
+}
+
+void DummyCouplingAdapter::writeData(const double* values, int totalNodes, double dt, int dataType) {
+    // Do nothing
+}
+
+void DummyCouplingAdapter::readData(double* values, int totalNodes, double dt, int dataTypee) {
+    // Do nothing
+}
+
+void DummyCouplingAdapter::advance(double& dt) {
+    // Do nothing - dt remains unchanged
+}
+
+bool DummyCouplingAdapter::isCouplingOngoing() const {
+    return false; // No coupling, so never ongoing
+}
+
+bool DummyCouplingAdapter::requiresWritingCheckpoint() const {
+    return false;
+}
+
+bool DummyCouplingAdapter::requiresReadingCheckpoint() const {
+    return false;
+}
+
+void DummyCouplingAdapter::finalize() {
+    // Do nothing
+}
+
+bool DummyCouplingAdapter::isActive() const {
+    return false;
+}
+
+double DummyCouplingAdapter::getMaxTimeStepSize() const {
+    return 1e30; // No time step limit
+}
+
+int DummyCouplingAdapter::getNumberOfCouplingNodes() const {
+    return 0;
+}
+
+// =============================================================================
+// preCICE Coupling Adapter Implementation (only if WITH_PRECICE is defined)
+// =============================================================================
+
+#ifdef WITH_PRECICE
+
+PreciceCouplingAdapter::PreciceCouplingAdapter() 
+    : active_(false)
+    , maxTimeStepSize_(0.0)
+    , precice_(nullptr)
+{
+}
+
+PreciceCouplingAdapter::~PreciceCouplingAdapter() {
+    if (active_) {
+        finalize();
+    }
+}
+
+bool PreciceCouplingAdapter::configure(const std::string& configFile) {
+    std::ifstream file(configFile);
+    if (!file.is_open()) {
+        std::cout << "No " << configFile << " file found in the current directory" << std::endl;
+        std::cout << "preCICE will not be active" << std::endl;
+        active_ = false;
+        return false;
+    }
+    
+    
+    std::string line;
+    while (std::getline(file, line)) {
+        // Remove leading/trailing whitespace
+        line.erase(0, line.find_first_not_of(" \t"));
+        line.erase(line.find_last_not_of(" \t") + 1);
+        
+        if (line.empty() || line[0] == '#') continue;
+        
+        // Debug output
+        //std::cout << "Reading line: " << line << std::endl;
+        
+        // Split by '/' and expect format: /PRECICE/KEY/VALUE
+        std::vector<std::string> parts;
+        std::istringstream iss(line);
+        std::string part;
+        
+        while (std::getline(iss, part, '/')) {
+            if (!part.empty()) {  // Skip empty parts (from leading '/')
+                parts.push_back(part);
+            }
+        }
+        
+        // Expected format: parts[0] = "PRECICE", parts[1] = "KEY", parts[2] = "VALUE"
+        if (parts.size() >= 3 && parts[0] == "PRECICE") {
+            std::string key = parts[1];
+            std::string value = parts[2];
+            
+            // Handle cases where VALUE might contain additional path segments
+            if (parts.size() > 3) {
+                for (size_t i = 3; i < parts.size(); ++i) {
+                    value += "/" + parts[i];
+                }
+            }
+            
+            //std::cout << "Key: " << key << ", Value: " << value << std::endl;
+            
+            if (key == "PARTICIPANT_NAME") {
+                participantName_ = value;
+            } else if (key == "CONFIG_FILE") {
+                configFile_ = value;
+            } else if (key == "MESH_NAME") {
+                meshName_ = value;
+            } else if (key == "READ") {
+                DataType dataType = stringToDataType(value);
+                if(dataType == DataType::NOTHING) {
+                    std::cout << "Warning: Unknown data type '" << value << "' in read configuration." << std::endl;
+                    continue;
+                }
+                readData_[static_cast<size_t>(dataType)].isActive = true;
+                if(DataType::POSITIONS == dataType) {
+                    // Special case for positions, set mode to REPLACE
+                    readData_[static_cast<size_t>(dataType)].mode = Mode::REPLACE;
+                } else if (DataType::FORCES== dataType) {
+                    // Special case for velocities, set mode to ADD
+                    readData_[static_cast<size_t>(dataType)].mode = Mode::ADD;
+                }
+            } else if (key == "WRITE") {
+                DataType dataType = stringToDataType(value);
+                if(dataType == DataType::NOTHING) {
+                    std::cout << "Warning: Unknown data type '" << value << "' in write configuration." << std::endl;
+                    continue;
+                }
+                writeData_[static_cast<size_t>(dataType)].isActive = true;
+            } else if (key == "INTERFACE") {
+                setGroupNodeId(std::stoi(value));
+            }
+        } else {
+            std::cout << "Warning: Ignoring malformed line: " << line << std::endl;
+        }
+    }
+    
+    // Print the configuration
+    //std::cout << "Participant Name: " << participantName_ << std::endl;
+    //std::cout << "Config File: " << configFile_ << std::endl;
+    //std::cout << "Mesh Name: " << meshName_ << std::endl;   
+    
+    active_ = true;
+    return true;
+}
+
+
+void PreciceCouplingAdapter::setNodes(const std::vector<int>& nodeIds) {
+    couplingNodeIds_ = nodeIds;
+    
+    // Allocate buffers for 3D data
+    int bufferSize = couplingNodeIds_.size() * 3;
+    vertexIds_.resize(couplingNodeIds_.size());
+    // loop over readData_
+    for(size_t i = 0; i < readData_.size(); ++i) {
+        if (readData_[i].isActive) {
+            readData_[i].buffer.resize(bufferSize);
+        }
+    }
+    // loop over writeData_
+    for(size_t i = 0; i < writeData_.size(); ++i) {
+        if (writeData_[i].isActive) {
+            writeData_[i].buffer.resize(bufferSize);
+        }
+    }
+}
+
+bool PreciceCouplingAdapter::initialize(const double* coordinates, int totalNodes, int mpiRank, int mpiSize) {
+    if (!active_) return false;
+    
+    //std::cout << "participant=" << participantName_ << std::endl;
+    //std::cout << "config_file=" << configFile_ << std::endl;
+    //std::cout << "mpi_rank=" << mpiRank << " mpi_size=" << mpiSize << std::endl;
+    
+    try {
+        // Create preCICE participant
+        precice_ = std::make_unique<precice::Participant>(participantName_, configFile_, mpiRank, mpiSize);
+        
+        // Set up mesh vertices
+        std::vector<double> meshVertices;
+        meshVertices.reserve(couplingNodeIds_.size() * 3);
+        
+        for (int nodeId : couplingNodeIds_) {
+            // Convert from 1-based Fortran indexing to 0-based C++ indexing
+            int idx = nodeId - 1;
+            meshVertices.push_back(coordinates[idx * 3]);
+            meshVertices.push_back(coordinates[idx * 3 + 1]);
+            meshVertices.push_back(coordinates[idx * 3 + 2]);
+        }
+        
+        // Set mesh vertices
+        precice_->setMeshVertices(meshName_, meshVertices, vertexIds_);
+        
+        // Check if initial data is required
+        if (precice_->requiresInitialData()) {
+            //std::cout << participantName_ << " writing initial data" << std::endl;
+            for(size_t i = 0; i < writeData_.size(); ++i) {
+                if (writeData_[i].isActive) {
+                  const std::string & dataName = dataTypeToString(static_cast<DataType>(i));
+                  precice_->writeData(meshName_, dataName , vertexIds_, writeData_[i].buffer);
+                }
+            }
+        }
+        
+        // Initialize preCICE
+        precice_->initialize();
+        maxTimeStepSize_ = precice_->getMaxTimeStepSize();
+        
+        
+    } catch (const std::exception& e) {
+        std::cerr << "Error initializing preCICE: " << e.what() << std::endl;
+        return false;
+    }
+    
+    return true;
+}
+
+void PreciceCouplingAdapter::writeData(const double* values, int totalNodes, double dt, int dataType) {
+    if (!active_ ) return;
+    if (!precice_) return;
+    if(!precice_->isCouplingOngoing()) {
+        return;
+    }
+
+        // Check if the data type is active 
+    const std::string& writeDataName = dataTypeToString(static_cast<DataType>(dataType));
+    if (!writeData_[static_cast<size_t>(dataType)].isActive) {
+//       std::cout << "Data type " << writeDataName << " is not active, skipping write." << std::endl;
+        return;
+    }
+    double maxTimeStepSize = precice_->getMaxTimeStepSize();
+    //std::cout << "maxTimeStepSize=" << maxTimeStepSize << std::endl;
+    //std::cout << "dt=" << dt << std::endl;
+    //std::cout << participantName_ << " writing data " << writeDataName << std::endl;
+    // Write data to preCICE
+    // Extract data for coupling nodes
+    extractNodeData(values, totalNodes, dataType);
+    precice_->writeData(meshName_, writeDataName, vertexIds_, writeData_[dataType].buffer);
+}
+
+void PreciceCouplingAdapter::readData(double* values, int totalNodes, double dt, int dataType) {
+    if (!active_) return;
+    if (!precice_) return;
+    if(!precice_->isCouplingOngoing()) {
+        return;
+    }
+    const std::string& readDataName = dataTypeToString(static_cast<DataType>(dataType));
+    if(!readData_[static_cast<size_t>(dataType)].isActive) {
+ //       std::cout << "Data type " << readDataName << " is not active, skipping read." << std::endl;
+        return;
+    }
+   double maxTimeStepSize = precice_->getMaxTimeStepSize();
+
+    //std::cout << participantName_ << " reading data " << readDataName << std::endl;                           
+    //std::cout << "maxTimeStepSize=" << maxTimeStepSize << std::endl;
+    //std::cout << "dt=" << dt << std::endl;
+    double cdt = std::min(dt, maxTimeStepSize);
+
+
+    // Read data from preCICE
+    precice_->readData(meshName_, readDataName, vertexIds_, cdt, readData_[dataType].buffer);
+    // Inject data into global arrays
+    injectNodeData(values, totalNodes, dataType);
+}
+
+void PreciceCouplingAdapter::advance(double& dt) {
+    if (!active_) return;
+    if (!precice_) return;
+    if(!precice_->isCouplingOngoing()) {
+        return;
+    }
+    
+    double dtToUse = std::min(dt, maxTimeStepSize_);
+    // Advance preCICE
+    precice_->advance(dtToUse);
+    // Update max time step size
+    maxTimeStepSize_ = precice_->getMaxTimeStepSize();
+    //std::cout << " advance " << dt << " " << dtToUse << " " << maxTimeStepSize_ << std::endl;
+    dt = dtToUse;
+}
+
+bool PreciceCouplingAdapter::isCouplingOngoing() const {
+    if (!active_) return false;
+    
+    if (!precice_) return false;
+    return precice_->isCouplingOngoing();
+}
+
+bool PreciceCouplingAdapter::requiresWritingCheckpoint() const {
+    if (!active_) return false;
+    if (!precice_) return false;
+    return precice_->requiresWritingCheckpoint();
+}
+
+bool PreciceCouplingAdapter::requiresReadingCheckpoint() const {
+    if (!active_) return false;
+    if (!precice_) return false;
+    return precice_->requiresReadingCheckpoint();
+}
+
+void PreciceCouplingAdapter::finalize() {
+    if (!active_) return;
+    
+    if (precice_) {
+        precice_->finalize();
+        precice_.reset();
+    }
+    
+    // Clear all data structures
+    couplingNodeIds_.clear();
+    vertexIds_.clear();
+    for (auto& data : readData_) {
+        data.buffer.clear();
+        data.isActive = false;
+    }
+    for (auto& data : writeData_) {
+        data.buffer.clear();
+        data.isActive = false;
+    }
+    
+    active_ = false;
+}
+
+bool PreciceCouplingAdapter::isActive() const {
+    return active_;
+}
+
+double PreciceCouplingAdapter::getMaxTimeStepSize() const {
+    return maxTimeStepSize_;
+}
+
+int PreciceCouplingAdapter::getNumberOfCouplingNodes() const {
+    return couplingNodeIds_.size();
+}
+
+
+void PreciceCouplingAdapter::extractNodeData(const double* globalValues, int totalNodes, int dataType) {
+   if(!writeData_[dataType].isActive) {
+        //std::cout << "Data type " << dataTypeToString(static_cast<DataType>(dataType))
+        //          << " is not active, skipping extraction." << std::endl;
+        return;
+    }
+    for (size_t i = 0; i < couplingNodeIds_.size(); ++i) {
+        int nodeId = couplingNodeIds_[i] - 1; // Convert to 0-based indexing
+         writeData_[dataType].buffer[i * 3] = globalValues[nodeId * 3];
+         writeData_[dataType].buffer[i * 3 + 1] = globalValues[nodeId * 3 + 1];
+         writeData_[dataType].buffer[i * 3 + 2] = globalValues[nodeId * 3 + 2];
+    }
+}
+
+void PreciceCouplingAdapter::injectNodeData(double *globalValues, int totalNodes, int dataType)
+{
+    if (!readData_[dataType].isActive)
+    {
+        //std::cout << "Data type " << dataTypeToString(static_cast<DataType>(dataType))
+        //          << " is not active, skipping injection." << std::endl;
+        return;
+    }
+    //std::cout<<"Injection mode for data type " << dataTypeToString(static_cast<DataType>(dataType))
+    //         << " is " << static_cast<size_t>(readData_[dataType].mode)<<std::endl;
+    if (readData_[dataType].mode == Mode::ADD)
+    {
+        for (size_t i = 0; i < couplingNodeIds_.size(); ++i)
+        {
+            int nodeId = couplingNodeIds_[i] - 1; // Convert to 0-based indexing
+            globalValues[nodeId * 3] += readData_[dataType].buffer[i * 3];
+            globalValues[nodeId * 3 + 1] += readData_[dataType].buffer[i * 3 + 1];
+            globalValues[nodeId * 3 + 2] += readData_[dataType].buffer[i * 3 + 2];
+        }
+    }
+    else if (readData_[dataType].mode == Mode::REPLACE)
+    {
+        // Replacement mode
+        //std::cout << "coupling nodes=" << couplingNodeIds_.size() << std::endl;
+        for (size_t i = 0; i < couplingNodeIds_.size(); ++i)
+        {
+            int nodeId = couplingNodeIds_[i] - 1; // Convert to 0-based indexing
+            globalValues[nodeId * 3] = readData_[dataType].buffer[i * 3];
+            globalValues[nodeId * 3 + 1] = readData_[dataType].buffer[i * 3 + 1];
+            globalValues[nodeId * 3 + 2] = readData_[dataType].buffer[i * 3 + 2];
+            //if(i==0 && dataType == static_cast<int>(DataType::POSITIONS)) {
+            //    std::cout << "Replacing data for node " << couplingNodeIds_[i] 
+            //              << " with values: (" 
+            //              << readData_[dataType].buffer[i * 3] << ", "
+            //              << readData_[dataType].buffer[i * 3 + 1] << ", "
+            //              << readData_[dataType].buffer[i * 3 + 2] << ")" << std::endl;
+            //}
+        }
+    }
+    else
+    {
+          std::cout << "Warning: Unknown mode for data type " << dataTypeToString(static_cast<DataType>(dataType))
+                    << ", skipping injection." << std::endl;
+    }
+}
+
+#endif // WITH_PRECICE
+
+// =============================================================================
+// Factory Function
+// =============================================================================
+
+CouplingAdapter* createCouplingAdapter() {
+#ifdef WITH_PRECICE
+    return new PreciceCouplingAdapter();
+#else
+    return new DummyCouplingAdapter();
+#endif
+}
+
+// =============================================================================
+// C Interface Implementation
+// =============================================================================
+
+extern "C" {
+    void* coupling_adapter_create() {
+        return createCouplingAdapter();
+    }
+    
+    void coupling_adapter_destroy(void* adapter) {
+        delete static_cast<CouplingAdapter*>(adapter);
+    }
+    
+    int coupling_adapter_configure(void* adapter, const char* filename) {
+        CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
+        return ca->configure(std::string(filename)) ? 1 : 0;
+    }
+    
+    void coupling_adapter_set_nodes(void* adapter, const int* nodeIds, int numNodes) {
+        CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
+        std::vector<int> nodes(nodeIds, nodeIds + numNodes);
+        ca->setNodes(nodes);
+    }
+    
+    int coupling_adapter_initialize(void* adapter, const double* coordinates, 
+                                   int totalNodes, int mpiRank, int mpiSize) {
+        CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
+        return ca->initialize(coordinates, totalNodes, mpiRank, mpiSize) ? 1 : 0;
+    }
+    
+    void coupling_adapter_write_data(void* adapter, const double* values, 
+                                    int totalNodes, double dt, int dataType) {
+        CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
+        ca->writeData(values, totalNodes, dt, dataType);
+    }
+    
+    void coupling_adapter_read_data(void* adapter, double* values, 
+                                   int totalNodes, double dt, int dataType) {
+        CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
+        ca->readData(values, totalNodes, dt, dataType);
+    }
+    
+    void coupling_adapter_advance(void* adapter, double* dt) {
+        CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
+        ca->advance(*dt);
+    }
+    
+    int coupling_adapter_is_coupling_ongoing(void* adapter) {
+        CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
+        return ca->isCouplingOngoing() ? 1 : 0;
+    }
+    
+    int coupling_adapter_requires_writing_checkpoint(void* adapter) {
+        CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
+        return ca->requiresWritingCheckpoint() ? 1 : 0;
+    }
+    
+    int coupling_adapter_requires_reading_checkpoint(void* adapter) {
+        CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
+        return ca->requiresReadingCheckpoint() ? 1 : 0;
+    }
+    
+    void coupling_adapter_finalize(void* adapter) {
+        CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
+        ca->finalize();
+    }
+    
+    int coupling_adapter_is_active(void* adapter) {
+        CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
+        return ca->isActive() ? 1 : 0;
+    }
+    
+    double coupling_adapter_get_max_time_step_size(void* adapter) {
+        CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
+        return ca->getMaxTimeStepSize();
+    }
+    
+    int coupling_adapter_get_num_coupling_nodes(void* adapter) {
+        CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
+        return ca->getNumberOfCouplingNodes();
+    }
+
+    int coupling_adapter_get_group_node_id(void* adapter) {
+        CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
+        return ca->getGroupNodeId();
+    }
+}

--- a/engine/source/coupling/coupling.h
+++ b/engine/source/coupling/coupling.h
@@ -1,0 +1,200 @@
+#ifndef ADAPTER_H
+#define ADAPTER_H
+#include <string>
+#include <vector>
+#include <memory>
+#include <array>
+
+// Abstract base class for coupling adapters
+class CouplingAdapter {
+private:
+    int groupNodeId_; // the group node ID for this adapter. 
+    int surfaceId_; // the surface ID for this adapter, not used yet
+
+public:
+    virtual ~CouplingAdapter() = default;
+    
+    // Configuration
+    virtual bool configure(const std::string& configFile) = 0;
+    virtual void setNodes(const std::vector<int>& nodeIds) = 0;
+    
+    // Initialization
+    virtual bool initialize(const double* coordinates, int totalNodes, int mpiRank, int mpiSize) = 0;
+    
+    // Data exchange
+    virtual void writeData(const double* values, int totalNodes, double dt, int dataType) = 0;
+    virtual void readData(double* values, int totalNodes, double dt, int dataType) = 0;
+    
+    // Simulation control
+    virtual void advance(double& dt) = 0;
+    virtual bool isCouplingOngoing() const = 0;
+    virtual bool requiresWritingCheckpoint() const = 0;
+    virtual bool requiresReadingCheckpoint() const = 0;
+    
+    // Finalization
+    virtual void finalize() = 0;
+    
+    // Getters
+    virtual bool isActive() const = 0;
+    virtual double getMaxTimeStepSize() const = 0;
+    virtual int getNumberOfCouplingNodes() const = 0;
+    int getGroupNodeId() const {
+        return groupNodeId_;
+    }
+    void setGroupNodeId(int id) {
+        groupNodeId_ = id;
+    }
+
+    // data that can be exchanged during the coupling process, can be extended                                                   
+    enum class DataType {
+         NOTHING = 0,
+         DISPLACEMENTS = 1,
+         FORCES = 2,
+         POSITIONS = 3,
+         DATA_COUNT = 4 // Total number of data types
+    };
+    // What to do with the recieved data:
+    enum class Mode {
+         SKIP = 0,
+         REPLACE = 1, // For positions, replace the existing data
+         ADD = 2 // For forces, we add to the existing data
+     };
+
+     // helpper functions to convert between strings and DataType enums
+    static DataType stringToDataType(const std::string& str) {
+        // Order by most common usage for better branch prediction
+        if (str == "DISPLACEMENTS") return DataType::DISPLACEMENTS;
+        if (str == "FORCES") return DataType::FORCES;
+        if (str == "POSITIONS") return DataType::POSITIONS;
+        return DataType::NOTHING;
+    }
+    static std::string dataTypeToString(DataType type) {
+        switch (type) {
+            case DataType::DISPLACEMENTS: return "DISPLACEMENTS";
+            case DataType::FORCES: return "FORCES";
+            case DataType::POSITIONS: return "POSITIONS";
+            case DataType::NOTHING: return "NOTHING";
+            case DataType::DATA_COUNT: break; // Don't convert this
+        }
+        return "NOTHING";
+    }
+    
+
+};
+
+// Dummy adapter for when no coupling library is available
+class DummyCouplingAdapter : public CouplingAdapter {
+public:
+    bool configure(const std::string& configFile) override;
+    void setNodes(const std::vector<int>& nodeIds) override;
+    bool initialize(const double* coordinates, int totalNodes, int mpiRank, int mpiSize) override;
+    void writeData(const double* values, int totalNodes, double dt, int dataType) override;
+    void readData(double* values, int totalNodes, double dt, int dataType) override;
+    void advance(double& dt) override;
+    bool isCouplingOngoing() const override;
+    bool requiresWritingCheckpoint() const override;
+    bool requiresReadingCheckpoint() const override;
+    void finalize() override;
+    bool isActive() const override;
+    double getMaxTimeStepSize() const override;
+    int getNumberOfCouplingNodes() const override;
+};
+
+// =========================================================
+// preCICE coupling adapter
+// =========================================================
+#ifdef WITH_PRECICE
+#include "precice/precice.hpp"
+
+// preCICE implementation of coupling adapter
+class PreciceCouplingAdapter : public CouplingAdapter {
+public:
+    PreciceCouplingAdapter();
+    ~PreciceCouplingAdapter() override;
+    
+    // Implement abstract interface
+    bool configure(const std::string& configFile) override;
+    void setNodes(const std::vector<int>& nodeIds) override;
+    bool initialize(const double* coordinates, int totalNodes, int mpiRank, int mpiSize) override;
+    void writeData(const double* values, int totalNodes, double dt, int dataType) override;
+    void readData(double* values, int totalNodes, double dt, int dataType) override;
+    void advance(double& dt) override;
+    bool isCouplingOngoing() const override;
+    bool requiresWritingCheckpoint() const override;
+    bool requiresReadingCheckpoint() const override;
+    void finalize() override;
+    bool isActive() const override;
+    double getMaxTimeStepSize() const override;
+    int getNumberOfCouplingNodes() const override;
+
+    struct CouplingData {
+      bool isActive = false; // Whether this data type is active
+      Mode mode = Mode::SKIP; // Mode for this data type
+      std::vector<double> buffer;
+    };
+
+private:
+    // Configuration data
+    bool active_;
+    std::string participantName_;
+    std::string configFile_;
+    std::string meshName_;
+
+    std::array<CouplingData, static_cast<size_t>(DataType::DATA_COUNT)> readData_; // Store coupling data for different types
+    std::array<CouplingData, static_cast<size_t>(DataType::DATA_COUNT)> writeData_; // Store coupling data for different types
+    // Coupling data
+    std::vector<int> couplingNodeIds_;  // Radioss node IDs
+    std::vector<int> vertexIds_;        // preCICE vertex IDs
+    double maxTimeStepSize_;
+    std::unique_ptr<precice::Participant> precice_;
+    // Helper functions
+    void extractNodeData(const double* globalValues, int totalNodes, int dataType);
+    void injectNodeData(double* globalValues, int totalNodes, int dataType);
+
+};
+
+#endif // WITH_PRECICE
+
+// Factory function to create the appropriate adapter
+CouplingAdapter* createCouplingAdapter();
+
+
+// C interface for Fortran binding
+// Should be kept generic enough to work with any coupling adapter (CWIPI, preCICE, etc.)
+extern "C" {
+    // Object management
+    void* coupling_adapter_create();
+    void coupling_adapter_destroy(void* adapter);
+    
+    // Configuration
+    int coupling_adapter_configure(void* adapter, const char* filename);
+    void coupling_adapter_set_nodes(void* adapter, const int* nodeIds, int numNodes);
+    
+    // Initialization
+    int coupling_adapter_initialize(void* adapter, const double* coordinates, 
+                                   int totalNodes, int mpiRank, int mpiSize);
+    
+    // Data exchange
+    void coupling_adapter_write_data(void* adapter, const double* values, 
+                                    int totalNodes, double dt, int dataType);
+    void coupling_adapter_read_data(void* adapter, double* values, 
+                                   int totalNodes, double dt, int dataType);
+    
+    // Simulation control
+    void coupling_adapter_advance(void* adapter, double* dt);
+    int coupling_adapter_is_coupling_ongoing(void* adapter);
+    int coupling_adapter_requires_writing_checkpoint(void* adapter);
+    int coupling_adapter_requires_reading_checkpoint(void* adapter);
+    
+    // Finalization
+    void coupling_adapter_finalize(void* adapter);
+    
+    // Getters
+    int coupling_adapter_is_active(void* adapter);
+    double coupling_adapter_get_max_time_step_size(void* adapter);
+    int coupling_adapter_get_num_coupling_nodes(void* adapter);
+
+    int coupling_adapter_get_group_node_id(void* adapter);
+}
+
+#endif

--- a/engine/source/coupling/coupling_adapter.F90
+++ b/engine/source/coupling/coupling_adapter.F90
@@ -1,0 +1,540 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 1986-2025 Altair Engineering Inc.
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Altair Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+!Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+!Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+      module coupling_adapter_mod
+        use iso_c_binding
+        implicit none
+
+        ! Data type constants
+        integer, parameter :: coupling_displacements = 1
+        integer, parameter :: coupling_forces = 2
+        integer, parameter :: coupling_positions = 3
+
+        ! Operation modes
+        integer, parameter :: coupling_replace = 1
+        integer, parameter :: coupling_add = 2
+
+        integer, parameter :: COUPLING_PRECICE = 1
+        integer, parameter :: COUPLING_CWIPI = 2
+
+        ! Generic coupling adapter type
+        type :: coupling_type
+          type(c_ptr) :: adapter_ptr = c_null_ptr
+          logical :: active = .false.
+          integer :: nb_coupling_nodes = 0
+          double precision :: dt_limit = 0.0d0
+          integer :: grnod_id = 0
+          integer :: coupler
+        end type coupling_type
+
+        ! C interface declarations
+        interface
+          function coupling_adapter_create() bind(c, name='coupling_adapter_create')
+            use iso_c_binding
+            type(c_ptr) :: coupling_adapter_create
+          end function coupling_adapter_create
+          subroutine coupling_adapter_destroy(adapter) bind(c, name='coupling_adapter_destroy')
+            use iso_c_binding
+            type(c_ptr), value :: adapter
+          end subroutine coupling_adapter_destroy
+          function coupling_adapter_configure(adapter, filename) bind(c, name='coupling_adapter_configure')
+            use iso_c_binding
+            type(c_ptr), value :: adapter
+            character(kind=c_char), intent(in) :: filename(*)
+            integer(c_int) :: coupling_adapter_configure
+          end function coupling_adapter_configure
+          subroutine coupling_adapter_set_nodes(adapter, node_ids, num_nodes) bind(c, name='coupling_adapter_set_nodes')
+            use iso_c_binding
+            type(c_ptr), value :: adapter
+            integer(c_int), intent(in) :: node_ids(*)
+            integer(c_int), value :: num_nodes
+          end subroutine coupling_adapter_set_nodes
+          function coupling_adapter_initialize(adapter, coordinates, total_nodes, mpi_rank, mpi_size) &
+            bind(c, name='coupling_adapter_initialize')
+            use iso_c_binding
+            type(c_ptr), value :: adapter
+            real(c_double), intent(in) :: coordinates(*)
+            integer(c_int), value :: total_nodes, mpi_rank, mpi_size
+            integer(c_int) :: coupling_adapter_initialize
+          end function coupling_adapter_initialize
+          subroutine coupling_adapter_write_data(adapter, values, total_nodes, dt, data_type) &
+            bind(c, name='coupling_adapter_write_data')
+            use iso_c_binding
+            type(c_ptr), value :: adapter
+            real(c_double), intent(in) :: values(*)
+            integer(c_int), value :: total_nodes, data_type
+            real(c_double), value :: dt
+          end subroutine coupling_adapter_write_data
+          subroutine coupling_adapter_read_data(adapter, values, total_nodes, dt, data_type, mode) &
+            bind(c, name='coupling_adapter_read_data')
+            use iso_c_binding
+            type(c_ptr), value :: adapter
+            real(c_double), intent(inout) :: values(*)
+            integer(c_int), value :: total_nodes, data_type, mode
+            real(c_double), value :: dt
+          end subroutine coupling_adapter_read_data
+
+          subroutine coupling_adapter_advance(adapter, dt) bind(c, name='coupling_adapter_advance')
+            use iso_c_binding
+            type(c_ptr), value :: adapter
+            real(c_double), intent(inout) :: dt
+          end subroutine coupling_adapter_advance
+          function coupling_adapter_is_coupling_ongoing(adapter) bind(c, name='coupling_adapter_is_coupling_ongoing')
+            use iso_c_binding
+            type(c_ptr), value :: adapter
+            integer(c_int) :: coupling_adapter_is_coupling_ongoing
+          end function coupling_adapter_is_coupling_ongoing
+          function coupling_adapter_requires_writing_checkpoint(adapter) &
+            bind(c, name='coupling_adapter_requires_writing_checkpoint')
+            use iso_c_binding
+            type(c_ptr), value :: adapter
+            integer(c_int) :: coupling_adapter_requires_writing_checkpoint
+          end function coupling_adapter_requires_writing_checkpoint
+          function coupling_adapter_requires_reading_checkpoint(adapter) &
+            bind(c, name='coupling_adapter_requires_reading_checkpoint')
+            use iso_c_binding
+            type(c_ptr), value :: adapter
+            integer(c_int) :: coupling_adapter_requires_reading_checkpoint
+          end function coupling_adapter_requires_reading_checkpoint
+          subroutine coupling_adapter_finalize(adapter) bind(c, name='coupling_adapter_finalize')
+            use iso_c_binding
+            type(c_ptr), value :: adapter
+          end subroutine coupling_adapter_finalize
+          function coupling_adapter_is_active(adapter) bind(c, name='coupling_adapter_is_active')
+            use iso_c_binding
+            type(c_ptr), value :: adapter
+            integer(c_int) :: coupling_adapter_is_active
+          end function coupling_adapter_is_active
+          function coupling_adapter_get_max_time_step_size(adapter) &
+            bind(c, name='coupling_adapter_get_max_time_step_size')
+            use iso_c_binding
+            type(c_ptr), value :: adapter
+            real(c_double) :: coupling_adapter_get_max_time_step_size
+          end function coupling_adapter_get_max_time_step_size
+
+          function coupling_adapter_get_num_coupling_nodes(adapter) &
+            bind(c, name='coupling_adapter_get_num_coupling_nodes')
+            use iso_c_binding
+            type(c_ptr), value :: adapter
+            integer(c_int) :: coupling_adapter_get_num_coupling_nodes
+          end function coupling_adapter_get_num_coupling_nodes
+          !    int coupling_adapter_get_group_node_id(void* adapter);
+          function coupling_adapter_get_group_node_id(adapter) &
+            bind(c, name='coupling_adapter_get_group_node_id')
+            use iso_c_binding
+            type(c_ptr), value :: adapter
+            integer(c_int) :: coupling_adapter_get_group_node_id
+          end function coupling_adapter_get_group_node_id
+
+        end interface
+
+      contains
+
+        ! Initialize coupling adapter
+        subroutine coupling_create(coupling)
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          type(coupling_type), intent(inout) :: coupling
+!-----------------------------------------------------------------------------------------------------------------------
+!                                                   Body
+!-----------------------------------------------------------------------------------------------------------------------
+          coupling%adapter_ptr = coupling_adapter_create()
+          if (c_associated(coupling%adapter_ptr)) then
+            coupling%active = .true.
+          else
+            coupling%active = .false.
+          end if
+        end subroutine coupling_create
+
+        ! Read configuration file *.cpl
+        subroutine coupling_configure(coupling, input_filename)
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          type(coupling_type), intent(inout) :: coupling
+          character(*), intent(in) :: input_filename
+!-----------------------------------------------------------------------------------------------------------------------
+!                                                   Local variables
+!-----------------------------------------------------------------------------------------------------------------------
+          character(kind=c_char) :: c_filename(len_trim(input_filename) + 1)
+          integer :: i, result
+          call coupling_create(coupling)
+          if (.not. c_associated(coupling%adapter_ptr)) return
+
+          ! Convert Fortran string to C string
+          do i = 1, len_trim(input_filename)
+            c_filename(i) = input_filename(i:i)
+          end do
+          c_filename(len_trim(input_filename) + 1) = c_null_char
+
+          result = coupling_adapter_configure(coupling%adapter_ptr, c_filename)
+          coupling%active = (result == 1)
+        end subroutine coupling_configure
+
+        ! Set coupling nodes
+        subroutine coupling_set_nodes(coupling, igrnod, ngrnod)
+          use GROUPDEF_MOD
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          type(coupling_type), intent(inout) :: coupling
+          integer, intent(in) :: ngrnod
+          type(GROUP_), intent(in) :: igrnod(ngrnod)
+!-----------------------------------------------------------------------------------------------------------------------
+!                                                   Local variables
+!-----------------------------------------------------------------------------------------------------------------------
+          integer :: i, j
+!------------------------------------------------------------------------------------------------------------------------
+!                                                   Body
+!------------------------------------------------------------------------------------------------------------------------
+          if (.not. c_associated(coupling%adapter_ptr)) return
+          coupling%grnod_id = coupling_adapter_get_group_node_id(coupling%adapter_ptr)
+          ! Find the group with matching ID
+          j = 0
+          do i = 1, ngrnod
+            if (igrnod(i)%id == coupling%grnod_id) then
+              j = i
+              exit
+            end if
+          end do
+
+          if (j == 0) then
+            write(6,*) "ERROR: coupling_set_nodes:",coupling%grnod_id, " not found in igrnod"
+            return
+          end if
+
+          coupling%nb_coupling_nodes = igrnod(j)%nentity
+
+          call coupling_adapter_set_nodes(coupling%adapter_ptr, igrnod(j)%entity, coupling%nb_coupling_nodes)
+        end subroutine coupling_set_nodes
+
+        ! Initialize coupling
+        subroutine coupling_initialize(coupling, X, nb_nodes, mpi_rank, mpi_commsize)
+          use precision_mod, only: WP
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          type(coupling_type), intent(inout) :: coupling
+          integer, intent(in) :: nb_nodes, mpi_rank, mpi_commsize
+          real(kind=WP), intent(in) :: X(3, nb_nodes)
+!-----------------------------------------------------------------------------------------------------------------------
+!                                                   Local variables
+!-----------------------------------------------------------------------------------------------------------------------
+          integer :: result
+          real(c_double) :: coordinates(3 * nb_nodes)
+          integer :: i, j, k
+!------------------------------------------------------------------------------------------------------------------------
+!                                                   Body
+!------------------------------------------------------------------------------------------------------------------------
+          if (.not. c_associated(coupling%adapter_ptr)) return
+
+          ! Convert coordinates to flat array
+          k = 1
+          do i = 1, nb_nodes
+            do j = 1, 3
+              coordinates(k) = real(X(j, i), c_double)
+              k = k + 1
+            end do
+          end do
+
+          result = coupling_adapter_initialize(coupling%adapter_ptr, coordinates, nb_nodes, mpi_rank, mpi_commsize)
+
+          if (result == 1) then
+            coupling%dt_limit = coupling_adapter_get_max_time_step_size(coupling%adapter_ptr)
+            coupling%nb_coupling_nodes = coupling_adapter_get_num_coupling_nodes(coupling%adapter_ptr)
+          else
+            coupling%active = .false.
+          end if
+        end subroutine coupling_initialize
+
+        ! Write data to coupling library
+        subroutine coupling_write(coupling, dt, global_values, nb_nodes, name_id)
+          use precision_mod, only: WP
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          type(coupling_type), intent(inout) :: coupling
+          integer, intent(in) :: nb_nodes, name_id
+          real(kind=WP), intent(in) :: global_values(3, nb_nodes), dt
+!-----------------------------------------------------------------------------------------------------------------------
+!                                                   Local variables
+!-----------------------------------------------------------------------------------------------------------------------
+          integer :: i, j, k
+          real(c_double), dimension(:,:), allocatable :: values
+!------------------------------------------------------------------------------------------------------------------------
+!                                                   Body
+!------------------------------------------------------------------------------------------------------------------------
+          if (.not. c_associated(coupling%adapter_ptr)) return
+          if (.not. coupling%active) return
+#ifdef MYREAL8
+          call coupling_adapter_write_data(coupling%adapter_ptr, global_values, nb_nodes, real(dt, c_double), name_id)
+#else
+          ! single precision, copy global_values into values
+          allocate(values(3 , nb_nodes))
+          values(1:3,1:nb_nodes) = real(global_values(1:3,1:nb_nodes), c_double)
+          call coupling_adapter_write_data(coupling%  adapter_ptr, values, nb_nodes, real(dt, c_double), name_id)
+          deallocate(values)
+#endif
+        end subroutine coupling_write
+
+        ! Read data from coupling library
+        subroutine coupling_read(coupling, dt, global_values, nb_nodes, mode, name_id)
+          use precision_mod, only: WP
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          type(coupling_type), intent(inout) :: coupling
+          integer, intent(in) :: nb_nodes, mode, name_id
+          real(kind=WP), intent(inout) :: global_values(3, nb_nodes)
+          double precision, intent(in) :: dt
+!-----------------------------------------------------------------------------------------------------------------------
+!                                                   Local variables
+!-----------------------------------------------------------------------------------------------------------------------
+          integer :: i, j, k
+          real(c_double), dimension(:,:), allocatable :: values
+!------------------------------------------------------------------------------------------------------------------------
+!                                                   Body
+!------------------------------------------------------------------------------------------------------------------------
+          if (.not. c_associated(coupling%adapter_ptr)) return
+          if (.not. coupling%active) return
+#ifdef MYREAL8
+          call coupling_adapter_read_data(coupling%adapter_ptr, global_values, nb_nodes, real(dt, c_double), name_id, mode)
+#else
+         ! single precision, copy global_values into values
+          allocate(values(3 , nb_nodes))
+          values(1:3,1:nb_nodes) = real(global_values(1:3,1:nb_nodes), c_double)
+          call coupling_adapter_read_data(coupling%adapter_ptr, values, nb_nodes, real(dt, c_double), name_id, mode)
+          ! Copy values back to global_values
+          global_values(:,:) = real(values(:,:), WP)
+          deallocate(values)
+#endif
+
+        end subroutine coupling_read
+
+
+!! \brief main subroutine to create syncrhonization points from resol.F. It does both reading and writing
+        subroutine coupling_sync(coupling, dt, nodes, name_id)
+          use precision_mod, only: WP
+          use nodal_arrays_mod, only : nodal_arrays_
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          type(coupling_type), intent(inout) :: coupling
+          integer, intent(in) ::  name_id !< the name of the data to synchronize
+          real(kind=WP), intent(inout) :: dt
+          type(nodal_arrays_), intent(inout) :: nodes
+!-----------------------------------------------------------------------------------------------------------------------
+!                                                   Local variables
+!-----------------------------------------------------------------------------------------------------------------------
+          integer :: numnod
+          real(c_double), dimension(:,:), allocatable :: values
+!------------------------------------------------------------------------------------------------------------------------
+!                                                   Body
+!------------------------------------------------------------------------------------------------------------------------
+          if (.not. c_associated(coupling%adapter_ptr)) return
+          if (.not. coupling%active) return
+          numnod = nodes%numnod
+#ifdef MYREAL8
+          if(name_id == coupling_displacements) then
+            call coupling_adapter_write_data(coupling%adapter_ptr, nodes%D, numnod, &
+              real(dt, c_double), coupling_displacements)
+            ! Read positions
+            call coupling_adapter_read_data(coupling%adapter_ptr, nodes%D, numnod, &
+              real(dt, c_double), coupling_positions, coupling_replace)
+          else if(name_id == coupling_forces) THEN
+            ! Write forces
+            NODES%FORCES(1:3,1:NUMNOD) = nodes%A(1:3,1:NUMNOD) - NODES%FORCES(1:3,1:NUMNOD)
+            call coupling_adapter_write_data(coupling%adapter_ptr, nodes%FORCES, numnod, &
+              real(dt, c_double), coupling_forces)
+            ! Read forces
+            call coupling_adapter_read_data(coupling%adapter_ptr, nodes%A, numnod, &
+              real(dt, c_double), coupling_forces, coupling_add)
+          else if(name_id == coupling_positions) then
+            ! Write positions
+            call coupling_adapter_write_data(coupling%adapter_ptr, nodes%X, numnod, &
+              real(dt, c_double), coupling_positions)
+            call coupling_adapter_read_data(coupling%adapter_ptr, nodes%X, numnod, &
+              real(dt, c_double), coupling_positions, coupling_replace)
+          end if
+#else
+          allocate(values(3, numnod))
+          if(name_id == coupling_displacements) then
+            ! Write displacements
+            values(1:3,1:numnod) = real(nodes%D(1:3,1:numnod), c_double)
+            call coupling_adapter_write_data(coupling%adapter_ptr, values, numnod, &
+              real(dt, c_double), coupling_displacements)
+            ! Read positions
+            call coupling_adapter_read_data(coupling%adapter_ptr, values, numnod, &
+              real(dt, c_double), coupling_positions, coupling_replace)
+            nodes%D(1:3,1:numnod) = real(values(1:3,1:numnod), WP)
+          else if(name_id == coupling_forces) THEN
+            ! Write forces
+            values(1:3,1:numnod) = real(nodes%A(1:3,1:numnod) - nodes%FORCES(1:3,1:numnod), c_double)
+            call coupling_adapter_write_data(coupling%adapter_ptr, values, numnod, &
+              real(dt, c_double), coupling_forces)
+            ! Read forces
+            call coupling_adapter_read_data(coupling%adapter_ptr, values, numnod, &
+              real(dt, c_double), coupling_forces, coupling_add)
+            nodes%A(1:3,1:numnod) = real(values(1:3,1:numnod), WP)
+          else if(name_id == coupling_positions) then
+            ! Write positions
+            values(1:3,1:numnod) = real(nodes%X(1:3,1:numnod), c_double)
+            call coupling_adapter_write_data(coupling%adapter_ptr, values, numnod, &
+              real(dt, c_double), coupling_positions)
+            call coupling_adapter_read_data(coupling%adapter_ptr, values, numnod, &
+              real(dt, c_double), coupling_positions, coupling_replace)
+            nodes%X(1:3,1:numnod) = real(values(1:3,1:numnod), WP)
+          end if
+          deallocate(values)
+#endif
+
+        end subroutine coupling_sync
+
+        ! Advance coupling
+        subroutine coupling_advance(coupling, dt)
+          use precision_mod, only: WP
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          type(coupling_type), intent(inout) :: coupling
+          real(kind=WP), intent(inout) :: dt
+!-----------------------------------------------------------------------------------------------------------------------
+!                                                   Local variables
+!-----------------------------------------------------------------------------------------------------------------------
+          real(c_double) :: c_dt
+!------------------------------------------------------------------------------------------------------------------------
+!                                                   Body
+!------------------------------------------------------------------------------------------------------------------------
+          if (.not. c_associated(coupling%adapter_ptr)) return
+          if (.not. coupling%active) return
+
+          c_dt = real(dt, c_double)
+          call coupling_adapter_advance(coupling%adapter_ptr, c_dt)
+          dt = real(c_dt, WP)
+
+          coupling%dt_limit = coupling_adapter_get_max_time_step_size(coupling%adapter_ptr)
+        end subroutine coupling_advance
+
+        ! Check if coupling is ongoing
+        subroutine coupling_ongoing(coupling, ongoing)
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          type(coupling_type), intent(inout) :: coupling
+          logical, intent(out) :: ongoing
+!-----------------------------------------------------------------------------------------------------------------------
+!                                                   Local variables
+!-----------------------------------------------------------------------------------------------------------------------
+          integer :: result
+!------------------------------------------------------------------------------------------------------------------------
+!                                                   Body
+!------------------------------------------------------------------------------------------------------------------------
+          ongoing = .false.
+          if (.not. c_associated(coupling%adapter_ptr)) return
+          if (.not. coupling%active) return
+
+          result = coupling_adapter_is_coupling_ongoing(coupling%adapter_ptr)
+          ongoing = (result == 1)
+          coupling%active = ongoing
+        end subroutine coupling_ongoing
+
+        subroutine coupling_requires_writing_checkpoint(coupling, required)
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          type(coupling_type), intent(in) :: coupling
+          logical, intent(out) :: required
+!-----------------------------------------------------------------------------------------------------------------------
+!                                                   Local variables
+!-----------------------------------------------------------------------------------------------------------------------
+          integer :: result
+!------------------------------------------------------------------------------------------------------------------------
+!                                                   Body
+!------------------------------------------------------------------------------------------------------------------------
+          required = .false.
+          if (.not. c_associated(coupling%adapter_ptr)) return
+          if (.not. coupling%active) return
+
+          result = coupling_adapter_requires_writing_checkpoint(coupling%adapter_ptr)
+          required = (result == 1)
+          if(required) then
+            write(6,*) "Error: Coupling requires writing checkpoint"
+            stop
+          end if
+        end subroutine coupling_requires_writing_checkpoint
+
+        subroutine coupling_requires_reading_checkpoint(coupling, required)
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          type(coupling_type), intent(in) :: coupling
+          logical, intent(out) :: required
+!-----------------------------------------------------------------------------------------------------------------------
+!                                                   Local variables
+!-----------------------------------------------------------------------------------------------------------------------
+          integer :: result
+!------------------------------------------------------------------------------------------------------------------------
+!                                                   Body
+!------------------------------------------------------------------------------------------------------------------------
+          required = .false.
+          if (.not. c_associated(coupling%adapter_ptr)) return
+          if (.not. coupling%active) return
+
+          result = coupling_adapter_requires_reading_checkpoint(coupling%adapter_ptr)
+          required = (result == 1)
+          if(required) then
+            write(6,*) "Error: Coupling requires writing checkpoint"
+            stop
+          end if
+        end subroutine coupling_requires_reading_checkpoint
+
+        ! Finalize coupling
+        subroutine coupling_finalize(coupling)
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          type(coupling_type), intent(inout) :: coupling
+!-----------------------------------------------------------------------------------------------------------------------
+!                                                   Body
+!------------------------------------------------------------------------------------------------------------------------
+          if (c_associated(coupling%adapter_ptr)) then
+            call coupling_adapter_finalize(coupling%adapter_ptr)
+            call coupling_adapter_destroy(coupling%adapter_ptr)
+            coupling%adapter_ptr = c_null_ptr
+          end if
+          coupling%active = .false.
+        end subroutine coupling_finalize
+
+      end module coupling_adapter_mod

--- a/engine/source/coupling/precice/precice_mod.F90
+++ b/engine/source/coupling/precice/precice_mod.F90
@@ -1,0 +1,96 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 1986-2025 Altair Engineering Inc.
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Altair Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+!Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+!Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+module precice_mod
+        use, intrinsic :: iso_c_binding
+        implicit none
+
+#ifdef WITH_PRECICE
+      interface
+        subroutine precicef_create(pname, fname, rank, size, len1, len2) &
+                   bind(C, name="precicef_create_")
+          use iso_c_binding
+          character(kind=c_char) :: pname(*), fname(*)
+          integer(c_int) :: rank, size
+          integer(c_int), value :: len1, len2  ! VALUE = pass by value
+        end subroutine
+        subroutine precicef_set_vertices(mesh_name, size, coordinates, ids, mesh_name_length) &
+           bind(C, name="precicef_set_vertices_")
+           use iso_c_binding
+           character(kind=c_char) :: mesh_name(*)
+           integer(c_int)  :: size
+           real(c_double)  :: coordinates(*)
+           integer(c_int)  :: ids(*)
+           integer(c_int), value, intent(in) :: mesh_name_length
+        end subroutine
+!        void precicef_requires_initial_data_(
+!   int *isRequired);
+        subroutine precicef_requires_initial_data(isRequired) &
+           bind(C, name="precicef_requires_initial_data_")
+          use iso_c_binding
+          integer(c_int), intent(out) :: isRequired
+        end subroutine
+!       void precicef_write_data_(
+!   const char *meshName,
+!   const char *dataName,
+!   const int  *size,
+!   int        *ids,
+!   double     *values,
+!   int         meshNameLength,
+!   int         dataNameLength);
+        subroutine precicef_write_data(mesh_name, data_name, ids, size, values, mesh_name_length, data_name_length) &
+           bind(C, name="precicef_write_data_")
+          use iso_c_binding
+          character(kind=c_char) :: mesh_name(*), data_name(*)
+          integer(c_int), intent(in) :: ids(*), size
+          real(c_double), intent(in) :: values(*)
+          integer(c_int), value, intent(in) :: mesh_name_length, data_name_length
+        end subroutine
+
+        !void precicef_get_max_time_step_size_(double *maxTimeStepSize);
+        subroutine precicef_get_max_time_step_size(maxTimeStepSize) &
+           bind(C, name="precicef_get_max_time_step_size_")
+          use iso_c_binding
+          real(c_double), intent(out) :: maxTimeStepSize
+        end subroutine
+!void precicef_read_data_(
+!    const char   *meshName,
+!    const char   *dataName,
+!    const int    *size,
+!    int          *ids,
+!    const double *relativeReadTime,
+!    double       *values,
+!    int           meshNameLength,
+!    int           dataNameLength);
+        subroutine precicef_read_data(mesh_name, data_name, ids, size, relative_read_time, values, mesh_name_length, data_name_length) &
+           bind(C, name="precicef_read_data_")
+          use iso_c_binding
+          character(kind=c_char) :: mesh_name(*), data_name(*)
+          integer(c_int), intent(in) :: ids(*), size
+          real(c_double), intent(in) :: relative_read_time
+          real(c_double), intent(out) :: values(*)
+          integer(c_int), value, intent(in) :: mesh_name_length, data_name_length
+        end subroutine
+
+      end interface
+#endif
+      end module precice_mod

--- a/engine/source/coupling/precice/precice_read_cpl.cpp
+++ b/engine/source/coupling/precice/precice_read_cpl.cpp
@@ -1,0 +1,252 @@
+#include <fstream>
+#include <sstream>
+#include <vector>
+#include <string>
+#include <cstring>
+#include <iostream>
+#include <algorithm>
+#include <cctype>
+#include <limits>
+#include <cerrno>
+
+extern "C"
+{
+    void cpp_precice_read_cpl(char *input_filename, char *participant_name, char *config_file, char *mesh_name, char *write_name, char *read_name, int *grnod_id)
+    {
+        // Input validation - check for null pointers first
+        if (!input_filename) {
+            std::cout << "Error: input_filename is null pointer" << std::endl;
+            return;
+        }
+        
+        if (!participant_name || !config_file || !mesh_name || !write_name || !read_name || !grnod_id) {
+            std::cout << "Error: One or more output parameters are null pointers" << std::endl;
+            return;
+        }
+        
+        // Debug: Print pointer address for debugging
+        std::cout << "Debug: input_filename pointer = " << static_cast<void*>(input_filename) << std::endl;
+        
+        // Handle Fortran string: may not be null-terminated and has limited buffer
+        std::string filename_str;
+        
+        try {
+            // Conservative approach: assume buffer might be small
+            // Try to detect actual buffer size by careful probing
+            const int max_safe_read = 256; // Conservative limit
+            char temp_char;
+            int i = 0;
+            bool found_null = false;
+            
+            // Probe memory very carefully
+            while (i < max_safe_read) {
+                // Try to read one byte, but be prepared for segfault
+                bool can_read = true;
+                try {
+                    temp_char = input_filename[i];
+                } catch (...) {
+                    // Memory access failed - we've hit the buffer limit
+                    can_read = false;
+                }
+                
+                if (!can_read) {
+                    std::cout << "Debug: Buffer limit detected at position " << i << std::endl;
+                    break;
+                }
+                
+                // Check for null terminator
+                if (temp_char == '\0') {
+                    found_null = true;
+                    std::cout << "Debug: Null terminator found at position " << i << std::endl;
+                    break;
+                }
+                
+                // Check for reasonable characters (printable ASCII + common whitespace)
+                if ((temp_char >= 32 && temp_char <= 126) || 
+                    temp_char == '\t' || temp_char == '\n' || temp_char == '\r') {
+                    filename_str += temp_char;
+                } else if (temp_char == ' ') {
+                    // Space might be padding from Fortran - we'll handle this later
+                    filename_str += temp_char;
+                } else {
+                    // Non-printable character might indicate end of string or garbage
+                    std::cout << "Debug: Non-printable character at position " << i 
+                              << " (ASCII " << static_cast<int>(temp_char) << ") - assuming end of string" << std::endl;
+                    break;
+                }
+                
+                i++;
+            }
+            
+            // For Fortran strings, remove trailing spaces (common padding)
+            filename_str.erase(filename_str.find_last_not_of(" \t\r\n") + 1);
+            
+            if (filename_str.empty()) {
+                std::cout << "Error: Empty filename after processing" << std::endl;
+                return;
+            }
+            
+            std::cout << "Debug: Successfully extracted filename from " << i << " byte buffer" << std::endl;
+            if (!found_null) {
+                std::cout << "Debug: No null terminator found - assuming Fortran fixed-length string" << std::endl;
+            }
+            
+        } catch (const std::exception& e) {
+            std::cout << "Error: Exception while processing filename: " << e.what() << std::endl;
+            return;
+        } catch (...) {
+            std::cout << "Error: Unknown exception while processing filename" << std::endl;
+            return;
+        }
+        
+        std::cout << "Debug: Processed filename = '" << filename_str << "' (length: " << filename_str.length() << ")" << std::endl;
+        
+        // Open file with error checking
+        std::ifstream file;
+        try {
+            file.open(filename_str.c_str());
+            if (!file.is_open()) {
+                std::cout << "Error: Cannot open file: " << filename_str << std::endl;
+                return;
+            }
+        } catch (const std::exception& e) {
+            std::cout << "Error: Exception while opening file: " << e.what() << std::endl;
+            return;
+        }
+        
+        // Parse file
+        std::string line;
+        std::vector<std::vector<std::string>> lines;
+        
+        try {
+            while (std::getline(file, line)) {
+                // Check if line starts with "/PRECICE" (case-insensitive)
+                if (line.length() >= 8) {
+                    std::string prefix = line.substr(0, 8);
+                    std::transform(prefix.begin(), prefix.end(), prefix.begin(), ::toupper);
+                    
+                    if (prefix == "/PRECICE") {
+                        std::vector<std::string> words;
+                        std::string word;
+                        std::istringstream ss(line);
+                        
+                        // Split by '/' delimiter
+                        while (std::getline(ss, word, '/')) {
+                            // Trim whitespace
+                            word.erase(0, word.find_first_not_of(" \t\r\n"));
+                            word.erase(word.find_last_not_of(" \t\r\n") + 1);
+                            words.push_back(word);
+                        }
+                        
+                        // Only add if we have enough tokens
+                        if (words.size() >= 4) {
+                            lines.push_back(words);
+                        } else {
+                            std::cout << "Warning: Malformed PRECICE line (insufficient tokens): " << line << std::endl;
+                        }
+                    }
+                }
+            }
+        } catch (const std::exception& e) {
+            std::cout << "Error: Exception while reading file: " << e.what() << std::endl;
+            file.close();
+            return;
+        }
+        
+        file.close();
+        
+        if (lines.empty()) {
+            std::cout << "Warning: No valid PRECICE configuration lines found in file" << std::endl;
+            return;
+        }
+        
+        // Initialize output parameters to safe defaults - check each pointer first
+        try {
+            participant_name[0] = '\0';
+            config_file[0] = '\0';
+            mesh_name[0] = '\0';
+            write_name[0] = '\0';
+            read_name[0] = '\0';
+            *grnod_id = 0;
+        } catch (...) {
+            std::cout << "Error: Cannot initialize output parameters - invalid pointers" << std::endl;
+            return;
+        }
+        
+        // Safe string copy function
+        auto safe_string_copy = [](char* dest, const std::string& src, const char* param_name) {
+            try {
+                if (src.length() >= 50) {
+                    std::cout << "Warning: " << param_name << " too long, truncating: " << src << std::endl;
+                    strncpy(dest, src.c_str(), 49);
+                    dest[49] = '\0';
+                } else {
+                    strcpy(dest, src.c_str());
+                }
+            } catch (...) {
+                std::cout << "Error: Failed to copy " << param_name << std::endl;
+            }
+        };
+        
+        // Process parsed lines
+        for (const auto &words : lines) {
+            // Ensure we have at least 4 elements
+            if (words.size() < 4) {
+                continue;
+            }
+            
+            // Convert key to uppercase for case-insensitive comparison
+            std::string key = words[2];
+            std::transform(key.begin(), key.end(), key.begin(), ::toupper);
+            
+            try {
+                if (key == "PARTICIPANT_NAME") {
+                    safe_string_copy(participant_name, words[3], "PARTICIPANT_NAME");
+                }
+                else if (key == "CONFIG_FILE") {
+                    safe_string_copy(config_file, words[3], "CONFIG_FILE");
+                }
+                else if (key == "MESH_NAME") {
+                    safe_string_copy(mesh_name, words[3], "MESH_NAME");
+                }
+                else if (key == "WRITE") {
+                    safe_string_copy(write_name, words[3], "WRITE");
+                }
+                else if (key == "READ") {
+                    safe_string_copy(read_name, words[3], "READ");
+                }
+                else if (key == "INTERFACE") {
+                    // Safe integer conversion
+                    char* endptr;
+                    errno = 0;
+                    long val = strtol(words[3].c_str(), &endptr, 10);
+                    
+                    if (errno != 0) {
+                        std::cout << "Error: Failed to convert INTERFACE value to integer: " << words[3] << std::endl;
+                        *grnod_id = 0;
+                    } else if (endptr == words[3].c_str()) {
+                        std::cout << "Error: INTERFACE value is not a valid integer: " << words[3] << std::endl;
+                        *grnod_id = 0;
+                    } else if (val < std::numeric_limits<int>::min() || val > std::numeric_limits<int>::max()) {
+                        std::cout << "Error: INTERFACE value out of integer range: " << words[3] << std::endl;
+                        *grnod_id = 0;
+                    } else {
+                        *grnod_id = static_cast<int>(val);
+                    }
+                }
+            } catch (const std::exception& e) {
+                std::cout << "Error: Exception while processing configuration line: " << e.what() << std::endl;
+                continue;
+            }
+        }
+        
+        // Print summary of what was found
+        std::cout << "preCICE configuration loaded successfully:" << std::endl;
+        std::cout << "  Participant: " << (strlen(participant_name) > 0 ? participant_name : "NOT SET") << std::endl;
+        std::cout << "  Config file: " << (strlen(config_file) > 0 ? config_file : "NOT SET") << std::endl;
+        std::cout << "  Mesh name: " << (strlen(mesh_name) > 0 ? mesh_name : "NOT SET") << std::endl;
+        std::cout << "  Write name: " << (strlen(write_name) > 0 ? write_name : "NOT SET") << std::endl;
+        std::cout << "  Read name: " << (strlen(read_name) > 0 ? read_name : "NOT SET") << std::endl;
+        std::cout << "  Interface ID: " << *grnod_id << std::endl;
+    }
+}

--- a/engine/source/engine/radioss2.F
+++ b/engine/source/engine/radioss2.F
@@ -193,6 +193,7 @@ C-----------------------------------------------
       USE SPMD_MOD
       use checksum_output_option_mod
       use file_descriptor_mod,only : fd_bin_th,fd_bin_rd_rst,fd_bin_wr_rst           ! Contains the file descriptors for all files / same as unit_c.inc
+      use coupling_adapter_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -347,6 +348,7 @@ C-------------------------------------------------------------------------------
       TYPE(nodal_arrays_), target :: nodes 
       TYPE(timer_) :: TIMERS
       TYPE(rbe3_) :: rbe3
+      TYPE(coupling_type) :: coupling
 C------------------------------------------------------------------
 C to build a IBM PARALLEL version
 C In starter : define install parameter nspmd 
@@ -653,7 +655,13 @@ C     Standard input reading
 C------------------------------------------------
       CALL LECINP(IRUNN,IRFL,IRFE,H3D_DATA,FLAG_CST_AMS,DYNAIN_DATA,
      .            SENSORS,DT,OUTPUT,GLOB_THERM)
+
+#ifdef WITH_PRECICE
+       FILNAM=ROOTNAM(1:ROOTLEN)//'_'//CHRUN//'.cpl'
+       call coupling_configure(coupling, TRIM(FILNAM))  
+#endif
       NFSKYI=5
+
       IF(KDTINT==0 )NFSKYI=4
       
       IF (GOT_INPUT==0)THEN
@@ -2198,7 +2206,7 @@ C---------------------------------------------------------------------
      .                   DIFFUSION    ,SEGVAR          ,DYNAIN_DATA     ,DRAPEG     ,USER_WINDOWS    ,
      .                   OUTPUT       ,INTERFACES      ,DT              ,LOADS      ,MAT_ELEM  , PYTHON,
      .                   NAMES_AND_TITLES, UNITAB ,SKEWS,LIFLOW         ,LRFLOW     ,glob_therm,PBLAST,
-     .                   RBE3)
+     .                   RBE3, coupling)
 C---------------------------------------------------------------------
       CURRENT_RUN = GLOBAL_COMP_TIME%RUN_NBR
       CALL SPMD_REDUCE_DB(GLOBAL_COMP_TIME%ENGINE_TIME(CURRENT_RUN),RESULT,1,0,"MAX ")

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -527,7 +527,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    user_windows_mod                             ../common_source/modules/user_windows_mod.F
       !||    xfem2vars_mod                                ../engine/share/modules/xfem2vars_mod.F
       !||====================================================================
-            SUBROUTINE RESOL(TIMERS, ELEMENT, NODES, AF,IAF,
+            SUBROUTINE RESOL(TIMERS, ELEMENT, NODES, coupling, AF,IAF,
      1        ISKWN   ,NETH   ,IPART  ,NOM_OPT,KXX    ,IXX    ,
      2        IXTG   ,IXS     ,IXQ    ,IXT    ,IXP    ,IXR    ,
      3        IFILL  ,MAT_ELEM,
@@ -722,6 +722,7 @@ C-----------------------------------------------
               use th_mod , only : th_has_noda_pext
               use output_mod , only : anim_has_noda_pext, h3d_has_noda_pext
               use damping_vref_compute_dampa_mod
+              use coupling_adapter_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -902,6 +903,7 @@ C-----------------------------------------------
               TYPE(UNIT_TYPE_) :: UNITAB !structure containing units conversion ratios
               INTEGER MIN_TAB(4)
               my_real :: DT2R
+              TYPE(coupling_type), intent(inout) :: coupling 
 C
 C     Mat + Prop timers
               INTEGER, DIMENSION(NUMMAT) :: POIN_UMP
@@ -1319,6 +1321,17 @@ C-------------------------------------------------------------------------------
               type (ams_work_) :: ams_work   !< Working areas for AMS
 
               type(component_), dimension(:), allocatable :: component
+C-----------------------------------------------------------------------------------
+C coupling coupling
+              logical :: ongoing
+              character(len=50) :: config_file
+              character(len=50) :: participant_name
+              character(len=50) :: data_name
+              character(len=50) :: mesh_name
+              character(len=50) :: data_name2
+              integer :: nb_coupling_nodes
+              integer, dimension(:), allocatable :: node_ids
+              double precision :: dt2max_coupling
 C-----------------------------------------------------------------------------------
               ELEMENT%SHELL%OFFSET = NUMELS + NUMELQ
               CALL PREPARE_DEBUG(NODES%ITAB,NUMNOD)
@@ -3190,6 +3203,15 @@ C First: try with reduced bounding box
               CALL PYTHON_UPDATE_TIME(TT,DT2)
               CALL PYTHON_UPDATE_NODAL_ENTITIES(NUMNOD, NODES, X=NODES%X,A=NODES%A,V=NODES%V,D=NODES%D,DR=NODES%DR,VR=NODES%VR)
               CALL PYTHON_SYNC(PYTHON%CONTEXT)
+              IF(coupling%active) THEN
+              ! ALLOCATION AND INITIALIZATION OF COUPLING COUPLING
+                ALLOCATE(NODES%FORCES(3,NUMNOD))
+                NODES%FORCES = ZERO
+                CALL COUPLING_SET_NODES(coupling, IGRNOD, NGRNOD)
+                CALL COUPLING_INITIALIZE(coupling,NODES%X,NUMNOD,ISPMD,NSPMD)
+                CALL COUPLING_ONGOING(coupling,ongoing)
+              ENDIF
+
 C===========================================================================
 C                 BEGINNING OF EXPLICIT ITERATION LOOP
 C===========================================================================                                        
@@ -3734,6 +3756,8 @@ C----------------------------------------
                 ELSE
                   NATIV_SMS_SIZ = 0
                 ENDIF
+
+                IF(coupling%active .AND. TT > ZERO) DT2T = MIN(DT2T,coupling%DT_LIMIT)
 
 C========================================================================================
 C                                     PARALLEL SECTION (SMP)
@@ -5001,7 +5025,9 @@ C
 C--- //------------------------------
 C       FORCE ASSEMBLY
 C-------------------------------------
-
+             IF(coupling%active) THEN
+               NODES%FORCES(1:3,1:NUMNOD) = nodes%A(1:3,1:NUMNOD)
+             ENDIF
 C========================================================================================
 C                                     PARALLEL SECTION (SMP)
 C========================================================================================
@@ -7137,6 +7163,14 @@ C===============================================================================
                 IF(IPARIT == 0.AND.NSPMD > 1.AND. NLOC_DMG%IMOD > 0)THEN
                   CALL SPMD_EXCH_SUB_POFF(NLOC_DMG)
                 ENDIF
+
+                IF(coupling%active) THEN
+                  ! FORCES WAS INITIALIZED TO THE ACCELERTION, BEFORE ASSEMBLY
+                  ! BEFORE THE CALL TO ACCELE, A CONTAINS THE FORCES
+                  ! AFTER THE CALL TO ACCELE, A CONTAINS THE ACCELERATION
+                  !NODES%FORCES(1:3,1:NUMNOD) = nodes%A(1:3,1:NUMNOD) - NODES%FORCES(1:3,1:NUMNOD) 
+                  CALL COUPLING_SYNC(coupling,DT2,nodes,COUPLING_FORCES)
+                ENDIF
 C========================================================================================
 C                                     PARALLEL SECTION (SMP)
 C========================================================================================
@@ -7151,7 +7185,7 @@ C       ACCELERATIONS (TRANSLATIONS)
 C-----------------------------------------------
 
                 !-----------------------------
-                !FINITE VOLUME METHOD FOR ALE
+                ! FINITE VOLUME METHOD FOR ALE
                 !-----------------------------
                 IF(ALEFVM_Param%IEnabled>0)THEN
                   CALL ALEFVM_ACCELE(NODES%A, NODES%AR, NODFTSK, NODLTSK, ALE_CONNECTIVITY%NALE)
@@ -7199,15 +7233,12 @@ C
      2                          PINCH_DATA%STIFPINCH, NODFTSK,            NODLTSK,
      3                                          DT2T,   DTFAC)
                 ENDIF
-C
-C---
 C--- //  ---------------------------------------
 C       TEMPERATURES COMPUTATION
 C-----------------------------------------------
                 IF (GLOB_THERM%ITHERM_FE > 0 )
      .             CALL TEMPUR(NODES%TEMP ,NODES%MCP,FTHE,NODFTSK,NODLTSK,NODES%WEIGHT,MCP_OFF,GLOB_THERM%HEAT_STORED)
 !$OMP END PARALLEL
-
 
 C------------------------------------------
 C       DT_DC for thick-shell
@@ -7228,7 +7259,6 @@ C===============================================================================
                   CALL ACCDTDC(GREFTSK,GRELTSK,IENUNL ,ALPHA_DC,NODES%A       ,NODES%MS   ,NODES%ITAB )
 !$OMP END PARALLEL
                 ENDIF
-
 
                 IF(NTSHEGG>0.AND.NSPMD > 1)
      .              CALL SPMD_EXCH_FA(IAD_STSH ,FR_STSH ,IAD_RTSH ,FR_RTSH ,NODES%A   )
@@ -8727,6 +8757,7 @@ C
                 CALL TRACE_OUT(5)
 C-------ADYREL----
                 IF (ISTAT==3) CALL ENER_W0
+                IF(coupling%active) CALL COUPLING_ADVANCE(coupling,DT2)
 C------------
 C       TEMPS
 C------------
@@ -9237,6 +9268,11 @@ C===============================================================================
               ENDIF
               CALL PYTHON_SYNC(PYTHON%CONTEXT)
               CALL PYTHON_UPDATE_NODAL_ENTITIES(NUMNOD,NODES,X=NODES%X, D=NODES%D, DR=NODES%DR)
+              IF(coupling%active) THEN
+                DT2MAX_COUPLING = DT2 
+                ! Read and write coupling positions
+                CALL COUPLING_SYNC(coupling,DT2,NODES,COUPLING_POSITIONS)
+              ENDIF
 C========================================================================================
 C                                   NON PARALLEL SECTION (SMP)
 C========================================================================================
@@ -9709,6 +9745,17 @@ C--- //0 ----------------
      7                ISLEN20E,NODES%IKINE   ,DIAG_SMS,SENSORS%SENSOR_TAB,INTERFACES%INTBUF_TAB ,INT24E2EUSE ,
      8                FORNEQS ,MULTI_FVM,INTERFACES)
                 END IF
+
+                IF(coupling%active) THEN
+                  CALL COUPLING_ONGOING(coupling, ONGOING)
+                    ! FAKE TIME STEPS TO FINALIZE COUPLING
+                    DO WHILE (ONGOING)
+                      DT2 = HUGE(DT2)
+                      CALL COUPLING_ADVANCE(coupling,DT2)
+                      CALL COUPLING_ONGOING(coupling, ONGOING)
+                    END DO
+                    CALL COUPLING_FINALIZE(coupling)
+                ENDIF
 
                 IF(ALLOCATED(ISENDTO))DEALLOCATE(ISENDTO)
                 IF(ALLOCATED(IRCVFROM))DEALLOCATE(IRCVFROM)

--- a/engine/source/engine/resol_head.F
+++ b/engine/source/engine/resol_head.F
@@ -81,7 +81,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .           DIFFUSION   ,SEGVAR      ,DYNAIN_DATA    ,DRAPEG     ,USER_WINDOWS    ,
      .           OUTPUT      ,INTERFACES  ,DT             ,LOADS      ,MAT_ELEM        ,
      .           PYTHON      ,NAMES_AND_TITLES, UNITAB    ,SKEWS      ,LIFLOW          ,
-     .           LRFLOW      ,glob_therm ,PBLAST          ,RBE3 )
+     .           LRFLOW      ,glob_therm ,PBLAST          ,RBE3 ,coupling)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -124,6 +124,7 @@ C-----------------------------------------------
       use PBLAST_MOD
       use TIMER_MOD
       use rbe3_mod
+      use coupling_adapter_mod 
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -141,6 +142,7 @@ C-----------------------------------------------
       type(connectivity_), intent(inout) :: ELEMENT 
       type(nodal_arrays_), intent(inout) :: NODES
       type(timer_), intent(inout) :: TIMERS
+      type(coupling_type), intent(inout) :: coupling
       INTEGER, INTENT(IN) :: LIFLOW  !< Size of IFLOW
       INTEGER, INTENT(IN) :: LRFLOW  !< Size of RFLOW
 
@@ -212,7 +214,7 @@ C-----------------------------------------------
       ITRACE(2)=NTHREAD
       CALL TRACE_IN(2,ITRACE,ZERO)
 C
-      CALL RESOL(TIMERS, ELEMENT,NODES,
+      CALL RESOL(TIMERS, ELEMENT,NODES,coupling,
      .  AF              ,IAF            ,
      1  ISKWN          ,NETH           ,IPART          ,NOM_OPT     ,KXX              ,IXX       ,
      2  IXTG            ,IXS            ,IXQ            ,IXT            ,IXP         ,IXR       ,


### PR DESCRIPTION
This pull request introduces support for preCICE coupling in the `engine`. The changes include modifications to build scripts (add -preCICE to enable this feature), CMake configurations, and source code to integrate preCICE as an optional coupling library. Additionally, new classes and modules have been added to manage coupling adapters and provide Fortran bindings for preCICE.

### Build Script Enhancements:
* **Command-line Options**: Added a `-preCICE` flag to `engine/build_script.sh` to enable preCICE coupling during the build process. The flag adjusts executable naming and passes the `precice` flag to CMake. 

### Coupling Adapter Framework:
* **Abstract Base Class**: Introduced `CouplingAdapter` in `engine/source/coupling/coupling.h` as an interface for coupling adapters, including methods for configuration, data exchange, and simulation control.
* **preCICE Adapter**: Added `PreciceCouplingAdapter` as a concrete implementation of `CouplingAdapter` to manage preCICE-specific operations. 
* **Synchronization points** are in `resol.F`. More might be added depending on the interface data should be send/received.

### Fortran Bindings:
* **preCICE Module**: Created `precice_mod.F90` to provide Fortran bindings for preCICE, enabling interaction with preCICE libraries from Fortran code.

### Usage
- Build the dedicated binary using "-preCICE" argument to build_script.sh
- Create the a .cpl files  (for instance modelA_0001.cpl if the engine file is named  modelA_0001.rad). For instance it contains
```
/PRECICE/PARTICIPANT_NAME/SolverTwo
/PRECICE/CONFIG_FILE/precice-config.xml
/PRECICE/MESH_NAME/MeshTwo
/PRECICE/WRITE/FORCES
/PRECICE/READ/POSITIONS
/PRECICE/INTERFACE/9
```
The names (participant, mesh, data) should be consistent with the names in `precice-config.xml`
As of now, INTERFACE should point to a GRNOD id. This will later be extended to support surface (for the cases where the element connectivity is required.


This is only the first step of making preCICE available with OpenRadioss, mainly focusing on the plumbing — wiring up the APIs, ensuring everything compiles and links properly. I haven't tested the actual functionality yet with another third-party solver.
For this POC, only FORCES, DISPLACEMENTS and POSITIONS are available for exchange.
