### PR TITLE
th_to_csv issue correction : number of global variables badly taken into account

### DIFF
--- a/tools/th_to_csv/src/th_to_csv.c
+++ b/tools/th_to_csv/src/th_to_csv.c
@@ -1,3 +1,4 @@
+
 //Copyright>
 //Copyright> Copyright (C) 1986-2024 Altair Engineering Inc.
 //Copyright>
@@ -1186,7 +1187,6 @@ void csvFileWrite(char* csvFilename,char* titleFilename,int *nbglobVar,int *nbPa
     tmpImpulse = (float *) malloc(sizeof(float)* *nbTimeStep);
     isImpulse = (int *)    malloc(sizeof(int)*nbData);
 
-
     fprintf(csvFile,"\"time\",");
     fprintf(csvFile,"\"INTERNAL ENERGY\",");
     fprintf(csvFile,"\"KINETIC ENERGY\",");
@@ -1200,17 +1200,28 @@ void csvFileWrite(char* csvFilename,char* titleFilename,int *nbglobVar,int *nbPa
     fprintf(csvFile,"\"SPRING ENERGY\",");
     fprintf(csvFile,"\"CONTACT ENERGY\",");
     fprintf(csvFile,"\"HOURGLASS ENERGY\",");
-
-    if (*nbglobVar >= 15)
-    {
-        fprintf(csvFile,"\"ELASTIC CONTACT ENERGY\",");
-        fprintf(csvFile,"\"FRICTIONAL CONTACT ENERGY\",");
-        fprintf(csvFile,"\"DAMPING CONTACT ENERGY \",");
-    }
+    fprintf(csvFile,"\"ELASTIC CONTACT ENERGY\",");
+    fprintf(csvFile,"\"FRICTIONAL CONTACT ENERGY\",");
+    fprintf(csvFile,"\"DAMPING CONTACT ENERGY \",");
     
-    if (*nbglobVar >= 16)
-    {
+    if(*nbglobVar >= 16)
         fprintf(csvFile,"\"PLASTIC WORK\",");
+    if(*nbglobVar >= 17)
+        fprintf(csvFile,"\"ADDED MASS\",");
+    if(*nbglobVar >= 18)
+        fprintf(csvFile,"\"PERCENTAGE ADDED MASS\",");
+    if(*nbglobVar >= 19)
+        fprintf(csvFile,"\"INLET MASS\",");
+    if(*nbglobVar >= 20)
+        fprintf(csvFile,"\"OUTLET MASS\",");
+    if(*nbglobVar >= 21)
+        fprintf(csvFile,"\"INLET ENERGY\",");
+    if(*nbglobVar >= 22)
+        fprintf(csvFile,"\"OUTLET ENERGY\",");
+    if(*nbglobVar >= 23)
+    {
+        for(i=23;i<=*nbglobVar;i++)
+        fprintf(csvFile,"\"NO NAME\",");
     }
 
     if (!titlesFile)


### PR DESCRIPTION
This pull request updates the CSV output logic in `th_to_csv.c` to improve how global variable columns are written based on their count, making the code more extensible and maintainable. The main changes involve removing hardcoded conditional blocks and introducing a more systematic approach for handling additional columns.

**CSV Output Logic Improvements:**

* Removed the conditional block for writing "ELASTIC CONTACT ENERGY", "FRICTIONAL CONTACT ENERGY", and "DAMPING CONTACT ENERGY" columns, so these columns are always written regardless of `*nbglobVar` value.
* Added new conditional checks to write additional columns ("ADDED MASS", "PERCENTAGE ADDED MASS", "INLET MASS", "OUTLET MASS", "INLET ENERGY", "OUTLET ENERGY") based on increasing values of `*nbglobVar`.
* Introduced a loop to write "NO NAME" columns for any remaining global variables beyond the predefined ones, ensuring all variables are accounted for in the output.

**Code Quality:**

* Minor formatting cleanup by removing an unnecessary blank line in the CSV writing function.

**Documentation:**

* Added copyright header for Altair Engineering Inc. at the top of the file.