### PR TITLE
openreader ALE_CLOSE handling

### DIFF
--- a/hm_cfg_files/config/CFG/radioss110/PROP/prop_p15_porous.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/PROP/prop_p15_porous.cfg
@@ -188,6 +188,6 @@ FORMAT(radioss51)
     CARD("%10d",IRBY);   
     if(Element_closure_opt==1)
     {
-        SUBOBJECTS(SUBGRP_ALE_CLOSE,/SUBOBJECT/ALE_CLOSE);
+        SUBOBJECTS(SUBGRP_ALE_CLOSE,/SUBOBJECT/ALE/CLOSE,_ID_);
     }
 }

--- a/hm_cfg_files/config/CFG/radioss2025/PROP/prop_p14_solid.cfg
+++ b/hm_cfg_files/config/CFG/radioss2025/PROP/prop_p14_solid.cfg
@@ -417,7 +417,7 @@ FORMAT(radioss2025)
     }
     if(Element_closure_opt==1)
     {
-        SUBOBJECTS(SUBGRP_ALE_CLOSE,/SUBOBJECT/ALE_CLOSE);
+        SUBOBJECTS(SUBGRP_ALE_CLOSE,/SUBOBJECT/ALE/CLOSE,_ID_);
     }
 }
 //File format for Radioss 2023
@@ -511,7 +511,7 @@ FORMAT(radioss2023)
     }
     if(Element_closure_opt==1)
     {
-        SUBOBJECTS(SUBGRP_ALE_CLOSE,/SUBOBJECT/ALE_CLOSE);
+        SUBOBJECTS(SUBGRP_ALE_CLOSE,/SUBOBJECT/ALE/CLOSE,_ID_);
     }
 }
 //File format for Radioss 2022
@@ -605,7 +605,7 @@ FORMAT(radioss2022)
     }
     if(Element_closure_opt==1)
     {
-        SUBOBJECTS(SUBGRP_ALE_CLOSE,/SUBOBJECT/ALE_CLOSE);
+        SUBOBJECTS(SUBGRP_ALE_CLOSE,/SUBOBJECT/ALE/CLOSE,_ID_);
     }
 }
 
@@ -701,7 +701,7 @@ FORMAT(radioss2019)
     }
     if(Element_closure_opt==1)
     {
-        SUBOBJECTS(SUBGRP_ALE_CLOSE,/SUBOBJECT/ALE_CLOSE);
+        SUBOBJECTS(SUBGRP_ALE_CLOSE,/SUBOBJECT/ALE/CLOSE,_ID_);
     }
 }
 
@@ -795,7 +795,7 @@ FORMAT(radioss140)
     }
     if(Element_closure_opt==1)
     {
-        SUBOBJECTS(SUBGRP_ALE_CLOSE,/SUBOBJECT/ALE_CLOSE);
+        SUBOBJECTS(SUBGRP_ALE_CLOSE,/SUBOBJECT/ALE/CLOSE,_ID_);
     }
 }       
 
@@ -874,7 +874,7 @@ FORMAT(radioss120)
     }
     if(Element_closure_opt==1)
     {
-        SUBOBJECTS(SUBGRP_ALE_CLOSE,/SUBOBJECT/ALE_CLOSE);
+        SUBOBJECTS(SUBGRP_ALE_CLOSE,/SUBOBJECT/ALE/CLOSE,_ID_);
     }
 }
 //File format for Radioss 100
@@ -953,7 +953,7 @@ FORMAT(radioss100)
     }
     if(Element_closure_opt==1)
     {
-        SUBOBJECTS(SUBGRP_ALE_CLOSE,/SUBOBJECT/ALE_CLOSE);
+        SUBOBJECTS(SUBGRP_ALE_CLOSE,/SUBOBJECT/ALE/CLOSE,_ID_);
     }
 }
 
@@ -1030,7 +1030,7 @@ FORMAT(radioss51)
     }
     if(Element_closure_opt==1)
     {
-        SUBOBJECTS(SUBGRP_ALE_CLOSE,/SUBOBJECT/ALE_CLOSE);
+        SUBOBJECTS(SUBGRP_ALE_CLOSE,/SUBOBJECT/ALE/CLOSE,_ID_);
     }
     
 }


### PR DESCRIPTION
This pull request updates the handling of ALE closure subobjects in multiple Radioss property configuration files. The main change is a consistent update to the `SUBOBJECTS` macro call, ensuring that ALE closure subobjects are referenced using the path `/SUBOBJECT/ALE/CLOSE,_ID_` instead of `/SUBOBJECT/ALE_CLOSE`. This affects several Radioss format versions and improves consistency and possibly correctness in subobject referencing.

**Subobject reference updates:**

* Updated `SUBOBJECTS` macro calls in `hm_cfg_files/config/CFG/radioss2025/PROP/prop_p14_solid.cfg` for the following Radioss format functions to use `/SUBOBJECT/ALE/CLOSE,_ID_`:
  - `FORMAT(radioss2025)`
  - `FORMAT(radioss2023)`
  - `FORMAT(radioss2022)`
  - `FORMAT(radioss2019)`
  - `FORMAT(radioss140)`
  - `FORMAT(radioss120)`
  - `FORMAT(radioss100)`
  - `FORMAT(radioss51)`

* Similarly updated the `SUBOBJECTS` macro call in `hm_cfg_files/config/CFG/radioss110/PROP/prop_p15_porous.cfg` for `FORMAT(radioss51)`