### PR TITLE
debug issue h3d per group of part

### DIFF
--- a/engine/source/output/h3d/h3d_build_fortran/create_h3d_output_per_part.F90
+++ b/engine/source/output/h3d/h3d_build_fortran/create_h3d_output_per_part.F90
@@ -132,13 +132,7 @@
               if(index > 0) then
                 do i=1,igrpart(index)%nentity
                   k = igrpart(index)%entity(i)  ! get the part id from the group
-                  ! find the part with this id
-                  do m=1,npart
-                    if (ipart(4,m) == k) then
-                      h3d_data%output_list(h3d_data%n_outp_h3d)%part(m) = 1
-                      exit
-                    end if
-                  end do
+                  h3d_data%output_list(h3d_data%n_outp_h3d)%part(k) = 1
                 end do
               end if
             end if


### PR DESCRIPTION
This pull request simplifies the logic for marking parts in the output list within the `create_h3d_output_per_part` subroutine. Instead of searching for the part index in a loop, it now directly uses the part ID to update the output list, making the code more efficient and easier to read.

Code simplification and efficiency:

* In `create_h3d_output_per_part.F90`, replaced the loop that searched for the part index with a direct assignment using the part ID `k` to update `h3d_data%output_list(h3d_data%n_outp_h3d)%part`. This removes unnecessary iteration and improves performance.