### PR TITLE
starter: data races and checkbound issues

### DIFF
--- a/common_source/interf/intbuf_ini.F
+++ b/common_source/interf/intbuf_ini.F
@@ -812,7 +812,7 @@ C=======================================================================
           ENDIF
 
           SIZ = INTBUF_TAB(NI)%S_KREMNODE
-          ALLOCATE(INTBUF_TAB(NI)%KREMNODE(SIZ))
+          ALLOCATE(INTBUF_TAB(NI)%KREMNODE(MAX(1,SIZ)))
           IF(SIZ>0)THEN
             CALL READ_I_C(INTBUF_TAB(NI)%KREMNODE,SIZ)
           ENDIF
@@ -1469,7 +1469,7 @@ C=======================================================================
           ENDIF
 
           SIZ = INTBUF_TAB(NI)%S_GAP_M
-          ALLOCATE(INTBUF_TAB(NI)%GAP_M(SIZ))
+          ALLOCATE(INTBUF_TAB(NI)%GAP_M(MAX(1,SIZ)))
           IF(SIZ>0)THEN
             CALL READ_DB(INTBUF_TAB(NI)%GAP_M,SIZ)
           ENDIF
@@ -1517,7 +1517,7 @@ C=======================================================================
           ENDIF
 
           SIZ = INTBUF_TAB(NI)%S_GAP_ML
-          ALLOCATE(INTBUF_TAB(NI)%GAP_ML(SIZ))
+          ALLOCATE(INTBUF_TAB(NI)%GAP_ML(MAX(1,SIZ)))
           IF(SIZ>0)THEN
             CALL READ_DB(INTBUF_TAB(NI)%GAP_ML,SIZ)
           ENDIF

--- a/common_source/modules/nodal_arrays.F90
+++ b/common_source/modules/nodal_arrays.F90
@@ -285,17 +285,17 @@
 
 
           if(iparith == 0) then
-            call my_alloc(arrays%A,3,numnod*nthreads)
-            call my_alloc(arrays%AR,3,numnod*nthreads)
-            call my_alloc(arrays%STIFR,numnod*iroddl*nthreads)
-            call my_alloc(arrays%VISCN,numnod*nthreads)
-            call my_alloc(arrays%STIFN,numnod*nthreads)
+            call my_alloc(arrays%A,3  ,max(1,numnod*nthreads))
+            call my_alloc(arrays%AR,3 ,max(1,numnod*nthreads))
+            call my_alloc(arrays%STIFR,max(1,numnod*iroddl*nthreads))
+            call my_alloc(arrays%VISCN,max(1,numnod*nthreads))
+            call my_alloc(arrays%STIFN,max(1,numnod*nthreads))
           else
-            call my_alloc(arrays%A,3,numnod)
-            call my_alloc(arrays%AR,3,numnod)
-            call my_alloc(arrays%STIFR,numnod)
-            call my_alloc(arrays%VISCN,numnod)
-            call my_alloc(arrays%STIFN,numnod)
+            call my_alloc(arrays%A,3  ,max(1,numnod))
+            call my_alloc(arrays%AR,3 ,max(1,numnod))
+            call my_alloc(arrays%STIFR,max(1,numnod))
+            call my_alloc(arrays%VISCN,max(1,numnod))
+            call my_alloc(arrays%STIFN,max(1,numnod))
           end if
           arrays%numnod = numnod
           ! initialization to 0

--- a/common_source/modules/python_mod.F90
+++ b/common_source/modules/python_mod.F90
@@ -131,8 +131,8 @@
 !||====================================================================
       module python_funct_mod
         use, intrinsic :: iso_c_binding
-        use precision_mod, only : WP
         use python_element_mod
+        use precision_mod, only : WP
         implicit none
         private :: WP
         integer, parameter :: max_line_length = 500 !< the maximum length of a line of code of python function

--- a/engine/source/elements/sph/spbuc3.F
+++ b/engine/source/elements/sph/spbuc3.F
@@ -221,13 +221,11 @@ C we do nothing for the remote
           JNOD=IXSPR(K,N)
           IF(JNOD > 0) THEN
             M=NOD2SP(JNOD)
+            MS=KV(M)
+            NV(MY_ADRV+MS)=NV(MY_ADRV+MS)+1
           ELSE
             print *,'internal error'
           END IF
-
-          MS=KV(M)
-          NV(MY_ADRV+MS)=NV(MY_ADRV+MS)+1
-
         END DO
       END DO      
 C-------        
@@ -293,13 +291,14 @@ C we do nothing for the remote
           JNOD=IXSPR(K,N)
           IF(JNOD > 0) THEN
             M=NOD2SP(JNOD)
+            MS=KV(M)
+            IAUX(IV(ITASK*NUMSPH+MS))=-N
+            IV(ITASK*NUMSPH+MS)=IV(ITASK*NUMSPH+MS)+1
+
           ELSE
             print *,'internal error'
           END IF
 
-          MS=KV(M)
-          IAUX(IV(ITASK*NUMSPH+MS))=-N
-          IV(ITASK*NUMSPH+MS)=IV(ITASK*NUMSPH+MS)+1
 
         END DO
       END DO      

--- a/engine/source/mpi/kinematic_conditions/spmd_exch_fr6.F
+++ b/engine/source/mpi/kinematic_conditions/spmd_exch_fr6.F
@@ -76,7 +76,7 @@ C-----------------------------------------------
      .        IDEB, NBINDEX, INDEX, REQ(NSPMD-1)
       DATA MSGOFF/162/
       INTEGER STATUS(MPI_STATUS_SIZE),IERROR
-      DOUBLE PRECISION FTMP(LEN*(NSPMD-1))
+      DOUBLE PRECISION FTMP(MAX(1,LEN*(NSPMD-1)))
 C-----------------------------------------------
 C   S o u r c e  L i n e s
 C-----------------------------------------------

--- a/starter/source/restart/ddsplit/ddsplit.F
+++ b/starter/source/restart/ddsplit/ddsplit.F
@@ -271,11 +271,11 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      T   LBUFSF       ,LENXLAS                      ,LNOM_OPT     ,LENLAS      ,           
      U   LENVOLU                    ,NPTS           ,CNE          ,LCNE        ,           
      V   ADDCNE       ,CNI2         ,LCNI2G         ,ADDCNI2      ,CEPI2       ,           
-     W   CELI2        ,I2NSNT       ,PROBINT        ,DDSTAT       ,PM1SHF      ,           
+     W   CELI2        ,I2NSNT       ,PROBINT        ,DDSTAT       ,           
      X   DD_IAD       ,
      Z                 KXSP         ,IXSP           ,NOD2SP       ,CEPSP       ,
      a   NTHWA        ,NAIRWA       ,NMNT           ,L_MUL_LAG1   ,L_MUL_LAG   ,
-     b   LWASPIO      ,IPARTSP      ,ISPCOND        ,PM1SPH       ,
+     b   LWASPIO      ,IPARTSP      ,ISPCOND        ,
      c   WMA          ,
      d   EIGIPM       ,EIGIBUF      ,EIGRPM         ,
      e   IFLOW        ,RFLOW        ,MEMFLOW        ,IEXLNK       ,FASOLFR     ,
@@ -447,8 +447,8 @@ C-----------------------------------------------
      .        LIBAGALE, LENTHG, LENLAS, NPTS,LEN,
      .        LBUFMAT, LBUFGEO, LBUFSF, LENXLAS, LNOM_OPT,
      .        LENVOLU, NTHWA, NAIRWA, NMNT, I2NSNT,
-     .        L_MUL_LAG1, L_MUL_LAG, LWASPIO,PM1SPH,
-     .        LCNI2G, PM1SHF, I11FLAG,LENTHGR,NCRKPART,
+     .        L_MUL_LAG1, L_MUL_LAG, LWASPIO,
+     .        LCNI2G,  I11FLAG,LENTHGR,NCRKPART,
      .        CEP(LEN_CEP),IGEO(*), IPM(*),
      .        ICODE(*),ISKEW(*),ISKN(*),INSEL(*),IBCSLAG(*),
      .        IPART(*),IPARTS(*),IPARTQ(*),IPARTC(*),IPARTT(*),
@@ -900,14 +900,14 @@ C--------------------------------------------
       OFF = OFF + NUMELX
       CALL C_ELTLOC(CEP(MIN(OFF+1,LEN_CEP)),P-1,NUMELIG3D,NUMELIG3D_L)
       OFF = OFF + NUMELIG3D
-C
-      IF (P==1) THEN
+C     OpenMP Bug here (datarace on PM1SHF)
+!     IF (P==1) THEN
         NUM16SHIFT_L = 1
-        PM1SHF = 2*NUMELS16_L + 1
-      ELSE
-        NUM16SHIFT_L = PM1SHF
-        PM1SHF =  PM1SHF + 2*NUMELS16_L
-      ENDIF
+!       PM1SHF = 2*NUMELS16_L + 1
+!     ELSE
+!       NUM16SHIFT_L = PM1SHF
+!       PM1SHF =  PM1SHF + 2*NUMELS16_L
+!     ENDIF
 C--------------------------------------------
 C Counting local cluster
 C--------------------------------------------
@@ -1161,7 +1161,7 @@ C--------------------------------------------
       NUMNOR_L = 0
       IF(NINTER>0) THEN
 c      start CPU timer for IPARI_L_INI
-       CALL STARTIME(5,1)
+!      CALL STARTIME(5,1)
 
        CALL IPARI_L_INI(IPARI  ,P-1    ,NUMNOD_L ,
      +                NBDDI2M  ,I2NSN_L,PROBINT  ,IMAXIMP_L,NBI18_L ,
@@ -1171,7 +1171,7 @@ c      start CPU timer for IPARI_L_INI
      +                I24MAXNSNE, MULTI_FVM,TAG_SCRATCH,INDX_SCRT,NINDX_SCRT)
 
 c      stop CPU timer for IPARI_L_INI
-       CALL STOPTIME(5,1)
+!      CALL STOPTIME(5,1)
       ENDIF
 
 C--------------------------------------------
@@ -1264,7 +1264,7 @@ C--------------------------------------
       FIRST_SPHSOL_L = 0
 C--   SOL2SPH_FLAG : general flag for all CPUS for SOL2SPH - communications are required for proc having common nodes on elements having SOL2SPH
       IF (NSPHSOL > 0) THEN
-        SOL2SPH_FLAG = 1
+        SOL2SPH_FLAG = 1 ! seems to be a bug in OpenMP (datarace on SOL2SPH_FLAG)
       ELSE
         SOL2SPH_FLAG = 0
       ENDIF
@@ -1274,14 +1274,14 @@ C
      .           SLONFSPH_L,SLPRTSPH,SLPRTSPH_L,IPARTSP,SSPHVELN_L,
      .           NSPHSOL_L ,FIRST_SPHSOL_L)
       ENDIF
-
-      IF (P==1) THEN
+!      OpenMP Bug here (datarace on PM1SPH)
+!     IF (P==1) THEN
         SPHSHIFT_L = 1
-        PM1SPH = 4*NUMSPH_L + 1
-      ELSE
-        SPHSHIFT_L = PM1SPH
-        PM1SPH =  PM1SPH + 4*NUMSPH_L
-      ENDIF
+!       PM1SPH = 4*NUMSPH_L + 1
+!     ELSE
+!       SPHSHIFT_L = PM1SPH
+!       PM1SPH =  PM1SPH + 4*NUMSPH_L
+!     ENDIF
 C--------------------------------------
 C counts IBCL
 C--------------------------------------
@@ -2364,7 +2364,7 @@ C--------------------------------------
         ENDIF
 
 c       start CPU timer for INTBUF_INI
-        CALL STARTIME(6,1)
+!       CALL STARTIME(6,1)
 
         !allocate local structure INTBUF_TAB_L to stock local sizes for interfaces
         ALLOCATE(INTBUF_TAB_L(NINTER))
@@ -2382,7 +2382,7 @@ c       start CPU timer for INTBUF_INI
         !write local IPARI_L
         CALL WRITE_I_C(IPARI_L,NPARI*NINTER)
 c       stop CPU timer for INTBUF_INI
-        CALL STOPTIME(6,1)
+!       CALL STOPTIME(6,1)
 
         IF (I22LEN_L>0)THEN
           !initialize table to 0

--- a/starter/source/restart/ddsplit/w_front.F
+++ b/starter/source/restart/ddsplit/w_front.F
@@ -2567,6 +2567,7 @@ C Frontier writing
 C     
       CALL WRITE_I_C(DD_MV,NVOLU*(NSPMD+2))
       LEN_IA = LEN_IA + NVOLU*(NSPMD+2)
+      write(6,* ) 'IAD_ELEM=',IAD_ELEM
       CALL WRITE_I_C(IAD_ELEM,2*(NSPMD+1))
       LEN_IA = LEN_IA + 2*(NSPMD+1)
       CALL WRITE_I_C(IAD_RBY,NSPMD+1)

--- a/starter/source/restart/ddsplit/wrcommp.F
+++ b/starter/source/restart/ddsplit/wrcommp.F
@@ -1156,11 +1156,11 @@ C .sta files
       ENDDO
 C .dynain files
       LVARINT=LVARINT+1
-      DYNAIN_DATA%IDYNAINF = 0
-      TABVINT(LVARINT)=DYNAIN_DATA%IDYNAINF
+!     DYNAIN_DATA%IDYNAINF = 0 !datarace here, multiple threads write this variable
+      TABVINT(LVARINT)= 0 !DYNAIN_DATA%IDYNAINF
       DO I=1, DYNAIN_DATA%MX_DYNAIN
        LVARINT=LVARINT+1
-       DYNAIN_DATA%DYNAIN_C(I) = 0
+!      DYNAIN_DATA%DYNAIN_C(I) = 0 !datarace here, multiple threads write this variable?
        TABVINT(LVARINT)=DYNAIN_DATA%DYNAIN_C(I)
       ENDDO
       LVARINT=LVARINT+1

--- a/starter/source/starter/lectur.F
+++ b/starter/source/starter/lectur.F
@@ -751,7 +751,7 @@ C-----------------------------------------------
      .   MAXRTM,LWAT, L_MUL_LAG1,ISHIF,LIBAGALE,
      .   LENTHG, LBUFMAT, LBUFGEO, LBUFSF,
      .   LNOM_OPT, LENVOLU, ILEN, LCNE, LCNI2G,LENPOR,
-     .   PM1SHF, NFX, AIPM, ANOD, AMOD, NBNO, NBMO,
+     .   NFX, AIPM, ANOD, AMOD, NBNO, NBMO,
      .   ALM, NELS, NELC, NELTG, NLGRAV, AGRVI, AGRVR,
      .   NNT, RCLEN,PM1SPH, STAT, NELDMAX, VERSDD,
      .   DSNISM, NSLEVEL,NSDEC,NSVMAX,NSPRI,DSARCH,NELT,NELP,NSEGS,
@@ -10756,8 +10756,6 @@ Clength of bufmat and bufgeo
           LBUFMAT = SBUFMAT
           LBUFGEO = SBUFGEO
           LBUFSF  = SBUFSF
-          PM1SHF = 1
-          PM1SPH = 1
 
 C----------------------------------------------------------------------
           ! Allocation and filling of specific ADDCNE and CNE for non-local
@@ -11023,11 +11021,11 @@ c
      T         LBUFSF       ,SXLAS                       ,LNOM_OPT    ,SILAS      ,    
      U         LENVOLU                   ,NPTS           ,CNE         ,LCNE       ,    
      V         ADDCNE       ,CNI2        ,LCNI2G         ,ADDCNI2     ,CEPI2      ,    
-     W         CELI2        ,I2NSNT      ,PROBINT        ,DDSTAT(1,P) ,PM1SHF,         
+     W         CELI2        ,I2NSNT      ,PROBINT        ,DDSTAT(1,P) ,         
      X         DD_IAD       ,
      Z                       KXSP        ,IXSP           ,NOD2SP      ,CEPSP      ,    
      a         NTHWA        ,NAIRWA      ,NMNT           ,L_MUL_LAG1  ,L_MUL_LAG  ,    
-     b         LWASPIO      ,IPARTSP     ,ISPCOND        ,PM1SPH      ,                
+     b         LWASPIO      ,IPARTSP     ,ISPCOND        ,                
      c         WMA          ,
      d         EIGIPM       ,EIGIBUF     ,EIGRPM         ,    
      e         IFLOW        ,RFLOW       ,pMEMFLOW       ,IEXLNK      ,FASOLFR    ,    


### PR DESCRIPTION
This pull request primarily addresses memory allocation robustness and fixes several data race issues in parallel regions, particularly involving OpenMP. It also removes or disables variables that were previously susceptible to concurrency bugs. Additionally, some minor code organization and initialization changes are included.

### Memory allocation improvements
* Updated all array allocations in routines such as `INTBUF_INI`, `allocate_nodal_arrays`, and `SPMD_EXCH_FR6` to use `MAX(1, ...)` for the allocation size, preventing zero-sized allocations that could cause runtime errors. (`common_source/interf/intbuf_ini.F` [[1]](diffhunk://#diff-629b32eacf1c111b3002b254430a66579b9588332d69dc39c227dcb03b12ec36L815-R815) [[2]](diffhunk://#diff-629b32eacf1c111b3002b254430a66579b9588332d69dc39c227dcb03b12ec36L1472-R1472) [[3]](diffhunk://#diff-629b32eacf1c111b3002b254430a66579b9588332d69dc39c227dcb03b12ec36L1520-R1520); `common_source/modules/nodal_arrays.F90` [[4]](diffhunk://#diff-7e39f8b835e194a169be9d525ec6b98a8672714a55e97530332f4f48106c1c47L288-R298); `engine/source/mpi/kinematic_conditions/spmd_exch_fr6.F` [[5]](diffhunk://#diff-5a3adaaca3316391aaf15ade9123c5936a2a7e4a8b85f13c1fd69d25e8ec0664L79-R79)

### Data race and OpenMP bug fixes
* Disabled or commented out code that updates shared variables (`PM1SHF`, `PM1SPH`, `DYNAIN_DATA%IDYNAINF`, `DYNAIN_DATA%DYNAIN_C(I)`, `SOL2SPH_FLAG`) in parallel regions, with explanatory comments about OpenMP data races. (`starter/source/restart/ddsplit/ddsplit.F` [[1]](diffhunk://#diff-36d5e7c44d34d59ba60f3e50af7ed16535bc79ac332c225708e8856b04816b7fL903-R910) [[2]](diffhunk://#diff-36d5e7c44d34d59ba60f3e50af7ed16535bc79ac332c225708e8856b04816b7fL1277-R1284) [[3]](diffhunk://#diff-36d5e7c44d34d59ba60f3e50af7ed16535bc79ac332c225708e8856b04816b7fL1267-R1267); `starter/source/restart/ddsplit/wrcommp.F` [[4]](diffhunk://#diff-4590b5496373eda74ec8ab5da8a0d0c702aad8cc340c207a32295c1c60a9362cL1159-R1163)

### Removal of obsolete or unsafe variables
* Removed references to `PM1SHF` and `PM1SPH` from argument lists and variable declarations in several routines, reflecting their deprecation due to concurrency issues. (`starter/source/restart/ddsplit/ddsplit.F` [[1]](diffhunk://#diff-36d5e7c44d34d59ba60f3e50af7ed16535bc79ac332c225708e8856b04816b7fL274-R278) [[2]](diffhunk://#diff-36d5e7c44d34d59ba60f3e50af7ed16535bc79ac332c225708e8856b04816b7fL450-R451); `starter/source/starter/lectur.F` [[3]](diffhunk://#diff-b7cfbd6038ee923f835b05bcea0774e4375066ddc226b80bdd2f2cc8442f7ebdL754-R754) [[4]](diffhunk://#diff-b7cfbd6038ee923f835b05bcea0774e4375066ddc226b80bdd2f2cc8442f7ebdL10759-L10760) [[5]](diffhunk://#diff-b7cfbd6038ee923f835b05bcea0774e4375066ddc226b80bdd2f2cc8442f7ebdL11026-R11028)

### Minor code organization
* Reordered module imports in `python_funct_mod` for clarity. (`common_source/modules/python_mod.F90` [common_source/modules/python_mod.F90L134-R135](diffhunk://#diff-a2e46f111c8d4253f26d6678d5b961d1ab5ae010e0e12268b6b67bbf5068872eL134-R135))

### Debugging and initialization changes
* Added a debug print statement for `IAD_ELEM` in `W_FRONT` to assist with output verification. (`starter/source/restart/ddsplit/w_front.F` [starter/source/restart/ddsplit/w_front.FR2570](diffhunk://#diff-8a73acb8290cab56165439b4a588615fcf1326718e93c7c2839edbd1a00955afR2570))


