### PR TITLE
Correct h3d output bug of WPLA in fully integrated triangle shell elements

### DIFF
--- a/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_shell_scalar_1.F
@@ -2455,23 +2455,15 @@ c ILAYER=NULL NPT=NULL
                         ENDDO
                       ENDIF ! igtyp
                     ELSE ! ITY == 7
-                      IF(IGTYP == 51 .OR. IGTYP == 52) THEN
-                        NPTT = BUFLY%NPTT
-                        DO IT = 1,NPTT
-                          DO IR =1,NPG
-                            DO  I=1,NEL
-                              VALUE(I) =  VALUE(I) + THIRD*BUFLY%LBUF(IR,1,IT)%PLA(I)/NPTT
-                              IS_WRITTEN_VALUE(I) = 1
-                            ENDDO
+                      NPTT = BUFLY%NPTT
+                      DO IT = 1,NPTT
+                        DO IR =1,NPG
+                          DO  I=1,NEL
+                            VALUE(I) =  VALUE(I) + THIRD*BUFLY%LBUF(IR,1,IT)%PLA(I)/NPTT
+                            IS_WRITTEN_VALUE(I) = 1
                           ENDDO
                         ENDDO
-                      ELSE
-                        DO I=1,NEL
-                          VALUE(I) = THIRD*(BUFLY%LBUF(1,1,1)%PLA(I) + BUFLY%LBUF(1,1,1)%PLA(I) +
-     .                                       BUFLY%LBUF(1,1,1)%PLA(I))
-                          IS_WRITTEN_VALUE(I) = 1
-                        ENDDO
-                      ENDIF ! igtyp
+                      ENDDO
                     ENDIF  ! ity
                   ELSE ! NPG == 1
                     IF(IGTYP == 51 .OR. IGTYP == 52)THEN


### PR DESCRIPTION
For shell properties other than type 51/52 the mean value of WPLA  over integration points was wrong in h3d output

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
