### PR TITLE
correction issue when using SET COLLECT and SET of SETs

### DIFF
--- a/starter/source/model/sets/create_set_clause.F
+++ b/starter/source/model/sets/create_set_clause.F
@@ -138,7 +138,7 @@ C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER JCLAUSE, ARRAY_SIZE,NSET_GENERAL,FLAG
       LOGICAL :: IS_AVAILABLE
-      INTEGER, INTENT(IN), DIMENSION(NSETS,2) :: ISETM
+      INTEGER, INTENT(IN), DIMENSION(NSET_GENERAL,2) :: ISETM
       INTEGER ARRAY(*)
       TYPE (SET_) ::  CLAUSE
       TYPE(SUBMODEL_DATA),INTENT(IN):: LSUBMODEL(*)


### PR DESCRIPTION
This pull request makes a minor change to the `CREATE_SET_LIST` subroutine in `starter/source/model/sets/create_set_clause.F`. The change updates the dimension of the `ISETM` input array to use `NSET_GENERAL` instead of `NSETS` . potential issue when using SETs of SETs and SETs COLLECT
