### PR TITLE
correction materail cfg files (dim)

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2020/MAT/3d_comp_12.cfg
+++ b/hm_cfg_files/config/CFG/radioss2020/MAT/3d_comp_12.cfg
@@ -227,7 +227,7 @@ GUI(COMMON) {
         SCALAR(MAT_BETA)          { DIMENSION="DIMENSIONLESS"; }
         SCALAR(MAT_HARD)          { DIMENSION="DIMENSIONLESS"; }
         SCALAR(MAT_SIG)           { DIMENSION="DIMENSIONLESS"; }
-        SCALAR(WPREF)             { DIMENSION="DIMENSIONLESS"; }
+        SCALAR(WPREF)             { DIMENSION="energydensity"; }
         SCALAR(MAT_SIGYT1)        { DIMENSION="pressure";      }
         SCALAR(MAT_SIGYT2)        { DIMENSION="pressure";      }
         SCALAR(MAT_SIGYC1)        { DIMENSION="pressure";      }

--- a/hm_cfg_files/config/CFG/radioss2020/MAT/matl14_compso.cfg
+++ b/hm_cfg_files/config/CFG/radioss2020/MAT/matl14_compso.cfg
@@ -181,7 +181,7 @@ DEFAULTS(COMMON)
     MAT_SIG                 = 1.0e10;
     MAT_SIGT1               = 1.0e30;
     STRFLAG                 = 1;
-    WPREF               = 1.0;
+    WPREF                   = 1.0;
 }
 
 GUI(COMMON) {
@@ -235,7 +235,7 @@ optional:
     SCALAR(MAT_BETA)        { DIMENSION="DIMENSIONLESS"; } // Depending on MAT_HARD
     SCALAR(MAT_HARD)        { DIMENSION="DIMENSIONLESS"; }
     SCALAR(MAT_SIG)         { DIMENSION="force";         }
-    SCALAR(WPREF)             { DIMENSION="DIMENSIONLESS"; }
+    SCALAR(WPREF)           { DIMENSION="energydensity"; }
     SCALAR(MAT_SIGYT1)      { DIMENSION="pressure";      }
     SCALAR(MAT_SIGYT2)      { DIMENSION="pressure";      }
     SCALAR(MAT_SIGYC1)      { DIMENSION="pressure";      }


### PR DESCRIPTION
This pull request updates the unit specification for the `WPREF` parameter in two material configuration files. The dimension for `WPREF` has been corrected from "DIMENSIONLESS" to "energydensity", ensuring more accurate physical representation and consistency across material definitions.

Unit specification corrections:

* Updated the dimension of `WPREF` from "DIMENSIONLESS" to "energydensity" in `hm_cfg_files/config/CFG/radioss2020/MAT/3d_comp_12.cfg`.
* Updated the dimension of `WPREF` from "DIMENSIONLESS" to "energydensity" in `hm_cfg_files/config/CFG/radioss2020/MAT/matl14_compso.cfg`.