### PR TITLE
Coupling: Stricter preCICE adapter configuration checks

### DIFF
--- a/engine/source/coupling/precice_coupling_adapter.cpp
+++ b/engine/source/coupling/precice_coupling_adapter.cpp
@@ -101,8 +101,8 @@ bool PreciceCouplingAdapter::configure(const std::string& configFile) {
             } else if (key == "READ") {
                 const auto dataType = stringToDataType(value);
                 if (dataType == DataType::NOTHING) {
-                    std::cout << "Warning: Unknown data type '" << value << "' in read configuration." << std::endl;
-                    continue;
+                    std::cerr << "Error: Unknown read data type '" << value << "' in the preCICE adapter configuration file " << configFile << std::endl;
+                    return false;
                 }
                 readData_[static_cast<size_t>(dataType)].isActive = true;
                 if (DataType::POSITIONS == dataType) {
@@ -115,15 +115,16 @@ bool PreciceCouplingAdapter::configure(const std::string& configFile) {
             } else if (key == "WRITE") {
                 const auto dataType = stringToDataType(value);
                 if (dataType == DataType::NOTHING) {
-                    std::cout << "Warning: Unknown data type '" << value << "' in write configuration." << std::endl;
-                    continue;
+                    std::cerr << "Error: Unknown write data type '" << value << "' in the preCICE adapter configuration file " << configFile << std::endl;
+                    return false;
                 }
                 writeData_[static_cast<size_t>(dataType)].isActive = true;
             } else if (key == "GRNOD") {
                 try {
                     setGroupNodeId(std::stoi(value));
                 } catch (const std::exception& e) {
-                    std::cout << "Warning: Invalid GRNOD value '" << value << "': " << e.what() << std::endl;
+                    std::cerr << "Error: Invalid nodes group GRNOD '" << value << "' in the preCICE adapter configuration file " << configFile << ": " << e.what() << std::endl;
+                    return false;
                 }
             }
         } else {


### PR DESCRIPTION
Throw an error instead of warning in case the adapter configuration contains wrong read or write data.

#### Description of the feature or the bug

At the moment, if I provide an unknown data type in a `.cpl` file for coupling with preCICE, there is an (easy to miss) warning at the top, but the simulation continues with the coupling routines still running, which is misleading.

Related issue: https://github.com/OpenRadioss/OpenRadioss/issues/4564

#### Description of the changes

This PR changes the configuration checks of:

- `PRECICE/READ/`
- `PRECICE/WRITE/`
- `PRECICE/GRNOD/`

to:

- write their output to `std::cerr`, instead of `std::cout`
- `return false` instead of `continue`

similarly to the pattern found elsewhere in the same file.

In the beginning of the simulation, instead of a warning, it now shows, for example:

```
Error: Unknown read data type 'BANANAS' in the preCICE adapter configuration file s1.cpl
```

and coupling exits. But the simulation still continues (to be discussed separately).