### PR TITLE
MAT LAW44 assign MAT_Iflag to 0 by default

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2026/MAT/matl44_cowper.cfg
+++ b/hm_cfg_files/config/CFG/radioss2026/MAT/matl44_cowper.cfg
@@ -347,6 +347,7 @@ FORMAT(radioss2026) {
 FORMAT(radioss2020) {
     ASSIGN(IO_FLAG, 0, EXPORT);
     ASSIGN(IO_FLAG, 1,IMPORT);
+    ASSIGN(MAT_Iflag, 0,IMPORT);
     if(IO_FLAG == 1)
     {
         HEADER("/MAT/%3s",LAW_NO);
@@ -416,6 +417,7 @@ FORMAT(radioss2020) {
 FORMAT(radioss51) {
     ASSIGN(IO_FLAG, 0, EXPORT);
     ASSIGN(IO_FLAG, 1,IMPORT);
+    ASSIGN(MAT_Iflag, 0,IMPORT);
     if(IO_FLAG == 1)
     {
         HEADER("/MAT/%3s",LAW_NO);
@@ -477,6 +479,7 @@ FORMAT(radioss51) {
 FORMAT(radioss44) {
     ASSIGN(IO_FLAG, 0, EXPORT);
     ASSIGN(IO_FLAG, 1,IMPORT);
+    ASSIGN(MAT_Iflag, 0,IMPORT);
     if(IO_FLAG == 1)
     {
         HEADER("/MAT/%3s",LAW_NO);


### PR DESCRIPTION
This pull request introduces a minor update to the `matl44_cowper.cfg` configuration file for the `radioss2026` material formats. The main change is the addition of an assignment for the `MAT_Iflag` variable in multiple format blocks to ensure it is initialized properly during import operations.

Initialization improvements:

* Added `ASSIGN(MAT_Iflag, 0,IMPORT);` to the `FORMAT(radioss2020)`, `FORMAT(radioss51)`, and `FORMAT(radioss44)` blocks to explicitly set `MAT_Iflag` to 0 when importing material data. [[1]](diffhunk://#diff-5c2958710eb6a240c11ca943b7a54a79b384a3b53d88d3865de887e745079f04R350) [[2]](diffhunk://#diff-5c2958710eb6a240c11ca943b7a54a79b384a3b53d88d3865de887e745079f04R420) [[3]](diffhunk://#diff-5c2958710eb6a240c11ca943b7a54a79b384a3b53d88d3865de887e745079f04R482)