### PR TITLE
open_reader : issue correction with get handle from element handle

### DIFF
--- a/reader/source/dyna2rad/dyna2rad/_private/convertinitialstrains.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/convertinitialstrains.cxx
@@ -109,14 +109,13 @@ void sdiD2R::ConvertInitialStrain::ConvertInitialStrainsShell()
               int Ishellform = 0;  // shell formulation in radioss property
               // radioss part read
               HandleRead partHRead;
-              elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("part_ID"), partHRead);
+              elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("PART"), partHRead);
 
               // dyna part read
               HandleRead elementdynaHRead;
               p_lsdynaModel->FindById(p_lsdynaModel->GetEntityType("*ELEMENT_SHELL"), eid, elementdynaHRead);
-              HandleRead partdynaHRead;
-              elementdynaHRead.GetEntityHandle(p_lsdynaModel,sdiIdentifier("PID"), partdynaHRead);
-              
+              ElementRead elementdynaRead(p_lsdynaModel, elementdynaHRead);
+              HandleRead partdynaHRead = elementdynaRead.GetOwner();
               EntityRead partdynaRead(p_lsdynaModel, partdynaHRead);
               sdiString partCard = partdynaRead.GetKeyword();
 
@@ -430,14 +429,14 @@ void sdiD2R::ConvertInitialStrain::ConvertInitialStrainsShell()
               int Ishellform = 0;  // shell formulation in radioss property
               // radioss part read
               HandleRead partHRead;
-              elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("part_ID"), partHRead);
+              elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("PART"), partHRead);
 
               // dyna part read
               HandleRead elementdynaHRead;
               p_lsdynaModel->FindById(p_lsdynaModel->GetEntityType("*ELEMENT_SHELL"), eid, elementdynaHRead);
-              HandleRead partdynaHRead;
-              elementdynaHRead.GetEntityHandle(p_lsdynaModel,sdiIdentifier("PID"), partdynaHRead);
               
+              ElementRead elementdynaRead(p_lsdynaModel, elementdynaHRead);
+              HandleRead partdynaHRead = elementdynaRead.GetOwner();
               EntityRead partdynaRead(p_lsdynaModel, partdynaHRead);
               sdiString partCard = partdynaRead.GetKeyword();
 


### PR DESCRIPTION
This pull request introduces improvements to the handling of value retrieval and entity ownership in the Radioss and LS-Dyna model conversion workflow. The main changes focus on enhancing the flexibility and correctness of identifier mapping, particularly for part and element associations, and refactoring the way owner handles are obtained for LS-Dyna elements.

**Value retrieval and identifier handling improvements:**

* Added a new overload for the `GetValue` method in `ModelViewPO` to support value retrieval using a `HandleRead` and `sdiIdentifier`, with specialized logic for nodes and elements, including custom handling for the `"PART"` identifier.
* Improved logic in `GetValueFromPreObject` to ensure correct attribute index retrieval based on the identifier name key.

**Entity ownership and handle association refactoring:**

* In `ConvertInitialStrainsShell`, replaced the use of `"part_ID"` with `"PART"` for Radioss part handle retrieval, ensuring consistency with identifier naming. [[1]](diffhunk://#diff-b828bd42aa5bb6a242c4f05e76910212afcc672a2b80970e9392310a9a130b00L112-R120) [[2]](diffhunk://#diff-b828bd42aa5bb6a242c4f05e76910212afcc672a2b80970e9392310a9a130b00L433-R442)
* Refactored LS-Dyna part handle retrieval: instead of using the `"PID"` identifier, now obtain the owner handle directly from the `ElementRead` object, improving robustness and clarity. [[1]](diffhunk://#diff-b828bd42aa5bb6a242c4f05e76910212afcc672a2b80970e9392310a9a130b00L112-R120) [[2]](diffhunk://#diff-b828bd42aa5bb6a242c4f05e76910212afcc672a2b80970e9392310a9a130b00L433-R442)

**General code consistency:**

* Minor formatting and whitespace adjustments to improve readability and maintain code style.

These changes collectively improve the accuracy and maintainability of the model conversion logic, particularly in scenarios involving part and element associations across different solvers.