### PR TITLE
add security check for beams

### DIFF
--- a/starter/source/elements/reader/hm_read_beam.F
+++ b/starter/source/elements/reader/hm_read_beam.F
@@ -155,7 +155,7 @@ C--------------------------------------------------
         ENDIF
 C direction input by vector VX,VY,VZ
         NORM = SQRT(VX(I)**2 + VY(I)**2 + VZ(I)**2)
-        IF (NORM > ZERO) THEN
+        IF (NORM > EM20) THEN
           IBEAM_VECTOR(I) = 1
           RBEAM_VECTOR(1,I) = VX(I) / NORM
           RBEAM_VECTOR(2,I) = VY(I) / NORM


### PR DESCRIPTION
This pull request makes a small but important change to the beam direction normalization logic in the `HM_READ_BEAM` subroutine. The threshold for considering a vector as non-zero has been updated to use `EM20` instead of `ZERO`, which likely represents a more appropriate lower bound for floating-point comparisons.

* Changed the conditional check for beam vector normalization from `NORM > ZERO` to `NORM > EM20` in the `HM_READ_BEAM` subroutine, improving numerical stability when determining if a beam direction vector is valid. (`starter/source/elements/reader/hm_read_beam.F`, [starter/source/elements/reader/hm_read_beam.FL160-R160](diffhunk://#diff-e74b67ff293f34799c8d25700886e5e3e041a406fecdbaa2e252f3ae84604417L160-R160))