### PR TITLE
GCC15 -maybe-uninitialized compatibility

### DIFF
--- a/engine/source/elements/solid/solide/preload_solid_ini.F90
+++ b/engine/source/elements/solid/solide/preload_solid_ini.F90
@@ -84,6 +84,8 @@
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Body
 ! ----------------------------------------------------------------------------------------------------------------------
+          t_start = 0 ! important initialization for GCC15's -maybe-uninitialized flag
+          t_stop  = 0 ! important initialization for GCC15's -maybe-uninitialized flag
 !
           sfac = one
           t_shift = zero


### PR DESCRIPTION
This pull request includes a small but important fix to the `preload_solid_ini` subroutine. The change initializes the variables `t_start` and `t_stop` to zero at the start of the subroutine to address potential warnings from GCC 15's `-maybe-uninitialized` flag.
