### PR TITLE
correction cfg files elements

### DIFF
--- a/hm_cfg_files/config/CFG/Keyword971/ELEMENTS/seatbelt.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/ELEMENTS/seatbelt.cfg
@@ -20,12 +20,12 @@
 ATTRIBUTES(COMMON) {
   // Common attributes
   NB_ELE    = SIZE("Number of elements");
-  id        = ARRAY[NB_ELE](ELEMS,"Element identifier","EID") { SUBTYPES = (/ELEMENT/BEAM_IDPOOL) ; }
-  PART      = ARRAY[NB_ELE](COMPONENT,"Part","PID");
-  node_ID1  = ARRAY[NB_ELE](NODE,"Node identifier 1","N1");
-  node_ID2  = ARRAY[NB_ELE](NODE,"Node identifier 2","N2");
-  node_ID3  = ARRAY[NB_ELE](NODE,"Node identifier 3","N3");
-  node_ID4  = ARRAY[NB_ELE](NODE,"Node identifier 4","N4");
+  id        = ARRAY[NB_ELE](INT,"Element identifier","EID") { SUBTYPES = (/ELEMENT/BEAM_IDPOOL) ; }
+  collector = ARRAY[NB_ELE](INT,"Part","PID");
+  node1     = ARRAY[NB_ELE](INT,"Node identifier 1","N1");
+  node2     = ARRAY[NB_ELE](INT,"Node identifier 2","N2");
+  node3     = ARRAY[NB_ELE](INT,"Node identifier 3","N3");
+  node4     = ARRAY[NB_ELE](INT,"Node identifier 4","N4");
   SLEN      = ARRAY[NB_ELE](FLOAT,"[SLEN] Initial slack length");
   SBRID     = ARRAY[NB_ELE](RETRACTOR,"[SBRID] Retractor ID");  
   //
@@ -43,13 +43,13 @@ mandatory:
     SIZE(NB_ELE) ;
     ARRAY(NB_ELE,"element data")
     {
-        DATA(id) ;
-        DATA(PART);
-        DATA(node_ID1);
-        DATA(node_ID2);
+        SCALAR(id) ;
+        SCALAR(collector);
+        SCALAR(node1);
+        SCALAR(node2);
  optional:
-        DATA(node_ID3);
-        DATA(node_ID4);
+        SCALAR(node1);
+        SCALAR(node2);
         DATA(SBRID);
         SCALAR(SLEN) {DIMENSION="l";}
     } 
@@ -61,6 +61,6 @@ FORMAT(Keyword971)
     COMMENT("$    EID     PID      N1      N2   SBRID            SLEN      N3      N4");
     FREE_CARD_LIST(NB_ELE)
     {
-        CARD("%8d%8d%8d%8d%8d%16lg%8d%8d",id,PART,node_ID1,node_ID2,SBRID,SLEN,node_ID3,node_ID4);
+        CARD("%8d%8d%8d%8d%8d%16lg%8d%8d",id,PART,node1,node2,SBRID,SLEN,node3,node4);
     }
 }

--- a/hm_cfg_files/config/CFG/Keyword971/ELEMENTS/sphcel.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/ELEMENTS/sphcel.cfg
@@ -20,9 +20,9 @@
 // MCDS attributes description
 ATTRIBUTES(COMMON) {
   NB_ELE    = SIZE("Number of elements");
-  PART      = ARRAY[NB_ELE](COMPONENT,"Part","PID");
+  collector = ARRAY[NB_ELE](INT,"Part","PID");
   id        = ARRAY[NB_ELE](INT,"Element identifier","EID");
-  node_ID1  = ARRAY[NB_ELE](NODE,"Node identifier","NID");
+  node1     = ARRAY[NB_ELE](INT,"Node identifier","NID");
   MASS      = ARRAY[NB_ELE](FLOAT,"Based on beam type","MASS");
 }
 
@@ -41,9 +41,9 @@ GUI(COMMON) {
     ARRAY(NB_ELE,"element data")
     {
  //        DATA(id) ;
-         DATA(node_ID1);
-         ASSIGN(id    ,node_ID1);
-         DATA(PART);
+         SCALAR(node1);
+         ASSIGN(id    ,node1);
+         SCALAR(collector);
          SCALAR(MASS){DIMENSION="m";}
     }
 }
@@ -53,7 +53,7 @@ FORMAT(Keyword971)
     COMMENT("$    NID     PID            MASS");
     FREE_CARD_LIST(NB_ELE)
     {
-        CARD("%8d%8d%16lg",node_ID1,PART,MASS);
-        ASSIGN(id    ,node_ID1,IMPORT);
+        CARD("%8d%8d%16lg",node1,collector,MASS);
+        ASSIGN(id    ,node1,IMPORT);
     }
 }


### PR DESCRIPTION
This pull request updates the configuration files for the `seatbelt` and `sphcel` elements to standardize attribute naming conventions and data types, improving consistency and clarity across the codebase. The changes primarily focus on renaming attributes, switching data types to `INT` where appropriate, and updating related sections in the element definitions.

**Seatbelt element configuration changes:**

* Renamed attributes in `seatbelt.cfg` from `PART`, `node_ID1`, `node_ID2`, `node_ID3`, and `node_ID4` to `collector`, `node1`, `node2`, `node3`, and `node4`, and changed their data types from `COMPONENT`/`NODE` to `INT`.
* Updated the mandatory and optional data section to use `SCALAR` for the new attribute names and removed the old names.
* Modified the card format in the `FORMAT(Keyword971)` section to use the new attribute names.

**Sphcel element configuration changes:**

* Renamed `PART` and `node_ID1` attributes to `collector` and `node1` in `sphcel.cfg` and changed their data types to `INT`.
* Updated the GUI and card assignment logic to use the new attribute names and types.
* Modified the card format in the `FORMAT(Keyword971)` section to use the new attribute names.