### PR TITLE
/FUNCT_PYTHON bug fix with ACTIVE_NODE

### DIFF
--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -712,6 +712,7 @@ C-----------------------------------------------
               USE PYTHON_SHARE_MEMORY_MOD
               USE PYTHON_REGISTER_MOD, ONLY : PYTHON_REGISTER
               USE FUNCT_PYTHON_UPDATE_ELEMENTS_MOD, ONLY : FUNCT_PYTHON_UPDATE_ELEMENTS
+              USE python_call_funct_cload_mod
               USE python_monvol_mod , ONLY : python_monvol
               USE OUTMAX_MOD
               USE FORCE_MOD , ONLY : FORCE
@@ -2160,6 +2161,7 @@ C save the Python functions into the Python interpreter dictionarry
               K7=K6+NUMELR
               K8=K7
               K9=K8+NUMELTG
+              CALL python_dummy_active_node(PYTHON)
               CALL FUNCT_PYTHON_UPDATE_ELEMENTS(PYTHON, ISPMD,
      .                 N2D,  NGROUP,  NIXC, NIXTG, NIXS,NIXQ,
      .                 NUMGEO, NUMELC, NUMELTG, NUMELS, NUMELQ, NUMMAT, NUMNOD,

--- a/engine/source/loads/general/python_call_funct_cload.F90
+++ b/engine/source/loads/general/python_call_funct_cload.F90
@@ -209,5 +209,31 @@
 !$OMP END CRITICAL
           y = argout(1)
         end subroutine python_call_funct_cload_dp
+
+        subroutine python_dummy_active_node(py)
+          use python_funct_mod
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                     Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          type(python_),                      intent(in) :: py !< the Fortran structure that holds the python function
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Local variables
+! ----------------------------------------------------------------------------------------------------------------------
+          double precision, dimension(3) :: zeros
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                      Body
+! ----------------------------------------------------------------------------------------------------------------------
+          if(py%nb_functs < 1) return
+          zeros(1:3) = 0.0d0
+          call python_set_active_node_values(1,"C",zeros)
+          call python_set_active_node_values(1,"A",zeros)
+          call python_set_active_node_values(1,"D",zeros)
+          call python_set_active_node_values(2,"DR",zeros)
+          call python_set_active_node_values(1,"V",zeros)
+          call python_set_active_node_values(2,"VR",zeros)
+          call python_set_active_node_values(2,"AR",zeros)
+ 
+        end subroutine python_dummy_active_node
       end module python_call_funct_cload_mod
 


### PR DESCRIPTION

ACTIVE_NODE may not work in case of ALE, even if /FUNCT_PYTHON is not used by any ALE option
This is due to TIMFUN function that calls every functions, even when not needed.

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
