### PR TITLE
/ANIM/ELEM/USER01 + /MAT/USER1 (law29) : output fixed

### DIFF
--- a/engine/source/user_interface/suforc3.F
+++ b/engine/source/user_interface/suforc3.F
@@ -127,7 +127,11 @@ C-----------------------------------------------
 C   S o u r c e  L i n e s
 C=======================================================================
       GBUF  => ELBUF_STR%GBUF
-      UVAR  => ELBUF_STR%GBUF%VAR
+
+      ! output is using BUFLY data instead of GBUF (see dfunc6.F)
+      NUVAR = ELBUF_STR%BUFLY(1)%NVAR_MAT         !NUVAR = ELBUF_STR%GBUF%G_NUVAR
+      UVAR => ELBUF_STR%BUFLY(1)%MAT(1,1,1)%VAR      !UVAR  => ELBUF_STR%GBUF%VAR
+
       NF1=NFT+1
 !
       DO I=1,6
@@ -140,7 +144,7 @@ C GATHER NODAL VARIABLES
      .             XX ,YY ,ZZ, UX  ,UY  ,UZ , 
      .             VX ,VY ,VZ, VRX ,VRY ,VRZ, 
      .             GBUF%OFF,OFF, NC,SID,IMAT,IPROP)
-      NUVAR   = ELBUF_STR%GBUF%G_NUVAR
+
       NUPARAM = IPM(9,IMAT(1))
 C-----------
       IG =IPROP(1)


### PR DESCRIPTION
#### /ANIM/ELEM/USER01 + /MAT/USER1 (law29) : output fixed

#### Description of the changes
In animation Files, /ANIM/ELEM/USER01 was not correctly output for user material based on user library for material /MAT/USER01. Subroutine suforc3.F is updated consequently.

`ELBUF_TAB(NG)%BUFLY(IL)%MAT(IR,IS,IT)%VAR( : )`
is now used instead of
`USER = ELBUF_TAB(NG)%GBUF%VAR( : )`
