### PR TITLE
OpenReader compatibility with gcc14

### DIFF
--- a/reader/source/dyna2rad/_private/convertsets.cxx
+++ b/reader/source/dyna2rad/_private/convertsets.cxx
@@ -22,9 +22,11 @@
 //Copyright>    commercial version may interest you: https://www.altair.com/radioss/.*/
 
 #include <unordered_set>
+#include <limits>
 #include <dyna2rad/convertsets.h>
 #include <dyna2rad/dyna2rad.h>
 #include <dyna2rad/sdiUtils.h>
+
 
 using namespace std;
 using namespace sdi;
@@ -49,9 +51,9 @@ void sdiD2R::ConvertSet::p_ConvertAllSets()
 {
     SelectionRead selDynaSetParAdd(p_lsdynaModel, "*SET_PART_ADD");
     SelectionRead selDynaSet(p_lsdynaModel, "*SET");
-    unsigned int setId = UINT32_MAX;
-    unsigned int setIdPrevious = UINT32_MAX;
-    unsigned int RenumberedSetIdPrevious = UINT32_MAX;
+    unsigned int setId = std::numeric_limits<unsigned int>::max();
+    unsigned int setIdPrevious =  std::numeric_limits<unsigned int>::max();
+    unsigned int RenumberedSetIdPrevious =  std::numeric_limits<unsigned int>::max();
     sdiString setType = "\0";
     sdiString keyWord = "\0";
     HandleEdit setHEdit;


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
This pull request makes improvements to the `reader/source/dyna2rad/_private/convertsets.cxx` file to enhance code clarity and maintainability. The key changes involve replacing hardcoded constants with `std::numeric_limits` for better readability and robustness.

### Code clarity and maintainability improvements:

* Added the `#include <limits>` directive to enable the use of `std::numeric_limits` for defining maximum values of data types.
* Replaced the hardcoded `UINT32_MAX` constant with `std::numeric_limits<unsigned int>::max()` in the `p_ConvertAllSets()` method to improve readability and ensure consistency with modern C++ practices.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
