### PR TITLE
/ANIM/BEAM/FORC: M31 (M3) and M32 (M6) are switched

### DIFF
--- a/engine/source/elements/beam/pbilan.F
+++ b/engine/source/elements/beam/pbilan.F
@@ -199,15 +199,18 @@ C
 C
       IF (ANIM_FT(1) /= 0 .OR. H3D_DATA%UND_FORC /= 0) THEN
         DO I=1,NEL
+          ! Beam force
           TANI(1,I)= FOR(I,1)
           TANI(2,I)= FOR(I,2)
           TANI(3,I)= FOR(I,3)
-          TANI(4,I)= MOM(I,1)
+          ! Beam Node_1 moment
+          TANI(4,I)= -MOM(I,1)
+          TANI(5,I)= -MOM(I,2) + HALF*AL(I)*FOR(I,3)
+          TANI(6,I)= -MOM(I,3) - HALF*AL(I)*FOR(I,2)
+          ! Beam Node_2 moment
+          TANI(7,I)= MOM(I,1)
           TANI(5,I)= MOM(I,2) + HALF*AL(I)*FOR(I,3)
-          TANI(6,I)= MOM(I,3) - HALF*AL(I)*FOR(I,2)
-          TANI(7,I)= -MOM(I,1)
-          TANI(8,I)= -MOM(I,2) + HALF*AL(I)*FOR(I,3)
-          TANI(9,I)= -MOM(I,3) - HALF*AL(I)*FOR(I,2)
+          TANI(9,I)= MOM(I,3) - HALF*AL(I)*FOR(I,2)
 C          TANI(10,I)= E1X(I)
 C          TANI(11,I)= E1Y(I)
 C          TANI(12,I)= E1Z(I)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

M31 (M3) and M32 (M6) are switched for Node_1 and Node_2 of beams in /ANIM/BEAM/FORC

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

M31 (M3) and M32 (M6) are switched for Node_1 and Node_2 of beams in /ANIM/BEAM/FORC

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
