### PR TITLE
OpenMP issue related to interface 22 - introduced by 0043df53a3083c971cc85511510df4bab074c894

### DIFF
--- a/engine/source/ale/aconve.F90
+++ b/engine/source/ale/aconve.F90
@@ -494,6 +494,7 @@
 
           ! ------------
           if(int22>0) then
+            call my_barrier()
             do nm=1,mat_number ! loop over the material number (1 if jmult=0)
               nf1 = nft+1+(nm-1)*numels            
               do itrimat=1,trimat
@@ -517,6 +518,7 @@
                   if(nvar==1.and.flag_mat_51==1) iflg = 1        
                   call a22conv3( phi(1,phi_add),iflg,real_itrimat,nvar,itask, &
                                   elbuf_tab,ixs,iparg,brick_add)
+                  call my_barrier()
                 enddo
               enddo
             enddo


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
Interface 22 : different results are obtained according to the number of omp tasks. This regression was introduced by 0043df53a3083c971cc85511510df4bab074c894

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
An omp barrier was missing after the a22conv routine

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
