### PR TITLE
node spliting; enable /ANIM/VECT*

### DIFF
--- a/engine/source/engine/node_spliting/detach_node.F90
+++ b/engine/source/engine/node_spliting/detach_node.F90
@@ -507,7 +507,7 @@
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Body
 ! ----------------------------------------------------------------------------------------------------------------------
-          !write(6,*) "detach_node",node_id,nodes%itab(node_id),"from:",shell_list(1:list_size)
+           write(6,*) "detach_node",node_id,nodes%itab(node_id),"from:",shell_list(1:list_size)
           !call flush(6)
 !         new_uid = nodes%max_uid + 1
 !         nodes%max_uid = new_uid

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -5874,6 +5874,7 @@ C  uncomment the following code for an example of node splitting (using non-phys
 !     5              ADDTMPL    ,IPARG     )
 !
 !               ENDIF
+!               CALL ALLOCATE_OUTPUT_DATA(OUTPUT,NUMNOD)
 !               LCNE0 = SIZE(ELEMENT%PON%PROCNE)
 !             endif
 


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
Minor changes:
enable print of the detached node list
enable /ANIM/VECT/* by calling ALLOCATE_OUTPUT_DATA function (that does the reallocation also)

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
