### PR TITLE
TSTOP isn't initialized in /DAMP/FUNCT

### DIFF
--- a/starter/source/general_controls/damping/hm_read_damp.F
+++ b/starter/source/general_controls/damping/hm_read_damp.F
@@ -337,6 +337,7 @@ C--------------------------------------------------
           CALL HM_GET_FLOATV('Alpha_zz',ALPHA_ZZ,IS_AVAILABLE,LSUBMODEL,UNITAB)
           ISK = 0
           TSTART = ZERO
+          TSTOP=EP30
           FULL_FORMAT = .TRUE. 
           IF (ALPHA==ZERO) ALPHA = ONE ! default =1 to add in manual
           FACTB = ALPHA


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
correction of not initialized value in /DAMP/FUNCT

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
