### PR TITLE
unify hm_reader OpenReader cfg files for ALE_MAT

### DIFF
--- a/hm_cfg_files/config/CFG/radioss110/MAT/mat_law11.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/MAT/mat_law11.cfg
@@ -178,7 +178,7 @@ FORMAT(radioss110)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -233,7 +233,7 @@ FORMAT(radioss51)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss110/MAT/mat_law51.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/MAT/mat_law51.cfg
@@ -478,7 +478,7 @@ FORMAT(radioss110)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -621,7 +621,7 @@ FORMAT(radioss51)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss110/MAT/mat_law6.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/MAT/mat_law6.cfg
@@ -330,7 +330,7 @@ FORMAT(radioss51)
 
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss110/MAT/matl10_law10.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/MAT/matl10_law10.cfg
@@ -246,7 +246,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss110/MAT/matl16_gray.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/MAT/matl16_gray.cfg
@@ -343,7 +343,7 @@ FORMAT(radioss90) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -416,7 +416,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss110/MAT/matl18_therm.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/MAT/matl18_therm.cfg
@@ -243,7 +243,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss110/MAT/matl20_bimat.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/MAT/matl20_bimat.cfg
@@ -183,7 +183,7 @@ FORMAT(radioss90) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -227,7 +227,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss110/MAT/matl21_dprag.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/MAT/matl21_dprag.cfg
@@ -252,7 +252,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss110/MAT/matl26_sesam.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/MAT/matl26_sesam.cfg
@@ -385,7 +385,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss110/MAT/matl2_plas.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/MAT/matl2_plas.cfg
@@ -181,7 +181,7 @@ FORMAT(radioss100)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -236,7 +236,7 @@ FORMAT(radioss51)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss110/MAT/matl37_biphas.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/MAT/matl37_biphas.cfg
@@ -244,7 +244,7 @@ FORMAT(radioss90) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -297,7 +297,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss110/MAT/matl3_hydpla.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/MAT/matl3_hydpla.cfg
@@ -334,7 +334,7 @@ FORMAT(radioss110) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -403,7 +403,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss110/MAT/matl41_lee_t.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/MAT/matl41_lee_t.cfg
@@ -406,7 +406,7 @@ FORMAT(radioss100) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -486,7 +486,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss110/MAT/matl46_les_fluid.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/MAT/matl46_les_fluid.cfg
@@ -239,7 +239,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss110/MAT/matl49_steinb.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/MAT/matl49_steinb.cfg
@@ -314,7 +314,7 @@ FORMAT(radioss110) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -390,7 +390,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss110/MAT/matl4_hyd_jcook.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/MAT/matl4_hyd_jcook.cfg
@@ -386,7 +386,7 @@ FORMAT(radioss110) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -459,7 +459,7 @@ FORMAT(radioss90) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -529,7 +529,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss110/MAT/matl5_jwl.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/MAT/matl5_jwl.cfg
@@ -240,7 +240,7 @@ FORMAT(radioss90) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -298,7 +298,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss120/MAT/mat_law51.cfg
+++ b/hm_cfg_files/config/CFG/radioss120/MAT/mat_law51.cfg
@@ -466,7 +466,7 @@ FORMAT(radioss120)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -609,7 +609,7 @@ FORMAT(radioss110)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -740,7 +740,7 @@ FORMAT(radioss51)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss120/MAT/matl37_biphas.cfg
+++ b/hm_cfg_files/config/CFG/radioss120/MAT/matl37_biphas.cfg
@@ -205,7 +205,7 @@ FORMAT(radioss120) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -265,7 +265,7 @@ FORMAT(radioss90) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -325,7 +325,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss120/MAT/matl5_jwl.cfg
+++ b/hm_cfg_files/config/CFG/radioss120/MAT/matl5_jwl.cfg
@@ -247,7 +247,7 @@ FORMAT(radioss120) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -308,7 +308,7 @@ FORMAT(radioss90) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -369,7 +369,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss120/MAT/matl75_75.cfg
+++ b/hm_cfg_files/config/CFG/radioss120/MAT/matl75_75.cfg
@@ -262,7 +262,7 @@ FORMAT(radioss120)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss120/MAT/matl80_80.cfg
+++ b/hm_cfg_files/config/CFG/radioss120/MAT/matl80_80.cfg
@@ -410,7 +410,7 @@ FORMAT(radioss120)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss130/MAT/mat_law51.cfg
+++ b/hm_cfg_files/config/CFG/radioss130/MAT/mat_law51.cfg
@@ -1072,7 +1072,7 @@ FORMAT(radioss130)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -1203,7 +1203,7 @@ FORMAT(radioss120)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -1344,7 +1344,7 @@ FORMAT(radioss110)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -1476,7 +1476,7 @@ FORMAT(radioss51)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss130/MAT/matl10_law10.cfg
+++ b/hm_cfg_files/config/CFG/radioss130/MAT/matl10_law10.cfg
@@ -262,7 +262,7 @@ FORMAT(radioss130) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -328,7 +328,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss130/MAT/matl20_bimat.cfg
+++ b/hm_cfg_files/config/CFG/radioss130/MAT/matl20_bimat.cfg
@@ -212,7 +212,7 @@ FORMAT(radioss130) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -256,7 +256,7 @@ FORMAT(radioss90) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -300,7 +300,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss130/MAT/matl21_dprag.cfg
+++ b/hm_cfg_files/config/CFG/radioss130/MAT/matl21_dprag.cfg
@@ -282,7 +282,7 @@ FORMAT(radioss130) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -349,7 +349,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss130/MAT/matl80_80.cfg
+++ b/hm_cfg_files/config/CFG/radioss130/MAT/matl80_80.cfg
@@ -440,7 +440,7 @@ FORMAT(radioss130)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -510,7 +510,7 @@ FORMAT(radioss120)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss140/MAT/mat_law11.cfg
+++ b/hm_cfg_files/config/CFG/radioss140/MAT/mat_law11.cfg
@@ -191,7 +191,7 @@ FORMAT(radioss110)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -247,7 +247,7 @@ FORMAT(radioss51)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss140/MAT/mat_law51.cfg
+++ b/hm_cfg_files/config/CFG/radioss140/MAT/mat_law51.cfg
@@ -1091,7 +1091,7 @@ FORMAT(radioss140)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -1434,7 +1434,7 @@ FORMAT(radioss130)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -1563,7 +1563,7 @@ FORMAT(radioss120)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -1706,7 +1706,7 @@ FORMAT(radioss110)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -1839,7 +1839,7 @@ FORMAT(radioss51)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss140/MAT/matl2_plas.cfg
+++ b/hm_cfg_files/config/CFG/radioss140/MAT/matl2_plas.cfg
@@ -178,7 +178,7 @@ FORMAT(radioss140)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -233,7 +233,7 @@ FORMAT(radioss100)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -289,7 +289,7 @@ FORMAT(radioss51)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss140/MAT/matl5_jwl.cfg
+++ b/hm_cfg_files/config/CFG/radioss140/MAT/matl5_jwl.cfg
@@ -252,7 +252,7 @@ FORMAT(radioss140) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -317,7 +317,7 @@ FORMAT(radioss120) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -378,7 +378,7 @@ FORMAT(radioss90) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -438,7 +438,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2017/MAT/mat_law11.cfg
+++ b/hm_cfg_files/config/CFG/radioss2017/MAT/mat_law11.cfg
@@ -192,7 +192,7 @@ FORMAT(radioss110)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -248,7 +248,7 @@ FORMAT(radioss51)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2017/MAT/mat_law51.cfg
+++ b/hm_cfg_files/config/CFG/radioss2017/MAT/mat_law51.cfg
@@ -1082,7 +1082,7 @@ FORMAT(radioss2017)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -1428,7 +1428,7 @@ FORMAT(radioss140)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -1771,7 +1771,7 @@ FORMAT(radioss130)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -1905,7 +1905,7 @@ FORMAT(radioss120)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -2047,7 +2047,7 @@ FORMAT(radioss110)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -2178,7 +2178,7 @@ FORMAT(radioss51)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2017/MAT/matl5_jwl.cfg
+++ b/hm_cfg_files/config/CFG/radioss2017/MAT/matl5_jwl.cfg
@@ -258,7 +258,7 @@ FORMAT(radioss2017) {
 	}
 	if(ALE_Form == 2)
 	{
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
 	}
 	else if(ALE_Form == 3)
 	{
@@ -324,7 +324,7 @@ FORMAT(radioss140) {
 	}
 	if(ALE_Form == 2)
 	{
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
 	}
 	else if(ALE_Form == 3)
 	{
@@ -389,7 +389,7 @@ FORMAT(radioss120) {
 	}
 	if(ALE_Form == 2)
 	{
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
 	}
 	else if(ALE_Form == 3)
 	{
@@ -450,7 +450,7 @@ FORMAT(radioss90) {
 	}
 	if(ALE_Form == 2)
 	{
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
 	}
 	else if(ALE_Form == 3)
 	{
@@ -510,7 +510,7 @@ FORMAT(radioss51) {
 	}
 	if(ALE_Form == 2)
 	{
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
 	}
 	else if(ALE_Form == 3)
 	{

--- a/hm_cfg_files/config/CFG/radioss2018/MAT/LAW_97.cfg
+++ b/hm_cfg_files/config/CFG/radioss2018/MAT/LAW_97.cfg
@@ -378,7 +378,7 @@ FORMAT(radioss2018)
     }
     if (ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT, /SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT, /SUBOBJECT/ALE/MAT,_ID_);
     }
     else if (ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2018/MAT/mat_law51.cfg
+++ b/hm_cfg_files/config/CFG/radioss2018/MAT/mat_law51.cfg
@@ -1081,7 +1081,7 @@ FORMAT(radioss2018)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -1435,7 +1435,7 @@ FORMAT(radioss2017)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -1764,7 +1764,7 @@ FORMAT(radioss140)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -2108,7 +2108,7 @@ FORMAT(radioss130)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -2244,7 +2244,7 @@ FORMAT(radioss120)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -2385,7 +2385,7 @@ FORMAT(radioss110)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -2518,7 +2518,7 @@ FORMAT(radioss51)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2018/MAT/mat_law6.cfg
+++ b/hm_cfg_files/config/CFG/radioss2018/MAT/mat_law6.cfg
@@ -399,7 +399,7 @@ FORMAT(radioss2018)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -505,7 +505,7 @@ FORMAT(radioss51)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2018/MAT/matl37_biphas.cfg
+++ b/hm_cfg_files/config/CFG/radioss2018/MAT/matl37_biphas.cfg
@@ -205,7 +205,7 @@ FORMAT(radioss2018) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -249,7 +249,7 @@ FORMAT(radioss120) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -309,7 +309,7 @@ FORMAT(radioss90) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -369,7 +369,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2018/MAT/matl3_hydpla.cfg
+++ b/hm_cfg_files/config/CFG/radioss2018/MAT/matl3_hydpla.cfg
@@ -299,7 +299,7 @@ FORMAT(radioss2018) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -382,7 +382,7 @@ FORMAT(radioss110) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -453,7 +453,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2018/MAT/matl49_steinb.cfg
+++ b/hm_cfg_files/config/CFG/radioss2018/MAT/matl49_steinb.cfg
@@ -307,7 +307,7 @@ FORMAT(radioss2018) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -375,7 +375,7 @@ FORMAT(radioss110) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -447,7 +447,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2018/MAT/matl4_hyd_jcook.cfg
+++ b/hm_cfg_files/config/CFG/radioss2018/MAT/matl4_hyd_jcook.cfg
@@ -341,7 +341,7 @@ FORMAT(radioss2018) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -436,7 +436,7 @@ FORMAT(radioss110) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -510,7 +510,7 @@ FORMAT(radioss90) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -582,7 +582,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2018/MAT/matl5_jwl.cfg
+++ b/hm_cfg_files/config/CFG/radioss2018/MAT/matl5_jwl.cfg
@@ -288,7 +288,7 @@ FORMAT(radioss2018) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -354,7 +354,7 @@ FORMAT(radioss140) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -419,7 +419,7 @@ FORMAT(radioss120) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -480,7 +480,7 @@ FORMAT(radioss90) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -540,7 +540,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2019/MAT/mat_law151.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/MAT/mat_law151.cfg
@@ -178,7 +178,7 @@ FORMAT(radioss2019)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2019/MAT/mat_law51.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/MAT/mat_law51.cfg
@@ -1081,7 +1081,7 @@ FORMAT(radioss2019)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -1436,7 +1436,7 @@ FORMAT(radioss2018)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -1790,7 +1790,7 @@ FORMAT(radioss2017)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -2119,7 +2119,7 @@ FORMAT(radioss140)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -2463,7 +2463,7 @@ FORMAT(radioss130)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -2599,7 +2599,7 @@ FORMAT(radioss120)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -2740,7 +2740,7 @@ FORMAT(radioss110)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -2873,7 +2873,7 @@ FORMAT(radioss51)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2019/MAT/mat_law6.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/MAT/mat_law6.cfg
@@ -400,7 +400,7 @@ FORMAT(radioss2018)
 
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -504,7 +504,7 @@ FORMAT(radioss51)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2019/MAT/matl10_law10.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/MAT/matl10_law10.cfg
@@ -301,7 +301,7 @@ FORMAT(radioss2019) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -381,7 +381,7 @@ FORMAT(radioss130) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -457,7 +457,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2019/MAT/matl3_hydpla.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/MAT/matl3_hydpla.cfg
@@ -274,7 +274,7 @@ FORMAT(radioss2018) {
     CARD("%20lg",MAT_PC);
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -356,7 +356,7 @@ FORMAT(radioss110) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -434,7 +434,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2019/MAT/matl49_steinb.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/MAT/matl49_steinb.cfg
@@ -299,7 +299,7 @@ FORMAT(radioss2018) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -367,7 +367,7 @@ FORMAT(radioss110) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -439,7 +439,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2019/MAT/matl4_hyd_jcook.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/MAT/matl4_hyd_jcook.cfg
@@ -321,7 +321,7 @@ FORMAT(radioss2018) {
     CARD("%20lg                                        %20lg",MAT_SPHEAT,MAT_T0);
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -423,7 +423,7 @@ FORMAT(radioss110) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -498,7 +498,7 @@ FORMAT(radioss90) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -569,7 +569,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2019/MAT/matl5_jwl.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/MAT/matl5_jwl.cfg
@@ -291,7 +291,7 @@ FORMAT(radioss2019) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -365,7 +365,7 @@ FORMAT(radioss2018) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -431,7 +431,7 @@ FORMAT(radioss140) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -496,7 +496,7 @@ FORMAT(radioss120) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -557,7 +557,7 @@ FORMAT(radioss90) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -617,7 +617,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2020/MAT/mat_law6.cfg
+++ b/hm_cfg_files/config/CFG/radioss2020/MAT/mat_law6.cfg
@@ -401,7 +401,7 @@ FORMAT(radioss2018)
 
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -505,7 +505,7 @@ FORMAT(radioss51)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2020/MAT/matl10_law10.cfg
+++ b/hm_cfg_files/config/CFG/radioss2020/MAT/matl10_law10.cfg
@@ -302,7 +302,7 @@ FORMAT(radioss2019) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -382,7 +382,7 @@ FORMAT(radioss130) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -458,7 +458,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2020/MAT/matl3_hydpla.cfg
+++ b/hm_cfg_files/config/CFG/radioss2020/MAT/matl3_hydpla.cfg
@@ -275,7 +275,7 @@ FORMAT(radioss2018) {
     CARD("%20lg",MAT_PC);
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -357,7 +357,7 @@ FORMAT(radioss110) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -435,7 +435,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2020/MAT/matl49_steinb.cfg
+++ b/hm_cfg_files/config/CFG/radioss2020/MAT/matl49_steinb.cfg
@@ -300,7 +300,7 @@ FORMAT(radioss2018) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -368,7 +368,7 @@ FORMAT(radioss110) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -440,7 +440,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2020/MAT/matl4_hyd_jcook.cfg
+++ b/hm_cfg_files/config/CFG/radioss2020/MAT/matl4_hyd_jcook.cfg
@@ -322,7 +322,7 @@ FORMAT(radioss2018) {
     CARD("%20lg                                        %20lg",MAT_SPHEAT,MAT_T0);
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -424,7 +424,7 @@ FORMAT(radioss110) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -499,7 +499,7 @@ FORMAT(radioss90) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -570,7 +570,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2021/MAT/matl16_gray.cfg
+++ b/hm_cfg_files/config/CFG/radioss2021/MAT/matl16_gray.cfg
@@ -356,7 +356,7 @@ FORMAT(radioss2021) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -431,7 +431,7 @@ FORMAT(radioss90) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -504,7 +504,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2021/MAT/matl80_80.cfg
+++ b/hm_cfg_files/config/CFG/radioss2021/MAT/matl80_80.cfg
@@ -448,7 +448,7 @@ FORMAT(radioss2021)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -522,7 +522,7 @@ FORMAT(radioss130)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -592,7 +592,7 @@ FORMAT(radioss120)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2022/MAT/matl80_80.cfg
+++ b/hm_cfg_files/config/CFG/radioss2022/MAT/matl80_80.cfg
@@ -558,7 +558,7 @@ FORMAT(radioss2022)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -634,7 +634,7 @@ FORMAT(radioss2021)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -708,7 +708,7 @@ FORMAT(radioss130)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -778,7 +778,7 @@ FORMAT(radioss120)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2023/MAT/mat_law51.cfg
+++ b/hm_cfg_files/config/CFG/radioss2023/MAT/mat_law51.cfg
@@ -790,7 +790,7 @@ FORMAT(radioss2023)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -1158,7 +1158,7 @@ FORMAT(radioss2019)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -1513,7 +1513,7 @@ FORMAT(radioss2018)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -1867,7 +1867,7 @@ FORMAT(radioss2017)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -2196,7 +2196,7 @@ FORMAT(radioss140)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -2540,7 +2540,7 @@ FORMAT(radioss130)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -2676,7 +2676,7 @@ FORMAT(radioss120)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -2817,7 +2817,7 @@ FORMAT(radioss110)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -2950,7 +2950,7 @@ FORMAT(radioss51)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2023/MAT/matl2_plas.cfg
+++ b/hm_cfg_files/config/CFG/radioss2023/MAT/matl2_plas.cfg
@@ -178,7 +178,7 @@ FORMAT(radioss140)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -233,7 +233,7 @@ FORMAT(radioss100)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -289,7 +289,7 @@ FORMAT(radioss51)
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {

--- a/hm_cfg_files/config/CFG/radioss2023/MAT/matl41_lee_t.cfg
+++ b/hm_cfg_files/config/CFG/radioss2023/MAT/matl41_lee_t.cfg
@@ -406,7 +406,7 @@ FORMAT(radioss2023) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -496,7 +496,7 @@ FORMAT(radioss100) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {
@@ -576,7 +576,7 @@ FORMAT(radioss51) {
     }
     if(ALE_Form == 2)
     {
-        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE_MAT,_ID_);
+        SUBOBJECTS(SUBGRP_ALE_MAT,/SUBOBJECT/ALE/MAT,_ID_);
     }
     else if(ALE_Form == 3)
     {


### PR DESCRIPTION
This pull request standardizes the path used for ALE material subobjects in multiple Radioss material configuration files. Specifically, it replaces `/SUBOBJECT/ALE_MAT` with `/SUBOBJECT/ALE/MAT` for cases where `ALE_Form == 2`. This change is applied consistently across various material laws and Radioss version formats, improving consistency and potentially resolving issues related to subobject referencing.

**Path Standardization for ALE Material Subobjects:**

* Updated the subobject path from `/SUBOBJECT/ALE_MAT` to `/SUBOBJECT/ALE/MAT` for `ALE_Form == 2` in all affected Radioss material law configuration files for Radioss 51, 90, 100, 110, and 120 formats. This affects files such as `mat_law6.cfg`, `mat_law11.cfg`, `mat_law51.cfg`, `matl2_plas.cfg`, `matl3_hydpla.cfg`, `matl4_hyd_jcook.cfg`, `matl5_jwl.cfg`, `matl10_law10.cfg`, `matl16_gray.cfg`, `matl18_therm.cfg`, `matl20_bimat.cfg`, `matl21_dprag.cfg`, `matl26_sesam.cfg`, `matl37_biphas.cfg`, `matl41_lee_t.cfg`, `matl46_les_fluid.cfg`, and `matl49_steinb.cfg`. [[1]](diffhunk://#diff-62412faec6a3401207bc982f398daa6e0c1bc65f1e252e4dad7021c24bf58c25L181-R181) [[2]](diffhunk://#diff-62412faec6a3401207bc982f398daa6e0c1bc65f1e252e4dad7021c24bf58c25L236-R236) [[3]](diffhunk://#diff-fc528a2ee8503413ad84d6bf3c7d795bcce449e27bb2f976f101234d95ef5b3aL481-R481) [[4]](diffhunk://#diff-fc528a2ee8503413ad84d6bf3c7d795bcce449e27bb2f976f101234d95ef5b3aL624-R624) [[5]](diffhunk://#diff-3de0e3a03d36e9d97bd5495fecce250aae3c14ecca85fedebe4bc5cd6182f6eaL333-R333) [[6]](diffhunk://#diff-e9abfe289fc60b308dadc56cd9c24c9058ba5e836214bd9b7ecc0ca695b5dba5L249-R249) [[7]](diffhunk://#diff-da8b24e91b54568aa3c27c07ea607ed6420f25a712e3f0412016125c7019511fL346-R346) [[8]](diffhunk://#diff-da8b24e91b54568aa3c27c07ea607ed6420f25a712e3f0412016125c7019511fL419-R419) [[9]](diffhunk://#diff-cd0ba852384a13542bab892da62bca0270a82f39c912b3a90fcadc11d302b46dL246-R246) [[10]](diffhunk://#diff-fa09fdada3a2f4cf0ca27c65e112090ecfac0d5b12644f4b0ce9b30901b30589L186-R186) [[11]](diffhunk://#diff-fa09fdada3a2f4cf0ca27c65e112090ecfac0d5b12644f4b0ce9b30901b30589L230-R230) [[12]](diffhunk://#diff-cf58df036d914eaf37da0e6d859d3638691f2bd8801609d8c6f431bceca92c1cL255-R255) [[13]](diffhunk://#diff-5f8ba058f640fc3e31968ec1972e5ae2eed5e192f4bdeaf397e7f49f4e55c640L388-R388) [[14]](diffhunk://#diff-d45abd3b86c1e6d7c29f4fb39a924c3996c9e38abfe286822fb3c086c92a94fdL184-R184) [[15]](diffhunk://#diff-d45abd3b86c1e6d7c29f4fb39a924c3996c9e38abfe286822fb3c086c92a94fdL239-R239) [[16]](diffhunk://#diff-de5d165000e39d111ad17bb743ce18711dda9070d144d8868bd6e972e21c5867L247-R247) [[17]](diffhunk://#diff-de5d165000e39d111ad17bb743ce18711dda9070d144d8868bd6e972e21c5867L300-R300) [[18]](diffhunk://#diff-64957a0e039581abba4c9728fbda685efc99b14f62199fa73419329f0870eb04L337-R337) [[19]](diffhunk://#diff-64957a0e039581abba4c9728fbda685efc99b14f62199fa73419329f0870eb04L406-R406) [[20]](diffhunk://#diff-e7fb5f2ea9d40aa40c66d37aff7814fce0232059583ea83d2726934a46db7a34L409-R409) [[21]](diffhunk://#diff-e7fb5f2ea9d40aa40c66d37aff7814fce0232059583ea83d2726934a46db7a34L489-R489) [[22]](diffhunk://#diff-49c83595fb04e388125bbe96915f4d66334e82b66ec8c9614e4b5b9446176ba2L242-R242) [[23]](diffhunk://#diff-b0c5b6e873beeb91406071cc13c0434e687a0c212d5bb4fd922b763d834d8d77L317-R317) [[24]](diffhunk://#diff-b0c5b6e873beeb91406071cc13c0434e687a0c212d5bb4fd922b763d834d8d77L393-R393) [[25]](diffhunk://#diff-f2968c617be7c9cbc1db8b468906d0a521401b2f5fd20da6fd409c8041bad586L389-R389) [[26]](diffhunk://#diff-f2968c617be7c9cbc1db8b468906d0a521401b2f5fd20da6fd409c8041bad586L462-R462) [[27]](diffhunk://#diff-f2968c617be7c9cbc1db8b468906d0a521401b2f5fd20da6fd409c8041bad586L532-R532) [[28]](diffhunk://#diff-d7601b2cdb333763f4a4e4404286a6a273bb65e375d25feffd266e4de2d5f64fL243-R243) [[29]](diffhunk://#diff-d7601b2cdb333763f4a4e4404286a6a273bb65e375d25feffd266e4de2d5f64fL301-R301) [[30]](diffhunk://#diff-0b3309fbf282fadd3fda12e34845a525e72ef69adcaa7e8cf3b2c230d4de463aL469-R469) [[31]](diffhunk://#diff-0b3309fbf282fadd3fda12e34845a525e72ef69adcaa7e8cf3b2c230d4de463aL612-R612) [[32]](diffhunk://#diff-0b3309fbf282fadd3fda12e34845a525e72ef69adcaa7e8cf3b2c230d4de463aL743-R743) [[33]](diffhunk://#diff-43b4c9b89b971bfabf5257ff1eee532a596dc14b4864b7ccf3ac86240c068131L208-R208) [[34]](diffhunk://#diff-43b4c9b89b971bfabf5257ff1eee532a596dc14b4864b7ccf3ac86240c068131L268-R268) [[35]](diffhunk://#diff-43b4c9b89b971bfabf5257ff1eee532a596dc14b4864b7ccf3ac86240c068131L328-R328) [[36]](diffhunk://#diff-0f13c8ce16c11af5184e4ccccaef01004a6f95a7269e3b053be71e9b3891d2cdL250-R250) [[37]](diffhunk://#diff-0f13c8ce16c11af5184e4ccccaef01004a6f95a7269e3b053be71e9b3891d2cdL311-R311) [[38]](diffhunk://#diff-0f13c8ce16c11af5184e4ccccaef01004a6f95a7269e3b053be71e9b3891d2cdL372-R372)

This update ensures that all ALE material subobject references use a consistent path, which should help maintain compatibility and reduce confusion or errors in future development and maintenance.