### PR TITLE
openReader : correction issue reading /groups/GEN_INCR

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2026/data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/radioss2026/data_hierarchy.cfg
@@ -436,7 +436,7 @@ HIERARCHY {
             ID_POOL    = 32;
             USER_NAMES = (GRNOD,GRNOD_BOX,
                            GRNOD_NODE,GRNOD_NODENS,
-                           GRNOD_GEN_INCR,GRNOD_GENE,
+                           GRNOD/GEN_INCR,GRNOD_GEN_INCR,GRNOD_GENE,
                            GRNOD_GRNOD,GRNOD_SURF,GRNOD_LINE,  
                            GRNOD_GRBEAM, GRNOD_GRSPRI,  GRNOD_GRTRUS, 
                            GRNOD_GRBRIC, GRNOD_GRSHEL, GRNOD_GRSH3N,  GRNOD_GRQUAD, 
@@ -455,7 +455,7 @@ HIERARCHY {
             USER_ID    = 2;
             ID_POOL    = 33;
             USER_NAMES = (GRSHEL,GRSHEL_BOX,GRSHEL_BOX2,
-                           GRSHEL_GEN_INCR,GRSHEL_GENE,
+                           GRSHEL/GEN_INCR,GRSHEL_GEN_INCR,GRSHEL_GENE,
                            GRSHEL_SHEL,GRSHEL_GRSHEL,
                            GRSHEL_PART,GRSHEL_MAT,  GRSHEL_PROP,
                            GRSHEL_SUBMODEL, GRSHEL_SUBSET);
@@ -472,7 +472,7 @@ HIERARCHY {
             USER_ID    = 3;
             ID_POOL    = 34;
             USER_NAMES = (GRBEAM,GRBEAM_BOX,GRBEAM_BOX2,
-                           GRBEAM_GEN_INCR,GRBEAM_GENE,
+                           GRBEAM/GEN_INCR,GRBEAM_GEN_INCR,GRBEAM_GENE,
                            GRBEAM_BEAM,GRBEAM_GRBEAM,
                            GRBEAM_PART,GRBEAM_MAT,  GRBEAM_PROP,
                            GRBEAM_SUBMODEL, GRBEAM_SUBSET);
@@ -489,7 +489,7 @@ HIERARCHY {
             USER_ID    = 4;
             ID_POOL    = 35;
             USER_NAMES = (GRBRIC,GRBRIC_BOX,GRBRIC_BOX2,
-                           GRBRIC_GEN_INCR,GRBRIC_GENE,
+                           GRBRIC/GEN_INCR,GRBRIC_GEN_INCR,GRBRIC_GENE,
                            GRBRIC_BRIC,GRBRIC_GRBRIC,
                            GRBRIC_PART,GRBRIC_MAT,  GRBRIC_PROP,
                            GRBRIC_SUBMODEL, GRBRIC_SUBSET);
@@ -506,7 +506,7 @@ HIERARCHY {
             USER_ID    = 5;
             ID_POOL    = 36;
             USER_NAMES = (GRTRUS,GRTRUS_BOX,GRTRUS_BOX2,
-                           GRTRUS_GEN_INCR,GRTRUS_GENE,
+                           GRTRUS/GEN_INCR,GRTRUS_GEN_INCR,GRTRUS_GENE,
                            GRTRUS_TRUS,GRTRUS_GRTRUS,
                            GRTRUS_PART,GRTRUS_MAT,  GRTRUS_PROP,
                            GRTRUS_SUBMODEL, GRTRUS_SUBSET);
@@ -523,7 +523,7 @@ HIERARCHY {
             USER_ID    = 6;
             ID_POOL    = 37;
             USER_NAMES = (GRSPRI,GRSPRI_BOX,GRSPRI_BOX2,
-                           GRSPRI_GEN_INCR,GRSPRI_GENE,
+                           GRSPRI/GEN_INCR,GRSPRI_GEN_INCR,GRSPRI_GENE,
                            GRSPRI_SPRI,GRSPRI_GRSPRI,
                            GRSPRI_PART,GRSPRI_MAT,  GRSPRI_PROP,
                            GRSPRI_SUBMODEL, GRSPRI_SUBSET);
@@ -540,7 +540,7 @@ HIERARCHY {
             USER_ID    = 7;
             ID_POOL    = 38;
             USER_NAMES = (GRQUAD,GRQUAD_BOX,GRQUAD_BOX2,
-                           GRQUAD_GEN_INCR,GRQUAD_GENE,
+                           GRQUAD/GEN_INCR,GRQUAD_GEN_INCR,GRQUAD_GENE,
                            GRQUAD_QUAD,GRQUAD_GRQUAD,
                            GRQUAD_PART,GRQUAD_MAT,  GRQUAD_PROP,
                            GRQUAD_SUBMODEL, GRQUAD_SUBSET);
@@ -557,7 +557,7 @@ HIERARCHY {
             USER_ID    = 15;
            /* ID_POOL    = 38;*/
             USER_NAMES = (GRTRIA,GRTRIA_BOX,GRTRIA_BOX2,
-                           GRTRIA_GEN_INCR,GRTRIA_GENE,
+                           GRTRIA/GEN_INCR,GRTRIA_GEN_INCR,GRTRIA_GENE,
                            GRTRIA_TRIA,GRTRIA_GRTRIA,
                            GRTRIA_PART,GRTRIA_MAT,  GRTRIA_PROP,
                            GRTRIA_SUBMODEL, GRTRIA_SUBSET);
@@ -574,7 +574,7 @@ HIERARCHY {
             USER_ID    = 8;
             ID_POOL    = 39;
             USER_NAMES = (GRSH3N,GRSH3N_BOX,GRSH3N_BOX2,
-                           GRSH3N_GEN_INCR,GRSH3N_GENE,
+                           GRSH3N/GEN_INCR,GRSH3N_GEN_INCR,GRSH3N_GENE,
                            GRSH3N_SH3N,GRSH3N_GRSH3N,
                            GRSH3N_PART,GRSH3N_MAT,  GRSH3N_PROP,
                            GRSH3N_SUBMODEL, GRSH3N_SUBSET);
@@ -645,7 +645,7 @@ HIERARCHY {
             USER_ID    = 12;
             ID_POOL    = 41;
             USER_NAMES = (LINE,LINE_BOX,LINE_BOX2,
-                          /* LINE_GEN_INCR,LINE_GENE,*/
+                          /* LINE/GEN_INCR,LINE_GEN_INCR,LINE_GENE,*/
                            LINE_SEG,LINE_LINE,LINE_SURF,LINE_EDGE,
                            LINE_GRBEAM,LINE_GRSPRI,LINE_GRTRUS,
                            LINE_PART,LINE_MAT,  LINE_PROP,
@@ -663,7 +663,7 @@ HIERARCHY {
             USER_ID    = 13;
             ID_POOL    = 44;
             USER_NAMES = (GRPART,
-                           GRPART_GEN_INCR,GRPART_GENE,
+                           GRPART/GEN_INCR,GRPART_GEN_INCR,GRPART_GENE,
                            GRPART_PART,GRPART_GRPART,
                            GRPART_PART,GRPART_MAT,  GRPART_PROP,
                            GRPART_SUBMODEL, GRPART_SUBSET);


### PR DESCRIPTION
This pull request updates the `USER_NAMES` lists in the `data_hierarchy.cfg` configuration file for Radioss 2026. The main change is the addition of new entries with a slash (e.g., `GRNOD/GEN_INCR`) alongside the existing underscore versions (e.g., `GRNOD_GEN_INCR`) for several element groups. This likely improves compatibility or naming consistency within the configuration.

**Element group naming updates:**

* Added new `GROUP/GEN_INCR` entries (with a slash) in addition to the existing `GROUP_GEN_INCR` (with an underscore) for the following element groups in the `USER_NAMES` lists:
  - `GRNOD`, `GRSHEL`, `GRBEAM`, `GRBRIC`, `GRTRUS`, `GRSPRI`, `GRQUAD`, `GRTRIA`, `GRSH3N`, and `GRPART` [[1]](diffhunk://#diff-a363c0d8a651ff98903e29e2017b1b7de6bec2b0f30a751e6e3c427dc5495302L439-R439) [[2]](diffhunk://#diff-a363c0d8a651ff98903e29e2017b1b7de6bec2b0f30a751e6e3c427dc5495302L458-R458) [[3]](diffhunk://#diff-a363c0d8a651ff98903e29e2017b1b7de6bec2b0f30a751e6e3c427dc5495302L475-R475) [[4]](diffhunk://#diff-a363c0d8a651ff98903e29e2017b1b7de6bec2b0f30a751e6e3c427dc5495302L492-R492) [[5]](diffhunk://#diff-a363c0d8a651ff98903e29e2017b1b7de6bec2b0f30a751e6e3c427dc5495302L509-R509) [[6]](diffhunk://#diff-a363c0d8a651ff98903e29e2017b1b7de6bec2b0f30a751e6e3c427dc5495302L526-R526) [[7]](diffhunk://#diff-a363c0d8a651ff98903e29e2017b1b7de6bec2b0f30a751e6e3c427dc5495302L543-R543) [[8]](diffhunk://#diff-a363c0d8a651ff98903e29e2017b1b7de6bec2b0f30a751e6e3c427dc5495302L560-R560) [[9]](diffhunk://#diff-a363c0d8a651ff98903e29e2017b1b7de6bec2b0f30a751e6e3c427dc5495302L577-R577) [[10]](diffhunk://#diff-a363c0d8a651ff98903e29e2017b1b7de6bec2b0f30a751e6e3c427dc5495302L666-R666).

* For the `LINE` group, updated the commented-out `USER_NAMES` to include the new `LINE/GEN_INCR` entry alongside the existing ones.