### PR TITLE
Fix TETRA10 output for /H3D/TENS/STRAIN

### DIFF
--- a/engine/source/output/h3d/h3d_results/h3d_solid_tensor_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_solid_tensor_1.F
@@ -2071,11 +2071,11 @@ C              STRAIN TENSOR IN GLOBAL SYSTEM
 c-----------
             ELSEIF (ISOLNOD==10 .OR. (ISOLNOD==4 .AND. ISROT==1)) THEN
 c-----------
-              IPT = IR
-c              IF (IR == 1 .AND. IS == 1 .AND. IT == 1) IPT = 1 
-c              IF (IR == 2 .AND. IS == 1 .AND. IT == 1) IPT = 2 
-c              IF (IR == 1 .AND. IS == 2 .AND. IT == 1) IPT = 3 
-c              IF (IR == 1 .AND. IS == 1 .AND. IT == 2) IPT = 4 
+              IPT = 0
+              IF (IR == 1 .AND. IS == 1 .AND. IT == 1) IPT = 1 
+              IF (IR == 2 .AND. IS == 1 .AND. IT == 1) IPT = 2 
+              IF (IR == 1 .AND. IS == 2 .AND. IT == 1) IPT = 3 
+              IF (IR == 1 .AND. IS == 1 .AND. IT == 2) IPT = 4 
               IF ( IPT > 0) THEN
                 LBUF =>  ELBUF_TAB(NG)%BUFLY(1)%LBUF(IPT,1,1)          
                 IF (MLW>=28.AND.MLW /= 49 .OR. MLW == 24) THEN 


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

Fix TETRA10 output for /H3D/TENS/STRAIN: output persistent for 8 integration points, although TETRA10 elements only have 4 integration points. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

Add the same specific condition of output for TETRA10, same as the one used for stresses. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
