### PR TITLE
set smaller penalty RBE3 stiffness in case of very small nodal stiffness of dependent node

### DIFF
--- a/engine/source/constraints/general/rbe3/rbe3pen_init.F90
+++ b/engine/source/constraints/general/rbe3/rbe3pen_init.F90
@@ -131,7 +131,7 @@
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                        Modules
 ! ----------------------------------------------------------------------------------------------------------------------
-          use constant_mod,          only : one,two,zero,zep05,em6,em20,third,fourth,four,ten,em10
+          use constant_mod,          only : one,two,zero,zep05,em6,em20,third,fourth,four,ten,em10,em03
           use precision_mod, only : WP
 ! ----------------------------------------------------------------------------------------------------------------------
           implicit none
@@ -196,7 +196,7 @@
             rrbe3pen_stf(1) = two*stfnm
             rrbe3pen_stf(2) = four*stfrm
           elseif (stifn(ns)<=em10) then ! small stif
-            rrbe3pen_stf(1) = fourth*stfnm*min(one,ms(ns)/msbar)
+            rrbe3pen_stf(1) = em03*stfnm*min(one,ms(ns)/msbar)
             rrbe3pen_stf(2) = em20 ! only have translation stif
           else
             rrbe3pen_stf(1) = stfnm*stifn(ns)/(stfnm+stifn(ns))


### PR DESCRIPTION


#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
still to decrease the penalty stiffness of RBE3 in special case to avoid instability

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
