### PR TITLE
Interface TYPE25 - mpi hang (engine) - add a condition for the mpi comms

### DIFF
--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -1314,7 +1314,7 @@ C-------------------------------------------------------------------------------
               TYPE(array_type), DIMENSION(:), ALLOCATABLE :: XCELL_REMOTE ! remote data structure for interface 18
               ! ----------
               my_real, DIMENSION(:), ALLOCATABLE :: FSKY_L
-              LOGICAL :: NEED_COMM_INT25_SOLID_EROSION !< boolean, true if the proc needs to comm some values related to interface type 25 with solid erosion
+              LOGICAL, DIMENSION(NSPMD) :: NEED_COMM_INT25_SOLID_EROSION !< boolean, true if the proc needs to comm some values related to interface type 25 with solid erosion
               INTEGER :: COMM_INT25_SOLID_EROSION !< integer, sub-communicator related to interface type 25 with solid erosion
 
               INTEGER :: CHECK_NEIGH_FLAG,CHECK_NEIGH_FLAG_RES
@@ -2207,7 +2207,7 @@ C===============================================================================
 C                                     PARALLEL SECTION (SMP)
 C========================================================================================
 
-              NEED_COMM_INT25_SOLID_EROSION = .FALSE.
+              NEED_COMM_INT25_SOLID_EROSION(1:NSPMD) = .FALSE.
               COMM_INT25_SOLID_EROSION = 0
 
               CALL PYTHON_BEGIN_OPENMP(PYTHON)
@@ -2638,7 +2638,7 @@ C Init var parallel SMP
                   IF(NINTER25/=0.AND.INTERFACES%PARAMETERS%INT25_EROSION_SOLID > 0) THEN
                     IF(ITSK==0) THEN
                       CHECK_NEIGH_FLAG = SHOOT_STRUCT%NUMBER_NEW_SURF + shoot_struct%NUMBER_REMOTE_SURF
-                      IF(NEED_COMM_INT25_SOLID_EROSION) THEN
+                      IF(NEED_COMM_INT25_SOLID_EROSION(ISPMD+1)) THEN
                         CALL SPMD_ALLREDUCE(CHECK_NEIGH_FLAG,CHECK_NEIGH_FLAG_RES,1,SPMD_MAX,COMM_INT25_SOLID_EROSION)
                       ELSEIF(NSPMD==1) THEN
                         CHECK_NEIGH_FLAG_RES = CHECK_NEIGH_FLAG 
@@ -2651,7 +2651,8 @@ C Init var parallel SMP
      .                                                ELEM_STATE,IPARI,INTLIST,NODES,
      .                                                NEWFRONT,IXS,ELEMENT%SHELL%IXC,IXTG,
      .                                                NODES%BOUNDARY_ADD,ptrX,
-     .                                                INTERFACES%INTBUF_TAB,INTERFACES%SPMD_ARRAYS,SHOOT_STRUCT  )
+     .                                                INTERFACES%INTBUF_TAB,INTERFACES%SPMD_ARRAYS,SHOOT_STRUCT,
+     .                                                NEED_COMM_INT25_SOLID_EROSION )
                       ENDIF
                     ENDIF
                     CALL MY_BARRIER()
@@ -5771,7 +5772,7 @@ C Init var parallel SMP
                       IF(NINTER25/=0.AND.INTERFACES%PARAMETERS%INT25_EROSION_SOLID > 0) THEN
                         IF(ITSK==0) THEN
                           CHECK_NEIGH_FLAG = SHOOT_STRUCT%NUMBER_NEW_SURF + shoot_struct%NUMBER_REMOTE_SURF
-                          IF(NEED_COMM_INT25_SOLID_EROSION) THEN
+                          IF(NEED_COMM_INT25_SOLID_EROSION(ISPMD+1)) THEN
                             CHECK_NEIGH_FLAG = SHOOT_STRUCT%NUMBER_NEW_SURF + shoot_struct%NUMBER_REMOTE_SURF
                             CALL SPMD_ALLREDUCE(CHECK_NEIGH_FLAG,CHECK_NEIGH_FLAG_RES,1,SPMD_MAX,COMM_INT25_SOLID_EROSION)
                           ELSEIF(NSPMD==1) THEN
@@ -5785,7 +5786,8 @@ C Init var parallel SMP
      .                                                  ELEM_STATE,IPARI,INTLIST,NODES,
      .                                                  NEWFRONT,IXS,ELEMENT%SHELL%IXC,IXTG,
      .                                                  NODES%BOUNDARY_ADD,NODES%X,
-     .                                                  INTERFACES%INTBUF_TAB,INTERFACES%SPMD_ARRAYS,SHOOT_STRUCT  )
+     .                                                  INTERFACES%INTBUF_TAB,INTERFACES%SPMD_ARRAYS,SHOOT_STRUCT,
+     .                                                  NEED_COMM_INT25_SOLID_EROSION)
                           ENDIF
                         ENDIF
                         CALL MY_BARRIER()

--- a/engine/source/engine/resol_init.F
+++ b/engine/source/engine/resol_init.F
@@ -319,7 +319,7 @@ c    .  I8A(3,3,*),I8AR(3,3,*),I8STIFN(3,*),I8STIFR(3,*),
 c    .  I8VISCN(3,*)
 C
 
-      LOGICAL, INTENT(inout) :: NEED_COMM_INT25_SOLID_EROSION !< boolean, true if the proc needs to comm some values related to interface type 25 with solid erosion
+      LOGICAL, DIMENSION(NSPMD), INTENT(inout) :: NEED_COMM_INT25_SOLID_EROSION !< boolean, true if the proc needs to comm some values related to interface type 25 with solid erosion
       INTEGER, INTENT(inout) :: COMM_INT25_SOLID_EROSION !< integer, sub-communicator related to interface type 25 with solid erosion
 C
       DOUBLE PRECISION XDP(3,*)     

--- a/engine/source/interfaces/interf/get_neighbour_surface.F90
+++ b/engine/source/interfaces/interf/get_neighbour_surface.F90
@@ -79,7 +79,8 @@
           elem_state,ipari,intlist,nodes, &
           newfront,ixs,ixc,ixtg,  &
           iad_elem,x,         &
-          intbuf_tab,spmd_arrays,shoot_struct  )
+          intbuf_tab,spmd_arrays,shoot_struct, &
+          need_comm  )
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   modules
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -106,6 +107,7 @@
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   arguments
 ! ----------------------------------------------------------------------------------------------------------------------
+          logical, dimension(nspmd), intent(in) :: need_comm !< boolean, true if the proc needs to comm some values related to interface type 25 with solid erosion
           integer, intent(in) :: ispmd !< processor id
           integer, intent(in) :: nspmd !< number of mpi processors
           integer, intent(in) :: ninter25 !< total number of interface /TYPE25
@@ -535,7 +537,7 @@
             s_buffer_size,r_buffer_size,s_buffer_2_size,r_buffer_2_size,&
             iad_elem,nodes,x, &
             s_buffer,r_buffer,s_buffer_2,r_buffer_2, &
-            intbuf_tab,shoot_struct)
+            intbuf_tab,shoot_struct,need_comm)
           ! --------------------------
 
           ! --------------------------

--- a/engine/source/mpi/interfaces/spmd_i7tool.F
+++ b/engine/source/mpi/interfaces/spmd_i7tool.F
@@ -2922,7 +2922,7 @@ C-----------------------------------------------
       TYPE(INTBUF_STRUCT_) INTBUF_TAB(*)
       TYPE(sorting_comm_type), DIMENSION(NINTER), INTENT(inout) :: SORT_COMM   ! structure for interface sorting comm
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) :: SENSOR_TAB
-      LOGICAL, INTENT(inout) :: NEED_COMM_INT25_SOLID_EROSION !< boolean, true if the proc needs to comm some values related to interface type 25 with solid erosion
+      LOGICAL, DIMENSION(NSPMD), INTENT(inout) :: NEED_COMM_INT25_SOLID_EROSION !< boolean, true if the proc needs to comm some values related to interface type 25 with solid erosion
       INTEGER, INTENT(inout) :: COMM_INT25_SOLID_EROSION !< integer, sub-communicator related to interface type 25 with solid erosion
 C-----------------------------------------------
       TYPE (GROUP_)  , DIMENSION(NGRBRIC) :: IGRBRIC

--- a/engine/source/mpi/interfaces/spmd_split_comm_inter.F
+++ b/engine/source/mpi/interfaces/spmd_split_comm_inter.F
@@ -77,7 +77,7 @@ C-----------------------------------------------
       integer,dimension(NINTER+1,NSPMD+1), intent(in) :: ISENDTO,IRCVFROM
       TYPE(sorting_comm_type), DIMENSION(NINTER), INTENT(inout) :: SORT_COMM   ! structure for interface sorting comm
 
-      LOGICAL, INTENT(inout) :: NEED_COMM_INT25_SOLID_EROSION !< boolean, true if the proc needs to comm some values related to interface type 25 with solid erosion
+      LOGICAL, DIMENSION(NSPMD), INTENT(inout) :: NEED_COMM_INT25_SOLID_EROSION !< boolean, true if the proc needs to comm some values related to interface type 25 with solid erosion
       INTEGER, INTENT(inout) :: COMM_INT25_SOLID_EROSION !< integer, sub-communicator related to interface type 25 with solid erosion
       
 C-----------------------------------------------
@@ -100,110 +100,111 @@ C-----------------------------------------------
         NB_INTER_7_INACTI = 0
         ALLOCATE( LIST_INTER_7_INACTI(NINTER) )
         LIST_INTER_7_INACTI(1:NINTER) = 0
-        NEED_COMM_INT25_SOLID_EROSION = .FALSE.
-!           -----------------------------
+        NEED_COMM_INT25_SOLID_EROSION(1:NSPMD) = .FALSE.
+        ! -----------------------------
 !       loop over the interface        
         DO KK=1,NBINTC
-            NIN = INTLIST(KK)
-            NTY   =IPARI(7,NIN)
-!           -----------------------------
-!           only tag the TYPE07 interface
-            IF(NTY==7) THEN
-                IF(COMM_TRI7VOX(NIN)%INIT) THEN
-                    I=0
-                    ALLOCATE(COMM_TRI7VOX(NIN)%PROC_LIST(NSPMD))
-                    ALLOCATE(SORT_COMM(NIN)%PROC_LIST(NSPMD))
-                    COMM_TRI7VOX(NIN)%PROC_LIST(1:NSPMD) = 0
-                    COMM_TRI7VOX(NIN)%RANK = -1
-                    !   list of processor for a given interface
-                    DO P=1,NSPMD
-                        IF(IRCVFROM(NIN,p)/=0.or.ISENDTO(NIN,P)/=0) THEN
-                            I=I+1
-                            COMM_TRI7VOX(NIN)%PROC_LIST(I) = P
-                        ENDIF
-                    ENDDO
-                    SORT_COMM(NIN)%PROC_LIST(1:NSPMD) = COMM_TRI7VOX(NIN)%PROC_LIST(1:NSPMD)
-                    COMM_TRI7VOX(NIN)%PROC_NUMBER = I
-                    SORT_COMM(NIN)%PROC_NUMBER = I
-                    COMM_TRI7VOX(NIN)%PROC_MIN = -1
-                    COMM_TRI7VOX(NIN)%RANK=-1
-                    COMM_TRI7VOX(NIN)%COMM=-1
-                    !   compute the main proc for a given interface
-                    DO I = 1,COMM_TRI7VOX(NIN)%PROC_NUMBER
-                        COMM_TRI7VOX(NIN)%PROC_MIN = min(COMM_TRI7VOX(NIN)%PROC_MIN,COMM_TRI7VOX(NIN)%PROC_LIST(I))
-                    ENDDO
-                    !   color the processor
-                    IF(IRCVFROM(NIN,ispmd+1)==0.and.ISENDTO(NIN,ispmd+1)==0) THEN
-                        COMM_TRI7VOX(NIN)%COLOR=0
-                        KEY = 0
-                    ELSE
-                        COMM_TRI7VOX(NIN)%COLOR=1
-                        KEY = 1
-                    ENDIF       
-                    !   create the communicator
-                    CALL MPI_COMM_SPLIT(SPMD_COMM_WORLD,COMM_TRI7VOX(NIN)%COLOR,KEY,COMM_TRI7VOX(NIN)%COMM,CODE)
-                    CALL MPI_COMM_SPLIT(SPMD_COMM_WORLD,COMM_TRI7VOX(NIN)%COLOR,KEY,SORT_COMM(NIN)%COMM,CODE)
-                    IF(COMM_TRI7VOX(NIN)%COLOR==1) THEN
-                        CALL MPI_COMM_RANK(COMM_TRI7VOX(NIN)%comm,COMM_TRI7VOX(NIN)%RANK,CODE)
-                    ENDIF
-                    COMM_TRI7VOX(NIN)%INIT = .false.
+          NIN = INTLIST(KK)
+          NTY   =IPARI(7,NIN)
+!         -----------------------------
+!         only tag the TYPE07 interface
+          IF(NTY==7) THEN
+            IF(COMM_TRI7VOX(NIN)%INIT) THEN
+              I=0
+              ALLOCATE(COMM_TRI7VOX(NIN)%PROC_LIST(NSPMD))
+              ALLOCATE(SORT_COMM(NIN)%PROC_LIST(NSPMD))
+              COMM_TRI7VOX(NIN)%PROC_LIST(1:NSPMD) = 0
+              COMM_TRI7VOX(NIN)%RANK = -1
+              !   list of processor for a given interface
+              DO P=1,NSPMD
+                IF(IRCVFROM(NIN,p)/=0.or.ISENDTO(NIN,P)/=0) THEN
+                  I=I+1
+                  COMM_TRI7VOX(NIN)%PROC_LIST(I) = P
                 ENDIF
-                !   ------------------------------
-                INACTI = IPARI(22,NIN)
-                IFQ = IPARI(31,NIN)
-                ITIED = IPARI(85,NIN)
-                IF(IMPL_S==0.OR.NEIG==0) THEN       
-                    IF( INACTI==5.OR.INACTI==6.OR.IFQ>0.OR.ITIED/=0)THEN
-                        NEED_COMM_INACTI = .TRUE.
-                        NB_INTER_7_INACTI = NB_INTER_7_INACTI + 1
-                        LIST_INTER_7_INACTI(NIN) = NB_INTER_7_INACTI
-                    ENDIF
-                ENDIF
-                !   ------------------------------
-            ENDIF
-
-           !   ------------------------------
-           ! communicator for interface type 25 with solid erosion
-            SOLID_EROSION = IPARI(100,NIN)
-            IDEL = IPARI(17,NIN)! idel option
-            IDELKEEP = IPARI(61,NIN)
-            IF(NTY==25.AND.IPARI(100,NIN)>0.AND.IDELKEEP/=1) THEN
-              ! ---------------
-              ! check if the proc has S or M node
-              IF(ISENDTO(NIN,ISPMD+1)>0.OR.IRCVFROM(NIN,ISPMD+1)>0) THEN 
-                        NEED_COMM_INT25_SOLID_EROSION = .TRUE.
+              ENDDO
+              SORT_COMM(NIN)%PROC_LIST(1:NSPMD) = COMM_TRI7VOX(NIN)%PROC_LIST(1:NSPMD)
+              COMM_TRI7VOX(NIN)%PROC_NUMBER = I
+              SORT_COMM(NIN)%PROC_NUMBER = I
+              COMM_TRI7VOX(NIN)%PROC_MIN = -1
+              COMM_TRI7VOX(NIN)%RANK=-1
+              COMM_TRI7VOX(NIN)%COMM=-1
+              !   compute the main proc for a given interface
+              DO I = 1,COMM_TRI7VOX(NIN)%PROC_NUMBER
+                COMM_TRI7VOX(NIN)%PROC_MIN = min(COMM_TRI7VOX(NIN)%PROC_MIN,COMM_TRI7VOX(NIN)%PROC_LIST(I))
+              ENDDO
+              !   color the processor
+              IF(IRCVFROM(NIN,ispmd+1)==0.and.ISENDTO(NIN,ispmd+1)==0) THEN
+                COMM_TRI7VOX(NIN)%COLOR=0
+                KEY = 0
+              ELSE
+                COMM_TRI7VOX(NIN)%COLOR=1
+                KEY = 1
+              ENDIF       
+              !   create the communicator
+              CALL MPI_COMM_SPLIT(SPMD_COMM_WORLD,COMM_TRI7VOX(NIN)%COLOR,KEY,COMM_TRI7VOX(NIN)%COMM,CODE)
+              CALL MPI_COMM_SPLIT(SPMD_COMM_WORLD,COMM_TRI7VOX(NIN)%COLOR,KEY,SORT_COMM(NIN)%COMM,CODE)
+              IF(COMM_TRI7VOX(NIN)%COLOR==1) THEN
+                CALL MPI_COMM_RANK(COMM_TRI7VOX(NIN)%comm,COMM_TRI7VOX(NIN)%RANK,CODE)
               ENDIF
-              ! ---------------
+                COMM_TRI7VOX(NIN)%INIT = .false.
+              ENDIF
+              !   ------------------------------
+              INACTI = IPARI(22,NIN)
+              IFQ = IPARI(31,NIN)
+              ITIED = IPARI(85,NIN)
+              IF(IMPL_S==0.OR.NEIG==0) THEN       
+                IF( INACTI==5.OR.INACTI==6.OR.IFQ>0.OR.ITIED/=0)THEN
+                  NEED_COMM_INACTI = .TRUE.
+                  NB_INTER_7_INACTI = NB_INTER_7_INACTI + 1
+                  LIST_INTER_7_INACTI(NIN) = NB_INTER_7_INACTI
+              ENDIF
             ENDIF
-        ENDDO
-!           -----------------------------
+            !   ------------------------------
+          ENDIF
 
-!           -----------------------------
+          !   ------------------------------
+          ! communicator for interface type 25 with solid erosion
+          SOLID_EROSION = IPARI(100,NIN)
+          IDEL = IPARI(17,NIN)! idel option
+          IDELKEEP = IPARI(61,NIN)
+          IF(NTY==25.AND.IPARI(100,NIN)>0.AND.IDELKEEP/=1) THEN
+            ! ---------------
+            ! check if the proc has S or M node
+            DO P=1,NSPMD
+              IF(ISENDTO(NIN,P)>0.OR.IRCVFROM(NIN,P)>0) THEN 
+                NEED_COMM_INT25_SOLID_EROSION(P) = .TRUE.
+              ENDIF
+            ENDDO
+            ! ---------------
+          ENDIF
+        ENDDO
+        ! -----------------------------
+
+        ! -----------------------------
         !   color the processor for inacti option
         IF(.NOT.NEED_COMM_INACTI) THEN
-            COLOR_INACTI = 0
-            KEY = 0
+          COLOR_INACTI = 0
+          KEY = 0
         ELSE
-            COLOR_INACTI = 1
-            KEY = 1
+          COLOR_INACTI = 1
+          KEY = 1
         ENDIF       
         !   create the communicator for the spmd_get_inacti communication
         CALL MPI_COMM_SPLIT(SPMD_COMM_WORLD,COLOR_INACTI,KEY,COMM_INACTI,CODE)  
-!           -----------------------------
+        ! -----------------------------
 
-!           -----------------------------
+        ! -----------------------------
         !   color the processor for interface type 25 + solid erosion option
-        IF(.NOT.NEED_COMM_INT25_SOLID_EROSION) THEN
-            COLOR_INT25_SOLID_EROSION = 0
-            KEY = 0
+        IF(.NOT.NEED_COMM_INT25_SOLID_EROSION(ISPMD+1)) THEN
+          COLOR_INT25_SOLID_EROSION = 0
+          KEY = 0
         ELSE
-            COLOR_INT25_SOLID_EROSION = 1
-            KEY = 1
+          COLOR_INT25_SOLID_EROSION = 1
+          KEY = 1
         ENDIF       
         !   create the communicator for the type25+solid erosion communication
         CALL MPI_COMM_SPLIT(SPMD_COMM_WORLD,COLOR_INT25_SOLID_EROSION,KEY,COMM_INT25_SOLID_EROSION,CODE)  
-c       write(*,*) 'need comm',ispmd,NEED_COMM_INT25_SOLID_EROSION
-!           -----------------------------
+        ! -----------------------------
 #endif
       RETURN
       END SUBROUTINE SPMD_SPLIT_COMM_INTER


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
A mpi hang can occured in spmd_exch_neighbour_segment routine if one processor shares several neighbour nodes with another processor and if this processor does not have any interface /TYPE25

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
Creation of a boolean array to check if remote processor has an interface TYPE25
This boolean is used to exchange some mpi message in spmd_exch_neighbour_segment routine

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
