### PR TITLE
starter stacksize reduction

### DIFF
--- a/starter/source/groups/linedge.F
+++ b/starter/source/groups/linedge.F
@@ -47,11 +47,14 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I,J,K,J1,J2
-      INTEGER IW1(4*NSEG0),IW2(4*NSEG0),IW5(4*NSEG0),IW6(4*NSEG0),
-     .        INDEX(8*NSEG0),IWORK(70000), IPERM(4)
+      INTEGER I,J,K,J1,J2,IPERM(4)
+C     INTEGER IW1(4*NSEG0),IW2(4*NSEG0),IW5(4*NSEG0),IW6(4*NSEG0),
+C    .        INDEX(8*NSEG0),IWORK(70000), IPERM(4)
+      integer, dimension(:), allocatable :: IW1,IW2,IW5,IW6,INDEX,IWORK
       DATA IPERM /2,3,4,1/
 C=======================================================================
+      ALLOCATE(IW1(4*NSEG0), IW2(4*NSEG0), IW5(4*NSEG0),IW6(4*NSEG0), INDEX(8*NSEG0))
+      ALLOCATE(IWORK(70000))
       K=0
       IW1 = 0
       IW2 = 0
@@ -158,5 +161,7 @@ C
 C-----------
       ENDIF
 C-----------
+      DEALLOCATE(IW1 ,IW2, IW5,IW6, INDEX,IWORK)
+
       RETURN
       END

--- a/starter/source/loads/reference_state/xref/hm_read_xref.F
+++ b/starter/source/loads/reference_state/xref/hm_read_xref.F
@@ -87,25 +87,27 @@ C MODIFIED ARGUMENT
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER  TAGELC(NUMELC),TAGELTG(NUMELTG),TAGELS(NUMELS)
-      INTEGER  TAGNOD(NUMNOD),IFLAGUNIT
+      INTEGER :: IFLAGUNIT
       INTEGER, DIMENSION(:), ALLOCATABLE :: ID
       INTEGER  I,J,IE,IN,IP,IR,NN,NITER,PARTID,UID,ITYP,ICOMPA
       INTEGER  SUB_ID,NNOD,SUB_INDEX,IMID, MAT_ID,MTN,NSOLID,NPT,ISMSTR
-      my_real
-     .  XTMP(3,NUMNOD)
+      my_real, dimension(:,:), allocatable :: xtmp
       my_real, DIMENSION(:), ALLOCATABLE ::
      .  XX,YY,ZZ
       CHARACTER MESS*40
       CHARACTER(LEN=NCHARTITLE) :: TITR,TITR1
       DATA MESS/'XREF'/
       LOGICAL :: IS_AVAILABLE,FOUND      
+      integer, dimension(:), allocatable :: TAGELC,TAGELTG,TAGELS,TAGNOD
 C-----------------------------------------------
 C   E x t e r n a l   F u n c t i o n s
 C-----------------------------------------------
       INTEGER USR2SYS,R2R_SYS
 C=======================================================================
       IS_AVAILABLE = .FALSE.
+      ALLOCATE(TAGELC(NUMELC),TAGELTG(NUMELTG),TAGELS(NUMELS),TAGNOD(NUMNOD))
+      ALLOCATE(XTMP(3,NUMNOD))
+
 C
       DO IE=1,NUMELC                          
         DO IN = 1,4                           
@@ -327,6 +329,9 @@ C
       IF (ALLOCATED(YY)) DEALLOCATE(YY)
       IF (ALLOCATED(ZZ)) DEALLOCATE(ZZ)
 C-----------
+      DEALLOCATE(TAGELC,TAGELTG,TAGELS,TAGNOD)
+      DEALLOCATE(XTMP)
+
       RETURN
  1000 FORMAT(//
      & 5X,'    REFERENCE STATE (XREF)  ',/


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

This pull request refactors memory management in two Fortran subroutines by replacing static array allocations with dynamic (allocatable) arrays. This change improves memory efficiency and reduces the risk of stack overflows, especially for large problem sizes. The changes also ensure proper allocation and deallocation of these arrays, preventing memory leaks.

**Dynamic memory allocation improvements:**

* In `LINEDGE` (`starter/source/groups/linedge.F`):
  - Converted several large local arrays (`IW1`, `IW2`, `IW5`, `IW6`, `INDEX`, `IWORK`) from static to allocatable arrays, and added explicit `ALLOCATE` and `DEALLOCATE` statements to manage their memory. [[1]](diffhunk://#diff-c6b44849d2865777f8440edc880c2f0cbbde3e8214713d5babef59d151580e75L50-R57) [[2]](diffhunk://#diff-c6b44849d2865777f8440edc880c2f0cbbde3e8214713d5babef59d151580e75R164-R165)

* In `HM_READ_XREF` (`starter/source/loads/reference_state/xref/hm_read_xref.F`):
  - Changed `TAGELC`, `TAGELTG`, `TAGELS`, `TAGNOD`, and `XTMP` from static to allocatable arrays, with corresponding allocation at the start and deallocation at the end of the subroutine. [[1]](diffhunk://#diff-ddc76922fee53cd4df41b8bafdfb2d1aa458e66ae2f0ade6436ddf5e4dca9a80L90-R110) [[2]](diffhunk://#diff-ddc76922fee53cd4df41b8bafdfb2d1aa458e66ae2f0ade6436ddf5e4dca9a80R332-R334)
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
