### PR TITLE
Correct test of temperature dependance in failure models for global beam elements

### DIFF
--- a/engine/source/elements/beam/fail_beam3.F
+++ b/engine/source/elements/beam/fail_beam3.F
@@ -138,7 +138,7 @@ c-----------------------------------------
 c------------------------------------   
         CASE (1)     !    Johnson-Cook                                                   
           !  Tstar computation for Jhonson-Cook failure : T* = (T-T0)/(TM-T0)
-          IF (jthe > 0 .or. elbuf_str%bufly(1)%l_temp > 0) THEN
+          IF (jthe > 0 .or. elbuf_str%gbuf%g_temp > 0) THEN
             T0 = MAT_PARAM%THERM%TREF
             TM = MAT_PARAM%THERM%TMELT
             TSTAR(1:NEL) = MAX(ZERO,(TEMPEL(1:NEL)-T0)) / MAX((TM-T0),EM20)
@@ -152,7 +152,7 @@ c------------------------------------
      .         ELBUF_STR%GBUF%FAIL(1)%TDEL  ,IOUT    ,ISTDO    )
 c---------------      
         CASE (10)     !    Tension Strain failure model
-          IF (jthe > 0 .or. elbuf_str%bufly(1)%l_temp > 0) THEN
+          IF (jthe > 0 .or. elbuf_str%gbuf%g_temp > 0) THEN
             T0 = MAT_PARAM%THERM%TREF
             TM = MAT_PARAM%THERM%TMELT
             TSTAR(1:NEL) = MAX(ZERO,(TEMPEL(1:NEL)-T0)) / MAX((TM-T0),EM20)


### PR DESCRIPTION
Test on temperature dependance in global beam failure models was based on  wrong element buffer level.
Inexistent layer variable was used instead of global buffer variable.
Possible engine failure due to not allocated memory access.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
