### PR TITLE
openreader read *ELEMENT_SHELL_BETA

### DIFF
--- a/hm_cfg_files/config/CFG/Keyword971_R14.1/data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R14.1/data_hierarchy.cfg
@@ -44,7 +44,7 @@ HIERARCHY
             FILE           = "ELEMENTS/shell.cfg";
             HM_TYPE        = 1;
             ID_POOL        = 2;
-            USER_NAMES     = (ELEMENT_SHELL,ELEMENT_SHELL_THICKNESS,ElShell3);
+            USER_NAMES     = (ELEMENT_SHELL,ELEMENT_SHELL_THICKNESS,ELEMENT_SHELL_BETA,ElShell3);
         }
     }    
     HIERARCHY {


### PR DESCRIPTION
This pull request makes a small update to the `data_hierarchy.cfg` configuration file, specifically within the `HIERARCHY` section. The change adds the `ELEMENT_SHELL_BETA` user name to the list of recognized element shell types.

* Added `ELEMENT_SHELL_BETA` to the `USER_NAMES` list in the `HIERARCHY` section of `hm_cfg_files/config/CFG/Keyword971_R14.1/data_hierarchy.cfg`.