### PR TITLE
Add clipping for element size regularization variable in /FAIL/TAB2

### DIFF
--- a/engine/source/materials/fail/tabulated/fail_tab2_b.F90
+++ b/engine/source/materials/fail/tabulated/fail_tab2_b.F90
@@ -319,6 +319,7 @@
                   reta = (three*biaxf/(three*rgtr2 - two))*                    &
                          (rgtr2 - min(max(triax(i),rgtr2),two_third))
                 endif
+                reta = max(zero, min(one, reta))
                 sizefac(i) = sizefac(i) + reta*(one - sizefac(i))
               end do
             end if

--- a/engine/source/materials/fail/tabulated/fail_tab2_c.F
+++ b/engine/source/materials/fail/tabulated/fail_tab2_c.F
@@ -287,6 +287,7 @@ c
               RETA = (THREE*BIAXF/(THREE*RGTR2 - TWO))*
      .               (RGTR2 - MIN(MAX(TRIAX(I),RGTR2),TWO_THIRD))
             ENDIF
+            RETA = MAX(ZERO, MIN(ONE, RETA))
             SIZEFAC(I) = SIZEFAC(I) + RETA*(ONE - SIZEFAC(I))
           ENDDO
         ENDIF

--- a/engine/source/materials/fail/tabulated/fail_tab2_ib.F90
+++ b/engine/source/materials/fail/tabulated/fail_tab2_ib.F90
@@ -302,6 +302,7 @@
                   reta = (three*biaxf/(three*rgtr2 - two))*                    &
                          (rgtr2 - min(max(triax(i),rgtr2),two_third))
                 endif
+                reta = max(zero, min(one, reta))
                 sizefac(i) = sizefac(i) + reta*(one - sizefac(i))
               end do
             end if

--- a/engine/source/materials/fail/tabulated/fail_tab2_s.F
+++ b/engine/source/materials/fail/tabulated/fail_tab2_s.F
@@ -266,6 +266,7 @@ c
               RETA = (THREE*BIAXF/(THREE*RGTR2 - TWO))*
      .               (RGTR2 - MIN(MAX(TRIAX(I),RGTR2),TWO_THIRD))
             ENDIF
+            RETA = MAX(ZERO, MIN(ONE, RETA))
             SIZEFAC(I) = SIZEFAC(I) + RETA*(ONE - SIZEFAC(I))
           ENDDO
         ENDIF


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

Add clipping for element size regularization variable in /FAIL/TAB2 to avoid overshooting of variable RETA.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

Add clipping for element size regularization variable in /FAIL/TAB2

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
