### PR TITLE
/INTER/TYPE25: fix size for SPMD+E2E+ Friction

### DIFF
--- a/engine/source/mpi/interfaces/spmd_i7tool.F
+++ b/engine/source/mpi/interfaces/spmd_i7tool.F
@@ -4679,7 +4679,7 @@ C
                   CALL READ_I_C(LEDGE_FIE(I)%P,E_LEDGE_SIZE*LENR_EDGE)
                   IPARI(69,I) = LENR_EDGE
                   IF(INTFRIC > 0) THEN
-                     ALLOCATE(IPARTFRIC_FIE(I)%P(LENR),STAT=IERROR1)
+                     ALLOCATE(IPARTFRIC_FIE(I)%P(LENR_EDGE),STAT=IERROR1)
                      CALL READ_I_C(IPARTFRIC_FIE(I)%P,LENR_EDGE)
                   ENDIF
                   IF(IPARI(97,I) > 0) THEN


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
This pull request makes a targeted fix to the allocation of the `IPARTFRIC_FIE(I)%P` array in the `SPMD_INITFI` subroutine to ensure it uses the correct size (`LENR_EDGE` instead of `LENR`). This change resolves a potential sizing issue when allocating memory for this array.

* Updated the allocation of `IPARTFRIC_FIE(I)%P` in the `SPMD_INITFI` subroutine to use `LENR_EDGE` instead of `LENR`, ensuring correct memory allocation for edge friction parameters.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
