### PR TITLE
update nom_opt after hierarchy rigid body re-ordering

### DIFF
--- a/starter/source/constraints/general/rbody/hierarchy_rbody.F90
+++ b/starter/source/constraints/general/rbody/hierarchy_rbody.F90
@@ -38,7 +38,8 @@
 !||--- uses       -----------------------------------------------------
 !||====================================================================
         subroutine hierarchy_rbody(nrbykin ,nnpby ,npby  ,slpby ,lpby  ,            &
-                                   nrby    ,rby   ,numnod,iout )
+                                   nrby    ,rby   ,numnod,iout  ,lnopt1,            &
+                                   nom_opt )
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                        Modules
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -53,12 +54,14 @@
 !                                                   arguments
 ! ----------------------------------------------------------------------------------------------------------------------
           integer, intent(in)                                      :: numnod          !< number of nodes
+          integer, intent(in)                                      :: lnopt1          !< 1er dimension of nom_opt
           integer, intent(in)                                      :: iout            !< out file unit
           integer, intent(in)                                      :: nrbykin         !< number of rbody
           integer, intent(in)                                      :: nnpby           !< 1er dimension of npby
           integer, intent(in)                                      :: nrby            !< 1er dimension of rby
           integer, intent(in)                                      :: slpby           !< dimesion of lpby
           integer, dimension(nnpby,nrbykin),    intent(inout)      :: npby            !< rbody data
+          integer, dimension(lnopt1,*),         intent(inout)      :: nom_opt         !< rbody id
           integer, dimension(slpby),            intent(inout)      :: lpby            !< rbodysecondary node data
           real(kind=WP),dimension(nrby,nrbykin),intent(inout)      :: rby             !< rbody data
 !
@@ -162,6 +165,7 @@
            npby(11,j) = iad_n
            npby(20,j) =nlev(i)  ! store level in npby(20,:)
            iad_n = iad_n + nsn
+           nom_opt(1,j) = npby(6,j)
         end do
         write(iout,1000) nhier
         deallocate(npby_copy)

--- a/starter/source/starter/lectur.F
+++ b/starter/source/starter/lectur.F
@@ -7966,7 +7966,8 @@ C     rigid body hierarchy
 C--------------------------------------------
       IF(NRBYKIN > 0) THEN
         call hierarchy_rbody(NRBYKIN ,NNPBY ,NPBY  ,SLRBODY ,LPBY  ,
-     .                       NRBY    ,RBY   ,NUMNOD,IOUT )
+     .                       NRBY    ,RBY   ,NUMNOD,IOUT    ,LNOPT1,
+     .                       NOM_OPT )
       ENDIF
 C--------------------------------------------
 C     Checking rigid structures


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
might get wrong rigid body id in Starter message, when hierarchy RBODY are defined 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
update rbody id in nom_opt after hierarchy rigid body re-ordering

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
