### PR TITLE
support empty line in set

### DIFF
--- a/starter/source/model/sets/hm_set.F
+++ b/starter/source/model/sets/hm_set.F
@@ -262,6 +262,8 @@ C-----------------------------------------------
 
            CALL HM_GET_STRING_INDEX('KEY_type', KEYSET, J, ncharline, IS_AVAILABLE)
 
+           IF(KEYSET(1:LEN_TRIM(KEYSET)) == '') CYCLE
+
            CALL HM_GET_INT_ARRAY_INDEX('opt_D',OPT_D,J,IS_AVAILABLE,LSUBMODEL)
            CALL HM_GET_INT_ARRAY_INDEX('opt_O',OPT_O,J,IS_AVAILABLE,LSUBMODEL)
            CALL HM_GET_INT_ARRAY_INDEX('opt_G',OPT_G,J,IS_AVAILABLE,LSUBMODEL)


### PR DESCRIPTION
This pull request introduces a small but important change to the `HM_SET` subroutine in `starter/source/model/sets/hm_set.F`. The change improves data validation by skipping further processing for empty string values.

Data validation improvement:

* Added a check to skip processing when the `KEYSET` variable is an empty string, preventing unnecessary or erroneous operations in the subroutine.