### PR TITLE
provide a method to replace TETRA4 with PROP using Itet=1 to TETRA10 element

### DIFF
--- a/reader/source/solver_interface/source/cfg_reading/cpp_convert_tetra4_to_tetra10.cpp
+++ b/reader/source/solver_interface/source/cfg_reading/cpp_convert_tetra4_to_tetra10.cpp
@@ -1,0 +1,49 @@
+//Copyright>    OpenRadioss
+//Copyright>    Copyright (C) 1986-2026 Altair Engineering Inc.
+//Copyright>
+//Copyright>    This program is free software: you can redistribute it and/or modify
+//Copyright>    it under the terms of the GNU Affero General Public License as published by
+//Copyright>    the Free Software Foundation, either version 3 of the License, or
+//Copyright>    (at your option) any later version.
+//Copyright>
+//Copyright>    This program is distributed in the hope that it will be useful,
+//Copyright>    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//Copyright>    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//Copyright>    GNU Affero General Public License for more details.
+//Copyright>
+//Copyright>    You should have received a copy of the GNU Affero General Public License
+//Copyright>    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//Copyright>
+//Copyright>
+//Copyright>    Commercial Alternative: Altair Radioss Software
+//Copyright>
+//Copyright>    As an alternative to this open-source version, Altair also offers Altair Radioss
+//Copyright>    software under a commercial license.  Contact Altair to discuss further if the
+//Copyright>    commercial version may interest you: https://www.altair.com/radioss/.
+
+#include "GlobalModelSDI.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <dll_settings.h>
+
+using namespace std;
+
+extern "C" 
+{
+
+CDECL void cpp_convert_tetra4_to_tetra10_(int *Itetra4ToConsider)
+{
+    GlobalEntitySDIConvertTetra4ToTetra10(Itetra4ToConsider);
+}
+
+CDECL void CPP_CONVERT_TETRA4_TO_TETRA10(int *Itetra4ToConsider)
+{cpp_convert_tetra4_to_tetra10_(Itetra4ToConsider);}
+
+CDECL void cpp_convert_tetra4_to_tetra10__(int *Itetra4ToConsider)
+{cpp_convert_tetra4_to_tetra10_(Itetra4ToConsider);}
+
+CDECL void cpp_convert_tetra4_to_tetra10(int *Itetra4ToConsider)
+{cpp_convert_tetra4_to_tetra10_(Itetra4ToConsider);}
+
+}

--- a/reader/source/solver_interface/source/elements/cpp_elem_count.cpp
+++ b/reader/source/solver_interface/source/elements/cpp_elem_count.cpp
@@ -101,13 +101,18 @@ CDECL void cpp_elem_count_(char *elemType, int *s_elemType, int *nbElems, int *i
         config = Element::HW_ELEMENT_CONFIG_QUAD4;   
         SelectionElementRead elems(g_pModelView,FilterElementConfig(config));
         *nbElems = elems.Count();
-    }
-    else if (strncmp(cname,"/TETRA4",7) == 0 )   
-    {    
-        config = Element::HW_ELEMENT_CONFIG_TETRA4;   
-        SelectionElementRead elems(g_pModelView,FilterElementConfig(config));
-        *nbElems = elems.Count();
-    }      
+    }*/
+    if (strncmp(cname,"/TETRA4",7) == 0 )   
+    {     
+        SelectionElementRead elems(g_pModelViewSDI, "/TETRA4"); 
+        *nbElems = 0;
+        while(elems.Next())
+        {
+            if ((int)elems->GetId() > 0) {
+                (*nbElems)++;
+            }
+        }
+    }/*  
     else if (strncmp(cname,"/PENTA6",7) == 0  && *isDyna == 0)   
     {    
         config = Element::HW_ELEMENT_CONFIG_PENTA6;  
@@ -118,7 +123,7 @@ CDECL void cpp_elem_count_(char *elemType, int *s_elemType, int *nbElems, int *i
         fflush(stdout);
     }   
 */  
-    if (strncmp(cname,"/BRICK20",8) == 0  && *isDyna == 0)   
+    else if (strncmp(cname,"/BRICK20",8) == 0  && *isDyna == 0)   
     {    
         SelectionElementRead elems(g_pModelViewSDI, "/BRIC20"); 
         *nbElems = elems.Count();

--- a/reader/source/solver_interface/source/elements/cpp_tetra4_read.cpp
+++ b/reader/source/solver_interface/source/elements/cpp_tetra4_read.cpp
@@ -54,6 +54,9 @@ CDECL void cpp_tetra4_read_(int *IXS, int *NIXS, int *NUMBRICK, int *IPARTS, int
     while(elems.Next())
     {
 // Get Submodel Id
+        if((int)elems->GetId() <= 0 ) {
+             continue;
+        }
         submodelId=0;
         includeId=0;
         HandleRead hInclude(elems->GetInclude());

--- a/reader/source/solver_interface/source/includes/GlobalModelSDI.h
+++ b/reader/source/solver_interface/source/includes/GlobalModelSDI.h
@@ -103,6 +103,9 @@ void GlobalModelSDIIsGroupUsed(char *type,int *id, bool *isUsed);
 
 void GlobalEntitySDIdeleteEntity();
 void GlobalEntitySDIRbodiesCreateMainNode(int *addedNodeId);
+void GlobalEntitySDICreateNode(double *x, double *y, double *z, int *newNodeId);
+void GlobalEntitySDIConvertTetra4ToTetra10(int *itetra4toconsider);
+
 
 
 #endif /* !defined(GlobalModelSDI__INCLUDED_) */

--- a/starter/source/devtools/hm_reader/hm_convert_tetra4_to_tetra10.F90
+++ b/starter/source/devtools/hm_reader/hm_convert_tetra4_to_tetra10.F90
@@ -1,0 +1,52 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 1986-2026 Altair Engineering Inc.
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Altair Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+!Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+!Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+      module hm_convert_tetra4_to_tetra10_mod
+        implicit none
+      contains
+! ======================================================================================================================
+!                                                   procedures
+! ======================================================================================================================
+!! \brief convert TETRA4 elements to TETRA10 elements in case PROPERTY card with ITETRA4=1 is used
+!! \details This routine reads all TETRA4 elements and convert them to TETRA10 elements by adding mid-side nodes.
+        subroutine hm_convert_tetra4_to_tetra10(itetra4toconsider)
+! ----------------------------------------------------------------------------------------------------------------------
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Modules
+! ----------------------------------------------------------------------------------------------------------------------
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          integer, intent(in) :: itetra4toconsider
+! ----------------------------------------------------------------------------------------------------------------------
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Body
+! ----------------------------------------------------------------------------------------------------------------------
+          call cpp_convert_tetra4_to_tetra10(itetra4toconsider)
+! ----------------------------------------------------------------------------------------------------------------------
+        end subroutine hm_convert_tetra4_to_tetra10
+      end module hm_convert_tetra4_to_tetra10_mod


### PR DESCRIPTION
This pull request introduces functionality to automatically convert all `/TETRA4` elements to `/TETRA10` elements in the Radioss model when the associated property card has `ITETRA4=1`. It includes the main C++ implementation, Fortran interface, and necessary integration and counting logic updates. The changes ensure that mid-edge nodes are created as needed and original elements are replaced, supporting both C++ and Fortran workflows.

**Tetra4 to Tetra10 Conversion Implementation:**

- Added `GlobalEntitySDIConvertTetra4ToTetra10` in `GlobalModelSDI.cpp` to:
  - Detect `/TETRA4` elements with `ITETRA4=1`, create 6 mid-edge nodes per element, and replace them with `/TETRA10` elements, ensuring node uniqueness and proper connectivity.
  - Added `GlobalEntitySDICreateNode` helper for node creation.
- Declared these functions in the header `GlobalModelSDI.h`.

**Fortran and C++ Integration:**

- Added new C++ wrapper file `cpp_convert_tetra4_to_tetra10.cpp` to expose the conversion function for Fortran and C linkage.
- Added Fortran module `hm_convert_tetra4_to_tetra10_mod` and subroutine to call the C++ conversion, providing a simple interface for Fortran code.

**Element Counting and Reading Logic Updates:**

- Updated `/TETRA4` element counting in `cpp_elem_count.cpp` to count only elements with positive IDs, matching the conversion/deletion logic. [[1]](diffhunk://#diff-7be0c5e4bfaa708d06121936d4659779c54e8e7f0685829df0ce5f968e35663fL104-R115) [[2]](diffhunk://#diff-7be0c5e4bfaa708d06121936d4659779c54e8e7f0685829df0ce5f968e35663fL121-R126)
- Updated `/TETRA4` element reading in `cpp_tetra4_read.cpp` to skip elements with non-positive IDs, preventing processing of deleted elements.