### PR TITLE
OpenReader : correction acces to solver name after converter in Radioss database

### DIFF
--- a/reader/source/cfgkernel/sdi/sdiModelViewPO.h
+++ b/reader/source/cfgkernel/sdi/sdiModelViewPO.h
@@ -257,7 +257,13 @@ protected:
 
     void SetDataPointer(IMECPreObject* ptr)
     {
-        if(!ptr || !(p_ptr && !strcmp(ptr->GetKernelFullType(), p_ptr->GetKernelFullType()))) p_pDescr = 0;
+         if(!ptr ||
+           !(p_ptr && !strcmp(ptr->GetKernelFullType(), p_ptr->GetKernelFullType())) ||
+           !(p_ptr && strlen(ptr->GetKernelFullType()) == 0 &&
+             !strcmp(ptr->GetInputFullType(), p_ptr->GetInputFullType())))
+        {
+            p_pDescr = 0;
+        }
         p_vpSubDescr.resize(0); /* we could check the subobjects one by one, but they might be different,
                                  * so this is a simple and safe approach */
         p_ptr = ptr;


### PR DESCRIPTION
This pull request updates the logic for setting the data pointer in the `TSDIEntityDataPO` class to improve type checking and pointer assignment safety. The main change enhances the conditional statement to handle additional cases when assigning the data pointer and descriptor.

Improvements to pointer assignment and type checking:

* Updated the conditional in the `SetDataPointer` method of `TSDIEntityDataPO` (in `sdiModelViewPO.h`) to reset `p_pDescr` not only when the pointer is null or types mismatch, but also when the kernel type string is empty and input types match. This makes pointer assignment more robust and prevents incorrect descriptor assignment.