### PR TITLE
/FUNCT_PYTHON disable OpenMP at engine

### DIFF
--- a/engine/source/engine/radioss2.F
+++ b/engine/source/engine/radioss2.F
@@ -1054,6 +1054,12 @@ C
      .            GLOB_THERM     ,PBLAST     ,ELEMENT       ,NODES            ,RBE3)
       ! Close restart file
        CALL CLOSE_C
+       if(python%nb_functs > 0) then
+         write(6,*) "INFO: ", python%nb_functs, " python functions: OpenMP disabled"
+         call omp_set_num_threads(1)
+         NTHREAD = 1
+       end if
+ 
        ! --------------------------------------------------------------------------------------------
       IF (NSPMD > 1)  CALL SPMD_RST_CHECK()
 c----------


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
After tests on windows, it appears that python called from OpenMP (even with critical) is not safe

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
