### PR TITLE
wrong output value of /H3D/SHELL/TENS/STRAIN for fully integration shell

### DIFF
--- a/engine/source/output/h3d/h3d_results/h3d_shell_tensor.F
+++ b/engine/source/output/h3d/h3d_results/h3d_shell_tensor.F
@@ -719,6 +719,7 @@ c               PLY=IPLY NPT=IPT
                              VALUE(2) = VALUE(2)+ GBUF%STRPG(PTS + JJ(2)+I) + FACTOR*GBUF%STRPG(PTS + JJ(7)+I) * THK
                              VALUE(3) = VALUE(3)+ GBUF%STRPG(PTS + JJ(3)+I) + FACTOR*GBUF%STRPG(PTS + JJ(8)+I) * THK
                           ENDDO
+                            VALUE(1:3) = VALUE(1:3)/NPG
                             VALUE(3) = VALUE(3) * HALF 
                             CALL H3D_WRITE_SH_TENSOR(IOK_PART,ISELECT,IS_WRITTEN_SHELL,
      .                                           SHELL_TENSOR,I,OFFSET,NFT,VALUE)
@@ -798,6 +799,7 @@ c               NPT=IPT    PLY=NULL ILAYER=NULL
                       VALUE(2) = VALUE(2)+ GBUF%STRPG(PTS + JJ(2)+I) + FACTOR*GBUF%STRPG(PTS + JJ(7)+I) * THK
                       VALUE(3) = VALUE(3)+ GBUF%STRPG(PTS + JJ(3)+I) + FACTOR*GBUF%STRPG(PTS + JJ(8)+I) * THK
                     ENDDO 
+                    VALUE(1:3) = VALUE(1:3)/NPG
                     VALUE(3) = VALUE(3) * HALF 
                     CALL H3D_WRITE_SH_TENSOR(IOK_PART,ISELECT,IS_WRITTEN_SHELL,
      .                                       SHELL_TENSOR,I,OFFSET,NFT,VALUE)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
wrong output values of strain tensor for F.I. shell (npg>1)

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

correction to fix wrong H3D output values
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
