### PR TITLE
modify thnms1 MONVOL & VENT

### DIFF
--- a/starter/source/output/th/hm_read_thgrou.F
+++ b/starter/source/output/th/hm_read_thgrou.F
@@ -1186,6 +1186,9 @@ C   monitored volume
      . 'AO      ','UO      ','AC      ','UC      ','CP      ',
      . 'CV      ','GAMA    ','DTBAG   ','NFV     ','MASS-IN ',
      . 'ENTHA-IN','ENER-INT','WORK    ','UPCRIT  '/
+C
+C Caution : all variables added or defined in VARMV/ must be added also in VARMVENT/
+C
       DATA VARMVENT/
      . 'MASS    ','VOL     ','P       ','A       ','T       ',
      . 'AO      ','UO      ','AC      ','UC      ','CP      ',
@@ -3257,7 +3260,7 @@ C-------------------------------------
      2      NVARS2        ,NVARS3        ,NVARS4           ,NVARS5            ,NVARS6           ,
      3      NVARS7        ,NVARS8        ,NVARS9           ,NVARS10           ,NVARSNLOC        ,
      4      NVARP         ,NVARR         ,NVART            ,NVARNS            ,NVARSPH          ,
-     5      NVARIN        ,NVARRW        ,NVARRB           ,NVARMV            ,NVARSE           ,
+     5      NVARIN        ,NVARRW        ,NVARRB           ,NVARSE            ,
      5      NVARAC        ,NVARJO        ,NVARMVENT        ,NVARPA            ,NVARFX           ,
      6      NVARGAU       ,NVARFR        ,NVARSLIP         ,NVARRET           ,NVARCLUS         ,
      7      NVARFLOW      ,NVARSURF      ,NVARC            ,NVARSENS          ,
@@ -3267,17 +3270,17 @@ C-------------------------------------
      B      VARS6_TITLE   ,VARS7_TITLE   ,VARS8_TITLE      ,VARS9_TITLE       ,VARSNLOC_TITLE   ,
      C      VARC_TITLE    ,VARS10_TITLE  ,
      D      VARNS_TITLE   ,VARSPH_TITLE  ,VARIN_TITLE      ,
-     E      VARRW_TITLE   ,VARRB_TITLE   ,VARMV_TITLE      ,VARSE_TITLE       ,VARAC_TITLE      ,
+     E      VARRW_TITLE   ,VARRB_TITLE   ,VARSE_TITLE      ,VARAC_TITLE       ,
      F      VARJO_TITLE   ,VARMVENT_TITLE,VARPA_TITLE      ,VARFX_TITLE       ,VARGAU_TITLE     ,
      G      VARFR_TITLE   ,VARSLIP_TITLE ,VARRET_TITLE     ,VARCLUS_TITLE     ,VARFLOW_TITLE    ,
      H      VARSURF_TITLE ,VARSENS_TITLE ,
-     I      VARN1         ,VARN1A        ,VARN2            ,VARNPINCH        ,
+     I      VARN1         ,VARN1A        ,VARN2            ,VARNPINCH         ,
      J      VARP          ,VARR          ,VART             ,VARS1             ,VARS2            ,
      K      VARS3         ,VARS4         ,VARS5            ,VARS6             ,VARS7            ,
-     L      VARS8         ,VARS9         ,VARS10           ,VARSNLOC         ,
+     L      VARS8         ,VARS9         ,VARS10           ,VARSNLOC          ,
      M      VARC          ,
      N      VARNS         ,VARSPH        ,VARIN            ,
-     O      VARRW         ,VARRB         ,VARMV            ,VARSE             ,VARAC            ,
+     O      VARRW         ,VARRB         ,VARSE            ,VARAC             ,
      P      VARJO         ,VARMVENT      ,VARPA            ,VARFX             ,VARGAU           ,
      Q      VARFR         ,VARSLIP       ,VARRET           ,VARCLUS           ,VARFLOW          ,
      R      VARSURF       ,VARSENS       )

--- a/starter/source/output/th/write_thnms1.F90
+++ b/starter/source/output/th/write_thnms1.F90
@@ -47,7 +47,7 @@
           nvars2        ,nvars3        ,nvars4           ,nvars5            ,nvars6           ,&
           nvars7        ,nvars8        ,nvars9           ,nvars10           ,nvarsnloc        ,&
           nvarp         ,nvarr         ,nvart            ,nvarns            ,nvarsph          ,&
-          nvarin        ,nvarrw        ,nvarrb           ,nvarmv            ,nvarse           ,&
+          nvarin        ,nvarrw        ,nvarrb           ,nvarse            ,&
           nvarac        ,nvarjo        ,nvarmvent        ,nvarpa            ,nvarfx           ,&
           nvargau       ,nvarfr        ,nvarslip         ,nvarret           ,nvarclus         ,&
           nvarflow      ,nvarsurf      ,nvarc            ,nvarsens          ,&
@@ -57,17 +57,17 @@
           vars6_title   ,vars7_title   ,vars8_title      ,vars9_title       ,varsnloc_title   ,&
           varc_title    ,vars10_title  ,&
           varns_title   ,varsph_title  ,varin_title      ,&
-          varrw_title   ,varrb_title   ,varmv_title      ,varse_title       ,varac_title      ,&
+          varrw_title   ,varrb_title   ,varse_title      ,varac_title       ,&
           varjo_title   ,varmvent_title,varpa_title      ,varfx_title       ,vargau_title     ,&
           varfr_title   ,varslip_title ,varret_title     ,varclus_title     ,varflow_title    ,&
           varsurf_title ,varsens_title,&
           varn1         ,varn1a        ,varn2            ,varnpinch         ,&
           varp          ,varr          ,vart             ,vars1             ,vars2            ,&
           vars3         ,vars4         ,vars5            ,vars6             ,vars7            ,&
-          vars8         ,vars9         ,vars10           ,varsnloc         ,&
+          vars8         ,vars9         ,vars10           ,varsnloc          ,&
           varc          ,&
           varns         ,varsph        ,varin            ,&
-          varrw         ,varrb         ,varmv            ,varse             ,varac            ,&
+          varrw         ,varrb         ,varse            ,varac             ,&
           varjo         ,varmvent      ,varpa            ,varfx             ,vargau           ,&
           varfr         ,varslip       ,varret           ,varclus           ,varflow          ,&
           varsurf       ,varsens)
@@ -106,7 +106,6 @@
           integer,                                   intent(in) :: nvarin
           integer,                                   intent(in) :: nvarrw
           integer,                                   intent(in) :: nvarrb
-          integer,                                   intent(in) :: nvarmv
           integer,                                   intent(in) :: nvarse
           integer,                                   intent(in) :: nvarac
           integer,                                   intent(in) :: nvarjo
@@ -147,7 +146,6 @@
           character(len=100),                        intent(in) :: varin_title(nvarin)
           character(len=100),                        intent(in) :: varrw_title(nvarrw)
           character(len=100),                        intent(in) :: varrb_title(nvarrb)
-          character(len=100),                        intent(in) :: varmv_title(nvarmv)
           character(len=100),                        intent(in) :: varse_title(nvarse)
           character(len=100),                        intent(in) :: varac_title(nvarac)
           character(len=100),                        intent(in) :: varjo_title(nvarjo)
@@ -187,7 +185,6 @@
           character(len=10),                        intent(in) :: varin(nvarin)
           character(len=10),                        intent(in) :: varrw(nvarrw)
           character(len=10),                        intent(in) :: varrb(nvarrb)
-          character(len=10),                        intent(in) :: varmv(nvarmv)
           character(len=10),                        intent(in) :: varse(nvarse)
           character(len=10),                        intent(in) :: varac(nvarac)
           character(len=10),                        intent(in) :: varjo(nvarjo)
@@ -350,11 +347,6 @@
 
           write(io, *) "$$ ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
           write(io, *) "$$ MONVOL"
-          write(io, *) "$$ ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-          call write_thnms1_titles(io,nvarmv,varmv_title,varmv,0)
-
-          write(io, *) "$$ ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-          write(io, *) "$$ VENT"
           write(io, *) "$$ ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
           call write_thnms1_titles(io,nvarmvent,varmvent_title,varmvent,0)
 


### PR DESCRIPTION
This pull request removes the `VARMV`/`nvarmv` group and its related variables, titles, and calls from both `hm_read_thgrou.F` and `write_thnms1.F90`. The change streamlines the handling of variable groups in the output routines and ensures consistency between the variable definitions and their usage.

**Removal of the `VARMV`/`nvarmv` group:**

* Removed all references to `VARMV`, `nvarmv`, `varmv`, and `varmv_title` from the argument lists, variable declarations, and data structures in both `hm_read_thgrou.F` and `write_thnms1.F90`. [[1]](diffhunk://#diff-d34e6cce478665cc842be66bb2a46a81a8034f16e5c5714aa5e929cb6b384b34L3260-R3263) [[2]](diffhunk://#diff-d34e6cce478665cc842be66bb2a46a81a8034f16e5c5714aa5e929cb6b384b34L3270-R3273) [[3]](diffhunk://#diff-d34e6cce478665cc842be66bb2a46a81a8034f16e5c5714aa5e929cb6b384b34L3280-R3283) [[4]](diffhunk://#diff-7aba56ff91f945b0d56340f15abd0ec136c9676b4aaf595bf92cc6a777a1cbafL50-R50) [[5]](diffhunk://#diff-7aba56ff91f945b0d56340f15abd0ec136c9676b4aaf595bf92cc6a777a1cbafL60-R60) [[6]](diffhunk://#diff-7aba56ff91f945b0d56340f15abd0ec136c9676b4aaf595bf92cc6a777a1cbafL70-R70) [[7]](diffhunk://#diff-7aba56ff91f945b0d56340f15abd0ec136c9676b4aaf595bf92cc6a777a1cbafL109) [[8]](diffhunk://#diff-7aba56ff91f945b0d56340f15abd0ec136c9676b4aaf595bf92cc6a777a1cbafL150) [[9]](diffhunk://#diff-7aba56ff91f945b0d56340f15abd0ec136c9676b4aaf595bf92cc6a777a1cbafL190)

**Output routine simplification:**

* Removed the block that wrote out the `MONVOL` section in `write_thnms1.F90`, including the call to `write_thnms1_titles` for `varmv` variables and its associated titles.

**Documentation and developer guidance:**

* Added a cautionary comment in `hm_read_thgrou.F` to remind developers that any variables added or defined in `VARMV/` must also be added in `VARMVENT/`, improving documentation for future maintenance.