### PR TITLE
Fix for 1D/2D seatbelt connection

### DIFF
--- a/starter/source/tools/seatbelts/create_seatbelt.F
+++ b/starter/source/tools/seatbelts/create_seatbelt.F
@@ -379,14 +379,14 @@ C--     if nshell = 2 and nspring = 1     -> node on edge of 2D belt
 C--     if nshell = 0 and nspring = 1     -> node at end of 1D belt
 C--     if nspring = 2 and nspring_2D = 1 -> node common between 1D and 2D seatblet
 C
-C       common nodes between 1D and 2D seatblet are tagged and stored in list
+C       common nodes between 1D and 2D seatblet are tagged and stored in list 
         IF (IDDLEVEL == 0) CALL MY_ALLOC(COMN_1D2D,N_COMN_1D2D)
         CALL MY_ALLOC(TAG_COMN_1D_2D,NUMNOD)
         COMN_1D2D(1:N_COMN_1D2D) = 0
         TAG_COMN_1D_2D(1:NUMNOD) = 0
         J = 0
         DO I=1,NUMNOD
-          IF (((TAG_NOD_SPRI2D(I))==1).AND.(TAG_NOD_SPRING(I)==2)) THEN
+          IF ((TAG_NOD_SPRING(I) > TAG_NOD_SPRI2D(I)).and.(TAG_NOD_SPRI2D(I) > 0)) THEN
             J = J + 1
             COMN_1D2D(J) = I
             TAG_COMN_1D_2D(I) = 1


### PR DESCRIPTION
Fix of detection of 1D/2D connection for cross connection

This pull request makes a targeted update to the logic for identifying common nodes between 1D and 2D elements in the `CREATE_SEATBELT` subroutine. The conditional statement determining which nodes are considered common has been revised to use a more general comparison, potentially fixing a bug or improving accuracy.

**Logic update for node identification:**

* In `create_seatbelt.F`, the condition for marking a node as common (`COMN_1D2D`) has been changed from checking specific values of `TAG_NOD_SPRI2D` and `TAG_NOD_SPRING` to a more general comparison: `TAG_NOD_SPRING(I) > TAG_NOD_SPRI2D(I)` and `TAG_NOD_SPRI2D(I) > 0`. This likely makes the common node detection more robust or corrects previous logic.