### PR TITLE
/FUNCT_PYTHON + /MONVOL

### DIFF
--- a/common_source/modules/cpp_python_funct.cpp
+++ b/common_source/modules/cpp_python_funct.cpp
@@ -96,7 +96,7 @@ std::string element_parenthesis_to_underscore(const std::string &input, const st
 
 std::string node_parenthesis_to_underscore(const std::string &input)
 {
-    std::regex pattern(R"(\b(DX|DY|DZ|AX|AY|AZ|CX|CY|CZ|VX|VY|VZ|ARX|ARY|ARZ|VRX|VRY|VRZ|DRX|DRY|DRZ|MONVOL_VOLUME|MONVOL_TEMPERATURE|MONVOL_AREA|MONVOL_PRESSURE)\b\s*\(\s*(\d+|ACTIVE_NODE)\s*\))");
+    std::regex pattern(R"(\b(DX|DY|DZ|AX|AY|AZ|CX|CY|CZ|VX|VY|VZ|ARX|ARY|ARZ|VRX|VRY|VRZ|DRX|DRY|DRZ|MONVOL_VOL|MONVOL_T|MONVOL_A|MONVOL_P)\b\s*\(\s*(\d+|ACTIVE_NODE)\s*\))");
     std::string result = std::regex_replace(input, pattern, "$1_$2");
     return result;
 }
@@ -777,7 +777,7 @@ extern "C"
 
     }
 
-    void cpp_python_initiazlize_global_variables()
+    void cpp_python_initialize_global_variables()
     {
         if (!python_initialized)
         {
@@ -898,7 +898,7 @@ extern "C"
         if (python_initialized)
         {
             // initialize the global variables found in the python function
-            cpp_python_initiazlize_global_variables();
+            cpp_python_initialize_global_variables();
             python_execute_code(function_code.str());
         }
         else

--- a/engine/source/airbag/airbag1.F
+++ b/engine/source/airbag/airbag1.F
@@ -25,17 +25,18 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||--- called by ------------------------------------------------------
       !||    monvol0      ../engine/source/airbag/monvol0.F
       !||--- calls      -----------------------------------------------------
-      !||    finter       ../engine/source/tools/curve/finter.F
       !||--- uses       -----------------------------------------------------
       !||    sensor_mod   ../common_source/modules/sensor_mod.F90
       !||====================================================================
       SUBROUTINE AIRBAGA(IVOLU ,NJET   ,IBAGJET ,NVENT   ,IBAGHOL,
      2                 ICBAG   ,RVOLU   ,RBAGJET ,RBAGHOL,RCBAG   ,
      3                 RVOLUV  ,NPC     ,TF      ,NSENSOR ,SENSOR_TAB ,
-     4                 VOL     ,PMAIN   ,WFEXT )
+     4                 VOL     ,PMAIN   ,WFEXT ,PYTHON)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------  
+      USE python_funct_mod
+      USE finter_mixed_mod
       USE SENSOR_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
@@ -64,6 +65,7 @@ C-----------------------------------------------
      .   RBAGHOL(NRBHOL,*),RCBAG(NRCBAG,*),RVOLUV(NRVOLU,*),VOL
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) ,INTENT(IN) :: SENSOR_TAB
       DOUBLE PRECISION, INTENT(INOUT) :: WFEXT
+      TYPE(PYTHON_), intent(inout) :: PYTHON
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -74,7 +76,7 @@ C-----------------------------------------------
      .   PDEF, PEXT, PVOIS, DTPDEFC,
      .   GAMA, AMU, TSTART, TSG,
      .   AMTOT, P, POLD, DV,
-     .   ROT, DYDX, FTEMP, FMASS, DT, AREA,
+     .   ROT,  FTEMP, FMASS, DT, AREA,
      .   CV, CP, CVG, CPG, CPA, CPB, CPC, CVI, CPI, CPAI, CPBI, CPCI,
      .   RMWI, RMWG,
      .   RNM_OLD, RNM, RNMG,
@@ -83,8 +85,6 @@ C-----------------------------------------------
      .   EFAC, DGEOUT, RIGHT, LEFT, 
      .   VOLD, VEPS, VMIN, AMTOT_OLD, TBAG_OLD, TBAG,SCALT,
      .   QOLD,Q,CX,QX,TEMP
-      my_real FINTER 
-      EXTERNAL FINTER
 C-----------------------------------------------
       PEXT     =RVOLU(3)
       POLD     =RVOLU(12)
@@ -238,7 +238,7 @@ C---------------------
         IF(TT >= TSTART)THEN
          TSG = (TT-TSTART)*RVOLU(26)
          IF(ITEMP > 0) THEN
-           TEMP=FTEMP*FINTER(ITEMP,TSG,NPC,TF,DYDX)
+           TEMP=FTEMP*FINTER_MIXED(PYTHON,NFUNCT,ITEMP,TSG,NPC,TF)
          ELSE
            TEMP=FTEMP
          ENDIF
@@ -250,7 +250,7 @@ C
         GMASS_OLD=RBAGJET(7,IJ)
         IF(TT >= TSTART)THEN
          IF(IMASS > 0) THEN
-           GMASS=FMASS*FINTER(IMASS,TSG,NPC,TF,DYDX)
+           GMASS=FMASS*FINTER_MIXED(PYTHON,NFUNCT,IMASS,TSG,NPC,TF)
            IF(IFLU == 1)GMASS = GMASS*RVOLU(26)*DT1 + GMASS_OLD
          ELSE
            GMASS=FMASS

--- a/engine/source/airbag/airbaga1.F
+++ b/engine/source/airbag/airbaga1.F
@@ -33,11 +33,13 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      2                    ICBAG  ,RVOLU   ,RBAGJET ,RBAGHOL ,RCBAG      ,
      3                    RVOLUV ,NPC     ,TF      ,NSENSOR ,SENSOR_TAB ,
      4                    VOL    ,PMAIN   ,GEO     ,IGEO    ,PM         ,
-     5                    WFEXT )
+     5                    WFEXT, PYTHON )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------  
+      USE python_funct_mod
       USE SENSOR_MOD
+      USE finter_mixed_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -67,6 +69,7 @@ C-----------------------------------------------
      .   GEO(NPROPG,*),PM(NPROPM,*)
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) ,INTENT(IN) :: SENSOR_TAB
       DOUBLE PRECISION,INTENT(INOUT) :: WFEXT
+      TYPE(PYTHON_), intent(inout) :: PYTHON
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -78,7 +81,7 @@ C-----------------------------------------------
      .   PDEF, PEXT, PVOIS, DTPDEFC,
      .   GAMA, AMU, TSTART, TSG,TSG2,
      .   AMTOT, P, POLD, DV,
-     .   ROT, DYDX, FTEMP, FMASS, DT, AREA,
+     .   ROT,  FTEMP, FMASS, DT, AREA,
      .   CV, CP, CVG, CPG, CPA, CPB, CPC, CVI, CPI, CPAI, CPBI, CPCI,
      .   RMWI, RMWG,
      .   RNM_OLD, RNM, RNMG,
@@ -90,8 +93,6 @@ C-----------------------------------------------
       my_real
      .   MW, CPD, CPE, CPF, CPDI, CPEI, CPFI, R_IGC1, DGMIN, ASTIME,
      .   DGEIN, HCONV, TEXT, MOLFR, MW_MIX
-      my_real FINTER 
-      EXTERNAL FINTER
 C-----------------------------------------------
       FTEMP = ZERO
       PEXT     =RVOLU(3)
@@ -264,7 +265,7 @@ C
             IF(IMOL == 0) THEN
                MW_MIX = MW_MIX + MW*MOLFR
             ELSE
-               MW_MIX = MW_MIX + MW*FINTER(IMOL,TSG,NPC,TF,DYDX)
+               MW_MIX = MW_MIX + MW*FINTER_MIXED(PYTHON,NFUNCT,IMOL,TSG,NPC,TF)
             ENDIF
          ENDDO
          RBAGJET(19,IJ) = MW_MIX
@@ -330,7 +331,7 @@ C
           IF (TSG2 <= ZERO) TSG2 = TSG
 C
           IF(ITEMP>0) THEN
-            TEMP=FTEMP*FINTER(ITEMP,TSG,NPC,TF,DYDX)
+            TEMP=FTEMP*FINTER_MIXED(PYTHON,NFUNCT,ITEMP,TSG,NPC,TF)
           ELSE
             TEMP=FTEMP
           ENDIF
@@ -347,14 +348,14 @@ C
          GMASS_OLD=RBAGJET(KK+2,IJ)
          IF(TT>=TSTART)THEN
           IF(IMASS>0) THEN
-            GMASS=HALF * FMASS * (FINTER(IMASS,TSG,NPC,TF,DYDX) + 
-     .            FINTER(IMASS,TSG2,NPC,TF,DYDX))
+            GMASS=HALF * FMASS * (FINTER_MIXED(PYTHON,NFUNCT,IMASS,TSG,NPC,TF) + 
+     .            FINTER_MIXED(PYTHON,NFUNCT,IMASS,TSG2,NPC,TF))
             IF(I_TYPINJ == 2) THEN
                MW_MIX = RBAGJET(19,IJ)
                IF(IMOL == 0) THEN
                  GMASS=GMASS*MW*MOLFR/MW_MIX
                ELSE
-                 GMASS=GMASS*MW*FINTER(IMOL,TSG,NPC,TF,DYDX)/MW_MIX
+                 GMASS=GMASS*MW*FINTER_MIXED(PYTHON,NFUNCT,IMOL,TSG,NPC,TF)/MW_MIX
                ENDIF
             ENDIF
             IF(IFLU==1)GMASS = GMASS*DT1 + GMASS_OLD

--- a/engine/source/airbag/fv_up_switch.F
+++ b/engine/source/airbag/fv_up_switch.F
@@ -66,7 +66,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      K     CPDPOLH, CPEPOLH, CPFPOLH  ,
      L     ELTG   , IPARG  , MATTG    ,
      M     IGROUPTG,IGROUPC, ELBUF_TAB, CFL_COEF,
-     N     PDISP_OLD, PDISP, WFEXT)
+     N     PDISP_OLD, PDISP, WFEXT, PYTHON )
 C-----------------------------------------------
 C   M O D U L E S
 C-----------------------------------------------
@@ -77,6 +77,8 @@ C-----------------------------------------------
 !     USE OMP_LIB
       USE SENSOR_MOD
       USE ANIM_MOD
+      USE python_funct_mod
+      use finter_mixed_mod
 C-----------------------------------------------
 C   I M P L I C I T   T Y P E S
 C-----------------------------------------------
@@ -126,6 +128,7 @@ C-----------------------------------------------
       TYPE(ELBUF_STRUCT_), DIMENSION(NGROUP), INTENT(IN) :: ELBUF_TAB
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) ,INTENT(IN) :: SENSOR_TAB
       DOUBLE PRECISION,INTENT(INOUT) :: WFEXT
+      TYPE(PYTHON_),INTENT(IN) :: PYTHON
 C-----------------------------------------------
 C   L O C A L   V A R I A B L E S
 C-----------------------------------------------
@@ -147,7 +150,7 @@ C-----------------------------------------------
      .        CPDI, CPEI, CPFI,
      .        RHOI, DATAINJ(6,NJET), SCALT,
      .        FVEL, TSTART, TSG, INJVEL,
-     .        DYDX, CPA, CPB, CPC, EFAC,
+     .        CPA, CPB, CPC, EFAC,
      .        PU(3,NPOLH), GAMA, FEL(NELT), DM(NPOLH),
      .        DQ(3,NPOLH), DE(NPOLH), DMI, RHO1, RE1, UX1,
      .        UY1, UZ1, RHO2, RE2, UX2, UY2, UZ2, VFX, VFY, VFZ, VREL(NELT), SS(NELT), SS_,
@@ -178,8 +181,8 @@ C-----------------------------------------------
       LOGICAL :: UP_SWITCH
 C
       MY_REAL
-     .         FINTER, GET_U_FUNC
-      EXTERNAL FINTER, GET_U_FUNC
+     .          GET_U_FUNC
+      EXTERNAL GET_U_FUNC
       CHARACTER*20 VENTTITLE
       INTEGER :: NODE_ID(5), INODE
       MY_REAL :: TAB_PVOL(NELT), DOT_PROD
@@ -587,10 +590,10 @@ C
       SCALT =RVOLU(26)
       IF(ITYP==6) THEN
         CALL FVINJT6(NJET, IBAGJET, RBAGJET, NPC, TF,NSENSOR, 
-     .               SENSOR_TAB,SCALT, DATAINJ )
+     .               SENSOR_TAB,SCALT, DATAINJ, PYTHON )
       ELSEIF(ITYP==8) THEN
         CALL FVINJT8(NJET, IBAGJET, RBAGJET, NPC, TF,NSENSOR,  
-     .               SENSOR_TAB,SCALT, IGEO, GEO, PM, IVOLU, DATAINJ )
+     .               SENSOR_TAB,SCALT, IGEO, GEO, PM, IVOLU, DATAINJ,PYTHON)
       ENDIF
 C
       DO IINJ=1,NJET
@@ -614,7 +617,7 @@ C        ITTF : 1 OR 2 +10 1 FLAG HAS BEEN ACTIVATED AND RVOLU(60) IS FILLED
          IF (TT>=TSTART.AND.DT1>ZERO)THEN
            TSG=(TT-TSTART)*SCALT
            IF (IVEL>0) THEN
-              INJVEL=FVEL*FINTER(IVEL,TSG,NPC,TF,DYDX)
+              INJVEL=FVEL*FINTER_MIXED(PYTHON,nfunct,IVEL,TSG,NPC,TF)
            ELSE
               INJVEL = FVEL
            ENDIF

--- a/engine/source/airbag/fvbag0.F
+++ b/engine/source/airbag/fvbag0.F
@@ -40,7 +40,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .                  FSAV  ,  IFVMESH , ICONTACT , LGAUGE    ,
      .                  GAUGE ,  IGEO    , GEO      , PM        , IPM,
      .                  IPARG ,  IGROUPTG, IGROUPC  , ELBUF_TAB , FEXT,
-     .                  FLAG  ,  H3D_DATA, ITAB     ,WEIGHT     ,WFEXT)
+     .                  FLAG  ,  H3D_DATA, ITAB     ,WEIGHT     ,WFEXT, PYTHON)
 C-----------------------------------------------
 C   D e s c r i p t i o n
 C-----------------------------------------------
@@ -57,6 +57,7 @@ C-----------------------------------------------
       USE FVMBAG_MESHCONTROL_MOD
       USE H3D_MOD
       USE SENSOR_MOD
+      USE python_funct_mod, only : python_
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -87,6 +88,7 @@ C-----------------------------------------------
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) ,INTENT(IN) :: SENSOR_TAB 
       INTEGER,INTENT(IN) :: ITAB(NUMNOD), WEIGHT(NUMNOD)
       DOUBLE PRECISION,INTENT(INOUT) :: WFEXT
+      TYPE(PYTHON_) :: PYTHON
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -266,7 +268,7 @@ C
      K            FVDATA(IFV)%CPDPOLH   ,FVDATA(IFV)%CPEPOLH,FVDATA(IFV)%CPFPOLH ,
      L            MONVOL(KI4)           ,IPARG              ,MONVOL(KI5)         ,
      M            IGROUPTG              ,IGROUPC            ,ELBUF_TAB           , FEXT                     , CFL_COEF             ,
-     N            FVDATA(IFV)%PDISP_OLD ,FVDATA(IFV)%PDISP  ,H3D_DATA            , ITAB                     , WFEXT)
+     N            FVDATA(IFV)%PDISP_OLD ,FVDATA(IFV)%PDISP  ,H3D_DATA            , ITAB                     , WFEXT, PYTHON)
               ELSE
                 CALL FV_UP_SWITCH(
      1            NNS                   ,NTG, MONVOL(KI2)   ,NJET                , FVDATA(IFV)%NPOLY        , FVDATA(IFV)%LENH ,NBA,
@@ -291,7 +293,7 @@ C
      K            FVDATA(IFV)%CPDPOLH   ,FVDATA(IFV)%CPEPOLH,FVDATA(IFV)%CPFPOLH ,
      L            MONVOL(KI4)           ,IPARG              ,MONVOL(KI5)         ,
      M            IGROUPTG              ,IGROUPC            ,ELBUF_TAB, CFL_COEF ,
-     N            FVDATA(IFV)%PDISP_OLD ,FVDATA(IFV)%PDISP  ,WFEXT)
+     N            FVDATA(IFV)%PDISP_OLD ,FVDATA(IFV)%PDISP  ,WFEXT, PYTHON)
               ENDIF
             ELSEIF (FLAG == 2) THEN
               CALL FVBAG2(IFV       , ITYP          , NNA           , NVENT       , NJET          , 

--- a/engine/source/airbag/fvbag1.F
+++ b/engine/source/airbag/fvbag1.F
@@ -69,7 +69,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      K                  CPDPOLH  , CPEPOLH, CPFPOLH  ,
      L                  ELTG     , IPARG  , MATTG    ,
      M                  IGROUPTG , IGROUPC, ELBUF_TAB, FEXT          , CFL_COEF ,
-     N                  PDISP_OLD, PDISP  , H3D_DATA , ITAB          , WFEXT)
+     N                  PDISP_OLD, PDISP  , H3D_DATA , ITAB          , WFEXT, PYTHON)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -82,6 +82,8 @@ C-----------------------------------------------
       USE ANIM_MOD
       USE H3D_MOD , only:H3D_DATABASE
       USE CAST_MOD, only: double_to_my_real
+      USE PYTHON_FUNCT_MOD, only : python_
+      USE FINTER_MIXED_MOD, only: finter_mixed
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -135,6 +137,7 @@ C-----------------------------------------------
       INTEGER,INTENT(IN)::ITAB(NUMNOD)
       my_real, INTENT(INOUT) :: CENTROID_POLH(3,NPOLH)
       DOUBLE PRECISION,INTENT(INOUT) :: WFEXT
+      type(python_) :: PYTHON
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -197,7 +200,7 @@ C-----------------------------------------------
      .        CPDI, CPEI, CPFI,
      .        RHOI, DATAINJ(6,NJET), SCALT, FMASS, GMASS_OLD,
      .        GMTOT_OLD, FVEL, TSTART, TSG, GMASS, DGMASS, INJVEL,
-     .        DYDX, GMTOT, RMWG, CPA, CPB, CPC, FTEMP, EFAC, CPG,
+     .         GMTOT, RMWG, CPA, CPB, CPC, FTEMP, EFAC, CPG,
      .        CVG, WSURF(3), GAMA, FEL(NELT), 
      .        DQ(3,NPOLH), DE(NPOLH), DMI, DQI(3), DEI, RHO1, RE1, UX1,
      .        UY1, UZ1, RHO2, RE2, UX2, UY2, UZ2, VFX, VFY, VFZ, SS,
@@ -224,8 +227,8 @@ C-----------------------------------------------
       LOGICAL :: boolTAGEL,EXIT_NEG_VOL,INJECTION_STARTED
       LOGICAL :: UP_SWITCH
 C
-      my_real FINTER, GET_U_FUNC
-      EXTERNAL FINTER, GET_U_FUNC
+      my_real  GET_U_FUNC
+      EXTERNAL  GET_U_FUNC
       CHARACTER*20 VENTTITLE
       MY_REAL :: DTOLD, PARAM_LAMBDA
       INTEGER :: PARAM_L_TYPE, NNODES,nodeID
@@ -696,10 +699,10 @@ C
       SCALT =RVOLU(26)
       IF(ITYP == 6) THEN
         CALL FVINJT6(NJET, IBAGJET, RBAGJET, NPC, TF, NSENSOR,
-     .               SENSOR_TAB,SCALT, DATAINJ )
+     .               SENSOR_TAB,SCALT, DATAINJ, PYTHON )
       ELSEIF(ITYP == 8) THEN
         CALL FVINJT8(NJET, IBAGJET, RBAGJET, NPC, TF, NSENSOR,
-     .               SENSOR_TAB,SCALT, IGEO, GEO, PM, IVOLU, DATAINJ )
+     .               SENSOR_TAB,SCALT, IGEO, GEO, PM, IVOLU, DATAINJ,PYTHON)
       ENDIF
 C
       DO IINJ=1,NJET
@@ -723,7 +726,7 @@ C        ITTF : 1 or 2 +10 1 flag has been activated and RVOLU(60) is filled
         IF (TT >= TSTART.AND.DT1 > ZERO)THEN
           TSG=(TT-TSTART)*SCALT
           IF (IVEL > 0) THEN
-            INJVEL=FVEL*FINTER(IVEL,TSG,NPC,TF,DYDX)
+            INJVEL=FVEL*FINTER_MIXED(python,nfunct,IVEL,TSG,NPC,TF)
           ELSE
             INJVEL = FVEL
           ENDIF

--- a/engine/source/airbag/fvinjt6.F
+++ b/engine/source/airbag/fvinjt6.F
@@ -31,11 +31,13 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    sensor_mod     ../common_source/modules/sensor_mod.F90
       !||====================================================================
       SUBROUTINE FVINJT6(NJET   , IBAGJET , RBAGJET , NPC    , TF      ,
-     2                   NSENSOR,SENSOR_TAB, SCALT,    DATAINJ )
+     2                   NSENSOR,SENSOR_TAB, SCALT,    DATAINJ ,PYTHON)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------  
       USE SENSOR_MOD
+      USE PYTHON_FUNCT_MOD
+      USE FINTER_MIXED_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -55,6 +57,7 @@ C     REAL
       my_real
      .   RBAGJET(NRBJET,*), TF(*),SCALT,DATAINJ(6,NJET)
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) ,INTENT(IN) :: SENSOR_TAB
+      type(python_) :: PYTHON
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -63,10 +66,6 @@ C-----------------------------------------------
      .   TSTART, FMASS, GMASS, GMASS_OLD, GMTOT, GMTOT_OLD, DGMASS,
      .   TSG,    DYDX,  RMWG,  FTEMP,  TEMP,  EFAC , 
      .   CPA,    CPB,   CPC,   CPG,    CVG
-C
-      my_real
-     .         FINTER
-      EXTERNAL FINTER
 C-----------------------------------------------
       DO IINJ=1,NJET
          FMASS=RBAGJET(5,IINJ)
@@ -83,7 +82,7 @@ C-----------------------------------------------
          IF (TT>=TSTART.AND.DT1>ZERO)THEN
             TSG=(TT-TSTART)*SCALT
             IF (IMASS>0) THEN
-               GMASS=FMASS*FINTER(IMASS,TSG,NPC,TF,DYDX)
+               GMASS=FMASS*FINTER_MIXED(python,nfunct,IMASS,TSG,NPC,TF)
                IF(IFLU==1)GMASS = GMASS*SCALT*DT1 + GMASS_OLD
             ELSE
                GMASS=FMASS
@@ -113,7 +112,7 @@ C------------
          IF(TT>=TSTART)THEN
             TSG = (TT-TSTART)*SCALT
             IF(ITEMP>0) THEN
-              TEMP=FTEMP*FINTER(ITEMP,TSG,NPC,TF,DYDX)
+              TEMP=FTEMP*FINTER_MIXED(python,nfunct,ITEMP,TSG,NPC,TF)
             ELSE
               TEMP=FTEMP
             ENDIF

--- a/engine/source/airbag/fvinjt8.F
+++ b/engine/source/airbag/fvinjt8.F
@@ -32,10 +32,12 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||====================================================================
       SUBROUTINE FVINJT8(NJET   , IBAGJET , RBAGJET , NPC    , TF,
      2                   NSENSOR,SENSOR_TAB, SCALT,    IGEO,     GEO,     
-     3                   PM     , IVOLU,   DATAINJ )
+     3                   PM     , IVOLU,   DATAINJ ,PYTHON)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------  
+      USE python_funct_mod, ONLY : python_
+      use finter_mixed_mod, ONLY : finter_mixed
       USE SENSOR_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
@@ -57,6 +59,7 @@ C     REAL
      .   RBAGJET(NRBJET,*), TF(*),SCALT, 
      .   GEO(NPROPG,*), PM(NPROPM,*), DATAINJ(6,NJET)
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) ,INTENT(IN) :: SENSOR_TAB
+      type(python_) :: python
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -65,15 +68,11 @@ C-----------------------------------------------
       my_real
      .   TSTART, ASTIME, DGMASSI, GMTOT_OLD, GMASS_OLD, GMOL_OLD, FMASS, 
      .   FTEMP,  MOLFR,  GMASS,   GMASS_DT,  GMTOT,     DGMASS,   EFAC , 
-     .   TSG,    DYDX,  RMWG,  TEMP,  
+     .   TSG,    RMWG,  TEMP,  
      .   CPA, CPB, CPC, CPD, CPE, CPF, MW, 
      .   CPA_NEW, CPB_NEW, CPC_NEW, CPD_NEW, CPE_NEW, CPF_NEW,MWMIX_NEW,
      .   DMASS_MIX, DMOL_MIX, DMASSG_MIX, DTEPS, MASS_MIX, MASS_MIX_DT, 
      .   MWMIX, FMASS1, MW1, MOLFR1, R_IGC1, DGMOUT
-C
-      my_real
-     .         FINTER
-      EXTERNAL FINTER
 C-----------------------------------------------
       R_IGC1   =PM(27,IVOLU(66))
 C---------------------
@@ -136,7 +135,7 @@ C
           TSG = (TT-TSTART)/ASTIME
 C
           IF(ITEMP>0) THEN
-            TEMP=FTEMP*FINTER(ITEMP,TSG,NPC,TF,DYDX)
+            TEMP=FTEMP*FINTER_MIXED(python,nfunct,ITEMP,TSG,NPC,TF)
           ELSE
             TEMP=FTEMP
           ENDIF
@@ -167,7 +166,7 @@ C
                MW1=PM(20,I_GAS1)
 C
                IF(IMASS1>0) THEN
-                 GMASS=FMASS1*FINTER(IMASS1,TSG,NPC,TF,DYDX)
+                 GMASS=FMASS1*FINTER_MIXED(python,nfunct,IMASS1,TSG,NPC,TF)
                ELSE
                  GMASS=FMASS1
                END IF
@@ -177,7 +176,7 @@ C
                 DMOL_MIX=DMOL_MIX+GMASS/MW1
                ELSEIF (IFLU==0) THEN
                 IF(IMASS1>0) THEN
-                  GMASS_DT=FMASS1*FINTER(IMASS1,TSG+DTEPS,NPC,TF,DYDX)
+                  GMASS_DT=FMASS1*FINTER_MIXED(python,nfunct,IMASS1,TSG+DTEPS,NPC,TF)
                 ELSE
                   GMASS_DT=FMASS1
                 END IF
@@ -187,14 +186,14 @@ C
               END DO ! end boucle sur IL
 C
               IF(IMASS>0) THEN
-                GMASS=FMASS*FINTER(IMASS,TSG,NPC,TF,DYDX)
+                GMASS=FMASS*FINTER_MIXED(python,nfunct,IMASS,TSG,NPC,TF)
               ELSE
                 GMASS=FMASS
               END IF
               DMASSG_MIX=GMASS
               IF (IFLU==0) THEN
                 IF(IMASS>0) THEN
-                  GMASS_DT=FMASS*FINTER(IMASS,TSG+DTEPS,NPC,TF,DYDX)
+                  GMASS_DT=FMASS*FINTER_MIXED(python,nfunct,IMASS,TSG+DTEPS,NPC,TF)
                 ELSE
                   GMASS_DT=FMASS
                 END IF
@@ -226,7 +225,7 @@ C
      .                *MW1
                ELSE
                 GMASS=MOLFR1
-     .                *FINTER(IMOL1,TSG,NPC,TF,DYDX)
+     .                *FINTER_MIXED(python,nfunct,IMOL1,TSG,NPC,TF)
      .                *MW1
                END IF
                IF (IFLU==1) THEN
@@ -241,7 +240,7 @@ C
      .                     *MW1
                  ELSE
                   GMASS_DT=MOLFR1
-     .                     *FINTER(IMOL1,TSG+DTEPS,NPC,TF,DYDX)
+     .                     *FINTER_MIXED(python,nfunct,IMOL1,TSG+DTEPS,NPC,TF)
      .                     *MW1
                  END IF
 C --- la fraction molaire n est pas un debit
@@ -259,15 +258,15 @@ C --- Somme de masse (masse x masse_molaire)/masse_mixture
      .                     *MW
               ELSE
                 GMASS=FMASS*MOLFR
-     .                     *FINTER(IMOL,TSG,NPC,TF,DYDX)
+     .                     *FINTER_MIXED(python,nfunct,IMOL,TSG,NPC,TF)
      .                     *MW
               END IF
               GMASS=GMASS
-     .              *FINTER(IMASS,TSG,NPC,TF,DYDX)/MASS_MIX
+     .              *FINTER_MIXED(python,nfunct,IMASS,TSG,NPC,TF)/MASS_MIX
               DMASS_MIX=FMASS*DMASS_MIX
-     .              *FINTER(IMASS,TSG,NPC,TF,DYDX)/MASS_MIX
+     .              *FINTER_MIXED(python,nfunct,IMASS,TSG,NPC,TF)/MASS_MIX
               DMOL_MIX =FMASS*DMOL_MIX
-     .              *FINTER(IMASS,TSG,NPC,TF,DYDX)/MASS_MIX
+     .              *FINTER_MIXED(python,nfunct,IMASS,TSG,NPC,TF)/MASS_MIX
               DMASSG_MIX=GMASS
               IF (IFLU==0) THEN
                IF (IMOL==0) THEN
@@ -275,12 +274,12 @@ C --- Somme de masse (masse x masse_molaire)/masse_mixture
      .                         *MW
                ELSE
                  GMASS_DT=FMASS*MOLFR
-     .                         *FINTER(IMOL,TSG+DTEPS,NPC,TF,DYDX)
+     .                         *FINTER_MIXED(python,nfunct,IMOL,TSG+DTEPS,NPC,TF)
      .                         *MW
                END IF
 C --- la fraction molaire n est pas un debit
 C --- pas de recalcul de DMASSG_MIX avec DTEPS
-               GMASS_DT=GMASS_DT*FINTER(IMASS,TSG+DTEPS,NPC,TF,DYDX)/MASS_MIX_DT
+               GMASS_DT=GMASS_DT*FINTER_MIXED(python,nfunct,IMASS,TSG+DTEPS,NPC,TF)/MASS_MIX_DT
               END IF
             END IF
 C

--- a/engine/source/airbag/monvol0.F
+++ b/engine/source/airbag/monvol0.F
@@ -56,10 +56,11 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      7                   PM       ,IPM     ,IPART   ,IPARTC ,
      8                   IPARTTG  ,IGROUPC ,IGROUPTG,FEXT   ,
      9                   FLAG     ,H3D_DATA ,T_MONVOL,frontier_global_mv,
-     A                   OUTPUT)
+     A                   OUTPUT, PYTHON)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
+      USE PYTHON_FUNCT_MOD, only : PYTHON_
       USE ELBUFDEF_MOD
       USE H3D_MOD
       USE GROUPDEF_MOD
@@ -97,6 +98,7 @@ C-----------------------------------------------
       TYPE(MONVOL_STRUCT_), DIMENSION(NVOLU), INTENT(INOUT) :: T_MONVOL
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR), INTENT(IN) :: SENSOR_TAB
       TYPE(OUTPUT_),INTENT(INOUT) :: OUTPUT
+      TYPE(PYTHON_), INTENT(IN) :: PYTHON     
 C-----------------------------------------------
 C     N(3,*)  NORMALE STOCKEE DANS WA
 C     PORO(*) STOCKE DANS WA
@@ -175,7 +177,7 @@ C=======================================================================
 C         VOLUME P=F(V)
 C=======================================================================
           CALL VOLPFV(MONVOL(K1),VOLMON(KK1),VOL(I),FSAV(1,I),NPC,
-     2                TF        ,PMAIN   , OUTPUT%WFEXT )
+     2                TF        ,PMAIN   , OUTPUT%WFEXT, PYTHON, NFUNCT) 
         ELSEIF(ITYP==3)THEN
 C=======================================================================
 C         GAS PARFAIT
@@ -189,7 +191,7 @@ C=======================================================================
            CALL AIRBAGA(MONVOL(K1),NJET ,MONVOL(IADJET),NVENT ,MONVOL(IADHOL),
      2 MONVOL(K2),VOLMON(KK1),VOLMON(RADJET),VOLMON(RADHOL),VOLMON(KK2),
      3 VOLMON  ,NPC     ,TF      ,NSENSOR ,SENSOR_TAB ,
-     4 VOL(I)    ,PMAIN ,OUTPUT%WFEXT)
+     4 VOL(I)    ,PMAIN ,OUTPUT%WFEXT, PYTHON)
         ELSEIF(ITYP==7.OR.ITYP==9)THEN
 C=======================================================================
 C         AIRBAGS1 (NOUVEAUX INJECTEURS)
@@ -197,13 +199,13 @@ C=======================================================================
            CALL AIRBAGA1(MONVOL(K1),NJET ,MONVOL(IADJET),NVENT ,MONVOL(IADHOL),
      2 MONVOL(K2),VOLMON(KK1),VOLMON(RADJET),VOLMON(RADHOL),VOLMON(KK2),
      3 VOLMON  ,NPC     ,TF      ,NSENSOR ,SENSOR_TAB ,
-     4 VOL(I)     ,PMAIN ,GEO     ,IGEO    ,PM, OUTPUT%WFEXT)
+     4 VOL(I)     ,PMAIN ,GEO     ,IGEO    ,PM, OUTPUT%WFEXT,PYTHON)
         ELSEIF(ITYP==10)THEN
 C=======================================================================
 C         LINEAIRE FLUIDE
 C=======================================================================
           CALL VOLP_LFLUID(MONVOL(K1),VOLMON(KK1),VOL(I),FSAV(1,I),NPC,
-     2                    TF        ,PMAIN, OUTPUT )
+     2                    TF        ,PMAIN, OUTPUT ,PYTHON,NFUNCT)
         ENDIF
 C=======================================================================
         IF(ITYP/=1)THEN
@@ -211,7 +213,7 @@ C=======================================================================
             CALL VOLPRE(MONVOL(K1),VOLMON(KK1),NJET ,MONVOL(IADJET),VOLMON(RADJET),
      2                 NSENSOR ,SENSOR_TAB ,X       ,V       ,A       ,
      3                 t_monvol(i)%normal  ,NPC     ,TF      ,NN  ,IGRSURF(IS)%NODES,
-     4                 FEXT    ,H3D_DATA,IGRSURF(IS)%ELTYP,IGRSURF(IS)%ELEM, OUTPUT%WFEXT)
+     4                 FEXT    ,H3D_DATA,IGRSURF(IS)%ELTYP,IGRSURF(IS)%ELEM, OUTPUT%WFEXT,PYTHON)
          ELSE
             CALL VOLPREP(MONVOL(K1),VOLMON(KK1),NJET ,MONVOL(IADJET),VOLMON(RADJET),
      2                 NSENSOR ,SENSOR_TAB  ,X       ,V       ,A       ,
@@ -220,13 +222,9 @@ C=======================================================================
      5                 IGRSURF(IS)%ELTYP,IGRSURF(IS)%ELEM,
      5                 T_MONVOL(I)%OMP_OUTPUT%NODE_NUMBER,T_MONVOL(I)%OMP_OUTPUT%TOTAL_CONTRIBUTION_NUMBER, 
      6                 T_MONVOL(I)%OMP_OUTPUT%CONTRIBUTION_INDEX,T_MONVOL(I)%OMP_OUTPUT%CONTRIBUTION_NUMBER,
-     7                 T_MONVOL(I)%OMP_OUTPUT%NODE_ID,T_MONVOL(I)%OMP_OUTPUT%CONTRIBUTION,OUTPUT%WFEXT)
+     7                 T_MONVOL(I)%OMP_OUTPUT%NODE_ID,T_MONVOL(I)%OMP_OUTPUT%CONTRIBUTION,OUTPUT%WFEXT,PYTHON)
          ENDIF
         ENDIF
-!       write(6,*) "Pressure in volume ", UID, " is ", VOLMON(KK1+12-1),LOC(VOLMON(KK1+12-1))
-!       write(6,*) "Temperature in volume ", UID, " is ",VOLMON(KK1+13-1),LOC(VOLMON(KK1+13-1))
-!       write(6,*) "Volume in volume ", UID, " is ",VOL(I)
-!       write(6,*) "Area in volume ", UID, " is ",VOLMON(KK1+18-1),LOC(VOLMON(KK1+18-1))
         T_MONVOL(I)%UID = UID ! store the uid of the monitored volume
         T_MONVOL(I)%volume = VOL(I)
         T_MONVOL(I)%pressure = VOLMON(KK1+12-1)

--- a/engine/source/airbag/volp_lfluid.F
+++ b/engine/source/airbag/volp_lfluid.F
@@ -29,10 +29,12 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||--- uses       -----------------------------------------------------
       !||    output_mod    ../common_source/modules/output/output_mod.F90
       !||====================================================================
-      SUBROUTINE VOLP_LFLUID(IVOLU, RVOLU, VOL, FSAV, NPC, TF, PMAIN, OUTPUT)
+      SUBROUTINE VOLP_LFLUID(IVOLU, RVOLU, VOL, FSAV, NPC, TF, PMAIN, OUTPUT,PYTHON, NFUNCT)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
+      USE python_funct_mod
+      USE finter_mixed_mod
       USE OUTPUT_MOD , ONLY : OUTPUT_
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
@@ -50,15 +52,15 @@ C-----------------------------------------------
       INTEGER NPC(*),IVOLU(*), PMAIN
       my_real TF(*), RVOLU(*), FSAV(*), VOL
       TYPE(OUTPUT_),INTENT(INOUT) :: OUTPUT
+      TYPE(PYTHON_), intent(inout) :: PYTHON
+      INTEGER, intent(in) :: NFUNCT
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER IFUNCT
 
-      my_real P0, VOL0, DYDX, AREA, VEPS, VINC, POLD, PEXT, VOLD, PRES, Q,  QOLD, DV,   XFUN
+      my_real P0, VOL0,  AREA, VEPS, VINC, POLD, PEXT, VOLD, PRES, Q,  QOLD, DV,   XFUN
       my_real SCALEF, BULK, PMAX, GMASS, DMASS, RHOI
-      my_real FINTER 
-      EXTERNAL FINTER
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
@@ -81,7 +83,7 @@ C   BULK
       IF(IFUNCT == 0) THEN
          BULK = SCALEF    
       ELSE
-         BULK = SCALEF * FINTER(IFUNCT,TT,NPC,TF,DYDX)
+         BULK = SCALEF * FINTER_MIXED(PYTHON,NFUNCT,IFUNCT,TT,NPC,TF)
       ENDIF
 
 C   FLUID MASS IN
@@ -90,7 +92,7 @@ C   FLUID MASS IN
       IF(IFUNCT == 0) THEN
          DMASS = SCALEF * DT1
       ELSE
-         DMASS = SCALEF * FINTER(IFUNCT,TT,NPC,TF,DYDX) * DT1
+         DMASS = SCALEF * FINTER_MIXED(PYTHON,NFUNCT,IFUNCT,TT,NPC,TF) * DT1
       ENDIF 
       GMASS = GMASS + DMASS
       RVOLU(54)=RVOLU(54)+DMASS
@@ -101,7 +103,7 @@ C   FLUID MASS OUT (time)
       IF(IFUNCT == 0) THEN
          DMASS = SCALEF * DT1
       ELSE
-         DMASS = SCALEF * FINTER(IFUNCT,TT,NPC,TF,DYDX) * DT1
+         DMASS = SCALEF * FINTER_MIXED(PYTHON,NFUNCT,IFUNCT,TT,NPC,TF) * DT1
       ENDIF 
       GMASS = GMASS - DMASS
 
@@ -111,7 +113,7 @@ C   FLUID MASS OUT (pressure)
       IF(IFUNCT == 0) THEN
          DMASS = SCALEF * DT1
       ELSE
-         DMASS = SCALEF * FINTER(IFUNCT,POLD,NPC,TF,DYDX) * DT1
+         DMASS = SCALEF * FINTER_MIXED(PYTHON,NFUNCT,IFUNCT,POLD,NPC,TF) * DT1
       ENDIF 
       GMASS = GMASS - DMASS
 
@@ -121,7 +123,7 @@ C   P0
       IF(IFUNCT == 0) THEN
          P0 = SCALEF    
       ELSE
-         P0 = SCALEF * FINTER(IFUNCT,TT,NPC,TF,DYDX)
+         P0 = SCALEF * FINTER_MIXED(PYTHON,NFUNCT,IFUNCT,TT,NPC,TF)
       ENDIF
 
 C   PMAX
@@ -130,7 +132,7 @@ C   PMAX
       IF(IFUNCT == 0) THEN
          PMAX = SCALEF    
       ELSE
-         PMAX = SCALEF * FINTER(IFUNCT,TT,NPC,TF,DYDX)
+         PMAX = SCALEF * FINTER_MIXED(PYTHON,NFUNCT,IFUNCT,TT,NPC,TF)
       ENDIF
 
       VOL0 = GMASS / RHOI

--- a/engine/source/airbag/volpfv.F
+++ b/engine/source/airbag/volpfv.F
@@ -28,7 +28,9 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    finter    ../engine/source/tools/curve/finter.F
       !||====================================================================
       SUBROUTINE VOLPFV(IVOLU,RVOLU  ,VOL,FSAV,NPC,
-     2                  TF   ,PMAIN, WFEXT)
+     2                  TF   ,PMAIN, WFEXT,PYTHON,NFUNCT)
+         USE python_funct_mod
+         USE finter_mixed_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -45,13 +47,13 @@ C-----------------------------------------------
       INTEGER NPC(*),IVOLU(*), PMAIN
       my_real TF(*),RVOLU(*),FSAV(*)
       DOUBLE PRECISION,INTENT(INOUT) :: WFEXT
+      TYPE(PYTHON_), intent(inout) :: PYTHON
+      INTEGER, intent(in) :: NFUNCT
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER ITFUN,ITYPFUN
-      my_real VOL,V0,DYDX,AREA,VEPS,VINC,POLD,PEXT,VOLD,PRES,Q,QOLD,DV,SCALE,XFUN
-      my_real FINTER 
-      EXTERNAL FINTER
+      my_real VOL,V0,AREA,VEPS,VINC,POLD,PEXT,VOLD,PRES,Q,QOLD,DV,SCALE,XFUN
 C-----------------------------------------------
 C
 C CALCUL DE LA PRESSION
@@ -79,7 +81,7 @@ C
       CASE DEFAULT
          
       END SELECT
-      PRES = SCALE * FINTER(ITFUN,XFUN,NPC,TF,DYDX)
+      PRES = SCALE * FINTER_MIXED(PYTHON,NFUNCT,ITFUN,XFUN,NPC,TF)
       IF (ITYPFUN == 3) THEN
          PRES = PRES * (V0-VINC) / (VOL-VINC)
       ENDIF

--- a/engine/source/airbag/volpres.F
+++ b/engine/source/airbag/volpres.F
@@ -33,12 +33,14 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       SUBROUTINE VOLPRE(IVOLU ,RVOLU   ,NJET    ,IBAGJET ,RBAGJET  ,
      2                NSENSOR ,SENSOR_TAB,X       ,V       ,A        ,
      3                NORMAL  ,NPC     ,TF      ,NN      ,SURF_NODES,
-     4                FEXT    ,H3D_DATA,SURF_ELTYP,SURF_ELEM,WFEXT)
+     4                FEXT    ,H3D_DATA,SURF_ELTYP,SURF_ELEM,WFEXT,PYTHON)
 C-----------------------------------------------
 C   M o d u l e s
 C----------------------------------------------- 
       USE H3D_MOD
       USE SENSOR_MOD
+      USE python_funct_mod
+      USE finter_mixed_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -61,6 +63,7 @@ C-----------------------------------------------
       TYPE(H3D_DATABASE) :: H3D_DATA
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) ,INTENT(IN) :: SENSOR_TAB
       DOUBLE PRECISION, INTENT(INOUT) :: WFEXT
+      TYPE(PYTHON_), intent(inout) :: PYTHON
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -72,7 +75,6 @@ C-----------------------------------------------
      .   XM,YM,ZM,NX3,NY3,NZ3,
      .   PS1,PS2,PS3,AN2,AN3,DET,MU,FACR,
      .   API,DIST,TSTART,TS,TMPO,FPT,FPA,FPZ,SCALT,SCALA,SCALD
-      my_real FINTER
 C===============================================
       API=HUNDRED80/PI
 C-----------------------------------------------
@@ -231,7 +233,7 @@ C
 C
        IF(NJ1 /= 0 .AND. TT >= TSTART)THEN
         TS=TT-TSTART
-        PJ0=FPT*FINTER(IPT,TS*SCALT,NPC,TF,DYDX)
+        PJ0=FPT*FINTER_MIXED(PYTHON,NFUNCT,IPT,TS*SCALT,NPC,TF)
         DO I=1,NN
         IF(SURF_ELTYP(I)==3)THEN
           PJ=FOURTH*PJ0
@@ -286,9 +288,9 @@ C
           TMPO = (NX1*NX2+NY1*NY2+NZ1*NZ2)/AN
           TMPO = SIGN(MIN(ONE,ABS(TMPO)),TMPO)
           THETA=API*ACOS(TMPO)
-          PJ=PJ*FPA*FINTER(IPA,THETA*SCALA,NPC,TF,DYDX)
+          PJ=PJ*FPA*FINTER_MIXED(PYTHON,NFUNCT,IPA,THETA*SCALA,NPC,TF)
           DIST = SQRT(AN1)
-          IF(IPZ/=0)PJ=PJ*FPZ*FINTER(IPZ,DIST*SCALD,NPC,TF,DYDX)
+          IF(IPZ/=0)PJ=PJ*FPZ*FINTER_MIXED(PYTHON,NFUNCT,IPZ,DIST*SCALD,NPC,TF)
 C
           FX=PJ*NORMAL(1,I)
           FY=PJ*NORMAL(2,I)
@@ -379,9 +381,9 @@ C
           TMPO = (NX1*NX2+NY1*NY2+NZ1*NZ2)/AN
           TMPO = SIGN(MIN(ONE,ABS(TMPO)),TMPO)
           THETA=API*ACOS(TMPO)
-          PJ=PJ*FPA*FINTER(IPA,THETA*SCALA,NPC,TF,DYDX)
+          PJ=PJ*FPA*FINTER_MIXED(PYTHON,NFUNCT,IPA,THETA*SCALA,NPC,TF)
           DIST = SQRT(AN1)
-          IF(IPZ/=0)PJ=PJ*FPZ*FINTER(IPZ,DIST*SCALD,NPC,TF,DYDX)
+          IF(IPZ/=0)PJ=PJ*FPZ*FINTER_MIXED(PYTHON,NFUNCT,IPZ,DIST*SCALD,NPC,TF)
 C
           FX=PJ*NORMAL(1,I)
           FY=PJ*NORMAL(2,I)
@@ -471,9 +473,9 @@ C
           TMPO = (NX1*NX2+NY1*NY2+NZ1*NZ2)/AN
           TMPO = SIGN(MIN(ONE,ABS(TMPO)),TMPO)
           THETA=API*ACOS(TMPO)
-          PJ=PJ*FPA*FINTER(IPA,THETA*SCALA,NPC,TF,DYDX)
+          PJ=PJ*FPA*FINTER_MIXED(PYTHON,NFUNCT,IPA,THETA*SCALA,NPC,TF)
           DIST = SQRT(AN1)
-          IF(IPZ/=0)PJ=PJ*FPZ*FINTER(IPZ,DIST*SCALD,NPC,TF,DYDX)
+          IF(IPZ/=0)PJ=PJ*FPZ*FINTER_MIXED(PYTHON,NFUNCT,IPZ,DIST*SCALD,NPC,TF)
 C
           FX=PJ*NORMAL(1,I)
           FY=PJ*NORMAL(2,I)

--- a/engine/source/airbag/volpresp.F
+++ b/engine/source/airbag/volpresp.F
@@ -36,10 +36,12 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      4                   IADMV  ,FSKY    ,FSKYV   ,FEXT    ,H3D_DATA  ,
      5                   SURF_ELTYP,SURF_ELEM,NODE_NUMBER,TOTAL_CONTRIBUTION_NUMBER, 
      6                   CONTRIBUTION_INDEX,CONTRIBUTION_NUMBER,
-     7                   NODE_ID,CONTRIBUTION,WFEXT)
+     7                   NODE_ID,CONTRIBUTION,WFEXT,PYTHON)
 C-----------------------------------------------
 C   M o d u l e s
 C----------------------------------------------- 
+      USE python_funct_mod
+      USE finter_mixed_mod
       USE H3D_MOD 
       USE SENSOR_MOD
 C-----------------------------------------------
@@ -53,7 +55,6 @@ C  o m m o n   B l o c k s
 C-----------------------------------------------
 #include      "param_c.inc"
 #include      "com04_c.inc"
-!#include      "com06_c.inc"
 #include      "com08_c.inc"
 #include      "scr14_c.inc"
 #include      "scr16_c.inc"
@@ -71,23 +72,22 @@ C-----------------------------------------------
       INTEGER, DIMENSION(NODE_NUMBER+1), INTENT(in) :: CONTRIBUTION_NUMBER !< number of contribution per node
       INTEGER, DIMENSION(NODE_NUMBER), INTENT(in) :: NODE_ID !< node id
       my_real, DIMENSION(TOTAL_CONTRIBUTION_NUMBER,3), INTENT(inout) :: CONTRIBUTION !< contribution array, the force are saved here
-
       my_real RVOLU(*),RBAGJET(NRBJET,*),X(3,*), V(3,*), A(3,*), NORMAL(3,NN),TF(*),FSKY(8,LSKY),FSKYV(LSKY,8),FEXT(3,*)
       TYPE(H3D_DATABASE) :: H3D_DATA
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) ,INTENT(IN) :: SENSOR_TAB
       DOUBLE PRECISION,INTENT(INOUT) :: WFEXT
+      TYPE(PYTHON_), intent(inout) :: PYTHON
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,J,II,NJ1,NJ2,NJ3,IPT,IPA,IPZ,N1,N2,N3,N4,IJ,ISENS,K,ITYP
       INTEGER :: ADDRESS,NOD,LOCAL_CONTRIBUTION_NUMBER
-      my_real :: PRES,FX,FY,FZ,P,PEXT,DP,Q,PJ,PJ0,DYDX,XX,YY,ZZ,
+      my_real :: PRES,FX,FY,FZ,P,PEXT,DP,Q,PJ,PJ0,XX,YY,ZZ,
      .           THETA,NX1,NX2,NY1,NY2,NZ1,NZ2,AN1,AN,
      .           XM,YM,ZM,NX3,NY3,NZ3,
      .           PS1,PS2,PS3,AN2,AN3,DET,MU,FACR,
      .           API,DIST,TSTART,TS,TMPO,FPT,FPA,FPZ,SCALT,SCALA,SCALD
       my_real, DIMENSION(3) :: TMP
-      my_real FINTER
 C-----------------------------------------------
       API=HUNDRED80/PI
 C-----------------------------------------------
@@ -289,7 +289,7 @@ C-------------------------------------------
 
         IF(NJ1/=0.AND.TT>=TSTART)THEN
           TS=TT-TSTART
-          PJ0=FPT*FINTER(IPT,TS*SCALT,NPC,TF,DYDX)
+          PJ0=FPT*FINTER_MIXED(PYTHON,NFUNCT,IPT,TS*SCALT,NPC,TF)
 !$OMP DO SCHEDULE(guided)
           DO I=1,TOTAL_CONTRIBUTION_NUMBER
             CONTRIBUTION(I,1) = ZERO
@@ -357,9 +357,9 @@ C-------------------------------------------
               TMPO = (NX1*NX2+NY1*NY2+NZ1*NZ2)/AN
               TMPO = SIGN(MIN(ONE,ABS(TMPO)),TMPO)
               THETA=API*ACOS(TMPO)
-              PJ=PJ*FPA*FINTER(IPA,THETA*SCALA,NPC,TF,DYDX)
+              PJ=PJ*FPA*FINTER_MIXED(PYTHON,NFUNCT,IPA,THETA*SCALA,NPC,TF)
               DIST = SQRT(AN1)
-              IF(IPZ/=0)PJ=PJ*FPZ*FINTER(IPZ,DIST*SCALD,NPC,TF,DYDX)
+              IF(IPZ/=0)PJ=PJ*FPZ*FINTER_MIXED(PYTHON,NFUNCT,IPZ,DIST*SCALD,NPC,TF)
 
               FX=PJ*NORMAL(1,I)
               FY=PJ*NORMAL(2,I)
@@ -455,9 +455,9 @@ C-------------------------------------------
               TMPO = (NX1*NX2+NY1*NY2+NZ1*NZ2)/AN
               TMPO = SIGN(MIN(ONE,ABS(TMPO)),TMPO)
               THETA=API*ACOS(TMPO)
-              PJ=PJ*FPA*FINTER(IPA,THETA*SCALA,NPC,TF,DYDX)
+              PJ=PJ*FPA*FINTER_MIXED(PYTHON,NFUNCT,IPA,THETA*SCALA,NPC,TF)
               DIST = SQRT(AN1)
-              IF(IPZ/=0)PJ=PJ*FPZ*FINTER(IPZ,DIST*SCALD,NPC,TF,DYDX)
+              IF(IPZ/=0)PJ=PJ*FPZ*FINTER_MIXED(PYTHON,NFUNCT,IPZ,DIST*SCALD,NPC,TF)
 
               FX=PJ*NORMAL(1,I)
               FY=PJ*NORMAL(2,I)
@@ -546,9 +546,9 @@ C-------------------------------------------
               TMPO = (NX1*NX2+NY1*NY2+NZ1*NZ2)/AN
               TMPO = SIGN(MIN(ONE,ABS(TMPO)),TMPO)
               THETA=API*ACOS(TMPO)
-              PJ=PJ*FPA*FINTER(IPA,THETA*SCALA,NPC,TF,DYDX)
+              PJ=PJ*FPA*FINTER_MIXED(PYTHON,NFUNCT,IPA,THETA*SCALA,NPC,TF)
               DIST = SQRT(AN1)
-              IF(IPZ/=0)PJ=PJ*FPZ*FINTER(IPZ,DIST*SCALD,NPC,TF,DYDX)
+              IF(IPZ/=0)PJ=PJ*FPZ*FINTER_MIXED(PYTHON,NFUNCT,IPZ,DIST*SCALD,NPC,TF)
 
               FX=PJ*NORMAL(1,I)
               FY=PJ*NORMAL(2,I)

--- a/engine/source/ams/sms_gravit.F
+++ b/engine/source/ams/sms_gravit.F
@@ -31,10 +31,12 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||====================================================================
       SUBROUTINE SMS_GRAVIT(IGRV  ,AGRV   ,NPC   ,TF   ,A     ,
      2                      V     ,X      ,SKEW  ,MS   ,SENSOR_TAB,
-     3                      WEIGHT,IB    ,ITASK,TAGSLV_RBY_SMS,NSENSOR, WFEXT)
+     3                      WEIGHT,IB    ,ITASK,TAGSLV_RBY_SMS,NSENSOR, WFEXT,python)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------  
+      USE python_funct_mod, ONLY : python_
+      use finter_mixed_mod, only : finter_mixed
       USE SENSOR_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
@@ -59,13 +61,14 @@ C-----------------------------------------------
      .   AGRV(LFACGRV,*), TF(*), A(3,*), V(3,*), MS(*),
      .   X(3,*), SKEW(LSKEW,*)
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) ,INTENT(IN) :: SENSOR_TAB
+      DOUBLE PRECISION,INTENT(INOUT) :: WFEXT
+      TYPE(python_), intent(inout) :: python
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER NL, N1, ISK, N2, IFUNC, K1, K2, K3, ISENS,K,NN,IAD,J, IADF, IADL
-      my_real NX, NY, NZ, AXI, A0, AA, VV, FX, FY, FZ, AX, DYDX, TS,GAMA, WFEXTT,FCX,FCY
+      my_real NX, NY, NZ, AXI, A0, AA, VV, FX, FY, FZ, AX,  TS,GAMA, WFEXTT,FCX,FCY
       my_real,EXTERNAL :: FINTER
-      DOUBLE PRECISION,INTENT(INOUT) :: WFEXT
 C=======================================================================
       WFEXTT=ZERO
 C
@@ -92,8 +95,8 @@ C
         ENDIF
 C
         IF (IFUNC > 0) THEN
-          A0   = FCY*FINTER(IFUNC,(TS-DT1)*FCX,NPC,TF,DYDX)
-          GAMA = FCY*FINTER(IFUNC,TS*FCX,NPC,TF,DYDX)
+          A0   = FCY*FINTER_MIXED(python,nfunct,IFUNC,(TS-DT1)*FCX,NPC,TF)
+          GAMA = FCY*FINTER_MIXED(python,nfunct,IFUNC,TS*FCX,NPC,TF)
         ELSE
           A0   = FCY
           GAMA = FCY

--- a/engine/source/ams/sms_mass_scale_2.F
+++ b/engine/source/ams/sms_mass_scale_2.F
@@ -56,7 +56,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    sensor_mod         ../common_source/modules/sensor_mod.F90
       !||    timer_mod          ../engine/source/system/timer_mod.F90
       !||====================================================================
-      SUBROUTINE SMS_MASS_SCALE_2(TIMERS,
+      SUBROUTINE SMS_MASS_SCALE_2(TIMERS,PYTHON,
      1        ITASK    ,NODFT    ,NODLT    ,NODII_SMS ,INDX2_SMS ,
      2        NODXI_SMS,MS       ,MS0      ,A         ,ICODT     ,
      3        ICODR    ,ISKEW    ,SKEW     ,JAD_SMS   ,JDI_SMS   ,
@@ -94,6 +94,7 @@ C-----------------------------------------------
       USE SENSOR_MOD
       USE ams_work_mod
       USE MY_ALLOC_MOD
+      use python_funct_mod, only : python_
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -121,6 +122,7 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       TYPE(TIMER_), INTENT(INOUT) :: TIMERS
+      TYPE(python_), INTENT(INOUT) :: PYTHON
       INTEGER  ITASK, NODFT,NSENSOR,NODLT, NODII_SMS(*), INDX2_SMS(*),
      .         NODXI_SMS(*), ICODT(*), ICODR(*),
      .         ISKEW(*), JAD_SMS(*), JDI_SMS(*), INDX1_SMS(*),
@@ -251,7 +253,7 @@ C----
 C
       CALL SMS_GRAVIT(IGRV  ,AGRV   ,NPC   ,TF   ,A     ,
      2                V     ,X      ,SKEW  ,MS   ,SENSOR_TAB,
-     3                WEIGHT,LGRAV ,ITASK,TAGSLV_RBY_SMS,NSENSOR,WFEXT)
+     3                WEIGHT,LGRAV ,ITASK,TAGSLV_RBY_SMS,NSENSOR,WFEXT, python)
 C
       CALL MY_BARRIER
 C

--- a/engine/source/constraints/fxbody/fxbodfp.F
+++ b/engine/source/constraints/fxbody/fxbodfp.F
@@ -235,10 +235,12 @@ C
      .                    SV     , FSAV   , FXBFP , WFEXT , FXBFC  ,
      .                    FXBGRVI, FXBGRVR, NLGRAV, IGRV  , NPC    ,
      .                    TF     , FXBGRP , TFGRAV, SENSOR_TAB, NSENSOR,
-     .                    MFEXT  , AGRV   )
+     .                    MFEXT  , AGRV  ,PYTHON )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------  
+      USE python_funct_mod, ONLY : python_
+      use finter_mixed_mod, ONLY : finter_mixed
       USE SENSOR_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
@@ -263,6 +265,7 @@ C-----------------------------------------------
      .        FXBFC(*), FXBGRVR(*), TF(*), FXBGRP(*), TFGRAV,
      .        MFEXT(*), AGRV(LFACGRV,*)
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) :: SENSOR_TAB
+      TYPE(python_), intent(inout) :: python
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -270,10 +273,8 @@ C-----------------------------------------------
      .        IAD, II, III, IIAD
       my_real
      .        MC(NME*NMOD), RC(NME*NMOD), TS, FI, ALPHA, BETA,
-     .        MFINT(NME+NMOD), FDALPHA(NMOD), ENINT, DYDX,
+     .        MFINT(NME+NMOD), FDALPHA(NMOD), ENINT,
      .        MFGRAV(NMOD+NME) 
-      my_real FINTER 
-      EXTERNAL FINTER
 C
       IBLO=FXBIPM(28)
       IF (NMOD>0) CALL FXBMAJP2(MC,  RC,     MVN,    NME,   NMOD,
@@ -302,7 +303,7 @@ C
                IF (TS<ZERO) CYCLE
             ENDIF
             IF (IFUNC > 0) THEN
-              FI=AGRV(1,NL)*FINTER(IFUNC,TS,NPC,TF,DYDX)
+              FI=AGRV(1,NL)*FINTER_MIXED(python,nfunct,IFUNC,TS,NPC,TF)
             ELSE
               FI=AGRV(1,NL)
             ENDIF

--- a/engine/source/constraints/fxbody/fxbyfor.F
+++ b/engine/source/constraints/fxbody/fxbyfor.F
@@ -43,10 +43,11 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .                   DT2T  , ITYPTST, NELTST , FXBGRVI , FXBGRVR,
      .                   IGRV  , NPC    , TF     , FXBGRP  , FXBGRW ,
      .                   IPARG , NSENSOR,SENSOR_TAB, IAD_ELEM, FR_ELEM,
-     .                   AGRV  )
+     .                   AGRV  , PYTHON)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
+      USE python_funct_mod, ONLY : python_
       USE ELBUFDEF_MOD            
       USE SENSOR_MOD
       USE ANIM_MOD
@@ -84,6 +85,7 @@ C-----------------------------------------------
      .   FXBGRW(*), AGRV(LFACGRV,*)
       TYPE (ELBUF_STRUCT_), DIMENSION (NGROUP) :: ELBUF_TAB
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) :: SENSOR_TAB
+      TYPE(python_) :: python
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -180,7 +182,7 @@ C
      .FXBSV(ALM)   ,FSAV(1,NN2) ,FXBFP(AVAR) ,FXBEFW(NFX) ,FXBFC(ALM)  ,
      .FXBGRVI(AGRVI),FXBGRVR(AGRVR),NLGRAV   ,IGRV        ,NPC         ,
      .TF           ,FXBGRP(AVAR),FXBGRW(NFX) ,SENSOR_TAB  ,NSENSOR     ,  
-     .MFEXTP(AVAR) ,AGRV        )
+     .MFEXTP(AVAR) ,AGRV    ,PYTHON    )
          ENDIF
       ENDDO
 C

--- a/engine/source/constraints/fxbody/fxgrvcor.F
+++ b/engine/source/constraints/fxbody/fxgrvcor.F
@@ -29,7 +29,9 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||====================================================================
       SUBROUTINE FXGRVCOR(FXBIPM, FXBGRVI , A      , IGRV, AGRV,
      .                    NPC   , TF      , MS     , V   , SKEW,
-     .                    FXBGRW, IAD_ELEM, FR_ELEM, WFEXT)
+     .                    FXBGRW, IAD_ELEM, FR_ELEM, WFEXT,python)
+        use python_funct_mod, only : python_
+        use finter_mixed_mod, only : finter_mixed
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -49,6 +51,7 @@ C-----------------------------------------------
       INTEGER FXBIPM(NBIPM,*), FXBGRVI(*), IGRV(NIGRV,*), NPC(*), IAD_ELEM(2,*), FR_ELEM(*)
       my_real  A(3,*), AGRV(LFACGRV,*), TF(*), MS(*), V(3,*), SKEW(LSKEW,*), FXBGRW(*)
       DOUBLE PRECISION, INTENT(INOUT) :: WFEXT
+      TYPE(python_), intent(inout) :: python
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -83,8 +86,8 @@ C
             N2=IGRV(2,NL)-10*ISK
             IFUNC=IGRV(3,NL)
             IF (IFUNC > 0) THEN
-              FI0=AGRV(1,NL)*FINTER(IFUNC,(TT-DT1)*AGRV(2,NL),NPC,TF,DYDX)
-              FI =AGRV(1,NL)*FINTER(IFUNC,TT*AGRV(2,NL),NPC,TF,DYDX)
+              FI0=AGRV(1,NL)*FINTER_MIXED(python,nfunct,IFUNC,(TT-DT1)*AGRV(2,NL),NPC,TF)
+              FI =AGRV(1,NL)*FINTER_MIXED(python,nfunct,IFUNC,TT*AGRV(2,NL),NPC,TF)
             ELSE
               FI0= AGRV(1,NL)
               FI = AGRV(1,NL)

--- a/engine/source/constraints/general/impvel/fixfingeo.F
+++ b/engine/source/constraints/general/impvel/fixfingeo.F
@@ -30,13 +30,16 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||--- uses       -----------------------------------------------------
       !||    sensor_mod       ../common_source/modules/sensor_mod.F90
       !||====================================================================
-      SUBROUTINE FIXFINGEO(IBFV   ,A     ,V      ,NPC    ,TF       ,
-     2                     VEL    ,MS    ,X      ,D      ,SENSOR_TAB,
-     3                     WEIGHT ,CPTREAC,NODREAC,NODNX_SMS,NSENSOR,
-     4                     FTHREAC,ITABM1,ITAB , WFEXT  )
+      SUBROUTINE FIXFINGEO(PYTHON, NODES, IBFV    ,NPC    ,TF       ,
+     2                     VEL    ,SENSOR_TAB,
+     3                     CPTREAC,NODREAC,NODNX_SMS,NSENSOR,
+     4                     FTHREAC, WFEXT  )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------  
+      USE python_funct_mod
+      use python_call_funct_cload_mod
+      use nodal_arrays_mod
       USE SENSOR_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
@@ -47,7 +50,6 @@ C   C o m m o n   B l o c k s
 C-----------------------------------------------
 #include      "com01_c.inc"
 #include      "com04_c.inc"
-!#include      "com06_c.inc"
 #include      "com08_c.inc"
 #include      "param_c.inc"
 #include      "sms_c.inc"
@@ -56,10 +58,12 @@ C
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+      TYPE(python_), INTENT(IN) :: PYTHON
+      TYPE(nodal_arrays_) :: NODES
       INTEGER ,INTENT(IN) :: NSENSOR
       INTEGER NPC(*),CPTREAC,NODREAC(*)
-      INTEGER IBFV(NIFV,*),WEIGHT(*), NODNX_SMS(*),ITABM1(*),ITAB(*)
-      my_real A(3,*), V(3,*), TF(*), VEL(LFXVELR,*), MS(*), X(3,*), D(3,*),FTHREAC(6,*)
+      INTEGER IBFV(NIFV,*), NODNX_SMS(*)
+      my_real :: TF(*), VEL(LFXVELR,*), FTHREAC(6,*)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -101,17 +105,17 @@ C-------------------------------------------------
            N1 = IABS(IBFV(1,N))
            N2 = IBFV(14,N)
 C        
-           VX1= V(1,N1)+A(1,N1)*DT12
-           VY1= V(2,N1)+A(2,N1)*DT12
-           VZ1= V(3,N1)+A(3,N1)*DT12
-           VX2= V(1,N2)+A(1,N2)*DT12
-           VY2= V(2,N2)+A(2,N2)*DT12
-           VZ2= V(3,N2)+A(3,N2)*DT12
+           VX1= NODES%V(1,N1)+NODES%A(1,N1)*DT12
+           VY1= NODES%V(2,N1)+NODES%A(2,N1)*DT12
+           VZ1= NODES%V(3,N1)+NODES%A(3,N1)*DT12
+           VX2= NODES%V(1,N2)+NODES%A(1,N2)*DT12
+           VY2= NODES%V(2,N2)+NODES%A(2,N2)*DT12
+           VZ2= NODES%V(3,N2)+NODES%A(3,N2)*DT12
 C
-           VX(N2) = VX(N2) + MS(N1)*VX1+ MS(N2)*VX2/IBFV(16,N)
-           VY(N2) = VY(N2) + MS(N1)*VY1+ MS(N2)*VY2/IBFV(16,N)
-           VZ(N2) = VZ(N2) + MS(N1)*VZ1+ MS(N2)*VZ2/IBFV(16,N)
-           MASS(N2) = MASS(N2) + MS(N1) + MS(N2)/IBFV(16,N)
+           VX(N2) = VX(N2) + NODES%MS(N1)*VX1+ NODES%MS(N2)*VX2/IBFV(16,N)
+           VY(N2) = VY(N2) + NODES%MS(N1)*VY1+ NODES%MS(N2)*VY2/IBFV(16,N)
+           VZ(N2) = VZ(N2) + NODES%MS(N1)*VZ1+ NODES%MS(N2)*VZ2/IBFV(16,N)
+           MASS(N2) = MASS(N2) + NODES%MS(N1) + NODES%MS(N2)/IBFV(16,N)
         ENDIF
       ENDDO
       DO N=1,NUMNOD
@@ -127,12 +131,12 @@ C
         IF(TT>STOPT)  THEN
            N1 = IABS(IBFV(1,N))
            N2 = IBFV(14,N)       
-           A(1,N1)=(VX(N2)-V(1,N1))/DT12
-           A(2,N1)=(VY(N2)-V(2,N1))/DT12
-           A(3,N1)=(VZ(N2)-V(3,N1))/DT12
-           A(1,N2)=(VX(N2)-V(1,N2))/DT12
-           A(2,N2)=(VY(N2)-V(2,N2))/DT12
-           A(3,N2)=(VZ(N2)-V(3,N2))/DT12
+           NODES%A(1,N1)=(VX(N2)-NODES%V(1,N1))/DT12
+           NODES%A(2,N1)=(VY(N2)-NODES%V(2,N1))/DT12
+           NODES%A(3,N1)=(VZ(N2)-NODES%V(3,N1))/DT12
+           NODES%A(1,N2)=(VX(N2)-NODES%V(1,N2))/DT12
+           NODES%A(2,N2)=(VY(N2)-NODES%V(2,N2))/DT12
+           NODES%A(3,N2)=(VZ(N2)-NODES%V(3,N2))/DT12
         ENDIF
       ENDDO
       DEALLOCATE(MASS, VX, VY, VZ)
@@ -170,9 +174,9 @@ C-----------------------
         ENDIF
 C
         IF(CPTREAC/=0) THEN
-           AOLD0(1)=A(1,I)
-           AOLD0(2)=A(2,I)
-           AOLD0(3)=A(3,I)
+           AOLD0(1)=NODES%A(1,I)
+           AOLD0(2)=NODES%A(2,I)
+           AOLD0(3)=NODES%A(3,I)
         ENDIF
 C
         L = IBFV(3,N)
@@ -188,30 +192,36 @@ C
         IF (L > 0) ISMOOTH = NPC(2*NFUNCT+L+1)
         IF (ISMOOTH == 0) THEN
           YC = FINTER2(TF,IADC,IPOSC,ILENC,TSC,DYDXC)
-        ELSE
+        ELSE IF(ISMOOTH > 0) THEN
           YC = FINTER2_SMOOTH(TF,IADC,IPOSC,ILENC,TSC,DYDXC)
+        ELSE
+          ISMOOTH = -ISMOOTH ! the id the python function is saved in the position of ISMOOTH in the NPC array 
+          ! interpolation function with ACTIVE_NODE enabled
+          CALL PYTHON_CALL_FUNCT_CLOAD(PYTHON, ISMOOTH,TSC, YC,I,NODES)
         ENDIF ! IF (ISMOOTH == 0)
         IBFV(5,N) = IPOSC
 C
         IF(IBFV(13,N) == 1) THEN
+             !/IMPDISP/FGEO
            FAC  = VEL(1,N)
            SKEW1= VEL(7,N)
            SKEW2= VEL(8,N)
            SKEW3= VEL(9,N)
         ELSEIF(IBFV(13,N) == 2) THEN
-           XA = X(1,I)
-           YA = X(2,I)
-           ZA = X(3,I)
+           !/IMPVEL/FGEO
+           XA = NODES%X(1,I)
+           YA = NODES%X(2,I)
+           ZA = NODES%X(3,I)
            I1 = IBFV(14,N)
-           XF = X(1,I1)
-           YF = X(2,I1)
-           ZF = X(3,I1)
+           XF = NODES%X(1,I1)
+           YF = NODES%X(2,I1)
+           ZF = NODES%X(3,I1)
            FAC= SQRT((XF-XA)**2+(YF-YA)**2+(ZF-ZA)**2)
            IF(FAC < VEL(7,N)) THEN
               VEL(3,N) = TT
               YC = ZERO
               WRITE(IOUT,'(A,I10,1X,I10,A,1PE12.5)') 
-     .       ' RIGID LINK ON NODES',ITAB(IBFV(1,N)),IBFV(14,N),
+     .       ' RIGID LINK ON NODES',NODES%ITAB(IBFV(1,N)),IBFV(14,N),
      .       ' ACTIVATED AT TIME',TT
            ENDIF
            SKEW1= (XF-XA)/FAC
@@ -228,21 +238,21 @@ C dw was already counted in WFEXT, in sms_fixvel...
         VEL(4,N)= (ONE-RW_SMS)*VEL(4,N)
 C
         YC = YC * FAC
-        AXI=ONE-AX+AX*X(2,I)
+        AXI=ONE-AX+AX*NODES%X(2,I)
 C
-        DD = SKEW1*D(1,I) + SKEW2*D(2,I) + SKEW3*D(3,I)
-        VV = SKEW1*V(1,I) + SKEW2*V(2,I) + SKEW3*V(3,I)
-        A0 = SKEW1*A(1,I) + SKEW2*A(2,I) + SKEW3*A(3,I)
+        DD = SKEW1*NODES%D(1,I) + SKEW2*NODES%D(2,I) + SKEW3*NODES%D(3,I)
+        VV = SKEW1*NODES%V(1,I) + SKEW2*NODES%V(2,I) + SKEW3*NODES%V(3,I)
+        A0 = SKEW1*NODES%A(1,I) + SKEW2*NODES%A(2,I) + SKEW3*NODES%A(3,I)
 C
         IF(IBFV(13,N) == 1) YC =(YC-DD)/DT2
         YC =(YC-VV)/DT12
         AA = YC - A0
 C
-        A(1,I)=SKEW1*YC
-        A(2,I)=SKEW2*YC
-        A(3,I)=SKEW3*YC
+        NODES%A(1,I)=SKEW1*YC
+        NODES%A(2,I)=SKEW2*YC
+        NODES%A(3,I)=SKEW3*YC
 C
-        DW = FOURTH*MS(I)*(YC*DT12+TWO*VV)*AA*AXI*WEIGHT(I)
+        DW = FOURTH*NODES%MS(I)*(YC*DT12+TWO*VV)*AA*AXI*NODES%WEIGHT(I)
         WFEXT = WFEXT + DT1*DW
 C  
 C dt2*dw into memory ; if sms on the degree of freedom,
@@ -252,12 +262,12 @@ C
         IF (CPTREAC/=0) THEN
             I=IABS(IBFV(1,N))
             IF (NODREAC(I)/=0) THEN
-              FTHREAC(1,NODREAC(I)) = FTHREAC(1,NODREAC(I)) + (A(1,I) -
-     &                                AOLD0(1))*MS(I)*DT12
-              FTHREAC(2,NODREAC(I)) = FTHREAC(2,NODREAC(I)) + (A(2,I) -
-     &                                AOLD0(2))*MS(I)*DT12
-              FTHREAC(3,NODREAC(I)) = FTHREAC(3,NODREAC(I)) + (A(3,I) -
-     &                                AOLD0(3))*MS(I)*DT12
+              FTHREAC(1,NODREAC(I)) = FTHREAC(1,NODREAC(I)) + (NODES%A(1,I) -
+     &                                AOLD0(1))*NODES%MS(I)*DT12
+              FTHREAC(2,NODREAC(I)) = FTHREAC(2,NODREAC(I)) + (NODES%A(2,I) -
+     &                                AOLD0(2))*NODES%MS(I)*DT12
+              FTHREAC(3,NODREAC(I)) = FTHREAC(3,NODREAC(I)) + (NODES%A(3,I) -
+     &                                AOLD0(3))*NODES%MS(I)*DT12
             ENDIF
         ENDIF
 C

--- a/engine/source/constraints/thermic/fixtemp.F
+++ b/engine/source/constraints/thermic/fixtemp.F
@@ -31,13 +31,16 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    glob_therm_mod   ../common_source/modules/mat_elem/glob_therm_mod.F90
       !||    sensor_mod       ../common_source/modules/sensor_mod.F90
       !||====================================================================
-      SUBROUTINE FIXTEMP(IBFT   ,VAL    , TEMP  ,NPC    ,TF   ,
-     .                   NSENSOR,SENSOR_TAB,GLOB_THERM)
+      SUBROUTINE FIXTEMP(PYTHON,IBFT   ,VAL    , TEMP  ,NPC    ,TF   ,
+     .                   NSENSOR,SENSOR_TAB,GLOB_THERM,snpc)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------  
+      USE redef3_mod, only: get_python_funct_id
       USE SENSOR_MOD
       use glob_therm_mod
+      USE PYTHON_FUNCT_MOD
+      USE vinter_mixed_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -57,12 +60,14 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+      type(python_) :: PYTHON
       type (glob_therm_) ,intent(inout)   :: glob_therm
       INTEGER ,INTENT(IN) :: NSENSOR
       INTEGER NPC(*)
       INTEGER IBFT(GLOB_THERM%NIFT,*)
       my_real :: TEMP(*),TF(*)
       my_real :: VAL(GLOB_THERM%LFACTHER,*)
+      integer, intent(in) :: SNPC
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) ,INTENT(IN) :: SENSOR_TAB
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
@@ -72,6 +77,8 @@ C-----------------------------------------------
       INTEGER INDEX(MVSIZ)
       my_real FAC, FACX, STARTT, STOPT, TS
       my_real YC(MVSIZ), TSC(MVSIZ), DYDXC(MVSIZ)
+      integer :: pyid
+      logical :: any_python_func
 C-----------------------------------------------
       IDEB = 0
       ISMOOTH = 0
@@ -121,15 +128,22 @@ C       sans aucun sensor
 C
         IDEB = IDEB + MIN(GLOB_THERM%NFXTEMP-IDEB,NVSIZ)
 C
-
+        any_python_func = .FALSE.
         IF(NCYCLE == 0)THEN
          DO II=1,IC
           N = INDEX(II)
           L = IBFT(2,N)
           IF (L > 0) ISMOOTH = NPC(2*NFUNCT+L+1)
           IPOSC(II) = 0
-          IADC(II)  = NPC(L) / 2 + 1
-          ILENC(II) = NPC(L+1) / 2 - IADC(II) - IPOSC(II)
+          pyid = get_python_funct_id(nfunct,l,npc,snpc)
+          if(pyid > 0) then
+            IADC(II)  =-pyid
+            ILENC(II) =-pyid 
+            any_python_func = .TRUE.
+          else
+            IADC(II)  = NPC(L) / 2 + 1
+            ILENC(II) = NPC(L+1) / 2 - IADC(II) - IPOSC(II)
+          endif
          ENDDO
         ELSE
          DO II=1,IC
@@ -137,16 +151,27 @@ C
           L = IBFT(2,N)
           IF (L > 0) ISMOOTH = NPC(2*NFUNCT+L+1)
           IPOSC(II) = IBFT(4,N)
-          IADC(II)  = NPC(L) / 2 + 1
-          ILENC(II) = NPC(L+1) / 2 - IADC(II) - IPOSC(II)
+          pyid = get_python_funct_id(nfunct,l,npc,snpc)
+          if(pyid > 0) then
+            IADC(II)  =-pyid
+            ILENC(II) =-pyid 
+            any_python_func = .TRUE.
+          else  
+            IADC(II)  = NPC(L) / 2 + 1
+            ILENC(II) = NPC(L+1) / 2 - IADC(II) - IPOSC(II)
+          endif
          ENDDO
         ENDIF
-!!        CALL VINTER(TF,IADC,IPOSC,ILENC,IC,TSC,DYDXC,YC)
-        IF (ISMOOTH == 0) THEN
-          CALL VINTER(TF,IADC,IPOSC,ILENC,IC,TSC,DYDXC,YC)
-        ELSE
-          CALL VINTER_SMOOTH(TF,IADC,IPOSC,ILENC,IC,TSC,DYDXC,YC)
-        ENDIF ! IF (ISMOOTH == 0)
+
+        if(any_python_func) then
+          call vinter_mixed(PYTHON,TF,IADC,IPOSC,ILENC,IC,TSC,DYDXC,YC)
+        else
+          IF (ISMOOTH == 0) THEN
+            CALL VINTER(TF,IADC,IPOSC,ILENC,IC,TSC,DYDXC,YC)
+          ELSE
+            CALL VINTER_SMOOTH(TF,IADC,IPOSC,ILENC,IC,TSC,DYDXC,YC)
+          ENDIF ! IF (ISMOOTH == 0)
+        ENDIF ! if(any_python_func)
 C
         IF(IVECTOR == 0) THEN
          DO II=1,IC

--- a/engine/source/elements/forint.F
+++ b/engine/source/elements/forint.F
@@ -1196,7 +1196,7 @@ C
           IF (IPREID>0) THEN
              FUN_ID = IPARG(73,NG)
              SENS_ID= IPARG(74,NG) 
-             CALL GET_PRELOAD_AXIAL(
+             CALL GET_PRELOAD_AXIAL(PYTHON, NFUNCT,
      1           FUN_ID        ,SENS_ID       ,NPC          ,SNPC          ,
      2           TF            ,STF           ,SENSORS      ,TT            ,
      3           PRELOAD1      ,STF_F         )
@@ -1256,7 +1256,7 @@ C
           IF (IPREID>0) THEN
              FUN_ID = IPARG(73,NG)
              SENS_ID= IPARG(74,NG) 
-             CALL GET_PRELOAD_AXIAL(
+             CALL GET_PRELOAD_AXIAL(PYTHON, NFUNCT,
      1           FUN_ID        ,SENS_ID       ,NPC          ,SNPC          ,
      2           TF            ,STF           ,SENSORS      ,TT            ,
      3           PRELOAD1      ,STF_F         )
@@ -1325,7 +1325,7 @@ c
           IF (IPREID>0) THEN
              FUN_ID = IPARG(73,NG)
              SENS_ID= IPARG(74,NG) 
-             CALL GET_PRELOAD_AXIAL(
+             CALL GET_PRELOAD_AXIAL(PYTHON, NFUNCT, 
      1           FUN_ID        ,SENS_ID       ,NPC          ,SNPC          ,
      2           TF            ,STF           ,SENSORS      ,TT            ,
      3           PRELOAD1      ,STF_F         )

--- a/engine/source/elements/spring/preload_axial.F90
+++ b/engine/source/elements/spring/preload_axial.F90
@@ -49,7 +49,7 @@
       !||    precision_mod       ../common_source/modules/precision_mod.F90
       !||    sensor_mod          ../common_source/modules/sensor_mod.F90
       !||====================================================================
-        subroutine get_preload_axial(                                         &
+        subroutine get_preload_axial(python, nfunct,                 &
           fun_id    ,    sens_id,          npc,            snpc,     &
           tf        ,        stf,      sensors,            time,     &
           preload1  ,      stf_f)
@@ -58,12 +58,16 @@
 ! ----------------------------------------------------------------------------------------------------------------------
           use constant_mod, only : zero,two_third
           use sensor_mod
+          use python_funct_mod, only : python_
+          use finter_mixed_mod, only : finter_mixed
           use precision_mod, only : WP
 ! ----------------------------------------------------------------------------------------------------------------------
           implicit none
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Arguments
 ! ----------------------------------------------------------------------------------------------------------------------
+          integer, intent (in   )                         :: nfunct       !< number of functions
+          type(python_) ,intent(inout)                     :: python       !< python module
           integer, intent (in   )                         :: fun_id       !< function id
           integer, intent (in   )                         :: sens_id      !< sensor id
           integer, intent (in   )                         :: snpc,stf     !< array dimension
@@ -77,12 +81,10 @@
 !                                                   Local variables
 ! ----------------------------------------------------------------------------------------------------------------------
           integer :: i,j,nld,isens
-          real(kind=WP) :: t_start,t_stop,t_shift,deri,tt,t_stif
+          real(kind=WP) :: t_start,t_stop,t_shift,tt,t_stif
 ! ----------------------------------------------------------------------------------------------------------------------
 !           e x t e r n a l   f u n c t i o n s
 ! ----------------------------------------------------------------------------------------------------------------------
-          real(kind=WP) :: finter
-          external finter
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Body
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -97,7 +99,7 @@
           end if
           tt = time-t_shift
           if (tt>=t_start.and.tt<t_stop) then
-            preload1= finter(fun_id,tt,npc,tf,deri)
+            preload1= finter_mixed(python,nfunct,fun_id,tt,npc,tf)
             t_stif = t_start + (t_stop-t_start)*two_third
             stf_f = zero
           end if

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -2381,8 +2381,8 @@ C     Multidomains + SPH
 
 C     THERMAL EXPANSION and IMPTEMP : Initialisation of nodal temperatures
               IF (GLOB_THERM%NFXTEMP  > 0 .AND. GLOB_THERM%ITHERM_FE > 0.AND.TT==ZERO) THEN
-                CALL FIXTEMP(IBFTEMP  ,FBFTEMP    ,NODES%TEMP    ,NPC    ,TF  ,
-     .               NSENSOR  ,SENSORS%SENSOR_TAB,GLOB_THERM )
+                CALL FIXTEMP(python,IBFTEMP  ,FBFTEMP    ,NODES%TEMP    ,NPC    ,TF  ,
+     .               NSENSOR  ,SENSORS%SENSOR_TAB,GLOB_THERM,SNPC )
               ENDIF
 C ---------------------
 C Allocating Array for PCONT2 - average normal
@@ -3533,7 +3533,7 @@ C
                 ENDIF
                 CALL FORCEFINGEO(IBFV ,NPC    ,TF      ,NODES%A    ,NODES%V    ,NODES%X     ,
      2                           VEL  ,SENSORS%SENSOR_TAB ,ELEMENT%PON%FSKY ,NODA_FEXT ,NODES%ITABM1,
-     3                           H3D_DATA,NSENSOR,PYTHON,WFEXT)
+     3                           H3D_DATA,NSENSOR,PYTHON,WFEXT,NODES)
                 IF(IMON>0) THEN
                   IF(IMONM > 0) CALL STOPTIME(TIMERS,44)
                   CALL STOPTIME(TIMERS,TIMER_KIN)
@@ -3679,7 +3679,7 @@ C
      7            PM              ,IPM                ,IPART              ,IPART(K3) ,
      8            IPART(K8)       ,IGROUPC            ,IGROUPTG           ,NODA_FEXT ,
      9            1               ,H3D_DATA           ,T_MONVOL           ,frontier_global_mv,
-     A            OUTPUT )
+     A            OUTPUT, PYTHON )
                 CALL TRACE_OUT(11)
                 IF (IMONM > 0) CALL STOPTIME(TIMERS,50)
               ENDIF
@@ -4582,7 +4582,7 @@ C
      .                      FSAV(1,N), IFVMESH,  ICONTACT_OLD, LGAUGE            ,
      .                      GAUGE    , IGEO,     GEO,          PM                , IPM ,
      .                      IPARG    , IGROUPTG, IGROUPC,      ELBUF_TAB         , NODA_FEXT,
-     .                      1        , H3D_DATA, NODES%ITAB,   NODES%WEIGHT      , OUTPUT%WFEXT)
+     .                      1        , H3D_DATA, NODES%ITAB,   NODES%WEIGHT      , OUTPUT%WFEXT, PYTHON)
 C
                 CALL TRACE_OUT(11)
                 IF (IMONM > 0) CALL STOPTIME(TIMERS,50)
@@ -4921,7 +4921,7 @@ C
      .                      FSAV(1,N), IFVMESH, ICONTACT_OLD,LGAUGE,
      .                      GAUGE    , IGEO,    GEO,         PM,                  IPM,
      .                      IPARG    , IGROUPTG,IGROUPC,     ELBUF_TAB,           NODA_FEXT,
-     .                      2        , H3D_DATA,NODES%ITAB, NODES%WEIGHT, OUTPUT%WFEXT)
+     .                      2        , H3D_DATA,NODES%ITAB, NODES%WEIGHT, OUTPUT%WFEXT, PYTHON)
                 IF (IMPL_S > 0 .AND. ISMDISP >0) THEN
                   CALL ASSIGN_PTRX(ptrx,IMPBUF_TAB%X_A,NUMNOD)
                 ELSE
@@ -4937,7 +4937,7 @@ C
      7            PM                ,IPM                ,IPART              ,IPART(K3) ,
      8            IPART(K8)         ,IGROUPC            ,IGROUPTG           ,NODA_FEXT      ,
      9            2                 ,H3D_DATA           ,T_MONVOL           ,frontier_global_mv,
-     A            OUTPUT)
+     A            OUTPUT, PYTHON)
 
                 CALL TRACE_OUT(11)
                 IF (IMONM > 0) CALL STOPTIME(TIMERS,50)
@@ -6108,7 +6108,7 @@ C-----------------------------------------------------
      .                       DT2T,   ITYPTST, NELTST,  FXBGRVI, FXBGRVR,
      .                       IGRV,   NPC,     TF    ,  FXBGRP,  FXBGRW ,
      .                       IPARG , NSENSOR,SENSORS%SENSOR_TAB,NODES%BOUNDARY_ADD, NODES%BOUNDARY,
-     .                       AGRV  )
+     .                       AGRV  ,PYTHON)
               END IF
 
 C----------------------------------------------------------
@@ -6874,7 +6874,7 @@ C===============================================================================
                 ITSK = OMP_GET_THREAD_NUM()
                 NODFTSK   = 1+ITSK*NUMNOD/ NTHREAD
                 NODLTSK   = (ITSK+1)*NUMNOD/NTHREAD
-                CALL SMS_MASS_SCALE_2(TIMERS,
+                CALL SMS_MASS_SCALE_2(TIMERS,PYTHON,
      1                ITSK     ,NODFTSK   ,NODLTSK  ,NODII_SMS ,INDX2_SMS ,
      2                NODXI_SMS,NODES%MS        ,NODES%MS0      ,NODES%A         ,NODES%ICODT     ,
      3                NODES%ICODR    ,NODES%ISKEW     ,SKEWS%SKEW,JAD_SMS   ,JDI_SMS   ,
@@ -7445,7 +7445,7 @@ C----------------------
                   IF (NFXBODY>0) THEN
                     CALL FXGRVCOR(FXBIPM, FXBGRVI, NODES%A,  IGRV, AGRV,
      .                            NPC,    TF,      NODES%MS, NODES%V   , SKEWS%SKEW,
-     .                            FXBGRW, NODES%BOUNDARY_ADD, NODES%BOUNDARY, OUTPUT%WFEXT)
+     .                            FXBGRW, NODES%BOUNDARY_ADD, NODES%BOUNDARY, OUTPUT%WFEXT, PYTHON)
                   END IF
                   IF (IMON>0) CALL STOPTIME(TIMERS,46)
                   IF (IMONM > 0) CALL STOPTIME(TIMERS,TIMER_KIN)
@@ -7862,7 +7862,7 @@ C--------------------------
               ENCIN2 = ZERO
               ENROT2 = ZERO
 C--------------------------
-C          IMPOSED VELOCITY
+C          IMPOSED VELOCITIES & DISPLACEMENTS 
 C--------------------------
               IF(NFXVEL/=0) THEN
                 IF(IMON>0) THEN
@@ -7878,10 +7878,10 @@ C--------------------------
      6                      TT_DOUBLE,NODES%DDP,PYTHON ,WFEXT)
 
                 IF (FXVEL_FGEO ==1) THEN
-                  CALL FIXFINGEO(IBFV   ,NODES%A     ,NODES%V      ,NPC    ,TF     ,
-     2                         VEL    ,NODES%MS    ,NODES%X      ,NODES%D      ,SENSORS%SENSOR_TAB ,
-     3                         NODES%WEIGHT,CPTREAC,NODREAC,PTR_SMS,NSENSOR    ,
-     4                         FTHREAC,NODES%ITABM1,NODES%ITAB, OUTPUT%WFEXT   )
+                  CALL FIXFINGEO(PYTHON, NODES, IBFV   ,NPC    ,TF     ,
+     2                         VEL    ,SENSORS%SENSOR_TAB ,
+     3                         CPTREAC,NODREAC,PTR_SMS,NSENSOR    ,
+     4                         FTHREAC, OUTPUT%WFEXT   )
                 ENDIF
 C
                 IF(IMON>0) THEN
@@ -7967,8 +7967,8 @@ C--------------------------
                   CALL STARTIME(TIMERS,TIMER_KIN)
                   IF(IMONM > 0) CALL STARTIME(TIMERS,44)
                 ENDIF
-                CALL FIXTEMP(IBFTEMP  ,FBFTEMP    ,NODES%TEMP    ,NPC    ,TF  ,
-     1                       NSENSOR  ,SENSORS%SENSOR_TAB,GLOB_THERM)
+                CALL FIXTEMP(PYTHON,IBFTEMP  ,FBFTEMP    ,NODES%TEMP    ,NPC    ,TF  ,
+     1                       NSENSOR  ,SENSORS%SENSOR_TAB,GLOB_THERM,SNPC)
                 IF (IMON>0) THEN
                   IF(IMONM > 0) CALL STOPTIME(TIMERS,44)
                   CALL STOPTIME(TIMERS,TIMER_KIN)
@@ -8411,7 +8411,7 @@ C Init var parallel SMP
      8               TF         ,NEWFRONT ,ICONTACT ,RWBUF    ,LPRW     ,
      9               NPRW     ,RBYL     ,NODES%D        ,NODES%DR       ,KINET    ,
      A               NSENSOR  ,SENSORS%SENSOR_TAB,INTERFACES%INTBUF_TAB, H3D_DATA ,IGRBRIC,
-     B               PYTHON)
+     B               PYTHON,NODES)
 
 !$OMP END PARALLEL
 
@@ -8443,7 +8443,7 @@ C===============================================================================
      9               NPRW     ,RBYL     ,NODES%D        ,NODES%DR       ,KINET    ,
      A               NODES%NODGLOB  ,NODES%WEIGHT   ,NBNCL    ,NBIKL    ,NBNODL   ,
      B               NBNODLR  ,FR_LAGF  ,LLAGF    ,NODES%BOUNDARY_ADD ,NODES%BOUNDARY  ,
-     C               INTERFACES%INTBUF_TAB ,H3D_DATA, PYTHON)
+     C               INTERFACES%INTBUF_TAB ,H3D_DATA, PYTHON, NODES)
                 END IF
               ENDIF
 c--------------
@@ -8914,7 +8914,7 @@ C                                     PARALLEL SECTION (SMP)
 C========================================================================================
 
                 IF (IMP_CHK > 0) THEN
-                  CALL IMP_CHKM(TIMERS,
+                  CALL IMP_CHKM(TIMERS, PYTHON,
      1     NODES%ICODE      ,NODES%ISKEW          ,ISKWN       ,IPART             ,IXTG       ,IXS              ,IXQ         ,
      2     ELEMENT%SHELL%IXC,IXT                  ,IXP         ,IXR               ,IXTG1      ,NODES%ITAB       ,NODES%ITABM1,
      3     NPC              ,IBCL                 ,IBFV        ,SENSORS%SENSOR_TAB,NNLINK     ,LNLINK      ,IPARG       ,IGRV,
@@ -8941,7 +8941,7 @@ C-----integer : 1:IKC,2:IKUD,3:W_DDL,4:IADM,5:JDIM,6:NDOFI,7:IDDLI
 C-----reel : 1,2,3,4:DIAG_K,LT_K,DIAG_M,LT_M,5,6:LB,DB,7:BKUD,8,9:D_IMP,DR_IMP
 C----       10,11,12:ELBUF_C,BUFMAT_C,X_C,13,14:DD,DDR,15,16:X_ac,V_zero,23,24:AC,ACR
 #if defined(MUMPS5)
-                  CALL IMP_SOLV(TIMERS,
+                  CALL IMP_SOLV(TIMERS, PYTHON,
      1            NODES%ICODE  ,NODES%ISKEW  ,ISKWN  ,IPART  ,IXTG   ,IXS    ,IXQ    ,
      2            ELEMENT%SHELL%IXC    ,IXT    ,IXP    ,IXR    ,IXTG1          ,NODES%ITAB   ,NODES%ITABM1 ,
      3            NPC    ,IBCL   ,IBFV   ,SENSORS%SENSOR_TAB,NNLINK ,LNLINK ,IPARG  ,IGRV   ,

--- a/engine/source/implicit/imp_dyna.F
+++ b/engine/source/implicit/imp_dyna.F
@@ -739,11 +739,12 @@ C--------------------------------------------
      8                    NSENSOR   ,TH_SURF ,DPL0CLD,
      9                    VEL0CLD   ,D       ,DR      ,NUMNOD ,NSURF  ,
      A                    NFUNCT    ,NCONLD  ,NGRAV   ,NINVEL ,STF    ,NUMSKW ,
-     B                    WFEXT)
+     B                    WFEXT, PYTHON)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE IMP_DYNA
+      use python_funct_mod, only: python_
       USE MESSAGE_MOD
       USE H3D_MOD
       USE SENSOR_MOD
@@ -765,6 +766,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+      type(python_), intent(inout) :: python
       INTEGER ,INTENT(IN) :: NSENSOR,NUMNOD,NSURF,NFUNCT,NCONLD,NGRAV,NINVEL
       INTEGER, INTENT(IN) :: STF
       INTEGER, INTENT(IN) :: SNPC
@@ -884,7 +886,7 @@ C---estimation a(t=0)----
           CALL GRAVIT_IMP(IGRV  ,AGRV  ,NPC   ,TF    ,DY_A,
      2                    V     ,X     ,SKEWS%SKEW  ,MS,WFEXC,
      3                    NSENSOR,SENSOR_TAB,WEIGHT,LGRAV,ITASK,
-     4                    NRBYAC,IRBYAC,NPBY  ,RBY    )
+     4                    NRBYAC,IRBYAC,NPBY  ,RBY, PYTHON)
 !         IF (IMON>0 .AND. ITASK == 0) CALL STOPTIME(TIMERS,4)
         ENDIF
          DO N=NODFT,NODLT
@@ -993,7 +995,7 @@ C
      8                    H3D_DATA,CPTREAC,FTHREAC,NODREAC,NSENSOR,
      9                    TH_SURF ,DPL0CLD,
      A                    VEL0CLD, NUMNOD,NSURF,NFUNCT,NCONLD,
-     B                    NGRAV,NFXVEL,STF,NUMSKW)
+     B                    NGRAV,NFXVEL,STF,NUMSKW,python)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -1002,6 +1004,7 @@ C-----------------------------------------------
       USE SENSOR_MOD
       USE TH_SURF_MOD , ONLY : TH_SURF_, TH_SURF_NUM_CHANNEL
       USE SKEW_MOD
+      use python_funct_mod, only: python_
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -1017,6 +1020,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+      type(python_), intent(inout) :: python
       INTEGER ,INTENT(IN) :: NSENSOR,NUMNOD,NSURF,NFUNCT,NCONLD,NGRAV,NFXVEL
       INTEGER ,INTENT(IN) :: STF
       INTEGER ,INTENT(IN) :: SNPC
@@ -1061,7 +1065,7 @@ C--------------------------------
           CALL GRAVIT_IMP(IGRV  ,AGRV  ,NPC   ,TF    ,A    ,
      2                    V     ,X     ,SKEWS%SKEW  ,MS,WFEXC,
      3                    NSENSOR,SENSOR_TAB,WEIGHT,LGRAV,ITASK,
-     5                    NRBYAC,IRBYAC,NPBY  ,RBY    )
+     5                    NRBYAC,IRBYAC,NPBY  ,RBY , PYTHON)
           WFEXT = WFEXT + WFEXC*DT2
         ENDIF
         IF(NFXVEL/=0) THEN

--- a/engine/source/implicit/imp_solv.F
+++ b/engine/source/implicit/imp_solv.F
@@ -140,7 +140,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||    th_surf_mod      ../common_source/modules/interfaces/th_surf_mod.F
       !||    timer_mod        ../engine/source/system/timer_mod.F90
       !||====================================================================
-      SUBROUTINE IMP_SOLV(TIMERS,
+      SUBROUTINE IMP_SOLV(TIMERS,PYTHON,
      1  ICODE  ,ISKEW  ,ISKWN  ,IPART  ,IXTG   ,IXS    ,IXQ    ,
      2  IXC    ,IXT    ,IXP    ,IXR    ,IXTG1          ,ITAB   ,ITABM1 ,
      3  NPC    ,IBCL   ,IBFV   ,SENSOR_TAB,NNLINK ,LNLINK ,IPARG  ,IGRV   ,
@@ -191,6 +191,7 @@ C-----------------------------------------------
         USE TH_SURF_MOD , ONLY : TH_SURF_
         USE SKEW_MOD
         use glob_therm_mod
+        use python_funct_mod, only: python_
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -218,6 +219,7 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
         TYPE(TIMER_) :: TIMERS
+        TYPE(PYTHON_) :: PYTHON
         INTEGER ,INTENT(IN) :: NSENSOR
         INTEGER ,INTENT(IN) :: SNPC
         INTEGER ,INTENT(IN) :: STF
@@ -528,7 +530,7 @@ C
      8                     NSENSOR    ,TH_SURF  ,DPL0CLD ,
      9                     VEL0CLD    ,D        ,DR              ,NUMNOD  ,NSURF  ,
      A                     NFUNCT     ,NCONLD   ,NGRAV           ,NINVEL  ,STF    ,NUMSKW,
-     B                     WFEXT)
+     B                     WFEXT,python)
 C
 C----------------------------------
 C       EXTERNAL FORCES A=Fext-Fint
@@ -580,7 +582,7 @@ C---------no //SMP for the moment, add it after----
      2                      V     ,X     ,SKEWS%SKEW  ,MS,TFEXC,
      3                      NSENSOR,SENSOR_TAB,WEIGHT,
      4                      LGRAV ,ITASK,
-     5                      NRBYAC,IRBYAC,NPBY  ,RBY    )
+     5                      NRBYAC,IRBYAC,NPBY  ,RBY, PYTHON)
             IF (IMON>0) CALL STOPTIME(TIMERS,4)
           ENDIF
 C---------no //SMP for the moment, add it after----
@@ -590,7 +592,7 @@ C---------no //SMP for the moment, add it after----
      2                      V     ,X     ,XFRAME  ,MS,TFEXC,
      3                      NSENSOR,SENSOR_TAB,WEIGHT,IFRAME,
      4                      LCFIELD ,ITASK,
-     5                      NRBYAC,IRBYAC,NPBY  ,RBY,ISKEW    )
+     5                      NRBYAC,IRBYAC,NPBY  ,RBY,ISKEW,PYTHON   )
             IF (IMON>0) CALL STOPTIME(TIMERS,4)
           ENDIF
 
@@ -1910,7 +1912,7 @@ C
      8                    NDOF  ,H3D_DATA,CPTREAC,FTHREAC,NODREAC,NSENSOR,
      9                    TH_SURF ,DPL0CLD,
      A                    VEL0CLD, NUMNOD,NSURF,NFUNCT,NCONLD,
-     B                    NGRAV,NFXVEL,STF,NUMSKW)
+     B                    NGRAV,NFXVEL,STF,NUMSKW,PYTHON)
             CALL DYNA_CPR0(NDDL0  )
           END IF
 C----------D_imp taking D_n-1 :exception for case with Gravity-----
@@ -3105,7 +3107,7 @@ C------------------------------------------
       !||    th_surf_mod     ../common_source/modules/interfaces/th_surf_mod.F
       !||    timer_mod       ../engine/source/system/timer_mod.F90
       !||====================================================================
-      SUBROUTINE IMP_CHKM(TIMERS,
+      SUBROUTINE IMP_CHKM(TIMERS,PYTHON,
      1  ICODE  ,ISKEW  ,ISKWN  ,IPART  ,IXTG   ,IXS    ,IXQ    ,
      2  IXC    ,IXT    ,IXP    ,IXR    ,IXTG1          ,ITAB   ,ITABM1 ,
      3  NPC    ,IBCL   ,IBFV   ,SENSOR_TAB,NNLINK ,LNLINK ,IPARG  ,IGRV   ,
@@ -3129,6 +3131,7 @@ C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
         USE TIMER_MOD
+        USE python_funct_mod, only: PYTHON_
         USE DSGRAPH_MOD
         USE IMP_WORKI
         USE ELBUFDEF_MOD
@@ -3163,6 +3166,7 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
         TYPE(TIMER_), INTENT(INOUT) :: TIMERS
+        TYPE(PYTHON_), INTENT(INOUT) :: PYTHON
         INTEGER ,INTENT(IN) :: SNPC    !< size of NPC
         INTEGER ,INTENT(IN) :: STF     !< size of TF / Tabulated function array
         INTEGER ,INTENT(IN) :: NSENSOR
@@ -3353,14 +3357,14 @@ C----------------------------------
      2                    V      ,X         ,SKEWS%SKEW ,MS,TFEXC,
      3                    NSENSOR,SENSOR_TAB            ,WEIGHT,
      4                    LGRAV  ,ITASK     ,
-     5                    NRBYAC ,IRBYAC    ,NPBY       ,RBY    )
+     5                    NRBYAC ,IRBYAC    ,NPBY       ,RBY , PYTHON)
         ENDIF
         IF(NLOADC/=0) THEN
           CALL CFIELD_IMP(ICFIELD  ,CFIELD,NPC   ,TF    ,AC,
      2                    V     ,X     ,XFRAME  ,MS,TFEXC,
      3                    NSENSOR,SENSOR_TAB,WEIGHT,IFRAME,
      4                    LCFIELD ,ITASK,
-     5                    NRBYAC,IRBYAC,NPBY  ,RBY,ISKWN    )
+     5                    NRBYAC,IRBYAC,NPBY  ,RBY,ISKWN, PYTHON    )
         ENDIF
 C-------------dU_d---------------------------------
         IF(NFXVEL/=0.AND.IMCONV==1) THEN

--- a/engine/source/loads/general/forcefingeo.F
+++ b/engine/source/loads/general/forcefingeo.F
@@ -35,11 +35,13 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       !||====================================================================
       SUBROUTINE FORCEFINGEO(IBFV  ,NPC    ,TF     ,A     ,V    ,X     ,
      2                       VEL   ,SENSOR_TAB,FSKY  ,FEXT ,ITABM1,
-     3                       H3D_DATA,NSENSOR, PYTHON,WFEXT)
+     3                       H3D_DATA,NSENSOR, PYTHON,WFEXT,NODES)
 C-----------------------------------------------
 C   M o d u l e s
 C----------------------------------------------- 
+      USE nodal_arrays_mod
       USE PYTHON_FUNCT_MOD
+      use python_call_funct_cload_mod
       USE H3D_MOD 
       USE SENSOR_MOD
 C-----------------------------------------------
@@ -67,6 +69,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+      TYPE(NODAL_ARRAYS_) :: NODES
       TYPE(PYTHON_), INTENT(inout) :: PYTHON
       INTEGER ,INTENT(IN) :: NSENSOR
       INTEGER IBFV(NIFV,*), NPC(*)
@@ -130,8 +133,8 @@ C
             F1 = FINTER_SMOOTH(NCUR,(TS-DT1)*FACX,NPC,TF,DYDX)
             F2 = FINTER_SMOOTH(NCUR,TS*FACX,NPC,TF,DYDX)
           ELSE IF(ISMOOTH < 0) THEN
-            CALL PYTHON_CALL_FUNCT1D(PYTHON, -ISMOOTH,TS-DT1, F1)
-            CALL PYTHON_CALL_FUNCT1D(PYTHON, -ISMOOTH,TS, F2)
+            CALL PYTHON_CALL_FUNCT_CLOAD(PYTHON, -ISMOOTH,TS-DT1, F1,N1,NODES)
+            CALL PYTHON_CALL_FUNCT_CLOAD(PYTHON, -ISMOOTH,TS, F2,N2,NODES)
           ENDIF ! IF (ISMOOTH == 0)
           NCUR_OLD = NCUR
           TS_OLD = TS

--- a/engine/source/loads/general/grav/gravit_imp.F
+++ b/engine/source/loads/general/grav/gravit_imp.F
@@ -36,11 +36,13 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       SUBROUTINE GRAVIT_IMP(IGRV  ,AGRV  ,NPC   ,TF    ,A ,
      2                  V     ,X     ,SKEW  ,MS,WFEXTT,
      3                  NSENSOR,SENSOR_TAB,WEIGHT,IB,ITASK,
-     4                  NRBYAC,IRBYAC,NPBY  ,RBY   )
+     4                  NRBYAC,IRBYAC,NPBY  ,RBY   , PYTHON)
 C-----------------------------------------------  
 C   M o d u l e s
 C-----------------------------------------------  
       USE SENSOR_MOD
+      USE PYTHON_FUNCT_MOD
+      USE FINTER_MIXED_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -66,6 +68,7 @@ C     REAL
      .   AGRV(LFACGRV,*), TF(*), A(3,*), V(3,*), MS(*),
      .   X(3,*), SKEW(LSKEW,*), WFEXTT, RBY(NRBY,*)
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) ,INTENT(IN) :: SENSOR_TAB
+      TYPE(PYTHON_), INTENT(INOUT) :: PYTHON
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -108,9 +111,9 @@ C-------only for Itask=0 first-----
         ENDIF
 
         IF (IFUNC > 0) THEN
-          IF (ISMOOTH == 0) THEN
-            A0   = AGRV(1,NL)*FINTER(IFUNC,(TS-DT1)*AGRV(2,NL),NPC,TF,DYDX)
-            GAMA = AGRV(1,NL)*FINTER(IFUNC,TS*AGRV(2,NL),NPC,TF,DYDX)
+          IF (ISMOOTH <= 0) THEN
+            A0   = AGRV(1,NL)*FINTER_MIXED(python,nfunct,IFUNC,(TS-DT1)*AGRV(2,NL),NPC,TF)
+            GAMA = AGRV(1,NL)*FINTER_MIXED(python,nfunct,IFUNC,TS*AGRV(2,NL),NPC,TF)
           ELSE
             A0   = AGRV(1,NL)*FINTER_SMOOTH(IFUNC,(TS-DT1)*AGRV(2,NL),NPC,TF,DYDX)
             GAMA = AGRV(1,NL)*FINTER_SMOOTH(IFUNC,TS*AGRV(2,NL),NPC,TF,DYDX)

--- a/engine/source/loads/general/load_centri/cfield_imp.F
+++ b/engine/source/loads/general/load_centri/cfield_imp.F
@@ -35,11 +35,13 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      2                  V     ,X     ,XFRAME  ,MS,WFEXTT,
      3                  NSENSOR,SENSOR_TAB,WEIGHT,IFRAME,
      4                  IB,ITASK,
-     5                  NRBYAC,IRBYAC,NPBY  ,RBY,ISKN   )
+     5                  NRBYAC,IRBYAC,NPBY  ,RBY,ISKN, PYTHON  )
 C-----------------------------------------------  
 C   M o d u l e s
 C-----------------------------------------------  
       USE SENSOR_MOD
+      USE PYTHON_FUNCT_MOD
+      USE FINTER_MIXED_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -55,6 +57,7 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER,INTENT(IN) :: NSENSOR
+      TYPE(PYTHON_), INTENT(INOUT) :: PYTHON
       INTEGER NPC(*)
       INTEGER ICFIELD(SIZFIELD,*),IB(*)
       INTEGER WEIGHT(*),ITASK,NRBYAC,IRBYAC(*),NPBY(NNPBY,*),IFRAME(LISKN,*),ISKN(LISKN,*)
@@ -64,7 +67,7 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER NL, N1, IFRA, N2, IFUNC, K1, K2, K3, ISENS,K,NN, IAD,J, PROC, IADF, IADL,IDIR,IFLAG,N1FRAM,IUN,JJ,IMOVFRAM
-      my_real NX, NY, NZ, AXI, A0, AA, VV, FX, FY, FZ, AX, DYDX, TS,
+      my_real NX, NY, NZ, AXI, A0, AA, VV, FX, FY, FZ, AX,  TS,
      .        GAMA, MA, VROT, X0, Y0, Z0, X1, Y1, Z1, X2, Y2, Z2, VROTM1
       my_real DIST(3),AREL(3),VN1FRAM(3),AN1FRAM(3),DW(3)
       my_real FINTER 
@@ -121,9 +124,9 @@ C
           IF(TS<0.0)RETURN
       ENDIF
 C
-      VROT = FAC(1,NL)*FINTER(IFUNC,TS*FAC(2,NL),NPC,TF,DYDX)
+      VROT = FAC(1,NL)*FINTER_MIXED(python,nfunct,IFUNC,TS*FAC(2,NL),NPC,TF)
       VROTM1=VROT
-      IF (DT2 > ZERO .AND. IFLAG == 2) VROTM1 = FAC(1,NL)*FINTER(IFUNC,(TS-DT2)*FAC(2,NL),NPC,TF,DYDX)
+      IF (DT2 > ZERO .AND. IFLAG == 2) VROTM1 = FAC(1,NL)*FINTER_MIXED(python,nfunct,IFUNC,(TS-DT2)*FAC(2,NL),NPC,TF)
       X0 = XFRAME(10,IFRA+1)
       Y0 = XFRAME(11,IFRA+1)
       Z0 = XFRAME(12,IFRA+1)

--- a/engine/source/loads/general/python_call_funct_cload.F90
+++ b/engine/source/loads/general/python_call_funct_cload.F90
@@ -65,6 +65,7 @@
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                      Body
 ! ----------------------------------------------------------------------------------------------------------------------
+!$OMP CRITICAL
           argin(1) = dble(x)
           ! the double precision function is called, then the result is converted to single
 !      subroutine python_set_active_node_values(name_len, name, val) bind(c, name="cpp_python_update_active_node")
@@ -118,10 +119,9 @@
             tmp = 0.0d0
             call python_set_active_node_values(2,"AR",tmp)
           endif
-!$OMP CRITICAL
           call python_call_function(py%functs(funct_id)%name, 1, argin, 1, argout)
-!$OMP END CRITICAL
           y = real(argout(1),kind(1.0))
+!$OMP END CRITICAL
         end subroutine python_call_funct_cload_sp
 
       !||====================================================================

--- a/engine/source/tools/finter_mixed.F90
+++ b/engine/source/tools/finter_mixed.F90
@@ -1,0 +1,93 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 1986-2025 Altair Engineering Inc.
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Altair Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+!Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+!Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+      !||====================================================================
+      !||    finter_mixed_mod   ../engine/source/tools/curve/vinter_mixed.F90
+      !||--- called by ------------------------------------------------------
+      !||    redef3             ../engine/source/elements/spring/redef3.F90
+      !||    redef3_law113      ../engine/source/elements/spring/redef3_law113.F
+      !||====================================================================
+      module finter_mixed_mod
+      use precision_mod, only : WP
+      contains
+! ======================================================================================================================
+!                                                   procedures
+! ======================================================================================================================
+!! \brief  interpolate a table of values, or evaluate a python function
+      !||====================================================================
+      !||    finter_mixed           ../engine/source/tools/curve/vinter_mixed.F90
+      !||--- called by ------------------------------------------------------
+      !||    redef3                 ../engine/source/elements/spring/redef3.F90
+      !||    redef3_law113          ../engine/source/elements/spring/redef3_law113.F
+      !||--- calls      -----------------------------------------------------
+      !||--- uses       -----------------------------------------------------
+      !||    precision_mod          ../common_source/modules/precision_mod.F90
+      !||    python_funct_mod       ../common_source/modules/python_mod.F90
+      !||====================================================================
+        real(kind=WP) function finter_mixed(python,nfunct,ifunc,x,npc,tf,dydx) result(y)
+!                                  FINTER(IPT,TS*SCALT,NPC,TF,DYDX)
+
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Modules
+! ----------------------------------------------------------------------------------------------------------------------
+          use python_funct_mod
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          type(python_) :: python
+          integer :: nfunct
+          real(kind=WP) :: x
+          real(kind=WP) :: tf(2,*)
+          real(kind=WP), optional :: dydx
+          integer, intent(in) :: ifunc
+          integer :: npc(*)
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Local variables
+! ----------------------------------------------------------------------------------------------------------------------
+          integer :: ismooth
+          real(kind=WP), external :: FINTER
+          real(kind=WP) :: unused_dxdy
+
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Body
+! ----------------------------------------------------------------------------------------------------------------------
+            ismooth = 0
+            if (ifunc > 0) ismooth = npc(2*nfunct+ifunc+1)
+            if(ismooth < 0) then 
+              call python_call_funct1d(python, -ismooth,x, y) 
+              if(present(dydx)) then
+              call python_deriv_funct1D(python, -ismooth,x, dydx) 
+              endif
+            else
+                if(present(dydx)) then
+                  y = FINTER(ifunc, x, npc, tf, dydx)
+                else
+                  y = FINTER(ifunc, x, npc, tf, unused_dxdy)
+                endif
+            endif
+          return
+        end function finter_mixed
+      end module finter_mixed_mod

--- a/engine/source/tools/lagmul/lag_fxv.F
+++ b/engine/source/tools/lagmul/lag_fxv.F
@@ -34,9 +34,11 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      2                   BLL    ,IADLL  ,LLL    ,JLL    ,SLL    ,
      3                   XLL    ,COMNTAG,ICFTAG ,JCFTAG ,MS     ,
      4                   IN     ,V      ,VR     ,A      ,AR     ,
-     5                   ISKIP  ,NCF_S  ,NC     ,PYTHON)
+     5                   ISKIP  ,NCF_S  ,NC     ,PYTHON, nodes)
 
       USE PYTHON_FUNCT_MOD
+      USE python_call_funct_cload_mod
+      USE nodal_arrays_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -57,6 +59,7 @@ C-----------------------------------------------
      .  XLL(*),BLL(*),SKEW(LSKEW,*),VEL(LFXVELR,*),TF(*),MS(*),IN(*),
      .  V(3,*),VR(3,*),A(3,*),AR(3,*)
       TYPE(PYTHON_), INTENT(INOUT) :: PYTHON
+      TYPE(nodal_arrays_), intent(in) :: NODES
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -93,7 +96,7 @@ C======================================================================|
           ELSE IF (ISMOOTH > 0) THEN
             VF = FINTER_SMOOTH(IFUN, TS, NPF, TF, DERI)
           ELSE
-            CALL PYTHON_CALL_FUNCT1D(PYTHON, -ISMOOTH, TS, VF) 
+            CALL PYTHON_CALL_FUNCT_CLOAD(PYTHON, -ISMOOTH,TS, VF,NNO,NODES)
           ENDIF ! IF (ISMOOTH == 0)
           NC = NC + 1
           BLL(NC) = -VF*FAC / DT12
@@ -168,8 +171,10 @@ C
       !||====================================================================
       SUBROUTINE LAG_FXVP(IBFV   ,VEL    ,SKEW   ,NPF    ,TF     ,
      2                    LAGCOMC,LAGCOMK,NC     ,NODGLOB,WEIGHT ,
-     3                    IK     ,PYTHON)
+     3                    IK     ,PYTHON,NODES)
       USE PYTHON_FUNCT_MOD
+      USE nodal_arrays_mod
+      use python_call_funct_cload_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -189,6 +194,7 @@ C-----------------------------------------------
      .        LAGCOMK(4,*),LAGCOMC(2,*),SKEW(LSKEW,*),VEL(LFXVELR,*),
      .        TF(*)
       TYPE(PYTHON_), INTENT(INOUT) :: PYTHON
+      TYPE(nodal_arrays_), intent(in) :: NODES
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -196,6 +202,7 @@ C-----------------------------------------------
       my_real
      .        TS, DERI, VF, FAC, FACX, FINTER, FINTER_SMOOTH
       EXTERNAL FINTER, FINTER_SMOOTH
+      INTEGER :: node_id
 C-----------------------------------------------
 C        NC : nombre de condition cinematique
 C        IC : numero de la condition cinematique (1,NC)
@@ -213,6 +220,7 @@ C======================================================================|
       DO N=1,NFXVEL
         IF (IBFV(8,N)/=0) THEN
          NNO = IABS(IBFV(1,N))
+         node_id = NNO
          IF(WEIGHT(NNO)==1) THEN  ! une seule fois en SPMD
 C   numerotation globale
           FACX   = VEL(5,N)
@@ -230,7 +238,7 @@ C   numerotation globale
           ELSE IF(ISMOOTH > 0) THEN
             VF = FINTER_SMOOTH(IFUN, TS, NPF, TF, DERI)
           ELSE
-            CALL PYTHON_CALL_FUNCT1D(PYTHON, -ISMOOTH, TS, VF) 
+            CALL PYTHON_CALL_FUNCT_CLOAD(PYTHON, -ISMOOTH,TS, VF,node_id,NODES)
           ENDIF
           NC = NC + 1
           LAGCOMC(2,NC) = -VF*FAC / DT12

--- a/engine/source/tools/lagmul/lag_mult.F
+++ b/engine/source/tools/lagmul/lag_mult.F
@@ -65,7 +65,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      8       TF     ,NEWFRONT,ICONTACT,RWBUF    ,LPRW     ,
      9       NPRW   ,RBYL    ,D       ,DR       ,KINET    ,
      A       NSENSOR,SENSOR_TAB,INTBUF_TAB ,H3D_DATA ,IGRBRIC,
-     B       PYTHON)
+     B       PYTHON, nodes)
 C======================================================================|
 C-----------------------------------------------
 C   M o d u l e s
@@ -75,6 +75,7 @@ C-----------------------------------------------
       USE H3D_MOD
       USE GROUPDEF_MOD
       USE SENSOR_MOD
+      USE nodal_arrays_mod
 C----------------------------------------------- 
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -107,6 +108,7 @@ C     REAL
       TYPE(H3D_DATABASE) :: H3D_DATA
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) ,INTENT(IN) :: SENSOR_TAB
       TYPE(PYTHON_), INTENT(INOUT) :: PYTHON
+      TYPE(nodal_arrays_), intent(in) :: nodes 
 C-----------------------------------------------
       TYPE (GROUP_)  , DIMENSION(NGRNOD)  :: IGRNOD
       TYPE (GROUP_)  , DIMENSION(NGRBRIC) :: IGRBRIC
@@ -324,7 +326,7 @@ C ---------------------
      2   WAG(IP0)  ,WAG(IP1)  ,WAG(IP2)  ,WAG(IP3)  ,WAG(IP4)  ,
      3   WAG(IP5)  ,WAG(IP6)  ,LAGBUF(J3),LAGBUF(J4),MS        ,
      4   IN        ,V         ,VR        ,A         ,AR        ,
-     5   ISKIP     ,NCF_S     ,N_MULT    ,PYTHON)
+     5   ISKIP     ,NCF_S     ,N_MULT    ,PYTHON, nodes)
 C ---------------------
       NCF_E = N_MULT
 C ---------------------
@@ -436,11 +438,12 @@ C
      9       NPRW   ,RBYL    ,D       ,DR       ,KINET    ,
      A       NODGLOB,WEIGHT  ,NBNCL   ,NBIKL    ,NBNODL   ,
      B       NBNODLR,FR_LAGF ,LLAGF   ,IAD_ELEM ,FR_ELEM  ,
-     C       INTBUF_TAB ,H3D_DATA, PYTHON)
+     C       INTBUF_TAB ,H3D_DATA, PYTHON, nodes)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE PYTHON_FUNCT_MOD
+      USE nodal_arrays_mod
       USE MESSAGE_MOD
       USE INTBUFDEF_MOD
       USE H3D_MOD
@@ -480,6 +483,7 @@ C     REAL
       TYPE(INTBUF_STRUCT_) INTBUF_TAB(*)
       TYPE(H3D_DATABASE) :: H3D_DATA
       TYPE(PYTHON_), INTENT(INOUT) :: PYTHON
+      TYPE(nodal_arrays_), intent(in) :: nodes 
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -679,7 +683,7 @@ C ---------------------
       IF(NFVLAG>0) CALL LAG_FXVP(
      1   IBFV      ,VEL        ,SKEW     ,NPF       ,TF        ,
      2   LAGCOM    ,LAGCOM(IK0),N_MULT   ,NODGLOB   ,WEIGHT    ,
-     3   N_IK      ,PYTHON)
+     3   N_IK      ,PYTHON, nodes)
 C ---------------------
       NCF_E = N_MULT
 C ---------------------

--- a/scripts/static_analysis.py
+++ b/scripts/static_analysis.py
@@ -419,13 +419,23 @@ if __name__ == "__main__":
     #compare the two lists
     for hash in list_of_hashes:
         if hash not in list_of_old_hashes:
-            print("New issue found: ", hash)
-            print(new_errors[hash])
             #if new_errors[hash] contains "WARNING", then it is a warning
             if "WARNING" in new_errors[hash]:
                 count_new_warnings += 1
+                if "ARRAY VS SCALAR" not in new_errors[hash]:
+                    print("New warning found: ", hash)
+                    print(new_errors[hash])
             else:
                 count_new_errors += 1
+
+    
+    for hash in list_of_hashes:
+        if hash not in list_of_old_hashes:
+            #if new_errors[hash] contains "WARNING", then it is a warning
+            if "WARNING" not in new_errors[hash]:
+                print("New error found: ", hash)
+                print(new_errors[hash])
+
 #       else:
 #           print("Issue already known: ")
 #           print(new_errors[hash])


### PR DESCRIPTION
And extend /FUNCT_PYTHON compatibility to more options. All options are now supported, except:

- model with /EIG

- Conductibility and Friction for contact interfaces interface type 2 rupture criterion

- material laws (even though small mathematical functions without callback to Fortran would work, thanks to the sampling done at the starter)

The airbag injector compatibility has to be checked: Some quantities are computed at the starter using the function. If those quantities (mass ratios) are not recomputed at t=0 at the engine, then it may fail.

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
