### PR TITLE
add debug flags for openreader compilation

### DIFF
--- a/reader/build_script.bash
+++ b/reader/build_script.bash
@@ -11,6 +11,10 @@ function my_help()
   echo "          linux64  : X86_64 Linux"
   echo "          linuxa64 : ARM64" 
   echo " " 
+  echo " -debug=[0|1]                        : debug version"
+  echo "                                          0 : no debug flags (default)"
+  echo "                                          1 : debug flags (-g -O0 -DDEBUG)"
+  echo " " 
   echo " Execution control"
   echo " -nt=[threads]      : number of threads for build "
   echo " -verbose           : Verbose build"
@@ -26,6 +30,7 @@ clean=0
 arch=none
 com=0
 cs=""
+debug=0
 
 number_of_arguments=$#
 if [ $number_of_arguments = 0 ]
@@ -58,6 +63,11 @@ else
        then
          com=1
          cs="_c"
+       fi
+
+       if [ "$arg" == "-debug" ]
+       then
+         debug=`echo $var|awk -F '=' '{print $2}'`
        fi
 
        if [ "$arg" == "-clean" ]
@@ -100,9 +110,16 @@ echo " Build OpenReader "
 echo " -----------------"
 echo " Build Arguments :"
 echo " arch =                 : " $arch
+echo " debug =                : " $debug
 echo " " 
 echo " threads =              : " $threads
 echo " " 
+
+# Debug mode check
+if [ "$debug" = "1" ]
+then
+   echo " Debug mode activated - using debug flags"
+fi
 
 # Load external libraries
 echo "Load external libraries"
@@ -117,7 +134,12 @@ fi
 
 cd ${build_directory}
 
-cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -Darch=${arch}  -Dcom=${com} ..
+if [ "$debug" = "1" ]
+then
+  cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -Darch=${arch} -Dcom=${com} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-g -O0 -DDEBUG" -DCMAKE_C_FLAGS="-g -O0 -DDEBUG" ..
+else
+  cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -Darch=${arch} -Dcom=${com} ..
+fi
 return_value=$?
 if [ $return_value -ne 0 ]
 then

--- a/starter/build_script.sh
+++ b/starter/build_script.sh
@@ -242,10 +242,10 @@ fi
 if [ $use_openreader == 1 ]
 then
     echo " "
-    echo "Build open_reader: ${built_in_arch} "
+    echo "Build open_reader: ${built_in_arch} " 
     echo "----------------"
     cd ../reader
-    ./build_script.bash -arch=${built_in_arch} -nt=${threads} ${orb}
+    ./build_script.bash -arch=${built_in_arch} -nt=${threads} -debug=${debug} -orb ${orb}
     return_value=$?
     if [ $return_value -ne 0 ]
     then


### PR DESCRIPTION
This pull request adds support for a debug build mode to the OpenReader build scripts, allowing users to easily enable debug flags when compiling. The main changes include updates to both the help text and command-line argument parsing, as well as modifications to the build process to apply debug flags when requested.

**Debug build mode support:**

* Added a `-debug=[0|1]` option to the help text in `reader/build_script.bash` to inform users about the new debug mode feature.
* Updated argument parsing in `reader/build_script.bash` to handle the new `-debug` option and set the `debug` variable accordingly. [[1]](diffhunk://#diff-b4e7dc5e62de72e44b81f140d0556bf359df8c7bfce8d62963b40720e248caccR33) [[2]](diffhunk://#diff-b4e7dc5e62de72e44b81f140d0556bf359df8c7bfce8d62963b40720e248caccR68-R72)
* Modified the build script to display the debug mode status in the build arguments output and print a message when debug mode is activated.
* Changed the CMake invocation in `reader/build_script.bash` to use debug flags (`-g -O0 -DDEBUG`) and set the build type to Debug when the debug mode is enabled.

**Integration with starter script:**

* Updated `starter/build_script.sh` to pass the `-debug` argument through to the reader build script, ensuring consistent debug mode behavior across build entry points.