### PR TITLE
enable /FUNCT_PYTHON by RUN_QA environement instead of -python

### DIFF
--- a/starter/source/starter/execargcheck.F
+++ b/starter/source/starter/execargcheck.F
@@ -104,13 +104,20 @@ C-----------------------------------------------
      .    '-HSTP_READ' , '-HSTP_WRITE', '-RXALEA', '-RSEED',
      .    '-PREVIEW',
      .    '-GRP_SIZE' , '-PYTHON' , '-THNMS1','-CHECKSUM_READ'/
-
+       INTEGER :: RUNQA
+       CHARACTER (LEN=255) :: STR
 C-----------------------------------------------
        IDUM=-1
        ITRACE=1
        IERRMSG=0
        GLOBAL_ERROR = 0
        PYTHON_ERROR = 1
+       STR = ' '
+      
+       CALL  GETENV('RUN_QA',STR)
+       RUNQA = 0
+       READ(STR,'(I10)')RUNQA
+       IF(RUNQA == 1) PYTHON_ERROR = 0
 
        GOT_INPUT = 0
        GOT_NCPU = 0


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
When running OpenRadioss within a script, adding the command line -python to enable /FUNCT_PYTHON may be impractical.
An environment variable may also be used.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
