### PR TITLE
Unecessary calls to TIMFUN, regression from  #4027

### DIFF
--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -3484,8 +3484,7 @@ C----------------------------------
 C       FUNCTIONS
 C----------------------------------
 
-!             IF(NFUNCT /= 0.AND.IALE+IEULER+GLOB_THERM%ITHERM+NEBCS>0) THEN
-              IF(.TRUE.) then
+              IF(NFUNCT /= 0.AND.IALE+IEULER+GLOB_THERM%ITHERM+NEBCS>0) THEN
                 CALL TIMFUN(PYTHON,FV, NPC, TF)
                 IF(EBCS_TAB%nebcs_loc/=0) THEN
                   !!! Need to "extrapolate values" whenever current time


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

In `engine/source/engine/resol.F`, replaced the unconditional `IF(.TRUE.)` with the original conditional check (`NFUNCT /= 0 .AND. IALE+IEULER+GLOB_THERM%ITHERM+NEBCS > 0`) before calling `TIMFUN`, restoring intended logic.
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
