### PR TITLE
openreader : controlvol initialstresses timehistory element_mass correction

### DIFF
--- a/hm_cfg_files/config/CFG/Keyword971/ELEMENTS/element_mass.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/ELEMENTS/element_mass.cfg
@@ -28,7 +28,7 @@ ATTRIBUTES(COMMON) {
     location_unit_solvermass   = ARRAY[entityidsmax](SOLVERMASS, "solvermasses");
     nodeid          = ARRAY[entityidsmax](NODE, "nodes to which the mass is added");
     masses          = ARRAY[entityidsmax](FLOAT, "Added mass");
-    componentid     = ARRAY[entityidsmax](COMPONENT, "Part ID: optional");
+    collector       = ARRAY[entityidsmax](INT, "Part ID: optional");
     skipcomment     = VALUE(STRING, "");
 }
 
@@ -107,7 +107,7 @@ FORMAT(Keyword971)
             COMMENT("$    EID      ID            MASS     PID");
             CARD_LIST(entityidsmax)
             {
-                CARD("%8d%8d%16lg%8d", location_unit_solvermass, nodeid, masses, componentid);
+                CARD("%8d%8d%16lg%8d", location_unit_solvermass, nodeid, masses, collector);
             }
     }
     else if(IO_FLAG == 1)
@@ -117,7 +117,7 @@ FORMAT(Keyword971)
             COMMENT("$    EID      ID            MASS     PID");
             FREE_CARD_LIST(entityidsmax)
             {
-                CARD("%8d%8d%16lg%8d", location_unit_solvermass, nodeid, masses, componentid);
+                CARD("%8d%8d%16lg%8d", location_unit_solvermass, nodeid, masses, collector);
             } { TOKEN_END = ("$HMNAME"); }
     }
 

--- a/reader/source/dyna2rad/dyna2rad/_private/convertcontrolvols.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/convertcontrolvols.cxx
@@ -735,7 +735,7 @@ void sdiD2R::ConvertControlVolume::ConvertInitialFoamReferenceGeometry()
                 if (elementHRead.IsValid())
                 {
                   HandleRead partHRead;
-                  elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("part_ID"), partHRead);
+                  elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("PART"), partHRead);
                   if (partHRead.IsValid())
                   {
                     PartIdnodeRef = partHRead.GetId(p_radiossModel);
@@ -758,7 +758,7 @@ void sdiD2R::ConvertControlVolume::ConvertInitialFoamReferenceGeometry()
                 if (elementHRead.IsValid())
                 {
                   HandleRead partHRead;
-                  elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("part_ID"), partHRead);
+                  elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("PART"), partHRead);
                   if (partHRead.IsValid())
                   {
                     PartIdnodeRef = partHRead.GetId(p_radiossModel);
@@ -782,7 +782,7 @@ void sdiD2R::ConvertControlVolume::ConvertInitialFoamReferenceGeometry()
                 if (elementHRead.IsValid())
                 {
                   HandleRead partHRead;
-                  elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("part_ID"), partHRead);
+                  elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("PART"), partHRead);
                   if (partHRead.IsValid())
                   {
                     PartIdnodeRef = partHRead.GetId(p_radiossModel);
@@ -920,7 +920,7 @@ void sdiD2R::ConvertControlVolume::ConvertInitialFoamReferenceGeometry()
                 if (elementHRead.IsValid())
                 {
                   HandleRead partHRead;
-                  elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("part_ID"), partHRead);
+                  elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("PART"), partHRead);
                   if (partHRead.IsValid())
                   {
                     PartIdnodeRef = partHRead.GetId(p_radiossModel);
@@ -954,7 +954,7 @@ void sdiD2R::ConvertControlVolume::ConvertInitialFoamReferenceGeometry()
                   if (elementHRead.IsValid())
                   {
                     HandleRead partHRead;
-                    elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("part_ID"), partHRead);
+                    elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("PART"), partHRead);
                     if (partHRead.IsValid())
                     {
                       PartIdnodeRef = partHRead.GetId(p_radiossModel);
@@ -988,7 +988,7 @@ void sdiD2R::ConvertControlVolume::ConvertInitialFoamReferenceGeometry()
                   if (elementHRead.IsValid())
                   {
                     HandleRead partHRead;
-                    elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("part_ID"), partHRead);
+                    elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("PART"), partHRead);
                     if (partHRead.IsValid())
                     {
                       PartIdnodeRef = partHRead.GetId(p_radiossModel);

--- a/reader/source/dyna2rad/dyna2rad/_private/convertinitialstresses.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/convertinitialstresses.cxx
@@ -109,7 +109,7 @@ void sdiD2R::ConvertInitialStress::ConvertInitialStressesShell()
               // get prop_id (p_radiossModel) only for shell 4N  in order to get Ishell formulation
               int Ishellform = 0;
               HandleRead partHRead;
-              elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("part_ID"), partHRead);
+              elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("PART"), partHRead);
 
               if (partHRead.IsValid())
               {
@@ -504,7 +504,7 @@ void sdiD2R::ConvertInitialStress::ConvertInitialStressesSolid()
               // get prop_id (p_radiossModel) Isolid formulation
               int Isolid = 0;
               HandleRead partHRead;
-              elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("part_ID"), partHRead);
+              elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("PART"), partHRead);
 
               if (partHRead.IsValid())
               {

--- a/reader/source/dyna2rad/dyna2rad/_private/converttimehistory.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/converttimehistory.cxx
@@ -317,7 +317,9 @@ void sdiD2R::ConvertTimeHistory::p_ConvertAllDBHistroy()
             if (elementHRead.IsValid())
             {
                 HandleRead partHRead;
-                elementHRead.GetEntityHandle(p_lsdynaModel, sdiIdentifier("PID"), partHRead);
+                ElementRead elementdynaRead(p_lsdynaModel, elementHRead);
+                HandleRead partdynaHRead = elementdynaRead.GetOwner();
+
                 if (partHRead.IsValid())
                 {
                     HandleRead propHRead;


### PR DESCRIPTION

This pull request updates how part IDs are handled in both configuration files and C++ source code, standardizing the terminology and improving consistency across the codebase. The most significant changes involve renaming and replacing the `componentid` field with `collector` in configuration, and consistently using the `PART` identifier instead of variations like `part_ID` or `PID` in entity handle lookups.

**Configuration updates:**

* Renamed the `componentid` attribute to `collector` in the `element_mass.cfg` configuration file, updating all references and formatting logic to use the new field. [[1]](diffhunk://#diff-0983a0297db683efd99a0d57a496fee471a16a04d2fb7463f782bbe2127d4c9cL31-R31) [[2]](diffhunk://#diff-0983a0297db683efd99a0d57a496fee471a16a04d2fb7463f782bbe2127d4c9cL110-R110) [[3]](diffhunk://#diff-0983a0297db683efd99a0d57a496fee471a16a04d2fb7463f782bbe2127d4c9cL120-R120)

**C++ source code consistency:**

* Replaced all uses of `part_ID` with `PART` when retrieving entity handles for elements in `convertcontrolvols.cxx` and `convertinitialstresses.cxx`, ensuring consistent identifier usage for part lookups. [[1]](diffhunk://#diff-f704fff46831ff115139b6a56397000440cd62ff53ac2b74407f74d8b139e8feL738-R738) [[2]](diffhunk://#diff-f704fff46831ff115139b6a56397000440cd62ff53ac2b74407f74d8b139e8feL761-R761) [[3]](diffhunk://#diff-f704fff46831ff115139b6a56397000440cd62ff53ac2b74407f74d8b139e8feL785-R785) [[4]](diffhunk://#diff-f704fff46831ff115139b6a56397000440cd62ff53ac2b74407f74d8b139e8feL923-R923) [[5]](diffhunk://#diff-f704fff46831ff115139b6a56397000440cd62ff53ac2b74407f74d8b139e8feL957-R957) [[6]](diffhunk://#diff-f704fff46831ff115139b6a56397000440cd62ff53ac2b74407f74d8b139e8feL991-R991) [[7]](diffhunk://#diff-a902c351699766ea1bd046797d81e9b38fbfd715b36451d86bffff44056e70dfL112-R112) [[8]](diffhunk://#diff-a902c351699766ea1bd046797d81e9b38fbfd715b36451d86bffff44056e70dfL507-R507)

* Updated the logic for retrieving part handles in `converttimehistory.cxx` to use the owner of the element via `GetOwner()` instead of a direct entity handle lookup with `PID`, improving reliability and clarity.