### PR TITLE
add possible missing third nodes for springs in state files

### DIFF
--- a/engine/source/output/sta/stat_spring_mp.F
+++ b/engine/source/output/sta/stat_spring_mp.F
@@ -70,7 +70,7 @@ C
 C-----------------------------------------------
 C     SPRING
 C-----------------------------------------------
-      CALL MY_ALLOC(NP,5*NUMELR)
+      CALL MY_ALLOC(NP,6*NUMELR)
       CALL MY_ALLOC(CLEF,2,NUMELR)
 C-----------------------------------------------
       JJ = 0
@@ -94,12 +94,17 @@ c
               NP(JJ+1) = IXR(NIXR,N)
               NP(JJ+2) = ITAB(IXR(2,N))
               NP(JJ+3) = ITAB(IXR(3,N))
-              NP(JJ+4) = IPRT
-              NP(JJ+5) = IABS(NINT(GBUF%OFF(I)))
+              IF(IXR(4,N) > 0) THEN
+                NP(JJ+4) = ITAB(IXR(4,N))
+              ELSE
+                NP(JJ+4) = 0
+              ENDIF
+              NP(JJ+5) = IPRT
+              NP(JJ+6) = IABS(NINT(GBUF%OFF(I)))
 c
               II = II + 1
 c
-              JJ = JJ + 5
+              JJ = JJ + 6
 c
               STAT_NUMELR =STAT_NUMELR+1
               CLEF(1,STAT_NUMELR)=IPRT
@@ -107,6 +112,7 @@ c
 c
               NODTAG(IXR(2,N))=1
               NODTAG(IXR(3,N))=1
+              IF(IXR(4,N) > 0)NODTAG(IXR(4,N))=1
             ENDDO ! DO I=LFT,LLT
           ENDIF ! IF (ITY == 6)
         ENDDO ! DO NG=1,NGROUP
@@ -120,17 +126,21 @@ C----
       IPRT0=0
       DO N=1,STAT_NUMELR
         K=STAT_INDXR(N)
-        JJ=5*(K-1)
-        IPRT=NP(JJ+4)
-        IOFF=NP(JJ+5)
+        JJ=6*(K-1)
+        IPRT=NP(JJ+5)
+        IOFF=NP(JJ+6)
         IF (IDEL==0 .OR. (IDEL==1 .AND. IOFF >= 1)) THEN
           IF (IPRT /= IPRT0) THEN
             WRITE(IUGEO,'(A,I10)')'/SPRING/',IPART(4,IPRT)
             WRITE(IUGEO,'(A)')
-     .    '#SPRING_ID      NOD1      NOD2'
+     .    '#SPRING_ID      NOD1      NOD2      NOD3'
             IPRT0=IPRT
           ENDIF
-          WRITE(IUGEO,'(3I10)') NP(JJ+1),NP(JJ+2),NP(JJ+3)
+          IF(NP(JJ+4) > 0) THEN
+            WRITE(IUGEO,'(4I10)') NP(JJ+1),NP(JJ+2),NP(JJ+3),NP(JJ+4)
+          ELSE
+            WRITE(IUGEO,'(3I10)') NP(JJ+1),NP(JJ+2),NP(JJ+3)
+          ENDIF
         ENDIF !IF (IDEL)
       ENDDO ! DO N=1,STAT_NUMELR
 C----

--- a/engine/source/output/sta/stat_spring_spmd.F
+++ b/engine/source/output/sta/stat_spring_spmd.F
@@ -78,7 +78,7 @@ C     SPRING
 C-----------------------------------------------
       CALL MY_ALLOC(IADG,NSPMD,NPART)
       CALL MY_ALLOC(IADD,NPART+1)
-      CALL MY_ALLOC(NP,5*NUMELR)
+      CALL MY_ALLOC(NP,6*NUMELR)
       CALL MY_ALLOC(NPGLOB,7*LENGR)
       CALL MY_ALLOC(CLEF,2,NUMELRG)
 C-----------------------------------------------
@@ -104,47 +104,59 @@ c
             NP(JJ+1) = IXR(NIXR,N)
             NP(JJ+2) = ITAB(IXR(2,N))
             NP(JJ+3) = ITAB(IXR(3,N))
-            NP(JJ+4) = IPRT
-            NP(JJ+5) = IABS(NINT(GBUF%OFF(I)))
+            IF(IXR(4,N) > 0) THEN
+              NP(JJ+4) = ITAB(IXR(4,N))
+            ELSE
+              NP(JJ+4) = 0
+            ENDIF
+            NP(JJ+5) = IPRT
+            NP(JJ+6) = IABS(NINT(GBUF%OFF(I)))
 c
             II = II + 1
 c
-            JJ = JJ + 5
+            JJ = JJ + 6
 c
             STAT_NUMELR = STAT_NUMELR + 1
 c
             NODTAG(IXR(2,N))=1
             NODTAG(IXR(3,N))=1
+            IF(IXR(4,N) > 0)NODTAG(IXR(4,N))=1
           ENDDO ! DO I=LFT,LLT
         ENDIF ! IF (ITY == 6)
       ENDDO ! DO NG=1,NGROUP
 C----
       STAT_NUMELR_G = 0
-      CALL SPMD_IGET_PARTN_STA(5,STAT_NUMELR,STAT_NUMELR_G,LENGR,NP,
+      CALL SPMD_IGET_PARTN_STA(6,STAT_NUMELR,STAT_NUMELR_G,LENGR,NP,
      .             IADG,NPGLOB,STAT_INDXR)
 C----
       IF (ISPMD == 0) THEN
         DO N=1,STAT_NUMELR_G
           STAT_INDXR(N)=N
-          CLEF(1,N)=NPGLOB(5*(N-1)+5)
-          CLEF(2,N)=NPGLOB(5*(N-1)+1)
+          CLEF(1,N)=NPGLOB(6*(N-1)+6)
+          CLEF(2,N)=NPGLOB(6*(N-1)+1)
         ENDDO
         CALL MY_ORDERS(0,WORK,CLEF,STAT_INDXR,STAT_NUMELR_G,2)
 C----
         IPRT0=0
         DO N=1,STAT_NUMELR_G
           K=STAT_INDXR(N)
-          JJ=5*(K-1)
-          IPRT=NPGLOB(JJ+4)
-          IOFF=NPGLOB(JJ+5)
+          JJ=6*(K-1)
+          IPRT=NPGLOB(JJ+5)
+          IOFF=NPGLOB(JJ+6)
           IF (IDEL==0 .OR. (IDEL==1 .AND. IOFF >= 1)) THEN
             IF (IPRT /= IPRT0) THEN
               WRITE(IUGEO,'(A,I10)')'/SPRING/',IPART(4,IPRT)
               WRITE(IUGEO,'(A)')
-     .      '#SPRING_ID      NOD1      NOD2'
+     .      '#SPRING_ID      NOD1      NOD2      NOD3'
               IPRT0=IPRT
             ENDIF
-            WRITE(IUGEO,'(3I10)') NPGLOB(JJ+1),NPGLOB(JJ+2),NPGLOB(JJ+3)
+            IF (NPGLOB(JJ+4) > 0) THEN
+              WRITE(IUGEO,'(4I10)') NPGLOB(JJ+1),NPGLOB(JJ+2),
+     .        NPGLOB(JJ+3),NPGLOB(JJ+4)
+            ELSE
+              WRITE(IUGEO,'(3I10)') NPGLOB(JJ+1),NPGLOB(JJ+2),
+     .        NPGLOB(JJ+3)
+            ENDIF
           ENDIF !IF (IDEL)
         ENDDO ! DO N=1,STAT_NUMELR_G
       ENDIF ! IF (ISPMD == 0)


### PR DESCRIPTION
This pull request updates the spring output routines to support a third node (`NOD3`) for spring elements, improving the handling and reporting of multi-node springs in both the standard and SPMD (parallel) output modules. The changes ensure that the code allocates, processes, and outputs data for springs with up to three nodes, rather than the previous two-node limitation.

**Spring element data structure and output enhancements:**

* Increased allocation for spring element arrays (`NP`) from 5 to 6 entries per element in both `stat_spring_mp.F` and `stat_spring_spmd.F` to accommodate an additional node (`NOD3`). [[1]](diffhunk://#diff-ab8d641a64bbdf36f1c3450e66162214277759d7efda5c0613ca47b8a07bacb5L73-R73) [[2]](diffhunk://#diff-b8c2d83540d58149f6a1d584e746eafeb8ddbf1bcea5f5bdcbcfdd2a704ea21cL81-R81)
* Modified how spring element data is stored: now includes the third node index (`ITAB(IXR(4,N))`) in the `NP` array, shifting the partition and offset indices accordingly. [[1]](diffhunk://#diff-ab8d641a64bbdf36f1c3450e66162214277759d7efda5c0613ca47b8a07bacb5L97-R111) [[2]](diffhunk://#diff-b8c2d83540d58149f6a1d584e746eafeb8ddbf1bcea5f5bdcbcfdd2a704ea21cL107-R155)
* Updated output formatting: when a spring element includes a third node, the output line now includes `NOD3` and uses a four-column format; otherwise, it defaults to three columns. The header is also updated to reflect the new format. [[1]](diffhunk://#diff-ab8d641a64bbdf36f1c3450e66162214277759d7efda5c0613ca47b8a07bacb5L123-R139) [[2]](diffhunk://#diff-b8c2d83540d58149f6a1d584e746eafeb8ddbf1bcea5f5bdcbcfdd2a704ea21cL107-R155)
* Adjusted SPMD-specific routines to use the new six-entry format for spring elements, including updates to partitioning and global arrays (`NPGLOB`), and output logic for three-node springs.
* Ensured that node tagging logic correctly marks the third node as used when present, improving downstream processing and consistency. [[1]](diffhunk://#diff-ab8d641a64bbdf36f1c3450e66162214277759d7efda5c0613ca47b8a07bacb5L97-R111) [[2]](diffhunk://#diff-b8c2d83540d58149f6a1d584e746eafeb8ddbf1bcea5f5bdcbcfdd2a704ea21cL107-R155)
