### PR TITLE
error message enhancement in case not supported units with more than 3 digits

### DIFF
--- a/starter/source/general_controls/computation/unit_code.F
+++ b/starter/source/general_controls/computation/unit_code.F
@@ -90,8 +90,8 @@ C        Read, skip trailing spaces
            CUNIT=FIELD(J3:J3)
            CFAC(1:2)=FIELD(J1:J2)
          ELSE          
-           J1 = -HUGE(J1)
-           J2 = -HUGE(J2)
+           J1 = 1
+           J2 = J3
            CUNIT=''
            CFAC(1:2)=''
            IERR1=0


### PR DESCRIPTION
This pull request makes a small but important change to the error handling logic in the `UNIT_CODE` subroutine. Instead of setting `J1` and `J2` to large negative values when a condition fails, they are now set to safe default values.

- Error handling improvement:
  * In `unit_code.F`, updated the fallback assignment for `J1` and `J2` to use valid index values (`1` and `J3`) instead of large negative numbers, which prevents potential out-of-bounds errors.