### PR TITLE
regression of /INISH +QEPH in aeb7654c2fc8becb2a42c51c658269350246328b

### DIFF
--- a/starter/source/elements/initia/hm_yctrl.F
+++ b/starter/source/elements/initia/hm_yctrl.F
@@ -460,8 +460,7 @@ C             sorting elements of D00 by ascending id (sorted only once)
                         PTSHEL(IE) = NUMSHEL 
                     ENDIF ! IE > 0   
 C---------store only up to 2 pts of NIP eij(6)+T, pointer= INISHVAR1             
-                    NVSH_STRA = MAX(NVSH_STRA,1+2*MAX(1,NPG)*7)
-!!                    NVSH_STRA = MAX(NVSH_STRA,NIP*MAX(1,NPG)*7)
+                    NVSH_STRA = MAX(NVSH_STRA,2+2*MAX(1,NPG)*7) ! QEPH used 1 and NVSHELL-1 is used 
                   ENDDO ! DO J=1,NB_ELEMENTS
 !
                 ELSEIF ( .NOT. GLOB ) THEN


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
/INISH/STRS_F/GLOB doesn't work for QEPH due to aeb7654c2fc8becb2a42c51c658269350246328b

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
correction of array address conflict of initial stress lecture for QEPH 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
