### PR TITLE
General fix for shell offset, that caused issues with contact interface type 25

### DIFF
--- a/starter/source/starter/lectur.F
+++ b/starter/source/starter/lectur.F
@@ -7420,18 +7420,26 @@ C--------------------------------------------
      .                      NGROUP,    NPARG,      IPARG,        NPROPG,
      .                      NUMGEO,      GEO,     DEFAULTS%SHELL%IOFFSET)
       IF (DEFAULTS%SHELL%IOFFSET>0) THEN
+
         IF (IDDLEVEL == 0) THEN 
           NULLIFY(X_C) 
           IF (DEFAULTS%SHELL%IOFFSET==1) THEN
             ALLOCATE(ITAGOSET(NUMELC+NUMELTG), STAT=Stat)
             ALLOCATE(XYZ(3*NUMNOD), STAT=Stat)
+          ELSE
+            ALLOCATE(ITAGOSET(0), STAT=Stat)
+          END IF
+        END IF
+
+          NULLIFY(X_C) 
+          IF (DEFAULTS%SHELL%IOFFSET==1) THEN
             XYZ(1:3*NUMNOD) = X(1:3*NUMNOD)
             X_C=>XYZ
           ELSE
-            ALLOCATE(ITAGOSET(0), STAT=Stat)
             X_C=>X
           END IF
-        END IF
+
+
           ITAGOSET = 0
           CALL SHELL_OFFSETP(
      .                NGROUP,    NPARG,      IPARG,        NPROPG,


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
Problem of negatives stiffnesses in contact general problem for all contacts

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
With option OFFSET shells, The new configuration X_C is projected from the initial configuration X
The initialization is done only if IDDLEVEL =0
So the offset is applied 2 times and for coating shells with large thicknesses results on negative jacobian

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
