### PR TITLE
correction issue when h3d key with comment just after

### DIFF
--- a/starter/source/model/sets/fill_igr.F
+++ b/starter/source/model/sets/fill_igr.F
@@ -135,7 +135,7 @@ C
                 READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
                 IF(CARTE(1:1) == '/') THEN 
                   BACKSPACE(tmp_engine)
-                ELSE
+                ELSE IF(CARTE(1:1) /= '#') THEN
                   ALLOCATE(GRPART_TMP(NVAR(CARTE)))
                   READ(CARTE, FMT=*) GRPART_TMP
                   DO J=1,NVAR(CARTE)
@@ -238,7 +238,7 @@ C
                 READ(UNIT=tmp_engine, FMT='(A)', IOSTAT=IO_ERR2) CARTE
                 IF(CARTE(1:1) == '/') THEN 
                   BACKSPACE(tmp_engine)
-                ELSE
+                ELSE IF(CARTE(1:1) /= '#') THEN
                   ALLOCATE(GRPART_TMP(NVAR(CARTE)))
                   READ(CARTE, FMT=*) GRPART_TMP
                   DO J=1,NVAR(CARTE)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
This pull request updates the logic in the `FILL_IGR` subroutine within the `starter/source/model/sets/fill_igr.F` file to improve how lines starting with specific characters are handled during processing. The primary change involves adding a new condition to skip lines starting with the `#` character.


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

* Modified the `ELSE` condition in the `FILL_IGR` subroutine to an `ELSE IF` condition that checks if the first character of the line (`CARTE(1:1)`) is not `#`, ensuring lines starting with `#` are ignored. [[1]](diffhunk://#diff-8767b1c17344b3591434491d958da39856342f2867f9c464185df13f9cbcc496L138-R138) [[2]](diffhunk://#diff-8767b1c17344b3591434491d958da39856342f2867f9c464185df13f9cbcc496L241-R241)




<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
