### PR TITLE
OpenReader : support of /DFS/WAV_SHA

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2026/data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/radioss2026/data_hierarchy.cfg
@@ -3495,7 +3495,7 @@ HIERARCHY {
             HM_CONFIG_TYPE = 4;
             HM_TYPE = 16;
             FILE    = "LOADS/wave.cfg";
-            USER_NAMES = (DFS_WAV_SHA,WAV_SHA);
+            USER_NAMES = (DFS_WAV_SHA,WAV_SHA,DFS/WAV_SHA);
         }
     }
     HIERARCHY {


### PR DESCRIPTION
This pull request makes a minor update to the `hm_cfg_files/config/CFG/radioss2026/data_hierarchy.cfg` file, specifically in the `HIERARCHY` section. The change adds an additional user name to the `USER_NAMES` list for the relevant configuration.

* Added `DFS/WAV_SHA` to the `USER_NAMES` list alongside the existing entries, improving user name mapping for the corresponding configuration.