### PR TITLE
correction potential issue with h3d QUAD TENSOR

### DIFF
--- a/engine/source/output/h3d/h3d_build_fortran/lech3d.F
+++ b/engine/source/output/h3d/h3d_build_fortran/lech3d.F
@@ -2545,7 +2545,7 @@ C--------------------------------------------------
                 IF ( KEY3_GLOB == H3D_KEYWORD_QUAD_SCALAR(J)%KEY3) IS_SCALAR = 1
                 IF ( KEY3_GLOB == H3D_KEYWORD_QUAD_VECTOR(J)%KEY3) IS_VECTOR = 1
                 IF ( KEY3_GLOB == H3D_KEYWORD_QUAD_TENSOR(J)%KEY3) IS_TENSOR = 1
-                IF ( IS_SCALAR == 1 .OR. IS_VECTOR == 1 .OR. IS_TORSOR == 1) IOK_H3DKEY = 1
+                IF ( IS_SCALAR == 1 .OR. IS_VECTOR == 1 .OR. IS_TENSOR == 1) IOK_H3DKEY = 1
 
                 IF ( IS_SCALAR == 1 .OR. IS_VECTOR == 1 .OR. IS_TENSOR == 1 ) THEN
                   IF(IS_SCALAR == 1) H3D_KEYWORD_QUAD = H3D_KEYWORD_QUAD_SCALAR(J)


### PR DESCRIPTION
This pull request fixes a bug in the `lech3d.F` file by correcting a typo in a conditional statement. The change ensures that the code checks for the correct variable (`IS_TENSOR` instead of the misspelled `IS_TORSOR`) when determining if a keyword is valid.

Bug fix:

* Fixed a typo in the conditional statement to check for `IS_TENSOR` instead of `IS_TORSOR`, ensuring correct identification of tensor keywords in the H3D output routine (`lech3d.F`).