### PR TITLE
not init beta value for damping with /DAMP/FUNCT

### DIFF
--- a/starter/source/general_controls/damping/hm_read_damp.F
+++ b/starter/source/general_controls/damping/hm_read_damp.F
@@ -167,6 +167,8 @@ C--------------------------------------------------
         FL_FREQ_RANGE = 0
         ITYPE = 0
         FACTB = ONE
+        ALPHA = ZERO
+        BETA = ZERO
 C        
         IF(KEY(1:5)=='INTER')THEN
           FLINT = 1
@@ -522,6 +524,7 @@ C
               ALPHA_X = ALPHA
               DAMPR(3,I) = ALPHA_X
               ALPHA = FACTB
+              DAMPR(4,I) = BETA
               DAMPR(5,I) = ALPHA_Y
               DAMPR(7,I) = ALPHA_Z
               DAMPR(9,I)  = ALPHA_XX


### PR DESCRIPTION
This pull request makes a small update to the damping subroutine initialization logic, specifically in how the `ALPHA` and `BETA` variables are set and stored in the `DAMPR` array.

Initialization improvements:

* The variables `ALPHA` and `BETA` are now explicitly initialized to zero at the start of the subroutine, improving clarity and preventing potential issues from uninitialized values.

Damping parameter storage:

* The value of `BETA` is now stored in the `DAMPR(4,I)` array element, ensuring that it is properly tracked for each iteration.