### PR TITLE
Correct beam and shell stiffness in old param buffer for law36

### DIFF
--- a/starter/source/materials/mat/hm_read_mat.F90
+++ b/starter/source/materials/mat/hm_read_mat.F90
@@ -1493,6 +1493,10 @@
             if (pm(22,i) == zero) pm(22,i) = matparam%shear
             if (pm(32,i) == zero) pm(32,i) = matparam%bulk
 !
+            ! stiffness storage to be cleaned !!!
+            if (pm(24,i) == zero) pm(24,i) = matparam%young/(one - matparam%nu**2)
+            if (pm(27,i) == zero) pm(27,i) = sqrt(matparam%young/matparam%rho0)
+
             ! to be defined
             ! if (matparam%stiff_contact == zero) matparam%stiff_contact = pm(?,i)
             ! if (matparam%stiff_hglass  == zero) matparam%stiff_hglass  = pm(?,i)


### PR DESCRIPTION
Correction to avoid non initialized material parameter values in old buffer which is still used in the code

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
