### PR TITLE
Correct formula of global element strain rate formulation for shells

### DIFF
--- a/engine/source/elements/sh3n/coque3n/c3forc3.F
+++ b/engine/source/elements/sh3n/coque3n/c3forc3.F
@@ -536,10 +536,9 @@ c-------------------------------------------
       asrate = one   ! to be changed for default value
 #include "vectorize.inc"
       do i = 1,nel
-        eps_k2 = (kxx(i)*kxx(i)+kyy(i)*kyy(i)+kxx(i)*kyy(i)              
-     &         + fourth*one_over_9*kxy(i)*kxy(i))*gbuf%thk(i)**2
-        eps_m2 = four_over_3*(exx(i)*exx(i)+eyy(i)*eyy(i)+exx(i)*eyy(i)  
-     &         + fourth*exy(i)*exy(i))
+        eps_k2 = (kxx(i)**2+kyy(i)**2+kxx(i)*kyy(i)+fourth*kxy(i)**2)
+     .         * one_over_9*gbuf%thk(i)**2
+        eps_m2 = four_over_3*(exx(i)**2+eyy(i)**2+exx(i)*eyy(i) + fourth*exy(i)**2)
         epsd_pg(i) = sqrt(eps_k2 + eps_m2)*dtinv
       end do
 !-------------------------------------------------------------------------------

--- a/engine/source/elements/sh3n/coquedk/cdkforc3.F
+++ b/engine/source/elements/sh3n/coquedk/cdkforc3.F
@@ -412,17 +412,16 @@ c-------------------------------------------
 !       e = 1/2 e eps_eq^2
 !       eps_eq = sqrt[ eps_m^2 + 1/12 k^2t^2 ]
 !-------------------------------------------------------------------------------
-        dt1 = dt1c(1)
-        dtinv = dt1 / max(dt1**2,em20)  ! inverse of dt
+      dt1 = dt1c(1)
+      dtinv = dt1 / max(dt1**2,em20)  ! inverse of dt
 #include "vectorize.inc"
-        do i = 1,nel
-          eps_k2 = (kxx(i)*kxx(i)+kyy(i)*kyy(i)+kxx(i)*kyy(i)              
-     &           + fourth*one_over_9*kxy(i)*kxy(i)) * gbuf%thk(i)**2
-          eps_m2 = four_over_3*(exx(i)*exx(i)+eyy(i)*eyy(i)+exx(i)*eyy(i)  
-     &           + fourth*exy(i)*exy(i))
-          epsd_pg(i) = sqrt(eps_k2 + eps_m2)*dtinv
-          epsd_glob(i) = epsd_glob(i) + epsd_pg(i) / npg
-        end do
+      do i = 1,nel
+        eps_k2 = (kxx(i)**2+kyy(i)**2+kxx(i)*kyy(i)+fourth*kxy(i)**2)
+     .         * one_over_9*gbuf%thk(i)**2
+        eps_m2 = four_over_3*(exx(i)**2+eyy(i)**2+exx(i)*eyy(i) + fourth*exy(i)**2)
+        epsd_pg(i) = sqrt(eps_k2 + eps_m2)*dtinv
+        epsd_glob(i) = epsd_glob(i) + epsd_pg(i) / npg
+      end do
 C----------------------------------------------------------------------------
        CALL CMAIN3(TIMERS,
      1     ELBUF_STR ,JFT       ,JLT       ,NFT       ,IPARG      ,

--- a/engine/source/elements/sh3n/coquedk6/cdk6forc3.F
+++ b/engine/source/elements/sh3n/coquedk6/cdk6forc3.F
@@ -395,10 +395,9 @@ c-------------------------------------------
       asrate = one   ! to be changed for default value
 #include "vectorize.inc"
       do i = 1,nel
-        eps_k2 = (kxx(i)*kxx(i)+kyy(i)*kyy(i)+kxx(i)*kyy(i)              
-     &         + fourth*one_over_9*kxy(i)*kxy(i)) * gbuf%thk(i)**2
-        eps_m2 = four_over_3*(exx(i)*exx(i)+eyy(i)*eyy(i)+exx(i)*eyy(i)  
-     &         + fourth*exy(i)*exy(i))
+        eps_k2 = (kxx(i)**2+kyy(i)**2+kxx(i)*kyy(i)+fourth*kxy(i)**2)
+     .         * one_over_9*gbuf%thk(i)**2
+        eps_m2 = four_over_3*(exx(i)**2+eyy(i)**2+exx(i)*eyy(i) + fourth*exy(i)**2)
         epsd_pg(i) = sqrt(eps_k2 + eps_m2)*dtinv
       end do
 !-------------------------------------------------------------------------------

--- a/engine/source/elements/shell/coque/cforc3.F
+++ b/engine/source/elements/shell/coque/cforc3.F
@@ -533,10 +533,9 @@ c-------------------------------------------
       asrate = one   ! to be changed for default value
 #include "vectorize.inc"
       do i = 1,nel
-        eps_k2 = (kxx(i)*kxx(i)+kyy(i)*kyy(i)+kxx(i)*kyy(i)              
-     &         + fourth*one_over_9*kxy(i)*kxy(i)) * gbuf%thk(i)**2
-        eps_m2 = four_over_3*(exx(i)*exx(i)+eyy(i)*eyy(i)+exx(i)*eyy(i)  
-     &         + fourth*exy(i)*exy(i))
+        eps_k2 = (kxx(i)**2+kyy(i)**2+kxx(i)*kyy(i)+fourth*kxy(i)**2)
+     .         * one_over_9*gbuf%thk(i)**2
+        eps_m2 = four_over_3*(exx(i)**2+eyy(i)**2+exx(i)*eyy(i) + fourth*exy(i)**2)
         epsd_pg(i) = sqrt(eps_k2 + eps_m2)*dtinv
       end do
 !-------------------------------------------------------------------------------

--- a/engine/source/elements/shell/coqueba/cbaforc3.F
+++ b/engine/source/elements/shell/coqueba/cbaforc3.F
@@ -752,10 +752,9 @@ C
         dtinv = dt1 / max(dt1**2,em20)  ! inverse of dt
 #include "vectorize.inc"
         do i = 1,nel
-          eps_k2 = (kxx(i)*kxx(i)+kyy(i)*kyy(i)+kxx(i)*kyy(i)              
-     &           + fourth*one_over_9*kxy(i)*kxy(i)) * gbuf%thk(i)**2
-          eps_m2 = four_over_3*(exx(i)*exx(i)+eyy(i)*eyy(i)+exx(i)*eyy(i)  
-     &           + fourth*exy(i)*exy(i))
+          eps_k2 = (kxx(i)**2+kyy(i)**2+kxx(i)*kyy(i)+fourth*kxy(i)**2)
+     .           * one_over_9*gbuf%thk(i)**2
+          eps_m2 = four_over_3*(exx(i)**2+eyy(i)**2+exx(i)*eyy(i) + fourth*exy(i)**2)
           epsd_pg(i) = sqrt(eps_k2 + eps_m2)*dtinv
           epsd_glob(i) = epsd_glob(i) + epsd_pg(i) / npg
         end do

--- a/engine/source/elements/shell/coquez/czforc3.F
+++ b/engine/source/elements/shell/coquez/czforc3.F
@@ -571,10 +571,9 @@ c-------------------------------------------
       asrate = one   ! to be changed for default value
 #include "vectorize.inc"
       do i = 1,nel
-        eps_k2 = (kxx(i)*kxx(i)+kyy(i)*kyy(i)+kxx(i)*kyy(i)              
-     &         + fourth*one_over_9*kxy(i)*kxy(i)) * gbuf%thk(i)**2
-        eps_m2 = four_over_3*(exx(i)*exx(i)+eyy(i)*eyy(i)+exx(i)*eyy(i)  
-     &         + fourth*exy(i)*exy(i))
+        eps_k2 = (kxx(i)**2+kyy(i)**2+kxx(i)*kyy(i)+fourth*kxy(i)**2)
+     .         * one_over_9*gbuf%thk(i)**2
+        eps_m2 = four_over_3*(exx(i)**2+eyy(i)**2+exx(i)*eyy(i) + fourth*exy(i)**2)
         epsd_pg(i) = sqrt(eps_k2 + eps_m2)*dtinv
       end do
 !-------------------------------------------------------------------------------

--- a/engine/source/materials/mat/mat122/sigeps122c.F
+++ b/engine/source/materials/mat/mat122/sigeps122c.F
@@ -37,7 +37,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      4     SIGOXX  ,SIGOYY  ,SIGOXY  ,SIGOYZ  ,SIGOZX  ,
      5     SIGNXX  ,SIGNYY  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
      6     THK     ,THKLY   ,OFF     ,SIGY    ,ETSE    ,
-     7     DMG     ,SEQ     ,SHF     ,SOUNDSP ,
+     7     DMG     ,SEQ     ,SHF     ,SOUNDSP ,ASRATE  ,
      8     EPSD_PG ,NFUNC   ,IFUNC   ,NPF     ,TF      ,
      9     NVARTMP ,VARTMP  ,IOFF_DUCT)
 C-----------------------------------------------
@@ -57,6 +57,7 @@ C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER, INTENT(IN) :: NEL,NUPARAM,NUVAR,
      .   NFUNC,IFUNC(NFUNC),NPF(SNPC),NVARTMP
+      my_real, INTENT(IN) :: ASRATE
       my_real, INTENT(IN) ::
      .   UPARAM(NUPARAM),TF(STF)
       my_real,DIMENSION(NEL), INTENT(IN) :: 
@@ -78,11 +79,18 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER IRES,I
+      my_real ,DIMENSION(NEL) :: EPSD
 C=======================================================================
 c
       IRES = NINT(UPARAM(17)) ! Plastic projection method
                               !  = 1 => Nice method
                               !  = 2 => Cutting plane
+                              
+      ! strain rate filtering, using global element strain rate
+      do i=1,nel
+        epsd(i) = asrate*epsd_pg(i) + (one-asrate)*uvar(i,18)
+        uvar(i,18) = epsd(i)
+      end do
 c--------------------------                        
       SELECT CASE (IRES)
 c      
@@ -95,7 +103,7 @@ c
      4         SIGOXX  ,SIGOYY  ,SIGOXY  ,SIGOYZ  ,SIGOZX  ,
      5         SIGNXX  ,SIGNYY  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
      6         THK     ,THKLY   ,OFF     ,SIGY    ,ETSE    ,
-     7         DMG     ,SEQ     ,EPSD_PG ,SHF     ,SOUNDSP ,
+     7         DMG     ,SEQ     ,EPSD    ,SHF     ,SOUNDSP ,
      8         NFUNC   ,IFUNC   ,NPF     ,TF      ,NVARTMP ,
      9         VARTMP  )
 c      
@@ -108,7 +116,7 @@ c
      4         SIGOXX  ,SIGOYY  ,SIGOXY  ,SIGOYZ  ,SIGOZX  ,
      5         SIGNXX  ,SIGNYY  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
      6         THK     ,THKLY   ,OFF     ,SIGY    ,ETSE    ,
-     7         DMG     ,SEQ     ,EPSD_PG ,SHF     ,SOUNDSP ,
+     7         DMG     ,SEQ     ,EPSD    ,SHF     ,SOUNDSP ,
      8         NFUNC   ,IFUNC   ,NPF     ,TF      ,NVARTMP ,
      9         VARTMP  )
     

--- a/engine/source/materials/mat_share/mulawc.F90
+++ b/engine/source/materials/mat_share/mulawc.F90
@@ -1588,25 +1588,26 @@
 !
               elseif (ilaw == 80) then
                 call sigeps80c(&
-                &jlt,          nuparam0,      nuvar,        nfunc,&
-                &ifunc,        npf,          npt,          ipt,&
-                &iflag,        tf,           tt,           dt1c,&
-                &uparam0,       rho,          area,         eint,&
-                &thklyl,       epspxx,       epspyy,       epspxy,&
-                &epspyz,       epspzx,       depsxx,       depsyy,&
-                &depsxy,       depsyz,       depszx,       epsxx,&
-                &epsyy,        epsxy,        epsyz,        epszx,&
-                &sigoxx,sigoyy,sigoxy,sigoyz,&
-                &sigozx,signxx,       signyy,       signxy,&
-                &signyz,       signzx,       sigvxx,       sigvyy,&
-                &sigvxy,       sigvyz,       sigvzx,       ssp,&
-                &viscmx,       thkn,         lbuf%pla,     uvar,&
-                &off,          ngl,          pm,           ipm,&
-                &matly(jmly),  etse,         gs,           vol0,&
-                &sigy,         el_temp,      die,          coef,&
-                &shf,          epsd_pg,      table,        ithk,&
-                &nvartmp,      vartmp,       epsthtot,     jthe,&
-                &idt_therm,    theaccfact)
+                 jlt,          nuparam0,      nuvar,        nfunc,&
+                 ifunc,        npf,          npt,          ipt,&
+                 iflag,        tf,           tt,           dt1c,&
+                 uparam0,       rho,          area,         eint,&
+                 thklyl,       epspxx,       epspyy,       epspxy,&
+                 epspyz,       epspzx,       depsxx,       depsyy,&
+                 depsxy,       depsyz,       depszx,       epsxx,&
+                 epsyy,        epsxy,        epsyz,        epszx,&
+                 sigoxx,sigoyy,sigoxy,sigoyz,&
+                 sigozx,signxx,       signyy,       signxy,&
+                 signyz,       signzx,       sigvxx,       sigvyy,&
+                 sigvxy,       sigvyz,       sigvzx,       ssp,&
+                 viscmx,       thkn,         lbuf%pla,     uvar,&
+                 off,          ngl,          pm,           ipm,&
+                 matly(jmly),  etse,         gs,           vol0,&
+                 sigy,         el_temp,      die,          coef,&
+                 shf,          epsd_pg,      table,        ithk,&
+                 nvartmp,      vartmp,       epsthtot,     jthe,&
+                 idt_therm,    theaccfact)
+                 lbuf%epsd(1:nel) = epsd_pg(1:nel)                
 !
               elseif (ilaw == 82) then
                 call sigeps82c(&
@@ -1772,28 +1773,30 @@
 !
               elseif (ilaw == 122) then
                 call sigeps122c(&
-                &jlt      ,nuparam0 ,nuvar    ,uparam0  ,uvar     ,&
-                &epsxx    ,epsyy    ,rho      ,lbuf%pla ,dpla     ,&
-                &depsxx   ,depsyy   ,depsxy   ,depsyz   ,depszx   ,&
-                &sigoxx,sigoyy,sigoxy,sigoyz,sigozx,&
-                &signxx   ,signyy   ,signxy   ,signyz   ,signzx   ,&
-                &thkn     ,thklyl   ,off      ,sigy     ,etse     ,&
-                &lbuf%dmg ,lbuf%seq ,shf      ,ssp      ,&
-                &epsd_pg  ,nfunc    ,ifunc    ,npf      ,tf       ,&
-                &nvartmp  ,vartmp   ,ioff_duct)
+                 jlt      ,nuparam0 ,nuvar    ,uparam0  ,uvar     ,   &
+                 epsxx    ,epsyy    ,rho      ,lbuf%pla ,dpla     ,   &
+                 depsxx   ,depsyy   ,depsxy   ,depsyz   ,depszx   ,   &
+                 sigoxx   ,sigoyy   ,sigoxy   ,sigoyz   ,sigozx   ,   &
+                 signxx   ,signyy   ,signxy   ,signyz   ,signzx   ,   &
+                 thkn     ,thklyl   ,off      ,sigy     ,etse     ,   &
+                 lbuf%dmg ,lbuf%seq ,shf      ,ssp      ,asrate   ,   &
+                 epsd_pg  ,nfunc    ,ifunc    ,npf      ,tf       ,   &
+                 nvartmp  ,vartmp   ,ioff_duct)
+                 lbuf%epsd(1:nel) = epsd_pg(1:nel)
 !
               elseif (ilaw == 125) then
                call sigeps125c(&
-               &jlt      ,matparam   ,nuvar    ,uvar      ,&
-               &rho      ,thkn       ,thklyl   , shf      ,&
-               &nfunc    ,ifunc      ,npf      ,tf        ,snpc    ,&
-               &stf      ,epsd_pg                                  ,&
-               &depsxx   ,depsyy     ,depsxy                       ,&
-               &epsxx    ,epsyy      ,epsxy    ,epsyz    ,epszx    ,&
-               &sigoxx   ,sigoyy     ,sigoxy                       ,&
-               &signxx   ,signyy     ,signxy   ,signzx   ,signyz   ,&
-               &off      ,sigy       ,etse     ,ssp      ,lbuf%dmg ,&
-               &gbuf%dmg ,lbuf%off  )
+                    jlt      ,matparam   ,nuvar    ,uvar      ,&
+                    rho      ,thkn       ,thklyl   , shf      ,&
+                    nfunc    ,ifunc      ,npf      ,tf        ,snpc    ,&
+                    stf      ,epsd_pg                                  ,&
+                    depsxx   ,depsyy     ,depsxy                       ,&
+                    epsxx    ,epsyy      ,epsxy    ,epsyz    ,epszx    ,&
+                    sigoxx   ,sigoyy     ,sigoxy                       ,&
+                    signxx   ,signyy     ,signxy   ,signzx   ,signyz   ,&
+                    off      ,sigy       ,etse     ,ssp      ,lbuf%dmg ,&
+                    gbuf%dmg ,lbuf%off  )
+                 lbuf%epsd(1:nel) = epsd_pg(1:nel)
 !
               elseif (ilaw == 127) then
                 ! ---
@@ -1807,16 +1810,17 @@
                 enddo
                 !---
                 call sigeps127c(&
-                &jlt      ,matparam   ,nuvar    ,uvar      ,         &
-                &rho      ,thkn       ,thklyl   ,shf       ,ncycle  ,&
-                &nfunc    ,ifunc      ,npf      ,tf        ,snpc    ,&
-                &stf      ,epsd_pg    ,npttot                       ,&
-                &depsxx   ,depsyy     ,depsxy   ,depsyz   ,depszx   ,&
-                &epsxx    ,epsyy      ,epsxy    ,epsyz    ,epszx    ,&
-                &sigoxx   ,sigoyy     ,sigoxy   ,sigozx   ,sigoyz   ,&
-                &signxx   ,signyy     ,signxy   ,signzx   ,signyz   ,&
-                &off      ,sigy       ,etse     ,ssp      ,lbuf%dmg ,&
-                &gbuf%dmg  ,lbuf%off)
+                 jlt      ,matparam   ,nuvar    ,uvar      ,         &
+                 rho      ,thkn       ,thklyl   ,shf       ,ncycle  ,&
+                 nfunc    ,ifunc      ,npf      ,tf        ,snpc    ,&
+                 stf      ,epsd_pg    ,npttot                       ,&
+                 depsxx   ,depsyy     ,depsxy   ,depsyz   ,depszx   ,&
+                 epsxx    ,epsyy      ,epsxy    ,epsyz    ,epszx    ,&
+                 sigoxx   ,sigoyy     ,sigoxy   ,sigozx   ,sigoyz   ,&
+                 signxx   ,signyy     ,signxy   ,signzx   ,signyz   ,&
+                 off      ,sigy       ,etse     ,ssp      ,lbuf%dmg ,&
+                 gbuf%dmg  ,lbuf%off)
+                 lbuf%epsd(1:nel) = epsd_pg(1:nel)
 !
               elseif (ilaw == 128) then
                 sigoxx(1:nel) = lbuf%sig(1:nel)
@@ -1952,14 +1956,14 @@
                   ! non-local material
                   if (inloc > 0) then
                     do i=jft,jlt
-                      dpla(i)  = max(varnl(i,it),zero)
+                      dpla(i) = max(varnl(i,it),zero)
                       epsd(i) = lbuf%epsdnl(i)
                     enddo
                     el_pla => lbuf%planl(1:nel)
                     ! classical local material
                   else
                     do i=jft,jlt
-                      dpla(i)  = lbuf%pla(i) - pla0(i)
+                      dpla(i) = lbuf%pla(i) - pla0(i)
                       epsd(i) = lbuf%epsd(i)
                     enddo
                     el_pla => lbuf%pla(1:nel)

--- a/starter/source/materials/mat/mat122/hm_read_mat122.F
+++ b/starter/source/materials/mat/mat122/hm_read_mat122.F
@@ -342,7 +342,7 @@ c--------------------------
       ! Number of functions
       NFUNC   = 3
       ! Number of user variables 
-      NUVAR   = 17
+      NUVAR   = 18
       ! Number of temporary variable for interpolation
       NVARTMP = 3
 c          


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

differences from reference solutions in several strain rate dependent material laws

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

1) Formula for global strain rate calculation is corrected for all shel element types
2) Added strain rate filtering in law122
3) Saved global strain rate for failure models when local value is not calculated in material law (several cases). 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
