### PR TITLE
correction on tetra4+Ismstr=11+/DT1/BRICK +law90

### DIFF
--- a/engine/source/elements/solid/solide4/s4derit3.F
+++ b/engine/source/elements/solid/solide4/s4derit3.F
@@ -160,7 +160,16 @@ C
         END DO
 
 
-       ELSEIF(IFORMDT==1)THEN
+       ELSEIF(IFORMDT==0)THEN
+         DO I=1,NEL
+             D = PX1(I)*PX1(I)+PY1(I)*PY1(I)+PZ1(I)*PZ1(I)
+     .       + PX2(I)*PX2(I)+PY2(I)*PY2(I)+PZ2(I)*PZ2(I)
+     .       + PX3(I)*PX3(I)+PY3(I)*PY3(I)+PZ3(I)*PZ3(I)
+     .       + PX4(I)*PX4(I)+PY4(I)*PY4(I)+PZ4(I)*PZ4(I)
+           DELTAX(I) = ONE / SQRT(D)
+         END DO
+
+      ELSEIF(IFORMDT==1)THEN
 
          GFAC=PM(105,MXT(1))
          LD  =TWO*SQRT(MAX(ONE-GFAC,ZERO))+ONE


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
special case of in model (tetra4+ismstr=11+law90+/DT1/BRICK) might get Nan result (Engine) due to the characteristic length compute missed.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
correction of special case tetra4+Ismstr=11+law90+/DT1/BRICK

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
