### PR TITLE
/MAT/LAW102 : bulk modulus update

### DIFF
--- a/starter/source/materials/mat/mat102/hm_read_mat102.F
+++ b/starter/source/materials/mat/mat102/hm_read_mat102.F
@@ -212,9 +212,9 @@ C-----------------------------------------------
       NUVAR     = 0 
       NFUNC     = 0 
       STIFINT   = E
-      PARMAT(1) = STIFINT/THREE !
-      PARMAT(2) = STIFINT
-      PARMAT(3) = NU
+      PARMAT(1) = E / three/(one - two*nu)  ! bulk
+      PARMAT(2) = E  ! young
+      PARMAT(3) = NU ! poisson
 c---------------------------   
       MTAG%G_PLA  = 1
       MTAG%L_PLA  = 1


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->


#### Description of the changes
Material Reader now updates the bulk modulus using parmat(1) instead of pm(32).
The value of parmat(1) is updated accordingly to ensure consistency with the bulk modulus.
As a result, solutions for purely linear elastic problems now match between LAW1 and LAW012.

**VERIFICATION TEST** 
E=1
nu=0.25
=> K=2/3
<img width="1446" height="599" alt="image" src="https://github.com/user-attachments/assets/50701b2e-c1b9-4dc3-8615-fecc4d965a13" />
_(Animation is showing Pressure at time for which µ=1+epsilon, this explains why P is not exactly 2/3, it is 2/3 + epsilon_2)_


**WORKAROUND**
Define a linear EoS with /EOS/LINEAR and expected bulk modulus K=E/3/(1-2.nu)
```
/EOS/LINEAR/[id]
Linear EoS (E=1, nu=0.25)
#                 P0                   B                 PSH                          
                 0.0           0.6666667                 0.0 
```
