### PR TITLE
correction check h3d key /H3D/PART

### DIFF
--- a/engine/source/output/h3d/h3d_build_fortran/lech3d.F
+++ b/engine/source/output/h3d/h3d_build_fortran/lech3d.F
@@ -868,6 +868,7 @@ C--------------------------------------------------
               CALL CREATE_H3D_PARTS(H3D_DATA,ID_INPUT,IPART,IGRPART)
               H3D_DATA%IPART_SELECT = 1
               IOK_H3DKEY_COMBINATION = 1
+              IOK_H3DKEY = 1
             ENDIF
 C--------------------------------------------------
             IF(KEY2 == 'NODA') THEN


### PR DESCRIPTION
This pull request introduces a minor update to the `lech3d.F` Fortran subroutine. The change ensures that the variable `IOK_H3DKEY` is set to 1 after creating H3D parts, likely to indicate successful initialization or a ready state.

* Set `IOK_H3DKEY` to 1 after calling `CREATE_H3D_PARTS` in the `LECH3D` subroutine to ensure proper status tracking.