### PR TITLE
correction /INITEMP option with solid elements

### DIFF
--- a/starter/source/elements/elbuf_init/suinit3.F
+++ b/starter/source/elements/elbuf_init/suinit3.F
@@ -198,10 +198,10 @@ c--------------------------
 !      
       IF (JTHE == 0 .and. GLOB_THERM%NINTEMP > 0) THEN
         DO I=1,NEL
-          TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,I)) + TEMP(IXS(3,I))
-     .                           + TEMP(IXS(4,I)) + TEMP(IXS(5,I))        
-     .                           + TEMP(IXS(6,I)) + TEMP(IXS(7,I))        
-     .                           + TEMP(IXS(8,I)) + TEMP(IXS(9,I))) 
+          TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,I+NFT)) + TEMP(IXS(3,I+NFT))
+     .                           + TEMP(IXS(4,I+NFT)) + TEMP(IXS(5,I+NFT))        
+     .                           + TEMP(IXS(6,I+NFT)) + TEMP(IXS(7,I+NFT))        
+     .                           + TEMP(IXS(8,I+NFT)) + TEMP(IXS(9,I+NFT))) 
         ENDDO
       ELSE
         TEMPEL(1:NEL) = PM(79,MAT(1:NEL))

--- a/starter/source/elements/solid/solide/sinit3.F
+++ b/starter/source/elements/solid/solide/sinit3.F
@@ -274,10 +274,10 @@ C Orthotropy wrt reference geometry
 !      
       IF (JTHE == 0 .and. GLOB_THERM%NINTEMP > 0) THEN
         DO I=1,NEL
-          TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,I)) + TEMP(IXS(3,I))
-     .                           + TEMP(IXS(4,I)) + TEMP(IXS(5,I))        
-     .                           + TEMP(IXS(6,I)) + TEMP(IXS(7,I))        
-     .                           + TEMP(IXS(8,I)) + TEMP(IXS(9,I))) 
+          TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,NFT+I)) + TEMP(IXS(3,NFT+I))
+     .                           + TEMP(IXS(4,NFT+I)) + TEMP(IXS(5,NFT+I))        
+     .                           + TEMP(IXS(6,NFT+I)) + TEMP(IXS(7,NFT+I))        
+     .                           + TEMP(IXS(8,NFT+I)) + TEMP(IXS(9,NFT+I))) 
         ENDDO
       ELSE
         TEMPEL(1:NEL) = TEMP0(1:NEL)

--- a/starter/source/elements/solid/solide4/s4init3.F
+++ b/starter/source/elements/solid/solide4/s4init3.F
@@ -208,10 +208,10 @@ C
 !      
       IF (JTHE == 0 .and. NINTEMP > 0) THEN
         DO I=1,NEL
-          TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,I)) + TEMP(IXS(3,I))
-     .                           + TEMP(IXS(4,I)) + TEMP(IXS(5,I))        
-     .                           + TEMP(IXS(6,I)) + TEMP(IXS(7,I))        
-     .                           + TEMP(IXS(8,I)) + TEMP(IXS(9,I))) 
+          TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,I+NFT)) + TEMP(IXS(3,I+NFT))
+     .                           + TEMP(IXS(4,I+NFT)) + TEMP(IXS(5,I+NFT))        
+     .                           + TEMP(IXS(6,I+NFT)) + TEMP(IXS(7,I+NFT))        
+     .                           + TEMP(IXS(8,I+NFT)) + TEMP(IXS(9,I+NFT))) 
         ENDDO
       ELSE
         TEMPEL(1:NEL) = TEMP0(1:NEL)

--- a/starter/source/elements/solid/solide8z/s8zinit3.F
+++ b/starter/source/elements/solid/solide8z/s8zinit3.F
@@ -423,10 +423,10 @@ c
 !       
         IF (JTHE == 0 .and. GLOB_THERM%NINTEMP > 0) THEN
           DO I=1,NEL
-            TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,I)) + TEMP(IXS(3,I))
-     .                             + TEMP(IXS(4,I)) + TEMP(IXS(5,I))      
-     .                             + TEMP(IXS(6,I)) + TEMP(IXS(7,I))      
-     .                             + TEMP(IXS(8,I)) + TEMP(IXS(9,I))) 
+            TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,I+NFT)) + TEMP(IXS(3,I+NFT))
+     .                             + TEMP(IXS(4,I+NFT)) + TEMP(IXS(5,I+NFT))      
+     .                             + TEMP(IXS(6,I+NFT)) + TEMP(IXS(7,I+NFT))      
+     .                             + TEMP(IXS(8,I+NFT)) + TEMP(IXS(9,I+NFT))) 
           ENDDO
         ELSE
           TEMPEL(1:NEL) = TEMP0(1:NEL)

--- a/starter/source/elements/thickshell/solide6c/s6cinit3.F
+++ b/starter/source/elements/thickshell/solide6c/s6cinit3.F
@@ -280,10 +280,10 @@ C
 !      
       IF (JTHE == 0 .and. GLOB_THERM%NINTEMP > 0) THEN
         DO I=1,NEL
-          TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,I)) + TEMP(IXS(3,I))
-     .                           + TEMP(IXS(4,I)) + TEMP(IXS(5,I))        
-     .                           + TEMP(IXS(6,I)) + TEMP(IXS(7,I))        
-     .                           + TEMP(IXS(8,I)) + TEMP(IXS(9,I))) 
+          TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,I+NFT)) + TEMP(IXS(3,I+NFT))
+     .                           + TEMP(IXS(4,I+NFT)) + TEMP(IXS(5,I+NFT))        
+     .                           + TEMP(IXS(6,I+NFT)) + TEMP(IXS(7,I+NFT))        
+     .                           + TEMP(IXS(8,I+NFT)) + TEMP(IXS(9,I+NFT))) 
         ENDDO
       ELSE
         TEMPEL(1:NEL) = TEMP0(1:NEL)
@@ -340,10 +340,10 @@ c
 !      
         IF (JTHE == 0 .and. GLOB_THERM%NINTEMP > 0) THEN
           DO I=1,NEL
-            TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,I)) + TEMP(IXS(3,I))
-     .                             + TEMP(IXS(4,I)) + TEMP(IXS(5,I))      
-     .                             + TEMP(IXS(6,I)) + TEMP(IXS(7,I))      
-     .                             + TEMP(IXS(8,I)) + TEMP(IXS(9,I))) 
+            TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,I+NFT)) + TEMP(IXS(3,I+NFT))
+     .                             + TEMP(IXS(4,I+NFT)) + TEMP(IXS(5,I+NFT))      
+     .                             + TEMP(IXS(6,I+NFT)) + TEMP(IXS(7,I+NFT))      
+     .                             + TEMP(IXS(8,I+NFT)) + TEMP(IXS(9,I+NFT))) 
           ENDDO
         ELSE
           TEMPEL(1:NEL) = TEMP0(1:NEL)

--- a/starter/source/elements/thickshell/solide8c/s8cinit3.F
+++ b/starter/source/elements/thickshell/solide8c/s8cinit3.F
@@ -318,10 +318,10 @@ C
 !      
       IF (JTHE == 0 .and. GLOB_THERM%NINTEMP > 0) THEN
         DO I=1,NEL
-          TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,I)) + TEMP(IXS(3,I))
-     .                           + TEMP(IXS(4,I)) + TEMP(IXS(5,I))        
-     .                           + TEMP(IXS(6,I)) + TEMP(IXS(7,I))        
-     .                           + TEMP(IXS(8,I)) + TEMP(IXS(9,I))) 
+          TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,I+NFT)) + TEMP(IXS(3,I+NFT))
+     .                           + TEMP(IXS(4,I+NFT)) + TEMP(IXS(5,I+NFT))        
+     .                           + TEMP(IXS(6,I+NFT)) + TEMP(IXS(7,I+NFT))        
+     .                           + TEMP(IXS(8,I+NFT)) + TEMP(IXS(9,I+NFT))) 
         ENDDO
       ELSE
         TEMPEL(1:NEL) = TEMP0(1:NEL)
@@ -409,10 +409,10 @@ C
 !      
          IF (JTHE == 0 .and. GLOB_THERM%NINTEMP > 0) THEN                    
            DO I=1,NEL                                                        
-             TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,I)) + TEMP(IXS(3,I))        
-     .                              + TEMP(IXS(4,I)) + TEMP(IXS(5,I))        
-     .                              + TEMP(IXS(6,I)) + TEMP(IXS(7,I))        
-     .                              + TEMP(IXS(8,I)) + TEMP(IXS(9,I)))       
+             TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,I+NFT)) + TEMP(IXS(3,I+NFT))        
+     .                              + TEMP(IXS(4,I+NFT)) + TEMP(IXS(5,I+NFT))        
+     .                              + TEMP(IXS(6,I+NFT)) + TEMP(IXS(7,I+NFT))        
+     .                              + TEMP(IXS(8,I+NFT)) + TEMP(IXS(9,I+NFT)))       
            ENDDO                                                             
          ELSE                                                                
            TEMPEL(1:NEL) = TEMP0(1:NEL)                                      

--- a/starter/source/elements/thickshell/solidec/scinit3.F
+++ b/starter/source/elements/thickshell/solidec/scinit3.F
@@ -283,10 +283,10 @@ C
 C
       IF (JTHE == 0 .and. GLOB_THERM%NINTEMP > 0) THEN
         DO I=1,NEL
-          TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,I)) + TEMP(IXS(3,I))
-     .                           + TEMP(IXS(4,I)) + TEMP(IXS(5,I))        
-     .                           + TEMP(IXS(6,I)) + TEMP(IXS(7,I))        
-     .                           + TEMP(IXS(8,I)) + TEMP(IXS(9,I))) 
+          TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,I+NFT)) + TEMP(IXS(3,I+NFT))
+     .                           + TEMP(IXS(4,I+NFT)) + TEMP(IXS(5,I+NFT))        
+     .                           + TEMP(IXS(6,I+NFT)) + TEMP(IXS(7,I+NFT))        
+     .                           + TEMP(IXS(8,I+NFT)) + TEMP(IXS(9,I+NFT))) 
         ENDDO
       ELSE
         TEMPEL(1:NEL) = TEMP0(1:NEL)
@@ -341,10 +341,10 @@ C
 C
         IF (JTHE == 0 .and. GLOB_THERM%NINTEMP > 0) THEN
           DO I=1,NEL
-            TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,I)) + TEMP(IXS(3,I))
-     .                             + TEMP(IXS(4,I)) + TEMP(IXS(5,I))      
-     .                             + TEMP(IXS(6,I)) + TEMP(IXS(7,I))      
-     .                             + TEMP(IXS(8,I)) + TEMP(IXS(9,I))) 
+            TEMPEL(I) = ONE_OVER_8 *(TEMP(IXS(2,I+NFT)) + TEMP(IXS(3,I+NFT))
+     .                             + TEMP(IXS(4,I+NFT)) + TEMP(IXS(5,I+NFT))      
+     .                             + TEMP(IXS(6,I+NFT)) + TEMP(IXS(7,I+NFT))      
+     .                             + TEMP(IXS(8,I+NFT)) + TEMP(IXS(9,I+NFT))) 
           ENDDO
         ELSE
           TEMPEL(1:NEL) = TEMP0(1:NEL)


### PR DESCRIPTION
This pull request updates the initialization of element temperatures across several subroutines to ensure the correct indexing of temperature values by offsetting with `NFT`. This change improves consistency and correctness when accessing temperature data for elements during initialization.

Temperature initialization logic updates:

* Changed temperature averaging in `TEMPEL(I)` calculations to use `I+NFT` as the index offset for all relevant temperature accesses in the following subroutines: `SUINIT3` (`elbuf_init/suinit3.F`), `SINIT3` (`solid/solide/sinit3.F`), `S4INIT3` (`solid/solide4/s4init3.F`), `S8ZINIT3` (`solid/solide8z/s8zinit3.F`), `S6CINIT3` (`thickshell/solide6c/s6cinit3.F`), `S8CINIT3` (`thickshell/solide8c/s8cinit3.F`), and `SCINIT3` (`thickshell/solidec/scinit3.F`). [[1]](diffhunk://#diff-c422f57c457d8af645b53ee5d4646520b562ab2314e067885a01854b1dd7a34eL201-R204) [[2]](diffhunk://#diff-756d56f05ae6af97bd8ea1a8248ab2d28c87b6de292dcfb88b84a6db2f08d957L277-R280) [[3]](diffhunk://#diff-5634cf9ef1f119615c4800bd279c1fbe6068cd4f5e50938c7d7c2d0cec09f516L211-R214) [[4]](diffhunk://#diff-29be926862e11aa5a5e1abfb720b63a74db3cf69a8cdd1f6370a54958347bd06L426-R429) [[5]](diffhunk://#diff-e913c0ca227a72e5f3311af4af22a8eb16daf900220ef6ca2a47bfa8efd9cc8dL283-R286) [[6]](diffhunk://#diff-e913c0ca227a72e5f3311af4af22a8eb16daf900220ef6ca2a47bfa8efd9cc8dL343-R346) [[7]](diffhunk://#diff-93bed2bbe131f21385dd2027761f95a9ed4cf66adfcdf9e3a66f093e594fc11fL321-R324) [[8]](diffhunk://#diff-93bed2bbe131f21385dd2027761f95a9ed4cf66adfcdf9e3a66f093e594fc11fL412-R415) [[9]](diffhunk://#diff-16770af7dd5e51e56c26aeba59a27a4bce09d60673431a54eab12b008e32d638L286-R289) [[10]](diffhunk://#diff-16770af7dd5e51e56c26aeba59a27a4bce09d60673431a54eab12b008e32d638L344-R347)

This change helps prevent potential errors in temperature assignment by ensuring the correct temperature values are averaged for each element.