### PR TITLE
openReader : correction GetValue from Element + correction type of SYSTEM in *ELEMENT_DISCRETE

### DIFF
--- a/hm_cfg_files/config/CFG/Keyword971/ELEMENTS/discrete.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/ELEMENTS/discrete.cfg
@@ -24,7 +24,7 @@ ATTRIBUTES(COMMON) {
   collector   = ARRAY[NB_ELE](INT,"Part","PID");
   node1       = ARRAY[NB_ELE](INT,"Node identifier 1","N1");
   node2       = ARRAY[NB_ELE](INT,"Node identifier 2","N2");
-  VID         = ARRAY[NB_ELE](VECTOR,"Orientation option","VID");//{ SUBTYPES = (/SYSTEM/DEFINE_SD_ORIENTATION) ; }
+  VID         = ARRAY[NB_ELE](SYSTEM,"Orientation option","VID");//{ SUBTYPES = (/SYSTEM/DEFINE_SD_ORIENTATION) ; }
   PF          = ARRAY[NB_ELE](INT,"Print flag","PF");
   LSD_SF      = ARRAY[NB_ELE](INT,"Scale factor on forces","S");
   LSD_OFFSET  = ARRAY[NB_ELE](INT,"Initial offset","OFFSET");

--- a/reader/source/cfgkernel/sdi/sdiModelViewPO.h
+++ b/reader/source/cfgkernel/sdi/sdiModelViewPO.h
@@ -476,63 +476,8 @@ public:
 
 
     // Get value of an attribute for this element (by attribute name)
-    virtual Status GetValue(const sdiIdentifier& identifier, sdiValue& value) const
-    {
-        if (!p_ptr) return false;
-        // Try to get the attribute as an array value at the element's index (p_index2)
-        int att_index = p_ptr->GetIndex(IMECPreObject::ATY_ARRAY, IMECPreObject::VTY_INT, identifier.GetNameKey());
-        if (att_index >= 0) {
-            value = sdiValue(p_ptr->GetIntValue(att_index, p_index2));
-            return true;
-        }
-        att_index = p_ptr->GetIndex(IMECPreObject::ATY_ARRAY, IMECPreObject::VTY_FLOAT, identifier.GetNameKey());
-        if (att_index >= 0) {
-            value = sdiValue(p_ptr->GetFloatValue(att_index, p_index2));
-            return true;
-        }
-        att_index = p_ptr->GetIndex(IMECPreObject::ATY_ARRAY, IMECPreObject::VTY_STRING, identifier.GetNameKey());
-        if (att_index >= 0) {
-            value = sdiValue(sdiString(p_ptr->GetStringValue(att_index, p_index2)));
-            return true;
-        }
-        att_index = p_ptr->GetIndex(IMECPreObject::ATY_ARRAY, IMECPreObject::VTY_OBJECT, identifier.GetNameKey());
-        if (att_index >= 0) {
-            int objId = p_ptr->GetObjectId(att_index, p_index2);
-            if (objId > 0) {
-                value = sdiValue(sdiValueEntity(sdiValueEntityType(
-                    this->GetModelView()->GetEntityType(p_ptr->GetInputFullType())), objId));
-                return true;
-            }
-        }
-            
-        // Try as single value (not array)
-        att_index = p_ptr->GetIndex(IMECPreObject::ATY_SINGLE, IMECPreObject::VTY_INT, identifier.GetNameKey());
-        if (att_index >= 0) {
-            value = sdiValue(p_ptr->GetIntValue(att_index));
-            return true;
-        }
-        att_index = p_ptr->GetIndex(IMECPreObject::ATY_SINGLE, IMECPreObject::VTY_FLOAT, identifier.GetNameKey());
-        if (att_index >= 0) {
-            value = sdiValue(p_ptr->GetFloatValue(att_index));
-            return true;
-        }
-        att_index = p_ptr->GetIndex(IMECPreObject::ATY_SINGLE, IMECPreObject::VTY_STRING, identifier.GetNameKey());
-        if (att_index >= 0) {
-            value = sdiValue(sdiString(p_ptr->GetStringValue(att_index)));
-            return true;
-        }
-        att_index = p_ptr->GetIndex(IMECPreObject::ATY_SINGLE, IMECPreObject::VTY_OBJECT, identifier.GetNameKey());
-        if (att_index >= 0) {
-            int objId = p_ptr->GetObjectId(att_index);
-            if (objId > 0) {
-                value = sdiValue(sdiValueEntity(sdiValueEntityType(
-                    this->GetModelView()->GetEntityType(p_ptr->GetInputFullType())), objId));
-                return true;
-            }
-        }
-        // Not found
-        return false;
-    }
+    inline virtual Status GetValue(const sdiIdentifier& identifier, sdiValue& value) const;
+    
     virtual unsigned int GetNodeCount() const
     {
         unsigned int node_count = 0;
@@ -1511,14 +1456,14 @@ public:
 
 
         if(isNewPo)
-        {         
+        {
             pObj = HCDI_GetPreObjectHandle(kernelFullType.c_str(), keyword.c_str(), "", (int) p_currentIncludeId, 0);
             p_preobjects[HCDI_OBJ_TYPE_ELEMS].push_back(pObj);
             pObj->AddIntArray("id", 1);
             for (int i = 0; i < aNodeId.size(); ++i) 
             {
-            sdiString nodeId = "node_ID" + std::to_string(i + 1);
-            pObj->AddIntArray(nodeId.c_str(), 1);
+                sdiString nodeId = "node_ID" + std::to_string(i + 1);
+                pObj->AddIntArray(nodeId.c_str(), 1);
             }
             pObj->AddObjectValue("PART", HCDI_get_entitystringtype(HCDI_OBJ_TYPE_COMPS).c_str(), owner.GetId(this));
         }
@@ -1539,7 +1484,7 @@ public:
         for (int i = 0; i < aNodeId.size(); ++i) {
             idIndex = pObj->GetIndex(IMECPreObject::ATY_ARRAY, IMECPreObject::VTY_INT, "node_ID" + std::to_string(i + 1));
             if(!isNewPo) {
-            pObj->resizeArray(IMECPreObject::VTY_INT, idIndex, arraySize + 1);
+                pObj->resizeArray(IMECPreObject::VTY_INT, idIndex, arraySize + 1);
             }
             pObj->SetIntValue(idIndex, elementIndex, aNodeId[i]);
         }
@@ -2062,8 +2007,8 @@ public:
         
     inline bool SetValueToPreObjectArray(IMECPreObject                  *pObj,
                                   unsigned int          index2,
-                                  const sdiIdentifier& identifier,
-                                  const sdiValue&      value) const;
+                                         const sdiIdentifier& identifier,
+                                         const sdiValue&      value) const;
                                   
 
     template <class ENTITYREAD>
@@ -2364,13 +2309,13 @@ inline ElemsByCompsCache::ElemsByCompsCache(const std::vector<IMECPreObject*>& p
                         index1 = j;
                         break;
                     }
-                }     
+                }
                 
                 // Find the element index within the preobject
                 unsigned int index2 = 0;
                 if (att_index_id >= 0) {
                     index2 = i; // assuming the order of collector and id attributes match
-                }      
+                }
 
                 (*this)[compId].push_back(ElemCache(index1, index2));
             }
@@ -2484,6 +2429,16 @@ const IDescriptor *TSDIEntityDataPO<SPECIALTYPE>::GetDescriptor() const
         p_pDescr=mv->GetDescriptor(p_ptr);
     }
     return p_pDescr;
+}
+
+
+Status SDIElementDataPO::GetValue(const sdiIdentifier& identifier,
+                                  sdiValue&            value) const
+{
+    const ModelViewPO* mv = static_cast<const ModelViewPO*>(this->GetModelView());
+    assert(mv);
+    sdiIdentifier arrayIdentifier(identifier.GetNameKey(), identifier.GetSolverIdx(), p_index2);
+    return mv->GetValueFromPreObject(p_ptr, arrayIdentifier, value, this, &p_pDescr);
 }
 
 
@@ -3987,129 +3942,6 @@ bool ModelViewPO::SetValueToPreObjectArray(IMECPreObject*              pObj,
     sdiIdentifier arrayIdentifier(identifier.GetNameKey(),identifier.GetSolverIdx(),arrayIndex);
 
     return SetValueToPreObject(pObj, arrayIdentifier, value);
-
-    /*
-    if(!pObj) return false;
-
-    printf("Setting value to array attribute %s at index %u\n",
-        identifier.GetNameKey().c_str(), arrayIndex);
-    printf("pObj key: %s\n", pObj->GetKernelFullType());
-    printf("pObj cfg type: %s\n", pObj->GetInputFullType());
-    printf("pObj config type: %s\n", pObj->getConfigType());
-    unsigned int attributeIndex = UINT_MAX;
-
-    sdiCompoundType compoundType = value.GetCompoundType();
-
-    sdiBasicType valueType = value.GetBasicType();
-     //switch(compoundType)
-
-    switch(valueType)
-    {
-    case BASIC_TYPE_BOOL:
-        printf("Value type is BOOL\n");
-        break;
-    case BASIC_TYPE_INT:
-        printf("Value type is INT\n");
-        break;          
-    case BASIC_TYPE_DOUBLE:
-        printf("Value type is FLOAT\n");
-        break;
-    case BASIC_TYPE_STRING:
-        printf("Value type is STRING\n");
-        break;
-    }
-
-    // First try to get as INT array
-    attributeIndex = pObj->GetIndex(
-        IMECPreObject::ATY_ARRAY, IMECPreObject::VTY_INT, identifier.GetNameKey().c_str());
-    
-    if(attributeIndex != UINT_MAX) {
-        printf("Found INT array attribute %s at index %u\n",
-            identifier.GetNameKey().c_str(), attributeIndex);
-        int value_loc = 0;
-        bool isOk = value.GetValue(value_loc);
-        if(!isOk) return false;
-        
-        // Ensure array is large enough
-        int currentSize = pObj->GetNbValues(IMECPreObject::VTY_INT, attributeIndex);
-        if(currentSize <= (int)arrayIndex) {
-            pObj->resizeArray(IMECPreObject::VTY_INT, attributeIndex, arrayIndex + 1);
-        }
-        
-        pObj->SetIntValue(attributeIndex, arrayIndex, value_loc);
-        printf("Set INT array value at index %u to %d\n", arrayIndex,  value_loc);
-        return true;
-    }
-    
-    // Try FLOAT array
-    attributeIndex = pObj->GetIndex(
-        IMECPreObject::ATY_ARRAY, IMECPreObject::VTY_FLOAT, identifier.GetNameKey().c_str());
-    
-    if(attributeIndex != UINT_MAX) {
-        printf("Found FLOAT array attribute %s at index %u\n",
-            identifier.GetNameKey().c_str(), attributeIndex);
-        double value_loc = 0.0;
-        bool isOk = value.GetValue(value_loc);
-        if(!isOk) return false;
-        
-        // Ensure array is large enough
-        int currentSize = pObj->GetNbValues(IMECPreObject::VTY_FLOAT, attributeIndex);
-        if(currentSize <= (int)arrayIndex) {
-            pObj->resizeArray(IMECPreObject::VTY_FLOAT, attributeIndex, arrayIndex + 1);
-        }
-        
-        pObj->SetFloatValue(attributeIndex, arrayIndex, value_loc);
-        printf("Set FLOAT array value at index %u to %f\n", arrayIndex,  value_loc);
-        return true;
-    }
-    
-    // Try STRING array
-    attributeIndex = pObj->GetIndex(
-        IMECPreObject::ATY_ARRAY, IMECPreObject::VTY_STRING, identifier.GetNameKey().c_str());
-    
-    if(attributeIndex != UINT_MAX) {
-        printf("Found STRING array attribute %s at index %u\n",
-            identifier.GetNameKey().c_str(), attributeIndex);
-        sdiString value_loc;
-        bool isOk = value.GetValue(value_loc);
-        if(!isOk) return false;
-        
-        // Ensure array is large enough
-        int currentSize = pObj->GetNbValues(IMECPreObject::VTY_STRING, attributeIndex);
-        if(currentSize <= (int)arrayIndex) {
-            pObj->resizeArray(IMECPreObject::VTY_STRING, attributeIndex, arrayIndex + 1);
-        }
-        
-        pObj->SetStringValue(attributeIndex, arrayIndex, value_loc.c_str());
-        printf("Set STRING array value at index %u to %s\n", arrayIndex,  value_loc.c_str());
-        return true;
-
-        
-    attributeIndex = pObj->GetIndex(
-        IMECPreObject::ATY_ARRAY, IMECPreObject::VTY_OBJECT, identifier.GetNameKey().c_str());
-
-    if(attributeIndex != UINT_MAX) {
-        printf("Found OBJECT attribute %s at index %u\n",
-            identifier.GetNameKey().c_str(), attributeIndex);
-        sdiValueEntity value_loc;
-        bool isOk = value.GetValue(value_loc);
-        if(!isOk) return false;
-        
-        // Ensure array is large enough
-        int currentSize = pObj->GetNbValues(IMECPreObject::VTY_OBJECT, attributeIndex);
-        if(currentSize <= (int)arrayIndex) {
-            pObj->resizeArray(IMECPreObject::VTY_OBJECT, attributeIndex, arrayIndex + 1);
-        }
-
-        pObj->SetObjectValue(attributeIndex, arrayIndex,identifier.GetNameKey().c_str(),value_loc.GetId());
-        printf("Set OBJECT array value at index %u to ID %u\n", arrayIndex,  value_loc.GetId());
-        return true;
-        }
-
-
-
-    }*/
-    
 }
 
 template <class ENTITYREAD>


### PR DESCRIPTION

This pull request refactors the attribute access and update logic for SDI element data and pre-object arrays, improving maintainability and consistency. The main changes include centralizing the attribute value retrieval for `SDIElementDataPO` and cleaning up legacy code for setting values in pre-object arrays. Additionally, there is a configuration update to the `VID` attribute type.

### Refactoring and code cleanup

* Centralized the logic for retrieving attribute values in `SDIElementDataPO` by delegating to `ModelViewPO::GetValueFromPreObject`, replacing the previous lengthy inline implementation with a single function call. This improves maintainability and consistency of attribute access. (`reader/source/cfgkernel/sdi/sdiModelViewPO.h`, [[1]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL479-L535) [[2]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fR2384-R2393)
* Removed a large block of commented-out, legacy code from `ModelViewPO::SetValueToPreObjectArray`, resulting in a cleaner and more readable function. (`reader/source/cfgkernel/sdi/sdiModelViewPO.h`, [reader/source/cfgkernel/sdi/sdiModelViewPO.hL3938-L4060](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL3938-L4060))

### Configuration update

* Changed the type of the `VID` attribute from `VECTOR` to `SYSTEM` in the discrete element configuration, likely to better reflect its intended usage as an orientation option. (`hm_cfg_files/config/CFG/Keyword971/ELEMENTS/discrete.cfg`, [hm_cfg_files/config/CFG/Keyword971/ELEMENTS/discrete.cfgL27-R27](diffhunk://#diff-b5a00bd5462a6cda996208c28a1c70670a6e53cd060555400f48c470b987a476L27-R27))