### PR TITLE
openReader : plug *ELEMENT_SEATBELT READING

### DIFF
--- a/hm_cfg_files/config/CFG/Keyword971/ELEMENTS/seatbelt.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/ELEMENTS/seatbelt.cfg
@@ -20,7 +20,7 @@
 ATTRIBUTES(COMMON) {
   // Common attributes
   NB_ELE    = SIZE("Number of elements");
-  id        = ARRAY[NB_ELE](INT,"Element identifier","EID") { SUBTYPES = (/ELEMENT/BEAM_IDPOOL) ; }
+  id        = ARRAY[NB_ELE](INT,"Element identifier","EID");// { SUBTYPES = (/ELEMENT/BEAM_IDPOOL) ; }
   collector = ARRAY[NB_ELE](INT,"Part","PID");
   node1     = ARRAY[NB_ELE](INT,"Node identifier 1","N1");
   node2     = ARRAY[NB_ELE](INT,"Node identifier 2","N2");
@@ -48,8 +48,8 @@ mandatory:
         SCALAR(node1);
         SCALAR(node2);
  optional:
-        SCALAR(node1);
-        SCALAR(node2);
+        SCALAR(node3);
+        SCALAR(node4);
         DATA(SBRID);
         SCALAR(SLEN) {DIMENSION="l";}
     } 
@@ -61,6 +61,6 @@ FORMAT(Keyword971)
     COMMENT("$    EID     PID      N1      N2   SBRID            SLEN      N3      N4");
     FREE_CARD_LIST(NB_ELE)
     {
-        CARD("%8d%8d%8d%8d%8d%16lg%8d%8d",id,PART,node1,node2,SBRID,SLEN,node3,node4);
+        CARD("%8d%8d%8d%8d%8d%16lg%8d%8d",id,collector,node1,node2,SBRID,SLEN,node3,node4);
     }
 }

--- a/hm_cfg_files/config/CFG/Keyword971_R14.1/data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R14.1/data_hierarchy.cfg
@@ -127,6 +127,19 @@ HIERARCHY
             USER_NAMES     = (ELEMENT_SPH);
         }
     }
+    
+    HIERARCHY {
+        KEYWORD = ELEMENT_SEATBELT_IDPOOL;
+        HIERARCHY {
+            KEYWORD        = ELEMENT_SEATBELT;
+            TITLE          = "ELEMENT_SEATBELT";
+            FILE            = "ELEMENTS/seatbelt.cfg";
+            //HM_CONFIG_TYPE = 1;
+            //HM_TYPE        = 6;
+            //ID_POOL        = 40;
+            USER_NAMES     = (ELEMENT_SEATBELT);
+        }
+    }
 }
 
 HIERARCHY {
@@ -5851,7 +5864,6 @@ HIERARCHY
         HIERARCHY {
             KEYWORD        = SHELL;
             TITLE          = "SHELL";
-          //FILE           = "ELEMENTS/shell.cfg";
             ID_POOL        = 2;
             USER_NAMES     = (SHELL);
         }
@@ -5944,6 +5956,15 @@ HIERARCHY
             TITLE          = "ELEMENT_SPH";
             ID_POOL        = 40;
             USER_NAMES     = (ELEMENT_SPH);
+        }
+    }
+    HIERARCHY {
+        KEYWORD = ELEMENT_SEATBELT_IDPOOL
+        HIERARCHY {
+            KEYWORD        = SEATBELT;
+            TITLE          = "SEATBELT";
+            //ID_POOL        = 11;
+            USER_NAMES     = (SEATBELT);
         }
     }
 }


### PR DESCRIPTION
This pull request updates the configuration files for seatbelt elements, focusing on improving the definition and hierarchy of seatbelt elements and their associated ID pools. The changes enhance how seatbelt elements are structured, referenced, and optionally defined, and add new hierarchy entries for better organization.

**Seatbelt element definition and structure:**

- Commented out the `SUBTYPES` assignment for the `id` attribute in `seatbelt.cfg`, which may affect how element identifiers are validated or pooled.
- Updated the `optional` section to include `node3` and `node4` instead of repeating `node1` and `node2`, allowing for additional node definitions in seatbelt elements.
- Corrected the format string in the `CARD` definition to use `collector` instead of `PART`, ensuring the right attribute is referenced in output formatting.

**Hierarchy and ID pool enhancements:**

- Added a new hierarchy block for `ELEMENT_SEATBELT_IDPOOL` and nested `ELEMENT_SEATBELT` in `data_hierarchy.cfg`, improving the organization and potential pooling of seatbelt elements.
- Added a similar hierarchy for `ELEMENT_SEATBELT_IDPOOL` and nested `SEATBELT` keyword, further supporting seatbelt element management.

**Minor cleanup:**

- Removed a commented-out file reference for the `SHELL` hierarchy entry, likely for clarity.