### PR TITLE
Correct X Y Heading Spacing for Functions in Starter

### DIFF
--- a/starter/source/tools/curve/hm_read_funct.F
+++ b/starter/source/tools/curve/hm_read_funct.F
@@ -295,9 +295,9 @@ C-----------------------------------------------------------------
      .       '    -----------'/
      .       '    NUMBER OF LOAD CURVES. . . . . . . . =',I10/)
 2100  FORMAT(/'    LOAD CURVE ID . . . . . . . . . . . =',I10//
-     .        '    X                     Y               ')
+     .        '    X                   Y                   ')
 2200  FORMAT(/'    LOAD SMOOTH CURVE ID . . . . . .  . =',I10)
 2300  FORMAT(/'    XSCALE                YSCALE                XSHIFT
      .                YSHIFT              ')
-2400  FORMAT(/'    X                     Y               ')
+2400  FORMAT(/'    X                   Y                   ')
       END


### PR DESCRIPTION
Y Heading for functions echoed in Starter was misaligned by 2 characters

#### Description of the feature or the bug
Y was 2 characters to right


#### Description of the changes
removed spaces


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
