### PR TITLE
Fix md5_inc not being used for linux64_AOCC

### DIFF
--- a/starter/CMake_Compilers/cmake_linux64_AOCC.txt
+++ b/starter/CMake_Compilers/cmake_linux64_AOCC.txt
@@ -81,10 +81,10 @@ if ( debug STREQUAL "1" )
 set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} -DCPP_comp=f90 -DCOMP_AOCC=1  -g -O0 -ffp-contract=off -frounding-math -fopenmp -Mextend -Mbackslash ${ADF} " )
 
 # C source files
-set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} ${zlib_inc} -O0 -g -fopenmp " )
+set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} ${zlib_inc} ${md5_inc} -O0 -g -fopenmp " )
 
 # CXX source files
-set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} ${zlib_inc} -O0 -g  -fopenmp -std=c++11  " )
+set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} ${zlib_inc} ${md5_inc} -O0 -g  -fopenmp -std=c++11  " )
 
 else ()
 
@@ -92,10 +92,10 @@ else ()
 set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS " -O3  ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} -DCPP_comp=f90 -DCOMP_AOCC=1  -O3 -ffp-contract=off -frounding-math -fopenmp -Mextend  -Mbackslash ${ADF} " )
 
 # C source files
-set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS "${precision_flag} -DMETIS5 ${cppmach} ${cpprel} ${zlib_inc} -O3 -fopenmp " )
+set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS "${precision_flag} -DMETIS5 ${cppmach} ${cpprel} ${zlib_inc} ${md5_inc} -O3 -fopenmp " )
 
 # CXX source files
-set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "${precision_flag} -DMETIS5 ${cppmach} ${cpprel} ${zlib_inc} -O3 -fopenmp -std=c++11  " )
+set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "${precision_flag} -DMETIS5 ${cppmach} ${cpprel} ${zlib_inc} ${md5_inc} -O3 -fopenmp -std=c++11  " )
 
 endif()
 


### PR DESCRIPTION
#### Description of the feature or the bug
Trying to compile **OpenRadioss starter** with **AOCC** on a linux architecture is failing due to `md5.h` not being found.
Comparing to other architecture/compilers, the issue is actually that `md5_inc` is set but never used in `OpenRadioss/starter/CMake_Compilers/cmake_linux64_AOCC.txt`

#### Description of the changes
The commit simply modify the `OpenRadioss/starter/CMake_Compilers/cmake_linux64_AOCC.txt` to add `md5_inc` on relevant `set_source_files_properties`. Those are added right after `zlib_inc` to keep consistency with other CMake_Compilers files.


