### PR TITLE
Add PartID for Layerfailure

### DIFF
--- a/engine/source/elements/forintc.F
+++ b/engine/source/elements/forintc.F
@@ -345,7 +345,8 @@ C
      S        APINCH,             STIFPINCH,          DRAPEG%INDX_SH4N,   IGRE,         
      T        JTUR,               DT,                 NCYCLE,             SNPC,         
      Y        STF,                GLOB_THERM,         NXLAYMAX,           IDEL7NOK,
-     U        USERL_AVAIL,        MAXFUNC,            SBUFMAT  )                                                         
+     U        USERL_AVAIL,        MAXFUNC,            SBUFMAT    ,
+     X        IPART      ,        LIPART1)                                                       
 
           ELSEIF (JHBE >= 21 .AND. JHBE <= 29) THEN
 
@@ -380,7 +381,8 @@ C
      S        DRAPE_SH4N,         NEL,                NLOC_DMG,           DRAPEG%INDX_SH4N,
      T        IGRE,               JTUR,               DT      ,           NCYCLE,
      Y        SNPC,               STF,                GLOB_THERM,         IDEL7NOK,   
-     U        USERL_AVAIL,        MAXFUNC,            SBUFMAT )
+     U        USERL_AVAIL,        MAXFUNC,            SBUFMAT    ,
+     X        IPART      ,        LIPART1)
 
         IF (ICRACK3D > 0 .AND. IXFEM > 0 .AND. ACTIFXFEM > 0) THEN
           DO IXEL=1,NXEL
@@ -409,7 +411,8 @@ C
      O        ISUBSTACK  ,UXINT_MEAN ,UYINT_MEAN,UZINT_MEAN,NLEVXF      ,
      P        NODEDGE    ,CRKEDGE    ,STACK    ,DRAPE_SH4N  ,NLOC_DMG,DRAPEG%INDX_SH4N,IGRE,
      *        DT         ,NCYCLE     ,SNPC      ,  STF      ,GLOB_THERM ,
-     *        IDEL7NOK   ,USERL_AVAIL,MAXFUNC  ,SBUFMAT)
+     *        IDEL7NOK   ,USERL_AVAIL,MAXFUNC  ,SBUFMAT   ,
+     X        IPART      ,        LIPART1)
           ENDDO
         ENDIF
 c
@@ -444,7 +447,8 @@ c
      R   XFEM_TAB, NG  ,CRKEDGE,      DRAPE_SH4N,         IPRI,
      S   NLOC_DMG,           DRAPEG%INDX_SH4N,   IGRE,               JTUR,
      T   OUTPUT,             DT,                 SNPC,               STF  , 
-     U   GLOB_THERM,         USERL_AVAIL,        MAXFUNC,            SBUFMAT )
+     U   GLOB_THERM,         USERL_AVAIL,        MAXFUNC,            SBUFMAT  ,
+     X        IPART)
 c
         IF (ICRACK3D > 0 .AND. IXFEM > 0 .AND. ACTIFXFEM > 0) THEN
           DO IXEL=1,NXEL
@@ -473,7 +477,8 @@ c
      O       ISUBSTACK   ,UXINT_MEAN  ,UYINT_MEAN  ,UZINT_MEAN,NLEVXF      ,
      P       NODEDGE     ,CRKEDGE     ,DRAPE_SH4N   ,IPRI       ,NLOC_DMG  ,
      Q       DRAPEG%INDX_SH4N,IGRE    ,DT           ,SNPC      ,  STF      ,
-     R       GLOB_THERM  ,USERL_AVAIL, MAXFUNC,SBUFMAT)
+     R       GLOB_THERM  ,USERL_AVAIL, MAXFUNC,SBUFMAT ,
+     X       IPART  )
           ENDDO
         END IF
 
@@ -545,7 +550,8 @@ C----6---------------------------------------------------------------7--
      M        DRAPEG%INDX_SH3N,IGRE,                 JTUR,            DT  ,
      N        NCYCLE,          SNPC,                 STF ,           GLOB_THERM ,
      O        NXLAYMAX,        IDEL7NOK,             USERL_AVAIL,    MAXFUNC,       
-     P        SBUFMAT     )
+     P        SBUFMAT     ,
+     X        IPART       ,        LIPART1)
           ELSE
 
             IF (ISH3N == 30) THEN
@@ -573,7 +579,8 @@ C----6---------------------------------------------------------------7--
      L          NLOC_DMG,                              DRAPEG%INDX_SH3N,     IGRE,            JTUR,
      M          DT,                                    NCYCLE,               SNPC,             STF,       
      M          GLOB_THERM  ,                          NXLAYMAX,             IDEL7NOK,        USERL_AVAIL,
-     M          MAXFUNC,                               SBUFMAT )
+     M          MAXFUNC,                               SBUFMAT  ,
+     X          IPART      ,        LIPART1)
      
             ELSE
               CALL C3FORC3(TIMERS,
@@ -604,7 +611,8 @@ C----6---------------------------------------------------------------7--
      P          CRKEDGE,               DRAPE_SH3N,                            IPRI,              NLOC_DMG,
      Q          XDP,                   DRAPEG%INDX_SH3N,                      IGRE,              JTUR,
      R          DT,                    SNPC,                                  STF,               GLOB_THERM,
-     S          IDEL7NOK,              USERL_AVAIL,                           MAXFUNC,           SBUFMAT)
+     S          IDEL7NOK,              USERL_AVAIL,                           MAXFUNC,           SBUFMAT ,
+     X          IPART      ,        LIPART1  )
 
                 IF (ICRACK3D > 0 .AND. IXFEM > 0 .AND. ACTIFXFEM > 0) THEN
                   DO IXEL=1,NXEL
@@ -635,7 +643,8 @@ C----6---------------------------------------------------------------7--
      O                CRKEDGE,           DRAPE_SH3N,           IPRI,             NLOC_DMG,
      P                DRAPEG%INDX_SH3N,  IGRE,                 DT  ,             NCYCLE  ,
      Q                SNPC,              STF,                 GLOB_THERM   ,     IDEL7NOK,
-     A                USERL_AVAIL,       MAXFUNC,              SBUFMAT )
+     A                USERL_AVAIL,       MAXFUNC,              SBUFMAT ,
+     X                IPART      ,        LIPART1   )
                   ENDDO
                 ENDIF
               ENDIF

--- a/engine/source/elements/sh3n/coque3n/c3forc3.F
+++ b/engine/source/elements/sh3n/coque3n/c3forc3.F
@@ -109,7 +109,8 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      P   CRKEDGE,     DRAPE_SH3N,  IPRI,        NLOC_DMG,
      Q   xdp,         INDX_DRAPE,  IGRE,        JTUR,
      R   DT,          SNPC,        STF,         GLOB_THERM,
-     S   IDEL7NOK,    USERL_AVAIL, MAXFUNC,     SBUFMAT)
+     S   IDEL7NOK,    USERL_AVAIL, MAXFUNC,     SBUFMAT ,
+     T   IPART,       LIPART1)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -195,6 +196,8 @@ C-----------------------------------------------
       TYPE (GROUP_PARAM_) :: GROUP_PARAM
       TYPE (DT_), INTENT(IN) :: DT
       type (glob_therm_) ,intent(inout) :: glob_therm
+      INTEGER, INTENT(IN) :: LIPART1
+      INTEGER, DIMENSION(LIPART1,NPART), INTENT(IN)     :: IPART
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -581,7 +584,8 @@ C--------------------------
      Q   INDX_DRAPE,THKE      ,SEDRAPE     ,NUMEL_DRAPE,DT     ,
      R   NCYCLE    ,SNPC     ,STF          ,NXLAYMAX           ,
      S   IDEL7NOK  ,USERL_AVAIL ,MAXFUNC    ,NPTTOT,
-     T   SBUFMAT   ,SDIR_A    , SDIR_B   ,GBUF%FOR_G,SSP_EQ )
+     T   SBUFMAT   ,SDIR_A    , SDIR_B   ,GBUF%FOR_G,SSP_EQ ,
+     X    IPART     ,LIPART1  ,IPARTTG   )
 C--------------------------
       IF ((IMON_MAT==1).AND.ITASK == 0)CALL STOPTIME(TIMERS,35)
 C--------------------------

--- a/engine/source/elements/sh3n/coquedk/cdkforc3.F
+++ b/engine/source/elements/sh3n/coquedk/cdkforc3.F
@@ -84,7 +84,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      L   NLOC_DMG,    INDX_DRAPE,  IGRE,        JTUR,
      M   DT,          NCYCLE,      SNPC,        STF,
      M   GLOB_THERM,  NXLAYMAX,    IDEL7NOK,    USERL_AVAIL,
-     N   MAXFUNC,     SBUFMAT)
+     N   MAXFUNC,     SBUFMAT,IPART     ,LIPART1 )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -158,6 +158,9 @@ C     REAL
       TYPE (SENSORS_) ,INTENT(INOUT) :: SENSORS
       TYPE (DT_), INTENT(IN) :: DT
       type (glob_therm_) ,intent(inout) :: glob_therm
+      INTEGER, INTENT(IN)  :: LIPART1
+      INTEGER, DIMENSION(LIPART1, NPART ), INTENT(IN)     :: IPART
+   
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -455,7 +458,8 @@ C----------------------------------------------------------------------------
      R    INDX_DRAPE ,THKE      ,SEDRAPE     ,NUMEL_DRAPE ,DT   ,
      Q    NCYCLE     ,SNPC      ,  STF ,
      S    NXLAYMAX   ,IDEL7NOK  ,USERL_AVAIL ,MAXFUNC     ,NPTTOT,
-     T    SBUFMAT    ,SDIR_A    ,SDIR_B,  GBUF%FORPG_G(PTF),SSP_EQ)
+     T    SBUFMAT    ,SDIR_A    ,SDIR_B,  GBUF%FORPG_G(PTF),SSP_EQ,
+     X    IPART      ,LIPART1   ,IPARTTG   )
 C----------------------------------------------------------------------------
 C     THICKNESS CORRECTION 
 C----------------------------

--- a/engine/source/elements/sh3n/coquedk6/cdk6forc3.F
+++ b/engine/source/elements/sh3n/coquedk6/cdk6forc3.F
@@ -81,7 +81,7 @@ cc
      M   INDX_DRAPE,  IGRE,        JTUR,        DT,
      N   NCYCLE,      SNPC,        STF ,        GLOB_THERM,
      N   NXLAYMAX,    IDEL7NOK,    USERL_AVAIL, MAXFUNC,
-     O   SBUFMAT  )
+     O   SBUFMAT ,IPART     ,LIPART1 )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -159,6 +159,10 @@ C     REAL
       TYPE (SENSORS_) ,INTENT(INOUT) :: SENSORS
       TYPE (DT_) ,INTENT(IN) :: DT
       type (glob_therm_) ,intent(inout)   :: glob_therm
+      integer, intent(in) :: LIPART1
+     
+      INTEGER, DIMENSION(LIPART1,NPART), INTENT(IN) :: IPART
+
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -434,7 +438,8 @@ c-------------------------------------------
      R   INDX_DRAPE,THKE      ,SEDRAPE     ,NUMEL_DRAPE ,DT      ,
      Q   NCYCLE    ,SNPC      ,STF         ,NXLAYMAX    ,IDEL7NOK  ,
      R   USERL_AVAIL ,MAXFUNC ,NPTTOT      ,SBUFMAT     ,SDIR_A    ,SDIR_B    ,
-     S   GBUF%FOR_G,SSP_EQ )
+     S   GBUF%FOR_G,SSP_EQ,
+     X    IPART     ,LIPART1  ,IPARTTG   )
 C----------------------------------------------------------------------------
 C     FORCES VISCOCITE 
 C----------------------------

--- a/engine/source/elements/shell/coque/cforc3.F
+++ b/engine/source/elements/shell/coque/cforc3.F
@@ -109,7 +109,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      R   XFEM_STR, IG,  CRKEDGE,     DRAPE_SH4N,  IPRI,
      S   NLOC_DMG,    INDX_DRAPE,  IGRE,        JTUR,
      T   OUTPUT,      DT,          SNPC,        STF  ,
-     T   GLOB_THERM,  USERL_AVAIL, MAXFUNC,     SBUFMAT )
+     T   GLOB_THERM,  USERL_AVAIL, MAXFUNC,     SBUFMAT ,IPART   )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -195,6 +195,8 @@ C
       TYPE (GROUP_PARAM_),INTENT(IN)    :: GROUP_PARAM
       TYPE (DT_), INTENT(IN) :: DT
       type (glob_therm_) ,intent(inout) :: glob_therm
+    
+      INTEGER, DIMENSION(LIPART1,NPART), INTENT(IN)     :: IPART
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -574,8 +576,9 @@ C-----------------------------
      P  F_DEF       ,ITASK       ,DRAPE_SH4N  ,VAR_REG    ,NLOC_DMG   ,
      R  INDX_DRAPE  ,THKE        ,SEDRAPE     ,NUMEL_DRAPE  ,DT        ,
      Q  NCYCLE      ,SNPC        ,STF         ,NXLAYMAX    ,IDEL7NOK   , 
-     S  USERL_AVAIL ,MAXFUNC    ,NPTTOT       ,SBUFMAT     ,SDIR_A     ,
-     T  SDIR_B      ,GBUF%FOR_G  ,SSP_EQ )
+     S  USERL_AVAIL ,MAXFUNC     ,NPTTOT      ,SBUFMAT     ,SDIR_A     ,
+     T  SDIR_B      ,GBUF%FOR_G  ,SSP_EQ ,
+     X    IPART     ,LIPART1     ,IPARTC     )
 C-----------------------------
       IF ((IMON_MAT==1).AND. ITASK == 0)CALL STOPTIME(TIMERS,35)
 C-----------------------------

--- a/engine/source/elements/shell/coqueba/cbaforc3.F
+++ b/engine/source/elements/shell/coqueba/cbaforc3.F
@@ -127,7 +127,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      S   FPINCH,      STIFPINCH,   INDX_DRAPE,  IGRE,
      T   JTUR,        DT       ,    NCYCLE,     SNPC,
      Y   STF ,        GLOB_THERM ,  NXLAYMAX,   IDEL7NOK,
-     U   USERL_AVAIL, MAXFUNC,     SBUFMAT)
+     U   USERL_AVAIL, MAXFUNC,     SBUFMAT,IPART     ,LIPART1  )
 C-----------------------------------------------
 C   M o d u l e s
 C----------------------------------------------- 
@@ -211,6 +211,10 @@ C     real or real*8
       TYPE (SENSORS_) ,INTENT(INOUT) :: SENSORS
       TYPE (DT_) ,INTENT(IN) :: DT
       type (glob_therm_) ,intent(inout)   :: glob_therm
+      integer, intent(in) :: LIPART1
+      !//TODO:no *
+      INTEGER, DIMENSION(LIPART1, NPART), INTENT(IN)     :: IPART
+
 C-----------------------------------------------
 C   L O C A L   V A R I A B L E S
 C-----------------------------------------------
@@ -837,7 +841,8 @@ C-----------------
      R    INDX_DRAPE ,THKE     ,SEDRAPE   ,NUMEL_DRAPE  ,DT   ,
      Q    NCYCLE     ,SNPC     ,STF       ,NXLAYMAX,    IDEL7NOK    ,
      S    USERL_AVAIL ,MAXFUNC ,NPTTOT    ,SBUFMAT,     SDIR_A      ,
-     T    SDIR_B     ,GBUF%FORPG_G(PTF)   ,SSP_EQ)        
+     T    SDIR_B     ,GBUF%FORPG_G(PTF)   ,SSP_EQ,
+     X    IPART      ,LIPART1  ,IPARTC     )   
         ENDIF
         SSP_MAX(JFT:JLT) = MAX(SSP_MAX(JFT:JLT),SSP_EQ(JFT:JLT))
 C-----------------

--- a/engine/source/elements/shell/coquez/czforc3.F
+++ b/engine/source/elements/shell/coquez/czforc3.F
@@ -112,7 +112,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      S   DRAPE_SH4N,  NEL,         NLOC_DMG,    INDX_DRAPE,
      T   IGRE,        JTUR,        DT,          NCYCLE,
      U   SNPC,        STF,         GLOB_THERM,  IDEL7NOK,
-     U   USERL_AVAIL, MAXFUNC,     SBUFMAT)
+     U   USERL_AVAIL, MAXFUNC,     SBUFMAT,IPART     ,LIPART1)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -196,6 +196,10 @@ C     real or real*8
       TYPE (MAT_ELEM_)   ,INTENT(INOUT) :: MAT_ELEM
       TYPE (DT_)         ,INTENT(IN)    :: DT
       type (glob_therm_) ,intent(inout) :: glob_therm
+      integer, intent(in) :: LIPART1
+ 
+      INTEGER, DIMENSION(LIPART1,NPART), INTENT(IN)     :: IPART
+
 C---+----1----+----2----+----3----+----4----+----5----+----6----+----7--
 C   L O C A L   V A R I A B L E S
 C--------------------------------
@@ -617,7 +621,8 @@ C-----------------------------------------------
      R      INDX_DRAPE,THKE      ,SEDRAPE     ,NUMEL_DRAPE,DT    ,
      Q      NCYCLE    ,SNPC      ,STF         ,NXLAYMAX  ,IDEL7NOK  ,
      S      USERL_AVAIL ,MAXFUNC ,NPTTOT      ,SBUFMAT   ,SDIR_A    ,
-     T      SDIR_B   ,GBUF%FOR_G ,SSP_EQ      )
+     T      SDIR_B   ,GBUF%FOR_G ,SSP_EQ    ,
+     X    IPART      ,LIPART1   ,IPARTC   )
 
 C-----------------------------------------------
 c        

--- a/engine/source/elements/solid/solide10/s10forc3.F
+++ b/engine/source/elements/solid/solide10/s10forc3.F
@@ -398,6 +398,7 @@ C-----------
 C GATHER NODAL VARIABLES FOR TOTAL STRAIN CASE.
 C-----------
       IF (ISMSTR >= 10.AND.ISMSTR <= 12) THEN
+      
        CALL SGCOOR10(
      1   XX,        YY,        ZZ,        X,
      2   XDP,       XX0,       YY0,       ZZ0,
@@ -435,9 +436,11 @@ C!!!!!!calcul local rep for ISMSTR 10 to 11 (offg>un)
         DO IP=1,NPT
          LBUF => ELBUF_TAB(NG)%BUFLY(IBID)%LBUF(IP,IBID,IBID)
          CALL S10PIJTO3(PX(1,1,IP),PY(1,1,IP),PZ(1,1,IP),LBUF%PIJ,LLT)
+    
         ENDDO
        END IF !(ISMSTR ==  11) THEN
        DO IP=1,NPT
+
         CALL S10DEFOT3(
      1   PX(1,1,IP),PY(1,1,IP),PZ(1,1,IP),VX0,
      2   VY0,       VZ0,       MFXX(1,IP),MFXY(1,IP),

--- a/engine/source/elements/xfem/c3forc3_crk.F
+++ b/engine/source/elements/xfem/c3forc3_crk.F
@@ -92,7 +92,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      O   CRKEDGE,     DRAPE_SH3N,  IPRI,        NLOC_DMG,
      P   INDX_DRAPE,  IGRE,        DT,          NCYCLE ,
      R   SNPC,        STF,         GLOB_THERM,  IDEL7NOK,
-     Q   USERL_AVAIL, MAXFUNC,     SBUFMAT)
+     Q   USERL_AVAIL, MAXFUNC,     SBUFMAT,IPART     ,LIPART1 )
 C-----------------------------------------------
       USE TIMER_MOD
       USE TABLE_MOD
@@ -171,6 +171,10 @@ C-----------------------------------------------
       TYPE (SENSORS_) ,INTENT(INOUT) :: SENSORS
       TYPE (DT_), INTENT(IN) :: DT
       type (glob_therm_) ,intent(inout)   :: glob_therm
+      integer, intent(in) :: LIPART1
+      !//TODO:no *
+      INTEGER, DIMENSION(LIPART1,NPART), INTENT(IN)     :: IPART
+    
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -481,7 +485,8 @@ C--------------------------
      R   INDX_DRAPE , THKE    ,SEDRAPE   ,NUMEL_DRAPE,     DT  ,
      Q   NCYCLE     ,SNPC      ,  STF    ,NXLAYMAX   ,IDEL7NOK ,
      S   USERL_AVAIL, MAXFUNC,      NPTTOT,BUFMAT     ,SDIR_A   ,
-     T   SDIR_B     ,GBUF%FOR_G,SSP_EQ )
+     T   SDIR_B     ,GBUF%FOR_G,SSP_EQ,
+     X    IPART     ,LIPART1 ,IPARTTG   )
 
 C--------------------------
         IF ((ITASK==0).AND.(IMON_MAT==1)) CALL STOPTIME(TIMERS,35)

--- a/engine/source/elements/xfem/cforc3_crk.F
+++ b/engine/source/elements/xfem/cforc3_crk.F
@@ -87,7 +87,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      N            ISUBSTACK,UXINT_MEAN,UYINT_MEAN,UZINT_MEAN,NLEVXF,
      O            NODEDGE,CRKEDGE,DRAPE_SH4N,IPRI  ,NLOC_DMG,INDX_DRAPE, IGRE,
      P            DT     ,SNPC      ,  STF   ,GLOB_THERM, 
-     Q            USERL_AVAIL,MAXFUNC,SBUFMAT)
+     Q            USERL_AVAIL,MAXFUNC,SBUFMAT,IPART    )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -169,6 +169,9 @@ C     REAL
       TYPE (SENSORS_) ,INTENT(INOUT) :: SENSORS
       TYPE (DT_), INTENT(IN) :: DT
       type (glob_therm_) ,intent(inout) :: glob_therm
+     
+      INTEGER, DIMENSION(LIPART1, NPART), INTENT(IN)     :: IPART
+     
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -473,7 +476,8 @@ C-----------------------------
      R    INDX_DRAPE ,THKE, SEDRAPE  ,NUMEL_DRAPE,DT   ,
      Q    NCYCLE     ,SNPC      ,  STF,NXLAYMAX ,
      S    IDEL7NOK   ,USERL_AVAIL ,MAXFUNC  ,NPTTOT    ,SBUFMAT,
-     T    SDIR_A     ,SDIR_B   ,GBUF%FOR_G,SSP_EQ )
+     T    SDIR_A     ,SDIR_B   ,GBUF%FOR_G,SSP_EQ,
+     X    IPART      ,LIPART1  ,IPARTC   )
 C-----------------------------
         IF ((ITASK==0).AND.(IMON_MAT==1)) CALL STOPTIME(TIMERS,35)
 C-----------------------------

--- a/engine/source/elements/xfem/czforc3_crk.F
+++ b/engine/source/elements/xfem/czforc3_crk.F
@@ -87,7 +87,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      O            NODEDGE,CRKEDGE, STACK ,DRAPE_SH4N,NLOC_DMG,
      P            INDX_DRAPE, IGRE ,DT, NCYCLE,SNPC,  STF  ,
      P            GLOB_THERM  ,IDEL7NOK ,USERL_AVAIL,
-     Q            MAXFUNC ,SBUFMAT)
+     Q            MAXFUNC ,SBUFMAT,IPART     ,LIPART1)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -140,6 +140,10 @@ C-----------------------------------------------
      .        IPARG(*),IXFEM,INOD_CRK(*),IEL_CRK(*),IADC_CRK(4,*),
      .        ELCUTC(2,*),NODEDGE(2,*),INDX_DRAPE(SCDRAPE)
       INTEGER, INTENT(IN) :: IGRE, NCYCLE
+      integer, intent(in) :: LIPART1
+      !//TODO:no *
+      INTEGER, DIMENSION(LIPART1, NPART), INTENT(IN)     :: IPART
+     
 C     REAL OR REAL*8
       my_real
      .   F11(MVSIZ),F12(MVSIZ),F13(MVSIZ),F14(MVSIZ),
@@ -506,7 +510,8 @@ C-----------------------------
      R       INDX_DRAPE, THKE     ,SEDRAPE     ,NUMEL_DRAPE,DT   ,
      Q       NCYCLE    ,SNPC      ,STF         ,NXLAYMAX  ,IDEL7NOK  ,
      S       USERL_AVAIL ,MAXFUNC ,NPTTOT      ,SBUFMAT   ,SDIR_A    ,
-     T       SDIR_B   ,GBUF%FOR_G ,SSP_EQ )
+     T       SDIR_B   ,GBUF%FOR_G ,SSP_EQ ,
+     X       IPART    ,LIPART1    ,IPARTC  )
 C-----------------------------
         IF ((ITASK==0).AND.(IMON_MAT==1)) CALL STOPTIME(TIMERS,35)
 C--------------------------

--- a/engine/source/materials/fail/fail_setoff_c.F
+++ b/engine/source/materials/fail/fail_setoff_c.F
@@ -36,7 +36,8 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .                         THK_LY   ,THKLY    ,OFF      ,STACK    ,
      .                         ISUBSTACK,IGTYP    ,FAILWAVE ,FWAVE_EL ,
      .                         NLAY_MAX ,LAYNPT_MAX,NUMGEO  ,NUMSTACK ,
-     .                         IGEO     ,PRINT_FAIL)
+     .                         IGEO     ,PRINT_FAIL,
+     .                         IPART    ,LIPART1  ,IPARTC   ,NPART)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -63,8 +64,10 @@ C-----------------------------------------------
       my_real, DIMENSION(NPROPG,NUMGEO), INTENT(IN) :: GEO
       INTEGER, DIMENSION(NPROPGI,NUMGEO),INTENT(IN) :: IGEO
       INTEGER,INTENT(IN) :: PID,NEL,NLAY,NPTTOT,IGTYP,ISUBSTACK,
-     .                      NLAY_MAX,LAYNPT_MAX,NUMGEO,NUMSTACK
-      INTEGER, DIMENSION(NEL), INTENT(IN)           :: NGL
+     .                      NLAY_MAX,LAYNPT_MAX,NUMGEO,NUMSTACK,LIPART1,
+     .                      NPART
+      INTEGER, DIMENSION(LIPART1,NPART), INTENT(IN)     :: IPART
+      INTEGER, DIMENSION(NEL), INTENT(IN)           :: NGL,IPARTC
       my_real, DIMENSION(NEL,NLAY_MAX*LAYNPT_MAX), INTENT(IN) :: THK_LY
       my_real, DIMENSION(NPTTOT*NEL), INTENT(IN)    :: THKLY
       my_real, DIMENSION(NEL), INTENT(INOUT)        :: OFF
@@ -73,6 +76,7 @@ C-----------------------------------------------
       INTEGER, DIMENSION(NEL), INTENT(INOUT)        :: FWAVE_EL
       TYPE (MAT_ELEM_) ,INTENT(INOUT)               :: MAT_ELEM
       LOGICAL, DIMENSION(NEL), INTENT(INOUT)        :: PRINT_FAIL
+         
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -114,6 +118,8 @@ c
           PTHKF(IL,IFL) = MAT_ELEM%MAT_PARAM(IMAT)%FAIL(IFL)%PTHK
         END DO
       END DO
+      
+      
       !=================================================================
       ! 1 LAYER PROPERTIES - TYPE1/TYPE9
       !=================================================================                                              
@@ -217,16 +223,16 @@ c
               ENDIF   
               DO I = 1,NINDXLY
 #include      "lockon.inc"                           
-                WRITE(IOUT, 3000) TRIM(FAIL_NAME(INDXLY(I))),ID_PLY,NGL(INDXLY(I))    
-                WRITE(ISTDO,3100) TRIM(FAIL_NAME(INDXLY(I))),ID_PLY,NGL(INDXLY(I)),TT 
+                WRITE(IOUT, 3000) TRIM(FAIL_NAME(INDXLY(I))),ID_PLY,NGL(INDXLY(I)),IPART(4,IPARTC(INDXLY(I)))    
+                WRITE(ISTDO,3100) TRIM(FAIL_NAME(INDXLY(I))),ID_PLY,NGL(INDXLY(I)),IPART(4,IPARTC(INDXLY(I))),TT 
 #include      "lockoff.inc"                          
               ENDDO ! |-> I
             ! -> Print out layer failure
             ELSE 
               DO I = 1,NINDXLY
 #include      "lockon.inc"                           
-                WRITE(IOUT, 2000) TRIM(FAIL_NAME(INDXLY(I))),IL,NGL(INDXLY(I))    
-                WRITE(ISTDO,2100) TRIM(FAIL_NAME(INDXLY(I))),IL,NGL(INDXLY(I)),TT 
+                WRITE(IOUT, 2000) TRIM(FAIL_NAME(INDXLY(I))),IL,NGL(INDXLY(I)),IPART(4,IPARTC(INDXLY(I)))    
+                WRITE(ISTDO,2100) TRIM(FAIL_NAME(INDXLY(I))),IL,NGL(INDXLY(I)),IPART(4,IPARTC(INDXLY(I))),TT 
 #include      "lockoff.inc"                          
               ENDDO ! |-> I
             ENDIF
@@ -346,8 +352,8 @@ c
             ENDIF                                   
             DO I = 1,NINDXLY                                          
 #include     "lockon.inc"                                             
-              WRITE(IOUT, 3000) TRIM(FAIL_NAME(INDXLY(I))),ID_PLY,NGL(INDXLY(I))                   
-              WRITE(ISTDO,3100) TRIM(FAIL_NAME(INDXLY(I))),ID_PLY,NGL(INDXLY(I)),TT                
+              WRITE(IOUT, 3000) TRIM(FAIL_NAME(INDXLY(I))),ID_PLY,NGL(INDXLY(I)),IPART(4,IPARTC(INDXLY(I)))                   
+              WRITE(ISTDO,3100) TRIM(FAIL_NAME(INDXLY(I))),ID_PLY,NGL(INDXLY(I)),IPART(4,IPARTC(INDXLY(I))),TT                
 #include     "lockoff.inc"                                            
             ENDDO ! |-> I                                                  
           ENDIF
@@ -393,10 +399,12 @@ c
       !=======================================================================
  1000 FORMAT(1X,'-- RUPTURE (',A,') OF SHELL ELEMENT NUMBER ',I10)
  1100 FORMAT(1X,'-- RUPTURE (',A,') OF SHELL ELEMENT :',I10,' AT TIME :',G11.4)
- 2000 FORMAT(1X,'-- FAILURE (',A,') OF LAYER',I3, ' ,SHELL ELEMENT NUMBER ',I10)
+ 2000 FORMAT(1X,'-- FAILURE (',A,') OF LAYER',I3, ' ,SHELL ELEMENT NUMBER ',I10,
+     .       1X,' BELONGING TO PART ID :', I5)
  2100 FORMAT(1X,'-- FAILURE (',A,') OF LAYER',I3, ' ,SHELL ELEMENT NUMBER ',I10,
-     .       1X,'AT TIME :',G11.4)
- 3000 FORMAT(1X,'-- FAILURE (',A,') OF PLY ID ',I10, ' ,SHELL ELEMENT NUMBER ',I10)
+     .       1X,' BELONGING TO PART ID :', I5,' AT TIME :',G11.4)
+ 3000 FORMAT(1X,'-- FAILURE (',A,') OF PLY ID ',I10, ' ,SHELL ELEMENT NUMBER ',I10,
+     .       1X,' BELONGING TO PART ID :', I5)
  3100 FORMAT(1X,'-- FAILURE (',A,') OF PLY ID ',I10, ' ,SHELL ELEMENT NUMBER ',I10,
-     .       1X,'AT TIME :',G11.4)
+     .       1X,' BELONGING TO PART ID :', I5,' AT TIME :',G11.4)
       END

--- a/engine/source/materials/fail/fail_setoff_npg_c.F
+++ b/engine/source/materials/fail/fail_setoff_npg_c.F
@@ -38,7 +38,8 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .           OFF      ,NPG      ,STACK    ,ISUBSTACK,
      .           IGTYP    ,FAILWAVE ,FWAVE_EL ,NLAY_MAX ,
      .           LAYNPT_MAX,NUMGEO  ,IPG      ,NUMSTACK ,
-     .           IGEO     ,PRINT_FAIL)
+     .           IGEO     ,PRINT_FAIL,
+     .           IPART    ,LIPART1  ,IPARTC   ,NPART)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -66,8 +67,9 @@ C-----------------------------------------------
       INTEGER, DIMENSION(NPROPGI,NUMGEO),INTENT(IN) :: IGEO
       INTEGER, INTENT(IN) :: PID,NEL,IR,IS,NLAY,NPTTOT,NPG,IGTYP,
      .                       ISUBSTACK,NLAY_MAX,LAYNPT_MAX,NUMGEO,
-     .                       IPG,NUMSTACK
-      INTEGER, DIMENSION(NEL), INTENT(IN)           :: NGL
+     .                       IPG,NUMSTACK,LIPART1,NPART
+      INTEGER, DIMENSION(LIPART1,NPART), INTENT(IN)     :: IPART
+      INTEGER, DIMENSION(NEL), INTENT(IN)           :: NGL,IPARTC
       my_real, DIMENSION(NEL,NLAY_MAX*LAYNPT_MAX), INTENT(IN) :: THK_LY
       my_real, DIMENSION(NPTTOT*NEL), INTENT(IN)    :: THKLY
       my_real, DIMENSION(NEL), INTENT(INOUT)        :: OFF
@@ -114,6 +116,7 @@ c
       NPTR = ELBUF_STR%NPTR
       NPTS = ELBUF_STR%NPTS
       JPG  = (IPG-1)*NEL
+      
 c         
       DO IL=1,NLAY
         NFAIL = ELBUF_STR%BUFLY(IL)%NFAIL
@@ -258,8 +261,8 @@ c
                 DO I = 1,NINDXLY     
                   FAIL_NAME = MAT_ELEM%MAT_PARAM(IMAT)%FAIL(FAIL_NUM(INDXLY(I)))%KEYWORD                       
 #include       "lockon.inc"                                
-                  WRITE(IOUT, 3000) TRIM(FAIL_NAME),ID_PLY,NGL(INDXLY(I))      
-                  WRITE(ISTDO,3100) TRIM(FAIL_NAME),ID_PLY,NGL(INDXLY(I)),TT   
+                  WRITE(IOUT, 3000) TRIM(FAIL_NAME),ID_PLY,NGL(INDXLY(I)),IPART(4,IPARTC(INDXLY(I)))       
+                  WRITE(ISTDO,3100) TRIM(FAIL_NAME),ID_PLY,NGL(INDXLY(I)),IPART(4,IPARTC(INDXLY(I))),TT   
 #include       "lockoff.inc"                               
                 ENDDO ! |-> I 
               ! -> Print out layer failure
@@ -267,8 +270,8 @@ c
                 DO I = 1,NINDXLY      
                   FAIL_NAME = MAT_ELEM%MAT_PARAM(IMAT)%FAIL(FAIL_NUM(INDXLY(I)))%KEYWORD                     
 #include       "lockon.inc"                                
-                  WRITE(IOUT, 2000) TRIM(FAIL_NAME),IL,NGL(INDXLY(I))      
-                  WRITE(ISTDO,2100) TRIM(FAIL_NAME),IL,NGL(INDXLY(I)),TT   
+                  WRITE(IOUT, 2000) TRIM(FAIL_NAME),IL,NGL(INDXLY(I)),IPART(4,IPARTC(INDXLY(I)))     
+                  WRITE(ISTDO,2100) TRIM(FAIL_NAME),IL,NGL(INDXLY(I)),IPART(4,IPARTC(INDXLY(I))),TT   
 #include       "lockoff.inc"                               
                 ENDDO ! |-> I 
               ENDIF                                   
@@ -406,8 +409,8 @@ c
                   DO I = 1,NINDXLY        
                     FAIL_NAME = MAT_ELEM%MAT_PARAM(IMAT)%FAIL(FAIL_NUM(INDXLY(I)))%KEYWORD              
 #include         "lockon.inc"                           
-                    WRITE(IOUT, 3000) TRIM(FAIL_NAME),ID_PLY,NGL(INDXLY(I))    
-                    WRITE(ISTDO,3100) TRIM(FAIL_NAME),ID_PLY,NGL(INDXLY(I)),TT 
+                    WRITE(IOUT, 3000) TRIM(FAIL_NAME),ID_PLY,NGL(INDXLY(I)),IPART(4,IPARTC(INDXLY(I)))   
+                    WRITE(ISTDO,3100) TRIM(FAIL_NAME),ID_PLY,NGL(INDXLY(I)),IPART(4,IPARTC(INDXLY(I))),TT 
 #include         "lockoff.inc"                          
                   ENDDO ! |-> I
                 ENDIF
@@ -450,10 +453,12 @@ c
       !=======================================================================
  1000 FORMAT(1X,'-- RUPTURE (',A,') OF SHELL ELEMENT NUMBER ',I10)
  1100 FORMAT(1X,'-- RUPTURE (',A,') OF SHELL ELEMENT :',I10,' AT TIME :',G11.4)
- 2000 FORMAT(1X,'-- FAILURE (',A,') OF LAYER',I3, ' ,SHELL ELEMENT NUMBER ',I10)
+ 2000 FORMAT(1X,'-- FAILURE (',A,') OF LAYER',I3, ' ,SHELL ELEMENT NUMBER ',I10,
+     .       1X,' BELONGING TO PART ID :', I5)
  2100 FORMAT(1X,'-- FAILURE (',A,') OF LAYER',I3, ' ,SHELL ELEMENT NUMBER ',I10,
-     .       1X,'AT TIME :',G11.4)
- 3000 FORMAT(1X,'-- FAILURE (',A,') OF PLY ID ',I10, ' ,SHELL ELEMENT NUMBER ',I10)
+     .       1X,' BELONGING TO PART ID :', I5,' AT TIME :',G11.4)
+ 3000 FORMAT(1X,'-- FAILURE (',A,') OF PLY ID ',I10, ' ,SHELL ELEMENT NUMBER ',I10,
+     .       1X,' BELONGING TO PART ID :', I5)
  3100 FORMAT(1X,'-- FAILURE (',A,') OF PLY ID ',I10, ' ,SHELL ELEMENT NUMBER ',I10,
-     .       1X,'AT TIME :',G11.4)
+     .       1X,' BELONGING TO PART ID :', I5,' AT TIME :',G11.4)
       END

--- a/engine/source/materials/mat_share/cmain3.F
+++ b/engine/source/materials/mat_share/cmain3.F
@@ -83,7 +83,8 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      R           INDX_DRAPE,THKE      ,SEDRAPE   ,NUMEL_DRAPE,DT        ,
      Q           NCYCLE    , SNPC     ,STF       ,NXLAYMAX  ,IDEL7NOK   ,
      S           USERL_AVAIL, MAXFUNC ,VARNL_NPTTOT, SBUFMAT   ,SDIR_A    ,
-     T          SDIR_B    ,FOR_G      ,SSP_EQ   )
+     T           SDIR_B    ,FOR_G      ,SSP_EQ   ,IPART     ,LIPART1,
+     T           IPARTC    )
 C-----------------------------------------------
 C   M o d u l e s
 C----------------------------------------------- 
@@ -170,6 +171,10 @@ C-----------------------------------------------
       TYPE (SENSORS_) ,INTENT(IN) :: SENSORS
       TYPE (DT_), INTENT(IN) :: DT
       my_real, dimension(nel,5), intent(inout) :: FOR_G
+      integer, intent(in) :: LIPART1
+      
+      INTEGER, DIMENSION(LIPART1,NPART), INTENT(IN)     :: IPART
+      INTEGER, DIMENSION(NEL), INTENT(IN)           :: IPARTC
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -298,7 +303,8 @@ c
      D       DIR1_CRK,DIR2_CRK,IPARG   ,JHBE    ,ISMSTR  ,JTHE    ,
      E       TENS    ,IR      ,IS      ,NLAY    ,NPT     ,IXLAY   ,
      F       IXEL    ,F_DEF   ,ITASK   ,STACK%PM ,ISUBSTACK,STACK ,
-     G       VARNL   ,NLOC_DMG,NLAY_MAX,LAYNPT_MAX,DT    ,SSP_EQ  )
+     G       VARNL   ,NLOC_DMG,NLAY_MAX,LAYNPT_MAX,DT    ,SSP_EQ  ,
+     J       IPART   ,IPARTC  ) 
 cc----------------------------
       ELSE   ! Radioss material laws , NPT > 0
 c----------------------------
@@ -334,7 +340,8 @@ c
      *       NPROPMI ,NPROPM  ,NPROPG,IMON_MAT,NUMGEO  ,
      *       NUMSTACK, DT1    ,TT  ,NXLAYMAX ,IDEL7NOK,USERL_AVAIL,
      *       MAXFUNC,NUMMAT,VARNL_NPTTOT,    SBUFMAT ,SDIR_A  ,SDIR_B  ,NPARG,
-     *       IDAMP_FREQ_RANGE,DAMP_BUF ,SSP_EQ  )
+     *       IDAMP_FREQ_RANGE,DAMP_BUF ,SSP_EQ  ,IPART  ,LIPART1,
+     T       IPARTC  ,NPART)
       ENDIF ! IF (NPT == 0) 
 C----------------------------------------------------------------------
       IF (IEXPAN > 0 .AND. JTHE > 0. AND. IDT_THERM==0) THEN

--- a/engine/source/materials/mat_share/mulawc.F90
+++ b/engine/source/materials/mat_share/mulawc.F90
@@ -194,7 +194,7 @@
         & npropmi  ,npropm   ,npropg   ,imon_mat  ,numgeo    ,          &
         & numstack ,dt1      ,tt       ,nxlaymax  ,idel7nok ,userl_avail, &
         & maxfunc  ,nummat   ,varnl_npttot,sbufmat,sdir_a   ,sdir_b ,nparg,&
-        & idamp_freq_range,damp_buf,ssp_eq)
+        & idamp_freq_range,damp_buf,ssp_eq, ipart ,lipart1 ,ipartc ,npart ) 
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Modules
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -296,6 +296,11 @@
           integer, intent(inout),dimension(mvsiz*nlay_max) :: indx
           integer, intent(inout),dimension(nel)            :: fwave_el
           integer, intent(inout),dimension(nxlaymax,mvsiz) :: elcrkini
+          !
+          integer, intent(in) :: lipart1
+          integer, intent(in) :: npart
+          integer, dimension(lipart1,npart), intent(in) :: ipart
+          integer, intent(in), dimension(nel) :: ipartc
           !
           real(kind=WP), intent(in) :: dt1
           real(kind=WP), intent(in) :: tt
@@ -2844,7 +2849,8 @@
               &thk_ly   ,thkly    ,off      ,stack    ,&
               &isubstack,igtyp    ,failwave ,fwave_el ,&
               &nlay_max ,laynpt_max,numgeo  ,numstack ,&
-              &igeo     ,print_fail)
+              &igeo     ,print_fail,                   &
+              &ipart    ,lipart1  ,ipartc   ,npart)
             else
               call fail_setoff_npg_c(&
               &elbuf_str,mat_elem ,geo      ,pid(1)   ,&
@@ -2853,7 +2859,8 @@
               &off      ,npg      ,stack    ,isubstack,&
               &igtyp    ,failwave ,fwave_el ,nlay_max ,&
               &laynpt_max,numgeo  ,ipg      ,numstack ,&
-              &igeo     ,print_fail)
+              &igeo     ,print_fail,                   &
+              &ipart    ,lipart1  ,ipartc   ,npart)
             endif
           endif
 !---

--- a/engine/source/materials/mat_share/usermat_shell.F
+++ b/engine/source/materials/mat_share/usermat_shell.F
@@ -109,7 +109,8 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      D       DIR1_CRK ,DIR2_CRK ,IPARG    ,JHBE      ,ISMSTR   ,JTHE     ,                        
      E       TENSX    ,IR       ,IS       ,NLAY      ,NPT      ,IXLAY    ,             
      F       IXEL     ,F_DEF    ,ITASK    ,PM_STACK ,ISUBSTACK ,STACK    ,
-     G       VARNL    ,NLOC_DMG ,NLAY_MAX ,LAYNPT_MAX,DT       ,SSP_EQ )
+     G       VARNL    ,NLOC_DMG ,NLAY_MAX ,LAYNPT_MAX,DT       ,SSP_EQ  ,
+     J       IPART    ,IPARTC ) 
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -181,6 +182,8 @@ C-----------------------------------------------
       TYPE (NLOCAL_STR_) :: NLOC_DMG 
       TYPE (MAT_ELEM_) ,INTENT(INOUT) ,TARGET :: MAT_ELEM
       TYPE (DT_) ,INTENT(IN) :: DT
+      INTEGER, DIMENSION(LIPART1,NPART), INTENT(IN)     :: IPART
+      integer, intent(in),dimension(NEL) ::  IPARTC
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -1985,7 +1988,8 @@ c--------------------------------------------------
      .                       THK_LY   ,THKLY    ,OFF      ,STACK    ,
      .                       ISUBSTACK,IGTYP    ,FAILWAVE ,FWAVE_EL ,
      .                       NLAY_MAX ,LAYNPT_MAX,NUMGEO  ,NUMSTACK ,
-     .                       IGEO     ,PRINT_FAIL)
+     .                       IGEO     ,PRINT_FAIL,                
+     .                       IPART    ,LIPART1  ,IPARTC   ,NPART)
         ELSE
           CALL FAIL_SETOFF_NPG_C(
      .                       ELBUF_STR,MAT_ELEM ,GEO      ,PID(1)   ,
@@ -1994,7 +1998,8 @@ c--------------------------------------------------
      .                       OFF      ,NPG      ,STACK    ,ISUBSTACK, 
      .                       IGTYP    ,FAILWAVE ,FWAVE_EL ,NLAY_MAX ,
      .                       LAYNPT_MAX,NUMGEO  ,IPG      ,NUMSTACK ,
-     .                       IGEO     ,PRINT_FAIL)
+     .                       IGEO     ,PRINT_FAIL,                
+     .                       IPART    ,LIPART1  ,IPARTC   ,NPART)
         ENDIF
       ENDIF  
 c---


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
For composite material, when there is a failure of layer, the message doesn't show the ID of part.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
Add part ID in the message

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
