### PR TITLE
openReader : element selection per part correction , correction SetValue , correction GetNextAvailableId 

### DIFF
--- a/hm_cfg_files/config/CFG/Keyword971/ELEMENTS/discrete.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/ELEMENTS/discrete.cfg
@@ -24,7 +24,7 @@ ATTRIBUTES(COMMON) {
   collector   = ARRAY[NB_ELE](INT,"Part","PID");
   node1       = ARRAY[NB_ELE](INT,"Node identifier 1","N1");
   node2       = ARRAY[NB_ELE](INT,"Node identifier 2","N2");
-  LSD_VECTOR  = ARRAY[NB_ELE](INT,"Orientation option","VID");//{ SUBTYPES = (/SYSTEM/DEFINE_SD_ORIENTATION) ; }
+  VID         = ARRAY[NB_ELE](VECTOR,"Orientation option","VID");//{ SUBTYPES = (/SYSTEM/DEFINE_SD_ORIENTATION) ; }
   PF          = ARRAY[NB_ELE](INT,"Print flag","PF");
   LSD_SF      = ARRAY[NB_ELE](INT,"Scale factor on forces","S");
   LSD_OFFSET  = ARRAY[NB_ELE](INT,"Initial offset","OFFSET");
@@ -46,7 +46,7 @@ GUI(COMMON) {
          SCALAR(node1);
  optional:
          SCALAR(node2);
-         SCALAR(LSD_VECTOR);
+         SCALAR(VID);
          SCALAR(LSD_SF);
          RADIO(PF)
          {
@@ -63,6 +63,6 @@ FORMAT(Keyword971)
     COMMENT("$    EID     PID      N1      N2     VID               S      PF          OFFSET");
     FREE_CARD_LIST(NB_ELE)
     {
-        CARD("%8d%8d%8d%8d%8d%16lg%8d%16lg",id,collector,node1,node2,LSD_VECTOR,LSD_SF,PF,LSD_OFFSET);
+        CARD("%8d%8d%8d%8d%8d%16lg%8d%16lg",id,collector,node1,node2,VID,LSD_SF,PF,LSD_OFFSET);
     }
 }

--- a/hm_cfg_files/config/CFG/radioss41/ELEM/spring.cfg
+++ b/hm_cfg_files/config/CFG/radioss41/ELEM/spring.cfg
@@ -28,7 +28,7 @@ ATTRIBUTES(COMMON) {
   node_ID4  = ARRAY[COUNT](INT,"Node identifier 4");
   node_ID5  = ARRAY[COUNT](INT,"Node identifier 5");
   node_ID6  = ARRAY[COUNT](INT,"Node identifier 6");
-  skew_ID   = ARRAY[COUNT](SYSTEM,"Skew system identifier 7");
+  Skew_ID   = ARRAY[COUNT](SYSTEM,"Skew system identifier");
 }
 
 DRAWABLES(COMMON) {
@@ -50,7 +50,7 @@ GUI(COMMON) {
          SCALAR(node_ID4);
          SCALAR(node_ID5);
          SCALAR(node_ID6);
-         DATA(skew_ID);
+         DATA(Skew_ID);
     }
 }
 FORMAT(radioss110) 
@@ -59,6 +59,6 @@ FORMAT(radioss110)
     COMMENT("#  sprg_ID  node_ID1  node_ID2  node_ID3  node_ID4  node_ID5  node_ID6                       Skew_ID");
     FREE_CARD_LIST(COUNT)
     {
-        CARD("%10d%10d%10d%10d%10d%10d%10d%20s%10d",id,node_ID1,node_ID2,node_ID3,node_ID4,node_ID5,node_ID6,_BLANK_,skew_ID);
+        CARD("%10d%10d%10d%10d%10d%10d%10d%20s%10d",id,node_ID1,node_ID2,node_ID3,node_ID4,node_ID5,node_ID6,_BLANK_,Skew_ID);
     }
 }

--- a/reader/source/dyna2rad/dyna2rad/_private/convertutils.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/convertutils.cxx
@@ -40,6 +40,7 @@ int ConvertUtils::GetComponentType(const EntityRead& compHRead) const
 {
     int retVal = -2;
     SelectionElementRead elems(compHRead);
+
     while (elems.Next())
     {
         size_t startPos = std::string("*ELEMENT_").length();


### PR DESCRIPTION
This pull request mainly updates configuration files for element definitions and adds debug logging to utility functions. The most significant changes include renaming and type adjustments for element attributes in configuration files, ensuring consistency in attribute naming, and adding debug output for easier tracing in utility functions.

**Configuration file updates (element definitions):**
* Renamed `LSD_VECTOR` to `VID` and changed its type from `INT` to `VECTOR` in `discrete.cfg`, updating all references in attributes, GUI, and format sections for consistency. [[1]](diffhunk://#diff-b5a00bd5462a6cda996208c28a1c70670a6e53cd060555400f48c470b987a476L27-R27) [[2]](diffhunk://#diff-b5a00bd5462a6cda996208c28a1c70670a6e53cd060555400f48c470b987a476L49-R49) [[3]](diffhunk://#diff-b5a00bd5462a6cda996208c28a1c70670a6e53cd060555400f48c470b987a476L66-R66)
* Renamed `skew_ID` to `Skew_ID` and updated its description in `spring.cfg`, ensuring consistent naming throughout attributes, GUI, and format sections. [[1]](diffhunk://#diff-cfc7dd2ba42956ce7cd2fb8b25efa7093f6776f6fdcc411ea85d8e2c8faf6dbfL31-R31) [[2]](diffhunk://#diff-cfc7dd2ba42956ce7cd2fb8b25efa7093f6776f6fdcc411ea85d8e2c8faf6dbfL53-R53) [[3]](diffhunk://#diff-cfc7dd2ba42956ce7cd2fb8b25efa7093f6776f6fdcc411ea85d8e2c8faf6dbfL62-R62)

**Debugs:**
* element selection per part correction
* correction SetValue Method on Elements
* correction redim of arrays while creating elements and nodes
* correction GetNextAvailableId for shells and nodes