### PR TITLE
/INIGRAV : uninit

### DIFF
--- a/starter/source/initial_conditions/inigrav/inigrav_eos.F
+++ b/starter/source/initial_conditions/inigrav/inigrav_eos.F
@@ -103,6 +103,8 @@ C IMAT : relevant for multifluid eos. imat=0 => monomaterial law
       ERROR(1:NEL)     = EP30
       TOL              = EM4
       CONVERGED(1:NEL) =.FALSE.
+      DVOL(1:NEL)      = ZERO
+      THETA(1:NEL)     = ZERO
 
       !===================================================================!
       !                     BUFFER INITIALIZATION                         !


### PR DESCRIPTION
#### /INIGRAV : uninit

#### Description of the changes
Two working arrays are now initialized to zero to prevent debugging tools or compiler tools from catching any floating-point exception signals.