### PR TITLE
Add the number of integration point indication for Beam 18 failure

### DIFF
--- a/engine/source/elements/beam/mulaw_ib.F
+++ b/engine/source/elements/beam/mulaw_ib.F
@@ -186,7 +186,7 @@ C---
      3         SIGOXX   ,SIGOXY   ,SIGOXZ   ,EPSXX    ,EPSP     ,
      4         SIGNXX   ,SIGNXY   ,SIGNXZ   ,ETSE     ,NUVAR    ,
      5         UVAR     ,IFUNC    ,NVARTMP  ,VARTMP   ,NPF      ,
-     6         TF       ,NFUNC    ,SIGY_IPT)
+     6         TF       ,NFUNC    ,SIGY_IPT,NGL ,IPT)
 C---
           CASE (71)
             CALL SIGEPS71PI(

--- a/engine/source/materials/mat/mat036/sigeps36pi.F
+++ b/engine/source/materials/mat/mat036/sigeps36pi.F
@@ -327,14 +327,15 @@ C---
           IF (PLA(I) > EPSMAX(I) .AND. OFF(I)==ONE) THEN
             OFF(I) = FOUR_OVER_5
 #include "lockon.inc"
-            WRITE(IOUT, 1000) NGL(I),PLA(I),EPSP(I)
+            WRITE(IOUT, 1000) NGL(I),IPT,PLA(I),EPSP(I)
+            WRITE(ISTDO,1000) NGL(I),IPT,PLA(I),EPSP(I)
 #include "lockoff.inc"
           END IF
         ENDDO
       END IF                                         
 c---------------------------------------------------------
- 1000 FORMAT(5X,'FAILURE BEAM ELEMENT NUMBER ',I10,
-     .          ' PLASTIC STRAIN =',1PE16.9,' STRAIN RATE =',1PE16.9)
+ 1000 FORMAT(5X,'FAILURE BEAM ELEMENT NUMBER',I3,',  INTEGRATION POINT NUMBER',I3,
+     .          ',  PLASTIC STRAIN = ',1PE16.9,',  STRAIN RATE = ',1PE16.9)
 c---------------------------------------------------------
       RETURN
       END

--- a/engine/source/materials/mat/mat044/sigeps44pi.F
+++ b/engine/source/materials/mat/mat044/sigeps44pi.F
@@ -33,7 +33,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      3               SIGOXX  ,SIGOXY  ,SIGOXZ  ,EPST    ,EPSP    ,      
      4               SIGNXX  ,SIGNXY  ,SIGNXZ  ,ETSE    ,NUVAR   ,
      5               UVAR    ,IFUNC   ,NVARTMP ,VARTMP  ,NPF     ,
-     6               TF      ,NFUNC   ,SIGY)      
+     6               TF      ,NFUNC   ,SIGY, NGL,IPT)      
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -45,10 +45,12 @@ C-----------------------------------------------
 #include      "scr17_c.inc"
 #include      "com04_c.inc"
 #include      "com08_c.inc"
+#include      "units_c.inc"
+#include      "comlock.inc"
 C-----------------------------------------------
 C   I N P U T   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER ,INTENT(IN) :: IMAT
+      INTEGER ,INTENT(IN) :: IMAT,NGL(NEL),IPT
       INTEGER ,INTENT(IN) :: NEL,NUPARAM,NUVAR,
      .   NFUNC,IFUNC(NFUNC),NPF(*),NVARTMP
       INTEGER ,DIMENSION(NPROPMI,NUMMAT) ,INTENT(IN) :: IPM
@@ -205,6 +207,10 @@ c--------------------------------
 c         test strain failure
           IF (DMG == ZERO .or. PLA(I) >= EPMAX(I)) THEN
             OFF(I)   = FOUR_OVER_5
+!#include "lockon.inc"
+            WRITE(IOUT, 1000) NGL(I),IPT
+            WRITE(ISTDO,1000) NGL(I),IPT
+!#include "lockoff.inc"
           ENDIF
           IF (VFLAG(I) == 1) THEN 
             ALPHA   = MIN(ONE, ASRATE(I)*DT1)
@@ -216,5 +222,8 @@ c
         ENDIF
       ENDDO                                          
 c-----------
+c---------------------------------------------------------
+ 1000 FORMAT(5X,' FAILURE BEAM ELEMENT NUMBER',I3,',  INTEGRATION POINT NUMBER ',I3)
+c---------------------------------------------------------
       RETURN
       END


### PR DESCRIPTION


#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
For Beam 18 when the failure criterion is defined in material law，the number of integration point is not indicated

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
Add this message for law36 law44

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
