### PR TITLE
correction potential issue with submodel transform

### DIFF
--- a/starter/source/model/submodel/lectranssub.F
+++ b/starter/source/model/submodel/lectranssub.F
@@ -651,7 +651,21 @@ C--------------------------------------------------
      .                    I1=ID,
      .                    C1=TITR,
      .                    I2=N0)
+              X0(1) = ZERO
+              X0(2) = ZERO
+              X0(3) = ZERO
+            ELSE
+C
+              X0(1) = X(1,I0)
+              X0(2) = X(2,I0) 
+              X0(3) = X(3,I0)
+              IF(TAGNODSUB(I0) == ITRANSSUB) THEN
+                DO J=1,I-1
+                  IF(RTRANS(J,1) == ITRANSSUB) CALL RTRANSPOS(X0,J,RTRANS)
+                END DO
+              END IF
             END IF
+
             IF (I1 == 0) THEN
               CALL ANCMSG(MSGID=694,
      .                    MSGTYPE=MSGERROR,
@@ -659,13 +673,19 @@ C--------------------------------------------------
      .                    I1=ID,
      .                    C1=TITR,
      .                    I2=N1)
+              X1(1) = ZERO
+              X1(2) = ZERO
+              X1(3) = ZERO
+            ELSE
+              X1(1) = X(1,I1)
+              X1(2) = X(2,I1) 
+              X1(3) = X(3,I1)
+              IF(TAGNODSUB(I1) == ITRANSSUB) THEN
+                DO J=1,I-1
+                  IF(RTRANS(J,1) == ITRANSSUB) CALL RTRANSPOS(X1,J,RTRANS)
+                END DO
+              END IF
             END IF
-            X0(1) = X(1,I0)
-            X0(2) = X(2,I0) 
-            X0(3) = X(3,I0)
-            X1(1) = X(1,I1)
-            X1(2) = X(2,I1) 
-            X1(3) = X(3,I1)
           ELSE
             X0(1) = X0(1) * FAC_L 
             X0(2) = X0(2) * FAC_L  
@@ -674,18 +694,6 @@ C--------------------------------------------------
             X1(2) = X1(2) * FAC_L  
             X1(3) = X1(3) * FAC_L 
           ENDIF
-C
-          IF(TAGNODSUB(I0) == ITRANSSUB) THEN
-            DO J=1,I-1
-              IF(RTRANS(J,1) == ITRANSSUB) CALL RTRANSPOS(X0,J,RTRANS)
-            END DO
-          END IF
-C
-          IF(TAGNODSUB(I1) == ITRANSSUB) THEN
-            DO J=1,I-1
-              IF(RTRANS(J,1) == ITRANSSUB) CALL RTRANSPOS(X1,J,RTRANS)
-            END DO
-          END IF
 C
           DO J=1,3
             RTRANS(I,J+11) = X0(J)
@@ -725,6 +733,11 @@ c
               X0(1) = X(1,I0)
               X0(2) = X(2,I0) 
               X0(3) = X(3,I0)
+              IF(TAGNODSUB(I0) == ITRANSSUB) THEN
+                DO J=1,I-1
+                  IF(RTRANS(J,1) == ITRANSSUB) CALL RTRANSPOS(X0,J,RTRANS)
+                END DO
+              END IF
             ENDIF
           ELSE
             X0(1) = ZERO
@@ -736,11 +749,6 @@ C
             RTRANS(I,J+11) = X0(J)
           ENDDO
 C
-          IF(TAGNODSUB(I0) == ITRANSSUB) THEN
-            DO J=1,I-1
-              IF(RTRANS(J,1) == ITRANSSUB) CALL RTRANSPOS(X0,J,RTRANS)
-            END DO
-          END IF
 C
           WRITE(IOUT,1000) ID,ID_TRANSSUB   
           WRITE(IOUT,1010) RTRANS(I,12),RTRANS(I,13),RTRANS(I,14),RTRANS(I,20),RTRANS(I,21),RTRANS(I,22)


### PR DESCRIPTION
This pull request refactors the handling of coordinate initialization and transformation logic in the `LECTRANSSUB` subroutine, improving clarity and correctness for nodes associated with `ITRANSSUB`. The main changes ensure that coordinate arrays `X0` and `X1` are properly zeroed or set, and that transformation routines are only applied at the appropriate points, reducing redundancy and potential errors.

**Coordinate Initialization and Transformation Logic:**

* Coordinates `X0` and `X1` are now explicitly set to zero when their respective node indices (`I0`, `I1`) are zero, and transformation routines are only applied if the node is tagged as `ITRANSSUB`.
* The transformation routine `RTRANSPOS` for `X0` and `X1` has been moved from the end of the subroutine to immediately after their initialization, ensuring transformations are applied only once and at the correct location. [[1]](diffhunk://#diff-5e4ac56f01e8567c2227777194affd1ce0e8d94a06eb700328507b2b6402041aR654-R688) [[2]](diffhunk://#diff-5e4ac56f01e8567c2227777194affd1ce0e8d94a06eb700328507b2b6402041aR736-R740)
* Removed redundant transformation blocks for `X0` and `X1` at the end of the subroutine, as these are now handled earlier in the logic. [[1]](diffhunk://#diff-5e4ac56f01e8567c2227777194affd1ce0e8d94a06eb700328507b2b6402041aL677-L688) [[2]](diffhunk://#diff-5e4ac56f01e8567c2227777194affd1ce0e8d94a06eb700328507b2b6402041aL739-L743)