### PR TITLE
correction error message h3d sph

### DIFF
--- a/engine/source/output/h3d/h3d_build_fortran/lech3d.F
+++ b/engine/source/output/h3d/h3d_build_fortran/lech3d.F
@@ -2355,6 +2355,11 @@ C--------------------------------------------------
 C--------------------------------------------------
               JMAX=MAX(H3D_NUM_KEY%SPH_SCALAR, H3D_NUM_KEY%SPH_TENSOR)
               DO J=1,JMAX
+                IS_SCALAR = 0
+                IS_TENSOR = 0
+                IF ( KEY3_GLOB == H3D_KEYWORD_SPH_SCALAR(J)%KEY3) IS_SCALAR = 1
+                IF ( KEY3_GLOB == H3D_KEYWORD_SPH_TENSOR(J)%KEY3) IS_TENSOR = 1
+                IF ( IS_SCALAR == 1 .OR. IS_TENSOR == 1) IOK_H3DKEY = 1
                 CPT_H3D = 0
                 IF (H3D_KEYWORD_SPH_SCALAR(J)%IS_ID   /= 0 .OR.
      .              H3D_KEYWORD_SPH_SCALAR(J)%IS_MODE /= 0) THEN


### PR DESCRIPTION
This pull request makes a targeted improvement in the `lech3d.F` Fortran subroutine, enhancing the logic for handling SPH (Smoothed Particle Hydrodynamics) scalar and tensor keywords. The main change is the explicit introduction of variables to distinguish between scalar, vector, and tensor types, and a clearer check for valid SPH keys.

Key update to SPH key handling:

* Added explicit flags (`IS_SCALAR`, `IS_TENSOR`) to clarify the type of SPH key being processed, and updated the logic to set `IOK_H3DKEY` when a valid scalar or tensor key is found.