### PR TITLE
correction issue with transform sca within transformed submodel : missing default value for scale factor

### DIFF
--- a/starter/source/model/submodel/lectranssub.F
+++ b/starter/source/model/submodel/lectranssub.F
@@ -740,10 +740,18 @@ C
 C
           CALL HM_GET_INTV('node1',N0,IS_AVAILABLE,LSUBMODEL)
 C
-          CALL HM_GET_FLOATV('scalefactor_x',RTRANS(I,20),IS_AVAILABLE,LSUBMODEL,UNITAB)
-          CALL HM_GET_FLOATV('scalefactor_y',RTRANS(I,21),IS_AVAILABLE,LSUBMODEL,UNITAB)
-          CALL HM_GET_FLOATV('scalefactor_z',RTRANS(I,22),IS_AVAILABLE,LSUBMODEL,UNITAB)
+          CALL HM_GET_FLOATV('scalefactor_x',SX,IS_AVAILABLE,LSUBMODEL,UNITAB)
+          CALL HM_GET_FLOATV('scalefactor_y',SY,IS_AVAILABLE,LSUBMODEL,UNITAB)
+          CALL HM_GET_FLOATV('scalefactor_z',SZ,IS_AVAILABLE,LSUBMODEL,UNITAB)
 c          
+          IF (SX == ZERO) SX = ONE
+          IF (SY == ZERO) SY = ONE
+          IF (SZ == ZERO) SZ = ONE
+c
+          RTRANS(I,20) = SX
+          RTRANS(I,21) = SY
+          RTRANS(I,22) = SZ
+c
           IF (N0 > 0) THEN
             I0 = USRTOS(N0,ITABM1)
             IF (I0 == 0) THEN


### PR DESCRIPTION
This pull request updates the handling of scale factors in the `LECTRANSSUB` subroutine to improve robustness and ensure valid transformation values. Instead of directly assigning values to the `RTRANS` array, the scale factors are first retrieved into temporary variables, checked for zero values, and set to one if necessary before assignment. This prevents invalid zero scale factors from being used in transformations.

**Improvements to scale factor handling:**

* Scale factors `scalefactor_x`, `scalefactor_y`, and `scalefactor_z` are now read into temporary variables (`TX`, `TY`, `TZ`) instead of directly into the `RTRANS` array.
* Added logic to set any scale factor that is zero to one, ensuring no zero values are used in transformations.
* Final scale factor values are assigned to the corresponding positions in the `RTRANS` array after validation.