### PR TITLE
Typo correction

### DIFF
--- a/common_source/modules/mat_elem/eos_param_mod.F90
+++ b/common_source/modules/mat_elem/eos_param_mod.F90
@@ -184,6 +184,7 @@
           target%p0 = this%p0
           target%pmin = this%pmin
           target%title = this%title
+          target%eostype = this%eostype
           call target%construct()
           if(this%nuparam >= 0) then
             do i= 1,this%nuparam

--- a/engine/source/elements/xelem/xforc28.F
+++ b/engine/source/elements/xelem/xforc28.F
@@ -77,7 +77,7 @@ C VISCM    |   NX    | F | W | NODAL VISCOSITY (TIME STEP)
 C VISCR    |   NX    | F | W | NODAL ROTATION VISCOSITY (TIME STEP)
 C----------+---------+---+---+--------------------------------------------
 C FORC     | 3*NX    | F | W | NODAL FORCES
-C TORQ     | 3*NX    | F | W | NODAL TORQUS
+C TORQ     | 3*NX    | F | W | NODAL TORQUE
 C----------+---------+---+---+--------------------------------------------
 C NUVAR    |  1      | I | R | NUMBER OF USER ELEMENT VARIABLES
 C UVAR     |NUVAR    | F |R/W| USER ELEMENT VARIABLES 

--- a/engine/source/elements/xelem/xforc29.F
+++ b/engine/source/elements/xelem/xforc29.F
@@ -73,7 +73,7 @@ C VISCM    |   NX    | F | W | NODAL VISCOSITY (TIME STEP)
 C VISCR    |   NX    | F | W | NODAL ROTATION VISCOSITY (TIME STEP)
 C----------+---------+---+---+--------------------------------------------
 C FORC     | 3*NX    | F | W | NODAL FORCES
-C TORQ     | 3*NX    | F | W | NODAL TORQUS
+C TORQ     | 3*NX    | F | W | NODAL TORQUE
 C----------+---------+---+---+--------------------------------------------
 C NUVAR    |  1      | I | R | NUMBER OF USER ELEMENT VARIABLES
 C UVAR     |NUVAR    | F |R/W| USER ELEMENT VARIABLES 

--- a/engine/source/elements/xelem/xforc30.F
+++ b/engine/source/elements/xelem/xforc30.F
@@ -73,7 +73,7 @@ C VISCM    |   NX    | F | W | NODAL VISCOSITY (TIME STEP)
 C VISCR    |   NX    | F | W | NODAL ROTATION VISCOSITY (TIME STEP)
 C----------+---------+---+---+--------------------------------------------
 C FORC     | 3*NX    | F | W | NODAL FORCES
-C TORQ     | 3*NX    | F | W | NODAL TORQUS
+C TORQ     | 3*NX    | F | W | NODAL TORQUE
 C----------+---------+---+---+--------------------------------------------
 C NUVAR    |  1      | I | R | NUMBER OF USER ELEMENT VARIABLES
 C UVAR     |NUVAR    | F |R/W| USER ELEMENT VARIABLES 

--- a/engine/source/elements/xelem/xforc31.F
+++ b/engine/source/elements/xelem/xforc31.F
@@ -73,7 +73,7 @@ C VISCM    |   NX    | F | W | NODAL VISCOSITY (TIME STEP)
 C VISCR    |   NX    | F | W | NODAL ROTATION VISCOSITY (TIME STEP)
 C----------+---------+---+---+--------------------------------------------
 C FORC     | 3*NX    | F | W | NODAL FORCES
-C TORQ     | 3*NX    | F | W | NODAL TORQUS
+C TORQ     | 3*NX    | F | W | NODAL TORQUE
 C----------+---------+---+---+--------------------------------------------
 C NUVAR    |  1      | I | R | NUMBER OF USER ELEMENT VARIABLES
 C UVAR     |NUVAR    | F |R/W| USER ELEMENT VARIABLES 

--- a/starter/source/output/th/th_titles.F90
+++ b/starter/source/output/th/th_titles.F90
@@ -2451,9 +2451,9 @@
             "DELTAP",&
             "VOL",&
             "SURF",&
-            "X TORQUS (IMPULSE)",&
-            "Y TORQUS (IMPULSE)",&
-            "Z TORQUS (IMPULSE)",&
+            "X-TORQUE IMPULSE",&
+            "Y-TORQUE IMPULSE",&
+            "Z-TORQUE IMPULSE",&
             "FRICTIONAL ENERGY CONVERTED INTO HEAT",&
             "ELASTIC CONTACT ENERGY",&
             "FRICTIONAL CONTACT ENERGY",&


### PR DESCRIPTION
#### Typo correction

#### Description of the changes
Fixed a typographical error: replaced "TORQUS" (nonexistent term) with "TORQUE", the correct word in English for mechanical torque.
+R2R update following 9528104311e695918033a889b9e4ef50dba2c7c5