### PR TITLE
add cfg files for engine /DT keywords

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2017/CARDS/eng_dt_ams.cfg
+++ b/hm_cfg_files/config/CFG/radioss2017/CARDS/eng_dt_ams.cfg
@@ -1,0 +1,78 @@
+//
+// ENG_DT_AMS
+//
+
+ATTRIBUTES(COMMON)
+{
+
+    KEYWORD_STR                             = VALUE(STRING, "Solver Keyword");
+    FScale11                                = VALUE(FLOAT,  "");
+    Iflag                                   = VALUE(INT,  "Iflag: Number of additional(optional) cards");
+    NITER                                   = VALUE(INT,  "");
+    NPRINT                                  = VALUE(INT,  "");
+    SCALE                                   = VALUE(FLOAT,  "Input tolerance for stop criteria");
+    Tmin                                    = VALUE(FLOAT,  "Minimum time step for option");
+
+}
+
+SKEYWORDS_IDENTIFIER(COMMON)
+{
+
+    KEYWORD_STR                             = -1;
+    FScale11                                = 4050;
+    Iflag                                   = 4869;
+    NITER                                   = 1700;
+    NPRINT                                  = 1701;
+    SCALE                                   = 13;
+    Tmin                                    = 4831;
+
+}
+
+DEFAULTS(COMMON)
+{
+
+    FScale11    = 1e-4;
+    NITER    = 1000;
+
+}
+
+GUI(COMMON)
+{
+
+    ASSIGN(KEYWORD_STR, "/DT/AMS/");
+    SCALAR(Iflag);
+    SCALAR(SCALE){ DIMENSION = "t" ;}
+    SCALAR(Tmin){ DIMENSION = "t" ;}
+    if( Iflag==1)
+    {
+       SCALAR(FScale11);
+    }
+    if( Iflag==2)
+    {
+       SCALAR(FScale11);
+       SCALAR(NITER);
+       SCALAR(NPRINT);
+    }
+
+}
+
+
+// File format
+FORMAT(radioss2017) 
+{
+        HEADER("/DT/AMS/%-d",Iflag);
+        CARD("%-20lf%1s%-20lf",SCALE,_BLANK_,Tmin);
+    
+    if( (Iflag==1) )
+    {
+        CARD("%-20lf",FScale11);
+    }
+
+    if( (Iflag==2) )
+    {
+        CARD("%-20lf",FScale11);
+        CARD("%-10d%-10d",NITER,NPRINT);
+    }
+
+
+}

--- a/hm_cfg_files/config/CFG/radioss2017/CARDS/eng_dt_shell.cfg
+++ b/hm_cfg_files/config/CFG/radioss2017/CARDS/eng_dt_shell.cfg
@@ -1,0 +1,111 @@
+//
+// ENG_DT_SHELL 
+//
+
+ATTRIBUTES(COMMON)
+{
+
+    KEYWORD_STR                             = VALUE(STRING, "Solver Keyword");
+    ENG_DT_SHELL_CST                        = VALUE(INT,  "");
+    ENG_DT_SHELL_DEFAULT                    = VALUE(INT,  "");
+    ENG_DT_SHELL_DEL                        = VALUE(INT,  "");
+    ENG_DT_SHELL_STOP                       = VALUE(INT,  "");
+    FScale11                                = VALUE(FLOAT,  "Tolerance for AMS convergence");
+    FScale12                                = VALUE(FLOAT,  "Scale factor on time");
+    FScale22                                = VALUE(FLOAT,  "Y grid velocity scale factor");
+    FScale33                                = VALUE(FLOAT,  "Z grid velocity scale factor");
+    Tmin1                                   = VALUE(FLOAT,  "Minimum time step");
+    Tmin2                                   = VALUE(FLOAT,  "Minimum time step");
+    Tmin3                                   = VALUE(FLOAT,  "Minimum time step");
+    Tmin4                                   = VALUE(FLOAT,  "Minimum time step");
+
+}
+
+SKEYWORDS_IDENTIFIER(COMMON)
+{
+
+    KEYWORD_STR                             = -1;
+    ENG_DT_SHELL_CST                        = 7395;
+    ENG_DT_SHELL_DEFAULT                    = 7399;
+    ENG_DT_SHELL_DEL                        = 7394;
+    ENG_DT_SHELL_STOP                       = 7393;
+    FScale11                                = 4050;
+    FScale12                                = 4053;
+    FScale22                                = 4051;
+    FScale33                                = 4052;
+    Tmin1                                   = 8112;
+    Tmin2                                   = 8116;
+    Tmin3                                   = 8120;
+    Tmin4                                   = 8124;
+
+}
+
+GUI(COMMON)
+{
+
+    FLAG(ENG_DT_SHELL_DEFAULT);
+    if(ENG_DT_SHELL_DEFAULT == TRUE)
+    {
+        ASSIGN(KEYWORD_STR, "/DT/SHELL");
+        SCALAR(FScale12){ DIMENSION = "t" ;}
+        ASSIGN(KEYWORD_STR, " ");
+        SCALAR(Tmin4){ DIMENSION = "t" ;}
+    }
+    FLAG(ENG_DT_SHELL_STOP);
+    if(ENG_DT_SHELL_STOP == TRUE)
+    {
+        ASSIGN(KEYWORD_STR, "/DT/SHELL/STOP");
+        SCALAR(FScale11){ DIMENSION = "t" ;}
+        ASSIGN(KEYWORD_STR, " ");
+        SCALAR(Tmin1){ DIMENSION = "t" ;}
+    }
+    FLAG(ENG_DT_SHELL_DEL);
+    if(ENG_DT_SHELL_DEL == TRUE)
+    {
+        ASSIGN(KEYWORD_STR, "/DT/SHELL/DEL");
+        SCALAR(FScale22){ DIMENSION = "t" ;}
+        ASSIGN(KEYWORD_STR, " ");
+        SCALAR(Tmin2){ DIMENSION = "t" ;}
+    }
+    FLAG(ENG_DT_SHELL_CST);
+    if(ENG_DT_SHELL_CST == TRUE)
+    {
+        ASSIGN(KEYWORD_STR, "/DT/SHELL/CST");
+        SCALAR(FScale33){ DIMENSION = "t" ;}
+        ASSIGN(KEYWORD_STR, " ");
+        SCALAR(Tmin3){ DIMENSION = "t" ;}
+    }
+
+}
+
+
+// File format
+FORMAT(radioss2017) 
+{
+
+    if( (ENG_DT_SHELL_DEFAULT == 1) )
+    {
+        HEADER("/DT/SHELL");
+        CARD("%-20lf%1s%-20lf",FScale12,_BLANK_,Tmin4);
+    }
+
+    if( (ENG_DT_SHELL_STOP == 1) )
+    {
+        HEADER("/DT/SHELL/STOP");
+        CARD("%-20lf%1s%-20lf",FScale11,_BLANK_,Tmin1);
+    }
+
+    if( (ENG_DT_SHELL_DEL == 1) )
+    {
+        HEADER("/DT/SHELL/DEL");
+        CARD("%-20lf%1s%-20lf",FScale22,_BLANK_,Tmin2);
+    }
+
+    if( (ENG_DT_SHELL_CST == 1) )
+    {
+        HEADER("/DT/SHELL/CST");
+        CARD("%-20lf%1s%-20lf",FScale33,_BLANK_,Tmin3);
+    }
+
+
+}

--- a/hm_cfg_files/config/CFG/radioss2023/CARDS/eng_dt_brick.cfg
+++ b/hm_cfg_files/config/CFG/radioss2023/CARDS/eng_dt_brick.cfg
@@ -1,0 +1,238 @@
+//
+// ENG_DT_BRICK 
+//
+
+ATTRIBUTES(COMMON)
+{
+
+    KEYWORD_STR                             = VALUE(STRING, "Solver Keyword");
+    ASP_m                                   = VALUE(FLOAT,  "Minimum Aspect ratio");
+    ASP_max                                 = VALUE(FLOAT,  "Maximum aspect ratio to deleted solid element");
+    ASP_max1                                = VALUE(FLOAT,  "Maximum aspect ratio to deleted solid element");
+    COL_min                                 = VALUE(FLOAT,  "Minimum collapse ratio to switch solid element to small strain formulation ");
+    ENG_DT_BRICK_CST                        = VALUE(INT,  "");
+    ENG_DT_BRICK_CST_1                      = VALUE(INT,  "");
+    ENG_DT_BRICK_DEFAULT                    = VALUE(INT,  "");
+    ENG_DT_BRICK_DEL                        = VALUE(INT,  "");
+    ENG_DT_BRICK_DEL_1                      = VALUE(INT,  "");
+    ENG_DT_BRICK_STOP                       = VALUE(INT,  "");
+    FScale11                                = VALUE(FLOAT,  "Tolerance for AMS convergence");
+    FScale12                                = VALUE(FLOAT,  "Scale factor on time");
+    FScale13                                = VALUE(FLOAT,  "Scale factor on time step for the option defined by 'Eltyp'");
+    FScale22                                = VALUE(FLOAT,  "Y grid velocity scale factor");
+    FScale23                                = VALUE(FLOAT,  "Scale factor on critical time step for the option defined by Eltyp");
+    FScale33                                = VALUE(FLOAT,  "Z grid velocity scale factor");
+    Tmin1                                   = VALUE(FLOAT,  "Minimum time step");
+    Tmin2                                   = VALUE(FLOAT,  "Minimum time step");
+    Tmin3                                   = VALUE(FLOAT,  "Minimum time step");
+    Tmin4                                   = VALUE(FLOAT,  "Minimum time step");
+    Tmin5                                   = VALUE(FLOAT,  "Minimum time step");
+    Tmin6                                   = VALUE(FLOAT,  "Minimum time step");
+    VDEF_m                                  = VALUE(FLOAT,  "Minimum Volume ratio");
+    VDEF_m1                                 = VALUE(FLOAT,  "Minimum volume ratio (V/Vo) to switch solid element to small strain formulation ");
+    VDEF_max                                = VALUE(FLOAT,  "Maximum volume ratio (V/Vo) to deleted solid element");
+    VDEF_max1                               = VALUE(FLOAT,  "Maximum volume ratio (V/Vo) to deleted solid element");
+
+}
+
+SKEYWORDS_IDENTIFIER(COMMON)
+{
+
+    KEYWORD_STR                             = -1;
+    ASP_m                                   = 1720;
+    ASP_max                                 = 7807;
+    ASP_max1                                = 7818;
+    COL_min                                 = 7808;
+    ENG_DT_BRICK_CST                        = 7441;
+    ENG_DT_BRICK_CST_1                      = 1719;
+    ENG_DT_BRICK_DEFAULT                    = 408;
+    ENG_DT_BRICK_DEL                        = 7440;
+    ENG_DT_BRICK_DEL_1                      = 7819;
+    ENG_DT_BRICK_STOP                       = 7439;
+    FScale11                                = 4050;
+    FScale12                                = 4053;
+    FScale13                                = 4055;
+    FScale22                                = 4051;
+    FScale23                                = 4054;
+    FScale33                                = 4052;
+    Tmin1                                   = 8112;
+    Tmin2                                   = 8116;
+    Tmin3                                   = 8120;
+    Tmin4                                   = 8124;
+    Tmin5                                   = 8128;
+    Tmin6                                   = 8132;
+    VDEF_m                                  = 1721;
+    VDEF_m1                                 = 7815;
+    VDEF_max                                = 7806;
+    VDEF_max1                               = 7817;
+
+}
+
+DEFAULTS(COMMON)
+{
+
+    ASP_m    = 0.0;
+    ASP_max    = 0.0;
+    ASP_max1    = 0.0;
+    COL_min    = 0.0;
+    FScale13    = 0.9;
+    FScale23    = 0.9;
+    VDEF_m    = 0.0;
+    VDEF_m1    = 0.0;
+    VDEF_max    = 0.0;
+    VDEF_max1    = 0.0;
+
+}
+
+GUI(COMMON)
+{
+
+    FLAG(ENG_DT_BRICK_DEFAULT);
+    if(ENG_DT_BRICK_DEFAULT == TRUE)
+    {
+        ASSIGN(KEYWORD_STR, "/DT/BRICK");
+        SCALAR(FScale12){ DIMENSION = "t" ;}
+        ASSIGN(KEYWORD_STR, " ");
+        SCALAR(Tmin4){ DIMENSION = "t" ;}
+    }
+    FLAG(ENG_DT_BRICK_STOP);
+    if(ENG_DT_BRICK_STOP == TRUE)
+    {
+        ASSIGN(KEYWORD_STR, "/DT/BRICK/STOP");
+        SCALAR(FScale11){ DIMENSION = "t" ;}
+        ASSIGN(KEYWORD_STR, " ");
+        SCALAR(Tmin1){ DIMENSION = "t" ;}
+    }
+    FLAG(ENG_DT_BRICK_DEL);
+    if(ENG_DT_BRICK_DEL == TRUE)
+    {
+        ASSIGN(KEYWORD_STR, "/DT/BRICK/DEL");
+        SCALAR(FScale22){ DIMENSION = "t" ;}
+        ASSIGN(KEYWORD_STR, " ");
+        SCALAR(Tmin2){ DIMENSION = "t" ;}
+    }
+    FLAG(ENG_DT_BRICK_CST);
+    if(ENG_DT_BRICK_CST == TRUE)
+    {
+        ASSIGN(KEYWORD_STR, "/DT/BRICK/CST");
+        SCALAR(FScale33){ DIMENSION = "t" ;}
+        ASSIGN(KEYWORD_STR, " ");
+        SCALAR(Tmin3){ DIMENSION = "t" ;}
+    }
+    FLAG(ENG_DT_BRICK_CST_1);
+    if(ENG_DT_BRICK_CST_1 == TRUE)
+    {
+        ASSIGN(KEYWORD_STR, "/DT/BRICK/CST/1");
+        SCALAR(FScale13){ DIMENSION = "t" ;}
+        ASSIGN(KEYWORD_STR, " ");
+        SCALAR(Tmin5){ DIMENSION = "t" ;}
+        ASSIGN(KEYWORD_STR, " ");
+        SCALAR(ASP_m);
+        ASSIGN(KEYWORD_STR, " ");
+        SCALAR(VDEF_m);
+        ASSIGN(KEYWORD_STR, " ");
+        SCALAR(ASP_max);
+        ASSIGN(KEYWORD_STR, " ");
+        SCALAR(VDEF_max);
+    }
+    FLAG(ENG_DT_BRICK_DEL_1);
+    if(ENG_DT_BRICK_DEL_1 == TRUE)
+    {
+        ASSIGN(KEYWORD_STR, "/DT/BRICK/DEL/1");
+        SCALAR(FScale23){ DIMENSION = "t" ;}
+        ASSIGN(KEYWORD_STR, " ");
+        SCALAR(Tmin6){ DIMENSION = "t" ;}
+        ASSIGN(KEYWORD_STR, " ");
+        SCALAR(COL_min);
+        ASSIGN(KEYWORD_STR, " ");
+        SCALAR(VDEF_m1);
+        ASSIGN(KEYWORD_STR, " ");
+        SCALAR(ASP_max1);
+        ASSIGN(KEYWORD_STR, " ");
+        SCALAR(VDEF_max1);
+    }
+
+}
+
+// File format
+FORMAT(radioss2017) 
+{
+
+    if( (ENG_DT_BRICK_DEFAULT == 1) )
+    {
+        HEADER("/DT/BRICK");
+        CARD("%-20lf%1s%-20lf",FScale12,_BLANK_,Tmin4);
+    }
+
+    if( (ENG_DT_BRICK_STOP == 1) )
+    {
+        HEADER("/DT/BRICK/STOP");
+        CARD("%-20lf%1s%-20lf",FScale11,_BLANK_,Tmin1);
+    }
+
+    if( (ENG_DT_BRICK_DEL == 1) )
+    {
+        HEADER("/DT/BRICK/DEL");
+        CARD("%-20lf%1s%-20lf",FScale22,_BLANK_,Tmin2);
+    }
+
+    if( (ENG_DT_BRICK_CST == 1) )
+    {
+        HEADER("/DT/BRICK/CST");
+        CARD("%-20lf%1s%-20lf",FScale33,_BLANK_,Tmin3);
+    }
+
+    if( (ENG_DT_BRICK_CST_1 == 1) )
+    {
+        HEADER("/DT/BRICK/CST/1");
+        CARD("%-20lf%1s%-20lf%1s",FScale13,_BLANK_,Tmin5,_BLANK_);
+        CARD("%-20lf%1s%-20lf%1s%-20lf%1s%-20lf",ASP_m,_BLANK_,VDEF_m,_BLANK_,ASP_max,_BLANK_,VDEF_max);
+    }
+
+
+
+}
+
+FORMAT(radioss2023) 
+{
+
+    if( (ENG_DT_BRICK_DEFAULT == 1) )
+    {
+        HEADER("/DT/BRICK");
+        CARD("%-20lf%1s%-20lf",FScale12,_BLANK_,Tmin4);
+    }
+
+    if( (ENG_DT_BRICK_STOP == 1) )
+    {
+        HEADER("/DT/BRICK/STOP");
+        CARD("%-20lf%1s%-20lf",FScale11,_BLANK_,Tmin1);
+    }
+
+    if( (ENG_DT_BRICK_DEL == 1) )
+    {
+        HEADER("/DT/BRICK/DEL");
+        CARD("%-20lf%1s%-20lf",FScale22,_BLANK_,Tmin2);
+    }
+
+    if( (ENG_DT_BRICK_CST == 1) )
+    {
+        HEADER("/DT/BRICK/CST");
+        CARD("%-20lf%1s%-20lf",FScale33,_BLANK_,Tmin3);
+    }
+
+    if( (ENG_DT_BRICK_CST_1 == 1) )
+    {
+        HEADER("/DT/BRICK/CST/1");
+        CARD("%-20lf%1s%-20lf%1s",FScale13,_BLANK_,Tmin5,_BLANK_);
+        CARD("%-20lf%1s%-20lf%1s%-20lf%1s%-20lf",ASP_m,_BLANK_,VDEF_m,_BLANK_,ASP_max,_BLANK_,VDEF_max);
+    }
+
+    if( (ENG_DT_BRICK_DEL_1 == 1) )
+    {
+        HEADER("/DT/BRICK/DEL/1");
+        CARD("%-20lf%1s%-20lf%1s",FScale23,_BLANK_,Tmin6,_BLANK_);
+        CARD("%-20lf%1s%-20lf%1s%-20lf%1s%-20lf",COL_min,_BLANK_,VDEF_m1,_BLANK_,ASP_max1,_BLANK_,VDEF_max1);
+    }
+
+
+}

--- a/hm_cfg_files/config/CFG/radioss2026/data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/radioss2026/data_hierarchy.cfg
@@ -4994,6 +4994,40 @@ HIERARCHY {
                           DT_NODA_SET,
                           DT_NODA_AMS);
         }
+		HIERARCHY {
+            KEYWORD = DT_AMS;
+            TITLE   = "DT_AMS";
+            FILE    = "CARDS/eng_dt_ams.cfg";
+            SUBTYPE    = USER;
+            USER_ID    = 7400;
+            USER_NAMES = (DT_AMS);
+        }
+		HIERARCHY {
+            KEYWORD = DT_BRICK;
+            TITLE   = "DT_BRICK";
+            FILE    = "CARDS/eng_dt_brick.cfg";
+            SUBTYPE    = USER;
+            USER_ID    = 7438;
+            USER_NAMES = (DT_BRICK,
+			DT_BRICK_DEFAULT,
+			DT_BRICK_STOP,
+			DT_BRICK_DEL,
+			DT_BRICK_CST,
+			DT_BRICK_CST_1,
+			DT_BRICK_DEL_1);
+        }
+		HIERARCHY {
+            KEYWORD = DT_SHELL;
+            TITLE   = "DT_SHELL";
+            FILE    = "CARDS/eng_dt_shell.cfg";
+            SUBTYPE    = USER;
+            USER_ID    = 7392;
+            USER_NAMES = (DT_SHELL,
+			DT_SHELL_DEFAULT,
+			DT_SHELL_STOP,
+			DT_SHELL_DEL,
+			DT_SHELL_CST);
+        }
         HIERARCHY {
             KEYWORD    = BRICK_TENS;
             TITLE      = "BRICK_TENS";


### PR DESCRIPTION
This pull request adds new configuration support for several Radioss solver keywords related to time step control for AMS, shell, and brick elements in the 2017, 2023, and 2026 versions. The changes introduce new card files, define their attributes, GUI logic, and file formats, and register them in the data hierarchy for proper integration.

**New Radioss solver keyword support:**

* Added new configuration card for AMS time step control with all attributes, GUI logic, and file format in `eng_dt_ams.cfg`, and registered it in the data hierarchy (`data_hierarchy.cfg`). [[1]](diffhunk://#diff-49cbc46463d614acc26708dde58dbd6124db7f0e823852b420d4afc45860a157R1-R78) [[2]](diffhunk://#diff-a363c0d8a651ff98903e29e2017b1b7de6bec2b0f30a751e6e3c427dc5495302R4993-R5026)
* Added new configuration card for shell time step control, including all relevant attributes, GUI logic, and file format in `eng_dt_shell.cfg`, and registered it in the data hierarchy (`data_hierarchy.cfg`). [[1]](diffhunk://#diff-8fd1736a744524f0652d2437285e2eb17e8f6e16f85e567229a0cb3c4b13cf92R1-R111) [[2]](diffhunk://#diff-a363c0d8a651ff98903e29e2017b1b7de6bec2b0f30a751e6e3c427dc5495302R4993-R5026)
* Added new configuration card for brick time step control for both 2017 and 2023 versions, with detailed attributes, GUI logic, file formats, and hierarchy registration in `eng_dt_brick.cfg` and `data_hierarchy.cfg`. [[1]](diffhunk://#diff-4c90fa5b74f54eb0e8cb8d8c4eb3d3f3cacc79cd5985cac6d20f2bed1e97fac5R1-R238) [[2]](diffhunk://#diff-a363c0d8a651ff98903e29e2017b1b7de6bec2b0f30a751e6e3c427dc5495302R4993-R5026)

**Data hierarchy integration:**

* Updated `data_hierarchy.cfg` to include new hierarchy entries for `DT_AMS`, `DT_BRICK`, and `DT_SHELL`, ensuring these new cards are recognized and properly categorized in the configuration system.

**Element-specific configuration enhancements:**

* Each card file provides detailed control over time step settings for AMS, shell, and brick elements, including support for advanced options such as convergence tolerance, aspect ratio, volume ratio, and multiple element-specific flags. [[1]](diffhunk://#diff-49cbc46463d614acc26708dde58dbd6124db7f0e823852b420d4afc45860a157R1-R78) [[2]](diffhunk://#diff-8fd1736a744524f0652d2437285e2eb17e8f6e16f85e567229a0cb3c4b13cf92R1-R111) [[3]](diffhunk://#diff-4c90fa5b74f54eb0e8cb8d8c4eb3d3f3cacc79cd5985cac6d20f2bed1e97fac5R1-R238)