### PR TITLE
correction on law42c (shell) to be plane-stress and consistency between Prony input in&out of material

### DIFF
--- a/engine/source/materials/mat/mat042/sigeps42c.F
+++ b/engine/source/materials/mat/mat042/sigeps42c.F
@@ -67,24 +67,34 @@ C----------------------------------------------------------------
 C----------------------------------------------------------------
 C  L O C A L  V A R I B L E S
 C----------------------------------------------------------------
-      INTEGER :: I,J,II,NPRONY,NORDER,ITER,JNV
+      INTEGER :: I,J,II,NPRONY,NORDER,ITER,JNV,NITER
       my_real :: SUM,FAC,FSCAL,TENSCUT,SUMDWDL,SUMDDWDDL,PARTP,AMAX
       my_real :: E11,E22,E12,EMAX,GMAX,GVMAX,NU,RBULK,A11,PUI11,PUI22,ALMA1,ALMA2,ALMA3
       my_real ,DIMENSION(3)       :: DDWDDL,DWDL,LAM_AL
       my_real ,DIMENSION(10)      :: MU,AL    
-      my_real ,DIMENSION(100)     :: GI,TAUX,H1,H2,H12,H10,H20,H120
-      my_real ,DIMENSION(NEL,100) :: H30,H31
-      my_real ,DIMENSION(NEL)     :: RVT,C30,C31,DC3EV3,CD10,CD20,CD120,GTMAX
-      my_real ,DIMENSION(NEL)     :: CP1,CP2,CD1,CD2,CD12,INVRV,INVV3,DEZZ,RV,TRAV,ROOTV
-      my_real ,DIMENSION(NEL)     :: S2,CS,KT3,EPSZZ,RHO
-      my_real ,DIMENSION(NEL,10)  :: EVMA1,EVMA2,EVMA3
-      my_real ,DIMENSION(NEL,3)   :: T,SV,SIGPRV,EVV,EV,EVM,CII        
+      my_real ,DIMENSION(NEL)     :: RVT,GTMAX,DLAM3
+      my_real ,DIMENSION(NEL)     :: INVRV,INVV3,DEZZ,RV,TRAV,ROOTV
+      my_real ,DIMENSION(NEL)     :: S2,CS,KT3,RHO,KIR3
+      my_real ,DIMENSION(NEL,3)   :: T,SV,SIGPRV,EVV,EV,EVM,CII,S_LDWDL      
       my_real ,DIMENSION(NEL,3,2) :: EIGV(NEL,3,2)      
+      my_real :: DAV,H0(4),DEPSZZ,TAUX
+      my_real ,DIMENSION(NEL)     :: A1,A2
+      my_real ,DIMENSION(NEL,4)   :: DEVS
+      my_real, DIMENSION(:) , ALLOCATABLE :: GI,BETA
+      my_real, DIMENSION(:,:) , ALLOCATABLE :: AA,BB,H11
 C=======================================================================
 C SET INITIAL MATERIAL CONSTANTS
       
       NORDER = IPARAM(1)
       NPRONY = IPARAM(2)
+      IF (NPRONY>0) THEN 
+        ALLOCATE(AA(NEL,NPRONY)) 
+        ALLOCATE(BB(NEL,NPRONY)) 
+        ALLOCATE(H11(6,NPRONY)) 
+        ALLOCATE(GI(NPRONY)) 
+        ALLOCATE(BETA(NPRONY)) 
+      ENDIF
+      SV(1:NEL,1:3) = ZERO
 !
       DO I=1,NORDER
         MU(I) = UPARAM(I)
@@ -99,27 +109,16 @@ C SET INITIAL MATERIAL CONSTANTS
       GVMAX = ZERO
       DO I=1,NPRONY                       
         GI(I)   = UPARAM(24 + I)          
-        TAUX(I) = UPARAM(24 + NPRONY + I) 
+        TAUX    = UPARAM(24 + NPRONY + I) 
         GVMAX = GVMAX +  GI(I)
+        BETA(I) = ONE/TAUX
       ENDDO                               
       DO I=1,NORDER
         GMAX = GMAX + MU(I)*AL(I)
       ENDDO                               
       GMAX = GMAX + GVMAX
 C
-C     User variables initialisation
-      IF (TIME == ZERO .AND. ISIGI == 0) THEN 
-        DO I=1,NEL                          
-          DO J=1,NUVAR                          
-            UVAR(I,J) = ZERO                  
-          ENDDO                               
-          UVAR(I,3) = ONE                      
-        ENDDO 
-      ELSEIF (TIME == ZERO ) THEN 
-        DO I=1,NEL                                  
-          UVAR(I,3) = ONE           
-        ENDDO 
-      ENDIF                                   
+      NITER = 4
 C     principal stretch (def gradient eigenvalues)
       DO I=1,NEL
         TRAV(I)  = EPSXX(I)+EPSYY(I)
@@ -178,288 +177,105 @@ C     Strain definition
           EV(I,3)=ONE/EV(I,1)/EV(I,2)
         ENDDO
       ENDIF
-      IF (NPRONY >  0) EV(1:NEL,3) = UVAR(1:NEL,3)
       DO I=1,NEL
         IF (OFF(I)==ZERO.OR.OFF(I)==FOUR_OVER_5) EV(I,1:3)=ONE
       ENDDO 
-C--------------------------------------
-C     Newton method =>  Find EV(3) : T3(EV(3)) = 0
-C--------------------------------------
-      IF (NPRONY  > 0) THEN
-C--------------------------------------
-C       Newton method =>  Find EV(3) : T3(EV(3)) = 0
-C--------------------------------------                                                             
-        DO ITER = 1,5
-!       ----------------------- 
-          DO I=1,NEL 
-            RV(I) = EV(I,1)*EV(I,2)*EV(I,3)                                    
-c----       normalized stretch => unified compressible/uncompressible formulation   
-            ! RVT = RV(I)**(-THIRD)
-            ! RV = 0 --> RVT = 0
-            ! else   --> RVT = exp( -third * ln( RV)) 
-            IF (RV(I)/= ZERO) THEN
-              RVT(I) = EXP( (-THIRD)* LOG(RV(I)) )
-              INVRV(I) = ONE / RV(I)
-            ELSE
-              RVT(I)   = ZERO
-              INVRV(I) = ZERO
-            ENDIF             
-            EVM(I,1) = EV(I,1)*RVT(I)                                      
-            EVM(I,2) = EV(I,2)*RVT(I)                                      
-            EVM(I,3) = EV(I,3)*RVT(I)
-          ENDDO  ! 1,NEL    
-!       -----------------------                                   
-          ! partial derivatives of strain energy
-          DO J = 1,NORDER
-            DO I=1,NEL 
-              ! EVMA(I) = MU * EVM(I) ** AL(I) :
-              ! EVM = 0 --> EVMA(I) = 0
-              ! AL  = 0 --> EVMA(I) = MU
-              ! else    --> EVMA(I) = MU * exp(AL(I) * ln( EVM(I)))
-              IF(EVM(I,1)==ZERO) THEN
-                EVMA1(I,J) = ZERO
-              ELSE
-               IF (AL(J) == ZERO) THEN
-                 EVMA1(I,J) = MU(J)
-               ELSE
-                 EVMA1(I,J) = MU(J) * EXP(AL(J)* LOG(EVM(I,1)) )
-               ENDIF
-              ENDIF
-!
-              IF(EVM(I,2)==ZERO) THEN
-                EVMA2(I,J) = ZERO
-              ELSE
-               IF (AL(J) == ZERO) THEN
-                 EVMA2(I,J) = MU(J)
-               ELSE
-                 EVMA2(I,J) = MU(J) * EXP(AL(J)* LOG(EVM(I,2)) )
-               ENDIF
-              ENDIF
-!              
-              IF(EVM(I,3)==ZERO) THEN
-                EVMA3(I,J) = ZERO
-              ELSE
-                IF (AL(J) == ZERO) THEN
-                  EVMA3(I,J) = MU(J)
-                ELSE
-                  EVMA3(I,J) = MU(J) * EXP(AL(J)* LOG(EVM(I,3)) )
-               ENDIF
-              ENDIF    
-            ENDDO       ! 1,NEL    
-          ENDDO         ! J=1,NORDER
-!       -----------------------                   
-          DO I=1,NEL
-            DWDL(1) = ZERO          
-            DWDL(2) = ZERO          
-            DWDL(3) = ZERO          
-            DO J=1,NORDER                                                
-              DWDL(1) = DWDL(1) + EVMA1(I,J)        
-              DWDL(2) = DWDL(2) + EVMA2(I,J)        
-              DWDL(3) = DWDL(3) + EVMA3(I,J)
-            END DO        
-            SUMDWDL = (DWDL(1) + DWDL(2) + DWDL(3)) * THIRD                            
-            PARTP   = RBULK*(RV(I)- ONE)                                           
-c---------
-c           principal cauchy stress
-            IF (EV(I,3) == ZERO) THEN
-              INVV3(I) = ZERO
-            ELSE
-              INVV3(I) = ONE / EV(I,3)
-            ENDIF
-            T(I,1)  = (DWDL(1) - SUMDWDL) *INVRV(I)  + PARTP                         
-            T(I,2)  = (DWDL(2) - SUMDWDL) *INVRV(I)  + PARTP                         
-            T(I,3)  = (DWDL(3) - SUMDWDL) *INVRV(I)  + PARTP                         
-c---------
-            KT3(I) = -THIRD*(DWDL(1) + DWDL(2)) + TWO_THIRD*(DWDL(3))          
-            KT3(I) = -EV(I,1)*EV(I,2)*KT3(I)*INVRV(I)*INVRV(I)  + RBULK*EV(I,1)*EV(I,2)
-!
-            ALMA1 = ZERO
-            ALMA2 = ZERO
-            ALMA3 = ZERO
-            DO J=1,NORDER
-              ALMA1 = ALMA1 + AL(J)*EVMA1(I,J)                                             
-              ALMA2 = ALMA2 + AL(J)*EVMA2(I,J)                                             
-              ALMA3 = ALMA3 + AL(J)*EVMA3(I,J)                                             
-            END DO        
-            KT3(I) = KT3(I) + (ONE_OVER_9*(ALMA1 + ALMA2 + FOUR*(ALMA3))) * INVRV(I)*INVV3(I)                                            
-C           Viscosity Treatment            
-            C30(I) = UVAR(I,5) 
-C
-            SUM = THIRD*(EVM(I,1)**2 +  EVM(I,2)**2 + EVM(I,3)**2)
-            C31(I)   =  EVM(I,3)**2 - SUM 
-            ! SV3 = ZERO
-            DC3EV3(I) = FOUR_OVER_3*RVT(I)*EVM(I,3)-TWO_THIRD*INVV3(I)* 
-     .                 (TWO_THIRD*EVM(I,3)**2 - THIRD*EVM(I,1)**2 - THIRD*EVM(I,2)**2)
-          ENDDO  ! 1,NEL
-!       -----------------------  
-          JNV = 8
-          DO II= 1,NPRONY
-            FAC= -TIMESTEP/TAUX(II)                          
-            H30(1:NEL,II) = UVAR(1:NEL,JNV + II)                
-            H31(1:NEL,II) = EXP(FAC)*H30(1:NEL,II)+ EXP(HALF*FAC)*(C31(1:NEL) - C30(1:NEL)) 
-          ENDDO
-C         Kirchoff visco stress --->
-C         PK2 stress, PK2 = F**(-1)*Taux* F**(-T)n 
-C         cauchy =Taux/RV is used here
-          DO II = 1,NPRONY
-                  FAC= -TIMESTEP/TAUX(II) 
-                  T(1:NEL,3) = T(1:NEL,3) + GI(II)*H31(1:NEL,II)*INVRV(1:NEL)
-                  KT3(1:NEL) = KT3(1:NEL) - GI(II)*H31(1:NEL,II)*INVV3(1:NEL)*INVRV(1:NEL)
-     .                 + DC3EV3(1:NEL)*GI(II)*EXP(HALF*FAC)*INVRV(1:NEL)
-          ENDDO
-          DO I=1,NEL                                                 
-            IF (OFF(I)==ZERO.OR.OFF(I)==FOUR_OVER_5) CYCLE
-            IF (ABS(KT3(I))>EM20) EV(I,3) = EV(I,3)  - T(I,3)/KT3(I)
-          ENDDO
-        ENDDO  ! iteration
-!       -----------------------
-C       stored converged solution
-        JNV = 8
-        DO II= 1,NPRONY
-           UVAR(1:NEL,JNV  + II) =  H31(1:NEL,II)
+!    old iterartive Pnony removed, new formulation uncoupling w/ Prony 
+!--------------------------------------
+!       Newton method =>  Find EV(3) : Kirchoff J*T3(EV(3)) = 0
+!--------------------------------------
+      DLAM3(1:NEL) =ZERO
+      DO ITER = 1,NITER
+        EV(1:NEL,3) = UVAR(1:NEL,3)+DLAM3(1:NEL) ! initial value takes lamda3(t)
+        DO I=1,NEL 
+          RV(I) = EV(I,1)*EV(I,2)*EV(I,3)                                    
+          RVT(I) = EXP( (-THIRD)* LOG(RV(I)) )
+          EVM(I,1:3) = EV(I,1:3)*RVT(I)                                      
+        ENDDO  ! 1,NEL    
+        KIR3(1:NEL) = ZERO
+        KT3(1:NEL) = ZERO
+        DO II = 1,NORDER
+          IF (MU(II)*AL(II) /= ZERO) THEN
+            DO I=1,NEL
+              IF (OFF(I)==ZERO.OR.OFF(I)==FOUR_OVER_5) CYCLE
+              LAM_AL(1:3) = EXP(AL(II)*LOG(EVM(I,1:3)))
+              SUMDWDL = THIRD*(LAM_AL(1)+LAM_AL(2)+LAM_AL(3))
+              SUM = MU(II)*(LAM_AL(3)-SUMDWDL) 
+              KIR3(I) = KIR3(I) + SUM 
+              KT3(I)  = KT3(I) + AL(II)*SUM
+            ENDDO
+          ENDIF
         ENDDO
-        DO I=1,NEL
-           UVAR(I,5) = C31(I) 
-C           
-           RV(I)   = EV(I,1)*EV(I,2)*EV(I,3)
-! compute viscos stress
-           ! RVT = RV(I) ** (-THIRD) :
-           ! RV(I) = 0 --> RVT = 0
-           ! else      --> RVT = exp((-THIRD) * ln(RV(I)) 
-           IF (RV(I) /= ZERO) THEN
-             RVT(I) = EXP( (-THIRD)* LOG(RV(I)) )
-           ELSE
-             RVT(I)   = ZERO
-           ENDIF            
-           EVM(I,1) = EV(I,1)*RVT(I)
-           EVM(I,2) = EV(I,2)*RVT(I)
-           EVM(I,3) = EV(I,3)*RVT(I)
-C           
-           CD10(I) = UVAR(I,6) 
-           CD20(I) = UVAR(I,7) 
-           CD120(I) = UVAR(I,8) 
-C
-           SUM  = THIRD*(EVM(I,1)**2 +  EVM(I,2)**2 + EVM(I,3)**2) 
-           CP1(I)   =  EVM(I,1)**2 - SUM                          
-           CP2(I)   =  EVM(I,2)**2 - SUM
-           CD1(I)  = EIGV(I,1,1)*CP1(I) + EIGV(I,1,2)*CP2(I)
-           CD2(I)  = EIGV(I,2,1)*CP1(I) + EIGV(I,2,2)*CP2(I)
-           CD12(I) = EIGV(I,3,1)*CP1(I) + EIGV(I,3,2)*CP2(I)                        
-           UVAR(I,6) = CD1(I)
-           UVAR(I,7) = CD2(I)
-           UVAR(I,8) = CD12(I) 
-           SV(I,1) = ZERO
-           SV(I,2) = ZERO
-           SV(I,3) = ZERO
-        ENDDO 
-        JNV = 8 + NPRONY    
-        DO II= 1,NPRONY
+        DO I=1,NEL 
+          IF (OFF(I)==ZERO.OR.OFF(I)==FOUR_OVER_5) CYCLE
+          PARTP = RBULK*(RV(I)- ONE)                                           
+          T(I,3)= KIR3(I)  + PARTP*RV(I)    !Kirchoff                     
+          KT3(I)= TWO_THIRD*KT3(I)/EV(I,3)+ RBULK*(TWO*RV(I)-ONE)*EV(I,1)*EV(I,2)          
+          IF (KT3(I)>EM20) DLAM3(I) = DLAM3(I) -T(I,3)/KT3(I)
+        ENDDO
+      END DO ! ITER = 1,NITER
+      EV(1:NEL,3) = UVAR(1:NEL,3)+DLAM3(1:NEL) ! initial value takes lamda3(t): looking for (t+dt)
+      DEZZ(1:NEL) = LOG(ONE+DLAM3(1:NEL)/UVAR(1:NEL,3))
+      UVAR(1:NEL,3) =  EV(1:NEL,3) 
+! compute T1,T2 Cauchy stress
+      DO I=1,NEL
+        RV(I) = EV(I,1)*EV(I,2)*EV(I,3)                                    
+        RVT(I) = EXP((-THIRD)*LOG(RV(I))) ! -> J^(-1/3)
+        EVM(I,1:3) = EV(I,1:3)*RVT(I) 
+        INVRV(I) = ONE / RV(I)
+      END DO
+      S_LDWDL(1:NEL,1:3) = ZERO
+      DO II = 1,NORDER
+         IF (MU(II)*AL(II) /= ZERO) THEN
+           DO I=1,NEL
+             LAM_AL(1:3) = EXP(AL(II)*LOG(EVM(I,1:3)))
+             S_LDWDL(I,1:3)  = S_LDWDL(I,1:3) + MU(II)*LAM_AL(1:3)
+           ENDDO
+         ENDIF
+      ENDDO
+      DO I=1,NEL
+        SUMDWDL = (S_LDWDL(I,1) + S_LDWDL(I,2) + S_LDWDL(I,3)) * THIRD                            
+        PARTP   = RBULK*(RV(I)- ONE)                                           
+        T(I,1)  = (S_LDWDL(I,1) - SUMDWDL) *INVRV(I)  + PARTP                         
+        T(I,2)  = (S_LDWDL(I,2) - SUMDWDL) *INVRV(I)  + PARTP                         
+      ENDDO                                                     
+      IF (NPRONY  > 0 ) THEN ! Prony same as /VISC/PRONY
+        A1(1:NEL) = ZERO
+        A2(1:NEL) = ZERO
+        JNV = 12
+        DO II=1,NPRONY
           DO I=1,NEL
-              FAC= -TIMESTEP/TAUX(II)                          
-              H10(II)   =  UVAR(I,JNV + II )                        
-              H20(II)   =  UVAR(I,JNV + NPRONY + II )                        
-              H120(II)  =  UVAR(I,JNV + 2*NPRONY + II )                
-              H1(II)  = EXP(FAC)*H10(II)+ EXP(HALF*FAC)*(CD1(I) - CD10(I))                
-              H2(II)  = EXP(FAC)*H20(II)+ EXP(HALF*FAC)*(CD2(I) - CD20(I))              
-              H12(II)  = EXP(FAC)*H120(II)+ EXP(HALF*FAC)*(CD12(I) - CD120(I)) 
-              UVAR(I,JNV +            II )= H1(II)              
-              UVAR(I,JNV + NPRONY   + II )= H2(II)   
-              UVAR(I,JNV + 2*NPRONY + II )= H12(II)          
-C           Kirchoff visco stress
-              SV(I,1) = SV(I,1) + GI(II)*H1(II)
-              SV(I,2) = SV(I,2) + GI(II)*H2(II)
-              SV(I,3) = SV(I,3) + GI(II)*H12(II)
-            ENDDO       ! 1,NEL                                                                   
-        ENDDO  !  NPRONY
-                             
-!     -----------------------
-      ELSE ! lam3=1/lam1/lam2 (incompressible formulation) with out viscosity
-!     -----------------------
-        DO J = 1,NORDER                                                                
-c----     normalized stretch => unified compressible/uncompressible formulation   
-C----     partial derivatives of strain energy
-          ! EVMA(I) = MU * EV(I) ** AL(I) :
-          ! EV  = 0 --> EVMA(I) = 0
-          ! AL  = 0 --> EVMA(I) = MU
-          ! else    --> EVMA(I) = MU * PUI
-          ! with PUI = exp(AL(I) * ln( EV(I)))
-          ! EVMA3 = MU * ( EV(1) * EV(2) )** (-AL(I))
-          ! --> EVMA3 = MU/ (PUI11 * PUI22)
-          DO I=1,NEL 
-            IF(EV(I,1)==ZERO) THEN
-              EVMA1(I,J) = ZERO
-            ELSE
-              IF (AL(J) == ZERO) THEN
-                EVMA1(I,J) = MU(J)
-                PUI11 = ONE
-              ELSE
-                PUI11 = EXP(AL(J)* LOG(EV(I,1)) )
-                EVMA1(I,J) = MU(J) * PUI11
-              ENDIF
-            ENDIF
-!            
-            IF(EV(I,2)==ZERO) THEN
-              EVMA2(I,J) = ZERO
-            ELSE
-              IF (AL(J) == ZERO) THEN
-                EVMA2(I,J) = MU(J)
-                PUI22 = ONE
-              ELSE
-                PUI22 = EXP(AL(J)* LOG(EV(I,2)) )
-                EVMA2(I,J) = MU(J) * PUI22
-              ENDIF
-            ENDIF
-!            
-            IF((EV(I,1)*EV(I,2))==ZERO) THEN
-              EVMA3(I,J) = ZERO
-            ELSE
-              IF (AL(J) == ZERO) THEN
-                EVMA3(I,J) = MU(J)
-              ELSE
-                EVMA3(I,J) = MU(J)/(PUI11*PUI22)
-              ENDIF
-            ENDIF
-          ENDDO    ! 1,NEL 
-        ENDDO      ! 1,NORDER
-!       -----------------------
+            AA(I,II) =  EXP(-BETA(II)*TIMESTEP) 
+            BB(I,II) =  GI(II)*EXP(-HALF*BETA(II)*TIMESTEP)  !bb/dt, and use directly despsij
+!  for computing DEPSZZ from (sigzz=0)
+            H0(3) = UVAR(I,JNV + (II - 1)*4 + 3)
+            A1(I)  = A1(I) +  AA(I,II)*H0(3) 
+            A2(I)  = A2(I) +  BB(I,II)
+          END DO
+        END DO  
         DO I=1,NEL
-          DWDL(1) = ZERO          
-          DWDL(2) = ZERO          
-          DWDL(3) = ZERO          
-          DO J=1,NORDER                                                
-            DWDL(1) = DWDL(1) + EVMA1(I,J)        
-            DWDL(2) = DWDL(2) + EVMA2(I,J)        
-            DWDL(3) = DWDL(3) + EVMA3(I,J)
-          END DO        
-c---------
-c         principal cauchy stress
-          T(I,1) = DWDL(1) - DWDL(3)                       
-          T(I,2) = DWDL(2) - DWDL(3)                                     
-          T(I,3) = ZERO            
-        ENDDO                                                     
-!       -----------------------
-!       compute stifness ! old formulation suspicious
-!        DO J = 1,NORDER
-!           ! CXX = 1/2 * MU * [1/2 * AL - 1] * EVX ** (AL - 4)
-!           ! CXY = 1/2 * MU * [1/2 * AL + 1] * (EVX * EVY) **(-AL - 4)
-!           ! AL - 4 = 0 --> CXX =  1/2 * MU * [1/2 * AL - 1]
-!           !            --> CXY = 1/2 * MU * [1/2 * AL + 1] * (EVX * EVY) **(-8)
-!           ! AL = 0     --> CXX =  1/2 * MU * [1/2 * AL - 1]* EVX ** (- 4)
-!           !            --> CXY = 1/2 * MU * [1/2 * AL + 1] * (EVX * EVY) **(-4)
-!           ! else       --> CXX =  1/2 * MU * [1/2 * AL - 1]* PUIXX / EVX**(4)
-!           !                 with PUIXX = exp( AL * ln(EVX) )
-!           !            --> CXY = 1/2 * MU * [1/2 * AL + 1] / ( PUIXX*PUIYY*(EVX**(4)*EVY**(4) )
-!        ENDDO    ! 1,NORDER
-!       -----------------------             
-        DO I=1,NEL
-          SV(I,1) = ZERO
-          SV(I,2) = ZERO
-          SV(I,3) = ZERO
-        ENDDO  ! 1,NEL
-!       -----------------------
-      ENDIF ! PRONY                                                                             
-C-------------------------------------------------------------
-c     tension cut                                                            
+           FAC = ONE/MAX(EM20,TWO_THIRD*A2(I))
+           DEPSZZ = -A1(I)*FAC + HALF*(DEPSXX(I) + DEPSYY(I))
+           DAV = THIRD*(DEPSXX(I) + DEPSYY(I) + DEPSZZ)
+           DEVS(I,1) = DEPSXX(I) - DAV
+           DEVS(I,2) = DEPSYY(I) - DAV
+           DEVS(I,3) = DEPSZZ    - DAV         
+           DEVS(I,4) = HALF*DEPSXY(I)          
+           DEZZ(I)   = DEZZ(I) + DEPSZZ
+        END DO
+!              
+        DO II= 1,NPRONY
+          DO I=1,NEL              
+            H0(1:4) = UVAR(I,JNV + (II - 1)*4 +1:4)
+            H11(1:4,II) = AA(I,II)*H0(1:4) + BB(I,II)*DEVS(I,1:4)
+            SV(I,1:2) = SV(I,1:2) + H11(1:2,II)
+            SV(I,3) = SV(I,3) + H11(4,II)
+            UVAR(I,JNV + (II - 1)*4 +1:4) = H11(1:4,II)
+          END DO
+        END DO 
+      END IF ! PRONY 
+!-------------------------------------------------------------
+!     tension cut                                                            
       DO I=1,NEL                                                             
         IF (OFF(I) /= ZERO .AND.                                             
      .   (T(I,1) > ABS(TENSCUT) .OR. T(I,2) > ABS(TENSCUT))) THEN        
@@ -469,31 +285,7 @@ c     tension cut
           OFF(I) = FOUR_OVER_5                                 
         ENDIF                                                                
       ENDDO                                                                  
-C-------------------------------------------------------------
-C     transform principal Cauchy stress to global directions
-C-------------------------------------------------------------      
-      IF (ISMSTR == 1 .OR. ISMSTR == 3 .OR. ISMSTR == 11) THEN  ! engineering strain
-        DO I=1,NEL
-          EPSZZ(I)  = EV(I,3) - ONE
-          UVAR(I,3) = EV(I,3)
-        ENDDO
-      ELSEIF (ISMSTR == 10) THEN  ! left gauchy-green strain
-        DO I=1,NEL
-          EPSZZ(I)  = EV(I,3) - ONE
-          UVAR(I,3) = EV(I,3)
-        ENDDO
-      ELSE  ! true strain
-        DO I=1,NEL
-          EPSZZ(I)  = LOG(EV(I,3))
-          UVAR(I,3) = EV(I,3)
-        ENDDO
-      ENDIF 
 ! new gt      
-      DO I=1,NEL
-        RV(I) = EV(I,1)*EV(I,2)*EV(I,3)                                    
-        AMAX = EXP((-THIRD)*LOG(RV(I))) ! -> J^(-1/3)
-        EVM(I,1:3) = EV(I,1:3)*AMAX 
-      ENDDO
       CII(1:NEL,1:3) = ZERO
       DO II = 1,NORDER
         IF (MU(II)*AL(II) /= ZERO) THEN
@@ -507,30 +299,29 @@ C-------------------------------------------------------------
       DO I = 1,NEL
         GTMAX(I) = GVMAX+HALF*MAX(CII(I,1),CII(I,2),CII(I,3)) 
       ENDDO
-c
+!
       DO I=1,NEL
-        RV(I)   = EV(I,1)*EV(I,2)*EV(I,3)
-        IF (RV(I) /= ZERO) THEN
-          INVRV(I) = ONE / RV(I)
-        ELSE
-          INVRV(I) = ZERO
-        ENDIF
-c
-        DEZZ(I) = -NU/(ONE-NU)*(DEPSXX(I)+DEPSYY(I))
-!!        DEZZ(I) = EPSZZ(I) - UVAR(I,4)
-        SIGNXX(I) = EIGV(I,1,1)*T(I,1) + EIGV(I,1,2)*T(I,2) + SV(I,1)*INVRV(I)
-        SIGNYY(I) = EIGV(I,2,1)*T(I,1) + EIGV(I,2,2)*T(I,2) + SV(I,2)*INVRV(I)
-        SIGNXY(I) = EIGV(I,3,1)*T(I,1) + EIGV(I,3,2)*T(I,2) + SV(I,3)*INVRV(I)
-        SIGNYZ(I) = SIGOYZ(I)+GS(I)*DEPSYZ(I)
-        SIGNZX(I) = SIGOZX(I)+GS(I)*DEPSZX(I)
+        SIGNXX(I) = EIGV(I,1,1)*T(I,1) + EIGV(I,1,2)*T(I,2) + SV(I,1)
+        SIGNYY(I) = EIGV(I,2,1)*T(I,1) + EIGV(I,2,2)*T(I,2) + SV(I,2)
+        SIGNXY(I) = EIGV(I,3,1)*T(I,1) + EIGV(I,3,2)*T(I,2) + SV(I,3)
+! transverse shear can't use visco(Prony) as /VISC due to incremental formulation
+        SIGNYZ(I) = SIGOYZ(I)+GS(I)*DEPSYZ(I) 
+        SIGNZX(I) = SIGOZX(I)+GS(I)*DEPSZX(I) 
         RHO(I)    = RHO0(I)*INVRV(I)
         THKN(I)   = THKN(I) + DEZZ(I)*THKLYL(I)*OFF(I)
-        UVAR(I,4) = EPSZZ(I)  
-C         
-        EMAX = MAX(GMAX,GTMAX(I))*(ONE + NU)
+         
+! 
+        EMAX = GTMAX(I)*(ONE + NU)
         A11  = EMAX/(ONE - NU**2)
         SOUNDSP(I)= SQRT(A11/RHO0(I))
       ENDDO
+      IF (NPRONY>0) THEN 
+        DEALLOCATE(AA) 
+        DEALLOCATE(BB) 
+        DEALLOCATE(H11) 
+        DEALLOCATE(GI) 
+        DEALLOCATE(BETA) 
+      ENDIF
 C-----------
       RETURN
       END

--- a/starter/source/elements/sh3n/coque3n/c3init3.F
+++ b/starter/source/elements/sh3n/coque3n/c3init3.F
@@ -94,6 +94,7 @@ C-----------------------------------------------
       use glob_therm_mod
       use initemp_shell_mod
       use element_mod , only : nixtg
+      use law42c_ini_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -490,6 +491,21 @@ c
           ENDDO ! DO IL = 1,NLAY
         ENDIF   
       ENDIF ! IF (MTN == 58) THEN
+      IF (MTN == 42 .OR. IGTYP == 51 .OR. IGTYP == 52) THEN
+          DO IL = 1,NLAY
+            NPTT  = ELBUF_STR%BUFLY(IL)%NPTT
+            ILAW  = ELBUF_STR%BUFLY(IL)%ILAW
+            NUVAR = ELBUF_STR%BUFLY(IL)%NVAR_MAT
+!
+            IF (ILAW == 42) THEN
+              DO IT=1,NPTT
+                LBUF => ELBUF_STR%BUFLY(IL)%LBUF(IR,IS,IT)
+                UVAR => ELBUF_STR%BUFLY(IL)%MAT(IR,IS,IT)%VAR 
+                CALL law42c_ini(NUVAR,UVAR,LLT)
+              ENDDO
+            ENDIF ! IF (ILAW == 42) THEN
+          ENDDO ! DO IL = 1,NLAY      
+      ENDIF
 C-----------------------------------------------------------------------
 C     CALCULATION OF INITIAL STRESSES
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7--

--- a/starter/source/elements/sh3n/coquedk/cmaini3.F
+++ b/starter/source/elements/sh3n/coquedk/cmaini3.F
@@ -56,6 +56,7 @@ C-----------------------------------------------
       USE STACK_MOD          
       USE DRAPE_MOD
       USE NAMES_AND_TITLES_MOD , ONLY : NCHARTITLE
+      use law42c_ini_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -237,6 +238,21 @@ C
             ENDIF ! ILAW
           ENDDO ! DO IL = 1,NLAY
         ENDIF  
+      ENDIF
+      IF (MTN == 42 .OR. IGTYP == 51 .OR. IGTYP == 52) THEN
+          DO IL = 1,NLAY
+            NPTT  = ELBUF_STR%BUFLY(IL)%NPTT
+            ILAW  = ELBUF_STR%BUFLY(IL)%ILAW
+            NUVAR = ELBUF_STR%BUFLY(IL)%NVAR_MAT
+!
+            IF (ILAW == 42) THEN
+              DO IT=1,NPTT
+                LBUF => ELBUF_STR%BUFLY(IL)%LBUF(IR,IS,IT)
+                UVAR => ELBUF_STR%BUFLY(IL)%MAT(IR,IS,IT)%VAR 
+                CALL law42c_ini(NUVAR,UVAR,LLT)
+              ENDDO
+            ENDIF ! IF (ILAW == 42) THEN
+          ENDDO ! DO IL = 1,NLAY      
       ENDIF
 C-----------
       RETURN

--- a/starter/source/elements/shell/coque/cinit3.F
+++ b/starter/source/elements/shell/coque/cinit3.F
@@ -95,6 +95,7 @@ C-----------------------------------------------
       use glob_therm_mod
       use initemp_shell_mod
       use element_mod , only : nixc
+      use law42c_ini_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -466,6 +467,21 @@ C
             ENDIF ! IF (ILAW == 58) THEN
           ENDDO ! DO IL = 1,NLAY      
         ENDIF 
+      END IF !(IGTYP == 51 .OR. IGTYP == 52 .AND. IGMAT > 0) THEN
+      IF (MTN == 42 .OR. IGTYP == 51 .OR. IGTYP == 52) THEN
+          DO IL = 1,NLAY
+            NPTT  = ELBUF_STR%BUFLY(IL)%NPTT
+            ILAW  = ELBUF_STR%BUFLY(IL)%ILAW
+            NUVAR = ELBUF_STR%BUFLY(IL)%NVAR_MAT
+!
+            IF (ILAW == 42) THEN
+              DO IT=1,NPTT
+                LBUF => ELBUF_STR%BUFLY(IL)%LBUF(IR,IS,IT)
+                UVAR => ELBUF_STR%BUFLY(IL)%MAT(IR,IS,IT)%VAR 
+                CALL law42c_ini(NUVAR,UVAR,LLT)
+              ENDDO
+            ENDIF ! IF (ILAW == 42) THEN
+          ENDDO ! DO IL = 1,NLAY      
       ENDIF
 C-----------------------------------------------------------------------
 C     calculation of initial constraints
@@ -636,15 +652,17 @@ C-----------------------------
       RETURN
       END SUBROUTINE CINIT3      
 !||====================================================================
-!||    csms11_ini    ../starter/source/elements/shell/coque/cinit3.F
+!||    csms11_ini   ../starter/source/elements/shell/coque/cinit3.F
 !||--- called by ------------------------------------------------------
-!||    cbainit3      ../starter/source/elements/shell/coqueba/cbainit3.F
-!||    cinit3        ../starter/source/elements/shell/coque/cinit3.F
-!||--- uses       -----------------------------------------------------
+!||    cbainit3     ../starter/source/elements/shell/coqueba/cbainit3.F
+!||    cinit3       ../starter/source/elements/shell/coque/cinit3.F
 !||====================================================================
       SUBROUTINE CSMS11_INI(
      1           JFT    ,JLT   ,IXC   ,X      ,X2S     ,
      2           Y2S    ,X3S   ,Y3S   ,X4S    ,Y4S     )
+C-----------------------------------------------
+C   M o d u l e s
+C-----------------------------------------------
       use element_mod , only : nixc
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s

--- a/starter/source/elements/shell/coque/set_elgroup_param.F
+++ b/starter/source/elements/shell/coque/set_elgroup_param.F
@@ -97,6 +97,12 @@ c
                 END IF
               CASE (25, 125, 127)
                 IF (IHBE == 23) DM = EM01
+              CASE (42, 69)
+                IF (IHBE == 11) THEN
+                  DM = ZEP04
+                ELSE
+                  DM = ZEP03
+                END IF
               CASE DEFAULT
                 IF (IHBE == 23 .AND. (IGTYP == 1 .or. IGTYP == 9)) DM = ZEP015
             END SELECT

--- a/starter/source/materials/mat/mat042/law42c_ini.F90
+++ b/starter/source/materials/mat/mat042/law42c_ini.F90
@@ -1,0 +1,55 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 1986-2025 Altair Engineering Inc.
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Altair Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+!Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+!Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+      module law42c_ini_mod
+      implicit none
+      contains
+        ! ======================================================================================================================
+        ! \brief initialization UVAR of law42c
+        ! ======================================================================================================================
+!||====================================================================
+        subroutine law42c_ini(nuvar,uvar,nel)
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                        Modules
+! ----------------------------------------------------------------------------------------------------------------------
+          use constant_mod, only : one
+          use precision_mod , only : WP
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                 implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          integer ,intent(in)                              :: nel       !< shell group size
+          integer ,intent(in)                              :: nuvar  !< 1er dimension of uvar
+          real(kind=WP),dimension(nel,nuvar),intent(inout) :: uvar      !< internal work array
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   local variables
+! ----------------------------------------------------------------------------------------------------------------------
+          integer :: i
+! ======================================================================================================================
+
+          uvar(1:nel,3) = one
+! ----------------------------------------------------------------------------------------------------------------------
+        end subroutine law42c_ini
+      end module law42c_ini_mod


### PR DESCRIPTION
improvement on law42 (Ogden) for shell 

This pull request introduces support for the initialization of material law 42 (likely a new or specialized material model) in several shell element routines. The changes add a new initialization subroutine for law 42 and ensure it is called in the relevant element initialization code paths. Additionally, there is a minor update to element group parameter selection for certain cases.

**Material Law 42 Initialization Support:**

* Added a new module and subroutine `law42c_ini_mod`/`law42c_ini` in `mat042/law42c_ini.F90` to handle initialization of the internal variable array `UVAR` for law 42 materials.
* Updated shell element initialization routines (`cinit3.F`, `c3init3.F`, `cmaini3.F`) to use the new `law42c_ini` subroutine when the material law is 42 or the element type matches specific criteria. This ensures proper initialization for those elements. [[1]](diffhunk://#diff-73437afca0aa347a4e74c3f1122b8cc49485c7cdcb28beddbc33b5e08116d7f5R97) [[2]](diffhunk://#diff-73437afca0aa347a4e74c3f1122b8cc49485c7cdcb28beddbc33b5e08116d7f5R470-R484) [[3]](diffhunk://#diff-4baba046f8d6b2f475908c50a9496dfcb252ac75102f290721f35a1d1346e2e5R96) [[4]](diffhunk://#diff-4baba046f8d6b2f475908c50a9496dfcb252ac75102f290721f35a1d1346e2e5R493-R507) [[5]](diffhunk://#diff-1838069de73b1c40f099cf9153e5505e6b45239c981d3069a4e86e356b1e846dR59) [[6]](diffhunk://#diff-1838069de73b1c40f099cf9153e5505e6b45239c981d3069a4e86e356b1e846dR242-R256)

**Element Group Parameter Update:**

* Modified `set_elgroup_param.F` to handle cases 42 and 69 in the element group selector, assigning `DM` based on `IHBE` value for these new cases.