### PR TITLE
openReader : correction issue for TITLE solvernames SLIPRING RETRACTOR SUBDOMAIN INIVOL

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2022/RAD2R/subdomain.cfg
+++ b/hm_cfg_files/config/CFG/radioss2022/RAD2R/subdomain.cfg
@@ -21,7 +21,7 @@ ATTRIBUTES {
   // Single values
   idsmax              =  SIZE("Number of COMPONENT");
   ids                 =  ARRAY[idsmax](COMPONENT, "Identifiers of the parts of the subdomain");
-  displayname         =  VALUE(STRING, "Title"); 
+  displayname         =  VALUE(STRING, "Title","TITLE");
   negativeIdsmax      =  SIZE("No. Negative item");
   negativeIds         =  ARRAY[negativeIdsmax](COMPONENT, "Set negative list item");
 

--- a/hm_cfg_files/config/CFG/radioss2022/SEATBELTS/retractor.cfg
+++ b/hm_cfg_files/config/CFG/radioss2022/SEATBELTS/retractor.cfg
@@ -34,7 +34,7 @@ ATTRIBUTES {
   Yscale1        = VALUE(FLOAT, "Loading function ordinate scale factor");
   Xscale2        = VALUE(FLOAT, "Pretensioner pullin function abcissa scale factor");
   Yscale2        = VALUE(FLOAT, "Pretensioner pullin function ordinatescale factor");
-  displayname    = VALUE(STRING, "Title");
+  displayname    = VALUE(STRING, "Title","TITLE");
 }
 
 DEFAULTS {

--- a/hm_cfg_files/config/CFG/radioss2022/SEATBELTS/slipring.cfg
+++ b/hm_cfg_files/config/CFG/radioss2022/SEATBELTS/slipring.cfg
@@ -39,7 +39,7 @@ ATTRIBUTES {
   Xscale3         = VALUE(FLOAT, "Static abcissa time scale factor");
   Xscale4         = VALUE(FLOAT, "Static abcissa force scale factor");
   Yscale4         = VALUE(FLOAT, "Static ordinate force scale factor");
-  displayname     = VALUE(STRING, "Title");
+  displayname     = VALUE(STRING, "Title","TITLE");
 }
 
 DEFAULTS {

--- a/hm_cfg_files/config/CFG/radioss2025/TABLE/inivol.cfg
+++ b/hm_cfg_files/config/CFG/radioss2025/TABLE/inivol.cfg
@@ -24,7 +24,7 @@ ATTRIBUTES(COMMON)
     secondarycomponentlist                  = ARRAY[secondarycomponentlistmax](COMPONENT, "Part of multi-material ALE elements to be filled");
 
     //Card 1
-    displayname                             = VALUE(STRING, "Initial volume fraction title");
+    displayname                             = VALUE(STRING, "Initial volume fraction title","TITLE");
 
     //Cards
     NIP                                     = SIZE("No. of items to be filled");


### PR DESCRIPTION
This pull request standardizes the definition of the `displayname` attribute across several configuration files by adding an additional `"TITLE"` label to its declaration. This change improves consistency and may enhance compatibility with tools or scripts that expect this label.

Attribute definition updates:

* In the following files, the `displayname` attribute now includes both `"Title"` and `"TITLE"` as labels in its declaration:  
  - `hm_cfg_files/config/CFG/radioss2022/RAD2R/subdomain.cfg`
  - `hm_cfg_files/config/CFG/radioss2022/SEATBELTS/retractor.cfg`
  - `hm_cfg_files/config/CFG/radioss2022/SEATBELTS/slipring.cfg`
  - `hm_cfg_files/config/CFG/radioss2025/TABLE/inivol.cfg`