### PR TITLE
Revert "Save global element strain rate of under-integrated shells to element buffer for output"

### DIFF
--- a/engine/source/elements/sh3n/coque3n/c3forc3.F
+++ b/engine/source/elements/sh3n/coque3n/c3forc3.F
@@ -541,7 +541,6 @@ c-------------------------------------------
         eps_m2 = four_over_3*(exx(i)**2+eyy(i)**2+exx(i)*eyy(i) + fourth*exy(i)**2)
         epsd_pg(i) = sqrt(eps_k2 + eps_m2)*dtinv
       end do
-      gbuf%epsd(1:nel) = asrate * epsd_pg(1:nel) + (one - asrate) * gbuf%epsd(1:nel)      
 !-------------------------------------------------------------------------------
       IF (JTHE /= 0 ) CALL TEMP3CG(JFT   ,JLT   ,PM     ,MAT   ,IXTG,   
      .                             TEMP ,TEMPEL )

--- a/engine/source/elements/sh3n/coquedk6/cdk6forc3.F
+++ b/engine/source/elements/sh3n/coquedk6/cdk6forc3.F
@@ -400,7 +400,6 @@ c-------------------------------------------
         eps_m2 = four_over_3*(exx(i)**2+eyy(i)**2+exx(i)*eyy(i) + fourth*exy(i)**2)
         epsd_pg(i) = sqrt(eps_k2 + eps_m2)*dtinv
       end do
-      gbuf%epsd(1:nel) = asrate * epsd_pg(1:nel) + (one - asrate) * gbuf%epsd(1:nel)      
 !-------------------------------------------------------------------------------
        CALL CMAIN3(TIMERS,
      1   ELBUF_STR ,JFT       ,JLT       ,NFT       ,IPARG      ,

--- a/engine/source/elements/shell/coque/cforc3.F
+++ b/engine/source/elements/shell/coque/cforc3.F
@@ -538,7 +538,6 @@ c-------------------------------------------
         eps_m2 = four_over_3*(exx(i)**2+eyy(i)**2+exx(i)*eyy(i) + fourth*exy(i)**2)
         epsd_pg(i) = sqrt(eps_k2 + eps_m2)*dtinv
       end do
-      gbuf%epsd(1:nel) = asrate * epsd_pg(1:nel) + (one - asrate) * gbuf%epsd(1:nel)      
 !-------------------------------------------------------------------------------
       IF ((IMON_MAT==1).AND. ITASK == 0)CALL STARTIME(TIMERS,35)
 C-----------------------------

--- a/engine/source/elements/shell/coquez/czforc3.F
+++ b/engine/source/elements/shell/coquez/czforc3.F
@@ -576,7 +576,6 @@ c-------------------------------------------
         eps_m2 = four_over_3*(exx(i)**2+eyy(i)**2+exx(i)*eyy(i) + fourth*exy(i)**2)
         epsd_pg(i) = sqrt(eps_k2 + eps_m2)*dtinv
       end do
-      gbuf%epsd(1:nel) = asrate * epsd_pg(1:nel) + (one - asrate) * gbuf%epsd(1:nel)      
 !-------------------------------------------------------------------------------
       ! transfer nodal temperature to gauss points (/heat/mat)
       IF (JTHE /= 0) THEN      


### PR DESCRIPTION


This reverts commit a70eb1d40a829399bd736d7643a15507e012c8ed.

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
