### PR TITLE
Fix MPI wrapper issues

### DIFF
--- a/engine/source/mpi/generic/spmd_alltoall.F90
+++ b/engine/source/mpi/generic/spmd_alltoall.F90
@@ -96,9 +96,9 @@
           tag = 0
           call spmd_in(tag)
           if (present(comm)) then
-            call MPI_Alltoall(sendbuf, sendcount, MPI_INT, recvbuf, recvcount, MPI_INT, comm, ierr)
+            call MPI_Alltoall(sendbuf, sendcount, MPI_INTEGER, recvbuf, recvcount, MPI_INTEGER, comm, ierr)
           else
-            call MPI_Alltoall(sendbuf, sendcount, MPI_INT, recvbuf, recvcount, MPI_INT, SPMD_COMM_WORLD, ierr)
+            call MPI_Alltoall(sendbuf, sendcount, MPI_INTEGER, recvbuf, recvcount, MPI_INTEGER, SPMD_COMM_WORLD, ierr)
           end if
           call spmd_out(tag,ierr)
 #else
@@ -195,10 +195,10 @@
           tag = 0
           call spmd_in(tag)
           if (present(comm)) then
-            call MPI_Alltoall(sendbuf, sendcount, MPI_INT, recvbuf, recvcount, MPI_INT, comm, ierr)
+            call MPI_Alltoall(sendbuf, sendcount, MPI_INTEGER, recvbuf, recvcount, MPI_INTEGER, comm, ierr)
           else
-            call MPI_Alltoall(sendbuf, sendcount, MPI_INT, recvbuf, recvcount,&
-              MPI_INT, SPMD_COMM_WORLD, ierr)
+            call MPI_Alltoall(sendbuf, sendcount, MPI_INTEGER, recvbuf, recvcount,&
+              MPI_INTEGER, SPMD_COMM_WORLD, ierr)
           end if
           call spmd_out(tag,ierr)
 #endif

--- a/engine/source/mpi/spmd_allgatherv.F90
+++ b/engine/source/mpi/spmd_allgatherv.F90
@@ -98,9 +98,9 @@
           tag = 0
           call spmd_in(tag)
           if (present(comm)) then
-            call MPI_Allgatherv(sendbuf, sendcount, MPI_INT, recvbuf, recvcounts, displs, MPI_INT, comm, ierr)
+            call MPI_Allgatherv(sendbuf, sendcount, MPI_INTEGER, recvbuf, recvcounts, displs, MPI_INTEGER, comm, ierr)
           else
-            call MPI_Allgatherv(sendbuf, sendcount, MPI_INT, recvbuf, recvcounts, displs, MPI_INT, SPMD_COMM_WORLD, ierr)
+            call MPI_Allgatherv(sendbuf, sendcount, MPI_INTEGER, recvbuf, recvcounts, displs, MPI_INTEGER, SPMD_COMM_WORLD, ierr)
           end if
           call spmd_out(tag,ierr)
 #else
@@ -176,6 +176,8 @@
               recvcounts, displs, MPI_DOUBLE_PRECISION, SPMD_COMM_WORLD, ierr)
           end if
           call spmd_out(tag,ierr)
+#else
+          recvbuf(1) = sendbuf
 #endif
         end subroutine spmd_allgatherv_double
 !||====================================================================
@@ -202,12 +204,14 @@
           tag = 0
           call spmd_in(tag)
           if (present(comm)) then
-            call MPI_Allgatherv(sendbuf, sendcount, MPI_INT, recvbuf, recvcounts, displs, MPI_INT, comm, ierr)
+            call MPI_Allgatherv(sendbuf, sendcount, MPI_INTEGER, recvbuf, recvcounts, displs, MPI_INTEGER, comm, ierr)
           else
-            call MPI_Allgatherv(sendbuf, sendcount, MPI_INT, recvbuf, recvcounts, &
-              displs, MPI_INT, SPMD_COMM_WORLD, ierr)
+            call MPI_Allgatherv(sendbuf, sendcount, MPI_INTEGER, recvbuf, recvcounts, &
+              displs, MPI_INTEGER, SPMD_COMM_WORLD, ierr)
           end if
           call spmd_out(tag,ierr)
+#else
+          recvbuf(1) = sendbuf
 #endif
         end subroutine spmd_allgatherv_int
 !||====================================================================
@@ -239,6 +243,8 @@
             call MPI_Allgatherv(sendbuf, sendcount, MPI_REAL, recvbuf, recvcounts, displs, MPI_REAL, SPMD_COMM_WORLD, ierr)
           end if
           call spmd_out(tag,ierr)
+#else
+          recvbuf(1) = sendbuf
 #endif
         end subroutine spmd_allgatherv_real
 

--- a/engine/source/mpi/spmd_mod.F90
+++ b/engine/source/mpi/spmd_mod.F90
@@ -504,7 +504,7 @@
             used_comm = SPMD_COMM_WORLD
           end if
 
-          call MPI_Reduce(sendbuf, recvbuf, buf_count, MPI_INT, mpi_op, root, used_comm, ierr)
+          call MPI_Reduce(sendbuf, recvbuf, buf_count, MPI_INTEGER, mpi_op, root, used_comm, ierr)
           call spmd_out(TAG_REDUCE,ierr)
 #else
           recvbuf(1:buf_count) = sendbuf(1:buf_count)
@@ -540,7 +540,7 @@
             used_comm = SPMD_COMM_WORLD
           end if
 
-          call MPI_Reduce(sendbuf, recvbuf, buf_count, MPI_REAL, mpi_op, root, used_comm, ierr)
+          call MPI_Reduce(sendbuf, recvbuf, buf_count, MPI_DOUBLE_PRECISION, mpi_op, root, used_comm, ierr)
           call spmd_out(TAG_REDUCE,ierr)
 #else
           recvbuf(1:buf_count) = sendbuf(1:buf_count)
@@ -724,7 +724,7 @@
           if(buf_count .ne. 1) then
             ierr = -1
           else
-            call MPI_Reduce(sendbuf, recvbuf, buf_count, MPI_INT, mpi_op, root, used_comm, ierr)
+            call MPI_Reduce(sendbuf, recvbuf, buf_count, MPI_INTEGER, mpi_op, root, used_comm, ierr)
           endif
           call spmd_out(TAG_REDUCE,ierr)
 #else
@@ -761,7 +761,7 @@
             used_comm = SPMD_COMM_WORLD
           end if
 
-          call MPI_Reduce(sendbuf, recvbuf, buf_count, MPI_REAL, mpi_op, root, used_comm, ierr)
+          call MPI_Reduce(sendbuf, recvbuf, buf_count, MPI_DOUBLE_PRECISION, mpi_op, root, used_comm, ierr)
           call spmd_out(TAG_REDUCE,ierr)
 #else
           recvbuf = sendbuf  ! In case MPI is not defined, just copy the value

--- a/engine/source/mpi/spmd_pack.F90
+++ b/engine/source/mpi/spmd_pack.F90
@@ -119,8 +119,8 @@
           integer, intent(in), optional :: comm
           double precision, dimension(incount), intent(in) :: inbuf
           integer, dimension(outsize), intent(inout) :: outbuf
-#ifdef MPI
           integer :: ierr, tag
+#ifdef MPI
           tag = 0  ! Default tag for pack operations
           call spmd_in(tag)
           if( present(comm) ) then

--- a/engine/source/mpi/spmd_recv.F90
+++ b/engine/source/mpi/spmd_recv.F90
@@ -87,7 +87,7 @@
           implicit none
 #include "spmd.inc"
           integer, intent(in) :: buf_count, source, tag
-          real, dimension(buf_count,1), intent(inout) :: buf
+          real, dimension(1,buf_count), intent(inout) :: buf
           integer, intent(in), optional :: comm
 #ifdef MPI
           integer :: ierr
@@ -175,7 +175,7 @@
           implicit none
 #include "spmd.inc"
           integer, intent(in) :: buf_count, source, tag
-          double precision, dimension(buf_count,1), intent(inout) :: buf
+          double precision, dimension(1,buf_count), intent(inout) :: buf
           integer, intent(in), optional :: comm
           integer :: ierr
 #ifdef MPI

--- a/engine/source/mpi/spmd_send.F90
+++ b/engine/source/mpi/spmd_send.F90
@@ -88,7 +88,7 @@
 #include "spmd.inc"
           integer, intent(in) :: buf_count, dest, tag
           integer, intent(in), optional :: comm
-          real, dimension(1,buf_count), intent(in) :: buf
+          real, dimension(buf_count,1), intent(in) :: buf
           integer :: ierr
 #ifdef MPI
           call spmd_in(tag)
@@ -259,7 +259,7 @@
 #include "spmd.inc"
           integer, intent(in) :: buf_count, dest, tag
           integer, intent(in), optional :: comm
-          double precision, intent(in) :: buf(1,buf_count)
+          double precision, intent(in) :: buf(buf_count,1)
 #ifdef MPI
           integer :: ierr
           ! the MPI datatype for double precision is MPI_DOUBLE_PRECISION

--- a/engine/source/mpi/spmd_unpack.F90
+++ b/engine/source/mpi/spmd_unpack.F90
@@ -116,8 +116,8 @@
           integer, intent(in), optional :: comm
           integer, dimension(insize), intent(in) :: inbuf
           double precision, dimension(outcount), intent(out) :: outbuf
-#ifdef MPI
           integer :: ierr, tag
+#ifdef MPI
           tag = 0  ! Default tag for unpack operations
           call spmd_in(tag)
           if( present(comm) ) then

--- a/engine/source/mpi/spmd_wait.F90
+++ b/engine/source/mpi/spmd_wait.F90
@@ -99,7 +99,7 @@
           use spmd_error_mod, only: spmd_in, spmd_out
           implicit none
 #include "spmd.inc"
-          integer, intent(in) :: request
+          integer, intent(inout) :: request
           integer, dimension(MPI_STATUS_SIZE), optional, intent(inout) :: status
 #ifdef MPI
           integer :: ierr
@@ -112,9 +112,6 @@
           call spmd_out(TAG_WAIT,ierr)
 #endif
         end subroutine spmd_wait
-! ======================================================================================================================
-
-! ======================================================================================================================
 ! ======================================================================================================================
 !||====================================================================
 !||    spmd_waitany                  ../engine/source/mpi/spmd_wait.F90


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

This pull request focuses on improving MPI interoperability and correctness in the Fortran SPMD communication routines. The main changes ensure proper use of MPI datatypes, fix array dimension mismatches in send/receive routines, and address minor interface and fallback behavior issues.

### MPI datatype corrections

* Updated all relevant MPI calls to use `MPI_INTEGER` and `MPI_DOUBLE_PRECISION` instead of `MPI_INT` and `MPI_REAL`, ensuring proper datatype compatibility with Fortran and MPI standards. This affects routines such as `spmd_alltoall_ints`, `spmd_alltoall_int`, `spmd_allgatherv_ints`, `spmd_allgatherv_int`, `spmd_allgatherv_real`, and `spmd_reduce_*` variants. [[1]](diffhunk://#diff-380088cc11818bec0b8c7d843ab87e9d40da9b1121fe4b520c166ca3ae4af57dL99-R101) [[2]](diffhunk://#diff-380088cc11818bec0b8c7d843ab87e9d40da9b1121fe4b520c166ca3ae4af57dL198-R201) [[3]](diffhunk://#diff-5672b7cbf00c1faa3b4e85d7834e83efdb4bc984b12c83c0ca32703ac8d7278bL101-R103) [[4]](diffhunk://#diff-5672b7cbf00c1faa3b4e85d7834e83efdb4bc984b12c83c0ca32703ac8d7278bL205-R214) [[5]](diffhunk://#diff-5672b7cbf00c1faa3b4e85d7834e83efdb4bc984b12c83c0ca32703ac8d7278bR246-R247) [[6]](diffhunk://#diff-29474ace1b0bfd380220830d1474ac2c071ec1baa8f7829ec420a507aa80dfdfL507-R507) [[7]](diffhunk://#diff-29474ace1b0bfd380220830d1474ac2c071ec1baa8f7829ec420a507aa80dfdfL543-R543) [[8]](diffhunk://#diff-29474ace1b0bfd380220830d1474ac2c071ec1baa8f7829ec420a507aa80dfdfL727-R727) [[9]](diffhunk://#diff-29474ace1b0bfd380220830d1474ac2c071ec1baa8f7829ec420a507aa80dfdfL764-R764)

### Array dimension fixes

* Corrected the dimensions of buffers in 2D send/receive routines to match expected input/output shapes, preventing data misalignment during communication. Specifically, swapped dimensions in `spmd_recv_reals2D`, `spmd_recv_doubles2D`, `spmd_send_reals2D`, and `spmd_send_doubles2D`. [[1]](diffhunk://#diff-411ba320fdc5dc11f178786201292adcd6f61ee44c9ba63930868503098b5335L90-R90) [[2]](diffhunk://#diff-411ba320fdc5dc11f178786201292adcd6f61ee44c9ba63930868503098b5335L178-R178) [[3]](diffhunk://#diff-6f2d400c46456c2ab3fdc6addd546a88d8bad6d9ab78d2630770d743e22860ddL91-R91) [[4]](diffhunk://#diff-6f2d400c46456c2ab3fdc6addd546a88d8bad6d9ab78d2630770d743e22860ddL262-R262)

### Fallback and interface improvements

* Added fallback assignments for non-MPI builds in several `spmd_allgatherv_*` routines to ensure correct behavior when MPI is not available. [[1]](diffhunk://#diff-5672b7cbf00c1faa3b4e85d7834e83efdb4bc984b12c83c0ca32703ac8d7278bR179-R180) [[2]](diffhunk://#diff-5672b7cbf00c1faa3b4e85d7834e83efdb4bc984b12c83c0ca32703ac8d7278bL205-R214) [[3]](diffhunk://#diff-5672b7cbf00c1faa3b4e85d7834e83efdb4bc984b12c83c0ca32703ac8d7278bR246-R247)
* Changed the intent of the `request` argument in `spmd_wait` from `in` to `inout` for proper MPI request handling.

### Code consistency

* Fixed misplaced preprocessor directives in `spmd_pack_doubles` and `spmd_unpack_doubles` for consistency and correctness. [[1]](diffhunk://#diff-335ceaa359e28d34ccc1974a5ebb5abc97a23d6bf3545c298b7e5897d371ecbbL122-R123) [[2]](diffhunk://#diff-09677912c9736639957aede29e32614c2c3409cc4535634d3ff3b4a1255834d4L119-R120)
* Removed redundant comment lines at the end of `spmd_wait` for code cleanliness.
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
