### PR TITLE
/FAIL/BIQUAD: possible division by 0

### DIFF
--- a/starter/source/materials/fail/biquad/hm_read_fail_biquad.F
+++ b/starter/source/materials/fail/biquad/hm_read_fail_biquad.F
@@ -197,6 +197,7 @@ c
       ENDIF
 c
       ! Check if minimum of first parabola is negative 
+      IF(X_1(2) .ne. Zero) then
       XMIN = -X_1(1)/(TWO*X_1(2))
       YMIN = X_1(2)*(XMIN**2) + X_1(1)*XMIN + C2
       IF (YMIN < ZERO) THEN 
@@ -204,8 +205,9 @@ c
      .              I1=MAT_ID,
      .              C1=TITR)          
       ENDIF
+      ENDIF
       ! Check if minimum of second parabola is negative 
-      IF (SFLAG == 1) THEN 
+      IF (SFLAG == 1 .and. X_2(3) .ne. 0) THEN 
         XMIN = -X_2(2)/(TWO*X_2(3))
         YMIN = X_2(3)*(XMIN**2) + X_2(2)*XMIN + X_2(1)
         IF (YMIN < ZERO) THEN 


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
This pull request introduces additional checks to the logic that determines if the minimum of a parabola is negative in the `hm_read_fail_biquad.F` file. The changes help prevent division by zero and ensure that the code only evaluates parabolas with valid quadratic coefficients.

Improvements to numerical stability and correctness:

* Added a check to ensure that the quadratic coefficient (`X_1(2)`) is nonzero before calculating the minimum of the first parabola, preventing potential division by zero errors.
* Updated the condition for checking the second parabola's minimum to require that its quadratic coefficient (`X_2(3)`) is also nonzero, further preventing invalid calculations.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
