### PR TITLE
/FUNCT_PYTHON: missing argument in C++ interface

### DIFF
--- a/common_source/modules/python_mod.F90
+++ b/common_source/modules/python_mod.F90
@@ -267,7 +267,7 @@
             bind(c, name="cpp_python_add_ints_to_dict")
             use, intrinsic :: iso_c_binding
             type(c_ptr), value, intent(in) :: context
-            integer(kind=c_int), value, intent(in) :: nvalues
+            integer(kind=c_int), value, intent(in) :: nvalues, len_name
             character(kind=c_char), dimension(len_name), intent(in) :: name
             type(c_ptr), value , intent(in) :: values
           end subroutine python_add_ints_to_dict
@@ -276,7 +276,7 @@
             bind(c, name="cpp_python_add_doubles_to_dict")
             use, intrinsic :: iso_c_binding
             type(c_ptr), value, intent(in) :: context
-            integer(kind=c_int), value, intent(in) :: nvalues
+            integer(kind=c_int), value, intent(in) :: nvalues, len_name
             character(kind=c_char), dimension(len_name), intent(in) :: name
             type(c_ptr), value :: values
           end subroutine python_add_doubles_to_dict


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

This pull request makes minor updates to the Fortran interface for two subroutines that interact with Python, ensuring both now explicitly receive the length of the `name` character array as an argument. This improves clarity and correctness when interfacing with C/Python code.

- Fortran-Python interface consistency:
  * Added the `len_name` argument to both `python_add_ints_to_dict` and `python_add_doubles_to_dict` subroutines to explicitly specify the length of the `name` character array. [[1]](diffhunk://#diff-a2e46f111c8d4253f26d6678d5b961d1ab5ae010e0e12268b6b67bbf5068872eL270-R270) [[2]](diffhunk://#diff-a2e46f111c8d4253f26d6678d5b961d1ab5ae010e0e12268b6b67bbf5068872eL279-R279)

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
