### PR TITLE
Upgrade CMakeLists.txt version to 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMake project file for Radioss Starter
 # --------------------------------------
  
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.15)
 project (OpenRadioss)
 
 set (actual_directory ${CMAKE_CURRENT_SOURCE_DIR})

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -238,7 +238,7 @@ This chapter explains how to setup Windows on different build configuration
 
    **Notes:**
 
-   * Intel OneAPI plugin for Visual Studio is recommended to use Intel OneAPI in Visual Studio 2019
+   * Intel OneAPI plugin for Visual Studio is recommended to use Intel OneAPI in Visual Studio 2022
    * Choose the default directory to install Intel oneAPI
 
 4. Install Git
@@ -267,7 +267,7 @@ The Git Bash tool is not needed, but can be installed.
 ### Build environment using cmd DOS shell
 
 Building using cmd.exe is using cmake.exe and ninja.exe
-Both are shipped with Visual Studio 2019.
+Both are shipped with Visual Studio 2022.
 
 1. Setup the compiler
    Load compiler settings in cmd.exe using following command :
@@ -744,7 +744,7 @@ Those bellongs to the most commonly used architectures:
 ### Build OpenRadioss with Visual Studio
 
 This sections assumes, that Intel OneAPI Compiler was successfully installed.
-Procedure was tested on Visual Studio 2019 and Visual Studio 2022
+Procedure was tested on Visual Studio 2022
 
 * Launch Visual Studio
 

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMake project file for Radioss Starter
 # --------------------------------------
  
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.15)
 project (Radioss_Engine)
 
 

--- a/qa-tests/CMakeLists.txt
+++ b/qa-tests/CMakeLists.txt
@@ -3,7 +3,7 @@
 # ctest -C Release --output-on-failure --timeout 600
 # set minimum cmake version
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 
 # project name and language
 project(OpenRadioss_test_suite LANGUAGES NONE)

--- a/reader/CMakeLists.txt
+++ b/reader/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMake Project for open_reader
 #
 
-cmake_minimum_required (VERSION 3.6)
+cmake_minimum_required (VERSION 3.15)
 project(open_reader)
 
 set (open_reader_root_dir ${CMAKE_CURRENT_SOURCE_DIR})

--- a/reader/source/cfgio/CMakeLists.txt
+++ b/reader/source/cfgio/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake project file for CMake
 
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.15)
 project (cfgio) 
 enable_language (CXX)
 

--- a/reader/source/cfgkernel/CMakeLists.txt
+++ b/reader/source/cfgkernel/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake project file for CMake
 
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.15)
 project (cfg_kernel) 
 enable_language (CXX)
 

--- a/reader/source/dyna2rad/CMakeLists.txt
+++ b/reader/source/dyna2rad/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake project file for CMake
 
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.15)
 project(dyna2rad)
 enable_language (CXX)
 

--- a/reader/source/io/CMakeLists.txt
+++ b/reader/source/io/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake project file for CMake
 
-cmake_minimum_required (VERSION 3.5)
+cmake_minimum_required (VERSION 3.15)
 project (io) 
 enable_language (CXX)
 

--- a/reader/source/sdi/CMakeLists.txt
+++ b/reader/source/sdi/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake project file for CMake
 
-cmake_minimum_required (VERSION 3.6)
+cmake_minimum_required (VERSION 3.15)
 project (sdi) 
 enable_language (CXX)
 

--- a/starter/CMakeLists.txt
+++ b/starter/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMake project file for Radioss Starter
 # --------------------------------------
  
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.15)
 project (Radioss_Starter)
 
 # Verbose


### PR DESCRIPTION
Issue : https://github.com/OpenRadioss/OpenRadioss/issues/4109


cmake Version 4.0 or higher dropped support of CMake file format prior to 3.5 
Upgrade file format to 3.15 which is lower than the cmake commonly used in Visual Studio and Rocky Linux 8.


#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
