### PR TITLE
/FUNCT_PYTHON in single precision: bug fix

### DIFF
--- a/common_source/modules/cpp_python_funct.cpp
+++ b/common_source/modules/cpp_python_funct.cpp
@@ -1346,7 +1346,7 @@ extern "C"
 #endif
     }
 
-    void cpp_python_sample_function(char *name, my_real *x, my_real *y, int n)
+    void cpp_python_sample_function(char *name, double *x, double *y, int n)
     {
         //write the name
         constexpr size_t N = 10000; // Number of points
@@ -1494,7 +1494,7 @@ extern "C"
     {
         std::cout << "ERROR: python not enabled" << std::endl;
     }
-    void cpp_python_sample_function(char *name, my_real *x, my_real *y, int n)
+    void cpp_python_sample_function(char *name, double*x, double*y, int n)
     {
         std::cout << "ERROR: python not enabled" << std::endl;
     }

--- a/common_source/sortie/plot_curve.F
+++ b/common_source/sortie/plot_curve.F
@@ -182,6 +182,8 @@ C=======================================================================
         CURVE(1:NB_POINTS) = 0
         INCR_X = (X_MAXVALUE-X_MINVALUE)/(SIZE_X-1)
         INCR_Y = (Y_MAXVALUE-Y_MINVALUE)/(SIZE_Y-1)
+        IF(INCR_X == 0) INCR_X = 1.0E-6
+        IF(INCR_Y == 0) INCR_Y = 1.0E-6
 c
         ALLOCATE(GRID(SIZE_X,SIZE_Y))
         DO J = 1, SIZE_Y

--- a/engine/source/interfaces/generic/inter_box_creation.F
+++ b/engine/source/interfaces/generic/inter_box_creation.F
@@ -83,6 +83,7 @@ C-----------------------------------------------
         IF(DIST_MAX==DZ_BOX) LEADING_DIMENSION = 3
         
         !   compute the number of cell in the leading direction, then compute the number of cell in the other direction
+        !   Possible overflow in sp here
         RATIO = SQRT( NUMNODG / (DX_BOX*DY_BOX+DX_BOX*DZ_BOX+DY_BOX*DZ_BOX))
         IF(LEADING_DIMENSION==1) THEN
             NB_CELL_X = NINT( RATIO * DX_BOX )


### PR DESCRIPTION
This pull request introduces several improvements and minor fixes across the C++ and Fortran codebases. The main changes address type consistency for function arguments, numerical stability in calculations, and code documentation for potential issues.

**Type consistency and compatibility:**

* Changed the argument types of `cpp_python_sample_function` from `my_real*` to `double*` in both the enabled and disabled Python code paths in `cpp_python_funct.cpp` to ensure consistency and avoid type mismatches. [[1]](diffhunk://#diff-8ee81975bf0e8025a7734ce71df8049246ed2119cc34a24144e2f9d289786b10L1349-R1349) [[2]](diffhunk://#diff-8ee81975bf0e8025a7734ce71df8049246ed2119cc34a24144e2f9d289786b10L1497-R1497)

**Numerical stability and bug fixes:**

* Added checks in `plot_curve.F` to prevent division by zero by assigning a small value (`1.0E-6`) to `INCR_X` and `INCR_Y` if their computed values are zero.

**Code documentation and maintainability:**

* Added a comment in `inter_box_creation.F` to highlight a possible overflow issue when using single precision (`sp`) in the calculation of `RATIO`.
