### PR TITLE
detonators compatibility update

### DIFF
--- a/starter/source/initial_conditions/detonation/eikonal_fast_marching_method.F90
+++ b/starter/source/initial_conditions/detonation/eikonal_fast_marching_method.F90
@@ -363,7 +363,7 @@
           do ii=1,neldet
             ng = idx_ng(ii)
             i  = idx_i(ii)
-            tmp = -elbuf_tab(ng)%gbuf%tb(i)
+            tmp = abs(elbuf_tab(ng)%gbuf%tb(i)) ! Tdet was potentially already computed with standard detonator (no fast marching method), see m5in2 subroutine
             tmp = min (tmp, tdet(ii))
             elbuf_tab(ng)%gbuf%tb(i) = -tmp
           end do


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->


#### Description of the changes
/DFS/DETONATORS/NODE
A compatibility issue has been fixed between legacy detonators based on direct spherical detonation waves (Ishadow = 0) and the new detonators based on the Fast Marching Method (Ishadow = 1). Both options can now be used together in the same input file, including cases where mat_id = 0 for the legacy detonator.

<img width="672" height="543" alt="image" src="https://github.com/user-attachments/assets/ca3c4eea-3469-47d2-8fb0-2e4869e83fc4" />

