### PR TITLE
correction when using /TRANSFORM/SCA and no center node defined

### DIFF
--- a/starter/source/model/submodel/lectranssub.F
+++ b/starter/source/model/submodel/lectranssub.F
@@ -726,6 +726,10 @@ c
               X0(2) = X(2,I0) 
               X0(3) = X(3,I0)
             ENDIF
+          ELSE
+            X0(1) = ZERO
+            X0(2) = ZERO
+            X0(3) = ZERO
           ENDIF
 C
           DO J=1,3


### PR DESCRIPTION
This pull request introduces a small but important update to the `LECTRANSSUB` subroutine. The change ensures that the `X0` array is explicitly set to zero when a specific condition is not met, which helps prevent potential issues with uninitialized variables.

* Explicitly initializes `X0(1)`, `X0(2)`, and `X0(3)` to zero if scale center node is not defined.
