### PR TITLE
correction issue : h3d per part, missing initialisation

### DIFF
--- a/engine/source/output/h3d/h3d_results/genh3d.F
+++ b/engine/source/output/h3d/h3d_results/genh3d.F
@@ -2121,6 +2121,14 @@ C  UPDATE RESULTS VALUES
 C-----------------------------------------------
 c
         DO I = 1,H3D_DATA%N_OUTP_H3D
+c
+          IS_WRITEN_NODE(1:NUMNOD) = 0
+          IS_WRITEN_SOLID(1:NUMELS) = 0
+          IS_WRITEN_SHELL(1:NUMELC+NUMELTG) = 0
+          IS_WRITEN_ONED(1:NUMELR+NUMELP+NUMELT) = 0
+          IS_WRITEN_QUAD(1:NUMELQ) = 0
+          IS_WRITEN_SPH(1:NUMSPH) = 0
+          IS_WRITEN_SKIN(1:NUMSKIN) = 0
 c-----
 c nodal scalar
 c-----


### PR DESCRIPTION
This pull request makes a targeted change to the `GENH3D` subroutine in `genh3d.F`, improving the initialization of several tracking arrays at the start of the main output loop. This update helps ensure that state is properly reset for each output, which can prevent bugs related to stale data.

Initialization improvements:

* Added explicit zero-initialization of the arrays `IS_WRITEN_NODE`, `IS_WRITEN_SOLID`, `IS_WRITEN_SHELL`, `IS_WRITEN_ONED`, `IS_WRITEN_QUAD`, `IS_WRITEN_SPH`, and `IS_WRITEN_SKIN` at the beginning of each output iteration in the main loop of `GENH3D`. This ensures that written-element tracking is reset for each output, reducing the risk of incorrect output or data corruption.