### PR TITLE
/FUNCT_PYTHON + MONVOL : bug fixes

### DIFF
--- a/engine/source/coupling/python/python_monvol.F90
+++ b/engine/source/coupling/python/python_monvol.F90
@@ -37,7 +37,7 @@
             character(kind=c_char), intent(in) :: basename(*)
             integer(c_int), intent(in) :: uid(*)
             real(kind=WP), intent(inout) :: reals(*)
-            integer(c_int), intent(in) :: num_reals
+            integer(c_int), intent(in), value :: num_reals
           end subroutine python_update_reals
 
         end interface
@@ -88,29 +88,29 @@
               reals(i) = t_monvol(i)%volume
               uid(i) = t_monvol(i)%uid
             end do
-            allocate(character(len=14) :: basename)
-            basename = 'MONVOL_VOLUME' // c_null_char
+            allocate(character(len=11) :: basename)
+            basename = 'MONVOL_VOL' // c_null_char
             call python_update_reals(basename, uid, reals, nvolu)
             deallocate(basename)
             do i = 1, nvolu
               reals(i) = t_monvol(i)%pressure
             end do
-            allocate(character(len=16) :: basename)
-            basename = 'MONVOL_PRESSURE' // c_null_char
+            allocate(character(len=9) :: basename)
+            basename = 'MONVOL_P' // c_null_char
             call python_update_reals(basename, uid, reals, nvolu)
             deallocate(basename)
             do i = 1, nvolu
               reals(i) = t_monvol(i)%area
             end do
-            allocate(character(len=12) :: basename)
-            basename = 'MONVOL_AREA' // c_null_char
+            allocate(character(len=9) :: basename)
+            basename = 'MONVOL_A' // c_null_char
             call python_update_reals(basename, uid, reals, nvolu)
             deallocate(basename)
             do i = 1, nvolu
               reals(i) = t_monvol(i)%temperature
             end do
-            allocate(character(len=19) :: basename)
-            basename = 'MONVOL_TEMPERATURE' // c_null_char
+            allocate(character(len=9) :: basename)
+            basename = 'MONVOL_T' // c_null_char
             call python_update_reals(basename, uid, reals, nvolu)
             deallocate(basename)
             deallocate(reals)

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -987,7 +987,7 @@ C-----------------------------------------------
               LOGICAL LOUT
               CHARACTER FILNAM*100
               INTEGER NODFT, NODLT,  I,J, N,
-     .           K1, K2, K3, K4, K5, K6, K7, K8, K9, K10, K11, K, ISK,
+     .           K1, K2, K3, K4, K5, K6, K7, K8, K9, K10, K11, K, ISK, KK1,
      .           N0, N1, N2, NN,  NNOD, NSENSOR,
      .           ISYNC, TWO_INTS(2),
      .           NELTST,ITYPTST,NWAFT, NBNCL, NBIKL,
@@ -3221,6 +3221,22 @@ C First: try with reduced bounding box
               CALL PYTHON_UPDATE_TIME(TT,DT2)
               CALL PYTHON_UPDATE_NODAL_ENTITIES(NUMNOD, NODES, X=NODES%X,A=NODES%A,V=NODES%V,D=NODES%D,DR=NODES%DR,VR=NODES%VR)
               CALL PYTHON_SYNC(PYTHON%CONTEXT)
+              IF(NVOLU > 0)THEN
+                IF(PYTHON%NB_FUNCTS > 0) THEN 
+                  K1 = 1
+                  KK1 = 0
+                  DO I=1,NVOLU
+                    T_MONVOL(I)%pressure = VOLMON(KK1+12)
+                    T_MONVOL(I)%temperature = VOLMON(KK1+13)
+                    T_MONVOL(I)%area = VOLMON(KK1+18)
+                    T_MONVOL(I)%volume = VOLMON(KK1+16)
+                    K1  = K1  + NIMV
+                    KK1 = KK1 + NRVOLU
+                  END DO
+                   CALL PYTHON_MONVOL(T_MONVOL)
+                ENDIF
+              ENDIF
+C
 
               IF(coupling%active) THEN
               ! ALLOCATION AND INITIALIZATION OF COUPLING COUPLING


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
This pull request introduces updates to the way monitored volume (`MONVOL`) data is handled and synchronized with the Python coupling interface, primarily focusing on more concise naming conventions and improved data transfer logic. The changes also include a minor variable addition and enhanced synchronization of monitored volume properties.

**Python coupling interface improvements:**

* Updated the `python_update_reals` interface to pass `num_reals` by value, ensuring correct argument semantics when interfacing with C.

* Shortened the `basename` strings used for volume, pressure, area, and temperature when calling `python_update_reals`, e.g., `'MONVOL_VOLUME'` is now `'MONVOL_VOL'`, which streamlines the data identifiers passed to Python.

**Engine logic and data synchronization enhancements:**

* Added new variable `KK1` to the `RESOL` subroutine to assist with indexing when updating monitored volume properties.

* Improved the monitored volume update logic in `RESOL` by extracting pressure, temperature, area, and volume from the `VOLMON` array using the new `KK1` index, then calling `PYTHON_MONVOL` to synchronize these properties with Python only when monitored volumes and Python functions are present.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
