### PR TITLE
Correction of area computation of beams type 18 Isect 4

### DIFF
--- a/starter/source/properties/beam/hm_read_prop18.F
+++ b/starter/source/properties/beam/hm_read_prop18.F
@@ -693,6 +693,7 @@ c---------------
           ENDIF   
 c---------------
         CASE (4)    ! circular section    Lobatto 5 OR 7 in radius 8 in circonference
+          AREA = PI*L(1)*L(1)                                                     
           !POINTS RADIALS ALIGNES
           IF (INTR == 17) THEN
              NIP = 17


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
Section Area not computed for beams Prop1 with Isect=4

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
Section Area not computed for beams Prop1 with Isect=4

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
