### PR TITLE
openReader : add security check , valid handle

### DIFF
--- a/reader/source/dyna2rad/dyna2rad/_private/convertrigids.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/convertrigids.cxx
@@ -299,8 +299,8 @@ void sdiD2R::ConvertRigid::ConvertConstrainedExtraNodes()
 
                     HandleRead dynaNODEIDHRead;
                     dynapartHread.GetEntityHandle(p_lsdynaModel, sdiIdentifier("NODEID"), dynaNODEIDHRead);
-                    EntityRead dynaNODEIDRead(p_lsdynaModel, dynaNODEIDHRead);
-
+                    EntityRead dynaNODEIDRead;
+                    if(dynaNODEIDHRead.IsValid()) dynaNODEIDRead = EntityRead(p_lsdynaModel, dynaNODEIDHRead);
                     if(slaveAttName == "NID")
                     {
                         if(slaveEntityId  == dynaNODEIDRead.GetId() &&


### PR DESCRIPTION
This pull request makes a minor update to the `ConvertConstrainedExtraNodes` method to improve robustness when handling node IDs. The change ensures that an `EntityRead` object is only initialized if the corresponding handle is valid, preventing potential errors from invalid handles.

- Improved error handling in `ConvertConstrainedExtraNodes` by checking if `dynaNODEIDHRead` is valid before initializing `dynaNODEIDRead` (`convertrigids.cxx`)