### PR TITLE
Add MIDFAIL and revise triaxiality limit for regularization in /FAIL/TAB2

### DIFF
--- a/engine/source/materials/fail/tabulated/fail_tab2_c.F
+++ b/engine/source/materials/fail/tabulated/fail_tab2_c.F
@@ -37,9 +37,11 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      1     NEL      ,NUPARAM  ,NUVAR    ,NFUNC    ,IFUNC    ,
      2     NPF      ,TABLE    ,TF       ,TIME     ,UPARAM   , 
      3     NGL      ,ALDT     ,DPLA     ,EPSP     ,UVAR     ,     
-     4     SIGNXX   ,SIGNYY   ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,            
+     4     SIGNXX   ,SIGNYY   ,SIGNXY   ,     
      5     TEMP     ,FOFF     ,DFMAX    ,TDELE    ,IPT      ,
-     6     IPG      ,DMG_FLAG ,DMG_SCALE,NTABLF   ,ITABLF   )   
+     6     IPG      ,DMG_FLAG ,DMG_SCALE,NTABLF   ,ITABLF   ,
+     7     NIPARAM  ,IPARAM   ,NOFF     ,OFF      ,NPT      ,
+     8     GVAR     )   
 C---------+---------+---+---+--------------------------------------------
       USE TABLE_MOD
       USE INTERFACE_TABLE_MOD
@@ -65,12 +67,17 @@ C-----------------------------------------------
       my_real, INTENT(IN) :: 
      .        TIME,UPARAM(NUPARAM),ALDT(NEL),
      .        DPLA(NEL),EPSP(NEL),TEMP(NEL),
-     .        SIGNXX(NEL),SIGNYY(NEL),SIGNXY(NEL),
-     .        SIGNYZ(NEL),SIGNZX(NEL)
+     .        SIGNXX(NEL),SIGNYY(NEL),SIGNXY(NEL)
       my_real, INTENT(INOUT) :: 
      .        UVAR(NEL,NUVAR),DFMAX(NEL),TDELE(NEL),
      .        DMG_SCALE(NEL)
       TYPE (TTABLE), INTENT(IN), DIMENSION(NTABLE) :: TABLE 
+      INTEGER, INTENT(IN) :: NIPARAM
+      INTEGER, DIMENSION(NIPARAM), INTENT(IN) :: IPARAM
+      INTEGER, INTENT(INOUT) :: NOFF(NEL)
+      my_real, INTENT(INOUT) :: OFF(NEL)
+      INTEGER, INTENT(IN) :: NPT
+      my_real, DIMENSION(NEL), INTENT(INOUT) :: GVAR !< Global element user variables
 C!-----------------------------------------------
 C!   VARIABLES FOR FUNCTION INTERPOLATION 
 C!-----------------------------------------------
@@ -86,23 +93,29 @@ C-----------------------------------------------
      .        ITAB_INST,ITAB_SIZE,IREG,
      .        IPOS(NEL,3),NDIM,IPOS2(NEL),
      .        IAD(NEL),ILEN(NEL),LOG_SCALE1,
-     .        LOG_SCALE2
+     .        LOG_SCALE2,MIDFAIL
       my_real 
      .        FCRIT  ,DN,DCRIT,ECRIT,EXP_REF,EXPO,EL_REF,
      .        SR_REF1,FSCALE_EL,SHRF,BIAXF  ,SR_REF2,
-     .        FSCALE_SR,CJC,FSCALE_DLIM,TEMP_REF, FSCALE_TEMP
+     .        FSCALE_SR,CJC,FSCALE_DLIM,TEMP_REF, FSCALE_TEMP,
+     .        RGTR1  ,RGTR2
       my_real
      .        LAMBDA,DF,INST(NEL)  ,DC(NEL)     ,L0(NEL)     ,
      .        TRIAX(NEL)  ,XI(NEL)     ,EPSF(NEL)   ,EPSL(NEL)   ,
      .        DEPSF(NEL)  ,DEPSL(NEL)  ,XVEC(NEL,3) ,DPL_DEF     ,
      .        COS3THETA   ,P           ,SVM         ,SIZEFAC(NEL),
      .        RATEFAC(NEL),DSIZE(NEL)  ,SOFTEXP(NEL),DLIM(NEL)   ,
-     .        TEMPFAC(NEL),TEMPFAC2(NEL),DFT(NEL)   ,VAR(NEL)
+     .        TEMPFAC(NEL),TEMPFAC2(NEL),DFT(NEL)   ,VAR(NEL)    ,
+     .        RETA
+      LOGICAL IS_MIDPT,COMP_MIDFAIL
 C!--------------------------------------------------------------
       !=======================================================================
       ! - INITIALISATION OF COMPUTATION ON TIME STEP
       !=======================================================================
       ! Recovering failure criterion parameters
+      !< Integer parameters
+      MIDFAIL       = IPARAM(1)
+      !< Real parameters
       FCRIT         = UPARAM(1)
       DN            = UPARAM(4)
       DCRIT         = UPARAM(5) 
@@ -123,6 +136,10 @@ C!--------------------------------------------------------------
       FSCALE_TEMP   = UPARAM(20)
       LOG_SCALE1    = NINT(UPARAM(21))
       LOG_SCALE2    = NINT(UPARAM(22))
+      RGTR1         = UPARAM(24)
+      RGTR1         = MAX(RGTR1,EM06)
+      RGTR2         = UPARAM(25)
+      RGTR2         = MIN(RGTR2,TWO_THIRD - EM06)
 c
       ITAB_EPSF = ITABLF(1)
       ITAB_INST = ITABLF(2)
@@ -131,16 +148,33 @@ c
       ! Set flag for stress softening
       DMG_FLAG = 1
 c
+      !< Flag to identify if mid-plane point
+      IS_MIDPT = .FALSE.
+      ! -> Odd number of integration points
+      IF (MOD(NPT,2) == 1) THEN
+        IF (IPT == (NPT/2 + 1)) IS_MIDPT = .TRUE.
+      ! -> Even number of integration points
+      ELSE
+        IF (IPT == NPT/2)       IS_MIDPT = .TRUE.
+        IF (IPT == (NPT/2 + 1)) IS_MIDPT = .TRUE.
+      ENDIF
+c
+      !< Midfail computation flag
+      COMP_MIDFAIL = .TRUE.
+      IF ((MIDFAIL == 4) .AND. (.NOT.IS_MIDPT)) COMP_MIDFAIL = .FALSE.
+c
       ! Checking element failure and recovering user variable
       DO I=1,NEL
         ! If necking control is activated
         IF ((ITAB_INST > 0).OR.(ECRIT > ZERO)) THEN 
-          ! Instability damage
-          INST(I) = UVAR(I,1)
-          ! Necking critical damage 
           IF (UVAR(I,2) == ZERO) UVAR(I,2) = ONE
-          DC(I)   = UVAR(I,2)
-        ENDIF   
+        ELSE
+          IF (UVAR(I,2) == ZERO) UVAR(I,2) = DCRIT
+        ENDIF
+        ! Instability damage
+        INST(I) = UVAR(I,1)
+        ! Necking critical damage 
+        DC(I)   = UVAR(I,2)
       END DO
 c      
       !====================================================================
@@ -247,11 +281,13 @@ c
         SIZEFAC(1:NEL) = SIZEFAC(1:NEL)*FSCALE_EL
         IF (IREG == 1) THEN 
           DO I = 1,NEL
-            IF (TRIAX(I) < SHRF) THEN 
-              SIZEFAC(I) = ONE
-            ELSEIF (TRIAX(I) > BIAXF) THEN 
-              SIZEFAC(I) = ONE
+            IF (TRIAX(I) < THIRD) THEN 
+              RETA =  SHRF*(ONE - MIN(MAX(TRIAX(I),ZERO),RGTR1)/RGTR1)
+            ELSEIF (TRIAX(I) >= THIRD) THEN 
+              RETA = (THREE*BIAXF/(THREE*RGTR2 - TWO))*
+     .               (RGTR2 - MIN(MAX(TRIAX(I),RGTR2),TWO_THIRD))
             ENDIF
+            SIZEFAC(I) = SIZEFAC(I) + RETA*(ONE - SIZEFAC(I))
           ENDDO
         ENDIF
       ELSE
@@ -372,7 +408,7 @@ c
       DO I=1,NEL
 c
         ! If the element is not broken
-        IF (FOFF(I) /= 0 .AND. DPLA(I) > ZERO) THEN
+        IF (FOFF(I) /= 0 .AND. DPLA(I) > ZERO .AND. COMP_MIDFAIL) THEN
 c
           ! Needs to initialize damage at a very small value the first time
           IF (DFMAX(I) == ZERO) DFMAX(I) = EM20
@@ -383,10 +419,16 @@ c
           DFMAX(I) = DFMAX(I) + DPL_DEF*DN*(DFMAX(I)**(ONE-(ONE/DN)))
           DFMAX(I) = MIN(DFMAX(I),DLIM(I))
           IF (DFMAX(I) >= ONE) THEN 
-            NINDX       = NINDX + 1
-            INDX(NINDX) = I
-            FOFF(I)     = 0
-            TDELE(I)    = TIME
+            IF ((MIDFAIL /= 1 .AND. MIDFAIL /= 2 .AND. MIDFAIL /= 3).OR.(IS_MIDPT)) THEN
+              NINDX       = NINDX + 1
+              INDX(NINDX) = I
+              FOFF(I)     = 0
+              TDELE(I)    = TIME
+            ENDIF
+            !< Instant failure of all integration points and element deletion
+            IF ((IS_MIDPT).AND.((MIDFAIL == 3).OR.(MIDFAIL == 4))) THEN 
+              OFF(I) = FOUR_OVER_5
+            ENDIF
           ENDIF
 c
           ! Compute the control necking instability damage
@@ -406,29 +448,50 @@ c
       ! - UPDATE UVAR AND THE STRESS TENSOR
       !====================================================================
       DO I = 1,NEL 
-        IF ((ITAB_INST > 0).OR.(ECRIT > ZERO)) THEN 
-          UVAR(I,1) = INST(I)
-          UVAR(I,2) = DC(I)
-          IF (DFMAX(I) >= DC(I)) THEN 
-            IF (DC(I) < ONE) THEN 
-              DMG_SCALE(I) = ONE - ((DFMAX(I)-DC(I))/MAX(ONE-DC(I),EM20))**SOFTEXP(I)
-            ELSE
-              DMG_SCALE(I) = ZERO
-            ENDIF
+        !< Save necking instability damage
+        UVAR(I,1) = INST(I)
+        !< Damage criterion for stress softening
+        IF (DFMAX(I) >= DC(I)) THEN
+          !< Flag for mid-point integration point softening
+          IF (MOD(NPT,2) == 1) THEN
+            IF ((IS_MIDPT).AND.(NOFF(I) == 0)) NOFF(I) = 1
           ELSE
-            DMG_SCALE(I) = ONE
+            IF ((IS_MIDPT).AND.(NOFF(I) == 0)) NOFF(I) = IPT
+            IF ((IS_MIDPT).AND.(NOFF(I) /= 0).AND.(IPT /= NOFF(I))) NOFF(I) = 1
+          ENDIF
+          !< Damage softening scale computation
+          IF (DC(I) < ONE) THEN 
+            DMG_SCALE(I) = ONE - ((DFMAX(I)-DC(I))/MAX(ONE-DC(I),EM20))**SOFTEXP(I)
+          ELSE
+            DMG_SCALE(I) = ZERO
+          ENDIF
+          !< Mid-point integration point softening synchronization
+          IF (IS_MIDPT) GVAR(I) = DMG_SCALE(I)
+          !< Synchronization of mid-point softening to other breaking integration points
+          IF ((MIDFAIL == 1).AND.(NOFF(I) == 1).AND.(.NOT.IS_MIDPT)) THEN
+            DMG_SCALE(I) = GVAR(I)
+            IF ((DMG_SCALE(I) == ZERO).AND.(FOFF(I) /= 0)) THEN
+              NINDX       = NINDX + 1
+              INDX(NINDX) = I
+              FOFF(I)     = 0
+              TDELE(I)    = TIME
+            ENDIF
           ENDIF
         ELSE
-          IF (DFMAX(I) >= DCRIT) THEN 
-            IF (DCRIT < ONE) THEN 
-              DMG_SCALE(I) = ONE - ((DFMAX(I)-DCRIT)/MAX(ONE-DCRIT,EM20))**SOFTEXP(I)
-            ELSE
-              DMG_SCALE(I) = ZERO
-            ENDIF
-          ELSE
-            DMG_SCALE(I) = ONE
+          DMG_SCALE(I) = ONE
+        ENDIF
+        !< Synchronization of mid-point softening to all integration points
+        IF (((MIDFAIL == 2).OR.(MIDFAIL == 3)).AND.(NOFF(I) == 1).AND.(.NOT.IS_MIDPT)) THEN
+          DMG_SCALE(I) = GVAR(I)
+          IF ((DMG_SCALE(I) == ZERO).AND.(FOFF(I) /= 0)) THEN
+            NINDX       = NINDX + 1
+            INDX(NINDX) = I
+            FOFF(I)     = 0
+            TDELE(I)    = TIME
           ENDIF
         ENDIF
+        !< Update necking critical damage
+        UVAR(I,2) = DC(I)
       ENDDO
 c
       !====================================================================

--- a/engine/source/materials/fail/tabulated/fail_tab2_ib.F90
+++ b/engine/source/materials/fail/tabulated/fail_tab2_ib.F90
@@ -121,9 +121,9 @@
           integer, dimension(nel, 3) :: ipos
           real(kind=WP) :: fcrit, dn, dcrit, ecrit, exp_ref, expo, el_ref, &
             sr_ref1, fscale_el, shrf, biaxf, sr_ref2, &
-            fscale_sr, cjc, fscale_dlim, temp_ref, fscale_temp
+            fscale_sr, cjc, fscale_dlim, temp_ref, fscale_temp,rgtr1, rgtr2
           real(kind=WP) :: lambda, df, dpl_def, cos3theta, det, p, svm, &
-            sxx, syy, szz
+            sxx, syy, szz, reta
           real(kind=WP), dimension(nel) :: inst, dc, l0, triax, xi, epsf, epsl, &
             depsf, depsl, sizefac, ratefac, dsize, &
             softexp, dlim, tempfac, tempfac2, dft, var
@@ -162,7 +162,10 @@
           fscale_temp   = uparam(20)               !> scale factor for temperature scaling function.
           log_scale1    = nint(uparam(21))
           log_scale2    = nint(uparam(22))
-
+          rgtr1         = uparam(24)
+          rgtr1         = max(rgtr1,em06)
+          rgtr2         = uparam(25)
+          rgtr2         = min(rgtr2,two_third - em06)
 !c
           itab_epsf = itablf(1)                   !> plastic strain at failure table or function identifier
           itab_inst = itablf(2)                   !> instability (necking) plastic strain table or function identifier.
@@ -173,13 +176,15 @@
           ! checking element failure and recovering user variable
           do i=1,nel
             ! if necking control is activated
-            if ((itab_inst > 0).or.(ecrit > zero)) then
-              ! instability damage
-              inst(i) = uvar(i,1)
-              ! necking critical damage
+            if ((itab_inst > 0).or.(ecrit > zero)) then 
               if (uvar(i,2) == zero) uvar(i,2) = one
-              dc(i)   = uvar(i,2)
-            end if
+            else
+              if (uvar(i,2) == zero) uvar(i,2) = dcrit
+            endif
+            ! instability damage
+            inst(i) = uvar(i,1)
+            ! necking critical damage
+            dc(i)   = uvar(i,2)
           end do
 !c
           !c
@@ -291,11 +296,13 @@
             sizefac(1:nel) = sizefac(1:nel)*fscale_el
             if (ireg == 1) then
               do i = 1,nel
-                if (triax(i) < shrf) then
-                  sizefac(i) = one
-                else if (triax(i) > biaxf) then
-                  sizefac(i) = one
-                end if
+                if (triax(i) < third) then 
+                  reta =  shrf*(one - min(max(triax(i),zero),rgtr1)/rgtr1)
+                elseif (triax(i) >= third) then 
+                  reta = (three*biaxf/(three*rgtr2 - two))*                    &
+                         (rgtr2 - min(max(triax(i),rgtr2),two_third))
+                endif
+                sizefac(i) = sizefac(i) + reta*(one - sizefac(i))
               end do
             end if
           else
@@ -455,29 +462,21 @@
           ! - update uvar and the stress tensor
           !====================================================================
           do i = 1,nel
-            if ((itab_inst > 0).or.(ecrit > zero)) then
-              uvar(i,1) = inst(i)
-              uvar(i,2) = dc(i)
-              if (dfmax(i) >= dc(i)) then
-                if (dc(i) < one) then
-                  dmg_scale(i) = one - ((dfmax(i)-dc(i))/max(one-dc(i),em20))**softexp(i)
-                else
-                  dmg_scale(i) = zero
-                end if
+            !< Save necking instability damage
+            uvar(i,1) = inst(i)
+            !< Damage criterion for stress softening
+            if (dfmax(i) >= dc(i)) then
+              !< Damage softening scale computation
+              if (dc(i) < one) then
+                dmg_scale(i) = one - ((dfmax(i)-dc(i))/max(one-dc(i),em20))**softexp(i)
               else
-                dmg_scale(i) = one
+                dmg_scale(i) = zero
               end if
             else
-              if (dfmax(i) >= dcrit) then
-                if (dcrit < one) then
-                  dmg_scale(i) = one - ((dfmax(i)-dcrit)/max(one-dcrit,em20))**softexp(i)
-                else
-                  dmg_scale(i) = zero
-                end if
-              else
-                dmg_scale(i) = one
-              end if
-            end if
+              dmg_scale(i) = one
+            endif
+            !< Update necking critical damage  
+            uvar(i,2) = dc(i)
           end do
 !c
           !====================================================================

--- a/engine/source/materials/fail/tabulated/fail_tab2_s.F
+++ b/engine/source/materials/fail/tabulated/fail_tab2_s.F
@@ -92,14 +92,16 @@ C-----------------------------------------------
       my_real 
      .        FCRIT  ,DN,DCRIT,ECRIT,EXP_REF,EXPO,EL_REF,
      .        SR_REF1,FSCALE_EL,SHRF,BIAXF  ,SR_REF2,
-     .        FSCALE_SR,CJC,FSCALE_DLIM,TEMP_REF, FSCALE_TEMP, VOLFRAC
+     .        FSCALE_SR,CJC,FSCALE_DLIM,TEMP_REF, FSCALE_TEMP, VOLFRAC,
+     .        RGTR1  ,RGTR2
       my_real
      .        LAMBDA,DF,INST(NEL)  ,DC(NEL)     ,L0(NEL)     ,
      .        TRIAX(NEL)  ,XI(NEL)     ,EPSF(NEL)   ,EPSL(NEL)   ,
      .        DEPSF(NEL)  ,DEPSL(NEL)  ,XVEC(NEL,3) ,DPL_DEF     ,
      .        COS3THETA   ,DET,P,SVM   ,SXX,SYY,SZZ ,SIZEFAC(NEL),
      .        RATEFAC(NEL),DSIZE(NEL)  ,SOFTEXP(NEL),DLIM(NEL)   ,
-     .        TEMPFAC(NEL),TEMPFAC2(NEL),DFT(NEL)   ,VAR(NEL)
+     .        TEMPFAC(NEL),TEMPFAC2(NEL),DFT(NEL)   ,VAR(NEL)    ,
+     .        RETA
 C!--------------------------------------------------------------
       !=======================================================================
       ! - INITIALISATION OF COMPUTATION ON TIME STEP
@@ -127,6 +129,10 @@ C!--------------------------------------------------------------
       LOG_SCALE1    = NINT(UPARAM(21))
       LOG_SCALE2    = NINT(UPARAM(22))
       VOLFRAC       = UPARAM(23)
+      RGTR1         = UPARAM(24)
+      RGTR1         = MAX(RGTR1,EM06)
+      RGTR2         = UPARAM(25)
+      RGTR2         = MIN(RGTR2,TWO_THIRD - EM06)
 c
       ITAB_EPSF = ITABLF(1)
       ITAB_INST = ITABLF(2)
@@ -136,12 +142,14 @@ c
       DO I=1,NEL
         ! If necking control is activated
         IF ((ITAB_INST > 0).OR.(ECRIT > ZERO)) THEN 
-          ! Instability damage
-          INST(I) = UVAR(I,1)
-          ! Necking critical damage 
           IF (UVAR(I,2) == ZERO) UVAR(I,2) = ONE
-          DC(I)   = UVAR(I,2)
+        ELSE
+          IF (UVAR(I,2) == ZERO) UVAR(I,2) = DCRIT
         ENDIF
+        ! Instability damage
+        INST(I) = UVAR(I,1)
+        ! Necking critical damage 
+        DC(I)   = UVAR(I,2)
       END DO
 c      
       !====================================================================
@@ -252,11 +260,13 @@ c
         SIZEFAC(1:NEL) = SIZEFAC(1:NEL)*FSCALE_EL
         IF (IREG == 1) THEN 
           DO I = 1,NEL
-            IF (TRIAX(I) < SHRF) THEN 
-              SIZEFAC(I) = ONE
-            ELSEIF (TRIAX(I) > BIAXF) THEN 
-              SIZEFAC(I) = ONE
+            IF (TRIAX(I) < THIRD) THEN 
+              RETA =  SHRF*(ONE - MIN(MAX(TRIAX(I),ZERO),RGTR1)/RGTR1)
+            ELSEIF (TRIAX(I) >= THIRD) THEN 
+              RETA = (THREE*BIAXF/(THREE*RGTR2 - TWO))*
+     .               (RGTR2 - MIN(MAX(TRIAX(I),RGTR2),TWO_THIRD))
             ENDIF
+            SIZEFAC(I) = SIZEFAC(I) + RETA*(ONE - SIZEFAC(I))
           ENDDO
         ENDIF
       ELSE
@@ -423,29 +433,21 @@ c
       ! - UPDATE UVAR AND THE STRESS TENSOR
       !====================================================================
       DO I = 1,NEL 
-        IF ((ITAB_INST > 0).OR.(ECRIT > ZERO)) THEN 
-          UVAR(I,1) = INST(I)
-          UVAR(I,2) = DC(I)
-          IF (DFMAX(I) >= DC(I)) THEN 
-            IF (DC(I) < ONE) THEN 
-              DMG_SCALE(I) = ONE - ((DFMAX(I)-DC(I))/MAX(ONE-DC(I),EM20))**SOFTEXP(I)
-            ELSE
-              DMG_SCALE(I) = ZERO
-            ENDIF
+        !< Save necking instability damage
+        UVAR(I,1) = INST(I)
+        !< Damage criterion for stress softening
+        IF (DFMAX(I) >= DC(I)) THEN 
+          !< Damage softening scale computation
+          IF (DC(I) < ONE) THEN 
+            DMG_SCALE(I) = ONE - ((DFMAX(I)-DC(I))/MAX(ONE-DC(I),EM20))**SOFTEXP(I)
           ELSE
-            DMG_SCALE(I) = ONE
+            DMG_SCALE(I) = ZERO
           ENDIF
         ELSE
-          IF (DFMAX(I) >= DCRIT) THEN 
-            IF (DCRIT < ONE) THEN 
-              DMG_SCALE(I) = ONE - ((DFMAX(I)-DCRIT)/MAX(ONE-DCRIT,EM20))**SOFTEXP(I)
-            ELSE
-              DMG_SCALE(I) = ZERO
-            ENDIF
-          ELSE
-            DMG_SCALE(I) = ONE
-          ENDIF
+          DMG_SCALE(I) = ONE
         ENDIF
+        !< Update necking critical damage
+        UVAR(I,2) = DC(I)
       ENDDO
 c
       !====================================================================

--- a/engine/source/materials/mat_share/mulawc.F90
+++ b/engine/source/materials/mat_share/mulawc.F90
@@ -2454,9 +2454,11 @@
                     &jlt      ,nupar    ,nvarf    ,nfunc_fail   ,ifunc_fail   ,&
                     &npf      ,table    ,tf       ,tt       ,uparamf  ,&
                     &ngl      ,el_len   ,dpla     ,epsd     ,uvarf    ,&
-                    &signxx   ,signyy   ,signxy   ,signyz   ,signzx   ,&
+                    &signxx   ,signyy   ,signxy   ,&
                     &el_temp  ,foff     ,dfmax    ,tdel     ,ipt      ,&
-                    &ipg      ,dmg_flag ,dmg_loc_scale,ntabl_fail,itabl_fail)
+                    &ipg      ,dmg_flag ,dmg_loc_scale,ntabl_fail,itabl_fail,&
+                    &nipar    ,iparamf  ,gbuf%noff,off      ,nptt     ,&
+                    &gbuf%var )
 !
                    case (42)     !    inievo
 !

--- a/engine/source/materials/mat_share/usermat_shell.F
+++ b/engine/source/materials/mat_share/usermat_shell.F
@@ -1694,9 +1694,11 @@ c
      1            JLT      ,NUPAR    ,NVARF    ,NFUNC_FAIL,IFUNC_FAIL,
      2            NPF      ,TABLE    ,TF       ,TT       ,UPARAMF  , 
      3            NGL      ,EL_LEN   ,DPLA     ,EPSPL    ,UVARF    ,     
-     4            SIGNXX   ,SIGNYY   ,SIGNXY   ,SIGNYZ   ,SIGNZX   ,              
+     4            SIGNXX   ,SIGNYY   ,SIGNXY   ,              
      5            EL_TEMP  ,FOFF     ,DFMAX    ,TDEL     ,IPT      ,
-     6            IPG      ,DMG_FLAG ,DMG_LOC_SCALE,NTABL_FAIL,ITABL_FAIL) 
+     6            IPG      ,DMG_FLAG ,DMG_LOC_SCALE,NTABL_FAIL,ITABL_FAIL,
+     7            NIPAR    ,IPARAMF  ,GBUF%NOFF,OFF      ,NPTT     ,
+     8            GBUF%VAR ) 
 c
               CASE (42)     !    INIEVO
 c

--- a/hm_cfg_files/config/CFG/radioss2026/FAIL/fail_tab2.cfg
+++ b/hm_cfg_files/config/CFG/radioss2026/FAIL/fail_tab2.cfg
@@ -1,0 +1,225 @@
+//Copyright>    CFG Files and Library ("CFG")
+//Copyright>    Copyright (C) 1986-2025 Altair Engineering Inc.
+//Copyright>
+//Copyright>    Altair Engineering Inc. grants to third parties limited permission to
+//Copyright>    use and modify CFG solely in connection with OpenRadioss software, provided
+//Copyright>    that any modification to CFG by a third party must be provided back to
+//Copyright>    Altair Engineering Inc. and shall be deemed a Contribution under and therefore
+//Copyright>    subject to the CONTRIBUTOR LICENSE AGREEMENT for OpenRadioss software.
+//Copyright>
+//Copyright>    CFG IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//Copyright>    INCLUDING, BUT NOT LIMITED TO, THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+//Copyright>    A PARTICULAR PURPOSE, AND NONINFRINGEMENT.  IN NO EVENT SHALL ALTAIR ENGINEERING
+//Copyright>    INC. OR ITS AFFILIATES BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY,
+//Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
+//Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
+//
+//FAIL/TAB2 : Tabulated failure model Version 2
+//
+
+ATTRIBUTES(COMMON){ 
+
+        IO_FLAG            = VALUE(INT,   "Import/Export flag");
+        _HMCOMMENTSFLAG    = VALUE(INT,   "Write HM Comments");
+        mat_id             = VALUE(MAT,   "Material");
+
+        EPSF_ID            = VALUE(FUNCT, "Failure strain table");
+        FCRIT              = VALUE(FLOAT, "Scale factor for failure strain table");
+        FAILIP             = VALUE(INT,   "Number of failed integration points prior to solid element deletion");
+        PTHK               = VALUE(FLOAT, "Percentage of failed layers in thickness prior to shell element deletion");
+        VOLFRAC            = VALUE(FLOAT, "Volume fraction of failed intg. points prior to solid element deletion");
+
+        N                  = VALUE(FLOAT, "Damage accumulation parameter n");    
+        DCRIT              = VALUE(FLOAT, "Critical accumulated damage value");
+        INST_ID            = VALUE(FUNCT, "Instability strain table");
+        ECRIT              = VALUE(FLOAT, "Scale factor for instability strain table");
+
+        FCT_EXP            = VALUE(FUNCT, "Fading exponent function identifier");
+        EXP_REF            = VALUE(FLOAT, "Reference element size for fading exponent");
+        EXP                = VALUE(FLOAT, "Fading exponent scale factor");
+        FCT_TEMP           = VALUE(FUNCT, "Temperature factor function identifier");
+        TEMP_REF           = VALUE(FLOAT, "Reference temperature");
+        FSCALE_TEMP        = VALUE(FLOAT, "Temperature function scale factor");
+
+        TAB_EL             = VALUE(FUNCT, "Element size factor table identifier");
+        IREG               = VALUE(INT,   "Element size dependency flag");
+        EL_REF             = VALUE(FLOAT, "Reference element size");
+        SR_REF1            = VALUE(FLOAT, "Reference strain rate for element size table");  
+        FSCALE_EL          = VALUE(FLOAT, "Element size function scale factor");
+
+        SHRF               = VALUE(FLOAT, "Stress triaxiality lower boundary for element size regularization");
+        BIAXF              = VALUE(FLOAT, "Stress triaxiality upper boundary for element size regularization");
+
+        FCT_SR             = VALUE(FUNCT, "Strain rate factor function identifier");
+        SR_REF2            = VALUE(FLOAT, "Reference strain rate");  
+        FSCALE_SR          = VALUE(FLOAT, "Strain rate function scale factor");
+        CJC                = VALUE(FLOAT, "Johnson-Cook strain rate factor");     
+
+        FCT_DLIM           = VALUE(FUNCT, "Damage limit function identifier");
+        FSCALE_DLIM        = VALUE(FLOAT, "Damage limit scale factor");
+
+        RGTR1              = VALUE(FLOAT, "First triaxiality limit for tubshape damage regularization");
+        RGTR2              = VALUE(FLOAT, "Second triaxiality limit for tubshape damage regularization");
+        MIDFAIL            = VALUE(INT,   "Shell elements mid-plane failure flag");
+    
+        ID_CARD_EXIST      = VALUE(BOOL,"Give an Id");
+}
+
+SKEYWORDS_IDENTIFIER(COMMON)
+{
+         IO_FLAG=-1;
+         _HMCOMMENTSFLAG=-1;
+}
+
+DEFAULTS(COMMON) {
+
+}
+
+GUI(COMMON){
+        SCALAR (FCRIT)         {DIMENSION="DIMENSIONLESS";}
+        SCALAR (PTHK)          {DIMENSION="DIMENSIONLESS";}
+        SCALAR (VOLFRAC)       {DIMENSION="DIMENSIONLESS";}
+        SCALAR (N)             {DIMENSION="DIMENSIONLESS";}
+        SCALAR (DCRIT)         {DIMENSION="DIMENSIONLESS";}
+        SCALAR (ECRIT)         {DIMENSION="DIMENSIONLESS";}
+        SCALAR (EXP_REF)       {DIMENSION="l"            ;}
+        SCALAR (EXP)           {DIMENSION="DIMENSIONLESS";}
+        SCALAR (TEMP_REF)      {DIMENSION="k"            ;}
+        SCALAR (FSCALE_TEMP)   {DIMENSION="DIMENSIONLESS";}
+        SCALAR (EL_REF)        {DIMENSION="l"            ;}
+        SCALAR (SR_REF1)       {DIMENSION="f"            ;}
+        SCALAR (FSCALE_EL)     {DIMENSION="DIMENSIONLESS";}
+        SCALAR (SHRF)          {DIMENSION="DIMENSIONLESS";}
+        SCALAR (BIAXF)         {DIMENSION="DIMENSIONLESS";}
+        SCALAR (SR_REF2)       {DIMENSION="f"            ;}
+        SCALAR (FSCALE_SR)     {DIMENSION="DIMENSIONLESS";}
+        SCALAR (CJC)           {DIMENSION="DIMENSIONLESS";}
+        SCALAR (FSCALE_DLIM)   {DIMENSION="DIMENSIONLESS";}
+        SCALAR (RGTR1)         {DIMENSION="DIMENSIONLESS";}
+        SCALAR (RGTR2)         {DIMENSION="DIMENSIONLESS";}
+}
+
+
+FORMAT(radioss2026) 
+{      
+        HEADER("/FAIL/TAB2/%d",mat_id);
+        //Card 1 
+        COMMENT("#  EPSF_ID               FCRIT              FAILIP          PTHICKFAIL             VOLFRAC   MIDFAIL");
+        CARD("%10d%20lg%10s%10d%20lg%20lg%10d",EPSF_ID,FCRIT,_BLANK_,FAILIP,PTHK,VOLFRAC,MIDFAIL);
+        //Card 2 
+        COMMENT("#                  N               DCRIT   INST_ID               ECRIT");
+        CARD("%20lg%20lg%10d%20lg",N,DCRIT,INST_ID,ECRIT);
+        //Card 3 
+        COMMENT("#  FCT_EXP             EXP_REF                 EXP  FCT_TEMP            TEMP_REF         FSCALE_TEMP");
+        CARD("%10d%20lg%20lg%10d%20lg%20lg",FCT_EXP,EXP_REF,EXP,FCT_TEMP,TEMP_REF,FSCALE_TEMP);
+        //Card 4
+        COMMENT("#   TAB_EL      IREG              EL_REF             SR_REF1           FSCALE_EL");
+        CARD("%10d%10d%20lg%20lg%20lg",TAB_EL,IREG,EL_REF,SR_REF1,FSCALE_EL); 
+        //Card 5
+        COMMENT("#               SHRF               BIAXF               RGTR1               RGTR2");
+        CARD("%20lg%20lg%20lg%20lg",SHRF,BIAXF,RGTR1,RGTR2); 
+        //Card 6
+	COMMENT("#   FCT_SR                       SR_REF2           FSCALE_SR             C_JCOOK");
+	CARD("%10d%10s%20lg%20lg%20lg",FCT_SR,_BLANK_,SR_REF2,FSCALE_SR,CJC);
+        //Card 7
+	COMMENT("# FCT_DLIM         FSCALE_DLIM");
+	CARD("%10d%20lg",FCT_DLIM,FSCALE_DLIM);
+        if (ID_CARD_EXIST==TRUE)
+        {
+          COMMENT("#  FAIL_ID") ;
+        }
+        FREE_CARD(ID_CARD_EXIST,"%10d",_ID_);
+}
+
+FORMAT(radioss2025) 
+{      
+        HEADER("/FAIL/TAB2/%d",mat_id);
+        //Card 1 
+        COMMENT("#  EPSF_ID               FCRIT              FAILIP          PTHICKFAIL             VOLFRAC");
+        CARD("%10d%20lg%10s%10d%20lg%20lg",EPSF_ID,FCRIT,_BLANK_,FAILIP,PTHK,VOLFRAC);
+        //Card 2 
+        COMMENT("#                  N               DCRIT   INST_ID               ECRIT");
+        CARD("%20lg%20lg%10d%20lg",N,DCRIT,INST_ID,ECRIT);
+        //Card 3 
+        COMMENT("#  FCT_EXP             EXP_REF                 EXP  FCT_TEMP            TEMP_REF         FSCALE_TEMP");
+        CARD("%10d%20lg%20lg%10d%20lg%20lg",FCT_EXP,EXP_REF,EXP,FCT_TEMP,TEMP_REF,FSCALE_TEMP);
+        //Card 4
+        COMMENT("#   TAB_EL      IREG              EL_REF             SR_REF1           FSCALE_EL");
+        CARD("%10d%10d%20lg%20lg%20lg",TAB_EL,IREG,EL_REF,SR_REF1,FSCALE_EL); 
+        //Card 5
+        COMMENT("#               SHRF               BIAXF");
+        CARD("%20lg%20lg",SHRF,BIAXF); 
+        //Card 6
+	COMMENT("#   FCT_SR                       SR_REF2           FSCALE_SR             C_JCOOK");
+	CARD("%10d%10s%20lg%20lg%20lg",FCT_SR,_BLANK_,SR_REF2,FSCALE_SR,CJC);
+        //Card 7
+	COMMENT("# FCT_DLIM         FSCALE_DLIM");
+	CARD("%10d%20lg",FCT_DLIM,FSCALE_DLIM);
+        if (ID_CARD_EXIST==TRUE)
+        {
+          COMMENT("#  FAIL_ID") ;
+        }
+        FREE_CARD(ID_CARD_EXIST,"%10d",_ID_);
+}
+
+FORMAT(radioss2024) 
+{      
+        HEADER("/FAIL/TAB2/%d",mat_id);
+        //Card 1 
+        COMMENT("#  EPSF_ID               FCRIT              FAILIP          PTHICKFAIL");
+        CARD("%10d%20lg%10s%10d%20lg",EPSF_ID,FCRIT,_BLANK_,FAILIP,PTHK);
+        //Card 2 
+        COMMENT("#                  N               DCRIT   INST_ID               ECRIT");
+        CARD("%20lg%20lg%10d%20lg",N,DCRIT,INST_ID,ECRIT);
+        //Card 3 
+        COMMENT("#  FCT_EXP             EXP_REF                 EXP  FCT_TEMP            TEMP_REF         FSCALE_TEMP");
+        CARD("%10d%20lg%20lg%10d%20lg%20lg",FCT_EXP,EXP_REF,EXP,FCT_TEMP,TEMP_REF,FSCALE_TEMP);
+        //Card 4
+        COMMENT("#   TAB_EL      IREG              EL_REF             SR_REF1           FSCALE_EL");
+        CARD("%10d%10d%20lg%20lg%20lg",TAB_EL,IREG,EL_REF,SR_REF1,FSCALE_EL); 
+        //Card 5
+        COMMENT("#               SHRF               BIAXF");
+        CARD("%20lg%20lg",SHRF,BIAXF); 
+        //Card 6
+	COMMENT("#   FCT_SR                       SR_REF2           FSCALE_SR             C_JCOOK");
+	CARD("%10d%10s%20lg%20lg%20lg",FCT_SR,_BLANK_,SR_REF2,FSCALE_SR,CJC);
+        //Card 7
+	COMMENT("# FCT_DLIM         FSCALE_DLIM");
+	CARD("%10d%20lg",FCT_DLIM,FSCALE_DLIM);
+        if (ID_CARD_EXIST==TRUE)
+        {
+          COMMENT("#  FAIL_ID") ;
+        }
+        FREE_CARD(ID_CARD_EXIST,"%10d",_ID_);
+}
+
+FORMAT(radioss2022) 
+{      
+        HEADER("/FAIL/TAB2/%d",mat_id);
+        //Card 1 
+        COMMENT("#  EPSF_ID               FCRIT              FAILIP          PTHICKFAIL");
+        CARD("%10d%20lg%10s%10d%20lg",EPSF_ID,FCRIT,_BLANK_,FAILIP,PTHK);
+        //Card 2 
+        COMMENT("#                  N               DCRIT   INST_ID               ECRIT");
+        CARD("%20lg%20lg%10d%20lg",N,DCRIT,INST_ID,ECRIT);
+        //Card 3 
+        COMMENT("#  FCT_EXP             EXP_REF                 EXP");
+        CARD("%10d%20lg%20lg",FCT_EXP,EXP_REF,EXP);
+        //Card 4
+        COMMENT("#   TAB_EL      IREG              EL_REF             SR_REF1           FSCALE_EL");
+        CARD("%10d%10d%20lg%20lg%20lg",TAB_EL,IREG,EL_REF,SR_REF1,FSCALE_EL); 
+        //Card 5
+        COMMENT("#               SHRF               BIAXF");
+        CARD("%20lg%20lg",SHRF,BIAXF); 
+        //Card 6
+	COMMENT("#   FCT_SR                       SR_REF2           FSCALE_SR             C_JCOOK");
+	CARD("%10d%10s%20lg%20lg%20lg",FCT_SR,_BLANK_,SR_REF2,FSCALE_SR,CJC);
+        //Card 7
+	COMMENT("# FCT_DLIM         FSCALE_DLIM");
+	CARD("%10d%20lg",FCT_DLIM,FSCALE_DLIM);
+        if (ID_CARD_EXIST==TRUE)
+        {
+          COMMENT("#  FAIL_ID") ;
+        }
+        FREE_CARD(ID_CARD_EXIST,"%10d",_ID_);
+}

--- a/starter/source/materials/fail/hm_read_fail.F
+++ b/starter/source/materials/fail/hm_read_fail.F
@@ -88,7 +88,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !||====================================================================
       SUBROUTINE HM_READ_FAIL(MAT_PARAM,NUMMAT ,MAXFAIL ,FAIL_TAG ,
      .                        NTABLE   ,TABLE  ,FAILWAVE,NLOC_DMG ,
-     .                        UNITAB  ,LSUBMODEL)
+     .                        UNITAB  ,LSUBMODEL,MLAW_TAG)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -105,6 +105,7 @@ C-----------------------------------------------
       USE HM_READ_FRACTAL_DMG_MOD
       USE HM_READ_FAIL_LEMAITRE_MOD
       USE HM_READ_FAIL_COMPOSITE_MOD
+      USE ELBUFTAG_MOD
       USE NAMES_AND_TITLES_MOD , ONLY : NCHARTITLE, NCHARLINE, NCHARKEY
 C============================================================================
 C   I m p l i c i t   T y p e s
@@ -129,6 +130,7 @@ C-----------------------------------------------
       TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(INOUT) :: MAT_PARAM
       TYPE (SUBMODEL_DATA),INTENT(IN) ::LSUBMODEL(*)
       TYPE (UNIT_TYPE_),INTENT(IN) :: UNITAB 
+      TYPE (MLAW_TAG_), DIMENSION(NUMMAT),INTENT(INOUT)  :: MLAW_TAG
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -425,7 +427,7 @@ c
               IRUPT = 41
               CALL HM_READ_FAIL_TAB2(MAT_PARAM(IMAT)%FAIL(IFL),
      .             MAT_ID   ,FAIL_ID  ,IRUPT    ,MAT_PARAM(IMAT)%TITLE,
-     .             LSUBMODEL,UNITAB   )
+     .             LSUBMODEL,UNITAB   ,MLAW_TAG(IMAT))
 c     
             ELSEIF (KEY(1:3) == 'TAB') THEN
               IRUPT = 37

--- a/starter/source/materials/fail/tabulated/hm_read_fail_tab2.F
+++ b/starter/source/materials/fail/tabulated/hm_read_fail_tab2.F
@@ -37,7 +37,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !||====================================================================
       SUBROUTINE HM_READ_FAIL_TAB2(FAIL ,
      .           MAT_ID   ,FAIL_ID  ,IRUPT    ,TITR     ,
-     .           LSUBMODEL,UNITAB   )
+     .           LSUBMODEL,UNITAB   ,MTAG     )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -46,6 +46,7 @@ C-----------------------------------------------
       USE MESSAGE_MOD 
       USE SUBMODEL_MOD
       USE HM_OPTION_READ_MOD
+      USE ELBUFTAG_MOD
       USE NAMES_AND_TITLES_MOD , ONLY : NCHARTITLE
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
@@ -66,16 +67,18 @@ C-----------------------------------------------
       TYPE(UNIT_TYPE_)   ,INTENT(IN)       :: UNITAB        ! table of input units
       TYPE(SUBMODEL_DATA),INTENT(IN)       :: LSUBMODEL(*)
       TYPE (FAIL_PARAM_) ,INTENT(INOUT)    :: FAIL
+      TYPE (MLAW_TAG_)   ,INTENT(INOUT)    :: MTAG
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER  :: ITAB_EPSF,FAILIP,ITAB_INST,
+      INTEGER  :: ITAB_EPSF,FAILIP,ITAB_INST,MIDFAIL,
      .            IFUN_EXP,ITAB_SIZE,IREG,IFUN_RATE,IFUN_DLIM,IFUN_TEMP  
       my_real  :: FCRIT,PTHKFAIL,DN,DCRIT,ECRIT,EXP_REF,EXPO,EL_REF,SR_REF1,
      .            FSCALE_EL,SHRF,BIAXF,SR_REF2,FSCALE_SR,CJC,FSCALE_DLIM,
-     .            LENGTH_UNIT,RATE_UNIT,TEMP_REF,FSCALE_TEMP,TEMP_UNIT,VOLFRAC
+     .            LENGTH_UNIT,RATE_UNIT,TEMP_REF,FSCALE_TEMP,TEMP_UNIT,VOLFRAC,
+     .            RGTR1,RGTR2
 C-----------------------------------------------
-      LOGICAL    ::     IS_AVAILABLE,IS_ENCRYPTED
+      LOGICAL  :: IS_AVAILABLE,IS_ENCRYPTED
 C=======================================================================
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
@@ -92,6 +95,7 @@ Card1
       CALL HM_GET_INTV   ('FAILIP'      ,FAILIP      ,IS_AVAILABLE,LSUBMODEL)
       CALL HM_GET_FLOATV ('PTHK'        ,PTHKFAIL    ,IS_AVAILABLE,LSUBMODEL,UNITAB) 
       CALL HM_GET_FLOATV ('VOLFRAC'     ,VOLFRAC     ,IS_AVAILABLE,LSUBMODEL,UNITAB) 
+      CALL HM_GET_INTV   ('MIDFAIL'     ,MIDFAIL     ,IS_AVAILABLE,LSUBMODEL)   
 Card2 
       CALL HM_GET_FLOATV ('N'           ,DN          ,IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV ('DCRIT'       ,DCRIT       ,IS_AVAILABLE,LSUBMODEL,UNITAB)
@@ -113,6 +117,8 @@ Card4
 Card5
       CALL HM_GET_FLOATV ('SHRF'        ,SHRF        ,IS_AVAILABLE,LSUBMODEL,UNITAB) 
       CALL HM_GET_FLOATV ('BIAXF'       ,BIAXF       ,IS_AVAILABLE,LSUBMODEL,UNITAB) 
+      CALL HM_GET_FLOATV ('RGTR1'       ,RGTR1       ,IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV ('RGTR2'       ,RGTR2       ,IS_AVAILABLE,LSUBMODEL,UNITAB)
 Card6
       CALL HM_GET_INTV   ('FCT_SR'      ,IFUN_RATE   ,IS_AVAILABLE,LSUBMODEL)
       CALL HM_GET_FLOATV ('SR_REF2'     ,SR_REF2     ,IS_AVAILABLE,LSUBMODEL,UNITAB) 
@@ -155,8 +161,12 @@ C-------------------------------------------------------------------------------
         SR_REF1 = ONE*RATE_UNIT
       ENDIF
       IF (FSCALE_EL == ZERO) FSCALE_EL = ONE
-      IF (SHRF  == ZERO)     SHRF      = -ONE
-      IF (BIAXF == ZERO)     BIAXF     = ONE
+      SHRF  = MAX(MIN(SHRF,ONE),ZERO)
+      BIAXF = MAX(MIN(BIAXF,ONE),ZERO)
+      IF (RGTR1 == ZERO) RGTR1 = THIRD
+      IF (RGTR2 == ZERO) RGTR2 = THIRD
+      RGTR1 = MIN(MAX(RGTR1,ZERO),THIRD)
+      RGTR2 = MIN(MAX(RGTR2,THIRD),TWO_THIRD)
       IF (((IFUN_RATE > 0).OR.(CJC > ZERO)).AND.(SR_REF2 == ZERO)) THEN
         CALL HM_GET_FLOATV_DIM('SR_REF2' ,RATE_UNIT,IS_AVAILABLE, LSUBMODEL, UNITAB)
         SR_REF2 = ONE*RATE_UNIT
@@ -182,8 +192,8 @@ C-------------------------------------------------------------------------------
       FAIL%KEYWORD = 'TAB2' 
       FAIL%IRUPT   = IRUPT 
       FAIL%FAIL_ID = FAIL_ID 
-      FAIL%NUPARAM = 23
-      FAIL%NIPARAM = 0
+      FAIL%NUPARAM = 25
+      FAIL%NIPARAM = 1
       FAIL%NUVAR   = 3
       FAIL%NFUNC   = 4
       FAIL%NTABLE  = 3
@@ -194,6 +204,8 @@ c
       ALLOCATE (FAIL%IPARAM(FAIL%NIPARAM))
       ALLOCATE (FAIL%IFUNC (FAIL%NFUNC))
       ALLOCATE (FAIL%TABLE (FAIL%NTABLE))
+c
+      FAIL%IPARAM(1)  = MIDFAIL
 c
       FAIL%UPARAM(1)  = FCRIT
       FAIL%UPARAM(2)  = FAILIP
@@ -218,6 +230,8 @@ c
       FAIL%UPARAM(21) = 0             ! Flag 1 for logarithmic scale in strain rate dependency
       FAIL%UPARAM(22) = 0             ! Flag 2 for logarithmic scale in strain rate dependency
       FAIL%UPARAM(23) = VOLFRAC     
+      FAIL%UPARAM(24) = RGTR1
+      FAIL%UPARAM(25) = RGTR2
 c
       FAIL%IFUNC(1) = IFUN_EXP
       FAIL%IFUNC(2) = IFUN_RATE
@@ -227,6 +241,8 @@ c
       FAIL%TABLE(1) = ITAB_EPSF
       FAIL%TABLE(2) = ITAB_INST
       FAIL%TABLE(3) = ITAB_SIZE
+c
+      MTAG%G_NUVAR = 1
 c-----------------------------------------------------------------------
       IF (IS_ENCRYPTED)THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
@@ -265,7 +281,8 @@ c-----------------------------------------------------------------------
         IF (ITAB_SIZE > 0) THEN 
           WRITE(IOUT,1011) IREG
           IF (IREG == 1) THEN 
-            WRITE(IOUT,1012) ITAB_SIZE,EL_REF,SR_REF1,FSCALE_EL,SHRF,BIAXF
+            WRITE(IOUT,1012) ITAB_SIZE,EL_REF,SR_REF1,FSCALE_EL,SHRF,BIAXF,
+     .        RGTR1,RGTR2
           ELSEIF(IREG == 2) THEN 
             WRITE(IOUT,1013) ITAB_SIZE,EL_REF,FSCALE_EL
           ENDIF
@@ -284,7 +301,7 @@ c-----------------------------------------------------------------------
           WRITE(IOUT,1018) IFUN_DLIM,FSCALE_DLIM
         ENDIF 
         ! element deletion control parameters
-        WRITE(IOUT,1019) FAILIP,PTHKFAIL,VOLFRAC
+        WRITE(IOUT,1019) FAILIP,PTHKFAIL,VOLFRAC,MIDFAIL
         WRITE(IOUT,1022)
       ENDIF  ! IS_ENCRYPTED             
 c-----------------------------------------------------------------------
@@ -336,7 +353,9 @@ c-----------------------------------------------------------------------
      & 5X,'    REFERENCE STRAIN RATE . . . . . . . . . . . . . . . =',1PG20.13/,
      & 5X,'    SCALE FACTOR FOR SIZE SCALING . . . . . . . . . . . =',1PG20.13/,
      & 5X,'TRIAXIALITY LOWER BOUNDARY FOR SIZE SCALING . . . . . . =',1PG20.13/,
-     & 5X,'TRIAXIALITY UPPER BOUNDARY FOR SIZE SCALING . . . . . . =',1PG20.13/)
+     & 5X,'TRIAXIALITY UPPER BOUNDARY FOR SIZE SCALING . . . . . . =',1PG20.13/,
+     & 5X,'1ST TRIAXIALITY VALUE FOR TUBSHAPE REGULARIZATION . . . =',1PG20.13/,
+     & 5X,'2ND TRIAXIALITY VALUE FOR TUBSHAPE REGULARIZATION . . . =',1PG20.13/)
  1013 FORMAT(
      & 5X,'ELEMENT SIZE SCALING TABLE ID . . . . . . . . . . . . . =',I10/,
      & 5X,'    SCALE FACTOR FOR SIZE SCALING . . . . . . . . . . . =',1PG20.13/,
@@ -368,7 +387,13 @@ c-----------------------------------------------------------------------
      & 5X,'SHELL ELEMENT DELETION PARAMETER PTHICKFAIL  . . . . . .=',1PG20.13,/,
      & 5X,'  > 0.0 : FRACTION OF FAILED THICKNESS                   ',/,
      & 5X,'  < 0.0 : FRACTION OF FAILED INTG. POINTS OR LAYERS      ',/,
-     & 5X,'FAILED VOLUME FRACTION PRIOR TO SOLID DELETION . . . .  =',1PG20.13/) 
+     & 5X,'FAILED VOLUME FRACTION PRIOR TO SOLID DELETION . . . . .=',1PG20.13/,
+     & 5X,'MID-POINT FAILURE PARAMETER FOR SHELLS. . . . . . . . . =',I10/,
+     & 5X,'   = 0: INACTIVE                                 ',/,
+     & 5X,'   = 1: MID-POINT SOFTENING SYNCHRONIZE THE BROKEN INTEGRATION POINTS SOFTENING',/,
+     & 5X,'   = 2: MID-POINT SOFTENING SYNCHRONIZE ALL INTEGRATION POINTS SOFTENING',/,
+     & 5X,'   = 3: SAME AS 2 + ELEMENT DELETION WHEN MID-POINT DAMAGE REACHES 1',/,
+     & 5X,'   = 4: MID-POINT DAMAGE, SOFTENING AND FAILURE ONLY',/) 
  1020 FORMAT(
      & 5X,'                                                         ',/,
      & 5X,'TEMPERATURE SCALING DEFINITION:                          ',/,

--- a/starter/source/materials/read_material_models.F
+++ b/starter/source/materials/read_material_models.F
@@ -180,7 +180,7 @@ c     /FAIL : Failure Models
 c-------------------------------------------------------------------     
       CALL HM_READ_FAIL(MAT_ELEM%MAT_PARAM,NUMMAT,MAXFAIL  ,FAIL_TAG,
      .                  NTABLE  ,TABLE    ,FAILWAVE ,NLOC_DMG,
-     .                  UNITAB  ,LSUBMODEL)
+     .                  UNITAB  ,LSUBMODEL,MLAW_TAG )
      
 c-------------------------------------------------------------------
 c     /VISC : Visco elastic  Models


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

There was a need to add MIDFAIL, RGTR1 and RGTR2 additional parameters in /FAIL/TAB2. The first parameter is only used to trigger shell element deletion in some cases. The two others are used for all element type and help to control the element size regularization limitation. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

Add MIDFAIL, RGTR1 and RGTR2 + revise the way SHRF and BIAXF parameters are working. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
