### PR TITLE
Correct filling non allocated table in law36 for shells

### DIFF
--- a/engine/source/materials/mat/mat036/sigeps36c.F90
+++ b/engine/source/materials/mat/mat036/sigeps36c.F90
@@ -51,10 +51,11 @@
                sigoxx  ,sigoyy  ,sigoxy ,sigoyz  ,sigozx  ,           &
                signxx  ,signyy  ,signxy ,signyz  ,signzx  ,           &
                soundsp ,thk     ,pla    ,impl_s  ,ikt     ,           &
-               off     ,etse    ,gs     ,yld     ,                    &
+               off     ,etse    ,gs     ,yld     ,l_dmg   ,           &
                dpla    ,gama_imp,signor ,shf     ,hardm   ,           &
                yldfac  ,inloc   ,dplanl ,dmg     ,planl   ,           &
-               l_planl ,sigbxx  ,sigbyy ,sigbxy  ,loff    )
+               l_sigb  ,l_planl ,sigbxx  ,sigbyy ,sigbxy  ,           &
+               loff    )
 ! -----------------------------------------------------------------------------------------------
 !       modules
 ! -----------------------------------------------------------------------------------------------
@@ -80,6 +81,8 @@
           integer ,intent(in) :: nvartmp
           integer ,intent(in) :: inloc
           integer ,intent(in) :: iplas
+          integer ,intent(in) :: l_sigb
+          integer ,intent(in) :: l_dmg
           integer ,intent(in) :: l_planl
           integer ,intent(in) :: impl_s
           integer ,intent(in) :: ikt
@@ -98,14 +101,14 @@
           real(kind=wp) ,dimension(nel)   ,intent(inout) :: epsd     ! lbuf%epsd
           real(kind=wp) ,dimension(nel)   ,intent(inout) :: pla
           real(kind=wp) ,dimension(nel)   ,intent(inout) :: dplanl
-          real(kind=wp) ,dimension(nel)   ,intent(inout) :: dmg
           real(kind=wp), dimension(nel),   intent(inout) :: off,thk,yld,hardm
           real(kind=wp) ,dimension(nel)   ,intent(out)   :: soundsp,etse,dpla,gama_imp
-          real(kind=wp), dimension(nel),   intent(inout) :: sigbxx,sigbyy,sigbxy
           real(kind=wp) ,dimension(nel)   ,intent(out)   :: signxx,signyy,signxy,signyz,signzx
-          real(kind=wp) ,dimension(nel*l_planl) ,intent(in)  :: planl
-          real(kind=wp) ,dimension(mvsiz,5)     ,intent(out) :: signor
-          real(kind=wp) ,dimension(nel,nuvar)   ,intent(out) :: uvar
+          real(kind=wp), dimension(nel*l_sigb)  ,intent(inout) :: sigbxx,sigbyy,sigbxy
+          real(kind=wp) ,dimension(nel*l_dmg)   ,intent(inout) :: dmg
+          real(kind=wp) ,dimension(nel*l_planl) ,intent(in)    :: planl
+          real(kind=wp) ,dimension(mvsiz,5)     ,intent(out)   :: signor
+          real(kind=wp) ,dimension(nel,nuvar)   ,intent(out)   :: uvar
 !-----------------------------------------------
 !       l o c a l   v a r i a b l e s
 !-----------------------------------------------
@@ -212,7 +215,6 @@
         dmg(1:nel)  = one - fail(1:nel)
       else
         fail(1:nel) = one
-        dmg(1:nel)  = zero
       endif
 !-----------------------------------------------------------------------------------------
         ! trial elastic stress

--- a/engine/source/materials/mat/mat036/sigeps36s.F90
+++ b/engine/source/materials/mat/mat036/sigeps36s.F90
@@ -56,7 +56,7 @@
                  soundsp ,uvar    ,vartmp  ,off     ,ngl     ,impl_s ,          &
                  epsd    ,ipla    ,yld     ,pla     ,inloc   ,planl  ,          &
                  dpla1   ,etse    ,al_imp  ,signor  ,amu     ,dpdm   ,          &
-                 yldfac  ,dmg     )
+                 yldfac  ,dmg     ,l_sigb  ,l_dmg   ,l_planl )
 ! ------------------------------------------------------------------------------
 !       modules
 ! ------------------------------------------------------------------------------
@@ -82,21 +82,26 @@
         integer, intent(in) :: ipla
         integer, intent(in) :: inloc
         integer, intent(in) :: impl_s
+        integer ,intent(in) :: l_sigb
+        integer ,intent(in) :: l_dmg
+        integer ,intent(in) :: l_planl
         integer ,dimension(nel), intent(in) :: ngl
-        integer ,dimension(nel,nvartmp)   ,intent(inout) :: vartmp
-        real(kind=wp)                     ,intent(in)    :: timestep,time
-        type(matparam_struct_)            ,intent(in)    :: mat_param
-        real(kind=wp), dimension(mvsiz)   ,intent(in)    :: dpdm
-        real(kind=wp) ,dimension(nel)     ,intent(in)    :: epsxx,epsyy,epszz,epsxy,epsyz,epszx
-        real(kind=wp) ,dimension(nel)     ,intent(in)    :: depsxx,depsyy,depszz,depsxy,depsyz,depszx
-        real(kind=wp) ,dimension(nel)     ,intent(inout) :: sigoxx,sigoyy,sigozz,sigoxy,sigoyz,sigozx
-        real(kind=wp) ,dimension(nel)     ,intent(inout) :: epsd,etse,amu,yldfac,dmg,planl
-        real(kind=wp) ,dimension(nel)     ,intent(inout) :: signxx,signyy,signzz, signxy,signyz,signzx
-        real(kind=wp), dimension(nel)     ,intent(inout) :: sigbxx,sigbyy,sigbzz,sigbxy,sigbyz,sigbzx
-        real(kind=wp) ,dimension(nel)     ,intent(inout) :: soundsp,dpla1,al_imp
-        real(kind=wp) ,dimension(nel)     ,intent(inout) :: off,yld,pla
-        real(kind=wp) ,dimension(mvsiz,6) ,intent(inout) :: signor
-        real(kind=wp) ,dimension(nel,nuvar),intent(inout):: uvar
+        integer ,dimension(nel,nvartmp)      ,intent(inout) :: vartmp
+        real(kind=wp)                        ,intent(in)    :: timestep,time
+        type(matparam_struct_)               ,intent(in)    :: mat_param
+        real(kind=wp), dimension(mvsiz)      ,intent(in)    :: dpdm
+        real(kind=wp) ,dimension(nel)        ,intent(in)    :: epsxx,epsyy,epszz,epsxy,epsyz,epszx
+        real(kind=wp) ,dimension(nel)        ,intent(in)    :: depsxx,depsyy,depszz,depsxy,depsyz,depszx
+        real(kind=wp) ,dimension(nel)        ,intent(inout) :: sigoxx,sigoyy,sigozz,sigoxy,sigoyz,sigozx
+        real(kind=wp) ,dimension(nel)        ,intent(inout) :: epsd,etse,amu,yldfac
+        real(kind=wp) ,dimension(nel)        ,intent(inout) :: signxx,signyy,signzz, signxy,signyz,signzx
+        real(kind=wp), dimension(nel*l_sigb) ,intent(inout) :: sigbxx,sigbyy,sigbzz,sigbxy,sigbyz,sigbzx
+        real(kind=wp) ,dimension(nel)        ,intent(inout) :: soundsp,dpla1,al_imp
+        real(kind=wp) ,dimension(nel)        ,intent(inout) :: off,yld,pla
+        real(kind=wp) ,dimension(mvsiz,6)    ,intent(inout) :: signor
+        real(kind=wp) ,dimension(nel*l_dmg)  ,intent(inout) :: dmg
+        real(kind=wp) ,dimension(nel*l_planl),intent(inout) :: planl
+        real(kind=wp) ,dimension(nel,nuvar)  ,intent(inout) :: uvar
 !-----------------------------------------------
 !   l o c a l   v a r i a b l e s
 !-----------------------------------------------

--- a/engine/source/materials/mat_share/mulaw.F90
+++ b/engine/source/materials/mat_share/mulaw.F90
@@ -1139,7 +1139,7 @@
                  ssp    ,uvar   ,vartmp ,off    ,ngl    ,impl_s ,             &
                  epsd   ,ipla   ,sigy   ,defp   ,inloc  ,lbuf%planl,          &
                  dpla   ,et     ,al_imp ,signor ,amu    ,dpdm  ,              &
-                 yldfac ,lbuf%dmg)          
+                 yldfac ,lbuf%dmg,l_sigb,l_dmg,l_planl)          
 !
           else if (mtn == 37) then
             if (n2d == 0) then

--- a/engine/source/materials/mat_share/mulaw8.F90
+++ b/engine/source/materials/mat_share/mulaw8.F90
@@ -669,7 +669,7 @@
                  sspp   ,uvar   ,vartmp ,off    ,ngl    ,0     ,            &
                  epsd   ,ipla   ,sigy   ,defp   ,inloc  ,lbuf%planl,        &
                  dpla   ,et     ,bidv   ,bidv6  ,amu    ,bidv  ,            &
-                 yldfac ,lbuf%dmg)          
+                 yldfac ,lbuf%dmg,bufly%l_sigb,bufly%l_dmg,bufly%l_planl)          
 
 !              call sigeps36(&
 !               llt      ,nuvar    ,nfunc    ,ifunc    ,npf      ,tf       ,&

--- a/engine/source/materials/mat_share/mulawc.F90
+++ b/engine/source/materials/mat_share/mulawc.F90
@@ -382,10 +382,10 @@
                      iptx,ilayer,irot,dmg_flag,lf_dammx,nipar,&
                      igmat,ipgmat,nptt,ipt_all,npttot,nuvarv,ilaw,&
                      ply_id,iseq,progressive_crack,&
-                     orth_damage,l_dmg,iprony,israte,nvartmp,inloc,idrape,nvar_damp,flag_incr
+                     orth_damage,iprony,israte,nvartmp,inloc,idrape,nvar_damp,flag_incr
           integer :: ij1,ij2,ij3,ij4,ij5
           integer :: ij(5),iflag(1)
-          integer :: l_sigb
+          integer :: l_sigb,l_dmg,l_planl
           integer ,dimension(maxfunc) :: ifunc
           integer ,dimension(mvsiz)   :: ioff_duct,nfis1,nfis2,nfis3
 !
@@ -611,6 +611,8 @@
             nuvarv = bufly%nvar_visc
             iseq   = bufly%l_seq
             l_sigb = bufly%l_sigb
+            l_dmg  = bufly%l_dmg
+            l_planl= bufly%l_planl
             iadbuf = max(1,ipm(7,imat))
             nuparam0=  ipm(9,imat)                      ! old uparam stored in bufmat
             uparam0 => bufmat(iadbuf:iadbuf+nuparam0-1) ! old uparam stored in bufmat
@@ -1236,10 +1238,11 @@
                   sigoxx  ,sigoyy  ,sigoxy  ,sigoyz  ,sigozx  ,      &
                   signxx  ,signyy  ,signxy  ,signyz  ,signzx  ,      &
                   ssp     ,thkn    ,lbuf%pla,impl_s  ,ikt     ,      &
-                  off     ,etse    ,gs      ,sigy    ,               &
+                  off     ,etse    ,gs      ,sigy    ,l_dmg   ,      &
                   dpla    ,g_imp   ,sigksi  ,shf     ,hardm   ,      &
                   yldfac  ,inloc   ,varnl(1,it),lbuf%dmg,lbuf%planl, &
-                  bufly%l_planl,sigbxx,sigbyy,sigbxy,lbuf%off)
+                  l_sigb  ,l_planl ,sigbxx  ,sigbyy  ,sigbxy  ,      &
+                  lbuf%off)
 !
               elseif (ilaw == 42) then
                 call sigeps42c(&


### PR DESCRIPTION
dmg table is not allocated for ifail = 0 in material law36, it should not be initialized
corrected passing of conditionnally allocated tables as arguments in material law routines

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
