### PR TITLE
bug correction : 1d element results with /H3D output per part

### DIFF
--- a/engine/source/output/h3d/h3d_results/h3d_oned_scalar.F90
+++ b/engine/source/output/h3d/h3d_results/h3d_oned_scalar.F90
@@ -171,6 +171,7 @@
             if (ity == 5) offset = numelt
             if (ity == 6) offset = numelt+numelp
 !
+            iok_part(1:nel) = 0
             do  i=1,nel
               if (ity == 4) then
                 id_elem(offset+nft+i) = ixt(nixt,nft+i)

--- a/engine/source/output/h3d/h3d_results/h3d_oned_tensor.F
+++ b/engine/source/output/h3d/h3d_results/h3d_oned_tensor.F
@@ -126,6 +126,7 @@ c
         IF (ITY == 5) OFFSET = NUMELT
         IF (ITY == 6) OFFSET = NUMELT+NUMELP
 c
+        IOK_PART(1:NEL) = 0
         DO  I=1,NEL 
           IF (ITY == 4) THEN
             ID_ELEM(OFFSET+NFT+I) = IXT(NIXT,NFT+I)

--- a/engine/source/output/h3d/h3d_results/h3d_oned_torsor.F
+++ b/engine/source/output/h3d/h3d_results/h3d_oned_torsor.F
@@ -92,6 +92,7 @@ C       IF(ANIM_K==0.AND.IPARG(8,NG)==1)GOTO 490
         IF (ITY == 5) OFFSET = NUMELT
         IF (ITY == 6) OFFSET = NUMELT+NUMELP
 c
+        IOK_PART(1:NEL) = 0
         DO  I=1,NEL 
           IF (ITY == 4) THEN
             ID_ELEM(OFFSET+NFT+I) = IXT(NIXT,NFT+I)

--- a/engine/source/output/h3d/h3d_results/h3d_oned_vector.F
+++ b/engine/source/output/h3d/h3d_results/h3d_oned_vector.F
@@ -126,6 +126,7 @@ c
         IF (ITY == 5) OFFSET = NUMELT
         IF (ITY == 6) OFFSET = NUMELT+NUMELP
 c
+        IOK_PART(1:NEL) = 0
         DO  I=1,NEL 
           IF (ITY == 4) THEN
             ID_ELEM(OFFSET+NFT+I) = IXT(NIXT,NFT+I)

--- a/engine/source/output/h3d/h3d_results/h3d_sph_tensor.F
+++ b/engine/source/output/h3d/h3d_results/h3d_sph_tensor.F
@@ -143,6 +143,7 @@ C-----------------------------------------------
           IPRT=IPARTSP(1 + NFT)
           MT1 =IPART(1,IPRT)
 
+          IOK_PART(1:NEL) = 0
           DO  I=1,NEL 
             ID_ELEM(NFT+I) = KXSP(NISP,NFT+I)
             IF( H3D_PART(IPARTSP(NFT+I)) == 1) IOK_PART(I) = 1


### PR DESCRIPTION
This pull request introduces a small but important initialization step in several output routines for H3D results. The main change is the explicit zeroing of the `IOK_PART` array at the beginning of element loops, ensuring that its values are reset before being used to mark valid elements. This helps prevent any unintended carry-over of values from previous calculations.

Initialization improvements for element validity arrays:

* [`engine/source/output/h3d/h3d_results/h3d_oned_scalar.F90`](diffhunk://#diff-6a7ee9f470ad0fdddba3ce47a3b8b8ac5e62f1b32f959f7059b46c6392163234R174): Added `iok_part(1:nel) = 0` before the element loop to initialize the validity array.
* [`engine/source/output/h3d/h3d_results/h3d_oned_tensor.F`](diffhunk://#diff-b12b5a20beefc9c72a1e1909f0a44d8b6cee21b8a3cec73dc0d1f0f0fb52b155R129): Added `IOK_PART(1:NEL) = 0` before the element loop for proper initialization.
* [`engine/source/output/h3d/h3d_results/h3d_oned_torsor.F`](diffhunk://#diff-44aee1f7ce5349863b22796702c8b4a163c10998c8db4dc22f6677578aaeec1cR95): Added `IOK_PART(1:NEL) = 0` before the element loop for proper initialization.
* [`engine/source/output/h3d/h3d_results/h3d_oned_vector.F`](diffhunk://#diff-e2858a7b8a7e342cc389b4444d1bc125f75eeb3de69aaccff0481cddce1658d5R129): Added `IOK_PART(1:NEL) = 0` before the element loop for proper initialization.
* [`engine/source/output/h3d/h3d_results/h3d_sph_tensor.F`](diffhunk://#diff-79d50de634c7ba86230a74406dfc4a896ed94def8bf518f949e7e3a15234dd75R146): Added `IOK_PART(1:NEL) = 0` before the element loop for proper initialization.