### PR TITLE
correction while checking FAIL_ID in /FAIL cards

### DIFF
--- a/starter/source/materials/fail/hm_read_fail.F
+++ b/starter/source/materials/fail/hm_read_fail.F
@@ -188,6 +188,8 @@ c
      .                          KEYWORD2  = KEY    )
 c
         !< Save failure ID to check duplication later
+        CALL HM_GET_BOOLV ('ID_CARD_EXIST',IS_ID_LINE,IS_AVAILABLE)
+        IF ( .NOT.  (IS_ID_LINE)) FAIL_ID = 0
         FAIL_ID_ARRAY(IFAIL) = FAIL_ID
         DO J = 1,IFAIL-1
           IF (FAIL_ID_ARRAY(J) == FAIL_ID .AND. FAIL_ID /= 0) THEN


### PR DESCRIPTION
This pull request introduces a small update to the failure ID handling logic in the `HM_READ_FAIL` subroutine. The change adds a check for the existence of an ID card line before assigning a failure ID, ensuring that `FAIL_ID` is set to zero if the ID line is not present.

* Added a call to `HM_GET_BOOLV` to check for the existence of an ID card line, and now sets `FAIL_ID` to zero if it is not present in `hm_read_fail.F`.