### PR TITLE
openReader : correction cfg file for *ELEMENT_BEAM_ORIENTATION reading

### DIFF
--- a/hm_cfg_files/config/CFG/Keyword971/ELEMENTS/beam.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/ELEMENTS/beam.cfg
@@ -369,10 +369,12 @@ FORMAT(Keyword971)
         {
             CARD("%10lg%10lg%10lg%10lg%10lg%10lg", offsetax, offsetay,offsetaz, offsetbx, offsetby, offsetbz);
         }
+        */
         if(if_ORIENTATION   == 1)
         {
             CARD("%10lg%10lg%10lg", LSD_VX,LSD_VY,LSD_VZ);
         }
+        /*
         if(if_WARPAGE   == 1)
         {
             CARD("%10d%10d",SN1,SN2);


### PR DESCRIPTION
This pull request makes a minor adjustment to the formatting of beam element configuration in the `beam.cfg` file. The change involves rearranging comment blocks to clarify which sections of code are commented out and which are active.