### PR TITLE
openreader : converter update 02122025

### DIFF
--- a/reader/source/dyna2rad/dyna2rad/_private/convertcards.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/convertcards.cxx
@@ -217,24 +217,21 @@ void sdiD2R::ConvertCard::p_ConvertCtrlTimeStep()
 
 
         int IMSCLOptFlag = GetValue<int>(*selectCtrlTS, "IMSCLOptFlag");
-        if(IMSCLOptFlag == 3)
+        if(IMSCLOptFlag == 3 || IMSCLOptFlag == 2)
         {
             sdiValueEntity LSD_IMSCL = GetValue<sdiValueEntity>(*selectCtrlTS, "LSD_IMSCL");
             unsigned int grPartId=LSD_IMSCL.GetId();
 
-            if(grPartId > 0)
-            {
-                HandleEdit amsHandleEdit;
-                p_radiossModel->CreateEntity(amsHandleEdit, "/AMS");
-                amsHandleEdit.SetValue(p_radiossModel, sdiIdentifier("GRPART_ID"), sdiValue(sdiValueEntity(radSetType, 
-                    DynaToRad::GetRadiossSetIdFromLsdSet(grPartId, "*SET_PART" ))));          
+            HandleEdit amsHandleEdit;
+            p_radiossModel->CreateEntity(amsHandleEdit, "/AMS");
+            amsHandleEdit.SetValue(p_radiossModel, sdiIdentifier("GRPART_ID"), sdiValue(sdiValueEntity(radSetType, 
+                DynaToRad::GetRadiossSetIdFromLsdSet(grPartId, "*SET_PART" ))));          
 
-                HandleEdit dtAmsHandleEdit;
-                p_radiossModel->CreateEntity(dtAmsHandleEdit, "/DT/AMS");
+            HandleEdit dtAmsHandleEdit;
+            p_radiossModel->CreateEntity(dtAmsHandleEdit, "/DT/AMS");
 
-                dtAmsHandleEdit.SetValue(p_radiossModel, sdiIdentifier("SCALE"), sdiValue(0.67));
-                dtAmsHandleEdit.SetValue(p_radiossModel, sdiIdentifier("Tmin"), sdiValue(abs(lsdDT2MS)));
-            }
+            dtAmsHandleEdit.SetValue(p_radiossModel, sdiIdentifier("SCALE"), sdiValue(0.67));
+            dtAmsHandleEdit.SetValue(p_radiossModel, sdiIdentifier("Tmin"), sdiValue(abs(lsdDT2MS)));
         }
         
 
@@ -892,7 +889,7 @@ void sdiD2R::ConvertCard::p_ConvertDbBinaryD3Plot()
         
         int nobeam = GetValue<int>(*selDbBinD3Plot, "LSD_NOBEAM");
         SelectionEdit selAnimSpring(p_radiossModel, "/ANIM/SPRING/FORC");
-        if(nobeam > 0)
+        if(nobeam == 0 || nobeam == 2)
         {
             if (selAnimSpring.Count() == 0)
             {

--- a/reader/source/dyna2rad/dyna2rad/_private/convertcontacts.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/convertcontacts.cxx
@@ -399,9 +399,11 @@ void sdiD2R::ConvertContact::ConvertEntities()
            keyWord.find("ERODING_SINGLE_SURFACE")       != keyWord.npos ||
            keyWord.find("ERODING_SURFACE_TO_SURFACE")   != keyWord.npos ||
            keyWord.find("NODES_TO_SURFACE")             != keyWord.npos ||
+           keyWord.find("AUTOMATIC_NODES_TO_SURFACE")   != keyWord.npos ||
+           keyWord.find("ERODING_NODES_TO_SURFACE")     != keyWord.npos ||
            keyWord.find("AUTOMATIC_ONE_WAY_SURFACE_TO_SURFACE_TIEBREAK") != keyWord.npos)
         {
-            if(lsdSST != 0.0 || lsdSFST != 0.0 || lsdSFST != 0.0 || lsdSFMT != 0.0) 
+            if(lsdSST != 0.0 || lsdMST != 0.0) 
                 radInterEdit.SetValue(sdiIdentifier("IGAP"), sdiValue(5.0));
         }
 
@@ -420,6 +422,8 @@ void sdiD2R::ConvertContact::ConvertEntities()
            keyWord.find("ERODING_SINGLE_SURFACE")       != keyWord.npos ||
            keyWord.find("ERODING_SURFACE_TO_SURFACE")   != keyWord.npos ||
            keyWord.find("NODES_TO_SURFACE")             != keyWord.npos ||
+           keyWord.find("AUTOMATIC_NODES_TO_SURFACE")   != keyWord.npos ||
+           keyWord.find("ERODING_NODES_TO_SURFACE")     != keyWord.npos ||
            keyWord.find("AUTOMATIC_ONE_WAY_SURFACE_TO_SURFACE_TIEBREAK") != keyWord.npos)
         {
             radInterEdit.SetValue(sdiIdentifier("THICK_S"), sdiValue(lsdSST));

--- a/reader/source/dyna2rad/dyna2rad/_private/convertcontrolvols.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/convertcontrolvols.cxx
@@ -735,7 +735,7 @@ void sdiD2R::ConvertControlVolume::ConvertInitialFoamReferenceGeometry()
                 if (elementHRead.IsValid())
                 {
                   HandleRead partHRead;
-                  elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("PART"), partHRead);
+                  elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("part_ID"), partHRead);
                   if (partHRead.IsValid())
                   {
                     PartIdnodeRef = partHRead.GetId(p_radiossModel);
@@ -758,7 +758,7 @@ void sdiD2R::ConvertControlVolume::ConvertInitialFoamReferenceGeometry()
                 if (elementHRead.IsValid())
                 {
                   HandleRead partHRead;
-                  elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("PART"), partHRead);
+                  elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("part_ID"), partHRead);
                   if (partHRead.IsValid())
                   {
                     PartIdnodeRef = partHRead.GetId(p_radiossModel);
@@ -782,7 +782,7 @@ void sdiD2R::ConvertControlVolume::ConvertInitialFoamReferenceGeometry()
                 if (elementHRead.IsValid())
                 {
                   HandleRead partHRead;
-                  elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("PART"), partHRead);
+                  elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("part_ID"), partHRead);
                   if (partHRead.IsValid())
                   {
                     PartIdnodeRef = partHRead.GetId(p_radiossModel);
@@ -920,7 +920,7 @@ void sdiD2R::ConvertControlVolume::ConvertInitialFoamReferenceGeometry()
                 if (elementHRead.IsValid())
                 {
                   HandleRead partHRead;
-                  elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("PART"), partHRead);
+                  elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("part_ID"), partHRead);
                   if (partHRead.IsValid())
                   {
                     PartIdnodeRef = partHRead.GetId(p_radiossModel);
@@ -954,7 +954,7 @@ void sdiD2R::ConvertControlVolume::ConvertInitialFoamReferenceGeometry()
                   if (elementHRead.IsValid())
                   {
                     HandleRead partHRead;
-                    elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("PART"), partHRead);
+                    elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("part_ID"), partHRead);
                     if (partHRead.IsValid())
                     {
                       PartIdnodeRef = partHRead.GetId(p_radiossModel);
@@ -988,7 +988,7 @@ void sdiD2R::ConvertControlVolume::ConvertInitialFoamReferenceGeometry()
                   if (elementHRead.IsValid())
                   {
                     HandleRead partHRead;
-                    elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("PART"), partHRead);
+                    elementHRead.GetEntityHandle(p_radiossModel, sdiIdentifier("part_ID"), partHRead);
                     if (partHRead.IsValid())
                     {
                       PartIdnodeRef = partHRead.GetId(p_radiossModel);

--- a/reader/source/dyna2rad/dyna2rad/_private/convertdefinetransform.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/convertdefinetransform.cxx
@@ -292,13 +292,6 @@ void sdiD2R::ConvertDefineTransform::ConvertSelectedEntity(int defineTransformId
              transformEdit.SetValue(sdiIdentifier("scalefactor_x"), sdiValue(a1));
              transformEdit.SetValue(sdiIdentifier("scalefactor_y"), sdiValue(a2));
              transformEdit.SetValue(sdiIdentifier("scalefactor_z"), sdiValue(a3));
-
-             HandleNodeEdit nodeHEdit;
-             sdiTriple centroid(0.0, 0.0, 0.0);
-             p_radiossModel->CreateNode(nodeHEdit, "/NODE", centroid);
-             if (nodeHEdit.IsValid())
-                 transformEdit.SetValue(sdiIdentifier("node1"), sdiValue(sdiValueEntity(1, nodeHEdit.GetId(p_radiossModel))));
-
          }
          else if (OPTION == "MIRROR" )
          {

--- a/reader/source/dyna2rad/dyna2rad/_private/convertmats.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/convertmats.cxx
@@ -12114,6 +12114,7 @@ void ConvertMat::p_ConvertEOS1(const EntityRead& lsdEosEntRead, sdiString& destC
     p_ConvertUtils.CopyValue(lsdEosEntRead, radEosEdit, "C3", "C3");
     p_ConvertUtils.CopyValue(lsdEosEntRead, radEosEdit, "C4", "C4");
     p_ConvertUtils.CopyValue(lsdEosEntRead, radEosEdit, "C5", "C5");
+    p_ConvertUtils.CopyValue(lsdEosEntRead, radEosEdit, "C6", "C6");
     p_ConvertUtils.CopyValue(lsdEosEntRead, radEosEdit, "E0", "MAT_EA");
 
     double lsdV0;

--- a/reader/source/dyna2rad/dyna2rad/_private/convertprops.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/convertprops.cxx
@@ -325,6 +325,11 @@ void ConvertProp::p_ConvertPropBasedOnCard(const EntityRead& dynaProp, const sdi
                     destCard = "/PROP/TYPE14";
                     isolid = 1;
                 }
+                else if (elform == 13 && (matCard.find("*MAT_OGDEN_RUBBER") != string::npos || matCard.find("*MAT_077_O") != string::npos))
+                {
+                    destCard = "/PROP/TYPE14";
+                    isolid = 24;
+                }
                 else if ((matCard.find("*MAT_SPOTWELD") != string::npos) || 
                          (matCard.find("*MAT_ARUP_ADHESIVE") != string::npos) ||
                          (matCard.find("*MAT_COHESIVE_MIXED_MODE_ELASTOPLASTIC_RATE") != string::npos) ||
@@ -454,6 +459,10 @@ void ConvertProp::p_ConvertPropBasedOnCard(const EntityRead& dynaProp, const sdi
                     {
                         radPropEdit.SetValue(sdiIdentifier("Ismstr"), sdiValue(10));
                     }
+                }
+                else if (elform == 13 && (matCard.find("*MAT_OGDEN_RUBBER") != string::npos || matCard.find("*MAT_077_O") != string::npos))
+                {
+                    radPropEdit.SetValue(sdiIdentifier("Itetra4"), sdiValue(3));
                 }
             }
             else if (keyword == "*SECTION_SEATBELT")

--- a/reader/source/dyna2rad/dyna2rad/_private/converttimehistory.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/converttimehistory.cxx
@@ -317,9 +317,7 @@ void sdiD2R::ConvertTimeHistory::p_ConvertAllDBHistroy()
             if (elementHRead.IsValid())
             {
                 HandleRead partHRead;
-                ElementRead elementdynaRead(p_lsdynaModel, elementHRead);
-                HandleRead partdynaHRead = elementdynaRead.GetOwner();
-
+                elementHRead.GetEntityHandle(p_lsdynaModel, sdiIdentifier("PID"), partHRead);
                 if (partHRead.IsValid())
                 {
                     HandleRead propHRead;


### PR DESCRIPTION
This pull request introduces several targeted improvements and bug fixes across the `reader/source/dyna2rad/dyna2rad/_private` module, focusing on contact handling, control volume entity mapping, property conversion, and time history processing. The changes enhance compatibility with additional entity types, correct mapping logic, and ensure more robust data handling for various simulation scenarios.

**Contact and Entity Handling Enhancements:**

* Added support for `AUTOMATIC_NODES_TO_SURFACE` and `ERODING_NODES_TO_SURFACE` contact types in `ConvertContact::ConvertEntities()`, ensuring these are properly recognized and processed. [[1]](diffhunk://#diff-e7ff61aa134ea48ca243aa50b96a11c664f354e5715a2e3fdc874270edb05754R402-R406) [[2]](diffhunk://#diff-e7ff61aa134ea48ca243aa50b96a11c664f354e5715a2e3fdc874270edb05754R425-R426)
* Updated logic for setting the `IGAP` parameter to use `lsdMST` instead of duplicate checks on `lsdSFST`, improving the assignment's correctness.

**Control Volume and Entity Mapping Fixes:**

* Changed the entity handle lookup from `"PART"` to `"part_ID"` in multiple locations within `ConvertControlVolume::ConvertInitialFoamReferenceGeometry()`, ensuring correct part identification. [[1]](diffhunk://#diff-f704fff46831ff115139b6a56397000440cd62ff53ac2b74407f74d8b139e8feL738-R738) [[2]](diffhunk://#diff-f704fff46831ff115139b6a56397000440cd62ff53ac2b74407f74d8b139e8feL761-R761) [[3]](diffhunk://#diff-f704fff46831ff115139b6a56397000440cd62ff53ac2b74407f74d8b139e8feL785-R785) [[4]](diffhunk://#diff-f704fff46831ff115139b6a56397000440cd62ff53ac2b74407f74d8b139e8feL923-R923) [[5]](diffhunk://#diff-f704fff46831ff115139b6a56397000440cd62ff53ac2b74407f74d8b139e8feL957-R957) [[6]](diffhunk://#diff-f704fff46831ff115139b6a56397000440cd62ff53ac2b74407f74d8b139e8feL991-R991)
* Updated time history entity mapping to use `"PID"` for part identification, replacing the previous owner-based approach for improved reliability.

**Property and Material Conversion Improvements:**

* Added handling for Ogden rubber materials (`*MAT_OGDEN_RUBBER`, `*MAT_077_O`) with `elform == 13` in `ConvertProp::p_ConvertPropBasedOnCard`, mapping them to the correct property type and setting `isolid` and `Itetra4` appropriately. [[1]](diffhunk://#diff-4ac5bd496a6924e0b3e9ec641c60d6e3bb17b68a79ec8fd99a022b17df17d827R328-R332) [[2]](diffhunk://#diff-4ac5bd496a6924e0b3e9ec641c60d6e3bb17b68a79ec8fd99a022b17df17d827R463-R466)
* Included support for copying the `C6` parameter in equation of state conversion, ensuring all relevant material properties are transferred.

**Control and Time Step Logic Adjustments:**

* Broadened the condition for AMS entity creation to include both `IMSCLOptFlag == 2` and `IMSCLOptFlag == 3` in `ConvertCard::p_ConvertCtrlTimeStep()`, and removed unnecessary nested checks for group part ID. [[1]](diffhunk://#diff-5786a09bb92ca9175da7159e1123114781841ce098fdb2dab6e198242774d441L220-L226) [[2]](diffhunk://#diff-5786a09bb92ca9175da7159e1123114781841ce098fdb2dab6e198242774d441L238)
* Refined beam animation selection logic to activate for `nobeam == 0` or `nobeam == 2`, instead of only when `nobeam > 0`.

**Code Cleanup:**

* Removed unused node creation logic from `ConvertDefineTransform::ConvertSelectedEntity`, streamlining the transform setup process.