### PR TITLE
FAST MARCHING METHOD : Update (SPMD)

### DIFF
--- a/starter/source/initial_conditions/detonation/detonation_times_printout.F90
+++ b/starter/source/initial_conditions/detonation/detonation_times_printout.F90
@@ -114,7 +114,7 @@
             nix = nixq
           else
             ix => ixtg(1:nixtg,1:numeltg)
-            nix = nixq
+            nix = nixtg
           end if
 
           if(ipri >= 3)then
@@ -128,7 +128,7 @@
                   mpr = mpr+1
                   iel = ix(nix,i+nft)
                   tdet=-elbuf_tab(ng)%gbuf%tb(i)
-                  write(iout,510) nel,tdet
+                  write(iout,510) iel,tdet
                   if(mpr == 50) mpr=0
                 end do
               endif

--- a/starter/source/initial_conditions/detonation/eikonal_compute_adjacent.F90
+++ b/starter/source/initial_conditions/detonation/eikonal_compute_adjacent.F90
@@ -118,7 +118,7 @@
             tdet_adj(1:nvois) = ep21
             xel_adj(1:3,1:nvois) = zero
             do kk=1,lgth2
-              vel_adj(kk) = vel(iev)
+              vel_adj(kk) = vel(elem_list_bij(iev))  !iev is global id (1:numel)
               iev_v = ale_connectivity%ee_connect%connected(iad2 + kk - 1)
               if(iev_v == 0)cycle
               iel_v = elem_list_bij(iev_v)

--- a/starter/source/initial_conditions/detonation/eikonal_init_sorting.F90
+++ b/starter/source/initial_conditions/detonation/eikonal_init_sorting.F90
@@ -1,0 +1,66 @@
+      module eikonal_init_sorting_mod
+      contains
+        subroutine eikonal_init_sorting(neldet, numel, elem_list, uelem_list, idx_ng , idx_i, elem_list_bij, xel, vel)
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Modules
+! ----------------------------------------------------------------------------------------------------------------------
+          use constant_mod, only : zero, ep21
+          use insertion_sort_mod , only : integer_insertion_sort_with_index
+          use precision_mod, only : WP
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          integer,intent(in) :: neldet,numel
+          integer,intent(inout) :: elem_list(neldet)
+          integer,intent(inout) :: uelem_list(neldet)
+          integer,intent(inout) :: idx_ng(neldet)
+          integer,intent(inout) :: idx_i(neldet)
+          integer,intent(inout) :: elem_list_bij(1:numel)
+          real(kind=WP),intent(inout) :: xel(3,neldet)
+          real(kind=WP),intent(inout) :: vel(neldet)
+
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Local variables
+! ----------------------------------------------------------------------------------------------------------------------
+          integer,allocatable,dimension(:) :: indx
+          integer,allocatable,dimension(:) :: int_tmp_array
+          real(kind=WP),allocatable,dimension(:) :: real_tmp_array
+          integer :: kk
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Body
+! ----------------------------------------------------------------------------------------------------------------------
+          allocate(int_tmp_array(neldet))
+          allocate(real_tmp_array(neldet))
+          allocate(indx(neldet))
+
+            indx(1:neldet) = [(kk, kk=1,neldet)]
+            call integer_insertion_sort_with_index(uelem_list, indx, neldet)
+            
+            !sort other arrays with same order usin indx array
+            int_tmp_array(:)  = elem_list(:)     ; elem_list(:)    = int_tmp_array(indx(:))
+            int_tmp_array(:)  = idx_ng(:)        ; idx_ng(:)       = int_tmp_array(indx(:))
+            int_tmp_array(:)  = idx_i(:)         ; idx_i(:)        = int_tmp_array(indx(:))
+            real_tmp_array(:) = xel(1,:)         ; xel(1,:)        = real_tmp_array(indx(:))
+            real_tmp_array(:) = xel(2,:)         ; xel(2,:)        = real_tmp_array(indx(:)) 
+            real_tmp_array(:) = xel(3,:)         ; xel(3,:)        = real_tmp_array(indx(:)) 
+            real_tmp_array(:) = vel(:)           ; vel(:)          = real_tmp_array(indx(:))
+
+            ! sorting bijective array
+            elem_list_bij(1:numel) = 0
+            do kk=1,neldet
+              elem_list_bij(elem_list(kk)) = kk
+            end do
+
+          deallocate(int_tmp_array)
+          deallocate(real_tmp_array)
+          deallocate(indx)
+
+        end subroutine eikonal_init_sorting
+! ----------------------------------------------------------------------------------------------------------------------
+      end module eikonal_init_sorting_mod
+
+


### PR DESCRIPTION
#### FAST MARCHING METHOD : Update

#### Description of the changes

The Fast Marching Method (FMM), recently introduced in OpenRadioss to model detonation waves in heterogeneous media (e.g., obstacles, varying propagation velocities), is used with high-explosive material laws.
The iterative numerical process is executed on the Starter side to compute the arrival times of the detonation wave, which are then transferred to the Engine via the restart file (.rst). (See: https://github.com/OpenRadioss/OpenRadioss/pull/3585)

This update includes:

- domain decomposition (SPMD): The algorithm now guarantees consistent detonation arrival times regardless of the number of MPI domains specified.

- Starter listing file :  It now displays the correct element IDs when outputting detonation times for triangular meshes.

**Verification Test :** 

<img width="893" height="434" alt="image" src="https://github.com/user-attachments/assets/418b0639-d4cd-49bc-8746-d2559d726939" />
The case description is provided below. The image above demonstrates that the results are now consistent when running with 16 SPMD domains.
<img width="1213" height="611" alt="image" src="https://github.com/user-attachments/assets/52d7d4a2-ec46-4fb8-8deb-d8ebd0934e6b" />


