### PR TITLE
fix #3979 for non-MPI engine

### DIFF
--- a/engine/source/mpi/init/inipar.F
+++ b/engine/source/mpi/init/inipar.F
@@ -366,7 +366,7 @@ C
       !||--- uses       -----------------------------------------------------
       !||    spmd_comm_world_mod   ../engine/source/mpi/spmd_comm_world.F90
       !||====================================================================
-      SUBROUTINE INIPAR(ITID,ICAS,NNODES,INPUT,GOT_INPUT,NBTASK)
+      SUBROUTINE INIPAR(coupling, ITID,ICAS,NNODES,INPUT,GOT_INPUT,NBTASK)
 C-----------------------------------------------------------------
         USE SPMD_COMM_WORLD_MOD, ONLY : SPMD_COMM_WORLD
         USE COUPLING_ADAPTER_MOD
@@ -390,6 +390,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l  V a r i a b l e s
 C-----------------------------------------------
+      type(coupling_type), intent(inout) :: coupling
       INTEGER ICODE, I, NTHREAD1
 #if defined(_OPENMP)
       INTEGER OMP_GET_MAX_THREADS


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

This pull request updates the non-MPI `INIPAR` subroutine in the `engine/source/mpi/init/inipar.F` file to include a new parameter for coupling functionality. The changes enhance the subroutine's capabilities by introducing a new argument and its associated variable.


<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
