### PR TITLE
add all global variables in th whatever TH/VERS

### DIFF
--- a/engine/source/output/th/hist1.F
+++ b/engine/source/output/th/hist1.F
@@ -292,13 +292,7 @@ C-------HIERARCHY INFO------------
       IWA(4)=NSUBS
       IWA(5)=NTHGRP2 
       IF(NSECT==0.AND.NSFLSW/=0) IWA(5)=NTHGRP2+1
-      IF (TH_VERS >= 2026)THEN
-        NGLOBTH=16  
-      ELSEIF (TH_VERS >= 2021) THEN
-        NGLOBTH=15   
-      ELSE
-        NGLOBTH=12
-      END IF
+      NGLOBTH=16
 c
       IF (IUNIT /= IUHIS) THEN
         IWA(6)= 0


### PR DESCRIPTION
This pull request simplifies the logic for setting the `NGLOBTH` variable in the `HIST1` subroutine. The code now always sets `NGLOBTH` to 16, regardless of the value of `TH_VERS`, removing the conditional branches for earlier versions.

Logic simplification:

* In `engine/source/output/th/hist1.F`, the conditional logic for setting `NGLOBTH` based on `TH_VERS` has been removed; `NGLOBTH` is now always set to 16.