### PR TITLE
Fix preCICE adapter reading wrong data type for displacements

### DIFF
--- a/common_source/modules/nodal_arrays.F90
+++ b/common_source/modules/nodal_arrays.F90
@@ -124,6 +124,7 @@
           real(kind=wp), dimension(:,:), allocatable :: AR !< accelerations
           real(kind=wp), dimension(:,:), allocatable :: V !< velocities
           real(kind=wp), dimension(:,:), allocatable :: X !< coordinates 3*(NUMNOD+NRCVVOIS)
+          real(kind=wp), dimension(:,:), allocatable :: X0 !< initial coordinates 3*NUMNOD
           real(kind=wp), dimension(:,:), allocatable :: D !< displacements 3*(NUMNOD+NRCVVOIS)
           real(kind=wp), dimension(:,:), allocatable :: VR !<velocities 3*(NUMNOD*IRODDL)
           real(kind=wp), dimension(:,:), allocatable :: DR !< displacements (SRD)
@@ -255,6 +256,9 @@
           call my_alloc(arrays%ICODR,numnod*iroddl)
           call my_alloc(arrays%V,3,numnod + nrcvvois)
           call my_alloc(arrays%X,3,numnod + nrcvvois)
+#if defined(WITH_PRECICE) || defined(WITH_CWIPI)
+          call my_alloc(arrays%X0,3,numnod)
+#endif
           call my_alloc(arrays%D,3,numnod + nrcvvois)
           call my_alloc(arrays%VR,3,numnod*iroddl)
           call my_alloc(arrays%MS,numnod)

--- a/engine/source/coupling/coupling.h
+++ b/engine/source/coupling/coupling.h
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <vector>
+#include <array>
 
 // Abstract base class for coupling adapters
 class CouplingAdapter {
@@ -64,6 +65,13 @@ public:
     int getSurfaceId() const { return surfaceId_; }
     void setSurfaceId(int id) { surfaceId_ = id; }
     virtual int getCommunicator() const { return 0; }
+    virtual void get_coupled_data(int* rd, int* wd) const { 
+        // Fill rd and wd fortran arrays with 4 zeros
+        for (int i = 0; i < 3; ++i) {
+            rd[i] = 0;
+            wd[i] = 0;
+        }
+    }
 
     // Data types that can be exchanged during the coupling process
     enum class DataType {
@@ -80,6 +88,7 @@ public:
          REPLACE = 1, // For positions, replace the existing data
          ADD = 2      // For forces, we add to the existing data
      };
+ 
 
      // Helper functions to convert between strings and DataType enums
     static DataType stringToDataType(const std::string& str) {

--- a/engine/source/coupling/coupling_c_interface.cpp
+++ b/engine/source/coupling/coupling_c_interface.cpp
@@ -30,198 +30,222 @@
 #include "cwipi_coupling_adapter.h"
 #endif
 
-extern "C" {
+extern "C"
+{
 
-// Factory function: creates and returns a new coupling adapter instance.
-// - If WITH_PRECICE: returns new PreciceCouplingAdapter()
-// - If WITH_CWIPI: returns new CwipiCouplingAdapter()
-// - Otherwise: returns DummyCouplingAdapter()
-// No direct preCICE or CWIPI function is called here; just object construction.
-void* coupling_adapter_create() {
-    return createCouplingAdapter();
-}
-
-// Deletes the adapter instance created by coupling_adapter_create.
-// - For both preCICE and CWIPI: calls the destructor of the adapter, which in turn calls finalize() if active.
-//   - PreciceCouplingAdapter::~PreciceCouplingAdapter():  finalize()
-//   - CwipiCouplingAdapter::~CwipiCouplingAdapter(): finalize()
-void coupling_adapter_destroy(void* adapter) {
-    delete static_cast<CouplingAdapter*>(adapter);
-}
-
-// Configures the adapter using a configuration file.
-// - preCICE: calls PreciceCouplingAdapter::configure(const std::string& configFile)
-//   - Parses config, sets up participant, mesh, data types, etc.
-// - CWIPI: calls CwipiCouplingAdapter::configure(const std::string& configFile)
-//   - Parses config, sets up application/coupling names, data types, etc.
-//      cwipi_init
-int coupling_adapter_configure(void* adapter, const char* filename) {
-    CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
-    return ca->configure(std::string(filename)) ? 1 : 0;
-}
-
-// Sets the list of node IDs to be used for coupling.
-// - preCICE: calls PreciceCouplingAdapter::setNodes(const std::vector<int>& nodeIds)
-//   - Allocates buffers, stores node IDs, prepares for mesh setup.
-// - CWIPI: calls CwipiCouplingAdapter::setNodes(const std::vector<int>& nodeIds)
-//   - Allocates buffers, stores node IDs, prepares for mesh setup.
-
-
-void coupling_adapter_set_nodes(void* adapter, const int* nodeIds, int numNodes) {
-    CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
-    std::vector<int> nodes(nodeIds, nodeIds + numNodes);
-    ca->setNodes(nodes);
-}
-
-// Initializes the coupling adapter with node coordinates and MPI info.
-// - preCICE: calls PreciceCouplingAdapter::initialize(const double* coordinates, int totalNodes, int mpiRank, int mpiSize)
-//   - Creates preCICE participant, sets mesh vertices, initializes coupling.
-//     PreciceCouplingAdapter::initialize()
-//     precice::Participant constructor
-//     precice_->setMeshVertices()
-//     precice_->writeData() (if initial data required)
-//     precice_->initialize()
-//     precice_->getMaxTimeStepSize()
-// - CWIPI: calls CwipiCouplingAdapter::initialize(const double* coordinates, int totalNodes, int mpiRank, int mpiSize)
-//   - Initializes CWIPI, creates coupling, defines mesh, locates points.
-//     CwipiCouplingAdapter::initialize()
-//     cwipi_create_coupling()
-//     cwipi_define_mesh() or cwipi_ho_define_mesh()
-//     cwipi_locate()
-//     cwipi_get_n_not_located_points()
-int coupling_adapter_initialize(void* adapter, const double* coordinates, 
-                               int totalNodes, int mpiRank, int mpiSize) {
-    CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
-    return ca->initialize(coordinates, totalNodes, mpiRank, mpiSize) ? 1 : 0;
-}
-
-// Writes data (e.g., displacements, forces, positions) to the coupling interface.
-// - preCICE: calls PreciceCouplingAdapter::writeData(const double* values, int totalNodes, double dt, int dataType)
-//   - Extracts node data, calls preCICE::writeData() for the mesh/data type.
-// - CWIPI: calls CwipiCouplingAdapter::writeData(const double* values, int totalNodes, double dt, int dataType)
-//   - Extracts node data, calls cwipi_issend() and cwipi_wait_issend() for async send.
-void coupling_adapter_write_data(void* adapter, const double* values, 
-                                int totalNodes, double dt, int dataType) {
-    CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
-    ca->writeData(values, totalNodes, dt, dataType);
-}
-
-// Reads data (e.g., displacements, forces, positions) from the coupling interface.
-// - preCICE: calls PreciceCouplingAdapter::readData(double* values, int totalNodes, double dt, int dataType)
-//   - Calls preCICE::readData() for the mesh/data type, injects into global arrays.
-// - CWIPI: calls CwipiCouplingAdapter::readData(double* values, int totalNodes, double dt, int dataType)
-//   - Calls cwipi_irecv() and cwipi_wait_irecv() for async receive, injects into global arrays.
-void coupling_adapter_read_data(void* adapter, double* values, 
-                               int totalNodes, double dt, int dataType) {
-    CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
-    ca->readData(values, totalNodes, dt, dataType);
-}
-
-// Advances the coupling interface by a time step.
-// - preCICE: calls PreciceCouplingAdapter::advance(double& dt)
-//   - Calls preCICE::advance(), updates max time step size.
-// - CWIPI: calls CwipiCouplingAdapter::advance(double& dt)
-//   - Calls cwipi_locate(), checks for not located points.
-void coupling_adapter_advance(void* adapter, double* dt) {
-    CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
-    ca->advance(*dt);
-}
-
-// Checks if the coupling is still ongoing.
-// - preCICE: calls PreciceCouplingAdapter::isCouplingOngoing()
-//   - Returns preCICE::isCouplingOngoing().
-// - CWIPI: calls CwipiCouplingAdapter::isCouplingOngoing()
-//   - Returns true if active and initialized (CWIPI does not have a strict ongoing state).
-int coupling_adapter_is_coupling_ongoing(void* adapter) {
-    CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
-    return ca->isCouplingOngoing() ? 1 : 0;
-}
-
-// Checks if a checkpoint write is required.
-// - preCICE: calls PreciceCouplingAdapter::requiresWritingCheckpoint()
-//   - Returns preCICE::requiresWritingCheckpoint().
-// - CWIPI: calls CwipiCouplingAdapter::requiresWritingCheckpoint()
-//   - Always returns false (not required for CWIPI).
-int coupling_adapter_requires_writing_checkpoint(void* adapter) {
-    CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
-    return ca->requiresWritingCheckpoint() ? 1 : 0;
-}
-
-// Checks if a checkpoint read is required.
-// - preCICE: calls PreciceCouplingAdapter::requiresReadingCheckpoint()
-//   - Returns preCICE::requiresReadingCheckpoint().
-// - CWIPI: calls CwipiCouplingAdapter::requiresReadingCheckpoint()
-//   - Always returns false (not required for CWIPI).
-int coupling_adapter_requires_reading_checkpoint(void* adapter) {
-    CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
-    return ca->requiresReadingCheckpoint() ? 1 : 0;
-}
-
-// Finalizes and cleans up the coupling adapter.
-// preCICE: PreciceCouplingAdapter::finalize() → precice_->finalize()
-// CWIPI: CwipiCouplingAdapter::finalize() → cwipi_delete_coupling(), cwipi_finalize()
-void coupling_adapter_finalize(void* adapter) {
-    CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
-    ca->finalize();
-}
-
-// Returns whether the adapter is active.
-int coupling_adapter_is_active(void* adapter) {
-    CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
-    return ca->isActive() ? 1 : 0;
-}
-
-// Returns the maximum allowed time step size for the coupling.
-// - preCICE: calls PreciceCouplingAdapter::getMaxTimeStepSize()
-double coupling_adapter_get_max_time_step_size(void* adapter) {
-    CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
-    return ca->getMaxTimeStepSize();
-}
-
-// Returns the number of coupling nodes.
-int coupling_adapter_get_num_coupling_nodes(void* adapter) {
-    CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
-    return ca->getNumberOfCouplingNodes();
-}
-
-// Returns the group node ID used for coupling.
-int coupling_adapter_get_group_node_id(void* adapter) {
-    CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
-    return ca->getGroupNodeId();
-}
-
-// Returns the surface ID used for coupling (not always used).
-int coupling_adapter_get_surface_id(void* adapter) {
-    CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
-    return ca->getSurfaceId();
-}
-
-// Returns the MPI communicator used by the adapter.
-// - preCICE: calls PreciceCouplingAdapter::getCommunicator()
-//   - Returns 0 (default, not used).
-// - CWIPI: calls CwipiCouplingAdapter::getCommunicator()
-//   - Returns Fortran MPI communicator handle (via MPI_Comm_c2f).
-int coupling_adapter_get_communicator(void* adapter) {
-    CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
-    return ca->getCommunicator();
-}
-
-
-// Sets the mesh connectivity for the coupling (only used for CWIPI).
-// - CWIPI: calls CwipiCouplingAdapter::setMesh(const int* elem_node_offsets, const int* elem_node_indices, int num_elements)
-//   - Stores mesh connectivity for later use in mesh definition.
-void coupling_adapter_set_mesh(void* adapter, const int* elem_node_offsets, const int* elem_node_indices, int num_elements) {
-    CouplingAdapter* ca = static_cast<CouplingAdapter*>(adapter);
-    
-    // Try to cast to CwipiCouplingAdapter to call setMesh
-#ifdef WITH_CWIPI
-    CwipiCouplingAdapter* cwipi_adapter = dynamic_cast<CwipiCouplingAdapter*>(ca);
-    if (cwipi_adapter) {
-        cwipi_adapter->setMesh(elem_node_offsets, elem_node_indices, num_elements);
-        return;
+    // Factory function: creates and returns a new coupling adapter instance.
+    // - If WITH_PRECICE: returns new PreciceCouplingAdapter()
+    // - If WITH_CWIPI: returns new CwipiCouplingAdapter()
+    // - Otherwise: returns DummyCouplingAdapter()
+    // No direct preCICE or CWIPI function is called here; just object construction.
+    void *coupling_adapter_create()
+    {
+        return createCouplingAdapter();
     }
+
+    // Deletes the adapter instance created by coupling_adapter_create.
+    // - For both preCICE and CWIPI: calls the destructor of the adapter, which in turn calls finalize() if active.
+    //   - PreciceCouplingAdapter::~PreciceCouplingAdapter():  finalize()
+    //   - CwipiCouplingAdapter::~CwipiCouplingAdapter(): finalize()
+    void coupling_adapter_destroy(void *adapter)
+    {
+        delete static_cast<CouplingAdapter *>(adapter);
+    }
+
+    // Configures the adapter using a configuration file.
+    // - preCICE: calls PreciceCouplingAdapter::configure(const std::string& configFile)
+    //   - Parses config, sets up participant, mesh, data types, etc.
+    // - CWIPI: calls CwipiCouplingAdapter::configure(const std::string& configFile)
+    //   - Parses config, sets up application/coupling names, data types, etc.
+    //      cwipi_init
+    int coupling_adapter_configure(void *adapter, const char *filename)
+    {
+        CouplingAdapter *ca = static_cast<CouplingAdapter *>(adapter);
+        return ca->configure(std::string(filename)) ? 1 : 0;
+    }
+
+    // Sets the list of node IDs to be used for coupling.
+    // - preCICE: calls PreciceCouplingAdapter::setNodes(const std::vector<int>& nodeIds)
+    //   - Allocates buffers, stores node IDs, prepares for mesh setup.
+    // - CWIPI: calls CwipiCouplingAdapter::setNodes(const std::vector<int>& nodeIds)
+    //   - Allocates buffers, stores node IDs, prepares for mesh setup.
+
+    void coupling_adapter_set_nodes(void *adapter, const int *nodeIds, int numNodes)
+    {
+        CouplingAdapter *ca = static_cast<CouplingAdapter *>(adapter);
+        std::vector<int> nodes(nodeIds, nodeIds + numNodes);
+        ca->setNodes(nodes);
+    }
+
+    // Initializes the coupling adapter with node coordinates and MPI info.
+    // - preCICE: calls PreciceCouplingAdapter::initialize(const double* coordinates, int totalNodes, int mpiRank, int mpiSize)
+    //   - Creates preCICE participant, sets mesh vertices, initializes coupling.
+    //     PreciceCouplingAdapter::initialize()
+    //     precice::Participant constructor
+    //     precice_->setMeshVertices()
+    //     precice_->writeData() (if initial data required)
+    //     precice_->initialize()
+    //     precice_->getMaxTimeStepSize()
+    // - CWIPI: calls CwipiCouplingAdapter::initialize(const double* coordinates, int totalNodes, int mpiRank, int mpiSize)
+    //   - Initializes CWIPI, creates coupling, defines mesh, locates points.
+    //     CwipiCouplingAdapter::initialize()
+    //     cwipi_create_coupling()
+    //     cwipi_define_mesh() or cwipi_ho_define_mesh()
+    //     cwipi_locate()
+    //     cwipi_get_n_not_located_points()
+    int coupling_adapter_initialize(void *adapter, const double *coordinates,
+                                    int totalNodes, int mpiRank, int mpiSize)
+    {
+        CouplingAdapter *ca = static_cast<CouplingAdapter *>(adapter);
+        return ca->initialize(coordinates, totalNodes, mpiRank, mpiSize) ? 1 : 0;
+    }
+
+    // Writes data (e.g., displacements, forces, positions) to the coupling interface.
+    // - preCICE: calls PreciceCouplingAdapter::writeData(const double* values, int totalNodes, double dt, int dataType)
+    //   - Extracts node data, calls preCICE::writeData() for the mesh/data type.
+    // - CWIPI: calls CwipiCouplingAdapter::writeData(const double* values, int totalNodes, double dt, int dataType)
+    //   - Extracts node data, calls cwipi_issend() and cwipi_wait_issend() for async send.
+    void coupling_adapter_write_data(void *adapter, const double *values,
+                                     int totalNodes, double dt, int dataType)
+    {
+        CouplingAdapter *ca = static_cast<CouplingAdapter *>(adapter);
+        ca->writeData(values, totalNodes, dt, dataType);
+    }
+
+    // Reads data (e.g., displacements, forces, positions) from the coupling interface.
+    // - preCICE: calls PreciceCouplingAdapter::readData(double* values, int totalNodes, double dt, int dataType)
+    //   - Calls preCICE::readData() for the mesh/data type, injects into global arrays.
+    // - CWIPI: calls CwipiCouplingAdapter::readData(double* values, int totalNodes, double dt, int dataType)
+    //   - Calls cwipi_irecv() and cwipi_wait_irecv() for async receive, injects into global arrays.
+    void coupling_adapter_read_data(void *adapter, double *values,
+                                    int totalNodes, double dt, int dataType)
+    {
+        CouplingAdapter *ca = static_cast<CouplingAdapter *>(adapter);
+        ca->readData(values, totalNodes, dt, dataType);
+    }
+
+    // Advances the coupling interface by a time step.
+    // - preCICE: calls PreciceCouplingAdapter::advance(double& dt)
+    //   - Calls preCICE::advance(), updates max time step size.
+    // - CWIPI: calls CwipiCouplingAdapter::advance(double& dt)
+    //   - Calls cwipi_locate(), checks for not located points.
+    void coupling_adapter_advance(void *adapter, double *dt)
+    {
+        CouplingAdapter *ca = static_cast<CouplingAdapter *>(adapter);
+        ca->advance(*dt);
+    }
+
+    // Checks if the coupling is still ongoing.
+    // - preCICE: calls PreciceCouplingAdapter::isCouplingOngoing()
+    //   - Returns preCICE::isCouplingOngoing().
+    // - CWIPI: calls CwipiCouplingAdapter::isCouplingOngoing()
+    //   - Returns true if active and initialized (CWIPI does not have a strict ongoing state).
+    int coupling_adapter_is_coupling_ongoing(void *adapter)
+    {
+        CouplingAdapter *ca = static_cast<CouplingAdapter *>(adapter);
+        return ca->isCouplingOngoing() ? 1 : 0;
+    }
+
+    // Checks if a checkpoint write is required.
+    // - preCICE: calls PreciceCouplingAdapter::requiresWritingCheckpoint()
+    //   - Returns preCICE::requiresWritingCheckpoint().
+    // - CWIPI: calls CwipiCouplingAdapter::requiresWritingCheckpoint()
+    //   - Always returns false (not required for CWIPI).
+    int coupling_adapter_requires_writing_checkpoint(void *adapter)
+    {
+        CouplingAdapter *ca = static_cast<CouplingAdapter *>(adapter);
+        return ca->requiresWritingCheckpoint() ? 1 : 0;
+    }
+
+    // Checks if a checkpoint read is required.
+    // - preCICE: calls PreciceCouplingAdapter::requiresReadingCheckpoint()
+    //   - Returns preCICE::requiresReadingCheckpoint().
+    // - CWIPI: calls CwipiCouplingAdapter::requiresReadingCheckpoint()
+    //   - Always returns false (not required for CWIPI).
+    int coupling_adapter_requires_reading_checkpoint(void *adapter)
+    {
+        CouplingAdapter *ca = static_cast<CouplingAdapter *>(adapter);
+        return ca->requiresReadingCheckpoint() ? 1 : 0;
+    }
+
+    // Finalizes and cleans up the coupling adapter.
+    // preCICE: PreciceCouplingAdapter::finalize() → precice_->finalize()
+    // CWIPI: CwipiCouplingAdapter::finalize() → cwipi_delete_coupling(), cwipi_finalize()
+    void coupling_adapter_finalize(void *adapter)
+    {
+        CouplingAdapter *ca = static_cast<CouplingAdapter *>(adapter);
+        ca->finalize();
+    }
+
+    // Returns whether the adapter is active.
+    int coupling_adapter_is_active(void *adapter)
+    {
+        CouplingAdapter *ca = static_cast<CouplingAdapter *>(adapter);
+        return ca->isActive() ? 1 : 0;
+    }
+
+    // Returns the maximum allowed time step size for the coupling.
+    // - preCICE: calls PreciceCouplingAdapter::getMaxTimeStepSize()
+    double coupling_adapter_get_max_time_step_size(void *adapter)
+    {
+        CouplingAdapter *ca = static_cast<CouplingAdapter *>(adapter);
+        return ca->getMaxTimeStepSize();
+    }
+
+    // Returns the number of coupling nodes.
+    int coupling_adapter_get_num_coupling_nodes(void *adapter)
+    {
+        CouplingAdapter *ca = static_cast<CouplingAdapter *>(adapter);
+        return ca->getNumberOfCouplingNodes();
+    }
+
+    // Returns the group node ID used for coupling.
+    int coupling_adapter_get_group_node_id(void *adapter)
+    {
+        CouplingAdapter *ca = static_cast<CouplingAdapter *>(adapter);
+        return ca->getGroupNodeId();
+    }
+
+    // Returns the surface ID used for coupling (not always used).
+    int coupling_adapter_get_surface_id(void *adapter)
+    {
+        CouplingAdapter *ca = static_cast<CouplingAdapter *>(adapter);
+        return ca->getSurfaceId();
+    }
+
+    // Returns the MPI communicator used by the adapter.
+    // - preCICE: calls PreciceCouplingAdapter::getCommunicator()
+    //   - Returns 0 (default, not used).
+    // - CWIPI: calls CwipiCouplingAdapter::getCommunicator()
+    //   - Returns Fortran MPI communicator handle (via MPI_Comm_c2f).
+    int coupling_adapter_get_communicator(void *adapter)
+    {
+        CouplingAdapter *ca = static_cast<CouplingAdapter *>(adapter);
+        return ca->getCommunicator();
+    }
+
+    void coupling_adapter_get_coupled_data(void *adapter, int *rd, int *wd)
+    {
+        CouplingAdapter *ca = static_cast<CouplingAdapter *>(adapter);
+        ca->get_coupled_data(rd, wd);
+    }
+
+    // Sets the mesh connectivity for the coupling (only used for CWIPI).
+    // - CWIPI: calls CwipiCouplingAdapter::setMesh(const int* elem_node_offsets, const int* elem_node_indices, int num_elements)
+    //   - Stores mesh connectivity for later use in mesh definition.
+    void coupling_adapter_set_mesh(void *adapter, const int *elem_node_offsets, const int *elem_node_indices, int num_elements)
+    {
+        CouplingAdapter *ca = static_cast<CouplingAdapter *>(adapter);
+
+        // Try to cast to CwipiCouplingAdapter to call setMesh
+#ifdef WITH_CWIPI
+        CwipiCouplingAdapter *cwipi_adapter = dynamic_cast<CwipiCouplingAdapter *>(ca);
+        if (cwipi_adapter)
+        {
+            cwipi_adapter->setMesh(elem_node_offsets, elem_node_indices, num_elements);
+            return;
+        }
 #endif
-    
-}
+    }
 
 } // extern "C"

--- a/engine/source/coupling/coupling_c_interface.h
+++ b/engine/source/coupling/coupling_c_interface.h
@@ -64,6 +64,7 @@ int coupling_adapter_get_num_coupling_nodes(void* adapter);
 int coupling_adapter_get_group_node_id(void* adapter);
 int coupling_adapter_get_surface_id(void* adapter);
 int coupling_adapter_get_communicator(void* adapter);
+void coupling_adapter_get_coupled_data(void* adapter, int* rd, int* wd);
 
 
 #ifdef __cplusplus

--- a/engine/source/coupling/cwipi_coupling_adapter.h
+++ b/engine/source/coupling/cwipi_coupling_adapter.h
@@ -31,19 +31,20 @@
 #include "cwipi.h"
 #include <mpi.h>
 
-class CwipiCouplingAdapter : public CouplingAdapter {
+class CwipiCouplingAdapter : public CouplingAdapter
+{
 public:
     CwipiCouplingAdapter();
     ~CwipiCouplingAdapter() override;
-    
+
     // Implement abstract interface
-    bool configure(const std::string& configFile) override;
-    void setNodes(const std::vector<int>& nodeIds) override;
-    void setMesh(const int* elem_node_offsets, const int* elem_node_indices, int num_elements);
-    bool initialize(const double* coordinates, int totalNodes, int mpiRank, int mpiSize) override;
-    void writeData(const double* values, int totalNodes, double dt, int dataType) override;
-    void readData(double* values, int totalNodes, double dt, int dataType) override;
-    void advance(double& dt) override;
+    bool configure(const std::string &configFile) override;
+    void setNodes(const std::vector<int> &nodeIds) override;
+    void setMesh(const int *elem_node_offsets, const int *elem_node_indices, int num_elements);
+    bool initialize(const double *coordinates, int totalNodes, int mpiRank, int mpiSize) override;
+    void writeData(const double *values, int totalNodes, double dt, int dataType) override;
+    void readData(double *values, int totalNodes, double dt, int dataType) override;
+    void advance(double &dt) override;
     bool isCouplingOngoing() const override;
     bool requiresWritingCheckpoint() const override;
     bool requiresReadingCheckpoint() const override;
@@ -52,12 +53,13 @@ public:
     double getMaxTimeStepSize() const override;
     int getNumberOfCouplingNodes() const override;
 
-    struct CouplingData {
-        bool isActive = false; // Whether this data type is active
+    struct CouplingData
+    {
+        bool isActive = false;  // Whether this data type is active
         Mode mode = Mode::SKIP; // Mode for this data type
         std::vector<double> buffer;
-        int sendRequest = -1;   // Track async send request
-        int recvRequest = -1;   // Track async receive request
+        int sendRequest = -1; // Track async send request
+        int recvRequest = -1; // Track async receive request
     };
 
 private:
@@ -70,32 +72,56 @@ private:
     int dimension_;
     double tolerance_;
     int order_;
-    
+
     std::array<CouplingData, static_cast<size_t>(DataType::DATA_COUNT)> readData_;
     std::array<CouplingData, static_cast<size_t>(DataType::DATA_COUNT)> writeData_;
-    
+
     // Coupling data
     std::vector<int> couplingNodeIds_;
     double maxTimeStepSize_;
     bool initialized_;
-    
+
     // CWIPI specific data
     MPI_Comm localComm_;
-    
+
     // Mesh connectivity storage
     std::vector<int> eltsConnecPointer_;
     std::vector<int> eltsConnec_;
     int numElements_;
-    
+
     // Helper functions
-    void extractNodeData(const double* globalValues, int totalNodes, int dataType);
-    void injectNodeData(double* globalValues, int totalNodes, int dataType);
+    void extractNodeData(const double *globalValues, int totalNodes, int dataType);
+    void injectNodeData(double *globalValues, int totalNodes, int dataType);
     std::string getFieldName(DataType type);
     int getTag(DataType type);
-    //override getCommuncator to return localComm_
-    int getCommunicator() const override {
+    // override getCommuncator to return localComm_
+    int getCommunicator() const override
+    {
         int FortranComm = MPI_Comm_c2f(localComm_);
         return FortranComm;
+    }
+
+public:
+    void get_coupled_data(int *rd, int *wd) const
+    {
+        // rd is the readData_ status (1: active)
+        // wd is the writeData_status
+        for (size_t i = 0; i < 3; ++i)
+        {
+            wd[i] = 0;
+            rd[i] = 0;
+        }
+        for (size_t i = 1; i < static_cast<size_t>(DataType::DATA_COUNT); ++i)
+        {
+            if (readData_[i].isActive)
+            {
+                rd[i - 1] = 1;
+            }
+            if (writeData_[i].isActive)
+            {
+                wd[i - 1] = 1;
+            }
+        }
     }
 };
 

--- a/engine/source/coupling/dummy_coupling_adapter.h
+++ b/engine/source/coupling/dummy_coupling_adapter.h
@@ -26,14 +26,15 @@
 #include "coupling.h"
 
 // Dummy adapter for when no coupling library is available
-class DummyCouplingAdapter : public CouplingAdapter {
+class DummyCouplingAdapter : public CouplingAdapter
+{
 public:
-    bool configure(const std::string& configFile) override;
-    void setNodes(const std::vector<int>& nodeIds) override;
-    bool initialize(const double* coordinates, int totalNodes, int mpiRank, int mpiSize) override;
-    void writeData(const double* values, int totalNodes, double dt, int dataType) override;
-    void readData(double* values, int totalNodes, double dt, int dataType) override;
-    void advance(double& dt) override;
+    bool configure(const std::string &configFile) override;
+    void setNodes(const std::vector<int> &nodeIds) override;
+    bool initialize(const double *coordinates, int totalNodes, int mpiRank, int mpiSize) override;
+    void writeData(const double *values, int totalNodes, double dt, int dataType) override;
+    void readData(double *values, int totalNodes, double dt, int dataType) override;
+    void advance(double &dt) override;
     bool isCouplingOngoing() const override;
     bool requiresWritingCheckpoint() const override;
     bool requiresReadingCheckpoint() const override;

--- a/engine/source/coupling/precice_coupling_adapter.h
+++ b/engine/source/coupling/precice_coupling_adapter.h
@@ -75,6 +75,7 @@ private:
     // Helper functions
     void extractNodeData(const double* globalValues, int totalNodes, int dataType);
     void injectNodeData(double* globalValues, int totalNodes, int dataType);
+
     
     // Static helper for bounds checking
     static constexpr int getDimensions() noexcept { return 3; }
@@ -84,6 +85,25 @@ private:
         const auto idx = nodeId - 1; // Convert to 0-based indexing
         return idx >= 0 && idx < totalNodes;
     }
+public:
+
+    void get_coupled_data(int* rd, int* wd) const { 
+        //rd is the readData_ status (1: active)
+        //wd is the writeData_status
+        for (size_t i = 0; i < 3; ++i) {
+            wd[i] = 0;
+            rd[i] = 0;
+        }
+        for (size_t i = 1; i < static_cast<size_t>(DataType::DATA_COUNT); ++i) {
+          if (readData_[i].isActive) {
+            rd[i-1] = 1;
+          }
+          if(writeData_[i].isActive){
+            wd[i-1] = 1;
+          }
+        }
+    }
+
 };
 
 #endif

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -2563,7 +2563,7 @@ C
                 ALLOCATE(NODES%FORCES(3,NUMNOD))
                 NODES%FORCES = ZERO
                 call coupling_set_interface(coupling, igrnod, ngrnod, igrsurf, nsurf,  nodes)
-                CALL COUPLING_INITIALIZE(coupling,NODES%X,NUMNOD,ISPMD,NSPMD)
+                CALL COUPLING_INITIALIZE(coupling,NODES,NUMNOD,ISPMD,NSPMD)
                 CALL COUPLING_ONGOING(coupling,ongoing)
               ENDIF
 
@@ -8787,6 +8787,7 @@ C===============================================================================
                 DT2MAX_COUPLING = DT2 
                 ! Read and write coupling positions
                 CALL COUPLING_SYNC(coupling,DT2,NODES,COUPLING_POSITIONS)
+                CALL COUPLING_SYNC(coupling,DT2,NODES,COUPLING_DISPLACEMENTS)
               ENDIF
 
               IF (ViperCoupling) THEN


### PR DESCRIPTION

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
In coupling_sync, the coupling_displacements case incorrectly passed coupling_positions to coupling_adapter_read_data. This caused the C++ adapter to check if POSITIONS was active (which it wasn't) and skip reading entirely, even when DISPLACEMENTS was configured.

Fixes: user-configured /PRECICE/READ/DISPLACEMENTS now works correctly.


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
