### PR TITLE
add global variable 16 in th to csv tool

### DIFF
--- a/tools/th_to_csv/src/th_to_csv.c
+++ b/tools/th_to_csv/src/th_to_csv.c
@@ -1201,11 +1201,16 @@ void csvFileWrite(char* csvFilename,char* titleFilename,int *nbglobVar,int *nbPa
     fprintf(csvFile,"\"CONTACT ENERGY\",");
     fprintf(csvFile,"\"HOURGLASS ENERGY\",");
 
-    if (*nbglobVar == 15)
+    if (*nbglobVar >= 15)
     {
         fprintf(csvFile,"\"ELASTIC CONTACT ENERGY\",");
         fprintf(csvFile,"\"FRICTIONAL CONTACT ENERGY\",");
         fprintf(csvFile,"\"DAMPING CONTACT ENERGY \",");
+    }
+    
+    if (*nbglobVar >= 16)
+    {
+        fprintf(csvFile,"\"PLASTIC WORK\",");
     }
 
     if (!titlesFile)


### PR DESCRIPTION
This pull request updates the logic for writing CSV column headers in `th_to_csv.c` to better support files with more global variables. The main change is making the conditions for adding extra energy columns more flexible, and introducing a new column when appropriate.

Improvements to CSV header generation:

* Changed the condition for adding "ELASTIC CONTACT ENERGY", "FRICTIONAL CONTACT ENERGY", and "DAMPING CONTACT ENERGY" columns from exactly 15 global variables to 15 or more, allowing these columns to appear for files with additional variables.
* Added a new "PLASTIC WORK" column when there are 16 or more global variables, supporting expanded data sets.