### PR TITLE
add pack and unpack to spmd_mod

### DIFF
--- a/engine/CMake_Compilers/legacy_fortran.cmake
+++ b/engine/CMake_Compilers/legacy_fortran.cmake
@@ -50,6 +50,8 @@ set_source_files_properties( ${source_directory}/source/mpi/spmd_mod.F90 PROPERT
 set_source_files_properties( ${source_directory}/source/mpi/generic/spmd_allgather.F90 PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/mpi/spmd_error.F90 PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/mpi/spmd_send.F90 PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
+set_source_files_properties( ${source_directory}/source/mpi/spmd_pack.F90 PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
+set_source_files_properties( ${source_directory}/source/mpi/spmd_unpack.F90 PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/mpi/spmd_wait.F90 PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/mpi/spmd_isend.F90 PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/mpi/spmd_recv.F90 PROPERTIES COMPILE_FLAGS "${legacy_flags}" )

--- a/engine/source/mpi/spmd_mod.F90
+++ b/engine/source/mpi/spmd_mod.F90
@@ -151,6 +151,8 @@
         use spmd_wait_mod, only: spmd_wait, spmd_waitall, spmd_waitany
         use spmd_allgatherv_mod, only: spmd_allgatherv
         use spmd_alltoall_mod, only: spmd_alltoall 
+        use spmd_pack_mod, only: spmd_pack
+        use spmd_unpack_mod, only: spmd_unpack
         implicit none
         ! Define the interface for spmd_send
 ! dummy tags for MPI calls that do not have a tag
@@ -213,6 +215,8 @@
         public :: SPMD_COMM_WORLD
         public :: spmd_allgatherv
         public :: spmd_alltoall
+        public :: spmd_pack
+        public :: spmd_unpack
 
       contains
 ! ======================================================================================================================

--- a/engine/source/mpi/spmd_pack.F90
+++ b/engine/source/mpi/spmd_pack.F90
@@ -1,0 +1,130 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 1986-2025 Altair Engineering Inc.
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Altair Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+!Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+!Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+
+
+      module spmd_pack_mod
+
+        implicit none
+        private
+        interface spmd_pack
+          module procedure spmd_pack_reals      !< Sends real numbers
+          module procedure spmd_pack_ints       !< Sends integers
+          module procedure spmd_pack_doubles    !< Sends double precision numbers
+        end interface spmd_pack
+        public spmd_pack
+      contains
+!||====================================================================
+!||    spmd_pack_reals       ../engine/source/mpi/spmd_pack.F90
+!||--- calls      -----------------------------------------------------
+!||    spmd_in               ../engine/source/mpi/spmd_error.F90
+!||    spmd_out              ../engine/source/mpi/spmd_error.F90
+!||--- uses       -----------------------------------------------------
+!||    spmd_comm_world_mod   ../engine/source/mpi/spmd_comm_world.F90
+!||    spmd_error_mod        ../engine/source/mpi/spmd_error.F90
+!||====================================================================
+        subroutine spmd_pack_reals(inbuf, incount, outbuf, outsize, position, comm)
+          use spmd_error_mod, only: spmd_in, spmd_out
+          use spmd_comm_world_mod, only: SPMD_COMM_WORLD
+          implicit none
+#include "spmd.inc"
+          integer, intent(in) :: incount, outsize
+          integer, intent(inout) :: position
+          integer, intent(in), optional :: comm
+          real, dimension(incount), intent(in) :: inbuf
+          integer, dimension(outsize), intent(inout) :: outbuf
+          integer :: ierr, tag
+#ifdef MPI
+          tag = 0  ! Default tag for pack operations
+          call spmd_in(tag)
+          if( present(comm) ) then
+            call MPI_Pack(inbuf, incount, MPI_REAL, outbuf, outsize, position, comm, ierr)
+          else
+            call MPI_Pack(inbuf, incount, MPI_REAL, outbuf, outsize, position, SPMD_COMM_WORLD, ierr)
+          end if
+          call spmd_out(tag,ierr)
+#endif
+        end subroutine spmd_pack_reals
+!||====================================================================
+!||    spmd_pack_ints        ../engine/source/mpi/spmd_pack.F90
+!||--- calls      -----------------------------------------------------
+!||    spmd_in               ../engine/source/mpi/spmd_error.F90
+!||    spmd_out              ../engine/source/mpi/spmd_error.F90
+!||--- uses       -----------------------------------------------------
+!||    spmd_comm_world_mod   ../engine/source/mpi/spmd_comm_world.F90
+!||    spmd_error_mod        ../engine/source/mpi/spmd_error.F90
+!||====================================================================
+        subroutine spmd_pack_ints(inbuf, incount, outbuf, outsize, position, comm)
+          use spmd_error_mod, only: spmd_in, spmd_out
+          use spmd_comm_world_mod, only: SPMD_COMM_WORLD
+          implicit none
+#include "spmd.inc"
+          integer, intent(in) :: incount, outsize
+          integer, intent(inout) :: position
+          integer, intent(in), optional :: comm
+          integer, dimension(incount), intent(in) :: inbuf
+          integer, dimension(outsize), intent(inout) :: outbuf
+          integer :: ierr, tag
+#ifdef MPI
+          tag = 0  ! Default tag for pack operations
+          call spmd_in(tag)
+          if( present(comm) ) then
+            call MPI_Pack(inbuf, incount, MPI_INTEGER, outbuf, outsize, position, comm, ierr)
+          else
+            call MPI_Pack(inbuf, incount, MPI_INTEGER, outbuf, outsize, position, SPMD_COMM_WORLD, ierr)
+          end if
+          call spmd_out(tag,ierr)
+#endif
+        end subroutine spmd_pack_ints
+!||====================================================================
+!||    spmd_pack_doubles     ../engine/source/mpi/spmd_pack.F90
+!||--- calls      -----------------------------------------------------
+!||    spmd_in               ../engine/source/mpi/spmd_error.F90
+!||    spmd_out              ../engine/source/mpi/spmd_error.F90
+!||--- uses       -----------------------------------------------------
+!||    spmd_comm_world_mod   ../engine/source/mpi/spmd_comm_world.F90
+!||    spmd_error_mod        ../engine/source/mpi/spmd_error.F90
+!||====================================================================
+        subroutine spmd_pack_doubles(inbuf, incount, outbuf, outsize, position, comm)
+          use spmd_error_mod, only: spmd_in, spmd_out
+          use spmd_comm_world_mod, only: SPMD_COMM_WORLD
+          implicit none
+#include "spmd.inc"
+          integer, intent(in) :: incount, outsize
+          integer, intent(inout) :: position
+          integer, intent(in), optional :: comm
+          double precision, dimension(incount), intent(in) :: inbuf
+          integer, dimension(outsize), intent(inout) :: outbuf
+#ifdef MPI
+          integer :: ierr, tag
+          tag = 0  ! Default tag for pack operations
+          call spmd_in(tag)
+          if( present(comm) ) then
+            call MPI_Pack(inbuf, incount, MPI_DOUBLE_PRECISION, outbuf, outsize, position, comm, ierr)
+          else
+            call MPI_Pack(inbuf, incount, MPI_DOUBLE_PRECISION, outbuf, outsize, position, SPMD_COMM_WORLD, ierr)
+          end if
+          call spmd_out(tag,ierr)
+#endif
+        end subroutine spmd_pack_doubles
+
+      end module spmd_pack_mod

--- a/engine/source/mpi/spmd_unpack.F90
+++ b/engine/source/mpi/spmd_unpack.F90
@@ -1,0 +1,127 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 1986-2025 Altair Engineering Inc.
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Altair Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+!Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+!Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+      module spmd_unpack_mod
+        implicit none
+        private
+        interface spmd_unpack
+          module procedure spmd_unpack_reals      !< Unpacks real numbers
+          module procedure spmd_unpack_ints       !< Unpacks integers
+          module procedure spmd_unpack_doubles    !< Unpacks double precision numbers
+        end interface spmd_unpack
+        public spmd_unpack
+      contains
+!||====================================================================
+!||    spmd_unpack_reals     ../engine/source/mpi/spmd_unpack.F90
+!||--- calls      -----------------------------------------------------
+!||    spmd_in               ../engine/source/mpi/spmd_error.F90
+!||    spmd_out              ../engine/source/mpi/spmd_error.F90
+!||--- uses       -----------------------------------------------------
+!||    spmd_comm_world_mod   ../engine/source/mpi/spmd_comm_world.F90
+!||    spmd_error_mod        ../engine/source/mpi/spmd_error.F90
+!||====================================================================
+        subroutine spmd_unpack_reals(inbuf, insize, position, outbuf, outcount, comm)
+          use spmd_error_mod, only: spmd_in, spmd_out
+          use spmd_comm_world_mod, only: SPMD_COMM_WORLD
+          implicit none
+#include "spmd.inc"
+          integer, intent(in) :: insize, outcount
+          integer, intent(inout) :: position
+          integer, intent(in), optional :: comm
+          integer, dimension(insize), intent(in) :: inbuf
+          real, dimension(outcount), intent(out) :: outbuf
+          integer :: ierr, tag
+#ifdef MPI
+          tag = 0  ! Default tag for unpack operations
+          call spmd_in(tag)
+          if( present(comm) ) then
+            call MPI_Unpack(inbuf, insize, position, outbuf, outcount, MPI_REAL, comm, ierr)
+          else
+            call MPI_Unpack(inbuf, insize, position, outbuf, outcount, MPI_REAL, SPMD_COMM_WORLD, ierr)
+          end if
+          call spmd_out(tag,ierr)
+#endif
+        end subroutine spmd_unpack_reals
+!||====================================================================
+!||    spmd_unpack_ints      ../engine/source/mpi/spmd_unpack.F90
+!||--- calls      -----------------------------------------------------
+!||    spmd_in               ../engine/source/mpi/spmd_error.F90
+!||    spmd_out              ../engine/source/mpi/spmd_error.F90
+!||--- uses       -----------------------------------------------------
+!||    spmd_comm_world_mod   ../engine/source/mpi/spmd_comm_world.F90
+!||    spmd_error_mod        ../engine/source/mpi/spmd_error.F90
+!||====================================================================
+        subroutine spmd_unpack_ints(inbuf, insize, position, outbuf, outcount, comm)
+          use spmd_error_mod, only: spmd_in, spmd_out
+          use spmd_comm_world_mod, only: SPMD_COMM_WORLD
+          implicit none
+#include "spmd.inc"
+          integer, intent(in) :: insize, outcount
+          integer, intent(inout) :: position
+          integer, intent(in), optional :: comm
+          integer, dimension(insize), intent(in) :: inbuf
+          integer, dimension(outcount), intent(out) :: outbuf
+          integer :: ierr, tag
+#ifdef MPI
+          tag = 0  ! Default tag for unpack operations
+          call spmd_in(tag)
+          if( present(comm) ) then
+            call MPI_Unpack(inbuf, insize, position, outbuf, outcount, MPI_INTEGER, comm, ierr)
+          else
+            call MPI_Unpack(inbuf, insize, position, outbuf, outcount, MPI_INTEGER, SPMD_COMM_WORLD, ierr)
+          end if
+          call spmd_out(tag,ierr)
+#endif
+        end subroutine spmd_unpack_ints
+!||====================================================================
+!||    spmd_unpack_doubles   ../engine/source/mpi/spmd_unpack.F90
+!||--- calls      -----------------------------------------------------
+!||    spmd_in               ../engine/source/mpi/spmd_error.F90
+!||    spmd_out              ../engine/source/mpi/spmd_error.F90
+!||--- uses       -----------------------------------------------------
+!||    spmd_comm_world_mod   ../engine/source/mpi/spmd_comm_world.F90
+!||    spmd_error_mod        ../engine/source/mpi/spmd_error.F90
+!||====================================================================
+        subroutine spmd_unpack_doubles(inbuf, insize, position, outbuf, outcount, comm)
+          use spmd_error_mod, only: spmd_in, spmd_out
+          use spmd_comm_world_mod, only: SPMD_COMM_WORLD
+          implicit none
+#include "spmd.inc"
+          integer, intent(in) :: insize, outcount
+          integer, intent(inout) :: position
+          integer, intent(in), optional :: comm
+          integer, dimension(insize), intent(in) :: inbuf
+          double precision, dimension(outcount), intent(out) :: outbuf
+#ifdef MPI
+          integer :: ierr, tag
+          tag = 0  ! Default tag for unpack operations
+          call spmd_in(tag)
+          if( present(comm) ) then
+            call MPI_Unpack(inbuf, insize, position, outbuf, outcount, MPI_DOUBLE_PRECISION, comm, ierr)
+          else
+            call MPI_Unpack(inbuf, insize, position, outbuf, outcount, MPI_DOUBLE_PRECISION, SPMD_COMM_WORLD, ierr)
+          end if
+          call spmd_out(tag,ierr)
+#endif
+        end subroutine spmd_unpack_doubles
+
+      end module spmd_unpack_mod


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
This pull request introduces two new Fortran modules, `spmd_pack_mod` and `spmd_unpack_mod`, providing standardized interfaces and implementations for packing and unpacking MPI messages containing real, integer, and double precision data. These modules encapsulate MPI packing and unpacking operations, handle optional communicator arguments, and integrate error handling for robust parallel communication.

**New MPI packing and unpacking modules:**

* Added `spmd_pack_mod` module in `spmd_pack.F90`, implementing generic `spmd_pack` interface with procedures for packing real, integer, and double precision arrays using MPI routines and error handling.
* Added `spmd_unpack_mod` module in `spmd_unpack.F90`, implementing generic `spmd_unpack` interface with procedures for unpacking real, integer, and double precision arrays using MPI routines and error handling.

**Error handling and communicator support:**

* Each procedure in both modules supports optional communicator arguments and integrates calls to `spmd_in` and `spmd_out` for error tracking. [[1]](diffhunk://#diff-335ceaa359e28d34ccc1974a5ebb5abc97a23d6bf3545c298b7e5897d371ecbbR1-R130) [[2]](diffhunk://#diff-09677912c9736639957aede29e32614c2c3409cc4535634d3ff3b4a1255834d4R1-R127)



#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
