### PR TITLE
openreader : correction title of option with HC_ID

### DIFF
--- a/reader/source/cfgio/MODEL_IO/mv_solver_input_infos.cpp
+++ b/reader/source/cfgio/MODEL_IO/mv_solver_input_infos.cpp
@@ -872,6 +872,10 @@ void SolverInputInfo::ProcessKeywordComments(std::vector<std::vector<string>>& c
             {
                 result[2].erase(result[2].begin(), std::find_if(result[2].begin(), result[2].end(), [](char c) {return c != ' ';}));
                 result[2].erase(std::find_if(result[2].rbegin(), result[2].rend(), [](char c) { return c != ' '; }).base(), result[2].end());
+                // Remove trailing carriage return if present
+                if (!result[2].empty() && result[2].back() == '\n') {
+                    result[2].pop_back();
+                }
                 //skwy_val.push_back(string("name=") + result[2]);
                 cfgkernel::Variant val(result[2]);
                 vallst.push_back(std::make_pair("name", val));


### PR DESCRIPTION
This pull request makes a small but important improvement to the processing of keyword comments in the `SolverInputInfo::ProcessKeywordComments` function. It ensures that any trailing newline character is removed from the processed string, in addition to trimming whitespace.

* Improved string cleaning in `SolverInputInfo::ProcessKeywordComments` by removing any trailing newline character (`'\n'`) from `result[2]` after trimming whitespace.