### PR TITLE
OpenReader : possible bad Id of node creation in element

### DIFF
--- a/reader/source/cfgkernel/sdi/sdiModelViewPO.h
+++ b/reader/source/cfgkernel/sdi/sdiModelViewPO.h
@@ -1672,7 +1672,14 @@ public:
             }
             pObj->SetIntValue(idIndex, elementIndex, aNodeId[i]);
         }
-
+        // Initialize remaining node IDs to 0 if element has fewer nodes than array size
+        for (int k = aNodeId.size(); k < 20; ++k) {
+            sdiString nodeId = "node_ID" + std::to_string(k + 1);
+            int nodeIndex = pObj->GetIndex(IMECPreObject::ATY_ARRAY, IMECPreObject::VTY_INT, nodeId);
+            if (nodeIndex >= 0) {
+                pObj->SetIntValue(nodeIndex, elementIndex, 0);
+            }
+        }
 
         handle = HandleElementEdit(type, (unsigned int) p_preobjects[HCDI_OBJ_TYPE_ELEMS].size()-1, elementIndex);
         


### PR DESCRIPTION
This pull request adds a safeguard to ensure that all node ID fields are initialized, even if an element has fewer nodes than the expected array size. This helps prevent uninitialized values in the data structure.

**Initialization improvements:**

* Added a loop to set remaining node ID fields to 0 in `ModelViewPO` when an element has fewer nodes than the array size, ensuring consistent initialization of all node ID fields.