### PR TITLE
correction in case of RBE3 penalty +zero nodal stiffness of depedent …

### DIFF
--- a/engine/source/constraints/general/rbe3/rbe3pen_init.F90
+++ b/engine/source/constraints/general/rbe3/rbe3pen_init.F90
@@ -192,10 +192,7 @@
           rrbe3pen_m(1:3) = zero
           lsm2 = rR(1)*rR(1)+rR(2)*rR(2)+rR(3)*rR(3)
 !-------set up rrbe3pen_stf
-          if (stifn(ns)<=em20) then ! free node w/ spc
-            rrbe3pen_stf(1) = two*stfnm
-            rrbe3pen_stf(2) = four*stfrm
-          elseif (stifn(ns)<=em10) then ! small stif
+          if (stifn(ns)<=em10) then ! zero or small stif
             rrbe3pen_stf(1) = em03*stfnm*min(one,ms(ns)/msbar)
             rrbe3pen_stf(2) = em20 ! only have translation stif
           else


### PR DESCRIPTION
…node

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
in case of RBE3 (Iform=3) penalty with zero nodal stiffness of dependent node, high added mass might happen.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
Correction to avoid high added mass or run failing in special case

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
