### PR TITLE
GCC15 portability: default value for pthkf to avoid error

### DIFF
--- a/starter/source/materials/fail/changchang/hm_read_fail_chang.F90
+++ b/starter/source/materials/fail/changchang/hm_read_fail_chang.F90
@@ -112,6 +112,8 @@
         pthkf = em06
       elseif (ifail_sh == 4) then    ! fiber only failure
         pthkf = one
+      else
+        pthkf   = zero
       endif                  
 ! ----------------------------------------------------------------------------------------------------------------------
 !     Filling buffer tables

--- a/starter/source/materials/fail/hashin/hm_read_fail_hashin.F90
+++ b/starter/source/materials/fail/hashin/hm_read_fail_hashin.F90
@@ -132,6 +132,8 @@
         pthkf = ratio
       elseif (ifail_sh == 3) then
         pthkf = one - em06
+      else
+        pthkf    = zero
       endif
 ! ----------------------------------------------------------------------------------------------------------------------
 !     Filling buffer tables

--- a/starter/source/materials/fail/puck/hm_read_fail_puck.F90
+++ b/starter/source/materials/fail/puck/hm_read_fail_puck.F90
@@ -114,6 +114,8 @@
         pthkf = em06
       elseif (ifail_sh == 2) tHEN
         pthkf =  one
+      else
+        pthkf = zero
       endif
       !< Stress tensor filtering frequency
       fcut = max(zero,fcut)        


### PR DESCRIPTION


#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
 -Werror=maybe-uninitialized compiler flag triggers an error because of pthkf

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
