### PR TITLE
/ANIM/ELEM/VEL : 2d compatibility with HLLC scheme

### DIFF
--- a/engine/source/output/anim/generate/dfuncc.F
+++ b/engine/source/output/anim/generate/dfuncc.F
@@ -151,6 +151,7 @@ C-----------------------------------------------
       my_real :: RHOi(21) !< submaterial  mass densities (max submat : 21)
       my_real :: RHO0g !< global initial mass density (mixture)
       LOGICAL detected
+      INTEGER :: IDX0,IDX1,IDX2
 C-----------------------------------------------
       CALL MY_ALLOC(WAL,NBF_L)
       NN1  = 1
@@ -160,6 +161,9 @@ C-----------------------------------------------
       NN6  = NN5 + NUMELTG
       NN9  = NN6 
       ISH_EINT = 13242 + 4*MX_PLY_ANIM + 2
+      IDX0 = 15921 + 4*MX_PLY_ANIM  ! VEL-Y 0:10
+      IDX1 = IDX0+10+1              ! VEL-Z 0:10
+      IDX2 = IDX1+10+1              ! VEL   0:10
       
       !-------------------------------------------------------!
       !     INITIALIZATION IF SCHLIEREN DEFINED               !
@@ -989,7 +993,7 @@ c------------------------------------ Tillotson Region id
                 ENDIF
               ENDIF
 
-c------------------------------------ Volumetric Strain (VSTRAIN)
+c------------------------------------ Volumetric Strain (GLOBAL VSTRAIN)
             elseif(IFUNC == 15899 + 4*MX_PLY_ANIM .and. N2D > 0) then
 !--------------------------------------------------
               DO I=LFT,LLT
@@ -1114,7 +1118,7 @@ c------------------------------------ Volumetric Strain (VSTRAIN)
                 end if
 
               enddo
-c------------------------------------ Volumetric Strain (VSTRAIN)
+c------------------------------------ Volumetric Strain (submaterial VSTRAIN)
             elseif(   IFUNC >= 15899 + 4*MX_PLY_ANIM +1
      .          .and. IFUNC <= 15899 + 4*MX_PLY_ANIM +10
      .          .and. N2D > 0) then
@@ -1192,12 +1196,51 @@ c------------------------------------ Volumetric Strain (VSTRAIN)
                       FUNC(EL2FA(NN3+NFT+I)) = ZERO
                     end if
                 enddo
-
-              end if
-
+            end if
 
 
-c------------------------------------ 
+c------------------------------------ 2D velocity VEL-GLOBAL
+          elseif( IFUNC >= IDX0 .AND. IFUNC <= IDX0+10) then
+            ILAY = IFUNC - IDX0
+            IF(MLW == 151 .AND. ILAY == 0)THEN
+              DO I=LFT,LLT
+                VEL(1) = MULTI_FVM%VEL(1, I + NFT)
+                VEL(2) = MULTI_FVM%VEL(2, I + NFT)
+                VEL(3) = MULTI_FVM%VEL(3, I + NFT)
+                FUNC(EL2FA(NN3+NFT+I)) = SQRT(VEL(1)*VEL(1)+VEL(2)*VEL(2)+VEL(3)*VEL(3))
+              ENDDO
+            ELSE
+              DO I=LFT,LLT
+                FUNC(EL2FA(NN3+NFT+I)) = ZERO
+              ENDDO
+            ENDIF
+c------------------------------------ 2D velocity VEL-Y
+          elseif( IFUNC >= IDX1 .AND. IFUNC <= IDX1+10) then
+            ILAY = IFUNC - IDX1
+            IF(MLW == 151 .AND. ILAY == 0)THEN
+              DO I=LFT,LLT
+                VEL(2) = MULTI_FVM%VEL(2, I + NFT)
+                FUNC(EL2FA(NN3+NFT+I)) = VEL(2)
+              ENDDO
+            ELSE
+              DO I=LFT,LLT
+                FUNC(EL2FA(NN3+NFT+I)) = ZERO
+              ENDDO
+            ENDIF
+c------------------------------------ 2D velocity VEL-Z
+          elseif( IFUNC >= IDX2 .AND. IFUNC <= IDX2+10) then
+            ILAY = IFUNC - IDX2
+            IF(MLW == 151 .AND. ILAY == 0)THEN
+              DO I=LFT,LLT
+                VEL(3) = MULTI_FVM%VEL(3, I + NFT)
+                FUNC(EL2FA(NN3+NFT+I)) = VEL(3)
+              ENDDO
+            ELSE
+              DO I=LFT,LLT
+                FUNC(EL2FA(NN3+NFT+I)) = ZERO
+              ENDDO
+            ENDIF
+c------------------------------------
             ELSE                                                      
               DO  I=LFT,LLT                                           
                 FUNC(EL2FA(NN3+NFT+I)) = ZERO                         

--- a/engine/source/output/anim/generate/genani.F
+++ b/engine/source/output/anim/generate/genani.F
@@ -404,7 +404,7 @@ C-----------------------------------------------
 
         CHARACTER*80 STR, MES*30, CAUX,TITL*100
         CHARACTER CHANIM*9,FILNAM*100, CHANIM1*4
-        INTEGER I, IDX,NBF, NBPART, MAGIC, J, IFUNC, FILEN, NPSOL,
+        INTEGER I, IDX,IDX0,IDX1,IDX2,NBF, NBPART, MAGIC, J, IFUNC, FILEN, NPSOL,
      .          NODCUT,NELCUT,LENR,LENI,LENCUT,LENCUTO,IXEL,
      .          MIC1,MIC2,MIC3,MIC4,MIC5,MAC1,MAC2,MAC3,NPSPR,N,K,
      .          I3000, NESCT,NERBY,NERWL,NNWL,TMPNBF,ISK(6),
@@ -2596,6 +2596,49 @@ C all NPTT for PID51
             IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 8',21)
             IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 9',21)
             IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Volumetric Strain - 10',22)
+
+            IDX0 = 15921 + 4*MX_PLY_ANIM  ! VEL-Y 0:10
+            IDX1 = IDX0+10+1              ! VEL-Z 0:10
+            IDX2 = IDX1+10+1              ! VEL   0:10
+
+            IDX = IDX0-1
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Magnitude',18)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Magnitude - 1',22) !phase 1 (multimat)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Magnitude - 2',22)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Magnitude - 3',22)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Magnitude - 4',22)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Magnitude - 5',22)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Magnitude - 6',22)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Magnitude - 7',22)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Magnitude - 8',22)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Magnitude - 9',22)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Magnitude - 10',23)
+
+            IDX = IDX1-1
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Y',10)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Y - 1',14) !phase 1 (multimat)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Y - 2',14)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Y - 3',14)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Y - 4',14)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Y - 5',14)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Y - 6',14)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Y - 7',14)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Y - 8',14)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Y - 9',14)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Y - 10',15)
+
+            IDX = IDX2-1
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Z',10)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Z - 1',14) !phase 1 (multimat)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Z - 2',14)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Z - 3',14)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Z - 4',14)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Z - 5',14)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Z - 6',14)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Z - 7',14)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Z - 8',14)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Z - 9',14)
+            IDX=IDX+1; IF(ANIM_CE(IDX) == 1) CALL ANI_TXT('Velocity Z - 10',15)
 
             !---NEXT ANIM
             !IDX=IDX+1

--- a/engine/source/output/anim/reader/anim_dcod_key_0.F
+++ b/engine/source/output/anim/reader/anim_dcod_key_0.F
@@ -64,7 +64,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I, IDX, N1, N2, N3, ITYP,IADG, J,NTITLE,IUS,ILAY,IPT
+      INTEGER I, IDX,IDX0,IDX1,IDX2, N1, N2, N3, ITYP,IADG, J,NTITLE,IUS,ILAY,IPT
       my_real X0,Y0,Z0,VNX,VNY,VNZ,V0
       LOGICAL :: LAW51_PHASE1, LAW51_PHASE2, LAW51_PHASE3, LAW51_PHASE4
 C-----------------------------------------------
@@ -2607,19 +2607,63 @@ C--------------------------
          ENDIF
        ELSEIF(KEY3(1:3) == 'VEL' .OR. KEY3(2:4) == 'VEL' )THEN
          IF(KEY3(1:5) == 'VEL  ')THEN
+           ! 3d
            ANIM_SE(4945) =1
            ANIM_SE(4946) =1
            ANIM_SE(4947) =1
            ANIM_SE(4948) =1
            ANIM_SE(4949) =1
            ANIM_SE(4950) =1 
-           ANIM_SE(4951) =1                         
+           ANIM_SE(4951) =1
+           ! 2d
+           IDX0 = 15921 + 4*MX_PLY_ANIM  ! VEL-Y 0:10
+           IDX1 = IDX0+10+1              ! VEL-Z 0:10
+           IDX2 = IDX1+10+1              ! VEL   0:10
+           ANIM_CE(IDX0) = 1
+           ANIM_CE(IDX1) = 1
+           ANIM_CE(IDX2) = 1
+           IF(KEY4(1:2) == '10')THEN
+             ANIM_CE(IDX2+10) = 1
+             ANIM_CE(IDX2+10) = 1
+             ANIM_CE(IDX2+10) = 1
+           ELSEIF(KEY4(1:1) >= '1' .AND. KEY4(1:1) <= '9') THEN
+             ILAY = ICHAR(KEY4(1:1)) - ICHAR('0')
+             ANIM_CE(IDX2+ILAY) = 1
+             ANIM_CE(IDX2+ILAY) = 1
+             ANIM_CE(IDX2+ILAY) = 1
+           ENDIF
          ELSEIF(KEY3(1:5) == 'VELX ')THEN
            ANIM_SE(4945) =1
          ELSEIF(KEY3(1:5) == 'VELY ')THEN
            ANIM_SE(4946) =1
+           IDX0 = 15921 + 4*MX_PLY_ANIM  ! VEL-Y 0:10
+           IDX1 = IDX0+10+1              ! VEL-Z 0:10
+           IDX2 = IDX1+10+1              ! VEL   0:10
+           IF(KEY4(1:2) == '10')THEN
+             ANIM_CE(IDX0+10) = 1
+             ANIM_CE(IDX0+10) = 1
+             ANIM_CE(IDX0+10) = 1
+           ELSEIF(KEY4(1:1) >= '1' .AND. KEY4(1:1) <= '9') THEN
+             ILAY = ICHAR(KEY4(1:1)) - ICHAR('0')
+             ANIM_CE(IDX0+ILAY) = 1
+             ANIM_CE(IDX0+ILAY) = 1
+             ANIM_CE(IDX0+ILAY) = 1
+           ENDIF
          ELSEIF(KEY3(1:5) == 'VELZ ')THEN
            ANIM_SE(4947) =1
+           IDX0 = 15921 + 4*MX_PLY_ANIM  ! VEL-Y 0:10
+           IDX1 = IDX0+10+1              ! VEL-Z 0:10
+           IDX2 = IDX1+10+1              ! VEL   0:10
+           IF(KEY4(1:2) == '10')THEN
+             ANIM_CE(IDX1+10) = 1
+             ANIM_CE(IDX1+10) = 1
+             ANIM_CE(IDX1+10) = 1
+           ELSEIF(KEY4(1:1) >= '1' .AND. KEY4(1:1) <= '9') THEN
+             ILAY = ICHAR(KEY4(1:1)) - ICHAR('0')
+             ANIM_CE(IDX1+ILAY) = 1
+             ANIM_CE(IDX1+ILAY) = 1
+             ANIM_CE(IDX1+ILAY) = 1
+           ENDIF
          ELSEIF(KEY3(1:5) == 'VELXY')THEN
            ANIM_SE(4948) =1
          ELSEIF(KEY3(1:5) == 'VELYZ')THEN
@@ -2722,7 +2766,9 @@ C--------------------------
            ANIM_SE(5173) = 1
          endif
         !ELSEIF()
-        !  IDX = 15899 + 4*MX_PLY_ANIM +22 + 1
+        ! last used index in ANIM_CE   : IDX =  4*MX_PLY_ANIM + 15943
+        ! next availability in ANIM_CE : IDX =  4*MX_PLY_ANIM + 15944
+        ! last introduction            : VEL,VELy and VELZ for ANIM_CE (2d)
        ELSE
          IXITKEY=IXITKEY+1
        ENDIF


### PR DESCRIPTION
#### /ANIM/ELEM/VEL : 2d compatibility with HLLC scheme

#### Description of the changes
In Animation files (see engine option /ANIM) It is now possible to output velocities (magnitude,y,z) in 2d when using HLLC scheme (collocated).

**Engine Keywords :**
/ANIM/ELEM/VEL
/ANIM/ELEM/VELY
/ANIM/ELEM/VELZ

**Example with Rayleigh-Taylor-instability (64x128 cells) :**
<img width="533" height="292" alt="image" src="https://github.com/user-attachments/assets/3bd24447-c3c4-4292-b930-af28cc42f781" />

genani.F : ANIM_CE is the array associated with output requests (2d solids). New entries have been added for global velocities and, when applicable, potential phase velocities (up to 10) :
<img width="519" height="320" alt="image" src="https://github.com/user-attachments/assets/c54c8472-ff90-410e-bc7b-b323330fdfbf" />


