### PR TITLE
/MAT/LAW102 : Drucker-Prager cut-off

### DIFF
--- a/engine/CMake_Compilers/legacy_fortran.cmake
+++ b/engine/CMake_Compilers/legacy_fortran.cmake
@@ -1369,7 +1369,6 @@ set_source_files_properties( ${source_directory}/source/materials/mat/mat087/mat
 set_source_files_properties( ${source_directory}/source/materials/mat/mat087/mat87c_swift_voce.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/materials/mat/mat087/mat87c_tabulated_totalsr.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/materials/mat/mat087/mat87c_hansel.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
-set_source_files_properties( ${source_directory}/source/materials/mat/mat102/sigeps102.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/materials/mat/mat022/sigeps22g.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/materials/mat/mat107/mat107c_newton.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/materials/mat/mat107/mat107_newton.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )

--- a/engine/source/materials/mat/mat102/sigeps102.F
+++ b/engine/source/materials/mat/mat102/sigeps102.F
@@ -26,12 +26,12 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !||    mulaw       ../engine/source/materials/mat_share/mulaw.F90
 !||====================================================================
        SUBROUTINE SIGEPS102(
-     1      NEL    , NUPARAM, NUVAR  , UPARAM  , RHO0    , RHO    , 
+     1      NEL    , NUPARAM, UPARAM  , RHO0    , RHO    ,
      2      DEPSXX , DEPSYY , DEPSZZ , DEPSXY  , DEPSYZ  , DEPSZX ,
      3      SIGOXX , SIGOYY , SIGOZZ , SIGOXY  , SIGOYZ  , SIGOZX ,
      4      SIGNXX , SIGNYY , SIGNZZ , SIGNXY  , SIGNYZ  , SIGNZX ,
-     5      SOUNDSP, UVAR   , OFF    , ET      ,
-     6      PSH    , PNEW   , DPDM   , SSP     , PLA     )   
+     5      OFF    ,
+     6      PSH    , PNEW   , DPDM   , SSP     , PLA     , PMIN)
 C-----------------------------------------------
 C   I M P L I C I T   T Y P E S
 C-----------------------------------------------
@@ -39,34 +39,26 @@ C-----------------------------------------------
 C----------------------------------------------------------------
 C  I N P U T   A R G U M E N T S
 C----------------------------------------------------------------
-      INTEGER NEL,NVARF,NUPARAM,NUVAR
-      my_real :: TIME,TIMESTEP   
-      my_real :: UPARAM(NUPARAM)
-      my_real ,DIMENSION(NEL) :: RHO, RHO0,
-     .   DEPSXX, DEPSYY, DEPSZZ, DEPSXY, DEPSYZ, DEPSZX,
-     .   SIGOXX, SIGOYY, SIGOZZ, SIGOXY, SIGOYZ, SIGOZX,
-     .   SSP   , DPDM  , PNEW, PSH, PLA
-C----------------------------------------------------------------
-C  O U T P U T   A R G U M E N T S
-C----------------------------------------------------------------
-      my_real
-     .      SIGNXX (NEL), SIGNYY (NEL), SIGNZZ(NEL),
-     .      SIGNXY (NEL), SIGNYZ (NEL), SIGNZX(NEL),
-     .      SOUNDSP(NEL), ET(NEL)
-C----------------------------------------------------------------
-C  I N P U T  O U T P U T   A R G U M E N T S
-C----------------------------------------------------------------
-      my_real
-     .      UVAR(NEL,NUVAR), OFF(NEL) ,MU(NEL),MU2(NEL)
+      INTEGER,INTENT(IN)                   :: NEL,NUPARAM
+      my_real,INTENT(IN)                   :: UPARAM(NUPARAM)
+      my_real,INTENT(IN),DIMENSION(NEL)    :: RHO, RHO0
+      my_real,INTENT(IN),DIMENSION(NEL)    :: DEPSXX, DEPSYY, DEPSZZ, DEPSXY, DEPSYZ, DEPSZX
+      my_real,INTENT(IN),DIMENSION(NEL)    :: SIGOXX, SIGOYY, SIGOZZ, SIGOXY, SIGOYZ, SIGOZX
+      my_real,INTENT(INOUT),DIMENSION(NEL) :: SIGNXX, SIGNYY, SIGNZZ, SIGNXY, SIGNYZ, SIGNZX
+      my_real,INTENT(IN),DIMENSION(NEL)    :: PNEW, PSH
+      my_real,INTENT(IN),DIMENSION(NEL)    :: OFF
+      my_real,INTENT(IN)                   :: PMIN
+      my_real,INTENT(INOUT),DIMENSION(NEL) :: SSP, DPDM, PLA
 C----------------------------------------------------------------
 C  L O C A L  V A R I B L E S
 C----------------------------------------------------------------
       my_real :: A0,A1,A2,AMAX
-      my_real :: DAV,POLD(NEL)
+      my_real :: POLD(NEL)
       my_real :: T1(NEL),T2(NEL),T3(NEL),T4(NEL),T5(NEL),T6(NEL)
       my_real :: PTOT,G0(NEL),RATIO(NEL),YIELD2(NEL)
       my_real :: PSTAR,G,GG,SCRT(NEL),AJ2(NEL),DPLA(NEL)
       my_real :: I3(NEL),COS3T(NEL),SQRT_J2,THETA,C,PHI,K
+      my_real :: MU(NEL),MU2(NEL)
       integer :: I,IFORM
 C----------------------------------------------------------------
 C  S o u r c e   L i n e s
@@ -82,7 +74,7 @@ C----------------------------------------------------------------
       GG        = TWO*G
       IFORM     = NINT(UPARAM(9))
       !----------------------------------------------------------------!
-      !  STATE INIT.                                                   !
+      !  INIT.                                                         !
       !----------------------------------------------------------------!        
       DO I=1,NEL
         POLD(I) = -(SIGOXX(I)+SIGOYY(I)+SIGOZZ(I))*THIRD 
@@ -91,7 +83,7 @@ C----------------------------------------------------------------
         MU2(I)  = MU(I) * MAX(ZERO,MU(I))
       ENDDO !next I    
       !----------------------------------------------------------------!
-      !  TEMPORARY DEVIATORIC STRESS TENSOR : T(1:6)                   !
+      !  DEVIATORIC STRESS TENSOR : T(1:6)                             !
       !----------------------------------------------------------------!  
       DO I=1,NEL
         T1(I)=SIGOXX(I)+POLD(I)+GG*(DEPSXX(I)-SCRT(I))
@@ -102,7 +94,7 @@ C----------------------------------------------------------------
         T6(I)=SIGOZX(I)        + G*DEPSZX(I)
       ENDDO !next I  
       !----------------------------------------------------------------!
-      !  SOUND SPEED                                                   !
+      !  SOUND SPEED (EOS + SHEAR)                                     !
       !----------------------------------------------------------------!      
       DO I=1,NEL
         DPDM(I) = DPDM(I) + ONEP333*G
@@ -125,6 +117,7 @@ C----------------------------------------------------------------
           PTOT     = PNEW(I)+PSH(I)
           G0(I)    = -PTOT*SIN(PHI)+SQRT_J2*(COS(THETA)-K*SIN(THETA)*SIN(PHI))-C*COS(PHI)
           G0(I)    = MAX(ZERO,G0(I))
+          IF(PTOT <= PMIN) G0(I) = ZERO !Drucker-Prager cut-off
           YIELD2(I)= AJ2(I)-G0(I)
         ENDDO
       !----SUBCASE --- FITTED DRUCKER PRAGER FROM MOHR COULOMB PARAMETERS (A0,A1,A2 CALCULATED DURING STARTER)
@@ -134,7 +127,8 @@ C----------------------------------------------------------------
           G0(I)    = A0 +A1 *PTOT+A2 *PTOT*PTOT
           G0(I)    = MIN(AMAX,G0(I))
           G0(I)    = MAX(ZERO,G0(I))
-          IF(PTOT <= PSTAR)G0(I)=ZERO
+          IF(PTOT <= PMIN) G0(I) = ZERO !Drucker-Prager cut-off
+          IF(PTOT <= PSTAR)G0(I)=ZERO !tensile cut-off (PSTAR is the root of the yield function)
           YIELD2(I)=AJ2(I)-G0(I)
         ENDDO !next I           
       ENDIF 

--- a/engine/source/materials/mat_share/mulaw.F90
+++ b/engine/source/materials/mat_share/mulaw.F90
@@ -1835,12 +1835,13 @@
 !
           elseif (mtn == 102) then
 
-            call sigeps102(nel    ,npar    ,nuvar  ,uparam0 , rho0     ,rho    ,&
-            &de1    ,de2     ,de3    ,de4    , de5      ,de6    ,&
-            &so1    ,so2     ,so3    ,so4    , so5      ,so6    ,&
-            &s1     ,s2      ,s3     ,s4     , s5       ,s6     ,&
-            &ssp    ,uvar    ,off    ,et     ,&
-            &psh    ,pnew    ,dpdm   ,ssp    , lbuf%pla )
+            call sigeps102(&
+             nel    ,npar    ,uparam0, rho0  ,rho       ,&
+             de1    ,de2     ,de3    ,de4    , de5      ,de6        ,&
+             so1    ,so2     ,so3    ,so4    , so5      ,so6        ,&
+             s1     ,s2      ,s3     ,s4     , s5       ,s6         ,&
+             off    ,&
+             psh    ,pnew    ,dpdm   ,ssp    , lbuf%pla ,pm(37,imat) )
 !
 !
           elseif (mtn == 103) then

--- a/starter/CMake_Compilers/legacy_fortran.cmake
+++ b/starter/CMake_Compilers/legacy_fortran.cmake
@@ -460,7 +460,6 @@ set_source_files_properties( ${source_directory}/source/materials/mat/mat058/law
 set_source_files_properties( ${source_directory}/source/materials/mat/mat058/cm58in3.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/materials/mat/mat087/hm_read_mat87.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/materials/mat/mat087/law87_upd.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
-set_source_files_properties( ${source_directory}/source/materials/mat/mat102/hm_read_mat102.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/materials/mat/mat022/hm_read_mat22.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/materials/mat/hm_read_mat.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/materials/mat/mat062/law62_upd.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )

--- a/starter/source/materials/mat/hm_read_mat.F90
+++ b/starter/source/materials/mat/hm_read_mat.F90
@@ -1016,8 +1016,8 @@
              case ('LAW102','DPRAG2')
               ilaw  = 102
               call hm_read_mat102(&
-              &uparam   ,maxuparam,nuparam  ,israte  ,imatvis  ,&
-              &nuvar    ,ifunc    ,maxfunc  ,nfunc   ,parmat   ,&
+              &uparam   ,maxuparam,nuparam  ,israte  ,&
+              &nuvar    ,nfunc    ,parmat   ,&
               &unitab   ,mat_id   ,titr     ,mtag    ,lsubmodel,&
               &pm(1,i)  ,ipm(1,i) ,matparam )
 !-------

--- a/starter/source/materials/mat/mat102/hm_read_mat102.F
+++ b/starter/source/materials/mat/mat102/hm_read_mat102.F
@@ -35,8 +35,8 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !||    message_mod              ../starter/share/message_module/message_mod.F
 !||    submodel_mod             ../starter/share/modules1/submodel_mod.F
 !||====================================================================
-      SUBROUTINE HM_READ_MAT102(UPARAM ,MAXUPARAM,NUPARAM  ,ISRATE   , IMATVIS  ,
-     .                          NUVAR  ,IFUNC    ,MAXFUNC  ,NFUNC    , PARMAT   , 
+      SUBROUTINE HM_READ_MAT102(UPARAM ,MAXUPARAM,NUPARAM  ,ISRATE   ,
+     .                          NUVAR  ,NFUNC    ,PARMAT   ,
      .                          UNITAB ,MAT_ID   ,TITR     ,MTAG     , LSUBMODEL,
      .                          PM     ,IPM      ,MATPARAM )
 C-----------------------------------------------
@@ -65,10 +65,13 @@ C-----------------------------------------------
       USE SUBMODEL_MOD , ONLY : SUBMODEL_DATA, NSUBMOD
       USE MATPARAM_DEF_MOD
       USE NAMES_AND_TITLES_MOD , ONLY : NCHARTITLE, NCHARKEY, NCHARFIELD
+      USE CONSTANT_MOD , ONLY : PI, HUNDRED80, FOUR, ZERO, INFINITY, NINE, ONE, SIX, THREE, TWO
+      USE PRECISION_MOD , ONLY : WP
+
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
-#include      "implicit_f.inc"
+      IMPLICIT NONE
 C-----------------------------------------------
 C   C o m m o n   B l o c k s
 C-----------------------------------------------
@@ -77,34 +80,26 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      TYPE (UNIT_TYPE_),INTENT(IN)                 :: UNITAB
-      my_real, DIMENSION(NPROPM),INTENT(INOUT)     :: PM
-      my_real, DIMENSION(100),INTENT(INOUT)        :: PARMAT
-      my_real, DIMENSION(MAXUPARAM) ,INTENT(INOUT) :: UPARAM
-      INTEGER, DIMENSION(NPROPMI),INTENT(INOUT)    :: IPM
-      INTEGER, DIMENSION(MAXFUNC),INTENT(INOUT)    :: IFUNC
-      INTEGER, INTENT(INOUT)                       :: ISRATE,IMATVIS,NFUNC,MAXFUNC,MAXUPARAM,NUPARAM,NUVAR
-      TYPE(MLAW_TAG_),INTENT(INOUT)                :: MTAG
-      INTEGER,INTENT(IN)                           :: MAT_ID
-      CHARACTER(LEN=NCHARTITLE) ,INTENT(IN)        :: TITR
-      TYPE(SUBMODEL_DATA),INTENT(IN)               :: LSUBMODEL(NSUBMOD)
-      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT)        :: MATPARAM
+      TYPE (UNIT_TYPE_),INTENT(IN)                       :: UNITAB
+      REAL(KIND=WP), DIMENSION(NPROPM),INTENT(INOUT)     :: PM
+      REAL(KIND=WP), DIMENSION(100),INTENT(INOUT)        :: PARMAT
+      REAL(KIND=WP), DIMENSION(MAXUPARAM) ,INTENT(INOUT) :: UPARAM
+      INTEGER, DIMENSION(NPROPMI),INTENT(INOUT)          :: IPM
+      INTEGER, INTENT(INOUT)                             :: ISRATE,NFUNC,MAXUPARAM,NUPARAM,NUVAR
+      TYPE(MLAW_TAG_),INTENT(INOUT)                      :: MTAG
+      INTEGER,INTENT(IN)                                 :: MAT_ID
+      CHARACTER(LEN=NCHARTITLE) ,INTENT(IN)              :: TITR
+      TYPE(SUBMODEL_DATA),INTENT(IN)                     :: LSUBMODEL(NSUBMOD)
+      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT)              :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      my_real   :: E,NU,C,PSTAR,AMAX,G, DELTA,STIFINT,PMIN,BID,PHI_DEG
-      my_real   :: A0,A1,A2,RHO0,RHOR
-  
-      CHARACTER(LEN=NCHARFIELD) :: STRING, KEYNET
-      CHARACTER(LEN=NCHARKEY) :: KEY
-
-      INTEGER   :: IFORM
-      
-      DOUBLE PRECISION :: PHI,K,ALPHA
-      
-      LOGICAL :: IS_ENCRYPTED,IS_AVAILABLE
-      
-      CHARACTER*64 :: CHAIN
+      REAL(KIND=WP)    :: E,NU,C,PSTAR,AMAX,G, DELTA,STIFINT,PMIN,PHI_DEG
+      REAL(KIND=WP)    :: A0,A1,A2,RHO0,RHOR
+      INTEGER          :: IFORM
+      REAL(KIND=WP)    :: PHI,K,ALPHA
+      LOGICAL          :: IS_ENCRYPTED,IS_AVAILABLE
+      CHARACTER*64     :: CHAIN
 C-----------------------------------------------
 C   S o u r c e   L i n e s
 C-----------------------------------------------
@@ -114,7 +109,7 @@ C-----------------------------------------------
 
       CALL HM_OPTION_IS_ENCRYPTED(IS_ENCRYPTED)
 
-      CALL HM_GET_INTV  ('IFORM',IFORM  ,IS_AVAILABLE, LSUBMODEL) 
+      CALL HM_GET_INTV  ('IFORM',IFORM  ,IS_AVAILABLE, LSUBMODEL)
       
       CALL HM_GET_FLOATV('MAT_RHO'      ,RHO0  ,IS_AVAILABLE, LSUBMODEL, UNITAB)
       
@@ -135,7 +130,7 @@ C-----------------------------------------------
 C     UNITS   
 C----------------------------------------------- 
       PHI_DEG = PHI
-      PHI     = PHI*3.141592653589793238D00/180.D00
+      PHI     = PHI*PI/HUNDRED80
 C----------------------------------------------- 
 C     DEFAULTS   
 C----------------------------------------------- 


### PR DESCRIPTION
#### /MAT/LAW102 : Drucker-Prager cut-off


#### Description of the changes
The Drucker–Prager cut-off, previously missing in law102, has now been implemented.
When the pressure cut-off is reached, the yield surface correctly degenerates to 0.0, and the deviatoric stress is nullified accordingly.
Minor code cleanup was also performed, including the removal of unused arguments and variables.

**Verification Test :**

Law 102 was compared to law10 when using a positive PMIN value (compression)
<img width="947" height="657" alt="image" src="https://github.com/user-attachments/assets/6fa103d8-cc48-4442-9606-1ff1de2af971" />

Input File for verification test : 
[TEST-CASES-10-102-PMIN.zip](https://github.com/user-attachments/files/22003681/TEST-CASES-10-102-PMIN.zip)

**Expected change / Previous behavior**  : 
<img width="1242" height="638" alt="image" src="https://github.com/user-attachments/assets/ae4add4f-360c-4a01-add4-11fed4b27a33" />

