### PR TITLE
Fast Marching Method for detonation wave : SPMD update

### DIFF
--- a/starter/source/initial_conditions/detonation/eikonal_init_start_list_2d.F90
+++ b/starter/source/initial_conditions/detonation/eikonal_init_start_list_2d.F90
@@ -175,7 +175,7 @@
               dcj = zero
               do ii=1,num_adj
                 iel = adjacent_elem(ii)
-                dcj = max(dcj,vel(iel)) ! chapman jouget velocity
+                dcj = max(dcj,vel(elem_list_bij(iel))) ! chapman jouget velocity
               end do
               xdet = x(1,nod_id)
               ydet = x(2,nod_id)


### PR DESCRIPTION
#### Fast Marching Method for detonation wave : SPMD update

#### Description of the changes
This update includes a fix for a bug identified with the configuration (MPI, OMP) = (12, 2). The initialization of the first elements around the detonation points for FMM now produces consistent initial detonation times with matching significant digits.
