### PR TITLE
ALE and EULER : printout update

### DIFF
--- a/common_source/modules/ale/ale_mod.F
+++ b/common_source/modules/ale/ale_mod.F
@@ -173,59 +173,61 @@ C-----------------------------------------------
 
         ! GRID FORMULATION PARAMETERS
         TYPE ALE_GRID_
-          my_real ALPHA
-          my_real GAMMA
-          my_real VGX
-          my_real VGY
-          my_real VGZ
-          my_real VGY0
-          my_real VGZ0
-          INTEGER NWALE_ENGINE       !        read from Engine input file with /ALE/GRID/...
-          INTEGER NWALE_RST          !        read from RESTART FILE
-          INTEGER NWALE              !        effective value used in numerical scheme
-          TYPE(FLOW_TRACKING_DATA_) FLOW_TRACKING_DATA
+          my_real :: ALPHA
+          my_real :: GAMMA
+          my_real :: VGX
+          my_real :: VGY
+          my_real :: VGZ
+          my_real :: VGY0
+          my_real :: VGZ0
+          INTEGER :: NWALE_ENGINE       !        read from Engine input file with /ALE/GRID/...
+          INTEGER :: NWALE_RST          !        read from RESTART FILE
+          INTEGER :: NWALE              !        effective value used in numerical scheme
+          TYPE(FLOW_TRACKING_DATA_) :: FLOW_TRACKING_DATA
         END TYPE ALE_GRID_
 
         ! UPWIND PARAMETERS
         TYPE ALE_UPWIND_
-          my_real UPWMG
-          my_real UPWOG
-          my_real UPWSM
-          my_real CUPWM
-          my_real UPWMG2
-          my_real UPWOG2
-          my_real UPWSM2
-          INTEGER I_SUPG_ON_OFF
-          INTEGER UPWM
-          INTEGER UPW_UPDATE
+          my_real :: UPWMG
+          my_real :: UPWOG
+          my_real :: UPWSM
+          my_real :: CUPWM
+          my_real :: UPWMG2
+          my_real :: UPWOG2
+          my_real :: UPWSM2
+          INTEGER :: I_SUPG_ON_OFF
+          INTEGER :: UPWM
+          INTEGER :: UPW_UPDATE
         END TYPE ALE_UPWIND_
 
         !GLOBAL PARAMETERS
         TYPE ALE_GLOBAL_
-          INTEGER NALENOVS
-          INTEGER ICAA
-          INTEGER INCOMP
-          INTEGER ISFINT
-          INTEGER I_DT_NODA_ALE_ON
-          INTEGER I_DT_NODA_ALE_ON_KEY
-          INTEGER IDT_ALE
-          LOGICAL IS_BOUNDARY_MATERIAL
-          INTEGER LCONV
-          INTEGER CODV(10)
-          INTEGER NVCONV
-          INTEGER SNALE
-          INTEGER SIELVS
+          INTEGER :: NALENOVS
+          INTEGER :: ICAA
+          INTEGER :: INCOMP
+          INTEGER :: ISFINT
+          INTEGER :: I_DT_NODA_ALE_ON
+          INTEGER :: I_DT_NODA_ALE_ON_KEY
+          INTEGER :: IDT_ALE
+          LOGICAL :: IS_BOUNDARY_MATERIAL
+          INTEGER :: LCONV
+          INTEGER :: CODV(10)
+          INTEGER :: NVCONV
+          INTEGER :: SNALE
+          INTEGER :: SIELVS
+          INTEGER :: IS_DEFINED_ALE    !not needed for RST
+          INTEGER :: IS_DEFINED_EULER  !not needed for RST
         END TYPE ALE_GLOBAL_
 
         !ALE SUBCCLING (obsolete)
         TYPE ALE_SUB_
-          INTEGER IALESUB
-          INTEGER IFSUB
-          INTEGER IFSUBM
-          INTEGER NODSUBDT
-          my_real DT1SAVE
-          my_real DTFSUB
-          my_real DTMSUB
+          INTEGER :: IALESUB
+          INTEGER :: IFSUB
+          INTEGER :: IFSUBM
+          INTEGER :: NODSUBDT
+          my_real :: DT1SAVE
+          my_real :: DTFSUB
+          my_real :: DTMSUB
         END TYPE ALE_SUB_
 
         !ALE REZONING (variable to rezone)
@@ -301,6 +303,8 @@ C-----------------------------------------------
           this%GLOBAL%NVCONV = 0
           this%GLOBAL%SNALE = 0
           this%GLOBAL%SIELVS = 0
+          this%GLOBAL%IS_DEFINED_ALE = 0
+          this%GLOBAL%IS_DEFINED_EULER = 0
           !---ALE%SUB
           this%SUB%IALESUB = 0
           this%SUB%IFSUB = 0

--- a/starter/source/starter/contrl.F
+++ b/starter/source/starter/contrl.F
@@ -192,6 +192,7 @@ C-----------------------------------------------
      .        NPYFUN
       INTEGER IARCHS(8)
       INTEGER IS_BEGIN,SCHAR
+      INTEGER :: NPROP,NALEMAT,NEULERMAT
       INTEGER     IHBE_DS,ISST_DS,IPLA_DS,IFRAME_DS,ITET4_D,ITET10_D,ICPRE_D,IMAS_DS,ICONTROL_D,
      .            IHBE_D,IPLA_D,ISTR_D,ITHK_D,ISHEA_D,ISST_D,
      .            ISH3N_D, ISTRA_D,NPTS_D,IDRIL_D,IOFFSET_D,DEF_INTER(100)
@@ -951,15 +952,25 @@ C---------------------------------------------------
       NLASER = 0
       CALL HM_OPTION_COUNT('/DFS/LASER',NLASER)
 C---------------------------------------------------
-      JEUL=0
-      CALL HM_OPTION_COUNT('/EULER/MAT', JEUL)
-      JEUL=MIN(JEUL,1)
+!  DETECT ALE OR EULER FRAMEWORK
+C---------------------------------------------------
+      CALL HM_OPTION_COUNT('/ALE/MAT',NALEMAT)
+      CALL HM_OPTION_COUNT('/EULER/MAT',NEULERMAT)
+      IF(NALEMAT > 0)  ALE%GLOBAL%IS_DEFINED_ALE = 1
+      IF(NEULERMAT > 0)ALE%GLOBAL%IS_DEFINED_EULER = 1
+      CALL HM_OPTION_COUNT('/PROP', NPROP)
+      DO I=1,NPROP
+        CALL HM_OPTION_START('/PROP')
+        CALL HM_OPTION_NEXT()
+        CALL HM_GET_INTV('Iale',JALE,IS_AVAILABLE,LSUBMODEL)
+        IF(JALE == 1) ALE%GLOBAL%IS_DEFINED_ALE = 1
+        IF(JALE == 2) ALE%GLOBAL%IS_DEFINED_EULER = 1
+        IF(ALE%GLOBAL%IS_DEFINED_EULER == 1 .AND. ALE%GLOBAL%IS_DEFINED_EULER == 1)EXIT
+      ENDDO
+      JEUL = ALE%GLOBAL%IS_DEFINED_EULER ! =1 : if /EULER/MAT or /PROP/SOLID (IALE=2) is defined within the input file
+      JALE = ALE%GLOBAL%IS_DEFINED_ALE   ! =1 : if /ALE/MAT or /PROP/SOLID (IALE=1) is defined within the input file
       LVEUL=32
       IF(INTEG8==1)LVEUL=52
-C---------------------------------------------------
-      JALE=0
-      CALL HM_OPTION_COUNT('/ALE/MAT', JALE)
-      JALE=MIN(JALE,1)
 C---------------------------------------------------
       NALEBCS = 0
       CALL HM_OPTION_COUNT('/ALE/BCS', NALEBCS)


### PR DESCRIPTION
#### ALE and EULER : printout update

#### Description of the changes
Fix: In contrl.F, property cards (/PROP/SOLID, /PROP/TYPE14, …) were not yet being processed by the reader. As a result, when /ALE/MAT or /EULER/MAT were absent and the ALE/EULER frameworks were enabled via a property flag, the expected printout was missing. The printout is now generated correctly.