### PR TITLE
openreader : update 07012026

### DIFF
--- a/reader/source/cfgkernel/CMake_arch/CMake_linux64.cmake
+++ b/reader/source/cfgkernel/CMake_arch/CMake_linux64.cmake
@@ -6,4 +6,4 @@ set (CXX_FLAGS "-Wno-deprecated -fpermissive -DGCC4 -DGCC32 -c -O2 -fPIC -Wno-wr
 # C Compiler Flags
 # --------------
 set (C_PRECOM_DEFINITION "-DNO_GZ_LIB -DTXT_MSG -DUNV -DHC_DATA_DLL_EXPORTS -D_64BITS -DLINUX -DOS_UNIX -DUSE_NAMESPACE -DFORTRAN_CALL_C_ -DBOOST_ALL_NO_LIB -DNDEBUG -DLINUX_PLATFORM" )
-set (C_FLAGS "-ansi  -w -c -O2 -fPIC -Wno-write-strings -m64 " )
+set (C_FLAGS "-std=c11 -w -c -O2 -fPIC -Wno-write-strings -m64 " )

--- a/reader/source/cfgkernel/CMake_arch/CMake_linuxa64.cmake
+++ b/reader/source/cfgkernel/CMake_arch/CMake_linuxa64.cmake
@@ -6,4 +6,4 @@ set (CXX_FLAGS "-Wno-deprecated -fpermissive -DGCC4 -DGCC32 -c -O2 -fPIC -Wno-wr
 # C Compiler Flags
 # --------------
 set (C_PRECOM_DEFINITION "-DNO_GZ_LIB -DTXT_MSG -DUNV -DHC_DATA_DLL_EXPORTS -D_64BITS -DLINUX -DOS_UNIX -DUSE_NAMESPACE -DFORTRAN_CALL_C_ -DBOOST_ALL_NO_LIB -DNDEBUG -DLINUX_PLATFORM" )
-set (C_FLAGS "-ansi  -w -c -O2 -fPIC -Wno-write-strings -march=armv8-a" )
+set (C_FLAGS "-std=c11 -w -c -O2 -fPIC -Wno-write-strings -march=armv8-a" )

--- a/reader/source/dyna2rad/dyna2rad/_private/convertcards.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/convertcards.cxx
@@ -217,7 +217,7 @@ void sdiD2R::ConvertCard::p_ConvertCtrlTimeStep()
 
 
         int IMSCLOptFlag = GetValue<int>(*selectCtrlTS, "IMSCLOptFlag");
-        if(IMSCLOptFlag == 3 || IMSCLOptFlag == 2)
+        if(IMSCLOptFlag == 3 || IMSCLOptFlag == 2 || IMSCLOptFlag == 1)
         {
             sdiValueEntity LSD_IMSCL = GetValue<sdiValueEntity>(*selectCtrlTS, "LSD_IMSCL");
             unsigned int grPartId=LSD_IMSCL.GetId();

--- a/reader/source/dyna2rad/dyna2rad/_private/convertmats.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/convertmats.cxx
@@ -1455,6 +1455,7 @@ void ConvertMat::p_ConvertMatL24(const EntityRead& dynaMat,sdiString& destCard, 
         {
             p_ConvertToMatLAW44(dynaMat, destCard, attribMap, radMat);
             matLawNumChoice = 44;
+            radMat.SetValue(p_radiossModel,sdiIdentifier("B"), sdiValue(0.0));
 //-------
             if(matLawNum != 24) radMat.SetValue(p_radiossModel, sdiIdentifier("VP"), sdiValue((int)lsdVp));
 
@@ -1575,6 +1576,7 @@ void ConvertMat::p_ConvertMatL24(const EntityRead& dynaMat,sdiString& destCard, 
                 {
                     p_ConvertToMatLAW44(dynaMat, destCard, attribMap, radMat);
                     matLawNumChoice = 44;
+                    radMat.SetValue(p_radiossModel,sdiIdentifier("B"), sdiValue(0.0));
                     radMat.SetEntityHandle(p_radiossModel, sdiIdentifier("fct_IDp"), epsEsCurveHEdit);
                     radMat.SetValue(p_radiossModel, sdiIdentifier("Optional_card"), sdiValue(1)); 
 //-------
@@ -10657,6 +10659,7 @@ void ConvertMat::p_ConvertMatL105(const EntityRead& dynaMat,sdiString& destCard,
         else if (lsdC > 0.0 && lsdP > 0.0)
         {
             p_ConvertToMatLAW44(dynaMat, destCard, attribMap, radMat);
+            radMat.SetValue(p_radiossModel,sdiIdentifier("B"), sdiValue(0.0));
 //-------
             if(matLawNum == 105)
             {
@@ -10776,7 +10779,7 @@ void ConvertMat::p_ConvertMatL105(const EntityRead& dynaMat,sdiString& destCard,
                 if (lsdC > 0.0 && lsdP > 0.0)
                 {
                     p_ConvertToMatLAW44(dynaMat, destCard, attribMap, radMat);
-
+                    radMat.SetValue(p_radiossModel,sdiIdentifier("B"), sdiValue(0.0));
                     radMat.SetEntityHandle(p_radiossModel, sdiIdentifier("fct_IDp"), epsEsCurveHEdit);
                     radMat.SetValue(p_radiossModel, sdiIdentifier("Optional_card"), sdiValue(1)); 
 //-------

--- a/reader/source/dyna2rad/dyna2rad/convertcontrolvols.h
+++ b/reader/source/dyna2rad/dyna2rad/convertcontrolvols.h
@@ -80,6 +80,8 @@ namespace sdiD2R
 
         void ConvertAirbagHybrid();
 
+        void ConvertAirbagReferenceGeometry();
+
     };
 }
 

--- a/reader/source/solver_interface/source/cfg_reading/GlobalModelSdi.cpp
+++ b/reader/source/solver_interface/source/cfg_reading/GlobalModelSdi.cpp
@@ -2714,3 +2714,30 @@ void GlobalEntitySDIdeleteEntity()
 
     g_pModelViewSDI->Delete(radEntityHEdit);
 }
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Create main node in /RBODY when MAIN node is empty
+///////////////////////////////////////////////////////////////////////////////////////////////////
+void GlobalEntitySDIRbodiesCreateMainNode(int *addedNodeId)
+{    
+    EntityType radNodeType = g_pModelViewSDI->GetEntityType("/NODE");
+    sdiValueEntity node1;
+    sdiValue tempVal(node1);
+     bool found =  g_pEntity->GetValue(sdiIdentifier("RBID"), tempVal);        
+    if(found) tempVal.GetValue(node1);
+
+    if(node1.GetId() == 0 || !found)
+    {
+        HandleEdit radNodeHEdit;
+        g_pModelViewSDI->CreateEntity(radNodeHEdit, "/NODE");
+        EntityEdit radNodeEdit(g_pModelViewSDI, radNodeHEdit);
+        radNodeEdit.SetValue(sdiIdentifier("X"), sdiValue(0.0));
+        radNodeEdit.SetValue(sdiIdentifier("Y"), sdiValue(0.0));
+        radNodeEdit.SetValue(sdiIdentifier("Z"), sdiValue(0.0));
+        *addedNodeId = radNodeHEdit.GetId(g_pModelViewSDI);
+
+        HandleRead rbodyHRead = g_pEntity->GetHandle();
+        HandleEdit rbodyHEdit(rbodyHRead.GetType(), rbodyHRead.GetPointer());
+        EntityEdit rbodyEdit(g_pModelViewSDI, rbodyHEdit);
+        rbodyEdit.SetValue(sdiIdentifier("independentnode"), sdiValue(sdiValueEntity(radNodeType, *addedNodeId)));
+    }
+}

--- a/reader/source/solver_interface/source/cfg_reading/cpp_add_rbodies_main_node.cpp
+++ b/reader/source/solver_interface/source/cfg_reading/cpp_add_rbodies_main_node.cpp
@@ -1,0 +1,49 @@
+//Copyright>    OpenRadioss
+//Copyright>    Copyright (C) 1986-2026 Altair Engineering Inc.
+//Copyright>
+//Copyright>    This program is free software: you can redistribute it and/or modify
+//Copyright>    it under the terms of the GNU Affero General Public License as published by
+//Copyright>    the Free Software Foundation, either version 3 of the License, or
+//Copyright>    (at your option) any later version.
+//Copyright>
+//Copyright>    This program is distributed in the hope that it will be useful,
+//Copyright>    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//Copyright>    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//Copyright>    GNU Affero General Public License for more details.
+//Copyright>
+//Copyright>    You should have received a copy of the GNU Affero General Public License
+//Copyright>    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//Copyright>
+//Copyright>
+//Copyright>    Commercial Alternative: Altair Radioss Software
+//Copyright>
+//Copyright>    As an alternative to this open-source version, Altair also offers Altair Radioss
+//Copyright>    software under a commercial license.  Contact Altair to discuss further if the
+//Copyright>    commercial version may interest you: https://www.altair.com/radioss/.
+
+#include "GlobalModelSDI.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <dll_settings.h>
+
+using namespace std;
+
+extern "C" 
+{
+
+CDECL void cpp_add_rbody_main_node_(int *addedNodeId)
+{
+    GlobalEntitySDIRbodiesCreateMainNode(addedNodeId);
+}
+
+CDECL void CPP_ADD_RBODY_MAIN_NODE(int *addedNodeId)
+{cpp_add_rbody_main_node_ (addedNodeId);}
+
+CDECL void cpp_add_rbody_main_node__(int *addedNodeId)
+{cpp_add_rbody_main_node_ (addedNodeId);}
+
+CDECL void cpp_add_rbody_main_node(int *addedNodeId)
+{cpp_add_rbody_main_node_ (addedNodeId);}
+
+}

--- a/reader/source/solver_interface/source/includes/GlobalModelSDI.h
+++ b/reader/source/solver_interface/source/includes/GlobalModelSDI.h
@@ -102,6 +102,7 @@ void GlobalModelSDIGetIncludesList(char **includeFiles);
 void GlobalModelSDIIsGroupUsed(char *type,int *id, bool *isUsed);
 
 void GlobalEntitySDIdeleteEntity();
+void GlobalEntitySDIRbodiesCreateMainNode(int *addedNodeId);
 
 
 #endif /* !defined(GlobalModelSDI__INCLUDED_) */


### PR DESCRIPTION
This pull request introduces several updates across the codebase, focusing on improvements to material and property conversion logic, build system modernization, and new functionality for handling rigid body nodes. The most significant changes include enhanced handling of function shifting in material muscle conversion, the addition of a utility to ensure rigid bodies have a main node, and updates to CMake flags for improved standards compliance.

**Material and Property Conversion Improvements:**
* Enhanced the `ConvertSecBeamRelatedMatMuscle` function to shift the abscissa of the SSP function by -1 when `flagSSP != 0`, creating a new recalculated function and updating `fct_id4` accordingly. This ensures correct function mapping for muscle materials.
* Updated logic in `ConvertCard::p_ConvertCtrlTimeStep` to include `IMSCLOptFlag == 1` in the conditional block, ensuring broader coverage for control time step conversion.
* Added explicit setting of the `"B"` parameter to `0.0` in several places within material conversion functions (`p_ConvertMatL24` and `p_ConvertMatL105`) to ensure correct Radioss material card generation. [[1]](diffhunk://#diff-057825db09943f337c2ad0205e0bf7b46040bfa25a77a83b06aef49b48cd96f5R1458) [[2]](diffhunk://#diff-057825db09943f337c2ad0205e0bf7b46040bfa25a77a83b06aef49b48cd96f5R1579) [[3]](diffhunk://#diff-057825db09943f337c2ad0205e0bf7b46040bfa25a77a83b06aef49b48cd96f5R10662) [[4]](diffhunk://#diff-057825db09943f337c2ad0205e0bf7b46040bfa25a77a83b06aef49b48cd96f5L10779-R10782)
* Removed special handling for Ogden rubber materials with `elform == 13` in property conversion, simplifying the logic for property type assignment. [[1]](diffhunk://#diff-4ac5bd496a6924e0b3e9ec641c60d6e3bb17b68a79ec8fd99a022b17df17d827L328-L332) [[2]](diffhunk://#diff-4ac5bd496a6924e0b3e9ec641c60d6e3bb17b68a79ec8fd99a022b17df17d827L463-L466)

**Rigid Body Node Management:**
* Introduced a new function, `GlobalEntitySDIRbodiesCreateMainNode`, which creates a main node in `/RBODY` if it does not exist, and added its declaration to the header. This ensures that rigid bodies are always initialized with a main node. [[1]](diffhunk://#diff-8da083615d20d1afa46084fb4a9d10008e4a741651fdeff831fb4f9b3fc3610fR2717-R2743) [[2]](diffhunk://#diff-c17d2749cef7877922faa2fc75972ef04db43e173fd30e304594266016e35b58R105)
* Added a new source file, `cpp_add_rbodies_main_node.cpp`, exposing the main node creation function to C and Fortran interfaces, facilitating integration with other parts of the codebase.

**Build System Modernization:**
* Updated CMake configuration files to use the `-std=c11` flag instead of the deprecated `-ansi` flag for C compilation, improving standards compliance and future-proofing the build process. [[1]](diffhunk://#diff-358a9bd4407b4df430aa9e6969a29ac965d88a528e42a1c744d59dc4210dcdfaL9-R9) [[2]](diffhunk://#diff-9d42e3dac809d4113845de7f2ca64aa8329addc8b54b764c532ad9cdb9de5b27L9-R9)

**Other Notable Changes:**
* Added a new method declaration, `ConvertAirbagReferenceGeometry`, to the `sdiD2R` namespace, preparing for future airbag modeling enhancements.
* Minor code cleanups, such as removing unnecessary blank lines and unused branches in property conversion logic.

These changes collectively improve the robustness, maintainability, and standards compliance of the codebase, while also introducing important new functionality for rigid body initialization and material conversion.