### PR TITLE
correction element cfg files for open_reader + not init thick value for shells

### DIFF
--- a/hm_cfg_files/config/CFG/Keyword971/ACCELEROMETER/element_seatbelt_accelerometer.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/ACCELEROMETER/element_seatbelt_accelerometer.cfg
@@ -20,14 +20,14 @@ ATTRIBUTES(COMMON)
     //INPUT ATTRIBUTES
 
     //Card 1
-    node1                                   = VALUE(NODE, "Node 1 ID");
-    node2                                   = VALUE(NODE, "Node 2 ID");
-    node3                                   = VALUE(NODE, "Node 3 ID");
+    NID1                                   = VALUE(NODE, "Node 1 ID");
+    NID2                                   = VALUE(NODE, "Node 2 ID");
+    NID3                                   = VALUE(NODE, "Node 3 ID");
     curve_id                                = VALUE(CURVE, "Gravitational accelerations due to body force loads.");
     igrav_gt                                = VALUE(INT,"");
     igrav                                   = VALUE(INT, "Gravitational accelerations due to body force loads.");
     intopt                                  = VALUE(INT, "Integration option");
-    mass                                    = VALUE(FLOAT, "Optional added mass for accelerometer");
+    MASS                                    = VALUE(FLOAT, "Optional added mass for accelerometer");
 
     IOFLAG                                  = VALUE(INT, "IOFLAG");
     KEYWORD_STR                             = VALUE(STRING,"");
@@ -44,9 +44,9 @@ GUI(COMMON)
     ASSIGN(KEYWORD_STR, "*ELEMENT_SEATBELT_ACCELEROMETER");
 
     //check for all DIMENSIONS
-    DATA(node1,      "NID1");
-    DATA(node2,      "NID2");
-    DATA(node3,      "NID3");
+    DATA(NID1,      "NID1");
+    DATA(NID2,      "NID2");
+    DATA(NID3,      "NID3");
     FLAG(igrav_gt);
     if(igrav_gt == 1)
     {
@@ -77,7 +77,7 @@ GUI(COMMON)
         ADD(1, "1: velocities are integrated directly from the local accelerations");
     }
 
-    SCALAR(mass)   {DIMENSION="m";}
+    SCALAR(MASS)   {DIMENSION="m";}
 }
 
 // File format
@@ -90,7 +90,7 @@ FORMAT(Keyword971)
 
     //Card 1
     COMMENT("$   SBACID      NID1      NID2      NID3     IGRAV    INTOPT      MASS");
-    CARD("%10d%10d%10d%10d%10d%10d%10lg", _ID_, node1, node2, node3, igrav, intopt, mass);
+    CARD("%10d%10d%10d%10d%10d%10d%10lg", _ID_, NID1, NID2, NID3, igrav, intopt, MASS);
 
     if(igrav > 1 && IOFLAG == 1)
     {

--- a/hm_cfg_files/config/CFG/Keyword971/ELEMENTS/shell.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/ELEMENTS/shell.cfg
@@ -33,11 +33,11 @@ ATTRIBUTES(COMMON) {
   node7     = ARRAY[NB_ELE](INT,"Mid-side node identifier 7","N7");
   node8     = ARRAY[NB_ELE](INT,"Mid-side node identifier 8","N8");
   // Shell (attributes)
-  LSD_ELEM_T1  = ARRAY[NB_ELE](FLOAT,"Shell thickness at node 1","THIC1");
-  LSD_ELEM_T2  = ARRAY[NB_ELE](FLOAT,"Shell thickness at node 2","THIC2");
-  LSD_ELEM_T3  = ARRAY[NB_ELE](FLOAT,"Shell thickness at node 3","THIC3");
-  LSD_ELEM_T4  = ARRAY[NB_ELE](FLOAT,"Shell thickness at node 4","THIC4");
-  LSD_ELEM_PSI = ARRAY[NB_ELE](FLOAT,"Orthotropic material base offset angle","BETA");
+  THIC1  = ARRAY[NB_ELE](FLOAT,"Shell thickness at node 1","THIC1");
+  THIC2  = ARRAY[NB_ELE](FLOAT,"Shell thickness at node 2","THIC2");
+  THIC3  = ARRAY[NB_ELE](FLOAT,"Shell thickness at node 3","THIC3");
+  THIC4  = ARRAY[NB_ELE](FLOAT,"Shell thickness at node 4","THIC4");
+  BETA = ARRAY[NB_ELE](FLOAT,"Orthotropic material base offset angle","BETA");
   LSD_SYSTEM   = ARRAY[NB_ELE](SYSTEM,"Material coordinate system ID","MCID");
   LSD_OFFSET   = ARRAY[NB_ELE](FLOAT,"[OFFSET] The offset distance from the plane of nodal points to the ref surface","OFFSET");
   NS1       = ARRAY[NB_ELE](FLOAT,"Scalar node 1","NS1");
@@ -111,15 +111,15 @@ GUI(COMMON) {
            Elem_Option==11 || Elem_Option==15 ||
            Elem_Option==4 || Elem_Option==7 || Elem_Option==10 || Elem_Option==12 || Elem_Option==16)
         {
-            SCALAR(LSD_ELEM_T1) { DIMENSION="l"; }
-            SCALAR(LSD_ELEM_T2) { DIMENSION="l"; }
-            SCALAR(LSD_ELEM_T3) { DIMENSION="l"; }
-            SCALAR(LSD_ELEM_T4) { DIMENSION="l"; }
+            SCALAR(THIC1) { DIMENSION="l"; }
+            SCALAR(THIC2) { DIMENSION="l"; }
+            SCALAR(THIC3) { DIMENSION="l"; }
+            SCALAR(THIC4) { DIMENSION="l"; }
         }
         if(Elem_Option==2 || Elem_Option==3 || Elem_Option==6 || Elem_Option==8 || Elem_Option==9 ||
            Elem_Option==11 || Elem_Option==15)
         {
-            SCALAR(LSD_ELEM_PSI) {DIMENSION = "a";}
+            SCALAR(BETA) {DIMENSION = "a";}
         }
         if(Elem_Option==4 || Elem_Option==7 || Elem_Option==10 || Elem_Option==12 || Elem_Option==16)
         {
@@ -191,7 +191,7 @@ FORMAT(Keyword971)
         FREE_CARD_LIST(NB_ELE)
         {
             CARD("%8d%8d%8d%8d%8d%8d%8d%8d%8d%8d",id,collector,node1,node2,node3,node4,node5,node6,node7,node8);
-            CARD("%16lg%16lg%16lg%16lg%16lg", LSD_ELEM_T1, LSD_ELEM_T2, LSD_ELEM_T3, LSD_ELEM_T4, LSD_ELEM_PSI);
+            CARD("%16lg%16lg%16lg%16lg%16lg", THIC1, THIC2, THIC3, THIC4, BETA);
         }
     }
     else if((if_BETA == 1 || (if_THICKNESS == 1 && if_MCID != 0)) && if_OFFSET == 0 && if_DOF == 0)

--- a/hm_cfg_files/config/CFG/radioss41/ELEM/shell3n.cfg
+++ b/hm_cfg_files/config/CFG/radioss41/ELEM/shell3n.cfg
@@ -26,20 +26,20 @@ ATTRIBUTES(COMMON) {
   node_ID2  = ARRAY[COUNT](INT,"Node identifier 2");
   node_ID3  = ARRAY[COUNT](INT,"Node identifier 3");
   // Shell (3N & 4N) attributes
-  THICKNESS = ARRAY[COUNT](FLOAT,"Thickness");
+  Thick = ARRAY[COUNT](FLOAT,"Thickness");
   PHI_Z		= ARRAY[COUNT](FLOAT,"Orthotropy angle to element skew ");
 }
 
 DRAWABLES(COMMON) {
  private:
-  LOC_THICKNESS  = SCALAR(THICKNESS);
-  PART_THICKNESS = SUBDRAWABLE(PART,THICKNESS);
+  LOC_THICKNESS  = SCALAR(Thick);
+  PART_THICKNESS = SUBDRAWABLE(PART,Thick);
  public:
-  THICKNESS      = WHILE_ZERO(LOC_THICKNESS,PART_THICKNESS);
+  Thick      = WHILE_ZERO(LOC_THICKNESS,PART_THICKNESS);
   TIME_STEP      = TIME_STEP();
  public:
   AREA           = AREA();
-  VOLUME         = EVAL(AREA*THICKNESS);
+  VOLUME         = EVAL(AREA*Thick);
 }
 
 GUI(COMMON) {
@@ -55,7 +55,7 @@ mandatory:
          SCALAR(node_ID3);
  optional:  
          SCALAR(PHI_Z) {DIMENSION = "a";}
-         SCALAR(THICKNESS) { DIMENSION="l"; }
+         SCALAR(Thick) { DIMENSION="l"; }
     }
 }
 FORMAT(radioss110) 
@@ -64,6 +64,6 @@ FORMAT(radioss110)
     COMMENT("#  tria_ID  node_ID1  node_ID2  node_ID3                                    PhiS               Thick");
     FREE_CARD_LIST(COUNT)
     {
-        CARD("%10d%10d%10d%10d%30s%20lg%20lg",id,node_ID1,node_ID2,node_ID3,_BLANK_,PHI_Z,THICKNESS);
+        CARD("%10d%10d%10d%10d%30s%20lg%20lg",id,node_ID1,node_ID2,node_ID3,_BLANK_,PHI_Z,Thick);
     }
 }

--- a/hm_cfg_files/config/CFG/radioss41/ELEM/shell4n.cfg
+++ b/hm_cfg_files/config/CFG/radioss41/ELEM/shell4n.cfg
@@ -27,20 +27,20 @@ ATTRIBUTES(COMMON) {
   node_ID3  = ARRAY[COUNT](INT,"Node identifier 3");
   node_ID4  = ARRAY[COUNT](INT,"Node identifier 4");
   // Shell (3N & 4N) attributes
-  THICKNESS = ARRAY[COUNT](FLOAT,"Thickness");
+  Thick = ARRAY[COUNT](FLOAT,"Thickness");
   PHI_Z		= ARRAY[COUNT](FLOAT,"Orthotropy angle to element skew ");
 }
 
 DRAWABLES(COMMON) {
  private:
-  LOC_THICKNESS  = SCALAR(THICKNESS);
-  PART_THICKNESS = SUBDRAWABLE(PART,THICKNESS);
+  LOC_THICKNESS  = SCALAR(Thick);
+  PART_THICKNESS = SUBDRAWABLE(PART,Thick);
  public:
-  THICKNESS      = WHILE_ZERO(LOC_THICKNESS,PART_THICKNESS);
+  Thick      = WHILE_ZERO(LOC_THICKNESS,PART_THICKNESS);
   TIME_STEP      = TIME_STEP();
  public:
   AREA           = AREA();
-  VOLUME         = EVAL(AREA*THICKNESS);
+  VOLUME         = EVAL(AREA*Thick);
 }
 
 GUI(COMMON) {
@@ -58,16 +58,16 @@ GUI(COMMON) {
  optional:
          SCALAR(node_ID4);
          SCALAR(PHI_Z) {DIMENSION = "a";}
-         SCALAR(THICKNESS) { DIMENSION="l"; }
+         SCALAR(Thick) { DIMENSION="l"; }
     }
 
 }
 FORMAT(radioss110) 
 {
     HEADER("/SHELL/%d",PART);
-    COMMENT("# shell_ID  node_ID1  node_ID2  node_ID3  node_ID4                          PhiS               Thick");
+    COMMENT("# shell_ID  node_ID1  node_ID2  node_ID3  node_ID4                         PHI_Z               Thick");
     FREE_CARD_LIST(COUNT)
     {
-        CARD("%10d%10d%10d%10d%10d%10s%20lg%20lg",id,node_ID1,node_ID2,node_ID3,node_ID4,_BLANK_,PHI_Z,THICKNESS);
+        CARD("%10d%10d%10d%10d%10d%10s%20lg%20lg",id,node_ID1,node_ID2,node_ID3,node_ID4,_BLANK_,PHI_Z,Thick);
     }
 }

--- a/reader/source/dyna2rad/dyna2rad/_private/convertelements.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/convertelements.cxx
@@ -300,6 +300,12 @@ void ConvertElem::ConvertEntities()
                         if (radThick != 0.0)
                             radElem.SetValue(p_radiossModel,sdiIdentifier("Thick"),sdiValue(radThick));
                     }
+                    else
+                    {
+                        double defaultThick = 0.0;
+                        radElem.SetValue(p_radiossModel,sdiIdentifier("Thick"),sdiValue(defaultThick));
+                    }
+
                     double elemBeta = 0.0;
                     sdiValue tempVal(elemBeta);
                     elemSelect->GetValue(sdiIdentifier("BETA"), tempVal);


### PR DESCRIPTION
This pull request standardizes and updates attribute naming conventions for shell and accelerometer elements across several configuration files. The changes replace older, inconsistent attribute names with newer, more descriptive ones, ensuring consistency between attribute definitions, GUI references, and file formats. Additionally, the radioss element conversion logic now ensures a default value for shell thickness is always set.

**Attribute Renaming and Standardization**

* Replaced `node1`, `node2`, `node3`, and `mass` with `NID1`, `NID2`, `NID3`, and `MASS` respectively in all sections of `element_seatbelt_accelerometer.cfg`, ensuring consistent naming in attributes, GUI, and format definitions. [[1]](diffhunk://#diff-a3185a64515c795a77e9efa7e71c96cc2788b43d4c3f1d66c60a5307a0511300L23-R30) [[2]](diffhunk://#diff-a3185a64515c795a77e9efa7e71c96cc2788b43d4c3f1d66c60a5307a0511300L47-R49) [[3]](diffhunk://#diff-a3185a64515c795a77e9efa7e71c96cc2788b43d4c3f1d66c60a5307a0511300L80-R80) [[4]](diffhunk://#diff-a3185a64515c795a77e9efa7e71c96cc2788b43d4c3f1d66c60a5307a0511300L93-R93)
* Updated shell element thickness and angle attributes: replaced `LSD_ELEM_T1`–`LSD_ELEM_T4` and `LSD_ELEM_PSI` with `THIC1`–`THIC4` and `BETA` in `shell.cfg`, including all relevant GUI and format sections. [[1]](diffhunk://#diff-57b0726b5424610f711898f946f7b2ae2ded4ac08a5961b1ec0e8bb7f34dc8edL36-R40) [[2]](diffhunk://#diff-57b0726b5424610f711898f946f7b2ae2ded4ac08a5961b1ec0e8bb7f34dc8edL114-R122) [[3]](diffhunk://#diff-57b0726b5424610f711898f946f7b2ae2ded4ac08a5961b1ec0e8bb7f34dc8edL194-R194)
* Renamed `THICKNESS` to `Thick` in both `shell3n.cfg` and `shell4n.cfg` for radioss elements, updating all attribute, drawable, GUI, and format references. [[1]](diffhunk://#diff-3c9aadbd3645fb77476bbe3c7ea83c7fed3425252080382d572ea1b58f69b76fL29-R42) [[2]](diffhunk://#diff-3c9aadbd3645fb77476bbe3c7ea83c7fed3425252080382d572ea1b58f69b76fL58-R58) [[3]](diffhunk://#diff-3c9aadbd3645fb77476bbe3c7ea83c7fed3425252080382d572ea1b58f69b76fL67-R67) [[4]](diffhunk://#diff-1c0e5df3beda621f0b2938e0a77d1a2034c0064e4b9965941162cf41dd29575fL30-R43) [[5]](diffhunk://#diff-1c0e5df3beda621f0b2938e0a77d1a2034c0064e4b9965941162cf41dd29575fL61-R71)

**Conversion Logic Enhancement**

* Modified radioss element conversion in `convertelements.cxx` to set a default value of `Thick` to 0.0 when not otherwise specified, preventing unset thickness attributes.
