### PR TITLE
/ITNER/TYPE25 + Irem + E2S: starter segfault

### DIFF
--- a/starter/source/interfaces/interf1/upgrade_remnode.F
+++ b/starter/source/interfaces/interf1/upgrade_remnode.F
@@ -383,22 +383,22 @@ C Set the new NREMNODE parameter for the given Interface
       INTBUF_TAB%KREMNODE_E2S(1:INTBUF_TAB%S_KREMNODE_E2S)=0
 
       OLD_SIZE = INTBUF_TAB%S_REMNODE_E2S
-      ALLOCATE (OLD_TAB(OLD_SIZE))
-      !save values
-      DO I=1,OLD_SIZE
-        OLD_TAB(I)=INTBUF_TAB%REMNODE_E2S(I)
-      ENDDO      
-      DEALLOCATE(INTBUF_TAB%REMNODE_E2S)
-
-      !reallocate with new size and copy saved values
       INTBUF_TAB%S_REMNODE_E2S = NREMNODE
-      ALLOCATE(INTBUF_TAB%REMNODE_E2S(INTBUF_TAB%S_REMNODE_E2S))
-      INTBUF_TAB%REMNODE_E2S(1:INTBUF_TAB%S_REMNODE_E2S)=0
-      DO I=1,OLD_SIZE
-        INTBUF_TAB%REMNODE_E2S(I) = OLD_TAB(I)
-      ENDDO   
-C
-      DEALLOCATE(OLD_TAB)
-C
+      IF(OLD_SIZE < INTBUF_TAB%S_REMNODE_E2S) THEN
+        ALLOCATE (OLD_TAB(OLD_SIZE))
+        !save values
+        DO I=1,OLD_SIZE
+          OLD_TAB(I)=INTBUF_TAB%REMNODE_E2S(I)
+        ENDDO      
+        DEALLOCATE(INTBUF_TAB%REMNODE_E2S)
 
+        !reallocate with new size and copy saved values
+        ALLOCATE(INTBUF_TAB%REMNODE_E2S(INTBUF_TAB%S_REMNODE_E2S))
+        INTBUF_TAB%REMNODE_E2S(1:INTBUF_TAB%S_REMNODE_E2S)=0
+        DO I=1,OLD_SIZE
+          INTBUF_TAB%REMNODE_E2S(I) = OLD_TAB(I)
+        ENDDO   
+C
+        DEALLOCATE(OLD_TAB)
+      ENDIF
       END


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

This pull request introduces improvements to memory allocation and safety checks in two subroutines. The main updates ensure more robust handling of array resizing and edge value calculations, including better handling of edge cases and clearer warnings for potential issues.

**Memory allocation and safety in node upgrade:**
* In `upgrade_remnode.F`, the subroutine `UPGRADE_REMNODE_E2S` now updates the size of `REMNODE_E2S` only if the new size is larger


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
