### PR TITLE
openreader : correction parameter evaluation with  *PARAMETER_EXPRESSION

### DIFF
--- a/hm_cfg_files/config/CFG/Keyword971/PARAMETER/parameter.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/PARAMETER/parameter.cfg
@@ -14,19 +14,51 @@
 //Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 //
-// Entity 
+// *PARAMETER 
 //
 
 ATTRIBUTES(COMMON)
 {
+    count                 = SIZE("Parameter count");
+    name_a                = ARRAY[count](STRING, "Parameter name"); 
+    type_a                = ARRAY[count](UINT, "Parameter Type");//TYPE_DOUBLE(0),TYPE_INTEGER, TYPE_STRING,TYPE_DOUBLE_EXPRESSION(10),TYPE_INTEGER_EXPRESSION
+    value_a               = ARRAY[count](STRING, "Temp Value String");
+    valueint_a            = ARRAY[count](INT, "Int Value");
+    valuedouble_a         = ARRAY[count](DOUBLE, "Double Value");
+    valuestring_a         = ARRAY[count](STRING, "String Value");
+    p_type                = VALUE(STRING, "");
+
+    //after split new preobject
     name               = VALUE(STRING, "Parameter name"); 
-    localname         = VALUE(STRING, "Local Name");
     type               = VALUE(UINT, "Parameter Type");//TYPE_DOUBLE(0),TYPE_INTEGER, TYPE_STRING,TYPE_DOUBLE_EXPRESSION(10),TYPE_INTEGER_EXPRESSION
     valueint           = VALUE(INT, "Int Value");
     valuedouble        = VALUE(DOUBLE, "Double Value");
     valuestring        = VALUE(STRING, "String Value");
-    //cardimage          = VALUE(STRING, "Card Image");
-    PARAM_SCOPE         = VALUE(STRING, "");
+    PARAM_SCOPE        = VALUE(STRING, "Parameter Scope");
+
+    c_indx             = VALUE(UINT, "");
+    col                = VALUE(UINT, "");
+    localoption        = VALUE(INT, "");
+}
+
+SKEYWORDS_IDENTIFIER(COMMON)
+{
+    count              = -1;
+    name_a             = -1;
+    type_a             = -1;
+    value_a            = -1;
+    valueint_a         = -1;
+    valuedouble_a      = -1;
+    valuestring_a      = -1;
+    p_type             = -1;
+    c_indx             = -1;
+    col                = -1;
+    localoption        = -1;
+}
+
+DEFINITIONS(COMMON)
+{
+  _SPLIT_ARRAY_TO_SINGLE = (count);
 }
 
 DRAWABLES(COMMON)
@@ -41,41 +73,72 @@ DRAWABLES(COMMON)
 
 GUI(COMMON)
 {
-	SCALAR(localname);
-	RADIO(type)
-	{
-	    ADD(0, "Double");
-		ADD(1, "Integer");
-		ADD(2, "String");
-	}
-	if(type == 0)
-	{
-	   SCALAR(valuedouble);
-	}
-	else if(type == 1)
-	{
-	   SCALAR(valueint);
-	}
-	else if(type == 2)
-	{
-	   SCALAR(valuestring);
-	}
+    RADIO(type)
+    {
+        ADD(0, "Double");
+        ADD(1, "Integer");
+        ADD(2, "String");
+    }
+    if(type == 0)
+    {
+       SCALAR(valuedouble);
+    }
+    else if(type == 1)
+    {
+       SCALAR(valueint);
+    }
+    else if(type == 2)
+    {
+       SCALAR(valuestring);
+    }
 }
+
 // File format
 FORMAT(Keyword971) 
 {
-    HEADER("*PARAMETER");
-    CARD_PREREAD("%1s%9s",APPEND_OPTIONS( [type(0) , "R"], [type(1) , "I"], [type(2) , "C"]),localname);	 
-     
-    ASSIGN(TYPE, type, IMPORT); //int type
-    ASSIGN(PARAM_SCOPE, "GLOBAL", IMPORT);
-    
-    if(type==0)
-       CARD("R%9s%lf",name, valuedouble); 
-    else if(type==1)
-       CARD("I%9s%d",name, valueint);  
-    else if (type==2)
-       CARD("C%9s%s",name, valuestring); 
-    else 
-       BLANK;
+    ASSIGN(_IOMODE_, 1, IMPORT);
+    ASSIGN(_IOMODE_, 0, EXPORT);
+    if(PARAM_SCOPE == "LOCAL") ASSIGN(localoption, 1, EXPORT);
+    else                       ASSIGN(localoption, 0, EXPORT);
+    HEADER("*PARAMETER%s", APPEND_OPTIONS( [localoption(1), "_LOCAL"] ));
+    if(_IOMODE_ == 1)
+    {
+       if(localoption == 1) ASSIGN(PARAM_SCOPE, "LOCAL");
+       else                 ASSIGN(PARAM_SCOPE, "GLOBAL");
+
+       FREE_CELL_LIST(count,"%10s%10s",name_a, value_a );
+
+       ASSIGN(c_indx, 0, IMPORT);
+       ASSIGN(col,    1, IMPORT);
+       CARD_LIST(count)
+       {
+          ASSIGN(p_type,      _ATTRIB(name_a, c_indx, col ));
+          if(p_type=="I")
+          {
+            ASSIGN(type_a, 1);
+            ASSIGN(name_a, _ERASE(name_a, "I"));
+            ASSIGN(valueint_a, _STOI(value_a));
+          }
+          else if(p_type=="R")
+          {
+            ASSIGN(type_a, 0);
+            ASSIGN(name_a, _ERASE(name_a, "R"));
+            ASSIGN(valuedouble_a, _STOF(value_a));
+          }
+          else if(p_type=="C")
+          {
+            ASSIGN(type_a, 2);
+            ASSIGN(name_a, _ERASE(name_a, "C"));
+            ASSIGN(valuestring_a, value_a);
+          }
+          ASSIGN(c_indx,    c_indx+1, IMPORT);
+       }
+    }
+    else
+    {
+        CARD("%1s%-9s%10lf",APPEND_OPTIONS( [type({1,0,2}), {"I","R","C"}] ), name, CELL_COND(if (type == 1)     valueint; 
+                                                                                              else if(type == 0) valuedouble;
+                                                                                              else if(type == 2) valuestring;) );
+
+    }
 }

--- a/hm_cfg_files/config/CFG/Keyword971/PARAMETER/parameter_expression.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/PARAMETER/parameter_expression.cfg
@@ -14,23 +14,27 @@
 //Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
 //Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
 //
-// Entity 
+// *PARAMETER_EXPRESSION
 //
 
 ATTRIBUTES(COMMON)
 {
-	name               = VALUE(STRING, "Parameter name"); 
-	type               = VALUE(UINT, "Parameter Type");//TYPE_DOUBLE(0),TYPE_INTEGER, TYPE_STRING,TYPE_DOUBLE_EXPRESSION(10),TYPE_INTEGER_EXPRESSION
-	valueint           = VALUE(INT, "Int Value");
-	valuedouble        = VALUE(DOUBLE, "Double Value");
+    name               = VALUE(STRING, "Parameter name"); 
+    type               = VALUE(UINT, "Parameter Type"); //TYPE_DOUBLE_EXPRESSION(10),TYPE_INTEGER_EXPRESSION(11)
+    valueint           = VALUE(INT, "Int Value");
+    valuedouble        = VALUE(DOUBLE, "Double Value");
     valueexpression    = VALUE(STRING, "Expression Value");
-	usesexpression     = VALUE(BOOL, "usesexpression");
-    PARAM_SCOPE         = VALUE(STRING, "");
+    usesexpression     = VALUE(BOOL, "usesexpression");
+    PARAM_SCOPE        = VALUE(STRING, "Parameter Scope");
+
+    localoption        = VALUE(INT, "");
 }
 
 SKEYWORDS_IDENTIFIER(COMMON)
 {
+    localoption        = -1;
 }
+
 DRAWABLES(COMMON)
 {
      _PARAM_NAME         = SCALAR(name);
@@ -38,31 +42,38 @@ DRAWABLES(COMMON)
      _PARAM_VALUE_DOUBLE = SCALAR(valuedouble);
      _PARAM_VALUE_INT    = SCALAR(valueint);
      _PARAM_TYPE         = SCALAR(type);
+     _PARAM_EXPRESSION   = SCALAR(valueexpression);
 }
 
 GUI(COMMON)
 {
-	SCALAR(name);
-	RADIO(type)
-	{
-		ADD(10, "Double Expression");
-		ADD(11, "Integer Expression");	
-	}
-	SCALAR(valueexpression);
-	if(type == 10)
-	{
-	   ASSIGN(valuedouble, [$valueexpression]);
-	}
-	else if(type == 11)
-	{
-	   ASSIGN(valueint, [$valueexpression]);
-	}
+    SCALAR(name);
+    RADIO(type)
+    {
+        ADD(10, "Double Expression");
+        ADD(11, "Integer Expression");	
+    }
+    SCALAR(valueexpression);
+    if(type == 10)
+    {
+        ASSIGN(valuedouble, [$valueexpression]);
+    }
+    else if(type == 11)
+    {
+        ASSIGN(valueint, [$valueexpression]);
+    }
 }
+
 // File format
 FORMAT(Keyword971) 
 {
-    HEADER("*PARAMETER_EXPRESSION");
-    ASSIGN(PARAM_SCOPE, "GLOBAL", IMPORT);
-    CARD("%1s%9s%70s",APPEND_OPTIONS( [type(10) , "R"], [type(11) , "I"]), name, valueexpression ); 
+    ASSIGN(_IOMODE_, 1, IMPORT);
+    ASSIGN(_IOMODE_, 0, EXPORT);
+    if(PARAM_SCOPE == "LOCAL") ASSIGN(localoption, 1, EXPORT);
+    else                       ASSIGN(localoption, 0, EXPORT);
+    HEADER("*PARAMETER_EXPRESSION%s", APPEND_OPTIONS( [localoption(1), "_LOCAL"] ));
+    if(localoption == 1) ASSIGN(PARAM_SCOPE, "LOCAL", IMPORT);
+    else                 ASSIGN(PARAM_SCOPE, "GLOBAL", IMPORT);
     ASSIGN(usesexpression, 1, IMPORT);
+    CARD("%1s%-9s%-70s",APPEND_OPTIONS( [type(10) , "R"], [type(11) , "I"]), name, valueexpression ){OFFSET("%-10s", " "), NO_END;}
 }

--- a/hm_cfg_files/config/CFG/Keyword971_R14.1/data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R14.1/data_hierarchy.cfg
@@ -154,7 +154,7 @@ HIERARCHY {
         USER_NAMES      = (INCLUDE);
     }
     HIERARCHY {
-        KEYWORD         = INCLUDE_TANSFRORM;
+        KEYWORD         = INCLUDE_TRANSFORM;
         TITLE           = "SOLVERSUBMODEL";
         FILE            = "INCLUDE/include_transform.cfg";
         USER_NAMES      = (INCLUDE_TRANSFORM);
@@ -173,31 +173,15 @@ HIERARCHY {
         CARD_IMAGE = PARAMETER_EXPRESSION;
         USER_ID = 7001;
         FILE    = "PARAMETER/parameter_expression.cfg";
-        USER_NAMES = (PARAMETER_EXPRESSION);
+        USER_NAMES = (PARAMETER_EXPRESSION,PARAMETER_EXPRESSION_LOCAL);
     }	
-    HIERARCHY {
-        KEYWORD =PARAMETER_EXPRESSION_LOCAL ;
-        TITLE   = "PARAMETER_EXPRESSION_LOCAL";
-        USER_ID = 7004;
-        CARD_IMAGE = PARAMETER_EXPRESSION_LOCAL;
-        FILE    = "PARAMETER/parameter_expression_local.cfg";
-        USER_NAMES = (PARAMETER_EXPRESSION_LOCAL);
-    }
-    HIERARCHY {
-        KEYWORD =PARAMETER_LOCAL ;
-        TITLE   = "PARAMETER_LOCAL";
-        CARD_IMAGE = PARAMETER_LOCAL;
-        USER_ID = 7003;
-        FILE    = "PARAMETER/parameter_local.cfg";
-        USER_NAMES = (PARAMETER_LOCAL);
-    } 
     HIERARCHY {
         KEYWORD =PARAMETER ;
         TITLE   = "PARAMETER";
         CARD_IMAGE = PARAMETER;
         USER_ID = 7000;
         FILE    = "PARAMETER/parameter.cfg";
-        USER_NAMES = (PARAMETER);
+        USER_NAMES = (PARAMETER,PARAMETER_LOCAL);
     }
 }
 


### PR DESCRIPTION
This pull request updates configuration files to improve how parameters and parameter expressions are handled, especially for local/global scope and file format consistency. The changes also fix a typo and streamline hierarchy definitions in the configuration.

**Parameter and Expression Configuration Improvements**

* Updated the parameter configuration in `parameter.cfg` to support arrays for multiple parameters, added new attributes for better control, and enhanced import/export logic to handle both local and global parameter scopes. The file format logic now uses arrays and conditional assignments for parsing and exporting parameters. [[1]](diffhunk://#diff-d136ef2bb4b7df01dcc84d47dfdaacbe2244ce328e81b0d376e376374c1a1a86L17-R61) [[2]](diffhunk://#diff-d136ef2bb4b7df01dcc84d47dfdaacbe2244ce328e81b0d376e376374c1a1a86R95-R143)
* Improved the parameter expression configuration in `parameter_expression.cfg` by adding support for local/global scope, refining attribute definitions, and updating the file format logic for more robust import/export handling. [[1]](diffhunk://#diff-92f18042a88d2c401169a35d67e3cc3834b3dc189c426ffbcee083a3d628bdfeL17-R45) [[2]](diffhunk://#diff-92f18042a88d2c401169a35d67e3cc3834b3dc189c426ffbcee083a3d628bdfeR66-R78)

**Copyright and Naming Fixes**

* Updated copyright years to 2026 in both `parameter.cfg` and `parameter_expression.cfg`. [[1]](diffhunk://#diff-d136ef2bb4b7df01dcc84d47dfdaacbe2244ce328e81b0d376e376374c1a1a86L2-R2) [[2]](diffhunk://#diff-92f18042a88d2c401169a35d67e3cc3834b3dc189c426ffbcee083a3d628bdfeL1-R2)
* Fixed a typo in the hierarchy definition: changed `INCLUDE_TANSFRORM` to `INCLUDE_TRANSFORM` in `data_hierarchy.cfg`.

**Hierarchy Streamlining**

* Consolidated user names in the hierarchy for parameters and parameter expressions by grouping local and global variants, removing redundant hierarchy blocks for local-only keywords.
