### PR TITLE
/INTER/TYPE25 optimization

### DIFF
--- a/engine/source/interfaces/int25/i25for3.F
+++ b/engine/source/interfaces/int25/i25for3.F
@@ -170,7 +170,8 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I, J1, IG, J, JG, K0, NBINTER, K1S, K, IE, NN, 
      . N,ITAG,
-     .        IGRN,ISS1,ISS2,IMS1,IMS2,PP,PPL,ITYPSUB
+     .        PP,PPL,ITYPSUB
+      logical :: ISS1,ISS2,IMS1,IMS2,IGRN
       my_real
      .   FXT(MVSIZ),FYT(MVSIZ),FZT(MVSIZ),
      . VIS2(MVSIZ), XMU(MVSIZ),STIF0(MVSIZ), FF(MVSIZ),
@@ -203,9 +204,6 @@ C-----------------------------------------------
      . FSAVSUB1(25,NISUB),IMPX,IMPY,IMPZ
       my_real
      .    STIFADH, FACTOR , GAPP, DGAPLOAD
-C
-      INTEGER BITGET
-      EXTERNAL BITGET
 C-----------------------------------------------
       DTMINI=ZERO
       IF (IRESP==1) THEN
@@ -715,7 +713,7 @@ C---------------------------------
         DO I=1,JLT
           IF(PENE(I) == ZERO)CYCLE
           IE=CE_LOC(I)
-          IMS2 = BITGET(MBINFLG(IE),1)
+          IMS2 = BTEST(MBINFLG(IE),1)
           FXI(I)=N1(I)*FNI(I)
           FYI(I)=N2(I)*FNI(I)
           FZI(I)=N3(I)*FNI(I)
@@ -725,7 +723,7 @@ C---------------------------------
           FSAV8 =FSAV8 +ABS(IMPX)
           FSAV9 =FSAV9 +ABS(IMPY)
           FSAV10=FSAV10+ABS(IMPZ)
-          IF (IMS2 > 0 ) THEN
+          IF (IMS2 ) THEN
             FSAV1 =FSAV1 -IMPX
             FSAV2 =FSAV2 -IMPY
             FSAV3 =FSAV3 -IMPZ
@@ -737,7 +735,7 @@ C---------------------------------
             FSAV11=FSAV11+FNI(I)*DT12
           END IF
           IF(ISENSINT(1)/=0) THEN
-            IF (IMS2 >0 ) THEN
+            IF (IMS2 ) THEN
               FSAVPARIT(1,1,I) =  -FXI(I)
               FSAVPARIT(1,2,I) =  -FYI(I)
               FSAVPARIT(1,3,I) =  -FZI(I)
@@ -849,17 +847,17 @@ C---------------------------------
               ITYPSUB = TYPSUB(JSUB)
               IF(ITYPSUB == 1 ) THEN  ! Defining specific inter
 
-                ISS1 = BITGET(INFLG_SUBS(JJ),0)
-                ISS2 = BITGET(INFLG_SUBS(JJ),1)
-                IGRN = BITGET(INFLG_SUBS(JJ),2)
+                ISS1 = BTEST(INFLG_SUBS(JJ),0)
+                ISS2 = BTEST(INFLG_SUBS(JJ),1)
+                IGRN = BTEST(INFLG_SUBS(JJ),2)
                 KSUB=LISUBM(KK)
                 DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBM(IE+1)))
-                  IMS1 = BITGET(INFLG_SUBM(KK),0)
-                  IMS2 = BITGET(INFLG_SUBM(KK),1)
+                  IMS1 = BTEST(INFLG_SUBM(KK),0)
+                  IMS2 = BTEST(INFLG_SUBM(KK),1)
                   IF(KSUB==JSUB)THEN
-                    IF(.NOT.(((IMS1 == 1 .OR.  IMS2 == 1) .AND. IGRN == 1).OR.
-     .                        (IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                        (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                    IF(.NOT.(((IMS1  .OR.  IMS2 ) .AND. IGRN ).OR.
+     .                        (IMS1  .AND. ISS2 ).OR.
+     .                        (IMS2  .AND. ISS1 )))  THEN
                       KK=KK+1
                       KSUB=LISUBM(KK)
                       CYCLE
@@ -868,7 +866,7 @@ C---------------------------------
                     IMPY=FYI(I)*DT12
                     IMPZ=FZI(I)*DT12
 
-                    IF(IMS2 > 0)THEN
+                    IF(IMS2)THEN
                       FSAVSUB1(1,JSUB)=FSAVSUB1(1,JSUB)-IMPX
                       FSAVSUB1(2,JSUB)=FSAVSUB1(2,JSUB)-IMPY
                       FSAVSUB1(3,JSUB)=FSAVSUB1(3,JSUB)-IMPZ
@@ -881,7 +879,7 @@ C---------------------------------
                     END IF
 C
                     IF(ISENSINT(JSUB+1)/=0) THEN
-                      IF(IMS2 > 0)THEN
+                      IF(IMS2)THEN
                         FSAVPARIT(JSUB+1,1,I) =  -FXI(I)
                         FSAVPARIT(JSUB+1,2,I) =  -FYI(I)
                         FSAVPARIT(JSUB+1,3,I) =  -FZI(I)
@@ -928,15 +926,15 @@ C
 
               ELSEIF(ITYPSUB == 3 ) THEN   ! Inter =0 : collecting forces from all inter with 2 surfs
 
-                ISS2 = BITGET(INFLG_SUBS(JJ),0)
-                ISS1 = BITGET(INFLG_SUBS(JJ),1)
+                ISS2 = BTEST(INFLG_SUBS(JJ),0)
+                ISS1 = BTEST(INFLG_SUBS(JJ),1)
                 KSUB=LISUBM(KK)
                 DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBM(IE+1)))
-                  IMS2 = BITGET(INFLG_SUBM(KK),0)
-                  IMS1 = BITGET(INFLG_SUBM(KK),1)
+                  IMS2 = BTEST(INFLG_SUBM(KK),0)
+                  IMS1 = BTEST(INFLG_SUBM(KK),1)
                   IF(KSUB==JSUB)THEN
-                    IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                        (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                    IF(.NOT.((IMS1  .AND. ISS2 ).OR.
+     .                        (IMS2  .AND. ISS1 )))  THEN
                       KK=KK+1
                       KSUB=LISUBM(KK)
                       CYCLE
@@ -947,7 +945,7 @@ C
                     IMPZ=FZI(I)*DT12
 
 
-                    IF(IMS2 > 0)THEN
+                    IF(IMS2)THEN
                       FSAVSUB1(1,JSUB)=FSAVSUB1(1,JSUB)-IMPX
                       FSAVSUB1(2,JSUB)=FSAVSUB1(2,JSUB)-IMPY
                       FSAVSUB1(3,JSUB)=FSAVSUB1(3,JSUB)-IMPZ
@@ -965,7 +963,7 @@ C
 
 
                     IF(ISENSINT(JSUB+1)/=0) THEN
-                      IF(IMS2 > 0)THEN
+                      IF(IMS2)THEN
                         FSAVPARIT(JSUB+1,1,I) =  -FXI(I)
                         FSAVPARIT(JSUB+1,2,I) =  -FYI(I)
                         FSAVPARIT(JSUB+1,3,I) =  -FZI(I)
@@ -1048,17 +1046,17 @@ C
                 ITYPSUB = TYPSUB(JSUB)
                 IF(ITYPSUB == 1 ) THEN
 
-                  ISS1 = BITGET(INFLG_SUBSFI(NIN)%P(JJ),0)
-                  ISS2 = BITGET(INFLG_SUBSFI(NIN)%P(JJ),1)
-                  IGRN = BITGET(INFLG_SUBSFI(NIN)%P(JJ),2)
+                  ISS1 = BTEST(INFLG_SUBSFI(NIN)%P(JJ),0)
+                  ISS2 = BTEST(INFLG_SUBSFI(NIN)%P(JJ),1)
+                  IGRN = BTEST(INFLG_SUBSFI(NIN)%P(JJ),2)
                   KSUB=LISUBM(KK)
                   DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBM(IE+1)))
-                    IMS1 = BITGET(INFLG_SUBM(KK),0)
-                    IMS2 = BITGET(INFLG_SUBM(KK),1)
+                    IMS1 = BTEST(INFLG_SUBM(KK),0)
+                    IMS2 = BTEST(INFLG_SUBM(KK),1)
                     IF(KSUB==JSUB)THEN
-                      IF(.NOT.(((IMS1 == 1 .OR.  IMS2 == 1) .AND. IGRN == 1).OR.
-     .                         (IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                         (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                      IF(.NOT.(((IMS1 .OR.  IMS2 ) .AND. IGRN).OR.
+     .                          (IMS1 .AND. ISS2 ).OR.
+     .                          (IMS2 .AND. ISS1 )))  THEN
                         KK=KK+1
                         KSUB=LISUBM(KK)
                         CYCLE
@@ -1067,7 +1065,7 @@ C
                       IMPY=FYI(I)*DT12
                       IMPZ=FZI(I)*DT12
 
-                      IF(IMS2 > 0)THEN
+                      IF(IMS2)THEN
                         FSAVSUB1(1,JSUB)=FSAVSUB1(1,JSUB)-IMPX
                         FSAVSUB1(2,JSUB)=FSAVSUB1(2,JSUB)-IMPY
                         FSAVSUB1(3,JSUB)=FSAVSUB1(3,JSUB)-IMPZ
@@ -1080,7 +1078,7 @@ C
                       END IF
 C
                       IF(ISENSINT(JSUB+1)/=0) THEN
-                        IF(IMS2 > 0)THEN
+                        IF(IMS2)THEN
                           FSAVPARIT(JSUB+1,1,I) =  -FXI(I)
                           FSAVPARIT(JSUB+1,2,I) =  -FYI(I)
                           FSAVPARIT(JSUB+1,3,I) =  -FZI(I)
@@ -1127,15 +1125,15 @@ C
 
                 ELSEIF(ITYPSUB == 3 ) THEN   ! Inter =0 : collecting forces from all inter with 2 surfaces
 
-                  ISS2 = BITGET(INFLG_SUBSFI(NIN)%P(JJ),0)
-                  ISS1 = BITGET(INFLG_SUBSFI(NIN)%P(JJ),1)
+                  ISS2 = BTEST(INFLG_SUBSFI(NIN)%P(JJ),0)
+                  ISS1 = BTEST(INFLG_SUBSFI(NIN)%P(JJ),1)
                   KSUB=LISUBM(KK)
                   DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBM(IE+1)))
-                    IMS2 = BITGET(INFLG_SUBM(KK),0)
-                    IMS1 = BITGET(INFLG_SUBM(KK),1)
+                    IMS2 = BTEST(INFLG_SUBM(KK),0)
+                    IMS1 = BTEST(INFLG_SUBM(KK),1)
                     IF(KSUB==JSUB)THEN
-                      IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                         (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                      IF(.NOT.((IMS1  .AND. ISS2 ).OR.
+     .                         (IMS2  .AND. ISS1 )))  THEN
                         KK=KK+1
                         KSUB=LISUBM(KK)
                         CYCLE
@@ -1145,7 +1143,7 @@ C
                       IMPY=FYI(I)*DT12
                       IMPZ=FZI(I)*DT12
 
-                      IF(IMS2 > 0)THEN
+                      IF(IMS2)THEN
                         FSAVSUB1(1,JSUB)=FSAVSUB1(1,JSUB)-IMPX
                         FSAVSUB1(2,JSUB)=FSAVSUB1(2,JSUB)-IMPY
                         FSAVSUB1(3,JSUB)=FSAVSUB1(3,JSUB)-IMPZ
@@ -1158,7 +1156,7 @@ C
                       END IF
 C
                       IF(ISENSINT(JSUB+1)/=0) THEN
-                        IF(IMS2 > 0)THEN
+                        IF(IMS2)THEN
                           FSAVPARIT(JSUB+1,1,I) =  -FXI(I)
                           FSAVPARIT(JSUB+1,2,I) =  -FYI(I)
                           FSAVPARIT(JSUB+1,3,I) =  -FZI(I)
@@ -2468,18 +2466,18 @@ C---------------------------------
               IF(ITYPSUB == 1 ) THEN
 C
 C            Find if node is on Surface S1 S2 ou GRNOD
-                ISS1 = BITGET(INFLG_SUBS(JJ),0)
-                ISS2 = BITGET(INFLG_SUBS(JJ),1)
-                IGRN = BITGET(INFLG_SUBS(JJ),2)
+                ISS1 = BTEST(INFLG_SUBS(JJ),0)
+                ISS2 = BTEST(INFLG_SUBS(JJ),1)
+                IGRN = BTEST(INFLG_SUBS(JJ),2)
                 KSUB=LISUBM(KK)
                 DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBM(IE+1)))
-                  IMS1 = BITGET(INFLG_SUBM(KK),0)
-                  IMS2 = BITGET(INFLG_SUBM(KK),1)
+                  IMS1 = BTEST(INFLG_SUBM(KK),0)
+                  IMS2 = BTEST(INFLG_SUBM(KK),1)
                   IF(KSUB==JSUB)THEN
 !                S and M candidates on the same sub_interface
-                    IF(.NOT.(((IMS1 == 1 .OR.  IMS2 == 1) .AND. IGRN == 1).OR.
-     .                      (IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                        (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                    IF(.NOT.(((IMS1  .OR.  IMS2 ) .AND. IGRN ).OR.
+     .                      (IMS1  .AND. ISS2 ).OR.
+     .                        (IMS2  .AND. ISS1 )))  THEN
                       KK=KK+1
                       KSUB=LISUBM(KK)
                       CYCLE
@@ -2562,16 +2560,16 @@ C
 
 C
 C            Find if node is on Surface S1 S2 ou GRNOD
-                ISS2 = BITGET(INFLG_SUBS(JJ),0)
-                ISS1 = BITGET(INFLG_SUBS(JJ),1)
+                ISS2 = BTEST(INFLG_SUBS(JJ),0)
+                ISS1 = BTEST(INFLG_SUBS(JJ),1)
                 KSUB=LISUBM(KK)
                 DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBM(IE+1)))
-                  IMS2 = BITGET(INFLG_SUBM(KK),0)
-                  IMS1 = BITGET(INFLG_SUBM(KK),1)
+                  IMS2 = BTEST(INFLG_SUBM(KK),0)
+                  IMS1 = BTEST(INFLG_SUBM(KK),1)
                   IF(KSUB==JSUB)THEN
 !                S and M candidates on the same sub_interface
-                    IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                       (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                    IF(.NOT.((IMS1  .AND. ISS2 ).OR.
+     .                       (IMS2  .AND. ISS1 )))  THEN
                       KK=KK+1
                       KSUB=LISUBM(KK)
                       CYCLE
@@ -2581,7 +2579,7 @@ C            Find if node is on Surface S1 S2 ou GRNOD
                     IMPY=FYT(I)*DT12
                     IMPZ=FZT(I)*DT12
 
-                    IF(IMS2 > 0)THEN
+                    IF(IMS2)THEN
 C                main side :
                       FSAVSUB1(4,JSUB)=FSAVSUB1(4,JSUB)-IMPX
                       FSAVSUB1(5,JSUB)=FSAVSUB1(5,JSUB)-IMPY
@@ -2597,7 +2595,7 @@ C
                     FSAVSUB1(14,JSUB)=FSAVSUB1(14,JSUB)+ABS(IMPZ)
 C
                     IF(ISENSINT(JSUB+1)/=0) THEN
-                      IF(IMS2 > 0)THEN
+                      IF(IMS2)THEN
                         FSAVPARIT(JSUB+1,4,I) =  -FXT(I)
                         FSAVPARIT(JSUB+1,5,I) =  -FYT(I)
                         FSAVPARIT(JSUB+1,6,I) =  -FZT(I)
@@ -2709,17 +2707,17 @@ C
                 JSUB=LISUBSFI(NIN)%P(JJ)
                 ITYPSUB = TYPSUB(JSUB)
                 IF(ITYPSUB == 1 ) THEN
-                  ISS1 = BITGET(INFLG_SUBSFI(NIN)%P(JJ),0)
-                  ISS2 = BITGET(INFLG_SUBSFI(NIN)%P(JJ),1)
-                  IGRN = BITGET(INFLG_SUBSFI(NIN)%P(JJ),2)
+                  ISS1 = BTEST(INFLG_SUBSFI(NIN)%P(JJ),0)
+                  ISS2 = BTEST(INFLG_SUBSFI(NIN)%P(JJ),1)
+                  IGRN = BTEST(INFLG_SUBSFI(NIN)%P(JJ),2)
                   KSUB=LISUBM(KK)
                   DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBM(IE+1)))
-                    IMS1 = BITGET(INFLG_SUBM(KK),0)
-                    IMS2 = BITGET(INFLG_SUBM(KK),1)
+                    IMS1 = BTEST(INFLG_SUBM(KK),0)
+                    IMS2 = BTEST(INFLG_SUBM(KK),1)
                     IF(KSUB==JSUB)THEN
-                      IF(.NOT.(((IMS1 == 1 .OR.  IMS2 == 1) .AND. IGRN == 1).OR.
-     .                         (IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                         (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                      IF(.NOT.(((IMS1  .OR.  IMS2 ) .AND. IGRN ).OR.
+     .                         (IMS1  .AND. ISS2 ).OR.
+     .                         (IMS2  .AND. ISS1 )))  THEN
                         KK=KK+1
                         KSUB=LISUBM(KK)
                         CYCLE
@@ -2800,16 +2798,16 @@ C
 
                 ELSEIF(ITYPSUB == 3 ) THEN   ! Inter =0 : collecting forces from all inter with 2 surfaces
 
-                  ISS2 = BITGET(INFLG_SUBSFI(NIN)%P(JJ),0)
-                  ISS1 = BITGET(INFLG_SUBSFI(NIN)%P(JJ),1)
-                  IGRN = BITGET(INFLG_SUBSFI(NIN)%P(JJ),2)
+                  ISS2 = BTEST(INFLG_SUBSFI(NIN)%P(JJ),0)
+                  ISS1 = BTEST(INFLG_SUBSFI(NIN)%P(JJ),1)
+                  IGRN = BTEST(INFLG_SUBSFI(NIN)%P(JJ),2)
                   KSUB=LISUBM(KK)
                   DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBM(IE+1)))
-                    IMS2 = BITGET(INFLG_SUBM(KK),0)
-                    IMS1 = BITGET(INFLG_SUBM(KK),1)
+                    IMS2 = BTEST(INFLG_SUBM(KK),0)
+                    IMS1 = BTEST(INFLG_SUBM(KK),1)
                     IF(KSUB==JSUB)THEN
-                      IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                         (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                      IF(.NOT.((IMS1  .AND. ISS2 ).OR.
+     .                         (IMS2  .AND. ISS1 )))  THEN
                         KK=KK+1
                         KSUB=LISUBM(KK)
                         CYCLE
@@ -2818,7 +2816,7 @@ C
                       IMPX=FXT(I)*DT12
                       IMPY=FYT(I)*DT12
                       IMPZ=FZT(I)*DT12
-                      IF(IMS2 > 0)THEN
+                      IF(IMS2)THEN
 C                main side :
                         FSAVSUB1(4,JSUB)=FSAVSUB1(4,JSUB)-IMPX
                         FSAVSUB1(5,JSUB)=FSAVSUB1(5,JSUB)-IMPY
@@ -2838,7 +2836,7 @@ C
                       FSAVSUB1(14,JSUB)=FSAVSUB1(14,JSUB)+ABS(IMPZ)
 C
                       IF(ISENSINT(JSUB+1)/=0) THEN
-                        IF(IMS2 > 0)THEN
+                        IF(IMS2)THEN
                           FSAVPARIT(JSUB+1,4,I) =  -FXT(I)
                           FSAVPARIT(JSUB+1,5,I) =  -FYT(I)
                           FSAVPARIT(JSUB+1,6,I) =  -FZT(I)

--- a/engine/source/interfaces/int25/i25for3_e2s.F
+++ b/engine/source/interfaces/int25/i25for3_e2s.F
@@ -129,8 +129,9 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I, J, K0, NBINTER, K1S, K, NI, IL, IE, PP, PPL
  
-      INTEGER JSUB,KSUB,NSUB,JJ,KK,ISS1,ISS2,IMS1,IMS2,ITYPSUB,
+      INTEGER JSUB,KSUB,NSUB,JJ,KK,ITYPSUB,
      .   TAGIP(4*MVSIZ)
+      logical :: ISS1,ISS2,IMS1,IMS2
       my_real
      .    VX(4*MVSIZ),  VY(4*MVSIZ),  VZ(4*MVSIZ),  VN(4*MVSIZ),
      .   FXI(4*MVSIZ), FYI(4*MVSIZ), FZI(4*MVSIZ), FNI(4*MVSIZ),
@@ -156,8 +157,6 @@ C-----------------------------------------------
      .   C1(4*MVSIZ),C2(4*MVSIZ),C3(4*MVSIZ),C4(4*MVSIZ),
      . CX,CY,CFI,AUX
 C
-      INTEGER BITGET
-      EXTERNAL BITGET
 C-----------------------------------------------
 
       IF (IRESP == 1) THEN
@@ -436,14 +435,14 @@ C---------------------------------
         DO I=1,JLT
           IF(PENE(I) == ZERO)CYCLE
           IE=CM_LOC(I)
-          IMS2 = BITGET(MBINFLG(IE),1)
+          IMS2 = BTEST(MBINFLG(IE),1)
           FXI(I)=NX(I)*FNI(I)
           FYI(I)=NY(I)*FNI(I)
           FZI(I)=NZ(I)*FNI(I)
           IMPX=FXI(I)*DT12
           IMPY=FYI(I)*DT12
           IMPZ=FZI(I)*DT12
-          IF (IMS2 > 0 ) THEN
+          IF (IMS2 ) THEN
             FSAV1 =FSAV1 -IMPX
             FSAV2 =FSAV2 -IMPY
             FSAV3 =FSAV3 -IMPZ
@@ -458,7 +457,7 @@ C---------------------------------
           FSAV9 =FSAV9 +ABS(IMPY)
           FSAV10=FSAV10+ABS(IMPZ)
           IF(ISENSINT(1)/=0) THEN
-            IF (IMS2 >0 ) THEN
+            IF (IMS2 ) THEN
               FSAVPARIT(1,1,I) =  -FXI(I)
               FSAVPARIT(1,2,I) =  -FYI(I)
               FSAVPARIT(1,3,I) =  -FZI(I)
@@ -534,15 +533,15 @@ C---------------------------------
 
               IF(ITYPSUB == 1 ) THEN  ! Defining specific inter
 
-                ISS1 = BITGET(INFLG_SUBE(JJ),0)
-                ISS2 = BITGET(INFLG_SUBE(JJ),1)
+                ISS1 = BTEST(INFLG_SUBE(JJ),0)
+                ISS2 = BTEST(INFLG_SUBE(JJ),1)
                 KSUB=LISUBE(KK)
                 DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBE(IE+1)))
-                  IMS1 = BITGET(INFLG_SUBM(KK),0)
-                  IMS2 = BITGET(INFLG_SUBM(KK),1)
+                  IMS1 = BTEST(INFLG_SUBM(KK),0)
+                  IMS2 = BTEST(INFLG_SUBM(KK),1)
                   IF(KSUB==JSUB)THEN
-                    IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                      (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                    IF(.NOT.((IMS1 .AND. ISS2 ).OR.
+     .                      (IMS2  .AND. ISS1 )))  THEN
                       KK=KK+1
                       KSUB=LISUBE(KK)
                       CYCLE
@@ -551,7 +550,7 @@ C---------------------------------
                     IMPY=FYI(I)*DT12
                     IMPZ=FZI(I)*DT12
 
-                    IF(IMS2 > 0)THEN
+                    IF(IMS2 )THEN
                       FSAVSUB1(1,JSUB)=FSAVSUB1(1,JSUB)-IMPX
                       FSAVSUB1(2,JSUB)=FSAVSUB1(2,JSUB)-IMPY
                       FSAVSUB1(3,JSUB)=FSAVSUB1(3,JSUB)-IMPZ
@@ -564,7 +563,7 @@ C---------------------------------
                     END IF
 C
                     IF(ISENSINT(JSUB+1)/=0) THEN
-                      IF(IMS2 > 0)THEN
+                      IF(IMS2 )THEN
                         FSAVPARIT(JSUB+1,1,I) =  -FXI(I)
                         FSAVPARIT(JSUB+1,2,I) =  -FYI(I)
                         FSAVPARIT(JSUB+1,3,I) =  -FZI(I)
@@ -612,21 +611,21 @@ C
 
               ELSEIF(ITYPSUB == 3 ) THEN   ! Inter =0 : collecting forces from all inter with 2 surfs
 
-                ISS2 = BITGET(INFLG_SUBE(JJ),0)
-                ISS1 = BITGET(INFLG_SUBE(JJ),1)
+                ISS2 = BTEST(INFLG_SUBE(JJ),0)
+                ISS1 = BTEST(INFLG_SUBE(JJ),1)
                 KSUB=LISUBE(KK)
                 DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBE(IE+1)))
-                  IMS2 = BITGET(INFLG_SUBM(KK),0)
-                  IMS1 = BITGET(INFLG_SUBM(KK),1)
+                  IMS2 = BTEST(INFLG_SUBM(KK),0)
+                  IMS1 = BTEST(INFLG_SUBM(KK),1)
                   IF(KSUB==JSUB)THEN
-                    IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                      (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                    IF(.NOT.((IMS1  .AND. ISS2 ).OR.
+     .                      (IMS2  .AND. ISS1 )))  THEN
                       KK=KK+1
                       KSUB=LISUBE(KK)
                       CYCLE
                     END IF
 
-                    IF(IMS2 > 0)THEN
+                    IF(IMS2 )THEN
                       FSAVSUB1(1,JSUB)=FSAVSUB1(1,JSUB)-IMPX
                       FSAVSUB1(2,JSUB)=FSAVSUB1(2,JSUB)-IMPY
                       FSAVSUB1(3,JSUB)=FSAVSUB1(3,JSUB)-IMPZ
@@ -643,7 +642,7 @@ C
                     FSAVSUB1(10,JSUB)=FSAVSUB1(10,JSUB)+ABS(IMPZ)
 
                     IF(ISENSINT(JSUB+1)/=0) THEN
-                      IF(IMS2 > 0)THEN
+                      IF(IMS2 )THEN
                         FSAVPARIT(JSUB+1,1,I) =  -FXI(I)
                         FSAVPARIT(JSUB+1,2,I) =  -FYI(I)
                         FSAVPARIT(JSUB+1,3,I) =  -FZI(I)
@@ -728,15 +727,15 @@ C
                 ITYPSUB = TYPSUB(JSUB)
 
                 IF(ITYPSUB == 1 ) THEN  ! Defining specific inter
-                  ISS1 = BITGET(INFLG_SUBSFIE(NIN)%P(JJ),0)
-                  ISS2 = BITGET(INFLG_SUBSFIE(NIN)%P(JJ),1)
+                  ISS1 = BTEST(INFLG_SUBSFIE(NIN)%P(JJ),0)
+                  ISS2 = BTEST(INFLG_SUBSFIE(NIN)%P(JJ),1)
                   KSUB=LISUBE(KK)
                   DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBE(IE+1)))
-                    IMS1 = BITGET(INFLG_SUBM(KK),0)
-                    IMS2 = BITGET(INFLG_SUBM(KK),1)
+                    IMS1 = BTEST(INFLG_SUBM(KK),0)
+                    IMS2 = BTEST(INFLG_SUBM(KK),1)
                     IF(KSUB==JSUB)THEN
-                      IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                         (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                      IF(.NOT.((IMS1 .AND. ISS2 ).OR.
+     .                         (IMS2 .AND. ISS1 )))  THEN
                         KK=KK+1
                         KSUB=LISUBE(KK)
                         CYCLE
@@ -745,7 +744,7 @@ C
                       IMPY=FYI(I)*DT12
                       IMPZ=FZI(I)*DT12
 
-                      IF(IMS2 > 0)THEN
+                      IF(IMS2 )THEN
                         FSAVSUB1(1,JSUB)=FSAVSUB1(1,JSUB)-IMPX
                         FSAVSUB1(2,JSUB)=FSAVSUB1(2,JSUB)-IMPY
                         FSAVSUB1(3,JSUB)=FSAVSUB1(3,JSUB)-IMPZ
@@ -758,7 +757,7 @@ C
                       END IF
 C
                       IF(ISENSINT(JSUB+1)/=0) THEN
-                        IF(IMS2 > 0)THEN
+                        IF(IMS2 )THEN
                           FSAVPARIT(JSUB+1,1,I) =  -FXI(I)
                           FSAVPARIT(JSUB+1,2,I) =  -FYI(I)
                           FSAVPARIT(JSUB+1,3,I) =  -FZI(I)
@@ -806,15 +805,15 @@ C
 
                 ELSEIF(ITYPSUB == 3 ) THEN   ! Inter =0 : collecting forces from all inter with 2surfs
 
-                  ISS2 = BITGET(INFLG_SUBSFIE(NIN)%P(JJ),0)
-                  ISS1 = BITGET(INFLG_SUBSFIE(NIN)%P(JJ),1)
+                  ISS2 = BTEST(INFLG_SUBSFIE(NIN)%P(JJ),0)
+                  ISS1 = BTEST(INFLG_SUBSFIE(NIN)%P(JJ),1)
                   KSUB=LISUBE(KK)
                   DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBE(IE+1)))
-                    IMS2 = BITGET(INFLG_SUBM(KK),0)
-                    IMS1 = BITGET(INFLG_SUBM(KK),1)
+                    IMS2 = BTEST(INFLG_SUBM(KK),0)
+                    IMS1 = BTEST(INFLG_SUBM(KK),1)
                     IF(KSUB==JSUB)THEN
-                      IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                       (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                      IF(.NOT.((IMS1 .AND. ISS2 ).OR.
+     .                       (IMS2  .AND. ISS1 )))  THEN
                         KK=KK+1
                         KSUB=LISUBE(KK)
                         CYCLE
@@ -824,7 +823,7 @@ C
                       IMPY=FYI(I)*DT12
                       IMPZ=FZI(I)*DT12
 
-                      IF(IMS2 > 0)THEN
+                      IF(IMS2 )THEN
                         FSAVSUB1(1,JSUB)=FSAVSUB1(1,JSUB)-IMPX
                         FSAVSUB1(2,JSUB)=FSAVSUB1(2,JSUB)-IMPY
                         FSAVSUB1(3,JSUB)=FSAVSUB1(3,JSUB)-IMPZ
@@ -841,7 +840,7 @@ C
                       FSAVSUB1(10,JSUB)=FSAVSUB1(10,JSUB)+ABS(IMPZ)
 C
                       IF(ISENSINT(JSUB+1)/=0) THEN
-                        IF(IMS2 > 0)THEN
+                        IF(IMS2 )THEN
                           FSAVPARIT(JSUB+1,1,I) =  -FXI(I)
                           FSAVPARIT(JSUB+1,2,I) =  -FYI(I)
                           FSAVPARIT(JSUB+1,3,I) =  -FZI(I)
@@ -970,15 +969,15 @@ C---------------------------------
 
               IF(ITYPSUB == 1 ) THEN  ! Defining specific inter
 
-                ISS1 = BITGET(INFLG_SUBE(JJ),0)
-                ISS2 = BITGET(INFLG_SUBE(JJ),1)
+                ISS1 = BTEST(INFLG_SUBE(JJ),0)
+                ISS2 = BTEST(INFLG_SUBE(JJ),1)
                 KSUB=LISUBE(KK)
                 DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBE(IE+1)))
-                  IMS1 = BITGET(INFLG_SUBM(KK),0)
-                  IMS2 = BITGET(INFLG_SUBM(KK),1)
+                  IMS1 = BTEST(INFLG_SUBM(KK),0)
+                  IMS2 = BTEST(INFLG_SUBM(KK),1)
                   IF(KSUB==JSUB)THEN
-                    IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                       (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                    IF(.NOT.((IMS1  .AND. ISS2 ).OR.
+     .                       (IMS2  .AND. ISS1 )))  THEN
                       KK=KK+1
                       KSUB=LISUBE(KK)
                       CYCLE
@@ -1050,15 +1049,15 @@ c     .                              +XP(I)*IMPY-YP(I)*IMPX
 
               ELSEIF(ITYPSUB == 3 ) THEN   ! Inter =0 : collecting forces from all inter with 2surfs
 
-                ISS2 = BITGET(INFLG_SUBE(JJ),0)
-                ISS1 = BITGET(INFLG_SUBE(JJ),1)
+                ISS2 = BTEST(INFLG_SUBE(JJ),0)
+                ISS1 = BTEST(INFLG_SUBE(JJ),1)
                 KSUB=LISUBE(KK)
                 DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBE(IE+1)))
-                  IMS2 = BITGET(INFLG_SUBM(KK),0)
-                  IMS1 = BITGET(INFLG_SUBM(KK),1)
+                  IMS2 = BTEST(INFLG_SUBM(KK),0)
+                  IMS1 = BTEST(INFLG_SUBM(KK),1)
                   IF(KSUB==JSUB)THEN
-                    IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                       (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                    IF(.NOT.((IMS1  .AND. ISS2 ).OR.
+     .                       (IMS2  .AND. ISS1 )))  THEN
                       KK=KK+1
                       KSUB=LISUBE(KK)
                       CYCLE
@@ -1068,7 +1067,7 @@ c     .                              +XP(I)*IMPY-YP(I)*IMPX
                     IMPY=FYT(I)*DT12
                     IMPZ=FZT(I)*DT12
 
-                    IF(IMS2 > 0) THEN
+                    IF(IMS2 ) THEN
                       FSAVSUB1(4,JSUB)=FSAVSUB1(4,JSUB)-IMPX
                       FSAVSUB1(5,JSUB)=FSAVSUB1(5,JSUB)-IMPY
                       FSAVSUB1(6,JSUB)=FSAVSUB1(6,JSUB)-IMPZ
@@ -1088,7 +1087,7 @@ C
                     FSAVSUB1(14,JSUB)=FSAVSUB1(14,JSUB)+ABS(IMPZ)
 C
                     IF(ISENSINT(JSUB+1)/=0) THEN
-                      IF(IMS2 > 0) THEN
+                      IF(IMS2 ) THEN
                         FSAVPARIT(JSUB+1,4,I) =  -FXT(I)
                         FSAVPARIT(JSUB+1,5,I) =  -FYT(I)
                         FSAVPARIT(JSUB+1,6,I) =  -FZT(I)
@@ -1178,15 +1177,15 @@ c     .                              +XP(I)*IMPY-YP(I)*IMPX
 
                 IF(ITYPSUB == 1 ) THEN  ! Defining specific inter
 
-                  ISS1 = BITGET(INFLG_SUBSFIE(NIN)%P(JJ),0)
-                  ISS2 = BITGET(INFLG_SUBSFIE(NIN)%P(JJ),1)
+                  ISS1 = BTEST(INFLG_SUBSFIE(NIN)%P(JJ),0)
+                  ISS2 = BTEST(INFLG_SUBSFIE(NIN)%P(JJ),1)
                   KSUB=LISUBE(KK)
                   DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBE(IE+1)))
-                    IMS1 = BITGET(INFLG_SUBM(KK),0)
-                    IMS2 = BITGET(INFLG_SUBM(KK),1)
+                    IMS1 = BTEST(INFLG_SUBM(KK),0)
+                    IMS2 = BTEST(INFLG_SUBM(KK),1)
                     IF(KSUB==JSUB)THEN
-                      IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                       (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                      IF(.NOT.((IMS1 .AND. ISS2 ).OR.
+     .                         (IMS2 .AND. ISS1 )))  THEN
                         KK=KK+1
                         KSUB=LISUBE(KK)
                         CYCLE
@@ -1259,15 +1258,15 @@ c     .                              +XP(I)*IMPY-YP(I)*IMPX
 
                 ELSEIF(ITYPSUB == 3 ) THEN   ! Inter =0 : collecting forces from all inter with 2 surfs
 
-                  ISS2 = BITGET(INFLG_SUBSFIE(NIN)%P(JJ),0)
-                  ISS1 = BITGET(INFLG_SUBSFIE(NIN)%P(JJ),1)
+                  ISS2 = BTEST(INFLG_SUBSFIE(NIN)%P(JJ),0)
+                  ISS1 = BTEST(INFLG_SUBSFIE(NIN)%P(JJ),1)
                   KSUB=LISUBE(KK)
                   DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBE(IE+1)))
-                    IMS2 = BITGET(INFLG_SUBM(KK),0)
-                    IMS1 = BITGET(INFLG_SUBM(KK),1)
+                    IMS2 = BTEST(INFLG_SUBM(KK),0)
+                    IMS1 = BTEST(INFLG_SUBM(KK),1)
                     IF(KSUB==JSUB)THEN
-                      IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                       (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                      IF(.NOT.((IMS1 .AND. ISS2 ).OR.
+     .                         (IMS2 .AND. ISS1 )))  THEN
                         KK=KK+1
                         KSUB=LISUBE(KK)
                         CYCLE
@@ -1276,7 +1275,7 @@ c     .                              +XP(I)*IMPY-YP(I)*IMPX
                       IMPX=FXT(I)*DT12
                       IMPY=FYT(I)*DT12
                       IMPZ=FZT(I)*DT12
-                      IF(IMS2 > 0 ) THEN
+                      IF(IMS2  ) THEN
 C                 main side :
                         FSAVSUB1(4,JSUB)=FSAVSUB1(4,JSUB)-IMPX
                         FSAVSUB1(5,JSUB)=FSAVSUB1(5,JSUB)-IMPY
@@ -1296,7 +1295,7 @@ C
                       FSAVSUB1(14,JSUB)=FSAVSUB1(14,JSUB)+ABS(IMPZ)
 C
                       IF(ISENSINT(JSUB+1)/=0) THEN
-                        IF(IMS2 > 0 ) THEN
+                        IF(IMS2) THEN
                           FSAVPARIT(JSUB+1,4,I) =  -FXT(I)
                           FSAVPARIT(JSUB+1,5,I) =  -FYT(I)
                           FSAVPARIT(JSUB+1,6,I) =  -FZT(I)

--- a/engine/source/interfaces/int25/i25for3e.F
+++ b/engine/source/interfaces/int25/i25for3e.F
@@ -129,7 +129,8 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I, J, K0, NBINTER, K1S, K, NI, IL, IE, PP, PPL
  
-      INTEGER JSUB,KSUB,NSUB,JJ,KK,ISS1,ISS2,IMS1,IMS2,ITYPSUB
+      INTEGER JSUB,KSUB,NSUB,JJ,KK,ITYPSUB
+      LOGICAL :: ISS1,ISS2,IMS1,IMS2
       INTEGER TAGIP(MVSIZ)
       my_real
      .   VX(MVSIZ), VY(MVSIZ), VZ(MVSIZ), VN(MVSIZ),
@@ -157,8 +158,6 @@ C-----------------------------------------------
      .   C1(MVSIZ),C2(MVSIZ),C3(MVSIZ),C4(MVSIZ),
      . CX,CY,CFI,AUX,GAPP
 C
-      INTEGER BITGET
-      EXTERNAL BITGET
 C-----------------------------------------------
       IF (IRESP == 1) THEN
         PREC = FIVEEM4
@@ -427,14 +426,14 @@ C---------------------------------
         DO I=1,JLT
           IF(PENE(I)==ZERO) CYCLE
           IE=CM_LOC(I)
-          IMS2 = BITGET(EBINFLG(IE),1)
+          IMS2 = BTEST(EBINFLG(IE),1)
           FXI(I)=NX(I)*FNI(I)
           FYI(I)=NY(I)*FNI(I)
           FZI(I)=NZ(I)*FNI(I)
           IMPX=FXI(I)*DT12
           IMPY=FYI(I)*DT12
           IMPZ=FZI(I)*DT12
-          IF (IMS2 > 0 ) THEN
+          IF (IMS2 ) THEN
             FSAV1 =FSAV1 -IMPX
             FSAV2 =FSAV2 -IMPY
             FSAV3 =FSAV3 -IMPZ
@@ -449,7 +448,7 @@ C---------------------------------
           FSAV9 =FSAV9 +ABS(IMPY)
           FSAV10=FSAV10+ABS(IMPZ)
           IF(ISENSINT(1)/=0) THEN
-            IF (IMS2 >0 ) THEN
+            IF (IMS2  ) THEN
               FSAVPARIT(1,1,I) =  -FXI(I)
               FSAVPARIT(1,2,I) =  -FYI(I)
               FSAVPARIT(1,3,I) =  -FZI(I)
@@ -518,16 +517,16 @@ C---------------------------------
               JSUB=LISUBE(JJ)
               ITYPSUB = TYPSUB(JSUB)
               IF(ITYPSUB == 1 ) THEN  ! Defining specific inter
-                ISS1 = BITGET(INFLG_SUBE(JJ),0)
-                ISS2 = BITGET(INFLG_SUBE(JJ),1)
+                ISS1 = BTEST(INFLG_SUBE(JJ),0)
+                ISS2 = BTEST(INFLG_SUBE(JJ),1)
                 IF(KK<ADDSUBE(IE+1)) THEN
                   KSUB=LISUBE(KK)
                   DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBE(IE+1)))
-                    IMS1 = BITGET(INFLG_SUBE(KK),0)
-                    IMS2 = BITGET(INFLG_SUBE(KK),1)
+                    IMS1 = BTEST(INFLG_SUBE(KK),0)
+                    IMS2 = BTEST(INFLG_SUBE(KK),1)
                     IF(KSUB==JSUB)THEN
-                      IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                       (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                      IF(.NOT.((IMS1 .AND. ISS2).OR.
+     .                       (IMS2 .AND. ISS1)))  THEN
                         KK=KK+1
                         IF(KK<ADDSUBE(IE+1)) KSUB=LISUBE(KK)
                         CYCLE
@@ -536,7 +535,7 @@ C---------------------------------
                       IMPY=FYI(I)*DT12
                       IMPZ=FZI(I)*DT12
 C
-                      IF(IMS2 > 0)THEN
+                      IF(IMS2 )THEN
                         FSAVSUB1(1,JSUB)=FSAVSUB1(1,JSUB)-IMPX
                         FSAVSUB1(2,JSUB)=FSAVSUB1(2,JSUB)-IMPY
                         FSAVSUB1(3,JSUB)=FSAVSUB1(3,JSUB)-IMPZ
@@ -549,7 +548,7 @@ C
                       END IF
 C
                       IF(ISENSINT(JSUB+1)/=0) THEN
-                        IF(IMS2 > 0)THEN
+                        IF(IMS2 )THEN
                           FSAVPARIT(JSUB+1,1,I) =  -FXI(I)
                           FSAVPARIT(JSUB+1,2,I) =  -FYI(I)
                           FSAVPARIT(JSUB+1,3,I) =  -FZI(I)
@@ -598,22 +597,22 @@ C
 
               ELSEIF(ITYPSUB == 3 ) THEN   ! Inter =0 : collecting forces from all inter with 2Surfs
 
-                ISS2 = BITGET(INFLG_SUBE(JJ),0)
-                ISS1 = BITGET(INFLG_SUBE(JJ),1)
+                ISS2 = BTEST(INFLG_SUBE(JJ),0)
+                ISS1 = BTEST(INFLG_SUBE(JJ),1)
                 IF(KK<ADDSUBE(IE+1)) THEN
                   KSUB=LISUBE(KK)
                   DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBE(IE+1)))
-                    IMS2 = BITGET(INFLG_SUBE(KK),0)
-                    IMS1 = BITGET(INFLG_SUBE(KK),1)
+                    IMS2 = BTEST(INFLG_SUBE(KK),0)
+                    IMS1 = BTEST(INFLG_SUBE(KK),1)
                     IF(KSUB==JSUB)THEN
-                      IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                      (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                      IF(.NOT.((IMS1 .AND. ISS2).OR.
+     .                      (IMS2 .AND. ISS1)))  THEN
                         KK=KK+1
                         IF(KK<ADDSUBE(IE+1)) KSUB=LISUBE(KK)
                         CYCLE
                       END IF
 
-                      IF(IMS2 > 0)THEN
+                      IF(IMS2 )THEN
                          FSAVSUB1(1,JSUB)=FSAVSUB1(1,JSUB)-IMPX
                          FSAVSUB1(2,JSUB)=FSAVSUB1(2,JSUB)-IMPY
                          FSAVSUB1(3,JSUB)=FSAVSUB1(3,JSUB)-IMPZ
@@ -630,7 +629,7 @@ C
                       FSAVSUB1(10,JSUB)=FSAVSUB1(10,JSUB)+ABS(IMPZ)
 
                       IF(ISENSINT(JSUB+1)/=0) THEN
-                        IF(IMS2 > 0)THEN
+                        IF(IMS2 )THEN
                           FSAVPARIT(JSUB+1,1,I) =  -FXI(I)
                           FSAVPARIT(JSUB+1,2,I) =  -FYI(I)
                           FSAVPARIT(JSUB+1,3,I) =  -FZI(I)
@@ -721,17 +720,17 @@ C            WRITE(6,*) "JJ=",JJ
                 ITYPSUB = TYPSUB(JSUB)
                 IF(ITYPSUB == 1 ) THEN  ! Defining specific inter
                   ASSERT(JSUB <= NISUB)
-                  ISS1 = BITGET(INFLG_SUBSFIE(NIN)%P(JJ),0)
-                  ISS2 = BITGET(INFLG_SUBSFIE(NIN)%P(JJ),1)
+                  ISS1 = BTEST(INFLG_SUBSFIE(NIN)%P(JJ),0)
+                  ISS2 = BTEST(INFLG_SUBSFIE(NIN)%P(JJ),1)
                   IF(KK<ADDSUBE(IE+1)) THEN
                     KSUB=LISUBE(KK)
                     DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBE(IE+1)))
                       ASSERT(KSUB <= NISUB)
-                      IMS1 = BITGET(INFLG_SUBE(KK),0)
-                      IMS2 = BITGET(INFLG_SUBE(KK),1)
+                      IMS1 = BTEST(INFLG_SUBE(KK),0)
+                      IMS2 = BTEST(INFLG_SUBE(KK),1)
                       IF(KSUB==JSUB)THEN
-                        IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                        (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                        IF(.NOT.((IMS1 .AND. ISS2).OR.
+     .                        (IMS2 .AND. ISS1)))  THEN
                           KK=KK+1
                           IF(KK<ADDSUBE(IE+1)) KSUB=LISUBE(KK)
                           CYCLE
@@ -740,7 +739,7 @@ C            WRITE(6,*) "JJ=",JJ
                         IMPY=FYI(I)*DT12
                         IMPZ=FZI(I)*DT12
 C
-                        IF(IMS2 > 0)THEN
+                        IF(IMS2 )THEN
                           FSAVSUB1(1,JSUB)=FSAVSUB1(1,JSUB)-IMPX
                           FSAVSUB1(2,JSUB)=FSAVSUB1(2,JSUB)-IMPY
                           FSAVSUB1(3,JSUB)=FSAVSUB1(3,JSUB)-IMPZ
@@ -753,7 +752,7 @@ C
                         END IF
 C
                         IF(ISENSINT(JSUB+1)/=0) THEN
-                          IF(IMS2 > 0)THEN
+                          IF(IMS2 )THEN
                             FSAVPARIT(JSUB+1,1,I) =  -FXI(I)
                             FSAVPARIT(JSUB+1,2,I) =  -FYI(I)
                             FSAVPARIT(JSUB+1,3,I) =  -FZI(I)
@@ -802,16 +801,16 @@ C
 
                 ELSEIF(ITYPSUB == 3 ) THEN   ! Inter =0 : collecting forces from all inter with 2Surfs
 
-                  ISS2 = BITGET(INFLG_SUBSFIE(NIN)%P(JJ),0)
-                  ISS1 = BITGET(INFLG_SUBSFIE(NIN)%P(JJ),1)
+                  ISS2 = BTEST(INFLG_SUBSFIE(NIN)%P(JJ),0)
+                  ISS1 = BTEST(INFLG_SUBSFIE(NIN)%P(JJ),1)
                   IF(KK<ADDSUBE(IE+1)) THEN
                     KSUB=LISUBE(KK)
                     DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBE(IE+1)))
-                      IMS2 = BITGET(INFLG_SUBE(KK),0)
-                      IMS1 = BITGET(INFLG_SUBE(KK),1)
+                      IMS2 = BTEST(INFLG_SUBE(KK),0)
+                      IMS1 = BTEST(INFLG_SUBE(KK),1)
                       IF(KSUB==JSUB)THEN
-                        IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                         (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                        IF(.NOT.((IMS1 .AND. ISS2).OR.
+     .                         (IMS2 .AND. ISS1)))  THEN
                           KK=KK+1
                           IF(KK<ADDSUBE(IE+1)) KSUB=LISUBE(KK)
                           CYCLE
@@ -821,7 +820,7 @@ C
                         IMPY=FYI(I)*DT12
                         IMPZ=FZI(I)*DT12
 
-                        IF(IMS2 > 0)THEN
+                        IF(IMS2)THEN
                           FSAVSUB1(1,JSUB)=FSAVSUB1(1,JSUB)-IMPX
                           FSAVSUB1(2,JSUB)=FSAVSUB1(2,JSUB)-IMPY
                           FSAVSUB1(3,JSUB)=FSAVSUB1(3,JSUB)-IMPZ
@@ -952,16 +951,16 @@ C---------------------------------
               ITYPSUB = TYPSUB(JSUB)
 
               IF(ITYPSUB == 1 ) THEN  ! Defining specific inter
-                ISS1 = BITGET(INFLG_SUBE(JJ),0)
-                ISS2 = BITGET(INFLG_SUBE(JJ),1)
+                ISS1 = BTEST(INFLG_SUBE(JJ),0)
+                ISS2 = BTEST(INFLG_SUBE(JJ),1)
                 IF(KK<ADDSUBE(IE+1)) THEN
                   KSUB=LISUBE(KK)
                   DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBE(IE+1)))
-                    IMS1 = BITGET(INFLG_SUBE(KK),0)
-                    IMS2 = BITGET(INFLG_SUBE(KK),1)
+                    IMS1 = BTEST(INFLG_SUBE(KK),0)
+                    IMS2 = BTEST(INFLG_SUBE(KK),1)
                     IF(KSUB==JSUB)THEN
-                      IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                       (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                      IF(.NOT.((IMS1 .AND. ISS2).OR.
+     .                       (IMS2 .AND. ISS1)))  THEN
                         KK=KK+1
                         IF(KK<ADDSUBE(IE+1)) KSUB=LISUBE(KK)
                         CYCLE
@@ -1030,16 +1029,16 @@ c     .                              +XP(I)*IMPY-YP(I)*IMPX
 
               ELSEIF(ITYPSUB == 3 ) THEN   ! Inter =0 : collecting forces from all inter with 2Surfs
 
-                ISS2 = BITGET(INFLG_SUBE(JJ),0)
-                ISS1 = BITGET(INFLG_SUBE(JJ),1)
+                ISS2 = BTEST(INFLG_SUBE(JJ),0)
+                ISS1 = BTEST(INFLG_SUBE(JJ),1)
                 IF(KK<ADDSUBE(IE+1)) THEN
                   KSUB=LISUBE(KK)
                   DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBE(IE+1)))
-                    IMS2 = BITGET(INFLG_SUBE(KK),0)
-                    IMS1 = BITGET(INFLG_SUBE(KK),1)
+                    IMS2 = BTEST(INFLG_SUBE(KK),0)
+                    IMS1 = BTEST(INFLG_SUBE(KK),1)
                     IF(KSUB==JSUB)THEN
-                      IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                       (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                      IF(.NOT.((IMS1  .AND. ISS2).OR.
+     .                       (IMS2  .AND. ISS1 )))  THEN
                         KK=KK+1
                         IF(KK<ADDSUBE(IE+1)) KSUB=LISUBE(KK)
                         CYCLE
@@ -1049,7 +1048,7 @@ c     .                              +XP(I)*IMPY-YP(I)*IMPX
                       IMPY=FYT(I)*DT12
                       IMPZ=FZT(I)*DT12
 
-                      IF(IMS2 > 0) THEN
+                      IF(IMS2) THEN
                         FSAVSUB1(4,JSUB)=FSAVSUB1(4,JSUB)-IMPX
                         FSAVSUB1(5,JSUB)=FSAVSUB1(5,JSUB)-IMPY
                         FSAVSUB1(6,JSUB)=FSAVSUB1(6,JSUB)-IMPZ
@@ -1068,7 +1067,7 @@ C
                       FSAVSUB1(14,JSUB)=FSAVSUB1(14,JSUB)+ABS(IMPZ)
 C
                       IF(ISENSINT(JSUB+1)/=0) THEN
-                        IF(IMS2 > 0) THEN
+                        IF(IMS2) THEN
                           FSAVPARIT(JSUB+1,4,I) =  -FXT(I)
                           FSAVPARIT(JSUB+1,5,I) =  -FYT(I)
                           FSAVPARIT(JSUB+1,6,I) =  -FZT(I)
@@ -1147,16 +1146,16 @@ c     .                              +XP(I)*IMPY-YP(I)*IMPX
                 ITYPSUB = TYPSUB(JSUB)
 
                 IF(ITYPSUB == 1 ) THEN  ! Defining specific inter
-                  ISS1 = BITGET(INFLG_SUBSFIE(NIN)%P(JJ),0)
-                  ISS2 = BITGET(INFLG_SUBSFIE(NIN)%P(JJ),1)
+                  ISS1 = BTEST(INFLG_SUBSFIE(NIN)%P(JJ),0)
+                  ISS2 = BTEST(INFLG_SUBSFIE(NIN)%P(JJ),1)
                   IF(KK<ADDSUBE(IE+1)) THEN  
                      KSUB=LISUBE(KK)
                     DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBE(IE+1)))
-                      IMS1 = BITGET(INFLG_SUBE(KK),0)
-                      IMS2 = BITGET(INFLG_SUBE(KK),1)
+                      IMS1 = BTEST(INFLG_SUBE(KK),0)
+                      IMS2 = BTEST(INFLG_SUBE(KK),1)
                       IF(KSUB==JSUB)THEN
-                        IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                         (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                        IF(.NOT.((IMS1  .AND. ISS2 ).OR.
+     .                         (IMS2 .AND. ISS1 )))  THEN
                           KK=KK+1
                           IF(KK<ADDSUBE(IE+1)) KSUB=LISUBE(KK)
                           CYCLE
@@ -1226,16 +1225,16 @@ c     .                              +XP(I)*IMPY-YP(I)*IMPX
 
                 ELSEIF(ITYPSUB == 3 ) THEN   ! Inter =0 : collecting forces from all inter with 2Surfs
 
-                  ISS2 = BITGET(INFLG_SUBSFIE(NIN)%P(JJ),0)
-                  ISS1 = BITGET(INFLG_SUBSFIE(NIN)%P(JJ),1)
+                  ISS2 = BTEST(INFLG_SUBSFIE(NIN)%P(JJ),0)
+                  ISS1 = BTEST(INFLG_SUBSFIE(NIN)%P(JJ),1)
                   IF(KK<ADDSUBE(IE+1)) THEN
                     KSUB=LISUBE(KK)
                     DO WHILE((KSUB<=JSUB).AND.(KK<ADDSUBE(IE+1)))
-                      IMS2 = BITGET(INFLG_SUBE(KK),0)
-                      IMS1 = BITGET(INFLG_SUBE(KK),1)
+                      IMS2 = BTEST(INFLG_SUBE(KK),0)
+                      IMS1 = BTEST(INFLG_SUBE(KK),1)
                       IF(KSUB==JSUB)THEN
-                        IF(.NOT.((IMS1 == 1 .AND. ISS2 == 1).OR.
-     .                       (IMS2 == 1 .AND. ISS1 == 1)))  THEN
+                        IF(.NOT.((IMS1  .AND. ISS2 ).OR.
+     .                       (IMS2  .AND. ISS1 )))  THEN
                           KK=KK+1
                           IF(KK<ADDSUBE(IE+1)) KSUB=LISUBE(KK)
                           CYCLE
@@ -1244,7 +1243,7 @@ c     .                              +XP(I)*IMPY-YP(I)*IMPX
                         IMPX=FXT(I)*DT12
                         IMPY=FYT(I)*DT12
                         IMPZ=FZT(I)*DT12
-                        IF(IMS2 > 0 ) THEN
+                        IF(IMS2 ) THEN
 C                 main side :
                           FSAVSUB1(4,JSUB)=FSAVSUB1(4,JSUB)-IMPX
                           FSAVSUB1(5,JSUB)=FSAVSUB1(5,JSUB)-IMPY
@@ -1264,7 +1263,7 @@ C
                         FSAVSUB1(14,JSUB)=FSAVSUB1(14,JSUB)+ABS(IMPZ)
 C 
                         IF(ISENSINT(JSUB+1)/=0) THEN
-                          IF(IMS2 > 0 ) THEN
+                          IF(IMS2  ) THEN
                             FSAVPARIT(JSUB+1,4,I) =  -FXT(I)
                             FSAVPARIT(JSUB+1,5,I) =  -FYT(I)
                             FSAVPARIT(JSUB+1,6,I) =  -FZT(I)

--- a/engine/source/interfaces/intsort/i25sto.F
+++ b/engine/source/interfaces/intsort/i25sto.F
@@ -155,28 +155,27 @@ C     REAL
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I,N,NE,IMS1,IMS2,ISS1,ISS2
+      INTEGER I,N,NE
+      LOGICAL IMS1,IMS2,ISS1,ISS2
 C     REAL
 C-----------------------------------------------
       my_real
      .   PENE(*)
-      INTEGER BITGET
-      EXTERNAL BITGET
 C=======================================================================
          DO I=1,LLT
            N  = PROV_N(I)
            NE = PROV_E(I)+ESHIFT
-           IMS1 = BITGET(MBINFLG(NE),0)
-           IMS2 = BITGET(MBINFLG(NE),1)
+           IMS1 = BTEST(MBINFLG(NE),0)
+           IMS2 = BTEST(MBINFLG(NE),1)
            IF(N <= NSN) THEN
-             ISS1 = BITGET(NBINFLG(N),0)
-             ISS2 = BITGET(NBINFLG(N),1)
+             ISS1 = BTEST(NBINFLG(N),0)
+             ISS2 = BTEST(NBINFLG(N),1)
            ELSE
-             ISS1 = BITGET(IREM(I24IREMP+6,N-NSN),0) 
-             ISS2 = BITGET(IREM(I24IREMP+6,N-NSN),1) 
+             ISS1 = BTEST(IREM(I24IREMP+6,N-NSN),0) 
+             ISS2 = BTEST(IREM(I24IREMP+6,N-NSN),1) 
            ENDIF
-           IF(.NOT.((IMS1 == 1 .and. ISS2==1).or.
-     .              (IMS2 == 1 .and. ISS1==1)))THEN
+           IF(.NOT.((IMS1.and.ISS2).or.
+     .              (IMS2.and.ISS1)))THEN
              PENE(I)=ZERO
            ENDIF
          ENDDO

--- a/engine/source/interfaces/intsort/i25trivox_edg.F
+++ b/engine/source/interfaces/intsort/i25trivox_edg.F
@@ -128,9 +128,10 @@ C     REAL
 c provisional
       INTEGER  IX,IY,IZ,IEDG,
      .         M1, M2, M3, M4, MM1,MM2,MM3,MM4,SS1,SS2,
-     .         IMS1,IMS2,ISS1,ISS2,
      .         AM1,AM2,AS1,AS2,
      .         IX1,IY1,IZ1,IX2,IY2,IZ2,REMOVE_REMOTE
+      logical  IMS1,IMS2,ISS1,ISS2
+
       INTEGER, DIMENSION(3) :: TMIN,TMAX
       my_real
      .   XMINB,YMINB,ZMINB,XMAXB,YMAXB,ZMAXB,AAA,
@@ -145,9 +146,6 @@ c provisional
       INTEGER :: EDGE_TYPE
       INTEGER :: EID
       INTEGER FIRST_ADD, PREV_ADD, CHAIN_ADD, CURRENT_ADD, MAX_ADD
-      INTEGER BITGET
-      EXTERNAL BITGET
-
 C-----------------------------------------------
       INTEGER IDS(4), PROV_IDS(2,MVSIZ)
 
@@ -437,8 +435,8 @@ C=======================================================================
         AM2 = MAX(MM1,MM2)
 
         IF(ILEV==2)THEN
-          IMS1 = BITGET(EBINFLG(IEDG),0)
-          IMS2 = BITGET(EBINFLG(IEDG),1)
+          IMS1 = BTEST(EBINFLG(IEDG),0)
+          IMS2 = BTEST(EBINFLG(IEDG),1)
         END IF
 
         !-------------------------------------------!
@@ -518,16 +516,16 @@ C--- IREMGAP - tag of deactivated lines
 
                 IF(ILEV==2)THEN
                   IF(JJ <= NEDGE) THEN
-                    ISS1=BITGET(EBINFLG(JJ),0)
-                    ISS2=BITGET(EBINFLG(JJ),1)
+                    ISS1=BTEST(EBINFLG(JJ),0)
+                    ISS2=BTEST(EBINFLG(JJ),1)
                   ELSE
 C                 double-check
-                    ISS1 = BITGET(IREM_EDGE(E_EBINFLG,JJ-NEDGE),0)
-                    ISS2 = BITGET(IREM_EDGE(E_EBINFLG,JJ-NEDGE),1)
+                    ISS1 = BTEST(IREM_EDGE(E_EBINFLG,JJ-NEDGE),0)
+                    ISS2 = BTEST(IREM_EDGE(E_EBINFLG,JJ-NEDGE),1)
                   ENDIF
 
-                  IF(.NOT.((IMS1 == 1 .and. ISS2==1).or.
-     .                     (IMS2 == 1 .and. ISS1==1)))THEN
+                  IF(.NOT.((IMS1 .and. ISS2).or.
+     .                     (IMS2 .and. ISS1)))THEN
                     CHAIN_ADD = LCHAIN_NEXT(CHAIN_ADD)
                     CYCLE
                   ENDIF
@@ -745,8 +743,8 @@ C=======================================================================
         IZ2=MAX(1,2+MIN(NBZ,IZ2))
 
         IF(ILEV==2)THEN
-          IMS1 = BITGET(MBINFLG(NE),0)
-          IMS2 = BITGET(MBINFLG(NE),1)
+          IMS1 = BTEST(MBINFLG(NE),0)
+          IMS2 = BTEST(MBINFLG(NE),1)
         END IF
 
 #ifdef WITH_ASSERT
@@ -810,14 +808,14 @@ C--- IREMGAP - tag of deactivated lines
 
                 IF(ILEV==2)THEN
                   IF(JJ <= NEDGE) THEN
-                    ISS1=BITGET(EBINFLG(JJ),0)
-                    ISS2=BITGET(EBINFLG(JJ),1)
+                    ISS1=BTEST(EBINFLG(JJ),0)
+                    ISS2=BTEST(EBINFLG(JJ),1)
                   ELSE
-                    ISS1 = BITGET(IREM_EDGE(E_EBINFLG,JJ-NEDGE),0)
-                    ISS2 = BITGET(IREM_EDGE(E_EBINFLG,JJ-NEDGE),1)
+                    ISS1 = BTEST(IREM_EDGE(E_EBINFLG,JJ-NEDGE),0)
+                    ISS2 = BTEST(IREM_EDGE(E_EBINFLG,JJ-NEDGE),1)
                   ENDIF
-                  IF(.NOT.((IMS1 == 1 .and. ISS2==1).or.
-     .                     (IMS2 == 1 .and. ISS1==1)))THEN
+                  IF(.NOT.((IMS1 .and. ISS2).or.
+     .                     (IMS2 .and. ISS1)))THEN
                     CHAIN_ADD = LCHAIN_NEXT(CHAIN_ADD)
                     CYCLE
                   ENDIF


### PR DESCRIPTION

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
Call intrinsic BTEST instead of BITGET.
Gfortran and ifx should replace the call to a subroutine by a cheap operation.

Should improve /INTER/TYPE25 with subinterfaces

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
