### PR TITLE
Fix potential issue with damage in /MAT/LAW76

### DIFF
--- a/engine/source/materials/mat/mat076/asso_plas76.F
+++ b/engine/source/materials/mat/mat076/asso_plas76.F
@@ -38,7 +38,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      3     DEPSXX  ,DEPSYY ,DEPSZZ  ,DEPSXY  ,DEPSYZ  ,DEPSZX  ,
      4     SIGOXX  ,SIGOYY ,SIGOZZ  ,SIGOXY  ,SIGOYZ  ,SIGOZX  ,
      5     SIGNXX  ,SIGNYY ,SIGNZZ  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
-     6     SOUNDSP ,UVAR   ,OFF     ,EPSD    ,YLD     )
+     6     SOUNDSP ,UVAR   ,OFF     ,EPSD    ,YLD     ,DMG     )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -62,7 +62,8 @@ C-----------------------------------------------
       my_real,DIMENSION(NEL),INTENT(IN) :: 
      .   RHO0,DEPSXX,DEPSYY,DEPSZZ,
      .   DEPSXY,DEPSYZ,DEPSZX,SIGOXX,SIGOYY,SIGOZZ,
-     .   SIGOXY,SIGOYZ,SIGOZX 
+     .   SIGOXY,SIGOYZ,SIGOZX
+      my_real, DIMENSION(NEL), INTENT(IN) :: DMG
 C-----------------------------------------------
 C   O U T P U T   A r g u m e n t s
 C-----------------------------------------------
@@ -255,7 +256,7 @@ c
       NINDX = 0
       DO I=1,NEL
         PHI(I) = (SVM(I)**2) - A0(I) - A1(I)*P(I) - A2(I)*P(I)*P(I)
-        IF (PHI(I) >= ZERO .AND. OFF(I) == ONE) THEN
+        IF (PHI(I) >= ZERO .AND. OFF(I) == ONE .AND. DMG(I) < ONE) THEN
           NINDX = NINDX + 1
           INDX(NINDX) = I
         ENDIF
@@ -388,14 +389,20 @@ C
 C          
             ! Cumulated plastic strains update       
             PLAT(I)  = PLAT(I) + DLAM*(SVM(I)/NORM)*THREE/(ONE + NUP(I))
+            PLAT(I)  = MAX(PLAT(I),ZERO)
             PLAC(I)  = PLAT(I)    
             PLAS(I)  = PLAS(I) + SQR3*(SVM(I)/NORM)*DLAM   
+            PLAS(I)  = MAX(PLAS(I),ZERO)
             PLA(I)   = PLA(I)  + TWO*DLAM*(SVM(I)/NORM)
+            PLA(I)   = MAX(PLA(I),ZERO)
             ! Plastic strain increments update
             DPLAT(I) = DPLAT(I) + DLAM*(SVM(I)/NORM)*THREE/(ONE + NUP(I))
+            DPLAT(I) = MAX(DPLAT(I),ZERO)
             DPLAC(I) = DPLAT(I)
             DPLAS(I) = DPLAS(I) + SQR3*(SVM(I)/NORM)*DLAM
+            DPLAS(I) = MAX(DPLAS(I),ZERO)
             DPLA(I)  = DPLA(I)  + TWO*DLAM*(SVM(I)/NORM)
+            DPLA(I)  = MAX(DPLA(I),ZERO)
 C
             ! Update pressure
             P(I) = -THIRD*(SIGNXX(I) + SIGNYY(I) + SIGNZZ(I))

--- a/engine/source/materials/mat/mat076/asso_qplas76c.F
+++ b/engine/source/materials/mat/mat076/asso_qplas76c.F
@@ -40,7 +40,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .     SIGNXX  ,SIGNYY  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
      .     PLA     ,DPLA    ,OFF     ,GS      ,
      .     YLD     ,SOUNDSP ,DEZZ    ,INLOC   ,DPLANL  ,
-     .     NVARTMP, VARTMP  ,LOFF    )
+     .     NVARTMP, VARTMP  ,LOFF    ,DMG     )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -67,6 +67,7 @@ C-----------------------------------------------
      .   SIGOXX,SIGOYY,SIGOXY,SIGOYZ,SIGOZX
       TYPE(TABLE_4D_), DIMENSION(NUMTABL) ,INTENT(IN) :: TABLE
       my_real, DIMENSION(NEL), INTENT(IN) :: LOFF
+      my_real, DIMENSION(NEL), INTENT(IN) :: DMG
 C-----------------------------------------------
 C   O U T P U T   A r g u m e n t s
 C-----------------------------------------------
@@ -253,7 +254,7 @@ C
         SVM2(I) = THREE_HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2) + THREE*SIGNXY(I)**2
         SVM(I)  = SQRT(SVM2(I))
         YLDS(I) = SVM2(I) - A0(I) - A1(I)*P(I) - A2(I)*P(I)*P(I)
-        IF (YLDS(I) > 0 .AND. OFF(I) == ONE) THEN
+        IF (YLDS(I) > 0 .AND. OFF(I) == ONE .AND. DMG(I) < ONE) THEN
           NINDX = NINDX + 1
           INDX(NINDX) = I
         ENDIF
@@ -332,12 +333,16 @@ C
 C                 
             DLAM    = YLDS(I)/FF(I)                          
             DPLA(I) = MAX(ZERO, DPLA(I) + TWO*DLAM*YLD_NORM )
+            DPLA(I) = MAX(DPLA(I),ZERO)
             PLA(I)  = PLA(I) + TWO*DLAM*YLD_NORM
+            PLA(I)  = MAX(PLA(I),ZERO)
             DPT = DLAM * YLD_NORM*BB
             DPS = DLAM * YLD_NORM*SQR3
             DPLAT(I) = DPLAT(I) + DPT
+            DPLAT(I) = MAX(DPLAT(I),ZERO)
             DPLAC(I) = DPLAT(I)
             DPLAS(I) = DPLAS(I) + DPS
+            DPLAS(I) = MAX(DPLAS(I),ZERO)
 c
             !  Plastic strains tensor update
             DPXX(I) = DLAM * NORMXX * NORM
@@ -352,8 +357,11 @@ C
 C            
             ! compute EPSPC(I), EPSPT(I), EPSPS(I)
             EPSPT(I) = EPSPT(I) + DPT
-            EPSPC(I) = EPSPC(I) + DPT                   
+            EPSPT(I) = MAX(EPSPT(I),ZERO)
+            EPSPC(I) = EPSPC(I) + DPT  
+            EPSPC(I) = MAX(EPSPC(I),ZERO)                 
             EPSPS(I) = EPSPS(I) + DPS 
+            EPSPS(I) = MAX(EPSPS(I),ZERO)
           ENDDO
 C            
           ! Update Yld values and criterion with new plastic strain and strain rate    

--- a/engine/source/materials/mat/mat076/no_asso_lplas76c.F
+++ b/engine/source/materials/mat/mat076/no_asso_lplas76c.F
@@ -40,7 +40,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .     SIGNXX  ,SIGNYY  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
      .     PLA     ,DPLA    ,OFF     ,GS      ,
      .     YLD     ,SOUNDSP ,DEZZ    ,INLOC   ,DPLANL  ,
-     .     NVARTMP, VARTMP  ,LOFF    )
+     .     NVARTMP, VARTMP  ,LOFF    ,DMG     )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -67,6 +67,7 @@ C-----------------------------------------------
      .   SIGOXX,SIGOYY,SIGOXY,SIGOYZ,SIGOZX
       TYPE(TABLE_4D_), DIMENSION(NUMTABL), INTENT(IN) :: TABLE
       my_real, DIMENSION(NEL), INTENT(IN) :: LOFF
+      my_real, DIMENSION(NEL), INTENT(IN) :: DMG
 C-----------------------------------------------
 C   O U T P U T   A r g u m e n t s
 C-----------------------------------------------
@@ -259,7 +260,7 @@ c
         SVM2(I) = THREE_HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2) + THREE*SIGNXY(I)**2
         SVM(I)  = SQRT(MAX(EM20,SVM2(I)))
         YLDS(I) = SVM(I) - A0(I) - A1(I)*P(I) - A2(I)*P(I)*P(I)
-        IF (YLDS(I) > 0 .AND. OFF(I) == ONE) THEN
+        IF (YLDS(I) > 0 .AND. OFF(I) == ONE .AND. DMG(I) < ONE) THEN
           NINDX = NINDX + 1
           INDX(NINDX) = I
         ENDIF
@@ -364,14 +365,20 @@ c
 c          
             ! compute EPSPC(I), EPSPT(I), EPSPS(I)
             EPSPT(I) = EPSPT(I) + DLAM* YLD_NORM * BB 
+            EPSPT(I) = MAX(EPSPT(I),ZERO)
             EPSPC(I) = EPSPT(I)                 
             EPSPS(I) = EPSPS(I) + DLAM* YLD_NORM*SQR3/TWO
+            EPSPS(I) = MAX(EPSPS(I),ZERO)
 c
             PLA(I)  = PLA(I)  + DLAM*YLD_NORM*OFF(I)
+            PLA(I)  = MAX(PLA(I),ZERO)
             DPLA(I) = DPLA(I) + DLAM *YLD_NORM
+            DPLA(I) = MAX(DPLA(I),ZERO)
             DPLAT(I) = DPLAT(I) + DLAM* YLD_NORM*BB 
+            DPLAT(I) = MAX(DPLAT(I),ZERO)
             DPLAC(I) = DPLAT(I)
             DPLAS(I) = DPLAS(I) + DLAM* YLD_NORM*SQR3/TWO
+            DPLAS(I) = MAX(DPLAS(I),ZERO)
 c
           ENDDO
 c            

--- a/engine/source/materials/mat/mat076/no_asso_plas76.F
+++ b/engine/source/materials/mat/mat076/no_asso_plas76.F
@@ -38,7 +38,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      3     DEPSXX  ,DEPSYY ,DEPSZZ  ,DEPSXY  ,DEPSYZ  ,DEPSZX  ,
      4     SIGOXX  ,SIGOYY ,SIGOZZ  ,SIGOXY  ,SIGOYZ  ,SIGOZX  ,
      5     SIGNXX  ,SIGNYY ,SIGNZZ  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
-     6     SOUNDSP ,UVAR   ,OFF     ,EPSD    ,YLD     )
+     6     SOUNDSP ,UVAR   ,OFF     ,EPSD    ,YLD     ,DMG     )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -63,6 +63,7 @@ C-----------------------------------------------
      .   RHO0,DEPSXX,DEPSYY,DEPSZZ,
      .   DEPSXY,DEPSYZ,DEPSZX,SIGOXX,SIGOYY,SIGOZZ,
      .   SIGOXY,SIGOYZ,SIGOZX 
+      my_real, DIMENSION(NEL), INTENT(IN) :: DMG
 C-----------------------------------------------
 C   O U T P U T   A r g u m e n t s
 C-----------------------------------------------
@@ -279,7 +280,7 @@ c
         ELSE
           PHI(I) = SVM(I) - A0(I) - A1(I)*P(I) - A2(I)*P(I)*P(I)
         ENDIF
-        IF (PHI(I) >= ZERO .AND. OFF(I) == ONE) THEN
+        IF (PHI(I) >= ZERO .AND. OFF(I) == ONE .AND. DMG(I) < ONE) THEN
           NINDX = NINDX + 1
           INDX(NINDX) = I
         ENDIF
@@ -459,14 +460,20 @@ c
 c          
             ! Cumulated plastic strains update       
             PLAT(I)  = PLAT(I) + DLAM*(SVM(I)/PSI(I))*THREE_HALF/(ONE + NUP(I))
+            PLAT(I)  = MAX(PLAT(I),ZERO)
             PLAC(I)  = PLAT(I)    
             PLAS(I)  = PLAS(I) + (SQR3/TWO)*(SVM(I)/PSI(I))*DLAM   
+            PLAS(I)  = MAX(PLAS(I),ZERO)
             PLA(I)   = PLA(I)  + (SVM(I)/PSI(I))*DLAM  
+            PLA(I)   = MAX(PLA(I),ZERO)
             ! Plastic strain increments update
             DPLAT(I) = DPLAT(I) + DLAM*(SVM(I)/PSI(I))*THREE_HALF/(ONE + NUP(I))
+            DPLAT(I) = MAX(DPLAT(I),ZERO)
             DPLAC(I) = DPLAT(I)
             DPLAS(I) = DPLAS(I) + (SQR3/TWO)*(SVM(I)/PSI(I))*DLAM   
+            DPLAS(I) = MAX(DPLAS(I),ZERO)
             DPLA(I)  = DPLA(I)  + (SVM(I)/PSI(I))*DLAM
+            DPLA(I)  = MAX(DPLA(I),ZERO)
 C
             ! Update pressure
             P(I) = -THIRD*(SIGNXX(I) + SIGNYY(I) + SIGNZZ(I))

--- a/engine/source/materials/mat/mat076/no_asso_qplas76c.F
+++ b/engine/source/materials/mat/mat076/no_asso_qplas76c.F
@@ -40,7 +40,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .     SIGNXX  ,SIGNYY  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
      .     PLA     ,DPLA    ,OFF     ,GS      ,
      .     YLD     ,SOUNDSP ,DEZZ    ,INLOC   ,DPLANL  ,
-     .     NVARTMP, VARTMP  ,LOFF    )
+     .     NVARTMP, VARTMP  ,LOFF    ,DMG     )
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -67,6 +67,7 @@ C-----------------------------------------------
      .   SIGOXX,SIGOYY,SIGOXY,SIGOYZ,SIGOZX
       TYPE(TABLE_4D_), DIMENSION(NUMTABL) ,INTENT(IN) :: TABLE
       my_real, DIMENSION(NEL), INTENT(IN) :: LOFF
+      my_real, DIMENSION(NEL), INTENT(IN) :: DMG
 C-----------------------------------------------
 C   O U T P U T   A r g u m e n t s
 C-----------------------------------------------
@@ -257,7 +258,7 @@ c
         SVM2(I) = THREE_HALF*(SXX(I)**2 + SYY(I)**2 + SZZ(I)**2) + THREE*SIGNXY(I)**2
         SVM(I)  = SQRT(SVM2(I))
         YLDS(I) = SVM2(I) - A0(I) - A1(I)*P(I) - A2(I)*P(I)*P(I)
-        IF (YLDS(I) > 0 .AND. OFF(I) == ONE) THEN
+        IF (YLDS(I) > 0 .AND. OFF(I) == ONE .AND. DMG(I) < ONE) THEN
           NINDX = NINDX + 1
           INDX(NINDX) = I
         ENDIF
@@ -356,14 +357,20 @@ c
 c            
             ! compute EPSPC(I), EPSPT(I), EPSPS(I)
             EPSPT(I) = EPSPT(I) + DLAM* YLD_NORM * BB 
+            EPSPT(I) = MAX(EPSPT(I),ZERO)
             EPSPC(I) = EPSPT(I)                 
             EPSPS(I) = EPSPS(I) + DLAM* YLD_NORM*SQR3/TWO
+            EPSPS(I) = MAX(EPSPS(I),ZERO)
 c
             PLA(I)  = PLA(I) + DLAM*YLD_NORM*OFF(I)
+            PLA(I)  = MAX(PLA(I),ZERO)
             DPLA(I) = DPLA(I) + DLAM *YLD_NORM
+            DPLA(I) = MAX(DPLA(I),ZERO)
             DPLAT(I) = DPLAT(I) + DLAM* YLD_NORM*BB 
+            DPLAT(I) = MAX(DPLAT(I),ZERO)
             DPLAC(I) = DPLAT(I)
             DPLAS(I) = DPLAS(I) + DLAM* YLD_NORM*SQR3/TWO
+            DPLAS(I) = MAX(DPLAS(I),ZERO)
 c
           ENDDO
 c            

--- a/engine/source/materials/mat/mat076/sigeps76.F
+++ b/engine/source/materials/mat/mat076/sigeps76.F
@@ -129,7 +129,7 @@ c
      3      DEPSXX ,DEPSYY ,DEPSZZ  ,DEPSXY  ,DEPSYZ  ,DEPSZX ,
      4      SIG0XX ,SIG0YY ,SIG0ZZ  ,SIG0XY  ,SIG0YZ  ,SIG0ZX ,
      5      SIGNXX ,SIGNYY ,SIGNZZ  ,SIGNXY  ,SIGNYZ  ,SIGNZX ,
-     6      SOUNDSP,UVAR   ,OFF     ,EPSD    ,YLD    )
+     6      SOUNDSP,UVAR   ,OFF     ,EPSD    ,YLD     ,DMG    )
       ELSE ! Non-associated plastic flow
         CALL NO_ASSO_PLAS76(
      1      NEL    ,NUPARAM,NUVAR   ,NFUNC   ,IFUNC   ,NVARTMP,
@@ -138,7 +138,7 @@ c
      3      DEPSXX ,DEPSYY ,DEPSZZ  ,DEPSXY  ,DEPSYZ  ,DEPSZX ,
      4      SIG0XX ,SIG0YY ,SIG0ZZ  ,SIG0XY  ,SIG0YZ  ,SIG0ZX ,
      5      SIGNXX ,SIGNYY ,SIGNZZ  ,SIGNXY  ,SIGNYZ  ,SIGNZX ,
-     6      SOUNDSP,UVAR   ,OFF     ,EPSD    ,YLD    )    
+     6      SOUNDSP,UVAR   ,OFF     ,EPSD    ,YLD     ,DMG    )    
       ENDIF
 c
       !====================================================================

--- a/engine/source/materials/mat/mat076/sigeps76c.F
+++ b/engine/source/materials/mat/mat076/sigeps76c.F
@@ -138,7 +138,7 @@ c
      .       SIGNXX  ,SIGNYY  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
      .       PLA     ,DPLA    ,OFF     ,GS      ,
      .       YLD     ,SOUNDSP ,DEZZ    ,INLOC   ,DPLANL  ,
-     .       NVARTMP ,VARTMP  ,LOFF    )
+     .       NVARTMP ,VARTMP  ,LOFF    ,DMG     )
 c
       ELSE   ! Non-associated plastic flow
         IF (IQUAD == 1) THEN ! Quadratic yield criterion
@@ -151,7 +151,7 @@ c
      .       SIGNXX  ,SIGNYY  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
      .       PLA     ,DPLA    ,OFF     ,GS      ,
      .       YLD     ,SOUNDSP ,DEZZ    ,INLOC   ,DPLANL  ,
-     .       NVARTMP ,VARTMP  ,LOFF    )
+     .       NVARTMP ,VARTMP  ,LOFF    ,DMG     )
         ELSE                 ! Non-quadratic yield criterion
           CALL NO_ASSO_LPLAS76C(
      .       NEL     ,NUPARAM ,NUVAR   ,NFUNC   ,IFUNC   ,
@@ -162,7 +162,7 @@ c
      .       SIGNXX  ,SIGNYY  ,SIGNXY  ,SIGNYZ  ,SIGNZX  ,
      .       PLA     ,DPLA    ,OFF     ,GS      ,
      .       YLD     ,SOUNDSP ,DEZZ    ,INLOC   ,DPLANL  ,
-     .       NVARTMP ,VARTMP  ,LOFF    )
+     .       NVARTMP ,VARTMP  ,LOFF    ,DMG     )
         ENDIF
       ENDIF
 c


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

Fix potential issue when element is fully damage with /MAT/LAW76. The plastic algorithm is still performed on fully damaged elements, which may causes problem. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

Avoid the plastic return mapping for fully damaged elements, which is usually done for most of the material laws. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
