### PR TITLE
correction message for energy sensor kinetic/internal energy

### DIFF
--- a/engine/source/tools/sensor/sensor_energy.F
+++ b/engine/source/tools/sensor/sensor_energy.F
@@ -301,9 +301,9 @@ c-----------------------------------------------------------------------
 1200  FORMAT('      TARGET MAX INTERNAL ENERGY = ',1PE12.5,/
      .       '      CURRENT INTERNAL ENERGY AFTER TMIN and TDELAY = ',1PE12.5)
 1300  FORMAT('      TARGET MIN KINETIC ENERGY = ',1PE12.5,/
-     .       '      CURRENT INTERNAL ENERGY AFTER TMIN and TDELAY = ',1PE12.5)
+     .       '      CURRENT KINETIC ENERGY AFTER TMIN and TDELAY = ',1PE12.5)
 1400  FORMAT('      TARGET MAX KINETIC ENERGY = ',1PE12.5,/
-     .       '      CURRENT INTERNAL ENERGY AFTER TMIN and TDELAY = ',1PE12.5)
+     .       '      CURRENT KINETIC ENERGY AFTER TMIN and TDELAY = ',1PE12.5)
 2100  FORMAT('      CONSTANT INT ENERGY = ',1PE12.5,', MEAN = ',1PE12.5)           
 2200  FORMAT('      CONSTANT KIN ENERGY = ',1PE12.5,', MEAN = ',1PE12.5)           
 c----------------------------------------------------------


### PR DESCRIPTION
This pull request makes a minor but important correction to the output formatting in the `SENSOR_ENERGY` subroutine. The change ensures that the energy type displayed in the output matches the actual value being reported.

* Output formatting fix:
  * In the `SENSOR_ENERGY` subroutine in `sensor_energy.F`, updated the output label from "CURRENT INTERNAL ENERGY AFTER TMIN and TDELAY" to "CURRENT KINETIC ENERGY AFTER TMIN and TDELAY" in the kinetic energy-related format statements to accurately reflect the reported value.