### PR TITLE
conservative time step for shell using hyper-elastic laws and standard sh3n shell time step with offset

### DIFF
--- a/engine/source/elements/sh3n/coque3n/c3coef3.F
+++ b/engine/source/elements/sh3n/coque3n/c3coef3.F
@@ -151,7 +151,7 @@ C
       SELECT CASE(IGTYP)
         CASE (1,9,10,11,16)
            DO I=JFT,JLT
-            ZOFFSET(I) = Z0
+            ZOFFSET(I) = Z0*THK0(I)
            ENDDO 
         CASE (17,51,52)
             IPOS   = IGEO(99,PID(1))

--- a/engine/source/elements/sh3n/coque3n/c3dt3.F
+++ b/engine/source/elements/sh3n/coque3n/c3dt3.F
@@ -35,7 +35,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      5                 SHF   ,IGTYP  ,IGMAT  ,G      ,A1     ,
      6                 A11R  ,G_DT   ,DTEL   ,ALDT   ,THK0   ,
      7                 AREA  ,NGL    ,IMAT   ,MTN    ,NEL   ,
-     8                 ZOFFSET)
+     8                 ZOFFSET,SSP_EQ)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -69,12 +69,13 @@ C-----------------------------------------------
       INTEGER,INTENT(IN)    :: G_DT, NEL
       my_real,DIMENSION(JLT), INTENT(INOUT) :: DTEL
       my_real,DIMENSION(NEL),INTENT(IN)  :: ZOFFSET
+      my_real,DIMENSION(NEL),INTENT(IN)  :: SSP_EQ
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER INDX(MVSIZ),I, II, NINDX,IDT
       my_real DT(MVSIZ)
-      my_real ATHK, MMIN,FAC
+      my_real ATHK, MMIN,FAC,F_OSET(NEL),F_DTE(NEL)
 C=======================================================================       
       DO I=JFT,JLT
         VISCMX(I) = SQRT(ONE + VISCMX(I)*VISCMX(I)) - VISCMX(I)
@@ -82,6 +83,8 @@ C=======================================================================
       ENDDO
 c---------------------------------------------------
 C
+      F_OSET(JFT:JLT) = ONE ! factor is on stiffness 
+      F_DTE(JFT:JLT) = ONE ! factor is on element dt fat =1/sqrt(f_k)
       IF (NODADT/=0) THEN
         IF(IGTYP == 52 .OR. 
      .   ((IGTYP == 11 .OR. IGTYP == 17 .OR. IGTYP == 51)
@@ -99,21 +102,30 @@ C
                 ENDIF
           ENDDO       
         ELSE
+           F_OSET(JFT:JLT)= ONE + ZEP2*ABS(ZOFFSET(JFT:JLT))/THK0(JFT:JLT)
            DO  I=JFT,JLT
             A1(I) = PM(24,IMAT)
             G(I)  = PM(22,IMAT)
            ENDDO
-           IF (MTN == 58  .or. MTN == 158) CALL CSSP2A11(PM   ,IMAT  ,SSP  ,A1   ,JLT   )
+           IF (MTN == 58 .or. MTN == 158) THEN 
+               CALL CSSP2A11(PM   ,IMAT  ,SSP  ,A1   ,JLT   )
+           ELSEIF (MTN == 42 .or. MTN == 62 .or. MTN == 69) THEN
+             DO I=JFT,JLT
+               FAC = MAX(SSP_EQ(I),SSP(I))/SSP(I)
+               F_OSET(I) = FAC*FAC*F_OSET(I)
+             ENDDO 
+           END IF
            DO  I=JFT,JLT
                IF (OFF(I)==ZERO) THEN
                  STI(I) = ZERO
                  STIR(I) = ZERO
                ELSE
                  ATHK   = AREA(I) * THK0(I)
-                 STI(I) = ATHK * A1(I) / ALDT(I)**2
+                 STI(I) = ATHK *F_OSET(I)* A1(I) / ALDT(I)**2
                  STIR(I) = STI(I) * (THK0(I) * THK0(I) * ONE_OVER_12 
      .                   + HALF * SHF(I) * AREA(I) * G(I)/A1(I))
-c                 STI(I) = 0.5 * ATHK * A1(I) / ALDT(I)**2
+     .                       +  STI(I)*ZOFFSET(I)*ZOFFSET(I)
+c                 STI(I) = 0.5 * ATHK * A1(I) / ALDT(I)**2        
 c                 STIR(I) = STI(I) * (THK0(I) * THK0(I) / 12. 
 c     .                   + AREA(I) /9.) 
                ENDIF
@@ -175,10 +187,27 @@ c dt = 2/w = sqrt( 2*(m+dmelc)/k)
          END DO
         ENDIF
 C
+      ELSE ! NODADT=0
+        F_OSET(JFT:JLT)= ONE + ZEP2*ABS(ZOFFSET(JFT:JLT))/THK0(JFT:JLT)
+        IF(IGTYP==1.OR.IGTYP==9) THEN 
+          DO I=JFT,JLT
+            F_DTE(I) = ONE/SQRT(F_OSET(I))
+          END DO 
+        END IF
+        IF (MTN == 42 .or. MTN == 62 .or. MTN == 69) THEN
+          DO I=JFT,JLT
+            FAC = SSP(I)/MAX(SSP_EQ(I),SSP(I))
+            F_DTE(I) = FAC*F_DTE(I)
+          ENDDO 
+          DO I=JFT,JLT
+            FAC = MAX(SSP_EQ(I),SSP(I))/SSP(I)
+            F_OSET(I) = FAC*FAC*F_OSET(I)
+          ENDDO 
+        END IF
       ENDIF
 C
       DO I=JFT,JLT
-        DT(I)=DTFAC1(7)*ALDT(I)/SSP(I)
+        DT(I)=DTFAC1(7)*F_DTE(I)*ALDT(I)/SSP(I)
       END DO
       IF(G_DT/=ZERO)THEN
          DO I=JFT,JLT
@@ -262,7 +291,7 @@ C
       IF(IDTMINS==2)RETURN
 C
       DO I=JFT,JLT
-         STI(I) = AREA(I) * THK0(I) * A1(I) / ALDT(I)**2
+         STI(I) = AREA(I) * THK0(I) * F_OSET(I) * A1(I) / ALDT(I)**2
          STI(I) = ZEP81 * ZEP81 * STI(I) * OFF(I)
          STIR(I)= ZERO
       ENDDO

--- a/engine/source/elements/sh3n/coque3n/c3forc3.F
+++ b/engine/source/elements/sh3n/coque3n/c3forc3.F
@@ -245,6 +245,7 @@ C-----------------------------------------------
       my_real, dimension(nel)   :: epsd_pg
 !     variables for heat transfer
       my_real, dimension(mvsiz) :: fheat
+      my_real, dimension(mvsiz) :: ssp_eq
 !
 C--- Variables for non-local formulation
       INTEGER :: NDDL, K, INOD(3),NC1(MVSIZ), NC2(MVSIZ), NC3(MVSIZ), L_NLOC, IPOS(3),INLOC
@@ -577,7 +578,7 @@ C--------------------------
      Q   INDX_DRAPE,THKE      ,SEDRAPE     ,NUMEL_DRAPE,DT     ,
      R   NCYCLE    ,SNPC     ,STF          ,NXLAYMAX           ,
      S   IDEL7NOK  ,USERL_AVAIL ,MAXFUNC    ,NPTTOT,
-     T   SBUFMAT   ,SDIR_A    , SDIR_B   ,GBUF%FOR_G)
+     T   SBUFMAT   ,SDIR_A    , SDIR_B   ,GBUF%FOR_G,SSP_EQ )
 C--------------------------
       IF ((IMON_MAT==1).AND.ITASK == 0)CALL STOPTIME(TIMERS,35)
 C--------------------------
@@ -591,7 +592,7 @@ C--------------------------
      5        SHF    ,IGTYP     ,IGMAT   ,G      ,A11     ,
      6        A11R   ,GBUF%G_DT ,GBUF%DT ,ALDT   ,THK0    ,
      7        AREA   ,NGL       ,IMAT    ,MTN    ,NEL      , 
-     8        ZOFFSET )
+     8        ZOFFSET,SSP_EQ  )
 c
 C--------keep  GBUF%FOR,GBUF%MOM in new local sys as LBUF%SIG    
       CALL C3SROTO3(JFT    ,JLT    ,ECOS    ,ESIN      ,GBUF%FOR,

--- a/engine/source/elements/sh3n/coquedk/cdkforc3.F
+++ b/engine/source/elements/sh3n/coquedk/cdkforc3.F
@@ -204,6 +204,7 @@ c  Indx uses locally unlike 4N shells
      .  DIMENSION(:) ,POINTER  :: DIR_A,DIR_B,CRKDIR,DADV
 !     variables for heat transfer
       my_real, dimension(mvsiz) :: fheat
+      my_real, dimension(mvsiz) :: ssp_eq
 !
 C--- Variables for non-local
       INTEGER :: NDDL, INOD(3),NC1(MVSIZ), NC2(MVSIZ), NC3(MVSIZ), L_NLOC, IPOS(3),INLOC
@@ -452,7 +453,7 @@ C----------------------------------------------------------------------------
      R    INDX_DRAPE ,THKE      ,SEDRAPE     ,NUMEL_DRAPE ,DT   ,
      Q    NCYCLE     ,SNPC      ,  STF ,
      S    NXLAYMAX   ,IDEL7NOK  ,USERL_AVAIL ,MAXFUNC     ,NPTTOT,
-     T    SBUFMAT    ,SDIR_A    ,SDIR_B,  GBUF%FORPG_G(PTF))
+     T    SBUFMAT    ,SDIR_A    ,SDIR_B,  GBUF%FORPG_G(PTF),SSP_EQ)
 C----------------------------------------------------------------------------
 C     THICKNESS CORRECTION 
 C----------------------------
@@ -546,7 +547,7 @@ C--------------------------
      5        IOFC   ,NNOD   ,AREA     ,G       ,SHF   ,
      6        MSTG   ,DMELTG ,JSMS     ,PTG     ,IGTYP ,
      7        IGMAT  ,A11R   ,GBUF%G_DT, GBUF%DT,MTN   ,
-     8        PM     ,MAT(JFT),NEL     ,ZOFFSET  )
+     8        PM     ,MAT(JFT),NEL     ,ZOFFSET ,SSP_EQ )
 C--------------------------
 C     THERMAL TIME STEP
 C--------------------------

--- a/engine/source/elements/sh3n/coquedk/cndt3.F
+++ b/engine/source/elements/sh3n/coquedk/cndt3.F
@@ -38,7 +38,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      4                 IOFC  ,NNE     ,AREA ,G    ,SHF   ,
      5                 MSC   ,DMELC   ,JSMS ,PTG  ,IGTYP ,
      6                 IGMAT ,A11R    ,G_DT ,DTEL ,MTN   ,
-     7                 PM    ,IMAT    ,NEL  ,ZOFFSET)
+     7                 PM    ,IMAT    ,NEL  ,ZOFFSET,SSP_EQ)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -73,12 +73,13 @@ C     REAL
      .   MSC(*), DMELC(*), PTG(3,*),A11R(*),DTEL(MVSIZ)
       my_real, DIMENSION(NPROPM,NUMMAT) ,INTENT(IN):: PM
       my_real, DIMENSION(NEL) , INTENT(IN) :: ZOFFSET
+      my_real, DIMENSION(MVSIZ),INTENT(IN) :: SSP_EQ
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER INDXOF(MVSIZ),
      .        I, J, II, NINDX,IDT,ITYEL
-      my_real DT(MVSIZ),FAC,MAS,DIVM,MMIN  ,IZ ,F_OSET(NEL)  
+      my_real DT(MVSIZ),FAC,MAS,DIVM,MMIN ,IZ ,F_OSET(NEL),F_DTE(NEL)  
 C=======================================================================
       DO I=JFT,JLT
         VISCMX(I) = MAX(VISCMX(I), AMU(I))
@@ -89,21 +90,41 @@ c---------------------------------------------------
 C
       ITYEL = 3
       IF (NNE==3) ITYEL = 7
-      F_OSET(JFT:JLT) = ONE 
+      F_OSET(JFT:JLT) = ONE ! factor is on stiffness 
+      F_DTE(JFT:JLT) = ONE ! factor is on element dt fat =1/sqrt(f_k)
       IF (NODADT/=0) THEN
         IF(IGTYP == 52 .OR. 
      .   ((IGTYP == 11 .OR. IGTYP == 17 .OR. IGTYP == 51)
      .                                   .AND. IGMAT > 0 )) THEN
         ELSE
-          IF (MTN == 58 .or. MTN == 158) CALL CSSP2A11(PM   ,IMAT  ,SSP  ,A1   ,JLT   )
-          F_OSET(JFT:JLT)=ONE + ZEP2*ABS(ZOFFSET(JFT:JLT))/THK0(JFT:JLT)
+! take into account nonlinear stiffnening laws      
+          F_OSET(JFT:JLT)= ONE + ZEP2*ABS(ZOFFSET(JFT:JLT))/THK0(JFT:JLT)
+          IF (MTN == 58 .or. MTN == 158) THEN 
+              CALL CSSP2A11(PM   ,IMAT  ,SSP  ,A1   ,JLT   )
+          ELSEIF (MTN == 42 .or. MTN == 62 .or. MTN == 69) THEN
+            DO I=JFT,JLT
+              FAC = MAX(SSP_EQ(I),SSP(I))/SSP(I)
+              F_OSET(I) = FAC*FAC*F_OSET(I)
+            ENDDO 
+          END IF
         END IF
       ELSE
+        F_OSET(JFT:JLT)= ONE + ZEP2*ABS(ZOFFSET(JFT:JLT))/THK0(JFT:JLT)
         IF(IGTYP==1.OR.IGTYP==9) THEN 
           DO I=JFT,JLT
-            FAC = ONE + ZEP2*ABS(ZOFFSET(I))/THK0(I)
-            F_OSET(I) = ONE/SQRT(FAC)
+            FAC = F_OSET(I)
+            F_DTE(I) = ONE/SQRT(FAC)
           END DO 
+        END IF
+        IF (MTN == 42 .or. MTN == 62 .or. MTN == 69) THEN
+          DO I=JFT,JLT
+            FAC = SSP(I)/MAX(SSP_EQ(I),SSP(I))
+            F_DTE(I) = FAC*F_OSET(I)
+          ENDDO 
+          DO I=JFT,JLT
+            FAC = MAX(SSP_EQ(I),SSP(I))/SSP(I)
+            F_OSET(I) = FAC*FAC*F_OSET(I)
+          ENDDO 
         END IF
       END IF
 C----- isub will add here-----
@@ -196,11 +217,11 @@ c dt = 2/w = sqrt( 2*(m+dmelc)/k)
       ENDIF
 C
       DO I=JFT,JLT
-        DT(I)=DTFAC1(ITYEL)*F_OSET(I)*ALDT(I)/SSP(I)   
+        DT(I)=DTFAC1(ITYEL)*F_DTE(I)*ALDT(I)/SSP(I)   
       ENDDO
       IF(G_DT>0)THEN
         DO I=JFT,JLT
-          DTEL(I)=F_OSET(I)*ALDT(I)/SSP(I)     ! DT=ALDT(I)/SSP(I) & DT=DT*DTFAC1 does not lead to same digits, so operation is made again here.
+          DTEL(I)=F_DTE(I)*ALDT(I)/SSP(I)     ! DT=ALDT(I)/SSP(I) & DT=DT*DTFAC1 does not lead to same digits, so operation is made again here.
         ENDDO
       ENDIF
       IF((NODADT/=0.OR.IDTMINS==2).AND.IDTMIN(ITYEL)==0)RETURN

--- a/engine/source/elements/sh3n/coquedk6/cdk6forc3.F
+++ b/engine/source/elements/sh3n/coquedk6/cdk6forc3.F
@@ -207,6 +207,7 @@ c  Indx uses locally unlike 4N shells
       my_real :: dtinv,asrate,eps_m2,eps_k2
       my_real, dimension(nel)   :: epsd_pg
       my_real, dimension(mvsiz) :: fheat
+      my_real, dimension(mvsiz) :: ssp_eq
 !
 C--- Variables for non-local
       INTEGER :: NDDL, K, INOD(3),NC1(MVSIZ), NC2(MVSIZ), NC3(MVSIZ), L_NLOC, IPOS(3),INLOC
@@ -431,7 +432,7 @@ c-------------------------------------------
      R   INDX_DRAPE,THKE      ,SEDRAPE     ,NUMEL_DRAPE ,DT      ,
      Q   NCYCLE    ,SNPC      ,STF         ,NXLAYMAX    ,IDEL7NOK  ,
      R   USERL_AVAIL ,MAXFUNC ,NPTTOT      ,SBUFMAT     ,SDIR_A    ,SDIR_B    ,
-     S   GBUF%FOR_G)
+     S   GBUF%FOR_G,SSP_EQ )
 C----------------------------------------------------------------------------
 C     FORCES VISCOCITE 
 C----------------------------
@@ -467,7 +468,7 @@ C--------------------------
      5        IOFC   ,NNOD   ,AREA     ,G      ,SHF   ,
      6        MSTG   ,DMELTG ,JSMS     ,PTG    ,IGTYP ,
      7        IGMAT  ,A11R   ,GBUF%G_DT, GBUF%DT,MTN   ,
-     8        PM     ,MAT(JFT), NEL     ,ZOFFSET)
+     8        PM     ,MAT(JFT), NEL     ,ZOFFSET,SSP_EQ)
 C--------------------------
 C     THERMAL TIME STEP
 C--------------------------

--- a/engine/source/elements/shell/coque/cforc3.F
+++ b/engine/source/elements/shell/coque/cforc3.F
@@ -253,6 +253,7 @@ C
       my_real :: dt1,dtinv,asrate,eps_m2,eps_k2
       my_real, dimension(nel)   :: epsd_pg
       my_real, dimension(mvsiz) :: fheat        ! variables for heat transfer
+      my_real, dimension(mvsiz) :: ssp_eq        
 !
 C--- Variables for non-local
       INTEGER :: NDDL, K, INOD(4),NC1(MVSIZ), NC2(MVSIZ), NC3(MVSIZ), NC4(MVSIZ),
@@ -571,7 +572,7 @@ C-----------------------------
      R  INDX_DRAPE  ,THKE        ,SEDRAPE     ,NUMEL_DRAPE  ,DT        ,
      Q  NCYCLE      ,SNPC        ,STF         ,NXLAYMAX    ,IDEL7NOK   , 
      S  USERL_AVAIL ,MAXFUNC    ,NPTTOT       ,SBUFMAT     ,SDIR_A     ,
-     T  SDIR_B      ,GBUF%FOR_G)
+     T  SDIR_B      ,GBUF%FOR_G  ,SSP_EQ )
 C-----------------------------
       IF ((IMON_MAT==1).AND. ITASK == 0)CALL STOPTIME(TIMERS,35)
 C-----------------------------

--- a/engine/source/elements/shell/coqueba/cbaforc3.F
+++ b/engine/source/elements/shell/coqueba/cbaforc3.F
@@ -291,6 +291,7 @@ C-----------------------------------------------
 !     variables for heat transfer
       my_real, dimension(mvsiz) :: fheat
       my_real, dimension(mvsiz) :: epsd_pg,epsd_glob
+      my_real, dimension(mvsiz) :: ssp_eq,ssp_max
       my_real :: dtinv,asrate,eps_m2,eps_k2
 !
 C-----------------------------------------------
@@ -465,8 +466,9 @@ C
          ALLOCATE(PINCH_LOCAL%EPINCHXZ(MVSIZ))
          ALLOCATE(PINCH_LOCAL%EPINCHYZ(MVSIZ))
          ALLOCATE(PINCH_LOCAL%EPINCHZZ(MVSIZ))
-       ENDIF
-C 
+      ENDIF
+C
+      SSP_MAX = ZERO
 C--------------------------
 C     CALCULS PRELIMINAIRES 
 C--------------------------
@@ -801,7 +803,8 @@ C-----------------
      O    IBID      ,IBID      ,ISUBSTACK ,STACK     ,
      P    F_DEF(1,1,NG),ITASK  ,DRAPE_SH4N     ,VAR_REG(1,1),
      Q    PINCH_LOCAL , GBUF%FORPGPINCH(PTFP), GBUF%MOMPGPINCH(PTMP),EZZAVG  ,
-     R    AREAPINCH  )
+     R    AREAPINCH  ) 
+          SSP_EQ(JFT:JLT) = SSP(JFT:JLT)
         ELSE
           CALL CMAIN3(TIMERS,
      1    ELBUF_STR ,JFT       ,JLT       ,NFT       ,IPARG      ,
@@ -832,8 +835,9 @@ C-----------------
      R    INDX_DRAPE ,THKE     ,SEDRAPE   ,NUMEL_DRAPE  ,DT   ,
      Q    NCYCLE     ,SNPC     ,STF       ,NXLAYMAX,    IDEL7NOK    ,
      S    USERL_AVAIL ,MAXFUNC ,NPTTOT    ,SBUFMAT,     SDIR_A      ,
-     T    SDIR_B     ,GBUF%FORPG_G(PTF))        
+     T    SDIR_B     ,GBUF%FORPG_G(PTF)   ,SSP_EQ)        
         ENDIF
+        SSP_MAX(JFT:JLT) = MAX(SSP_MAX(JFT:JLT),SSP_EQ(JFT:JLT))
 C-----------------
         IF ((ITASK==0).AND.(IMON_MAT == 1)) CALL STOPTIME(TIMERS,35)
 C      
@@ -1066,7 +1070,7 @@ C
      5        IOFC   ,NNOD   ,AREA     , G      ,SHF   ,     
      6        MSC    ,DMELC  ,JSMS     , BID    ,IGTYP ,     
      7        IGMAT  ,A11R   ,GBUF%G_DT, GBUF%DT,MTN   ,
-     8        PM     ,MAT(JFT) , NEL     ,ZOFFSET)
+     8        PM     ,MAT(JFT) , NEL  ,ZOFFSET  ,SSP_MAX)
 C
       ENDIF
 C--------------------------

--- a/engine/source/elements/shell/coquez/czforc3.F
+++ b/engine/source/elements/shell/coquez/czforc3.F
@@ -256,6 +256,7 @@ C--------------------------------
       my_real :: dtinv,asrate,eps_m2,eps_k2
       my_real, dimension(nel)   :: epsd_pg
       my_real, dimension(mvsiz) :: fheat    !  variable for heat transfer
+      my_real, dimension(mvsiz) :: ssp_eq    !  for time step compute
 !
 C--- variables for the non-local
       INTEGER :: NDDL, K, INOD(4),NC1(MVSIZ), NC2(MVSIZ), NC3(MVSIZ), NC4(MVSIZ),
@@ -614,7 +615,7 @@ C-----------------------------------------------
      R      INDX_DRAPE,THKE      ,SEDRAPE     ,NUMEL_DRAPE,DT    ,
      Q      NCYCLE    ,SNPC      ,STF         ,NXLAYMAX  ,IDEL7NOK  ,
      S      USERL_AVAIL ,MAXFUNC ,NPTTOT      ,SBUFMAT   ,SDIR_A    ,
-     T      SDIR_B   ,GBUF%FOR_G )
+     T      SDIR_B   ,GBUF%FOR_G ,SSP_EQ      )
 
 C-----------------------------------------------
 c        
@@ -648,7 +649,7 @@ C
      5        IOFC  ,NNOD ,AREA,G  ,SHF   ,
      6        MSC   ,DMELC,JSMS,BID , IGTYP ,
      7        IGMAT  ,A11R   ,GBUF%G_DT, GBUF%DT,MTN   ,
-     8        PM     ,MAT(JFT),NEL, ZOFFSET)
+     8        PM     ,MAT(JFT),NEL, ZOFFSET,SSP_EQ )
 c-------------------------------
          CALL CZFINTCE(JFT  ,JLT  ,THK0 ,THK02,A_I     ,X13     ,
      2                 X24  ,Y13  ,Y24  ,Z1   ,MX23    ,MX13    ,

--- a/engine/source/elements/xfem/c3forc3_crk.F
+++ b/engine/source/elements/xfem/c3forc3_crk.F
@@ -228,6 +228,7 @@ C---
 C
 !     variables for heat transfer
       my_real, dimension(mvsiz) :: fheat
+      my_real, dimension(mvsiz) :: ssp_eq
 !
       my_real,
      .  DIMENSION(:) ,POINTER  ::  OFFG,THKG,STRAG,FORG,MOMG,
@@ -478,7 +479,7 @@ C--------------------------
      R   INDX_DRAPE , THKE    ,SEDRAPE   ,NUMEL_DRAPE,     DT  ,
      Q   NCYCLE     ,SNPC      ,  STF    ,NXLAYMAX   ,IDEL7NOK ,
      S   USERL_AVAIL, MAXFUNC,      NPTTOT,BUFMAT     ,SDIR_A   ,
-     T   SDIR_B     ,GBUF%FOR_G)
+     T   SDIR_B     ,GBUF%FOR_G,SSP_EQ )
 
 C--------------------------
         IF ((ITASK==0).AND.(IMON_MAT==1)) CALL STOPTIME(TIMERS,35)
@@ -493,7 +494,7 @@ C--------------------------
      5          SHF      ,IGTYP     ,IGMAT   ,G     ,A11      ,
      6          A11R     ,GBUF%G_DT ,GBUF%DT ,ALDT  ,THK0     ,
      7          AREA     ,NGL       ,IMAT    ,MTN   ,NEL      ,
-     8          ZOFFSET)
+     8          ZOFFSET  ,SSP_EQ   )
 
 C--------------------------
 C     BALANCES BY MATERIAL

--- a/engine/source/elements/xfem/cforc3_crk.F
+++ b/engine/source/elements/xfem/cforc3_crk.F
@@ -225,6 +225,7 @@ C---
       TARGET :: DIRA,DIRB
 !     variables for heat transfer
       my_real, dimension(mvsiz) :: fheat
+      my_real, dimension(mvsiz) :: ssp_eq
 !
 C---
       TYPE(BUF_LAY_) ,POINTER :: BUFLY
@@ -470,7 +471,7 @@ C-----------------------------
      R    INDX_DRAPE ,THKE, SEDRAPE  ,NUMEL_DRAPE,DT   ,
      Q    NCYCLE     ,SNPC      ,  STF,NXLAYMAX ,
      S    IDEL7NOK   ,USERL_AVAIL ,MAXFUNC  ,NPTTOT    ,SBUFMAT,
-     T    SDIR_A     ,SDIR_B   ,GBUF%FOR_G)
+     T    SDIR_A     ,SDIR_B   ,GBUF%FOR_G,SSP_EQ )
 C-----------------------------
         IF ((ITASK==0).AND.(IMON_MAT==1)) CALL STOPTIME(TIMERS,35)
 C-----------------------------

--- a/engine/source/elements/xfem/czforc3_crk.F
+++ b/engine/source/elements/xfem/czforc3_crk.F
@@ -233,6 +233,7 @@ C---
       TARGET :: DIRA,DIRB
 !     variables for heat transfer
       my_real, dimension(mvsiz) :: fheat
+      my_real, dimension(mvsiz) :: ssp_eq
 !
 C---
       TYPE(BUF_LAY_) ,POINTER :: BUFLY
@@ -503,7 +504,7 @@ C-----------------------------
      R       INDX_DRAPE, THKE     ,SEDRAPE     ,NUMEL_DRAPE,DT   ,
      Q       NCYCLE    ,SNPC      ,STF         ,NXLAYMAX  ,IDEL7NOK  ,
      S       USERL_AVAIL ,MAXFUNC ,NPTTOT      ,SBUFMAT   ,SDIR_A    ,
-     T       SDIR_B   ,GBUF%FOR_G)
+     T       SDIR_B   ,GBUF%FOR_G ,SSP_EQ )
 C-----------------------------
         IF ((ITASK==0).AND.(IMON_MAT==1)) CALL STOPTIME(TIMERS,35)
 C--------------------------
@@ -534,7 +535,7 @@ C
      5             IOFC   ,NNOD   ,AREA   , G      ,SHF   ,
      6             MSC    ,DMELC  ,JSMS   , BID    ,IGTYP ,
      7             IGMAT  ,A11R   ,GBUF%G_DT, GBUF%DT,MTN   ,
-     8             PM     ,MAT(JFT),NEL     ,ZOFFSET)
+     8             PM     ,MAT(JFT),NEL     ,ZOFFSET,SSP_EQ)
         CALL CZFINTCE(JFT  ,JLT  ,THK0 ,THK02,A_I    ,X13    ,
      2                X24  ,Y13  ,Y24  ,Z1   ,MX23   ,MX13   ,
      3                MX34 ,MY13 ,MY23 ,MY34 ,FORG   ,MOMG   ,

--- a/engine/source/materials/mat_share/cmain3.F
+++ b/engine/source/materials/mat_share/cmain3.F
@@ -83,7 +83,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      R           INDX_DRAPE,THKE      ,SEDRAPE   ,NUMEL_DRAPE,DT        ,
      Q           NCYCLE    , SNPC     ,STF       ,NXLAYMAX  ,IDEL7NOK   ,
      S           USERL_AVAIL, MAXFUNC ,VARNL_NPTTOT, SBUFMAT   ,SDIR_A    ,
-     T          SDIR_B    ,FOR_G)
+     T          SDIR_B    ,FOR_G      ,SSP_EQ   )
 C-----------------------------------------------
 C   M o d u l e s
 C----------------------------------------------- 
@@ -158,6 +158,7 @@ C-----------------------------------------------
      .   F_DEF(MVSIZ,*),ALDT(MVSIZ),VARNL(NEL,*)
       my_real, DIMENSION(NEL), INTENT(IN) :: THKE
       my_real, dimension(mvsiz), intent(inout) :: fheat
+      my_real, dimension(mvsiz), intent(  out) :: SSP_EQ
       TYPE (TTABLE) TABLE(*)
       TYPE (ELBUF_STRUCT_), TARGET :: ELBUF_STR
       TYPE (STACK_PLY) :: STACK
@@ -205,6 +206,7 @@ C=======================================================================
       IDAMP_FREQ_RANGE = IPARG(93)
       DAMP_BUF => ELBUF_STR%DAMP_RANGE
       ZCFAC(1:MVSIZ,1:2) = ZERO
+      SSP_EQ = ZERO
 C--------------------------------------------------
 C     add source terme for law not user
       IF (JTHE > 0 .AND. (MTN < 28 .OR. MTN == 32)) THEN
@@ -264,6 +266,7 @@ c
      9       IR      ,IS      ,F_DEF   ,ISMSTR  ,NU      ,VOL0    ,
      A       KFTS    ,ZSHIFT  ,IDAMP_FREQ_RANGE,MAT_ELEM,DAMP_BUF ,
      B       FOR_G )
+             SSP_EQ(JFT:JLT) = SSP(JFT:JLT)
 c----------------------------
       ELSE IF (MTN > 28 .AND. MTN < 32 .or. MTN == 99 .or. MTN == 200) THEN
 c---    user material law libraries here
@@ -292,7 +295,7 @@ c
      F       IXEL    ,ITHK    ,F_DEF   ,ISHPLYXFEM,
      G       ITASK   ,STACK%PM ,ISUBSTACK,STACK ,ALPE    ,
      H       PLY_EXX ,PLY_EYY ,PLY_EXY ,PLY_EXZ ,PLY_EYZ ,PLY_F   ,
-     I       VARNL   ,NLOC_DMG,NLAY_MAX,LAYNPT_MAX,DT    )
+     I       VARNL   ,NLOC_DMG,NLAY_MAX,LAYNPT_MAX,DT    ,SSP_EQ  )
 cc----------------------------
       ELSE   ! User-type Radioss laws , NPT > 0
 c----------------------------
@@ -328,7 +331,7 @@ c
      *       NPROPMI ,NPROPM  ,NPROPG,IMON_MAT,NUMGEO  ,
      *       NUMSTACK, DT1    ,TT  ,NXLAYMAX ,IDEL7NOK,USERL_AVAIL,
      *       MAXFUNC,NUMMAT,VARNL_NPTTOT,    SBUFMAT ,SDIR_A  ,SDIR_B  ,NPARG,
-     *       IDAMP_FREQ_RANGE,DAMP_BUF)
+     *       IDAMP_FREQ_RANGE,DAMP_BUF ,SSP_EQ  )
       ENDIF ! IF (NPT == 0) 
 C----------------------------------------------------------------------
       IF (IEXPAN > 0 .AND. JTHE > 0. AND. IDT_THERM==0) THEN

--- a/engine/source/materials/mat_share/mulawc.F90
+++ b/engine/source/materials/mat_share/mulawc.F90
@@ -191,7 +191,7 @@
         & npropmi  ,npropm   ,npropg   ,imon_mat  ,numgeo    ,          &
         & numstack ,dt1      ,tt       ,nxlaymax  ,idel7nok ,userl_avail, &
         & maxfunc  ,nummat   ,varnl_npttot,sbufmat,sdir_a   ,sdir_b ,nparg,&
-        & idamp_freq_range,damp_buf)
+        & idamp_freq_range,damp_buf,ssp_eq)
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Modules
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -351,6 +351,7 @@
           real(kind=WP), intent(inout), dimension(sdir_a) :: dir_a
           real(kind=WP), intent(inout), dimension(sdir_b) :: dir_b
           real(kind=WP), dimension(mvsiz), intent(inout) :: fheat
+          real(kind=WP), dimension(mvsiz), intent(inout) :: ssp_eq
           !
           target :: aldt, ipm, varnl
           type(elbuf_struct_),intent(inout), target :: elbuf_str
@@ -2757,6 +2758,7 @@
                   yld(jft:jlt)     = yld(jft:jlt) + sigy(jft:jlt) * thkly(jpos:jpos+jlt-1)
                 end select
               endif
+              ssp_eq(jft:jlt)     = ssp_eq(jft:jlt) + ssp(jft:jlt) * thkly(jpos:jpos+jlt-1)
 !-----------------------------------------------
               if (impl_s > 0) then
                 call putsignorc3(jft ,jlt ,iun,ng,ipt,g_imp ,sigksi)
@@ -2871,12 +2873,14 @@
               rho(i) = geo(ipgmat+1,pid(1))
               ssp(i) = geo(ipgmat+9,pid(1))
             enddo
+            ssp_eq(jft:jlt)     = ssp(jft:jlt) 
           elseif (igtyp == 52 .or.&
           &((igtyp == 17 .or. igtyp == 51) .and. igmat > 0)) then
             do i=jft,jlt
               ssp(i) = stack%pm(9,isubstack)
               rho(i) = stack%pm(1,isubstack)
             enddo
+            ssp_eq(jft:jlt)     = ssp(jft:jlt) 
           endif
 !---
 ! special treatment for law 19

--- a/engine/source/materials/mat_share/usermat_shell.F
+++ b/engine/source/materials/mat_share/usermat_shell.F
@@ -112,7 +112,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      F       IXEL     ,ITHK     ,F_DEF    ,ISHPLYXFEM,                        
      G       ITASK    ,PM_STACK , ISUBSTACK,STACK    ,ALPE     ,
      H       PLY_EXX  ,PLY_EYY  ,PLY_EXY  ,PLY_EXZ   ,PLY_EYZ  ,PLY_F    ,
-     I       VARNL    ,NLOC_DMG ,NLAY_MAX ,LAYNPT_MAX,DT       )
+     I       VARNL    ,NLOC_DMG ,NLAY_MAX ,LAYNPT_MAX,DT       ,SSP_EQ )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -164,6 +164,7 @@ C-----------------------------------------------
       INTEGER, INTENT(IN) :: NLAY_MAX, LAYNPT_MAX
       my_real DM
       my_real, intent(in),dimension(mvsiz) :: epsd_pg !< global strain rate by Gauss pt
+      my_real, intent(inout),dimension(mvsiz) :: SSP_EQ   ! for time step compute 
       my_real FOR(NEL,5),MOM(NEL,3),GSTR(NEL,8),THK(*),EINT(JLT,2),OFF(*),
      .   DIR_A(*),DIR_B(*),VISCMX(*),PM(NPROPM,*),THK_LY(NEL,*),
      .   AREA(*),GEO(NPROPG,*),TF(*),DT1C(*),THKLY(*),ALDT(*),
@@ -1929,6 +1930,7 @@ C-----------------------------------------------
               ZCFAC(JFT:JLT,2) = MIN(ETSE(JFT:JLT),ZCFAC(JFT:JLT,2))  
           ENDIF
           YLD(JFT:JLT) = YLD(JFT:JLT) + SIGY(JFT:JLT)*THLY(JFT:JLT)
+          SSP_EQ(JFT:JLT) = SSP_EQ(JFT:JLT) + SSP(JFT:JLT)*THLY(JFT:JLT)
 c-----------------------------------------------
           IF (IMPL_S > 0) THEN
             CALL PUTSIGNORC3(JFT ,JLT ,IUN,NG,IPT,G_IMP ,SIGKSI)
@@ -2038,12 +2040,14 @@ C---------------------------
           RHO(I) = GEO(IPGMAT+1,PID(1))
           SSP(I) = GEO(IPGMAT+9,PID(1))
         ENDDO
+        SSP_EQ(JFT:JLT) = SSP(JFT:JLT)
       ELSEIF (IGTYP == 52 .OR.
      .      ((IGTYP == 17 .OR. IGTYP == 51) .AND. IGMAT > 0)) THEN
         DO I=JFT,JLT
           SSP(I) = PM_STACK(9,ISUBSTACK)
           RHO(I) = PM_STACK(1,ISUBSTACK) 
         ENDDO
+        SSP_EQ(JFT:JLT) = SSP(JFT:JLT)
       ENDIF   
 !---
 ! Special treatment for law 19


### PR DESCRIPTION


#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
might get instability issue of shell elements using hyper-elastic laws(e.g. law42), or standard triangular shell w/ offset.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
improvement on the conservative time step of shells w/ some special laws or offset (SH3N).

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
