### PR TITLE
openReader : correction handling th_truss by converter

### DIFF
--- a/reader/source/cfgkernel/sdi/sdiCFGTypeMapper.h
+++ b/reader/source/cfgkernel/sdi/sdiCFGTypeMapper.h
@@ -111,13 +111,17 @@ protected:
         SDITypeMapper::Init();
     }
 
-    virtual void SortTmpKeywordList()
+    virtual void Pretreat()
     {
-        std::stable_sort(p_tmpkeywordlist.begin(), p_tmpkeywordlist.end(), [](const auto& lhs, const auto& rhs)
+        // first call parent implementation...
+        SDITypeMapper::Pretreat();
+        // ... now we resort, putting control cards in their initial order in the end,
+        // to distinguish Starter and Engine
+        std::sort(p_tmpkeywordlist.begin(), p_tmpkeywordlist.end(), [](const auto& lhs, const auto& rhs)
                          {
                              if(lhs.myDBtype == HCDI_OBJ_TYPE_CARDS && rhs.myDBtype == HCDI_OBJ_TYPE_CARDS)
                              { // control cards have to keep their order, to distinguish Starter and Engine
-                                 return false;
+                          return lhs.myinitialorder < rhs.myinitialorder;
                              }
                              else if(lhs.myDBtype == HCDI_OBJ_TYPE_CARDS)
                              { // in order not to mess up the sorting, we have to put all control cards...
@@ -161,7 +165,7 @@ private: // used by constructor from CFGKernel
                 {
                     auto username = list[i];
                     p_tmpkeywordlist.push_back(
-                        myKeywordInfo(username, (unsigned int) type, idpool));
+                        myKeywordInfo(username, (unsigned int) type, p_tmpkeywordlist.size(), idpool));
                 }
                 useLastLevel = false; // if we have user names in higher levels, we don't use the last level
             }
@@ -190,7 +194,8 @@ private: // used by constructor from CFGKernel
                     int configType = pSubtype->getHMConfigType();
                     int subType = pSubtype->getHMType();
                     p_tmpkeywordlist.push_back(
-                        myKeywordInfo(username, (unsigned int)type, idpool, configType, subType));
+                        myKeywordInfo(username, (unsigned int)type, p_tmpkeywordlist.size(),
+                                      idpool, configType, subType));
                     return;
                 }
             }

--- a/reader/source/io/model_readers/radioss/radiossblk/radiossblk.cxx
+++ b/reader/source/io/model_readers/radioss/radiossblk/radiossblk.cxx
@@ -72,7 +72,7 @@ class SDIModelViewRadiossblk: public ModelViewPO
 {
 public:
     SDIModelViewRadiossblk(std::vector<IMECPreObject*> (&preobjects)[HCDI_OBJ_TYPE_HC_MAX]) :
-        ModelViewPO(SDICFGTypeMapper(), preobjects, HCDI_OBJ_TYPE_HC_MAX)
+        ModelViewPO(SDICFGTypeMapper("/", true, '/'), preobjects, HCDI_OBJ_TYPE_HC_MAX)
     {
         p_pIdManager = new SDIIdManagerRadiossblk(*this);
 

--- a/reader/source/sdi/tools/sdiTypeMapper.h
+++ b/reader/source/sdi/tools/sdiTypeMapper.h
@@ -82,9 +82,11 @@ protected:
         unsigned int myconfigType;
         unsigned int mysubType;
         unsigned int mysubkeywordcount = 0;
-        myKeywordInfo(const sdiString& keyword, unsigned int DBtype, int idpool=0,
-                      int configType=0, int subType=0) :
-            mykeyword(keyword), myDBtype(DBtype)
+        size_t myinitialorder = 0;
+        myKeywordInfo(const sdiString& keyword, unsigned int DBtype,
+                      size_t initialorder = 0,
+                      int idpool=0, int configType=0, int subType=0) :
+            mykeyword(keyword), myDBtype(DBtype), myinitialorder(initialorder)
         {
             myidpool = idpool > 0 ? idpool : 0;
             myconfigType = configType > 0 ? configType : 0;
@@ -612,12 +614,12 @@ public:
         if (nullptr == file) return;
 
         fprintf(file, "1 to 1 mapping\n");
-        std::vector<myKeywordInfo> p_tmpkeywordlist;
+        std::vector<myKeywordInfo> tmpkeywordlist;
         for(EntityType type = ENTITY_TYPE_NONE; type < p_maxDBtype; ++type)
         {
             if(!GetKeyword(type).empty())
             {
-                p_tmpkeywordlist.push_back(myKeywordInfo(GetKeyword(type), (unsigned int) type));
+                tmpkeywordlist.push_back(myKeywordInfo(GetKeyword(type), (unsigned int) type));
                 // sorted by type
                 fprintf(file, "%s   %s   (%u)\n",
                         GetKeyword(type).c_str(),
@@ -627,11 +629,11 @@ public:
             }
         }
         // sorted alphabetically
-        sort(p_tmpkeywordlist.begin(), p_tmpkeywordlist.end(), [](const myKeywordInfo& lhs, const myKeywordInfo& rhs)
+        sort(tmpkeywordlist.begin(), tmpkeywordlist.end(), [](const myKeywordInfo& lhs, const myKeywordInfo& rhs)
              {
                  return lhs.mykeyword < rhs.mykeyword;
              });
-        for(auto keyword : p_tmpkeywordlist)
+        for(auto keyword : tmpkeywordlist)
         {
             /*
             fprintf(file, "%s   %s   (%u)\n",


### PR DESCRIPTION
This pull request refactors the keyword mapping and sorting logic in the SDI configuration kernel, focusing on improved ordering and clarity for control cards and keyword info objects. The changes introduce a new `myinitialorder` field to track the original order of keywords, update constructors and sorting methods to utilize this field, and adjust related usages throughout the codebase.

### Refactoring keyword info and sorting logic

* Added a new `myinitialorder` field to the `myKeywordInfo` struct/class in `sdiTypeMapper.h` and updated its constructor to accept and store this value. This allows tracking the original order of keywords for more precise sorting and handling.
* Updated the logic for populating `p_tmpkeywordlist` in `sdiCFGTypeMapper.h` to pass the current list size as `myinitialorder` when creating new `myKeywordInfo` objects, ensuring each keyword's initial position is recorded. [[1]](diffhunk://#diff-e137762ea4387156c3641f71924a7c4b886546ee5d9198335a712d246190ec26L164-R168) [[2]](diffhunk://#diff-e137762ea4387156c3641f71924a7c4b886546ee5d9198335a712d246190ec26L193-R198)

### Improved sorting behavior for control cards

* Replaced the `SortTmpKeywordList` method with a new `Pretreat` method in `SDICFGTypeMapper`, which first calls the parent implementation and then sorts `p_tmpkeywordlist` using `myinitialorder` for control cards. This ensures control cards retain their initial order, helping to distinguish between Starter and Engine cards.

### Code cleanup and consistency

* Renamed local variables from `p_tmpkeywordlist` to `tmpkeywordlist` in the 1-to-1 mapping logic in `sdiTypeMapper.h` for clarity and consistency, and updated all related usages and sorting operations. [[1]](diffhunk://#diff-273abff5501c1432446b13e25d3a85d6b44ba4dde6629ee3e554195c7fb5891bL615-R622) [[2]](diffhunk://#diff-273abff5501c1432446b13e25d3a85d6b44ba4dde6629ee3e554195c7fb5891bL630-R636)

### Constructor updates for model view

* Updated the `SDIModelViewRadiossblk` constructor to instantiate `SDICFGTypeMapper` with additional parameters (`"/", true, '/'`), likely reflecting new or required initialization options.