### PR TITLE
correction, use of INITEMP with SETs, GRNOD was not built

### DIFF
--- a/hm_cfg_files/config/CFG/radioss100/LOADS/imptemp.cfg
+++ b/hm_cfg_files/config/CFG/radioss100/LOADS/imptemp.cfg
@@ -21,7 +21,7 @@ ATTRIBUTES(COMMON) {
  
  curveid    = VALUE(FUNCT,"Time function identifier");
  rad_sensor_id = VALUE(SENSOR, "Sensor identifier");
- entityid = VALUE(SETS,"Node group to which the imposed temperature is applied");
+ entityid = VALUE(SETS,"Node group to which the imposed temperature is applied") { SUBTYPES = (/SETS/GRNOD); }
  xscale  = VALUE(FLOAT, "Abscissa scale factor for funct_IDT");
  magnitude  = VALUE(FLOAT, "Ordinate scale factor for funct_IDT");
  rad_tstart = VALUE(FLOAT, "Start time");


### PR DESCRIPTION
This pull request introduces a small change to the configuration of imposed temperature loads in the `imptemp.cfg` file. The change improves the specificity of the `entityid` attribute by restricting its allowed subtypes.

* Configuration improvement:
  * [`hm_cfg_files/config/CFG/radioss100/LOADS/imptemp.cfg`](diffhunk://#diff-ef88ec5a5310a9718859bf5a5439765640bd74d9dac6ff6c77f3e11dac007531L24-R24): Updated the `entityid` attribute to specify `SUBTYPES = (/SETS/GRNOD)`, restricting the node group to which the imposed temperature can be applied to only those of subtype `GRNOD`.