### PR TITLE
correction issue with inivel/tra and rot for submodel rotation

### DIFF
--- a/starter/source/initial_conditions/general/inivel/hm_read_inivel.F
+++ b/starter/source/initial_conditions/general/inivel/hm_read_inivel.F
@@ -229,6 +229,7 @@ C--------------------------------------------------
 
         !---READER /INIVEL/TRA,ROT,T+G,GRID  (0,1,2,3)
         ELSEIF (ITYPE <= 3) THEN
+          ISK = 0
           IFRA  = 0
           CALL HM_GET_INTV('entityid',IGR,IS_AVAILABLE,LSUBMODEL)
           CALL HM_GET_INTV('inputsystem',ISK,IS_AVAILABLE,LSUBMODEL)
@@ -236,8 +237,6 @@ C--------------------------------------------------
           CALL HM_GET_FLOATV('vector_X',VL1,IS_AVAILABLE,LSUBMODEL,UNITAB)
           CALL HM_GET_FLOATV('vector_Y',VL2,IS_AVAILABLE,LSUBMODEL,UNITAB)
           CALL HM_GET_FLOATV('vector_Z',VL3,IS_AVAILABLE,LSUBMODEL,UNITAB)    
-
-          IF(IFRA == 0 .AND. SUB_INDEX  /=  0) CALL SUBROTVECT(VL1,VL2,VL3,RTRANS,SUB_ID,LSUBMODEL)
           
           IF (TSTART>ZERO .OR. SENS_ID>0) THEN 
             NINIT = NINIT + 1


### PR DESCRIPTION
This pull request makes a small update to the `hm_read_inivel.F` subroutine related to how the `ISK` variable is initialized and slightly adjusts the logic for handling vector rotation. The main focus is on ensuring `ISK` is initialized before it is potentially set by `HM_GET_INTV`, and removing an bad call to `SUBROTVECT`.

- Initialization and input handling:
  * Added explicit initialization of `ISK` to 0 before calling `HM_GET_INTV('inputsystem', ...)` to ensure it has a known value.

- Vector rotation logic:
  * Removed the conditional call to `SUBROTVECT`,  vector rotation is not required.

