### PR TITLE
Change LAW88 Young modulus estimation

### DIFF
--- a/starter/source/materials/mat/mat088/hm_read_mat88.F90
+++ b/starter/source/materials/mat/mat088/hm_read_mat88.F90
@@ -534,7 +534,13 @@
             table_mat(2)%x(1)%values(1:nout) = x_out2(1:nout)
             table_mat(2)%y1d(1:nout) = y_out2(1:nout)
           endif
-        endif
+        ! --> Hysteretic unloading parameters
+        elseif (hys /= zero) then
+          iunl_for = 2
+          hys = abs(hys)
+          hys = max(hys,zero)
+          hys = min(hys,one)
+        endif 
 !
         !<======================================================================
         !< Automatic estimation of the elastic parameters
@@ -562,13 +568,13 @@
             sigpeak = min(sigpeak,abs(table_mat(1)%y1d(npt)))
           endif
         elseif (ndim == 2) then
+          do i = 1,npt-1
+            dx = table_mat(1)%x(1)%values(i+1) - table_mat(1)%x(1)%values(i)
+            dy = table_mat(1)%y2d(i+1,1) - table_mat(1)%y2d(i,1)
+            !< Compute the true stress vs true strain slope
+            dydx = max((dy/dx)*(one+(table_mat(1)%x(1)%values(i+1)))**2,dydx)
+          enddo
           do j = 1,nl
-            do i = 1,npt-1
-              dx = table_mat(1)%x(1)%values(i+1) - table_mat(1)%x(1)%values(i)
-              dy = table_mat(1)%y2d(i+1,j) - table_mat(1)%y2d(i,j)
-              !< Compute the true stress vs true strain slope
-              dydx = max((dy/dx)*(one+(table_mat(1)%x(1)%values(i+1)))**2,dydx)
-            enddo
             if (abs(table_mat(1)%y2d(1,j)) > zero) then 
               sigpeak = min(sigpeak,abs(table_mat(1)%y2d(1,j)))
             endif


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

Young modulus estimation in /MAT/LAW88 was too much conservative. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

Change Young modulus estimation in /MAT/LAW88 to keep only the first loading curves (quasi-static). 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
