### PR TITLE
/INTER/TYPE25: negative edge stiffness fix

### DIFF
--- a/starter/source/interfaces/inter3d1/i25sti_edg.F
+++ b/starter/source/interfaces/inter3d1/i25sti_edg.F
@@ -70,7 +70,11 @@ C-----------------------------------------------
         B=LEDGE(3,I)
         IF(B/=0) STFB=STFM(B)
         IF(STFA/=ZERO.AND.STFB/=ZERO)THEN
-          STFE(I)=TWO*STFA*STFB/MAX(ZERO,STFA+STFB)
+          IF(STFA + STFB < ZERO) THEN
+            STFE(I)= ZERO                                 
+          ELSE
+            STFE(I)=TWO*STFA*STFB/MAX(ZERO,STFA+STFB)
+          END IF
         ELSE
           STFE(I)=MAX(STFA,STFB)
         END IF


### PR DESCRIPTION
This pull request updates the logic in the `I25STI_EDG` subroutine to handle cases where the sum of `STFA` and `STFB` is negative. The main change ensures that `STFE(I)` is set to zero in such cases, improving the robustness of the calculation.

Calculation logic improvement:

* In `starter/source/interfaces/inter3d1/i25sti_edg.F`, added a conditional check so that if `STFA + STFB` is less than zero, `STFE(I)` is set to zero; otherwise, the original calculation is performed.