### PR TITLE
wrong compatibility check of /PRELOAD/AXIAL and spring type23 using mat113

### DIFF
--- a/starter/source/elements/spring/rinit3.F
+++ b/starter/source/elements/spring/rinit3.F
@@ -1609,8 +1609,8 @@ C
             IF (MTN==113) THEN  
               J=1+NFT
               I0=IXR(1,J)
-              IFUNC = IGEO(101,I0)
               IMAT   = IXR(5,J)
+              IFUNC = IPM(10 + 1,IMAT)
               IADBUF = IPM(7,IMAT) - 1
               IH= NINT(UPARAM(IADBUF + 4 + 12*6 + 1))
               IF (IFUNC==0) IH =0


### PR DESCRIPTION


#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
Starter might stop due to compatibility check between /PRELOAD/AXIAL and spring tyep23+mat 113
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
correction of wrong compatibility check

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
