### PR TITLE
Correction of internal heat calculation in material laws 2,63,64,71,73

### DIFF
--- a/engine/source/materials/mat/mat002/sigeps02c.F
+++ b/engine/source/materials/mat/mat002/sigeps02c.F
@@ -220,7 +220,7 @@ C-----------------
       IF (JTHE /= 0) THEN
         ! heat increment due to plastic work for /heat/mat
         DO I=1,NEL
-          FHEAT(I) = FHEAT(I) + SIGY(I)*DPLA(I)*VOL(I)
+          FHEAT(I) = FHEAT(I) + SIGY(I)*DPLA(I)*VOL(I) * MAT_PARAM%THERM%EFRAC
         ENDDO
       ELSEIF (RHOCP > ZERO) THEN   ! adiabatic conditions => temp is updated locally
         DO I=1,NEL

--- a/engine/source/materials/mat/mat063/sigeps63c.F
+++ b/engine/source/materials/mat/mat063/sigeps63c.F
@@ -122,7 +122,7 @@ C-----------------------------------------------
      .   SIGOXX(NEL0),SIGOYY(NEL0),
      .   SIGOXY(NEL0),SIGOYZ(NEL0),SIGOZX(NEL0),
      .   GS(*),VOL(NEL0) ,TEMPEL(NEL0),
-     .   DIE(NEL0),COEF(NEL0),DPLANL(NEL0)
+     .   DIE(NEL0),COEF,DPLANL(NEL0)
       my_real ,DIMENSION(NUPARAM) :: UPARAM
       INTEGER, INTENT(IN) :: JTHE
       my_real, DIMENSION(NEL0), INTENT(IN) :: LOFF
@@ -198,6 +198,7 @@ C-----------------------------------------------
          EPS0= UPARAM(20)
          CP  = UPARAM(21)
          HL  = UPARAM(23)
+         COEF= UPARAM(24)                     
          G3  = THREE*G
 C
          NNU1 = NU / (ONE  - NU)
@@ -210,17 +211,12 @@ C
          NU6 = HALF - NNU2 + HALF*NNU1
          DO I=1,NEL0
            TEMP(I) = UPARAM(22)
-C latent heat            
-           COEF(I)  = UPARAM(24)                     
          ENDDO
 C
        IF (ISIGI==0) THEN
        IF(TIME==0.0)THEN
          DO I=1,NEL0
-           UVAR(I,1) = ZERO
            UVAR(I,2) = VM0
-           UVAR(I,3) = ZERO  
-           UVAR(I,4) = ZERO
          ENDDO
        ENDIF
        ENDIF
@@ -239,46 +235,30 @@ C
        ENDDO
 C
         IF(JTHE > 0 ) THEN
-         DO I=1,NEL0              
-           TEMP(I) = TEMPEL(I)
-         ENDDO  
+          DO I=1,NEL0              
+            TEMP(I) = TEMPEL(I)
+          ENDDO  
         ELSE
           DO I=1,NEL0
-            VOL0 = VOL(I) * RHO0(I)
+            VOL0  = VOL(I) * RHO0(I)
             VM(I) = UVAR(I,2)      
-            TEMP(I) = TEMP(I) 
-     .              + (   COEF(I)*(EINT(I,1)+ EINT(I,2))
-     .                  + VM(I)*HL ) * CP /VOL0
-clm     .                + COEF(I)*CP(I)*(EINT(I,1)+ EINT(I,2))/VOL0 
-clm     .                + CP(I)*VM(I)*HL(I)/VOL0
+            TEMP(I) = TEMP(I) + (COEF*(EINT(I,1)+EINT(I,2)) + VM(I)*HL) * CP/VOL0
           ENDDO
         ENDIF
 C
 C compute YLD stress
        DO I=1,NEL0
          VM(I) = UVAR(I,2)  
+         AUX0 = PLA(I)+EPS0
+         AUX1 = LOG(MAX(EM20,AUX0))
+         AUX2 = EXP( (CN - ONE)*AUX1 )
+         AUX3 = (BHS - AHS) * EXP(-CM * AUX0 * AUX2)
+         KT(I)= K1 + K2*TEMP(I)
 
-clm         YLD(I) = ( BHS(I) - (BHS(I) - AHS(I))*
-clm     .          EXP(-CM(I) * EXP(CN(I)*LOG(MAX(EM20,PLA(I)+EPS0(I))))))
-clm     .          *( K1(I) + K2(I)*TEMP(I) ) + DH(I)*VM(I)        
-clm        H(I) = CM(I)*CN(I)*( BHS(I) - AHS(I) )
-clm     .          * EXP( (CN(I) - 1)*LOG( MAX(EM20,PLA(I) + EPS0(I))))
-clm     .          * EXP(-CM(I)*EXP(CN(I)*LOG(MAX(EM20, PLA(I)+EPS0(I)))))
-clm     .          * (K1(I)+K2(I)*TEMP(I))          
-
-        AUX0 = PLA(I)+EPS0
-        AUX1 = LOG(MAX(EM20,AUX0))
-        AUX2 = EXP( (CN - ONE)*AUX1 )
-        AUX3 = (BHS - AHS) * EXP(-CM * AUX0 * AUX2)
-        KT(I)= K1 + K2*TEMP(I)
-
-        YLD(I) = ( BHS - AUX3 ) * KT(I)
-     .         + DH*VM(I)        
-        H(I)   = CM*CN* AUX2 * AUX3 * KT(I)
-
-c       H(I)  = H(I) 
-ctmp + DH(I)*UVAR(I,3)
-        DPLA(I) =ZERO
+         YLD(I) = ( BHS - AUX3 ) * KT(I)
+     .          + DH*VM(I)        
+         H(I)   = CM*CN* AUX2 * AUX3 * KT(I)
+         DPLA(I) =ZERO
        ENDDO      
 C-------------------
 C     PROJECTION

--- a/engine/source/materials/mat/mat064/sigeps64c.F
+++ b/engine/source/materials/mat/mat064/sigeps64c.F
@@ -44,7 +44,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      D   VISCMAX, THK,     PLA,     UVAR,
      E   OFF,     NGL,     IPM,     MAT,
      F   ETSE,    GS,      VOL,     YLD,
-     G   TEMPEL,  DIE,     COEF,    INLOC,
+     G   TEMPEL,  DIE,     INLOC,
      H   DPLANL,  JTHE,    LOFF)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
@@ -125,7 +125,7 @@ C-----------------------------------------------
      .   SIGOXX(NEL0),SIGOYY(NEL0),
      .   SIGOXY(NEL0),SIGOYZ(NEL0),SIGOZX(NEL0),
      .   GS(*),VOL(NEL0),TEMPEL(NEL0),
-     .   DIE(NEL0),COEF(NEL0),DPLANL(NEL0)
+     .   DIE(NEL0),DPLANL(NEL0)
       my_real, DIMENSION(NEL0), INTENT(IN) :: LOFF
 C-----------------------------------------------
 C   O U T P U T   A r g u m e n t s
@@ -201,6 +201,7 @@ C
          CP  = UPARAM(11)
          YFAC(1) = UPARAM(13)
          YFAC(2) = UPARAM(14) 
+         HL  = UPARAM(15)
          G3  = THREE*G
          NNU1 = NU / (ONE - NU)
          NNU2    = NNU1*NNU1
@@ -212,24 +213,7 @@ C
          NU6 = HALF - NNU2 + HALF*NNU1
          DO I=1,NEL0
            TEMP(I)  = UPARAM(12)
-C latent heat            
-           HL  = UPARAM(15)
-           COEF(I)  = ONE
-C
          ENDDO
-C
-       IF (ISIGI==0) THEN
-       IF(TIME==0.0)THEN
-         DO I=1,NEL0
-           UVAR(I,1)=ZERO
-           UVAR(I,2)=ZERO
-           UVAR(I,3) = ZERO  
-           UVAR(I,4) = ZERO
-           UVAR(I,5) = ZERO
-           UVAR(I,6) = ZERO
-         ENDDO
-       ENDIF
-       ENDIF
 C-----------------------------------------------
 C  Calculation of temperature. (conduction or adiabatic)
 C--------------------    
@@ -241,9 +225,7 @@ C--------------------
           DO I=1,NEL0
             VOL0 = VOL(I) * RHO0(I)
             VM(I) = UVAR(I,2)      
-            TEMP(I) = TEMP(I) 
-     .                       + COEF(I)*CP*(EINT(I,1)+ EINT(I,2))/VOL0
-     .                       + CP*VM(I)*HL/VOL0
+            TEMP(I) = TEMP(I) + (EINT(I,1)+ EINT(I,2) + VM(I)*HL) * CP / VOL0
           ENDDO
         ENDIF
 C

--- a/engine/source/materials/mat/mat073/sigeps73c.F
+++ b/engine/source/materials/mat/mat073/sigeps73c.F
@@ -46,7 +46,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      C   UVAR,      OFF,       NGL,       ITABLE,
      D   ETSE,      GS,        SIGY,      DPLA1,
      E   EPSP,      TABLE,     VOL,       TEMPEL,
-     F   DIE,       COEF,      NPF,       NFUNC,
+     F   DIE,       NPF,       NFUNC,
      G   IFUNC,     TF,        SHF,       HARDM,
      H   SEQ_OUTPUT,INLOC,     DPLANL,    JTHE,
      I   LOFF)
@@ -79,7 +79,7 @@ C-----------------------------------------------
      .   EPSXY(NEL) ,EPSYZ(NEL) ,EPSZX(NEL) ,
      .   SIGOXX(NEL),SIGOYY(NEL),
      .   SIGOXY(NEL),SIGOYZ(NEL),SIGOZX(NEL),SHF(NEL),
-     .   GS(NEL),VOL(NEL),TEMPEL(NEL),DIE(NEL),COEF(NEL),HARDM(*),
+     .   GS(NEL),VOL(NEL),TEMPEL(NEL),DIE(NEL),HARDM(*),
      .   SEQ_OUTPUT(NEL),DPLANL(NEL)
       TYPE(TTABLE) TABLE(*)
       my_real, DIMENSION(NEL), INTENT(IN) :: LOFF
@@ -208,10 +208,6 @@ C
 C-----------------------------------------------
 C  calculation of the temperature (conduction or adiabatic)
 C--------------------    
-        DO I=1,NEL    
-          COEF(I) = ONE
-        END DO
-C
         IF(JTHE > 0 ) THEN
          DO I=1,NEL     
            TEMP(I) = TEMPEL(I)
@@ -221,8 +217,7 @@ C
          DO I=1,NEL
            TEMP(I) = UPARAM(20)
            VOL0    = VOL(I) * RHO0(I)
-           TEMP(I) = TEMP(I) 
-     .             + COEF(I)*RHOCP*(EINT(I,1)+ EINT(I,2))/VOL0
+           TEMP(I) = TEMP(I) + (EINT(I,1)+ EINT(I,2)) * RHOCP/VOL0
          ENDDO
         ENDIF
 C
@@ -483,10 +478,6 @@ C
 C-----------------------------------------------
 C  calculation of the temperature (conduction or adiabatic)
 C--------------------    
-        DO I=1,NEL    
-          COEF(I) = ONE
-        END DO
-C
         IF(JTHE > 0 ) THEN
          DO I=1,NEL     
            TEMP(I) = TEMPEL(I)
@@ -496,8 +487,7 @@ C
          DO I=1,NEL
            TEMP(I) = UPARAM(20)
            VOL0    = VOL(I) * RHO0(I)
-           TEMP(I) = TEMP(I) 
-     .             + COEF(I)*RHOCP*(EINT(I,1)+ EINT(I,2))/VOL0
+           TEMP(I) = TEMP(I) + (EINT(I,1)+ EINT(I,2)) * RHOCP/VOL0
          ENDDO
         ENDIF
 C

--- a/engine/source/materials/mat_share/mulawc.F90
+++ b/engine/source/materials/mat_share/mulawc.F90
@@ -388,12 +388,12 @@
             epsyz ,epszx ,epspxx,epspyy,epspxy,epspyz,epspzx,sigoxx,&
             sigoyy,sigoxy,sigoyz,sigozx,signxx,signyy,signxy,signyz,&
             signzx,sigvxx,sigvyy,sigvxy,sigvyz,sigvzx,&
-            wmc, epsd, yld,dpla,vol0, coef,hardm,g_imp,visc,wplar,&
+            wmc, epsd, yld,dpla,vol0,hardm,g_imp,visc,wplar,&
             tstar,  vm, vm0, seq0, vol_ipt,&
             areamin,dareamin,dmg_glob_scale,dmg_loc_scale,et_imp, epsthtot
           real(kind=WP), dimension(nel,5) :: dmg_orth_scale
 !
-          real(kind=WP) :: zt,dtinv, vol2,asrate, &
+          real(kind=WP) :: zt,dtinv, vol2,asrate,coef, &
             r1,r2,s1,s2,r12a,r22a,s12b,s22b,rs1,rs2,rs3,&
             t1,t2,t3,fact,r3r3,s3s3,&
             bidon1,bidon2,bidon3,bidon4,bidon5,vv,aa,trelax,t0,tm
@@ -506,7 +506,7 @@
           iun=1
 !
           dmg_flag = 0
-          trelax   = zero
+          trelax = zero
 !
           degmb(jft:jlt) = for(jft:jlt,1)*exx(jft:jlt)+for(jft:jlt,2)*eyy(jft:jlt)  &
           &              + for(jft:jlt,3)*exy(jft:jlt)+for(jft:jlt,4)*eyz(jft:jlt)  &
@@ -549,7 +549,6 @@
           if(flag_zcfac) zcfac(jft:jlt,2)= one
           etse(jft:jlt)   = one
           if(flag_etimp) etimp(jft:jlt)= zero
-          coef(jft:jlt)   = one
           if(flag_law25)then
             wplar(jft:jlt)=zero
             nfis1(jft:jlt)=0
@@ -615,6 +614,7 @@
             niparam  =  mat_elem%mat_param(imat)%niparam
             uparam   => mat_elem%mat_param(imat)%uparam
             iparam   => mat_elem%mat_param(imat)%iparam
+            coef = mat_elem%mat_param(imat)%therm%efrac
 
             if (igtyp == 11 .or. igtyp == 16 .or. igtyp == 17 .or.    &
             &            igtyp == 51 .or. igtyp == 52) then
@@ -1078,7 +1078,7 @@
                 call sigeps02c(mat_elem%mat_param(imat),                       &
                      nel        ,eint      ,thkn     ,el_temp  ,fheat    ,     &
                      off        ,sigy      ,dt1      ,ipla     ,sigksi   ,     &
-                     vol_ipt      ,gs        ,thklyl   ,etse     ,g_imp    ,     &
+                     vol_ipt    ,gs        ,thklyl   ,etse     ,g_imp    ,     &
                      dpla       ,tstar     ,jthe     ,hardm    ,epchk    ,     &
                      npttot     ,lbuf%pla  ,off_old  ,lbuf%off ,ioff_duct,     &
                      sigoxx     ,sigoyy    ,sigoxy   ,sigoyz   ,sigozx   ,     &
@@ -1436,42 +1436,42 @@
                 &ngl    , ismstr , ipm     , gs      )
               elseif (ilaw == 63) then
                 call sigeps63c(&
-                &jlt,          nuparam0,      nuvar,        nfunc,&
-                &ifunc,        npf,          npt,          ipt,&
-                &iflag,        tf,           tt,           dt1c,&
-                &uparam0,       rho,          area,         eint,&
-                &thklyl,       epspxx,       epspyy,       epspxy,&
-                &epspyz,       epspzx,       depsxx,       depsyy,&
-                &depsxy,       depsyz,       depszx,       epsxx,&
-                &epsyy,        epsxy,        epsyz,        epszx,&
-                &sigoxx,sigoyy,sigoxy,sigoyz,&
-                &sigozx,signxx,       signyy,       signxy,&
-                &signyz,       signzx,       sigvxx,       sigvyy,&
-                &sigvxy,       sigvyz,       sigvzx,       ssp,&
-                &viscmx,       thkn,         lbuf%pla,     uvar,&
-                &off,          ngl,          etse,         gs,&
-                &vol_ipt,        sigy,         el_temp,       die,&
-                &coef,         inloc,        varnl(1,it),  jthe,&
-                &lbuf%off)
+                 jlt,          nuparam0,      nuvar,        nfunc,&
+                 ifunc,        npf,          npt,          ipt,&
+                 iflag,        tf,           tt,           dt1c,&
+                 uparam0,       rho,          area,         eint,&
+                 thklyl,       epspxx,       epspyy,       epspxy,&
+                 epspyz,       epspzx,       depsxx,       depsyy,&
+                 depsxy,       depsyz,       depszx,       epsxx,&
+                 epsyy,        epsxy,        epsyz,        epszx,&
+                 sigoxx,       sigoyy,       sigoxy,       sigoyz,&
+                 sigozx,       signxx,       signyy,       signxy,&
+                 signyz,       signzx,       sigvxx,       sigvyy,&
+                 sigvxy,       sigvyz,       sigvzx,       ssp,&
+                 viscmx,       thkn,         lbuf%pla,     uvar,&
+                 off,          ngl,          etse,         gs,&
+                 vol0,         sigy,         el_temp,       die,&
+                 coef,         inloc,        varnl(1,it),  jthe,&
+                 lbuf%off)
               elseif (ilaw == 64) then
                 call sigeps64c(&
-                &jlt,          nuparam0,      nuvar,        nfunc,&
-                &ifunc,        npf,          npt,          ipt,&
-                &iflag,        tf,           tt,           dt1c,&
-                &uparam0,       rho,          area,         eint,&
-                &thklyl,       epspxx,       epspyy,       epspxy,&
-                &epspyz,       epspzx,       depsxx,       depsyy,&
-                &depsxy,       depsyz,       depszx,       epsxx,&
-                &epsyy,        epsxy,        epsyz,        epszx,&
-                &sigoxx,sigoyy,sigoxy,sigoyz,&
-                &sigozx,signxx,       signyy,       signxy,&
-                &signyz,       signzx,       sigvxx,       sigvyy,&
-                &sigvxy,       sigvyz,       sigvzx,       ssp,&
-                &viscmx,       thkn,         lbuf%pla,     uvar,&
-                &off,          ngl,          ipm,          matly(jmly),&
-                &etse,         gs,           vol_ipt,        sigy,&
-                &el_temp,       die,          coef,         inloc,&
-                &varnl(1,it),  jthe,         lbuf%off)
+                 jlt,          nuparam0,      nuvar,        nfunc,&
+                 ifunc,        npf,          npt,          ipt,&
+                 iflag,        tf,           tt,           dt1c,&
+                 uparam0,       rho,          area,         eint,&
+                 thklyl,       epspxx,       epspyy,       epspxy,&
+                 epspyz,       epspzx,       depsxx,       depsyy,&
+                 depsxy,       depsyz,       depszx,       epsxx,&
+                 epsyy,        epsxy,        epsyz,        epszx,&
+                 sigoxx,       sigoyy,       sigoxy,       sigoyz,&
+                 sigozx,       signxx,       signyy,       signxy,&
+                 signyz,       signzx,       sigvxx,       sigvyy,&
+                 sigvxy,       sigvyz,       sigvzx,       ssp,&
+                 viscmx,       thkn,         lbuf%pla,     uvar,&
+                 off,          ngl,          ipm,          matly(jmly),&
+                 etse,         gs,           vol0,         sigy,&
+                 el_temp,      die,          inloc,             &
+                 varnl(1,it),  jthe,         lbuf%off)
 !
               elseif (ilaw == 65) then
                 call sigeps65c(&
@@ -1531,14 +1531,15 @@
                 &epspyz,       epspzx,       depsxx,       depsyy,&
                 &depsxy,       depsyz,       depszx,       epsxx,&
                 &epsyy,        epsxy,        epsyz,        epszx,&
-                &sigoxx,sigoyy,sigoxy,sigoyz,&
-                &sigozx,signxx,       signyy,       signxy,&
+                &sigoxx,       sigoyy,       sigoxy,       sigoyz,&
+                &sigozx,       signxx,       signyy,       signxy,&
                 &signyz,       signzx,       sigvxx,       sigvyy,&
                 &sigvxy,       sigvyz,       sigvzx,       ssp,&
                 &viscmx,       thkn,         lbuf%pla,     uvar,&
                 &off,          ngl,          ipm,          matly(jmly),&
-                &etse,         gs,           sigy,         vol_ipt,&
-                &el_temp,       ismstr,       jthe)
+                &etse,         gs,           sigy,         vol0,&
+                &el_temp,      ismstr,       jthe)
+!
               elseif (ilaw == 72) then
                 call sigeps72c(&
                 &jlt      ,nuparam0  ,nuvar    ,&
@@ -1549,6 +1550,7 @@
                 &ssp      ,thkn     ,lbuf%pla ,uvar     ,off      ,&
                 &etse     ,gs       ,sigy     ,hardm    ,lbuf%seq ,&
                 &dpla     ,lbuf%dmg ,inloc    ,varnl(1,it),lbuf%off)
+!
               elseif (ilaw == 73) then
                 call sigeps73c(&
                 &jlt,          nuparam0,      nuvar,        tt,&
@@ -1557,15 +1559,15 @@
                 &epspxy,       epspyz,       epspzx,       depsxx,&
                 &depsyy,       depsxy,       depsyz,       depszx,&
                 &epsxx,        epsyy,        epsxy,        epsyz,&
-                &epszx,        sigoxx,sigoyy,sigoxy,&
-                &sigoyz,sigozx,signxx,       signyy,&
+                &epszx,        sigoxx,       sigoyy,       sigoxy,&
+                &sigoyz,       sigozx,       signxx,       signyy,&
                 &signxy,       signyz,       signzx,       sigvxx,&
                 &sigvyy,       sigvxy,       sigvyz,       sigvzx,&
                 &ssp,          viscmx,       thkn,         lbuf%pla,&
                 &uvar,         off,          ngl,          itable,&
                 &etse,         gs,           sigy,         dpla,&
-                &lbuf%epsd,    table,        vol_ipt,        el_temp,&
-                &die,          coef,         npf,          nfunc,&
+                &lbuf%epsd,    table,        vol0,         el_temp,&
+                &die,          npf,          nfunc,&
                 &ifunc,        tf,           shf,          hardm,&
                 &lbuf%seq,     inloc,        varnl(1,it),  jthe,&
                 &lbuf%off)
@@ -3002,8 +3004,9 @@
           enddo
 !
           if (jthe > 0 .and. mtn /= 2) then
-            die(jft:jlt) = die(jft:jlt) +&
-            &coef(jft:jlt)*( degmb(jft:jlt)*half*vol0(jft:jlt) + degfx(jft:jlt)*thk0(jft:jlt)*half*vol0(jft:jlt) )
+            die(jft:jlt) = die(jft:jlt)                                         &
+                         + coef*(degmb(jft:jlt)*half*vol0(jft:jlt)     &
+                         + degfx(jft:jlt)*thk0(jft:jlt) *half*vol0(jft:jlt) )
           endif
 !---------------------------------------------------
 !      check element failure with xfem


### PR DESCRIPTION
Added missing energy scaling factor defined in /heat/mat with law2
Correct element volume used in conjunction with total energy in laws 63,64,71,74 for temperature update

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
