### PR TITLE
improvement in RBE3 penalty method

### DIFF
--- a/common_source/modules/constraints/rbe3_mod.F90
+++ b/common_source/modules/constraints/rbe3_mod.F90
@@ -68,7 +68,7 @@
         type rbe3_pen
           integer :: nrbe3_lp                                        !< number of RBE3 of penalty formulation (local)
           real(kind=WP) , dimension(:)   , allocatable ::  rrbe3pen_vi  !< damp(nrbe3_lp)
-          real(kind=WP) , dimension(:,:) , allocatable ::  rrbe3pen_d   !< disp(3*nrbe3_lp)
+          real(kind=WP) , dimension(:,:) , allocatable ::  rrbe3pen_f   !< force(3*nrbe3_lp)
           real(kind=WP) , dimension(:,:) , allocatable ::  rrbe3pen_m   !< mom(3*nrbe3_lp)
           real(kind=WP) , dimension(:,:) , allocatable ::  rrbe3pen_stf !< stif(2*nrbe3_lp)
           real(kind=WP) , dimension(:)   , allocatable ::  rrbe3pen_fac !< stif_fac(nrbe3_lp) stif factor stability
@@ -142,7 +142,7 @@
           type(rbe3_pen),INTENT(INOUT) :: rbe3pen
 
           call my_alloc( rbe3pen%rrbe3pen_vi,rbe3pen%nrbe3_lp)
-          call my_alloc( rbe3pen%rrbe3pen_d,3,rbe3pen%nrbe3_lp)
+          call my_alloc( rbe3pen%rrbe3pen_f,3,rbe3pen%nrbe3_lp)
           call my_alloc( rbe3pen%rrbe3pen_m,3,rbe3pen%nrbe3_lp)
           call my_alloc( rbe3pen%rrbe3pen_stf,2,rbe3pen%nrbe3_lp)
           call my_alloc( rbe3pen%rrbe3pen_fac,rbe3pen%nrbe3_lp)

--- a/engine/source/constraints/general/rbe3/rbe3f.F
+++ b/engine/source/constraints/general/rbe3/rbe3f.F
@@ -481,9 +481,10 @@ C  MS(NS) = ZERO
      .          STIFN   ,STIFR       ,STIFNM      ,STIFRM      ,         
      .          V       ,VR          ,FRBE3(6*IAD+1),X         ,         
      .         LSKEW    ,NUMSKW      ,SKEW          ,
-     .         PEN%RRBE3PEN_D(1,N_P) ,PEN%RRBE3PEN_STF(1,N_P) ,         
+     .         PEN%RRBE3PEN_F(1,N_P) ,PEN%RRBE3PEN_STF(1,N_P) ,         
      .         PEN%RRBE3PEN_FAC(N_P) ,PEN%RRBE3PEN_VI(N_P)    ,
-     .         PEN%RRBE3PEN_M(1,N_P) ,DT1           ,IRODDL )
+     .         PEN%RRBE3PEN_M(1,N_P) ,DT1           ,IN       ,
+     .         IRODDL )
         ENDIF
       ENDDO
 C

--- a/engine/source/constraints/general/rbe3/rbe3pen_init.F90
+++ b/engine/source/constraints/general/rbe3/rbe3pen_init.F90
@@ -91,7 +91,7 @@
                   ns               ,irot          ,numnod       ,nml       ,         &
                   ms               ,in            ,stifn        ,stifr     ,         &
                   rbe3%lrbe3(iad+1)     ,rbe3%frbe3(6*iad+1)    ,x         ,         &
-              rbe3%pen%rrbe3pen_d(1,n_p), rbe3%pen%rrbe3pen_stf(1,n_p)     ,         &
+              rbe3%pen%rrbe3pen_f(1,n_p), rbe3%pen%rrbe3pen_stf(1,n_p)     ,         &
               rbe3%pen%rrbe3pen_fac(n_p), rbe3%pen%rrbe3pen_vi(n_p )       ,         &
               rbe3%pen%rrbe3pen_m(1,n_p))
 !       
@@ -125,7 +125,7 @@
         subroutine rbe3fpen_ininp(                                      &
                 ns      ,irot        ,numnod     ,nml         ,         &
                 ms      ,in          ,stifn      ,stifr       ,         &
-                iml     ,frbe3       ,x          ,rrbe3pen_d  ,         &
+                iml     ,frbe3       ,x          ,rrbe3pen_f  ,         &
             rrbe3pen_stf,rrbe3pen_fac,rrbe3pen_vi,rrbe3pen_m  )
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                        Modules
@@ -148,7 +148,7 @@
           real(kind=WP), dimension(numnod),  intent(in   )         :: in              !< nodal inertia
           real(kind=WP), dimension(numnod),  intent(in   )         :: stifn           !< nodal stifness
           real(kind=WP), dimension(numnod),  intent(in   )         :: stifr           !< nodal rotational stifness
-          real(kind=WP), dimension(3),       intent(inout)         :: rrbe3pen_d      !< initial displacement
+          real(kind=WP), dimension(3),       intent(inout)         :: rrbe3pen_f      !< force
           real(kind=WP), dimension(2),       intent(inout)         :: rrbe3pen_stf    !< stiffness
           real(kind=WP),                     intent(inout)         :: rrbe3pen_fac    !< stiffness factor
           real(kind=WP),                     intent(inout)         :: rrbe3pen_vi     !< damping coefficient
@@ -187,7 +187,7 @@
 !
         disdp(1:3)= x(1:3,ns) - xbar(1:3)
         rR(1:3)   = disdp(1:3)
-        rrbe3pen_d(1:3) = disdp(1:3)  
+        rrbe3pen_f(1:3) = zero  
         rrbe3pen_m(1:3) = zero  
         lsm2 = rR(1)*rR(1)+rR(2)*rR(2)+rR(3)*rR(3)
 !-------set up rrbe3pen_stf 
@@ -307,9 +307,12 @@
         end do
 !       
       endif !if (icoline>0) then
-      rrbe3pen_fac = max(one,(facn+facr))  ! used for ref node
+      if (in(ns)>zero) then
+        rrbe3pen_fac = max(one,(facn+facr))  ! solid/solid(shell)
+      else
+        rrbe3pen_fac = max(one,facn)         ! shell/solid(shell)
+      end if
 !-------set up rrbe3pen_vi
-      ins = in(ns) 
       damp= zep05
       rdummy = one/ms(ns)+one/msbar
       dk_m = rrbe3pen_stf(1)/rdummy

--- a/engine/source/output/restart/restart_rbe3pen.F90
+++ b/engine/source/output/restart/restart_rbe3pen.F90
@@ -106,7 +106,7 @@
        rbe3pen%nrbe3_lp = nrbe3pen_l
        call allocate_rbe3pen(rbe3pen)
        call read_db ( rbe3pen%rrbe3pen_vi,nrbe3pen_l)
-       call read_db ( rbe3pen%rrbe3pen_d,3*nrbe3pen_l)
+       call read_db ( rbe3pen%rrbe3pen_f,3*nrbe3pen_l)
        call read_db ( rbe3pen%rrbe3pen_m,3*nrbe3pen_l)
        call read_db ( rbe3pen%rrbe3pen_stf,2*nrbe3pen_l)
        call read_db ( rbe3pen%rrbe3pen_fac,nrbe3pen_l)
@@ -148,7 +148,7 @@
 ! ----------------------------------------------------------------------------------------------------------------------
        nrbe3pen_l = rbe3pen%nrbe3_lp 
        call write_db ( rbe3pen%rrbe3pen_vi,nrbe3pen_l)
-       call write_db ( rbe3pen%rrbe3pen_d,3*nrbe3pen_l)
+       call write_db ( rbe3pen%rrbe3pen_f,3*nrbe3pen_l)
        call write_db ( rbe3pen%rrbe3pen_m,3*nrbe3pen_l)
        call write_db ( rbe3pen%rrbe3pen_stf,2*nrbe3pen_l)
        call write_db ( rbe3pen%rrbe3pen_fac,nrbe3pen_l)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

Actual Rbe3 penalty formulation might not be free to rigid rotation in case of dependent node has only translation dofs (solid)  
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
improvement of penalty formulation of RBE3

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
