### PR TITLE
Engine build_script.sh: Add a warning for MPI options without MPI

### DIFF
--- a/engine/build_script.sh
+++ b/engine/build_script.sh
@@ -90,6 +90,7 @@ ADF=""
 MPI="-DMPI=smp"
 pmpi="SMP Only"
 clean=0
+mpi=0
 mpi_os=0
 mpi_root=""
 mpi_libdir=""
@@ -135,6 +136,7 @@ else
          then
             dmpi=_${pmpi}
             MPI=-DMPI=${pmpi}
+            mpi=1
          else 
             pmpi="SMP Only"
          fi
@@ -284,6 +286,16 @@ else
        fi
 
    done
+
+   if [[ $mpi == 0 && ($mpi_os == 1 || -n $mpi_root || -n $mpi_libdir || -n $mpi_incdir) ]]
+   then
+     echo " "
+     echo "Warning:"
+     echo "--------"
+     echo "You have provided MPI options, but not enabled MPI."
+     echo "Set the MPI implementation with -mpi=[mpi]."
+     echo " "
+   fi
 
    if [ $got_arch == 0 ] 
    then


### PR DESCRIPTION
#### Description of the feature or the bug

Prevents misuses such as:

```
./build_script.sh -arch=linux64_gf -mpi-os
```

The trail of thought that led me to this was:

1. Try with `-mpi=ompi`
2. Get an error that the MPI header is not found
3. I see that I can either set paths, or set `-mpi-os` (assuming "instead of `-mpi=[mpi]`"). I assume that this will just pick whatever it finds first, on my responsibility and convenience.
4. It does not complain, and I assume I have built with MPI. However, `-DMPI` does not appear in the build flags.


#### Description of the changes

In the `engine/build_script.sh`, adds:

- a variable `mpi`, initialized to 0, set to 1 `if [ "$pmpi" != "smp" ]`
- check if `mpi` is set to 0 while any of the `mpi_os`, `mpi_root`, `mpi_libdir`, `mpi_incdir` is not default. If yes, throw a warning.

Warning instead of error to not break any workflows. But in my case, I would have preferred to have received an error.

