### PR TITLE
openReader CNODE handling

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2026/data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/radioss2026/data_hierarchy.cfg
@@ -20,11 +20,23 @@
 //========================================================================================
 
 HIERARCHY {
-    KEYWORD         = NODE;
+    KEYWORD         = NODES;
     TITLE           = "NODE";
     TYPE            = NODE;
-    FILE            = "NODE/node.cfg";
-    USER_NAMES      = (NODE);
+    //
+    HIERARCHY {
+        KEYWORD         = NODE;
+        TITLE           = "NODE";
+        FILE            = "NODE/node.cfg";
+        USER_NAMES      = (NODE);
+    }
+
+    HIERARCHY {
+        KEYWORD         = CNODE;
+        TITLE           = "CNODE";
+        FILE            = "NODE/cnode.cfg";
+        USER_NAMES      = (CNODE);
+    }
 }
 
 HIERARCHY {

--- a/hm_cfg_files/config/CFG/radioss41/NODE/cnode.cfg
+++ b/hm_cfg_files/config/CFG/radioss41/NODE/cnode.cfg
@@ -1,0 +1,113 @@
+//Copyright>    CFG Files and Library ("CFG")
+//Copyright>    Copyright (C) 1986-2025 Altair Engineering Inc.
+//Copyright>
+//Copyright>    Altair Engineering Inc. grants to third parties limited permission to
+//Copyright>    use and modify CFG solely in connection with OpenRadioss software, provided
+//Copyright>    that any modification to CFG by a third party must be provided back to
+//Copyright>    Altair Engineering Inc. and shall be deemed a Contribution under and therefore
+//Copyright>    subject to the CONTRIBUTOR LICENSE AGREEMENT for OpenRadioss software.
+//Copyright>
+//Copyright>    CFG IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//Copyright>    INCLUDING, BUT NOT LIMITED TO, THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+//Copyright>    A PARTICULAR PURPOSE, AND NONINFRINGEMENT.  IN NO EVENT SHALL ALTAIR ENGINEERING
+//Copyright>    INC. OR ITS AFFILIATES BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY,
+//Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
+//Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
+//
+//  Node Setup File
+// 
+
+ATTRIBUTES(COMMON) {
+// INPUT ATTRIBUTES
+    Search_Value                          = VALUE(FLOAT,  "Search_Value");
+    COUNT                                 = SIZE("Node Number");
+    //id                                  = ARRAY[COUNT](NODE,"Node identifier");
+    id                                    = ARRAY[COUNT](INT,"Node identifier");
+    globalx                               = ARRAY[COUNT](FLOAT,"X coordinate");
+    globaly                               = ARRAY[COUNT](FLOAT,"Y coordinate");
+    globalz                               = ARRAY[COUNT](FLOAT,"Z coordinate");
+
+// HM INTERNAL
+    KEYWORD_STR                           = VALUE(STRING, "Solver Keyword");
+    NUM_COMMENTS                          = SIZE("NUM_COMMENTS");
+    CommentEnumField                      = VALUE(INT,"User Comments");
+    COMMENTS                              = ARRAY[NUM_COMMENTS](STRING,"Entity Comments");
+}
+
+SKEYWORDS_IDENTIFIER(COMMON)
+{
+    Search_Value                       = 4805;
+    KEYWORD_STR                        = 9000;
+    COMMENTS                           = 5109;
+    CommentEnumField                   = 7951;
+    NUM_COMMENTS                       = 5110;
+//
+    COUNT                              = -1;
+    id                                 = -1;
+    globalx                            = -1;
+    globaly                            = -1;
+    globalz                            = -1;
+}
+
+CHECK(COMMON)
+{
+
+}
+
+DEFAULTS(COMMON)
+{
+
+}
+
+GUI(COMMON) {
+    RADIO(CommentEnumField)
+    {
+        ENUM_VALUE_FLAG=TRUE;
+        ADD(1, "Hide in Menu/Export");
+        ADD(2, "Show in Menu/Export");
+        ADD(3, "Do Not Export");
+    }
+    if(CommentEnumField == 2)
+    {  
+        SIZE(NUM_COMMENTS);
+        ARRAY(NUM_COMMENTS,"")
+        {
+            SCALAR(COMMENTS);
+        }   
+    }
+
+    ASSIGN(KEYWORD_STR, "/CNODE");
+
+    SCALAR(Search_Value) {DIMENSION="l";}
+    SIZE(COUNT) ;
+
+    ARRAY(COUNT,"Node data")
+    {
+         //DATA(id) ;
+         SCALAR(id) ;
+         SCALAR(globalx) {DIMENSION="l";}
+         SCALAR(globaly) {DIMENSION="l";}
+         SCALAR(globalz) {DIMENSION="l";}
+    }
+}
+
+// File format
+FORMAT(radioss110) 
+{
+    HEADER("/CNODE/%-20lf",Search_Value);
+    COMMENT("#  node_ID                 Xc                  Yc                  Zc");
+    FREE_CARD_LIST(COUNT)
+    {
+        CARD("%10d%20lg%20lg%20lg",id,globalx,globaly,globalz);
+    }
+}
+FORMAT(radioss51)
+{  
+    HEADER("/CNODE/%-20lf",Search_Value);
+    COMMENT("#  node_ID                 Xc                  Yc                  Zc");
+    FREE_CARD_LIST(COUNT)
+    {
+        CARD("%10d%20lg%20lg%20lg",id,globalx,globaly,globalz);
+    }
+}
+

--- a/reader/source/cfgkernel/sdi/sdiModelViewPO.h
+++ b/reader/source/cfgkernel/sdi/sdiModelViewPO.h
@@ -392,6 +392,9 @@ public:
         return HandleEdit(this->p_entityType, this->p_index, p_index2);
     }
 
+    // Get value of an attribute for this element (by attribute name)
+    inline virtual Status GetValue(const sdiIdentifier& identifier, sdiValue& value) const;
+    
     friend class SDISelectionDataPOArray<SPECIALTYPE>;
     friend class SDIElementSelectionDataElemCache;
 
@@ -481,8 +484,6 @@ public:
     }
 
 
-    // Get value of an attribute for this element (by attribute name)
-    inline virtual Status GetValue(const sdiIdentifier& identifier, sdiValue& value) const;
     
     virtual unsigned int GetNodeCount() const
     {
@@ -708,12 +709,12 @@ public:
 
             sdiString kernelFullType = this->p_pre_obj_lst->at(i)->GetKernelFullType();
 
+            sdiString inputFullType = this->p_pre_obj_lst->at(i)->GetInputFullType();
+
             bool isSame = true;
-            if (kernelFullType.find("/ELEMS") == 0) {
-                kernelFullType.erase(0, 6); // Remove "/ELEMS"
-                if (!(strcmp(this->p_keyword.c_str(), kernelFullType.c_str()) == 0)) {
-                    isSame = false;
-                }
+            
+            if (!(strcmp(this->p_keyword.c_str(), inputFullType.c_str()) == 0)) {
+                isSame = false;
             }
 
             if(this->p_pre_obj_lst->at(i) != nullptr && isSame)
@@ -2438,13 +2439,17 @@ const IDescriptor *TSDIEntityDataPO<SPECIALTYPE>::GetDescriptor() const
 }
 
 
-Status SDIElementDataPO::GetValue(const sdiIdentifier& identifier,
+template<sdi::SpecializationType SPECIALTYPE>
+Status TSDIEntityDataPOArray<SPECIALTYPE>::GetValue(const sdiIdentifier& identifier,
                                   sdiValue&            value) const
 {
     const ModelViewPO* mv = static_cast<const ModelViewPO*>(this->GetModelView());
     assert(mv);
     sdiIdentifier arrayIdentifier(identifier.GetNameKey(), identifier.GetSolverIdx(), p_index2);
-    return mv->GetValueFromPreObject(p_ptr, arrayIdentifier, value, this, &p_pDescr);
+    bool isOk = mv->GetValueFromPreObject(this->p_ptr, arrayIdentifier, value, this, &(this->p_pDescr));
+    if(isOk) return true;
+
+    return mv->GetValueFromPreObject(this->p_ptr, identifier, value, this, &(this->p_pDescr));
 }
 
 

--- a/reader/source/solver_interface/source/nodes/cpp_nodes_count.cpp
+++ b/reader/source/solver_interface/source/nodes/cpp_nodes_count.cpp
@@ -55,24 +55,9 @@ CDECL void cpp_nodes_count_(int *nbNodes, int *nbCnodes)
 {
     sdiValue search_value_val;
     SelectionNodeRead nodes(g_pModelViewSDI, "/NODE");
-    sdiIdentifier search_value_identifier("Search_Value");
-    bool is_cnode;
-    int cpt = 0;
-    int cpt1 = 0;
-    while(nodes.Next())
-    {
-        is_cnode = nodes->GetValue(search_value_identifier, search_value_val);
-        if(!is_cnode)
-        {
-            cpt = cpt + 1;
-        }
-        else
-        {
-            cpt1 = cpt1 + 1;
-        }
-    }
-    *nbNodes = cpt;
-    *nbCnodes = cpt1;
+    SelectionNodeRead cnodes(g_pModelViewSDI, "/CNODE");
+    *nbNodes = nodes.Count();
+    *nbCnodes = cnodes.Count();
 }
 CDECL void CPP_NODES_COUNT(int *nbNodes, int *nbCnodes)
 {cpp_nodes_count_ (nbNodes,nbCnodes);}


### PR DESCRIPTION
This pull request refactors the handling of nodes and cnodes in both the configuration files and the C++ codebase, resulting in clearer separation and improved maintainability. The most significant changes are the introduction of explicit support for `CNODE` entities, updates to configuration and hierarchy files, and simplification of node/cnode reading logic in the solver interface.

**Configuration and Hierarchy Updates:**

* Added a new hierarchy entry for `CNODE` in `data_hierarchy.cfg`, with an associated configuration file `NODE/cnode.cfg` that defines attributes, GUI, and formats for cnodes. This makes cnodes a first-class entity, separate from nodes. [[1]](diffhunk://#diff-a363c0d8a651ff98903e29e2017b1b7de6bec2b0f30a751e6e3c427dc5495302L23-R41) [[2]](diffhunk://#diff-5abe5498c4668bd4b5d20df99c0873b68d519a99c8a35396ff59882f0c28c109R1-R113)

**Solver Interface Refactoring:**

* Simplified node and cnode counting logic in `cpp_nodes_count.cpp` by using direct counts from `SelectionNodeRead` for `/NODE` and `/CNODE`, removing the previous attribute-based distinction.
* Refactored reading logic in `cpp_nodes_read.cpp` to process nodes and cnodes in separate loops, eliminating the need for attribute-based filtering and ensuring each entity type is handled independently. [[1]](diffhunk://#diff-aa23f19e28896428ebb51e60dff767418243545f39ec1a7637ffa402d23966d3L47-L58) [[2]](diffhunk://#diff-aa23f19e28896428ebb51e60dff767418243545f39ec1a7637ffa402d23966d3L148-R181)

**API and Class Changes:**

* Moved the implementation of the `GetValue` method from `SDIElementDataPO` to `TSDIEntityDataPOArray`, generalizing attribute value retrieval for array-based entities. [[1]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fR389-R391) [[2]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL478-L479) [[3]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL2435-R2451)
* Updated selection logic in `SDISelectionDataPOArray` to use the input full type for entity matching, improving robustness when distinguishing between different entity types.

**Cnode-specific Reading Logic:**

* Updated the cnode reading function (`cpp_cnode_read_`) to use the `/CNODE` selector, ensuring only cnodes are processed and their attributes are correctly read and assigned. [[1]](diffhunk://#diff-aa23f19e28896428ebb51e60dff767418243545f39ec1a7637ffa402d23966d3L216-R243) [[2]](diffhunk://#diff-aa23f19e28896428ebb51e60dff767418243545f39ec1a7637ffa402d23966d3L231-R267) [[3]](diffhunk://#diff-aa23f19e28896428ebb51e60dff767418243545f39ec1a7637ffa402d23966d3L251-R285)