### PR TITLE
correction issue with nonlocal reading

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2026/data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/radioss2026/data_hierarchy.cfg
@@ -2477,9 +2477,9 @@ HIERARCHY {
     HIERARCHY {
         KEYWORD = NONLOCAL;
         TITLE = "NONLOCAL";
-        TYPE = MATERIALBEHAVIOR;
+        SUBTYPE = USER;
         FILE = "MAT/mat_NONLOCAL.cfg";
-        USER_NAMES = (NONLOCAL);
+        USER_NAMES = (NONLOCAL,NONLOCAL_MAT);
     } 
     HIERARCHY {
         KEYWORD = VISC_PRONY;


### PR DESCRIPTION
This pull request updates the configuration for the `NONLOCAL` keyword in the Radioss 2026 data hierarchy. The changes clarify the keyword's subtype and expand the list of user names associated with it.

Configuration updates for `NONLOCAL` keyword:

* Changed the `SUBTYPE` from `MATERIALBEHAVIOR` to `USER` in the `HIERARCHY` block for `NONLOCAL` in `hm_cfg_files/config/CFG/radioss2026/data_hierarchy.cfg`.
* Expanded the `USER_NAMES` list to include both `NONLOCAL` and `NONLOCAL_MAT`.
