### PR TITLE
correction interface with c++ cpp_add_rbody_main_node function

### DIFF
--- a/starter/source/devtools/hm_reader/hm_rbodies_add_main_node.F90
+++ b/starter/source/devtools/hm_reader/hm_rbodies_add_main_node.F90
@@ -22,6 +22,14 @@
 !Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
       module hm_rbodies_add_main_node_mod
         implicit none
+        
+        interface
+          subroutine add_rbody_main_node(addednodeid) bind(C, name="cpp_add_rbody_main_node")
+            use, intrinsic :: iso_c_binding
+            integer(C_INT), intent(inout) :: addednodeid
+          end subroutine add_rbody_main_node
+        end interface
+        
       contains
 ! ======================================================================================================================
 !                                                   procedures
@@ -67,7 +75,7 @@
                                     option_titr = rbodyidtitle)
             call hm_get_intv('node_ID',m_id,is_available,lsubmodel)
             if(m_id == 0 )  then
-              call cpp_add_rbody_main_node(addednodeid)
+              call add_rbody_main_node(addednodeid)
               if(addednodeid > 0)  call ancmsg(msgid=3122,      &
                                              msgtype=msgwarning,&
                                              anmode=aninfo,     &


### PR DESCRIPTION
This pull request introduces a Fortran interface for a C function and updates the internal subroutine call to use the new interface. The main goal is to enable calling a C-implemented function from Fortran code for adding a main node to a rigid body.

**C/Fortran interoperability:**

* Added a Fortran interface for the C function `cpp_add_rbody_main_node`, exposing it as `add_rbody_main_node` using the `bind(C, name="cpp_add_rbody_main_node")` attribute. (`starter/source/devtools/hm_reader/hm_rbodies_add_main_node.F90`, [starter/source/devtools/hm_reader/hm_rbodies_add_main_node.F90R25-R32](diffhunk://#diff-722206d10f59fb4cc9fe7d327a80c12fcf5da207e29348e1fe88e4a2cf6785b7R25-R32))
* Updated the call in the `hm_rbodies_add_main_node` subroutine to use the new `add_rbody_main_node` interface instead of calling `cpp_add_rbody_main_node` directly. (`starter/source/devtools/hm_reader/hm_rbodies_add_main_node.F90`, [starter/source/devtools/hm_reader/hm_rbodies_add_main_node.F90L70-R78](diffhunk://#diff-722206d10f59fb4cc9fe7d327a80c12fcf5da207e29348e1fe88e4a2cf6785b7L70-R78))