### PR TITLE
Heisenbug fixed in mqvisb.F

### DIFF
--- a/engine/source/elements/solid/solide/sboltlaw.F
+++ b/engine/source/elements/solid/solide/sboltlaw.F
@@ -46,11 +46,12 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      D   OFF,     IPM,     RHOREF,  RHOSP,
      E   VOL0DP,  ISMSTR,  JSPH,    JTUR,
      F   ITY,     JTHE,    JSMS,    NPG ,
-     G   glob_therm)
+     G   glob_therm,NUMGEO,IGEO)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       use glob_therm_mod
+      USE prop_param_mod , only : n_var_igeo
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -74,6 +75,7 @@ C-----------------------------------------------
       INTEGER, INTENT(IN) :: JTHE
       INTEGER, INTENT(IN) :: ISMSTR
       INTEGER, INTENT(IN) :: JSPH,NPG
+      INTEGER,INTENT(IN) :: NUMGEO
 C
       INTEGER NEL
       my_real
@@ -96,6 +98,7 @@ C
      .   RHOREF(*)  ,RHOSP(*) 
       DOUBLE PRECISION VOL0DP(*) 
       type (glob_therm_) ,intent(inout) :: glob_therm
+      integer,dimension(n_var_igeo,numgeo),intent(in)  :: igeo
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -146,7 +149,7 @@ C
      5   VD2,     DELTAX,  VIS,     D1,
      6   D2,      D3,      PNEW,    PSH,
      7   MAT,     NGL,     QNEW,    SSP_EQ,
-     8   VOL0,    MSSA,    DMELS,   IBID,
+     8   VOL0,    MSSA,    DMELS,   IGEO,
      9   FACQ0,   CONDE,   DTEL,    G_DT,
      A   IPM,     RHOREF,  RHOSP,   NEL,
      B   ITY,     ISMSTR,  JTUR,    JTHE,

--- a/engine/source/materials/mat/mat001/m1law.F
+++ b/engine/source/materials/mat/mat001/m1law.F
@@ -45,11 +45,13 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      C   VOL_AVG, DTEL,    G_DT,    NEL,
      D   IPM,     RHOREF,  RHOSP,   ITY,
      E   JTUR,    JTHE,    JSPH,    ISMSTR,
-     F   JSMS,    NPG ,    glob_therm)
+     F   JSMS,    NPG ,    glob_therm,
+     G   NUMGEO,  IGEO)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       use glob_therm_mod
+      USE prop_param_mod , only : n_var_igeo
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -72,6 +74,7 @@ C-----------------------------------------------
       INTEGER, INTENT(IN) :: JTUR
       INTEGER, INTENT(IN) :: JTHE
       INTEGER, INTENT(IN) :: JSPH,NPG
+      INTEGER,INTENT(IN) :: NUMGEO
 C
       INTEGER NELTST,ITYPTST,PID(*),G_DT,NEL
       INTEGER MAT(*),NGL(*), IPM(NPROPMI,*)
@@ -87,10 +90,11 @@ C
      .   D1(*), D2(*), D3(*), D4(*), D5(*), D6(*),
      .   MSSA(*), DMELS(*),CONDE(*),AMU(*),VOL_AVG(*),DTEL(*), RHOREF(*), RHOSP(*)
       type (glob_therm_) ,intent(inout) :: glob_therm
+      integer,dimension(n_var_igeo,numgeo),intent(in)  :: igeo
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I, MX, J,IBID
+      INTEGER I, MX, J
       my_real
      .   RHO0(MVSIZ), 
      .   G(MVSIZ), G1(MVSIZ), G2(MVSIZ),
@@ -143,7 +147,7 @@ C
      5   VD2,     DELTAX,  VIS,     D1,
      6   D2,      D3,      PNEW,    PSH,
      7   MAT,     NGL,     QNEW,    SSP_EQ,
-     8   VOL,     MSSA,    DMELS,   IBID,
+     8   VOL,     MSSA,    DMELS,   IGEO,
      9   FACQ0,   CONDE,   DTEL,    G_DT,
      A   IPM,     RHOREF,  RHOSP,   NEL,
      B   ITY,     ISMSTR,  JTUR,    JTHE,

--- a/engine/source/materials/mat/mat001/m1lawi.F
+++ b/engine/source/materials/mat/mat001/m1lawi.F
@@ -45,11 +45,13 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      C   VOL_AVG, DTEL,    G_DT,    NEL,
      D   IPM,     RHOREF,  RHOSP,   ITY,
      E   JTUR,    JTHE,    JSPH,    ISMSTR,
-     F   JSMS,    NPG ,    glob_therm)
+     F   JSMS,    NPG ,    glob_therm,
+     G   NUMGEO,  IGEO)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       use glob_therm_mod
+      USE prop_param_mod , only : n_var_igeo
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -72,6 +74,7 @@ C-----------------------------------------------
       INTEGER, INTENT(IN) :: JTUR
       INTEGER, INTENT(IN) :: JTHE
       INTEGER, INTENT(IN) :: JSPH,NPG
+      INTEGER,INTENT(IN) :: NUMGEO
 C
       INTEGER NELTST,ITYPTST,PID(*),G_DT,NEL
       INTEGER MAT(*),NGL(*), IPM(NPROPMI,*)
@@ -88,10 +91,11 @@ C
      .   D1(*), D2(*), D3(*), D4(*), D5(*), D6(*),
      .   MSSA(*), DMELS(*),CONDE(*),AMU(*),VOL_AVG(*),DTEL(*), RHOREF(*), RHOSP(*)
       type (glob_therm_) ,intent(inout) :: glob_therm
+      integer,dimension(n_var_igeo,numgeo),intent(in)  :: igeo
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I, MX, J,IBID
+      INTEGER I, MX, J
       my_real
      .   RHO0(MVSIZ), 
      .   G(MVSIZ), G1(MVSIZ), G2(MVSIZ),
@@ -142,7 +146,7 @@ C
      5   VD2,     DELTAX,  VIS,     D1,
      6   D2,      D3,      PNEW,    PSH,
      7   MAT,     NGL,     QNEW,    SSP_EQ,
-     8   VOL,     MSSA,    DMELS,   IBID,
+     8   VOL,     MSSA,    DMELS,   IGEO,
      9   FACQ0,   CONDE,   DTEL,    G_DT,
      A   IPM,     RHOREF,  RHOSP,   NEL,
      B   ITY,     ISMSTR,  JTUR,    JTHE,

--- a/engine/source/materials/mat/mat001/m1lawtot.F
+++ b/engine/source/materials/mat/mat001/m1lawtot.F
@@ -58,11 +58,12 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      G   ISELECT, IPM,     RHOREF,  RHOSP,
      H   SIGL,    ITY,     ISMSTR,  JTUR,
      I   JTHE,    JCVT,    JSPH,    JSMS,
-     J   NPG ,    glob_therm)
+     J   NPG ,    glob_therm,NUMGEO,IGEO)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       use glob_therm_mod
+      USE prop_param_mod , only : n_var_igeo
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -88,6 +89,7 @@ C-----------------------------------------------
       INTEGER, INTENT(IN) :: JCVT
       INTEGER, INTENT(IN) :: JSPH
       INTEGER, INTENT(IN) :: JSMS,NPG
+      INTEGER,INTENT(IN) :: NUMGEO
 C
       INTEGER NELTST,ITYPTST,PID(*),G_DT,NEL,ISELECT
       INTEGER MAT(*),NGL(*),IPM(NPROPMI,*)
@@ -107,10 +109,11 @@ C
      .   MFYZ(*)  ,MFZX(*)  ,MFZY(*)  ,MFZZ(*)  ,OFFG0(*) ,VOL_AVG(*),
      .   EPSTH(*),DTEL(*),ETOTSH(NEL,6), RHOREF(*), RHOSP(*),AMU(*)
       type (glob_therm_) ,intent(inout) :: glob_therm
+      integer,dimension(n_var_igeo,numgeo),intent(in)  :: igeo
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I, MX, J,IBID,NLAR,INDEX(MVSIZ),NSM,IPRES,ISTAB
+      INTEGER I, MX, J,NLAR,INDEX(MVSIZ),NSM,IPRES,ISTAB
       my_real
      .   RHO0(MVSIZ), 
      .   G(MVSIZ), G1(MVSIZ), G2(MVSIZ),
@@ -434,7 +437,7 @@ C
      5   VD2,     DELTAX,  VIS,     D1,
      6   D2,      D3,      PNEW,    PSH,
      7   MAT,     NGL,     QNEW,    SSP_EQ,
-     8   VOL,     MSSA,    DMELS,   IBID,
+     8   VOL,     MSSA,    DMELS,   IGEO,
      9   FACQ0,   CONDE,   DTEL,    G_DT,
      A   IPM,     RHOREF,  RHOSP,   NEL,
      B   ITY,     ISMSTR,  JTUR,    JTHE,

--- a/engine/source/materials/mat/mat002/m2law.F
+++ b/engine/source/materials/mat/mat002/m2law.F
@@ -52,12 +52,14 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      G   NEL,     IPM,        RHOREF,  RHOSP,
      H   IPG,     DMG,        ITY,     JTUR,
      I   JTHE,    JSPH,       ISMSTR,  JSMS,
-     J   NPG ,    DPDM ,      FHEAT,   glob_therm)
+     J   NPG ,    DPDM ,      FHEAT,   glob_therm,
+     H   NUMGEO,  IGEO)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       use glob_therm_mod
       use matparam_def_mod
+      USE prop_param_mod , only : n_var_igeo
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -85,6 +87,7 @@ C-----------------------------------------------
       INTEGER, INTENT(IN) :: JTHE
       INTEGER, INTENT(IN) :: JSPH
       INTEGER, INTENT(IN) :: JLAG
+      INTEGER,INTENT(IN) :: NUMGEO
 C
       INTEGER NELTST,ITYPTST,PID(NEL),G_DT,NEL,IPG
       INTEGER MAT(NEL),NGL(NEL), IPM(NPROPMI,*)
@@ -105,6 +108,7 @@ C
      .        RHOREF(NEL)  ,RHOSP(NEL)
       type (glob_therm_)      ,intent(inout) :: glob_therm
       type (matparam_struct_) ,intent(in)    :: mat_param
+      integer,dimension(n_var_igeo,numgeo),intent(in)  :: igeo
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -394,7 +398,7 @@ c-----------------------------------------
      5   VD2,     DELTAX,  VIS,     D1,
      6   D2,      D3,      PNEW,    PSH,
      7   MAT,     NGL,     QNEW,    SSP_EQ,
-     8   VOL,     MSSA,    DMELS,   IBID,
+     8   VOL,     MSSA,    DMELS,   IGEO,
      9   FACQ0,   CONDE,   DTEL,    G_DT,
      A   IPM,     RHOREF,  RHOSP,   NEL,
      B   ITY,     ISMSTR,  JTUR,    JTHE,

--- a/engine/source/materials/mat/mat022/m22law.F
+++ b/engine/source/materials/mat/mat022/m22law.F
@@ -47,11 +47,13 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      E   DTEL,    G_DT,    NEL,     IPM,
      F   RHOREF,  RHOSP,   NFT,     JSPH,
      G   ITY,     JTUR,    JTHE,    ISMSTR,
-     H   JSMS,    NPG ,    glob_therm)
+     H   JSMS,    NPG ,    glob_therm,
+     I   NUMGEO,  IGEO)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       use glob_therm_mod
+      USE prop_param_mod , only : n_var_igeo
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -79,6 +81,7 @@ C-----------------------------------------------
       INTEGER, INTENT(IN) :: JTHE
       INTEGER, INTENT(IN) :: NFT
       INTEGER, INTENT(IN) :: JSPH,NPG
+      INTEGER,INTENT(IN) :: NUMGEO
       INTEGER NELTST,ITYPTST ,PID(*), G_DT
       INTEGER MAT(*),NGL(*),IPLA,NEL,IPM(NPROPMI,*)
       my_real
@@ -99,6 +102,7 @@ C-----------------------------------------------
      .   MSSA(*), DMELS(*), CONDE(*),DTEL(*),
      .   RHOREF(*)  ,RHOSP(*)  
       type (glob_therm_) ,intent(inout) :: glob_therm
+      integer,dimension(n_var_igeo,numgeo),intent(in)  :: igeo
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -389,7 +393,7 @@ C-----------------------------------------------
      5   VD2,     DELTAX,  VIS,     D1,
      6   D2,      D3,      PNEW,    PSH,
      7   MAT,     NGL,     QNEW,    SSP_EQ,
-     8   VOL,     MSSA,    DMELS,   IBID,
+     8   VOL,     MSSA,    DMELS,   IGEO,
      9   FACQ0,   CONDE,   DTEL,    G_DT,
      A   IPM,     RHOREF,  RHOSP,   NEL,
      B   ITY,     ISMSTR,  JTUR,    JTHE,

--- a/engine/source/materials/mat/mat024/m24law.F
+++ b/engine/source/materials/mat/mat024/m24law.F
@@ -53,12 +53,14 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      F   G_DT,    IPM,     RHOREF,  RHOSP,
      G   EPSD,    ITY,     JTUR,    JTHE,
      H   JHBE,    JCVT,    JSPH,    ISMSTR,
-     I   JSMS,    NPG ,    SVIS,   glob_therm)
+     I   JSMS,    NPG ,    SVIS,   glob_therm,
+     J   NUMGEO,  IGEO)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE ELBUFDEF_MOD            
       use glob_therm_mod
+      USE prop_param_mod , only : n_var_igeo
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -83,6 +85,7 @@ C-----------------------------------------------
       INTEGER, INTENT(IN) :: JHBE
       INTEGER, INTENT(IN) :: JCVT
       INTEGER, INTENT(IN) :: JSPH,NPG
+      INTEGER,INTENT(IN) :: NUMGEO
       INTEGER MAT(NEL),NGL(NEL),PID(NEL),G_DT, IPM(NPROPMI,*)
       INTEGER NELTST,ITYPTST,OFFSET,NEL
       my_real DT2T
@@ -100,6 +103,7 @@ C-----------------------------------------------
       my_real, DIMENSION(MVSIZ,6), INTENT(INOUT) :: SVIS
       TYPE(L_BUFEL_)  :: LBUF     
       type (glob_therm_) ,intent(inout) :: glob_therm
+      integer,dimension(n_var_igeo,numgeo),intent(in)  :: igeo
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -155,7 +159,7 @@ C
      5   VD2,     DELTAX,  VIS,     D1,
      6   D2,      D3,      PNEW,    PSH,
      7   MAT,     NGL,     Q,       SSP_EQ,
-     8   VOL,     MSSA,    DMELS,   IBID,
+     8   VOL,     MSSA,    DMELS,   IGEO,
      9   FACQ0,   CONDE,   DTEL,    G_DT,
      A   IPM,     RHOREF,  RHOSP,   NEL,
      B   ITY,     ISMSTR,  JTUR,    JTHE,

--- a/engine/source/materials/mat/mat046/m46law.F
+++ b/engine/source/materials/mat/mat046/m46law.F
@@ -48,12 +48,14 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      E   VOL_AVG, DTEL,    G_DT,    NEL,
      F   D4,      D5,      D6,      RHOREF,
      G   RHOSP,   ISMSTR,  ITY,     JSMS,
-     H   JTUR,    JTHE  ,  NPG ,    SVIS,   glob_therm)
+     H   JTUR,    JTHE  ,  NPG ,    SVIS,   glob_therm,
+     I   IGEO)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
       USE ALE_MOD
       use glob_therm_mod
+      USE prop_param_mod , only : n_var_igeo
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -92,6 +94,7 @@ C-----------------------------------------------
      .         RHOREF(*)  ,RHOSP(*)  
       my_real, DIMENSION(MVSIZ,6), INTENT(INOUT) :: SVIS
       type (glob_therm_) ,intent(inout) :: glob_therm
+      integer,dimension(n_var_igeo,numgeo),intent(in)  :: igeo
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -174,7 +177,7 @@ C-----------------------
      5   VD2,     DELTAX,  VIS,     D1,
      6   D2,      D3,      PNEW,    PSH,
      7   MAT,     NGL,     Q,       SSP_EQ,
-     8   VOL,     MSSA,    DMELS,   IBID,
+     8   VOL,     MSSA,    DMELS,   IGEO,
      9   FACQ0,   CONDE,   DTEL,    G_DT,
      A   IPM,     RHOREF,  RHOSP,   NEL,
      B   ITY,     ISMSTR,  JTUR,    JTHE,

--- a/engine/source/materials/mat_share/mmain.F90
+++ b/engine/source/materials/mat_share/mmain.F90
@@ -827,7 +827,7 @@
             &off,        ipm,        rhoref,     rhosp,&
             &lbuf%vol0dp,ismstr,     jsph,       jtur,&
             &ity,        jthe,       jsms,       npg ,&
-              glob_therm)
+             glob_therm, numgeo,     igeo)
           else if (mtn == 1) then
 !
             if (jhbe==17.and.iint==3.and.ismstr == 1) then
@@ -846,7 +846,8 @@
               &vol_avg,  gbuf%dt,  gbuf%g_dt,nel,&
               &ipm,      rhoref,   rhosp,    ity,&
               &jtur,     jthe,     jsph,     ismstr,&
-              &jsms,     npg ,     glob_therm)
+              &jsms,     npg ,     glob_therm,&
+               numgeo,   igeo)
             else if(ismstr >= 10.and.ismstr <= 12)then
               call m1lawtot(&
               &pm,         off,        lbuf%sig,   lbuf%eint,&
@@ -867,7 +868,7 @@
               &iselect,    ipm,        rhoref,     rhosp,&
               &lbuf%sigl,  ity,        ismstr,     jtur,&
               &jthe,       jcvt,       jsph,       jsms,&
-              &npg ,       glob_therm)
+              &npg ,       glob_therm, numgeo,     igeo)
             else
               call m1law(&
               &pm,       off,      lbuf%sig, lbuf%eint,&
@@ -884,7 +885,8 @@
               &vol_avg,  gbuf%dt,  gbuf%g_dt,nel,&
               &ipm,      rhoref,   rhosp,    ity,&
               &jtur,     jthe,     jsph,     ismstr,&
-              &jsms,     npg ,     glob_therm)
+              &jsms,     npg ,     glob_therm,&
+              &numgeo,   igeo)
             end if
 !
           elseif (mtn == 2) then
@@ -907,7 +909,8 @@
                  nel,      ipm,      rhoref,   rhosp,      &
                  ipg,      lbuf%dmg, ity,      jtur,       &
                  jthe,     jsph,     ismstr,   jsms,       &
-                 npg ,     dpdm  ,   fheat ,   glob_therm)
+                 npg ,     dpdm  ,   fheat ,   glob_therm,&
+                 numgeo,   igeo)
 !----------------
             if (istrain > 0 .and.&
             &(h3d_strain == 1 .or. th_strain == 1 )) then
@@ -1640,7 +1643,8 @@
             &gbuf%dt,  gbuf%g_dt,nel,      ipm,&
             &rhoref,   rhosp,    nft,      jsph,&
             &ity,      jtur,     jthe,     ismstr,&
-            &jsms,     npg ,     glob_therm)
+            &jsms,     npg ,     glob_therm,&
+            numgeo,    igeo)
           else if (mtn == 23) then
             call m22law(&
             &pm,       off,      lbuf%sig, lbuf%eint,&
@@ -1659,7 +1663,8 @@
             &gbuf%dt,  gbuf%g_dt,nel,      ipm,&
             &rhoref,   rhosp,    nft,      jsph,&
             &ity,      jtur,     jthe,     ismstr,&
-            &jsms,     npg ,     glob_therm)
+            &jsms,     npg ,     glob_therm,&
+             numgeo,   igeo)
           else if (mtn == 24) then
             call m24law(&
             &lbuf,     pm,       off,      lbuf%sig,&
@@ -1679,7 +1684,8 @@
             &gbuf%g_dt,ipm,      rhoref,   rhosp,&
             &lbuf%epsd,ity,      jtur,     jthe,&
             &jhbe,     jcvt,     jsph,     ismstr,&
-            &jsms,     npg,      svis ,    glob_therm)
+            &jsms,     npg,      svis ,    glob_therm,&
+             numgeo,   igeo)
 !     like law25 for shell + s33 = eps33*e33
           else if (mtn == 25) then
             call m25law(mat_elem%mat_param(imat),&
@@ -1783,7 +1789,8 @@
             &vol_avg,  gbuf%dt,  gbuf%g_dt,nel,&
             &d4,       d5,       d6,       rhoref,&
             &rhosp,    ismstr,   ity,      jsms,&
-            &jtur,     jthe,     npg,svis ,glob_therm)
+            &jtur,     jthe,     npg,svis ,glob_therm,&
+             igeo)
 !
           else if (mtn == 49) then
             call m49law (mat      ,pm       ,off     ,lbuf%sig,lbuf%pla, &


### PR DESCRIPTION
#### Heisenbug fixed in mqvisb.F

#### Description of the changes
The recent PR  08515205237dda3c65338ae0342c5263401b78e0 introduced the use of the IGEO array, which was already available as a subroutine argument. In some specific cases, however, this argument was not properly passed in the calling sequence. As a result, the IGEO array was replaced by an uninitialized integer (IBID), which could lead to unpredictable behavior due to out-of-bounds memory access, depending on the runtime state.

This has now been properly fixed ; all routines calling the MQVISCB subroutine now correctly pass the IGEO array.