### PR TITLE
(Viper Coupling) bug fixes & code cleanup

### DIFF
--- a/engine/source/coupling/viper/viper_interface_mod.F90
+++ b/engine/source/coupling/viper/viper_interface_mod.F90
@@ -40,15 +40,17 @@
         implicit none
 #include "spmd.inc"
 
-        logical :: ViperCoupling     ! set in engine/source/input/freform.F with the engine flag /VIPER/ON
+        logical :: ViperCoupling                              ! set in engine/source/input/freform.F with the engine flag /VIPER/ON
 
         type :: viper_coupling_
-          integer :: numon             ! number of 'alive' elements (i.e. not eroded/deleted/null)
-          integer :: ivout             ! trigger for specific testing
-          integer :: id! file id for printing time
-          integer, dimension(:), allocatable :: ITABM1,IXEM1         ! nodal & elemental arrays for coupling re-indexing
-          integer :: NUMELE,NUMEL_SC,NUMEL_SCG, ioffset_3shell,ioffset_4shell    ! elemental counts
+          integer :: numon                                    ! number of 'alive' elements (i.e. not eroded/deleted/null)
+          integer :: io_dt                                    ! file id for printing time
+          integer, dimension(:), allocatable :: ITABM1,IXEM1  ! nodal & elemental arrays for coupling re-indexing
+          integer :: NUMELEv                                  ! total number of elements Viper will use
+          integer :: NUMELEr                                  ! total number of elements Radioss has;
+                                                              ! total has since been removed from main code, so storing here
           real(kind=wp):: TSTOP
+          real(kind=wp):: DT_MIN
         end type viper_coupling_
 
 
@@ -72,9 +74,9 @@
 !||====================================================================
         subroutine viper_coupling_initialize(VIPER, NODES, ELEMENT,   NUMNOD,&
           NIXS, NUMELS, IXS, NIXC, NUMELC,NIXTG, NUMELTG,IXTG, &
-          ISTDO, NELEML, NUMELQ, NUMELT, NUMELP, NUMELR, &
-          DTMIN, TSTOP, DTANIM, TT, NPARG, NGROUP, IPARG, ELBUF_TAB, &
-          TT_DOUBLE, TANIM)
+          ISTDO, NUMELQ, NUMELT, NUMELP, NUMELR, &
+          TSTOP, DTANIM, TT, NPARG, NGROUP, IPARG, ELBUF_TAB, &
+          TT_DOUBLE, TANIM, DTMIN)
           use nodal_arrays_mod, only: nodal_arrays_
           use connectivity_mod, only: connectivity_
 
@@ -87,82 +89,82 @@
           integer, intent(in) :: NUMNOD
           integer, intent(in) :: NIXS, NUMELS, NIXC, NUMELC, NIXTG, NUMELTG !< dimensions of connectivity arrays
           integer, intent(in) :: IXS(NIXS,NUMELS), IXTG(NIXTG,NUMELTG)
-          integer, intent(in) :: ISTDO, NELEML, NUMELQ, NUMELT, NUMELP, NUMELR
-          real(kind=WP), intent(inout) :: DTMIN, TSTOP, DTANIM, TT
+          integer, intent(in) :: ISTDO, NUMELQ, NUMELT, NUMELP, NUMELR
+          real(kind=WP), intent(inout) :: TSTOP, DTANIM, TT
           integer, intent(in) :: NPARG, NGROUP
           integer, intent(in) :: IPARG(NPARG,NGROUP)
           type(ELBUF_STRUCT_), dimension(NGROUP), intent(in) :: ELBUF_TAB
-          real(kind=WP), intent(inout) :: TANIM
+          real(kind=WP), intent(inout) :: TANIM, DTMIN
           double precision, intent(inout) :: TT_DOUBLE
 
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Local variables
 ! ----------------------------------------------------------------------------------------------------------------------
+          integer :: iNUMELEr_TOTAL, iNUMELEv_TOTAL, iNUMEL_SC, iNUMEL_SCG, ioffset_3shell,ioffset_4shell    ! elemental counts
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Body
 ! ----------------------------------------------------------------------------------------------------------------------
+          ! Calculate & internally store the number of elements used by Radioss; before 9 Dec 2025, this value was
+          ! calculated outside of this subroutine for use throughout the code, but is now no longer used
+          iNUMELEr_TOTAL = NUMELS+NUMELQ+NUMELC+NUMELT+NUMELP+NUMELR+NUMELTG
+          VIPER%NUMELEr  = iNUMELEr_TOTAL
           WRITE(ISTDO,*) "Number of elements in Radioss:"
-          WRITE(ISTDO,*) "  NIXS     = ",NIXS      ! This is the number of characteristics per element in the IXS array
-          WRITE(ISTDO,*) "  NELEML   = ",NELEML    ! This is the total number of elements
-          WRITE(ISTDO,*) "  NUMELS   = ",NUMELS    ! This is the number of SOLIDS
-          !WRITE(ISTDO,*) '  NUMELS8  = ',NUMELS8   ! This is the number of 8-node solids
-          !WRITE(ISTDO,*) '  NUMELS10 = ',NUMELS10  ! This is the number of 10-node tetrahedra
-          !WRITE(ISTDO,*) '  NUMELS16 = ',NUMELS16  ! This is the number of 16-node solids
-          !WRITE(ISTDO,*) '  NUMELS20 = ',NUMELS20  ! This is the number of 20-node solids
-          WRITE(ISTDO,*) "  NUMELQ   = ",NUMELQ    ! This is the number of quads
-          WRITE(ISTDO,*) "  NUMELC   = ",NUMELC    ! This is the number of 4-shells
-          WRITE(ISTDO,*) "  NUMELT   = ",NUMELT    ! This is the number of trias (aka 3-shells)
-          WRITE(ISTDO,*) "  NUMELP   = ",NUMELP    ! This is the number of beams / rebar
-          WRITE(ISTDO,*) "  NUMELR   = ",NUMELR    ! This is the number of springs
-          WRITE(ISTDO,*) "  NUMELTG  = ",NUMELTG   ! This is the number of 3-shells
+          WRITE(ISTDO,*) "  NIXS     = ",NIXS             ! This is the number of characteristics per element in the IXS array
+          WRITE(ISTDO,*) "  NELEML   = ",iNUMELEr_TOTAL   ! This is the total number of elements
+          WRITE(ISTDO,*) "  NUMELS   = ",NUMELS           ! This is the number of SOLIDS
+          !WRITE(ISTDO,*)"  NUMELS8  = ",NUMELS8          ! This is the number of 8-node solids
+          !WRITE(ISTDO,*)"  NUMELS10 = ",NUMELS10         ! This is the number of 10-node tetrahedra
+          !WRITE(ISTDO,*)"  NUMELS16 = ",NUMELS16         ! This is the number of 16-node solids
+          !WRITE(ISTDO,*)"  NUMELS20 = ",NUMELS20         ! This is the number of 20-node solids
+          WRITE(ISTDO,*) "  NUMELQ   = ",NUMELQ           ! This is the number of quads
+          WRITE(ISTDO,*) "  NUMELC   = ",NUMELC           ! This is the number of 4-shells
+          WRITE(ISTDO,*) "  NUMELT   = ",NUMELT           ! This is the number of trias (aka 3-shells)
+          WRITE(ISTDO,*) "  NUMELP   = ",NUMELP           ! This is the number of beams / rebar
+          WRITE(ISTDO,*) "  NUMELR   = ",NUMELR           ! This is the number of springs
+          WRITE(ISTDO,*) "  NUMELTG  = ",NUMELTG          ! This is the number of 3-shells
 
-!           Allocate the arays for inverse index lookup
-          VIPER%NUMEL_SC       = NUMELS+NUMELC                                        ! The total number of elements used by Viper
-          VIPER%NUMEL_SCG      = VIPER%NUMEL_SC+NUMELTG                                     ! The total number of elements used by Viper
-          VIPER%NUMELE= VIPER%NUMEL_SCG                                            ! The total number of elements used by Viper
-          VIPER%ioffset_4shell = NUMELS+NUMELQ                                        ! The (assumed) index offset for 4-shells (confirmed that NUMELS8,NUMELS10,NUMELS16,NUMELS20 are not in the array)
-          VIPER%ioffset_3shell = VIPER%ioffset_4shell+NUMELC+NUMELT+NUMELP+NUMELR           ! The (assumed) index offset for 3-shells
-          WRITE(ISTDO,"(a,I18)") "Radioss2Viper: the total number of elements used by Viper: ",VIPER%NUMELE
+!         Allocate the arays for inverse index lookup
+          iNUMEL_SC      = NUMELS+NUMELC                              ! The total number of solids + 4-shells
+          iNUMEL_SCG     = iNUMEL_SC+NUMELTG                          ! The total number of solids + 4-shells + 3-shells
+          iNUMELEv_TOTAL = iNUMEL_SCG                                 ! The total number of elements used by Viper
+          ioffset_4shell = NUMELS+NUMELQ                              ! The (assumed) index offset for 4-shells
+                                                                      ! (confirmed that NUMELS8,NUMELS10,NUMELS16,NUMELS20 are not in the array)
+          ioffset_3shell = ioffset_4shell+NUMELC+NUMELT+NUMELP+NUMELR ! The (assumed) index offset for 3-shells
+          WRITE(ISTDO,"(a,I18)") "Radioss2Viper: the total number of elements used by Viper: ",iNUMELEv_TOTAL
           ALLOCATE(VIPER%ITABM1(NUMNOD))
-          ALLOCATE(VIPER%IXEM1(VIPER%NUMELE))
+          ALLOCATE(VIPER%IXEM1(iNUMELEv_TOTAL))
 
-!           Initialize node ordering & send nodal masses to Viper
-!           Based upon the ordering of the element numbers in the 0000.out & from our experimentation,
-!           we are assuming the order of elements in ELBUF_TAB is the same as in 0000.out, therefore we are adding offsets as required
-          viper%numon = VIPER%NUMELE
-          viper%ivout = 0
-          CALL RadiossViper_InitTab(NUMNOD, NODES%ITAB, VIPER%ITABM1, 1, 0)              ! nodes
-
-          CALL RadiossViper_InitTab(NUMELS, IXS,VIPER%IXEM1(1:NUMELS), NIXS, 0)              ! solids
-
-          CALL RadiossViper_InitTab(NUMELC, ELEMENT%SHELL%IXC, &
-            VIPER%IXEM1(1+NUMELS:VIPER%NUMEL_SC), NIXC, viper%ioffset_4shell) ! 4-shells
-
-          CALL RadiossViper_InitTab(NUMELTG, IXTG, &
-            VIPER%IXEM1(1+VIPER%NUMEL_SC:VIPER%NUMEL_SCG), NIXTG, viper%ioffset_3shell) ! 3-shells
-          CALL RadiossViper_ReceiveSendInitialTimes(DTMIN,TSTOP,DTANIM,TT)
+!         Initialize node ordering & send nodal masses to Viper
+!         Based upon the ordering of the element numbers in the 0000.out & from our experimentation,
+!         we are assuming the order of elements in ELBUF_TAB is the same as in 0000.out, therefore we are adding offsets as required
+          VIPER%NUMELEv = iNUMELEv_TOTAL
+          VIPER%numon   = iNUMELEv_TOTAL
+          CALL RadiossViper_InitTab(NUMNOD,  NODES%ITAB,        VIPER%ITABM1,                        1,     0)              ! nodes
+          CALL RadiossViper_InitTab(NUMELS,  IXS,               VIPER%IXEM1(1          :NUMELS),     NIXS,  0)              ! solids
+          CALL RadiossViper_InitTab(NUMELC,  ELEMENT%SHELL%IXC, VIPER%IXEM1(1+NUMELS   :iNUMEL_SC),  NIXC,  ioffset_4shell) ! 4-shells
+          CALL RadiossViper_InitTab(NUMELTG, IXTG,              VIPER%IXEM1(1+iNUMEL_SC:iNUMEL_SCG), NIXTG, ioffset_3shell) ! 3-shells
+          CALL RadiossViper_ReceiveSendInitialTimes(DTMIN,VIPER%DT_MIN,TSTOP,DTANIM,TT)
           CALL RadiossViper_ReceiveSendInitialNumbers(TSTOP,NUMNOD,NUMELS,NUMELC,NUMELTG)
           IF (TSTOP > 0.) THEN
-            CALL RadiossViper_SendMass(NUMNOD,NODES%MS,VIPER%ITABM1)                                                 ! required only for energy calculation checks
-            CALL RadiossViper_SendInitialStatus(viper%numon,NELEML,VIPER%NUMELE,&
+            CALL RadiossViper_SendMass(NUMNOD,NODES%MS,VIPER%ITABM1)
+            CALL RadiossViper_SendInitialStatus(VIPER%numon,iNUMELEr_TOTAL,iNUMELEv_TOTAL,&
               NPARG,NGROUP,VIPER%IXEM1,IPARG,ELBUF_TAB)  ! required to tell Viper of void elements
             TT_DOUBLE = TT
-            TANIM     = TT
+            TANIM     = 0.
             IF (TT > 0.) THEN
-!                Viper is starting from a remap; need to set animation times correctly
-              WRITE(ISTDO,"(a,F12.6,a)") &
+!             Viper is starting from a remap; need to set animation times correctly
+              WRITE(ISTDO,"(a,F12.9,a)") &
                 "Radioss2Viper: the simulation is starting at ", &
-                TT, &
-                " due to Viper-remapping"
+                TT, " due to Viper-remapping"
               DO WHILE (TANIM < TT)
                 TANIM = TANIM + DTANIM
               END DO
               TANIM = TANIM - DTANIM  ! this will enforce printing the initial dump
             END IF
           END IF
-          VIPER%TSTOP= TSTOP-1.d-8    ! TSTOP can change to facilitate an early exit; use this to send a kill-command to Viper
-          VIPER%id = 1701
-          OPEN(unit=VIPER%id,file="TimeLog.txt")
+          VIPER%TSTOP = TSTOP-1.d-8    ! TSTOP can change to facilitate an early exit; use this to send a kill-command to Viper
+          VIPER%io_dt = 1701
+          OPEN(unit=VIPER%io_dt,file="TimeLog.txt")
         end subroutine viper_coupling_initialize
 
 
@@ -207,8 +209,12 @@
             idmin = min(idmin,itab1D(i))
           end do
           if (iverbose) print*, "Radioss2Viper: InitTab: IDs in the range ",idmin,idmax
+
+          ! allocate array & initialise to illegal index
           allocate(itabtmp(idmax))
-          itabtmp = -1 ! initialise to illegal index
+          do i = 1,idmax
+             itabtmp(i) = -1
+          end do
 
           ! place the shuffled index in the array entry corresponding to the user id
           do j = 1,numnod
@@ -219,7 +225,7 @@
           j = 1
           do i = 1,numnod
             do while (itabtmp(j)==-1)
-              j = j + 1                     ! advance to skip over -1
+              j = j + 1                      ! advance to skip over -1
             end do
             itabm1(i) = itabtmp(j) + ioffset ! fill in the correct entry using the correct offset value
             j = j + 1                        ! advance to next entry
@@ -239,33 +245,24 @@
 !||    viper_coupling_initialize              ../engine/source/coupling/viper/viper_interface_mod.F90
 !||--- calls      -----------------------------------------------------
 !||====================================================================
-        subroutine RadiossViper_ReceiveSendInitialTimes(dt_min,t_max,dt_out,t_now)
+        subroutine RadiossViper_ReceiveSendInitialTimes(dt_min,dt_min_viper,t_max,dt_out,t_now)
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Arguments
 ! ----------------------------------------------------------------------------------------------------------------------
           real(kind=WP), intent(inout) :: dt_min
-          real(kind=WP), intent(out)   :: t_max,dt_out,t_now
-! ----------------------------------------------------------------------------------------------------------------------
-!                                                   Local variables
-! ----------------------------------------------------------------------------------------------------------------------
-          real(kind=WP)                :: dt_min_viper
-          integer                :: ierror
+          real(kind=WP), intent(out)   :: t_max,dt_out,t_now,dt_min_viper
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Body
 ! ----------------------------------------------------------------------------------------------------------------------
-          t_now  = 0.
-          t_max  = 0.
-          dt_out = 0.
-          if (iverbose) then
-            print*, "Radioss2Viper: ReceiveSendInitialTimes: entering: t_now,t_max,dt_min,dt_out: ", &
-              t_now, t_max, dt_min, dt_out
-          end if
+
+          if (iverbose) print*, "Radioss2Viper: ReceiveSendInitialTimes: entering"
           call SPMD_RECV(dt_min_viper, 1, 1, 9931, MPI_COMM_WORLD)
           call SPMD_RECV(t_max,        1, 1, 9932, MPI_COMM_WORLD)
           call SPMD_RECV(dt_out,       1, 1, 9933, MPI_COMM_WORLD)
           call SPMD_RECV(t_now,        1, 1, 9934, MPI_COMM_WORLD)
-          dt_min = max(dt_min,dt_min_viper)
-          call SPMD_SEND(dt_min,       1,  1, 9935, MPI_COMM_WORLD)
+          dt_min = max(dt_min,dt_min_viper)                            ! note: prior to this line, dt_min == dt_min_radioss
+          dt_min_viper = dt_min                                        ! synchronise both dt_min's
+          call SPMD_SEND(dt_min,       1, 1, 9935, MPI_COMM_WORLD)
           if (iverbose) then
             print*, "Radioss2Viper: ReceiveSendInitialTimes: exiting: t_now,t_max,dt_min,dt_out: ", &
               t_now, t_max, dt_min, dt_out
@@ -290,17 +287,17 @@
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Local variables
 ! ----------------------------------------------------------------------------------------------------------------------
-          integer                :: ikill,ierror
+          integer                :: ikill
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Body
 ! ----------------------------------------------------------------------------------------------------------------------
 
           if (iverbose) print*, "Radioss2Viper: Entering ReceiveSendInitialNumbers: ", t_max
-          call SPMD_SEND(numnodes,   1,1, 9940)
-          call SPMD_SEND(numsolids,  1,1, 9941)
-          call SPMD_SEND(num4shells, 1,1, 9942)
-          call SPMD_SEND(num3shells, 1,1, 9943)
-          call SPMD_RECV(ikill,      1,1, 9944)
+          call SPMD_SEND(numnodes,   1,1, 9940, MPI_COMM_WORLD)
+          call SPMD_SEND(numsolids,  1,1, 9941, MPI_COMM_WORLD)
+          call SPMD_SEND(num4shells, 1,1, 9942, MPI_COMM_WORLD)
+          call SPMD_SEND(num3shells, 1,1, 9943, MPI_COMM_WORLD)
+          call SPMD_RECV(ikill,      1,1, 9944, MPI_COMM_WORLD)
           if (ikill == 1) then
             print*, "Radioss2Viper: ReceiveSendInitialNumbers: ABORTING due to number mismatch"
             t_max = 0.
@@ -309,7 +306,7 @@
 
         end subroutine RadiossViper_ReceiveSendInitialNumbers
 ! ----------------------------------------------------------------------------------------------------------------------
-! This will send nodal masses from to Viper for calculation of total energy; this needs to be done once
+! This will send nodal masses to Viper
 !||====================================================================
 !||    radiossviper_sendmass       ../engine/source/coupling/viper/viper_interface_mod.F90
 !||--- called by ------------------------------------------------------
@@ -325,18 +322,18 @@
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Local variables
 ! ----------------------------------------------------------------------------------------------------------------------
-          integer             :: i,ierror
+          integer             :: i
           real(kind=WP), dimension(:), allocatable :: MSviper !(numnod)
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Body
 ! ----------------------------------------------------------------------------------------------------------------------
           allocate(MSviper(numnod))
-          print*, "Radioss2Viper: SendMass: entering with numnod = ",numnod
-!     make new arrays where the elements are in the correct order
-          do i = 1,numnod     ! tests show tha this is slower if openmp-parallel
+          if (iverbose) print*, "Radioss2Viper: SendMass: entering with numnod = ",numnod
+!         make new arrays where the elements are in the correct order
+          do i = 1,numnod
             MSviper(i) = MS(itabm1(i))
           end do
-          call SPMD_SEND(MSviper,numnod,  1, 9930)
+          call SPMD_SEND(MSviper,numnod,  1, 9930, MPI_COMM_WORLD)
           if (iverbose) print*, "Radioss2Viper: SendMass: exiting"
           deallocate(MSviper)
         end subroutine RadiossViper_SendMass
@@ -348,27 +345,27 @@
 !||    viper_coupling_initialize        ../engine/source/coupling/viper/viper_interface_mod.F90
 !||--- calls      -----------------------------------------------------
 !||====================================================================
-        subroutine RadiossViper_SendInitialStatus(n,numele,numele_viper,nparg,ngroup,ixem1,iparg,elbuf_tab)
+        subroutine RadiossViper_SendInitialStatus(n,numele_radioss,numele_viper,nparg,ngroup,ixem1,iparg,elbuf_tab)
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Arguments
 ! ----------------------------------------------------------------------------------------------------------------------
-          integer, intent(in)    :: numele,numele_viper,nparg,ngroup
+          integer, intent(in)    :: numele_radioss,numele_viper,nparg,ngroup
           integer, intent(in)    :: ixem1(numele_viper),iparg(nparg,ngroup)
           integer, intent(out)   :: n
           type(ELBUF_STRUCT_),dimension(ngroup), intent(in):: elbuf_tab
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Local variables
 ! ----------------------------------------------------------------------------------------------------------------------
-          integer                :: i,j,k,ierror
-          integer                :: Eviper(numele_viper),Evipertmp(numele)
+          integer                :: i,j,k
+          integer                :: Eviper(numele_viper),Evipertmp(numele_radioss)
           logical                :: viper_element
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Body
 ! ----------------------------------------------------------------------------------------------------------------------
 
-          print*, "Radioss2Viper: SendInitialStatus: entering:", numele,numele_viper
-!     make new erosion arrary in Viper's order & determine the number of eroded elements
-!     first, we put them in a contigious array; we will sort and send only if the number of active elements has changed
+          print*, "Radioss2Viper: SendInitialStatus: entering:", numele_radioss,numele_viper
+!         make new erosion arrary in Viper's order & determine the number of eroded elements
+!         first, we put them in a contigious array; we will sort and send only if the number of active elements has changed
           n = 0
           k = 0
           do i = 1,ngroup
@@ -379,7 +376,7 @@
                 viper_element = .false.
               end if
               k = k + 1
-              if (k <= numele) then
+              if (k <= numele_radioss) then
                 if (ELBUF_TAB(i)%GBUF%OFF(j) == 1 .and. ELBUF_TAB(i)%BUFLY(1)%ILAW > 0 .and. viper_element) then
                   n = n + 1
                   Evipertmp(k) = ELBUF_TAB(i)%GBUF%OFF(j)   ! pass element status (eroded or not)
@@ -395,7 +392,7 @@
           end do
           if (iverbose) print*, "Radioss2Viper: _SendInitialStatus: filled secondary array"
           call SPMD_SEND(Eviper, numele_viper, 1, 9950, MPI_COMM_WORLD)
-          print*, "Radioss2Viper: SendInitialStatus: exiting", numele,numele_viper,n
+          print*, "Radioss2Viper: SendInitialStatus: exiting", numele_radioss,numele_viper,n
 
         end subroutine RadiossViper_SendInitialStatus
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -408,40 +405,46 @@
 !||--- calls      -----------------------------------------------------
 !||====================================================================
         subroutine RadiossViper_SendXVE( &
-          numnod, numele, numele_viper, nparg, ngroup, &
-          numonIO, ivoutIO, X, V, itabm1, ixem1, iparg, elbuf_tab)
+          numnod, numele_radioss, numele_viper, nparg, ngroup, &
+          numonIO, X, V, itabm1, ixem1, iparg, elbuf_tab)
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Arguments
 ! ----------------------------------------------------------------------------------------------------------------------
-          integer, intent(in)    :: numnod,numele,numele_viper,nparg,ngroup
+          integer, intent(in)    :: numnod,numele_radioss,numele_viper,nparg,ngroup
           integer, intent(in)    :: itabm1(numnod),ixem1(numele_viper),iparg(nparg,ngroup)
-          integer, intent(inout) :: numonIO,ivoutIO
+          integer, intent(inout) :: numonIO
           real(kind=WP), intent(in)    :: X(3,numnod),V(3,numnod)
           type(ELBUF_STRUCT_),dimension(ngroup), intent(in) :: elbuf_tab
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Local variables
 ! ----------------------------------------------------------------------------------------------------------------------
-          integer                :: i,j,k,n,ierror
-          integer                :: Eviper(numele_viper),Evipertmp(numele)
-          real(kind=WP), dimension(:,:), allocatable :: Xviper,Vviper
+          integer                :: i,j,k,n
+          integer                :: Eviper(numele_viper),Evipertmp(numele_radioss)
+          real(kind=WP), dimension(:), allocatable :: Xviper,Vviper
           logical                :: viper_element,kill_element
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Body
 ! ----------------------------------------------------------------------------------------------------------------------
-          allocate(Xviper(3,numnod),Vviper(3,numnod))
+          allocate(Xviper(3*numnod))
+          allocate(Vviper(3*numnod))
 
           if (iverbose) print*, "Radioss2Viper: Entering SendXVE "
-!     make temporary position & velocity arrays where the elements are in the correct order for Viper
-          do i = 1,numnod     ! tests show that this is slower if openmp-parallel
-            Xviper(1:3,i) = X(1:3,itabm1(i))
-            Vviper(1:3,i) = V(1:3,itabm1(i))
+!         make temporary position & velocity arrays where the elements are in the correct order for Viper
+          do i = 1,numnod
+            Xviper(3*i-2) = X(1,itabm1(i))
+            Xviper(3*i-1) = X(2,itabm1(i))
+            Xviper(3*i  ) = X(3,itabm1(i))
+
+            Vviper(3*i-2) = V(1,itabm1(i))
+            Vviper(3*i-1) = V(2,itabm1(i))
+            Vviper(3*i  ) = V(3,itabm1(i))
           end do
           call SPMD_SEND(Xviper,  3*numnod,  1, 9902, MPI_COMM_WORLD)
           call SPMD_SEND(Vviper,  3*numnod,  1, 9903, MPI_COMM_WORLD)
 
           if (iverbose) print*, "Radioss2Viper: SendXVE: Sent position & velocity"
-!     make new erosion arrary in Viper's order & determine the number of eroded elements
-!     first, we put them in a contigious array; we will sort and send only if the number of active elements has changed
+!         make new erosion arrary in Viper's order & determine the number of eroded elements
+!         first, we put them in a contigious array; we will sort and send only if the number of active elements has changed
           n = 0
           k = 0
           do i = 1,ngroup
@@ -452,24 +455,7 @@
                 viper_element = .false.
               end if
               k = k + 1
-!           Coupling tests where elements are manually eroded
-!            if (ivoutIO==200 .and. k < 125 .and. .false.) then  ! Testing Chinook plate that is 2 FE thick
-!            if (ivoutIO==200 .and. 0 < k .and. k < 101 .and. .false.) then  ! Testing Chinook plate that is 3 FE thick; removes central sheet
-              if (ivoutIO==200 .and. .false.) then  ! Testing Chinook plate that is 3 FE thick; removes selected central elements
-                kill_element = .false.
-                if ( 1 <= k .and. k <=   6 ) kill_element = .true.
-                if (15 <= k .and. k <=  16 ) kill_element = .true.
-                if (30 <= k .and. k <=  35 ) kill_element = .true.
-                if (47 <= k .and. k <=  48 ) kill_element = .true.
-                if (61 <= k .and. k <=  66 ) kill_element = .true.
-                if (92 <= k .and. k <= 100 ) kill_element = .true.
-                if (k==24 .or. k==45 .or. k==69 .or. k==72 .or. k==74)  kill_element = .true.
-                if (kill_element) then
-                  viper_element = .false.
-                  ELBUF_TAB(i)%GBUF%OFF(j) = 0
-                end if
-              end if
-              if (k <= numele) then
+              if (k <= numele_radioss) then
                 if (ELBUF_TAB(i)%GBUF%OFF(j) == 1 .and. ELBUF_TAB(i)%BUFLY(1)%ILAW > 0 .and. viper_element) then
                   n = n + 1
                   Evipertmp(k) = ELBUF_TAB(i)%GBUF%OFF(j)   ! pass active status
@@ -488,8 +474,8 @@
             call SPMD_SEND(Eviper, numele_viper,  1, 9908, MPI_COMM_WORLD)
           end if
           numonIO = n
-          ivoutIO = ivoutIO + 1
-          deallocate(Xviper,Vviper)
+          deallocate(Xviper)
+          deallocate(Vviper)
         end subroutine RadiossViper_SendXVE
 ! ----------------------------------------------------------------------------------------------------------------------
 ! This will receive the FORCES on the nodes from Viper
@@ -510,17 +496,22 @@
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Local variables
 ! ----------------------------------------------------------------------------------------------------------------------
-          real(kind=WP), dimension(:,:), allocatable :: Aviper!(3,numnod)
-          integer                :: i
+          real(kind=WP), dimension(:), allocatable :: Aviper!(3*numnod)
+          integer                :: i,j
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Body
 ! ----------------------------------------------------------------------------------------------------------------------
-          allocate(Aviper(3,numnod))
+          allocate(Aviper(3*numnod))
           if (iverbose) print*, "Radioss2Viper: ReceiveAccelerations: ", numnod
           call SPMD_RECV(Aviper, 3*numnod, 1, 9910, MPI_COMM_WORLD)
           do i = 1,numnod
-            A(   1:3,itabm1(i)) = A(   1:3,itabm1(i)) + Aviper(1:3,i)
-            Fext(1:3,itabm1(i)) = Fext(1:3,itabm1(i)) + Aviper(1:3,i)
+            A(1,itabm1(i)) = A(1,itabm1(i)) + Aviper(3*i-2)
+            A(2,itabm1(i)) = A(2,itabm1(i)) + Aviper(3*i-1)
+            A(3,itabm1(i)) = A(3,itabm1(i)) + Aviper(3*i  )
+
+            Fext(1,itabm1(i)) = Fext(1,itabm1(i)) + Aviper(3*i-2)
+            Fext(2,itabm1(i)) = Fext(2,itabm1(i)) + Aviper(3*i-1)
+            Fext(3,itabm1(i)) = Fext(3,itabm1(i)) + Aviper(3*i  )
           end do
           deallocate(Aviper)
         end subroutine RadiossViper_ReceiveAccelerations
@@ -533,39 +524,46 @@
 !||    resol                        ../engine/source/engine/resol.F
 !||--- calls      -----------------------------------------------------
 !||====================================================================
-        subroutine RadiossViper_ReceiveSendDT(id_ViperCouplingIO,time,dt_rad)
+        subroutine RadiossViper_ReceiveSendDT(id_iodt,time,dt_min,dt_rad,mstop,mrest)
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Arguments
 ! ----------------------------------------------------------------------------------------------------------------------
-          integer, intent(in)    :: id_ViperCouplingIO
-          real(kind=WP), intent(in)    :: time
+          integer, intent(in)          :: id_iodt
+          real(kind=WP), intent(in)    :: time,dt_min
           real(kind=WP), intent(inout) :: dt_rad
+          integer, intent(inout)       :: mstop,mrest
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Local variables
 ! ----------------------------------------------------------------------------------------------------------------------
           real(kind=WP)          :: dt_viper, dt_rad_in
-          integer                :: ierror
           character(len=16)      :: dt_selected
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Body
 ! ----------------------------------------------------------------------------------------------------------------------
 
           dt_rad_in = dt_rad
-          call SPMD_RECV(dt_viper, 1,  1, 9925, MPI_COMM_WORLD )
+          call SPMD_RECV(dt_viper, 1,  1, 9925, MPI_COMM_WORLD)
           dt_rad = min(dt_rad,dt_viper)
+          if (dt_rad < dt_min) then
+            mstop = 1
+            mrest = 1
+            print*, "Radioss2Viper: ReceiveSendDT: WARNING! dt_rad < dt_min: ", dt_rad, dt_min
+          endif
           call SPMD_SEND(dt_rad,   1,  1, 9926, MPI_COMM_WORLD)
-          print*, "Radioss2Viper: ReceiveSendDT: exiting: dt_rad_in, dt_viper_in, dt_out: ", &
-            dt_rad_in, dt_viper, dt_rad
+
           if (dt_rad_in < dt_viper) then
             dt_selected = "dt_Radioss"
           else
             dt_selected = "dt_Viper"
           end if
-          write(id_ViperCouplingIO,"(3(a,Es13.6),3a,Es13.6)")&
+          write(id_iodt,"(3(a,Es13.6),3a,Es13.6)")&
           &"Time_Radioss=",time, &
             "   dt_Radioss=",dt_rad_in, &
             "   dt_Viper=",dt_viper, &
             "   dt_selected=",trim(dt_selected),"=",dt_rad
+
+          print*, "Radioss2Viper: ReceiveSendDT: exiting: dt_rad_in, dt_viper_in, dt_out: ", &
+            dt_rad_in, dt_viper, dt_rad
 
         end subroutine RadiossViper_ReceiveSendDT
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -583,21 +581,24 @@
 !                                                   Arguments
 ! ----------------------------------------------------------------------------------------------------------------------
           real(kind=WP), intent(in) :: tstop,tstop_viper
-          integer, intent(in)             :: mstop
+          integer,       intent(in) :: mstop
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Local variables
 ! ----------------------------------------------------------------------------------------------------------------------
-          integer             :: ikill, ierror
+          integer             :: ikill
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Body
 ! ----------------------------------------------------------------------------------------------------------------------
 
-          if (tstop < tstop_viper .or. mstop > 0) then
-            print*, "Radioss2Viper: SendKill: ABORTING!  Sending kill-command to Viper!"
+          ikill = 0
+          if (tstop < tstop_viper) then
+            print*, "Radioss2Viper: SendKill: ABORTING!  Sending kill-command to Viper! (tstop < tstop_viper): ", tstop, tstop_viper
             ikill = 1
-          else
-            ikill = 0
-          end if
+          endif
+          if (mstop > 0) then
+            print*, "Radioss2Viper: SendKill: ABORTING!  Sending kill-command to Viper! (mstop > 0): ", mstop
+            ikill = 1
+          endif
           call SPMD_SEND(ikill,   1,  1, 9960, MPI_COMM_WORLD)
 
         end subroutine RadiossViper_SendKill

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -2737,9 +2737,9 @@ C
               IF (ViperCoupling) THEN
                  call viper_coupling_initialize(VIPER, NODES, ELEMENT, NUMNOD,
      .                                          NIXS, NUMELS, IXS, NIXC, NUMELC,NIXTG, NUMELTG,IXTG,
-     .                                          ISTDO, NELEML, NUMELQ, NUMELT, NUMELP, NUMELR,
-     .                                          DTMIN, TSTOP, OUTPUT%DTANIM, TT, NPARG, NGROUP, IPARG, ELBUF_TAB,
-     .                                          TT_DOUBLE, OUTPUT%TANIM)
+     .                                          ISTDO, NUMELQ, NUMELT, NUMELP, NUMELR,
+     .                                          TSTOP, OUTPUT%DTANIM, TT, NPARG, NGROUP, IPARG, ELBUF_TAB,
+     .                                          TT_DOUBLE, OUTPUT%TANIM, DTMIN)
               ENDIF
 
 C===========================================================================
@@ -2748,6 +2748,9 @@ C===========================================================================
  100          CONTINUE
 
               NCYCLE_DEBUG = NCYCLE
+              IF (ViperCoupling) THEN
+                print*, "Radioss: start of loop with time ",TT
+              ENDIF
 
 C========================================================================================
 C                                     NON PARALLEL SECTION (SMP)
@@ -6400,7 +6403,7 @@ C Exchange Time Step
 C-----------------------------------------------------
               IF (ViperCoupling) THEN
 C                Compare timesteps from Viper and Radioss & select the smallest
-                 CALL RadiossViper_ReceiveSendDT(VIPER%id,TT,DT2)
+                 CALL RadiossViper_ReceiveSendDT(VIPER%io_dt,TT,VIPER%DT_MIN,DT2,MSTOP,MREST)
               ENDIF
 C-----------------------------------------------------
 ! reducing dt2 due to /INIVEL
@@ -8994,7 +8997,7 @@ C===============================================================================
 
               IF (ViperCoupling) THEN
 C                Send positions to Viper
-                 CALL RadiossViper_SendXVE(NUMNOD,NELEML,VIPER%NUMELE,NPARG,NGROUP,viper%NUMON,VIPER%ivout,
+                 CALL RadiossViper_SendXVE(NUMNOD,VIPER%NUMELEr,VIPER%NUMELEv,NPARG,NGROUP,viper%NUMON,
      .                 NODES%X,NODES%V,VIPER%ITABM1,VIPER%IXEM1,IPARG,ELBUF_TAB)
                  CALL RadiossViper_SendKill(MSTOP,TSTOP,VIPER%TSTOP)
               ENDIF
@@ -9433,7 +9436,8 @@ C--- //0 ----------------
                 ELSE
                   STATE_H3D = 2
                 ENDIF
-                IF( STATE_ANIM == 1 .OR. STATE_H3D == 1 ) THEN
+                ! Warning: an extra loop will cause hanging if coupled to Viper
+                IF( (STATE_ANIM == 1 .OR. STATE_H3D == 1) .and. .not.ViperCoupling ) THEN
                   CALL TRACE_OUT(3)
                   GOTO 100
                 ELSEIF( STATE_ANIM == 2 .OR. STATE_H3D == 2 ) THEN
@@ -9806,7 +9810,7 @@ c-----------
 C                Deallocate indexing arrays
                  IF(ALLOCATED(VIPER%ITABM1))DEALLOCATE(VIPER%ITABM1)
                  IF(ALLOCATED(VIPER%IXEM1))DEALLOCATE(VIPER%IXEM1)
-                 CLOSE(VIPER%id)
+                 CLOSE(VIPER%io_dt)
               ENDIF
 c-----------
               RETURN


### PR DESCRIPTION
#### Description of the feature or the bug
This includes several small bug fixes, including
-from the initial refactor
-readding total number of elements (now a vipercoupling variable)
-Correctly passing kill commands to/from Viper
-Ensuring Radioss does not perform an extra loop if coupled to Viper
-correct synchronisation of output times if Viper Remaps
This include small format changes, including
-adding/aligning comments
-removing unused variables & code


#### Description of the changes
This commit includes several small fixes & modifications, as described above.
