### PR TITLE
fixing NaN issue when the Fs=-1 it's used for fs=0 or 1 and update ri…

### DIFF
--- a/engine/source/elements/solid/solidez/mmodul.F
+++ b/engine/source/elements/solid/solidez/mmodul.F
@@ -280,7 +280,35 @@ C----- w/o armature :--> isotropic
           G3(I,3)   = UPARAM(12)
         ENDDO
         CALL MSTIFORTHV(JFT    ,JLT   ,QC  ,QCG  ,QGC    ,
-     .                  QG     ,CC    ,G3  ,G33  ,CG     )   
+     .                  QG     ,CC    ,G3  ,G33  ,CG     )  
+      ELSEIF (MTN == 123) THEN     
+         DO I=JFT,JLT
+          CC(I,1,1) = mat_param%uparam(31)
+          CC(I,2,2) = mat_param%uparam(32)
+          CC(I,3,3) = mat_param%uparam(33)
+          CC(I,1,2) = mat_param%uparam(34)
+          CC(I,2,3) = mat_param%uparam(36)
+          CC(I,1,3) = mat_param%uparam(35)
+          G3(I,1)   = mat_param%uparam(4)
+          G3(I,2)   = mat_param%uparam(5)
+          G3(I,3)   = mat_param%uparam(6)
+        ENDDO
+        CALL MSTIFORTHV(JFT    ,JLT   ,QC  ,QCG  ,QGC    ,
+     .                  QG     ,CC    ,G3  ,G33  ,CG     )  
+      ELSEIF (MTN == 125) THEN     
+         DO I=JFT,JLT
+          CC(I,1,1) = mat_param%uparam(81)
+          CC(I,2,2) = mat_param%uparam(82)
+          CC(I,3,3) = mat_param%uparam(83)
+          CC(I,1,2) = mat_param%uparam(84)
+          CC(I,2,3) = mat_param%uparam(86)
+          CC(I,1,3) = mat_param%uparam(85)
+          G3(I,1)   = mat_param%uparam(4)
+          G3(I,2)   = mat_param%uparam(5)
+          G3(I,3)   = mat_param%uparam(6)
+        ENDDO
+        CALL MSTIFORTHV(JFT    ,JLT   ,QC  ,QCG  ,QGC    ,
+     .                  QG     ,CC    ,G3  ,G33  ,CG     ) 
       ELSEIF (MTN == 127) THEN     
         DO I=JFT,JLT
           CC(I,1,1) = mat_param%uparam(41)

--- a/engine/source/materials/mat/mat125/sigeps125.F90
+++ b/engine/source/materials/mat/mat125/sigeps125.F90
@@ -601,17 +601,17 @@
               signzx(i) = w13*g13*epszx(i)
               signyz(i) = w23*g23*epsyz(i)
               ! shear treatement
-              if(abs(signxy(i)) >= tau(i) ) then
+              if(abs(signxy(i)) >= tau(i) .and. ems(i) > gamma(i) ) then
                 scale =  (sc(i) - tau(i))/(ems(i)- gamma(i))
                 tauxy = tau(i) + scale*(abs(epsxy(i)) - gamma(i))
                 signxy(i) = sign(tauxy,signxy(i))
               end if
-              if(abs(signzx(i)) >= tau1(i) ) then
+              if(abs(signzx(i)) >= tau1(i) .and. ems13 (i) > gamma1(i) ) then
                 scale =  (sc13(i) - tau1(i))/(ems13 (i)- gamma1(i))
                 tauzx = tau1(i) + scale*(abs(epszx(i)) - gamma1(i))
                 signzx(i) = sign(tauzx,signzx(i))
               end if
-              if(abs(signyz(i)) >= tau2(i) ) then
+              if(abs(signyz(i)) >= tau2(i) .and. ems23(i) > gamma2(i) ) then
                 scale =  (sc23(i)- tau2(i))/(ems23(i) - gamma2(i))
                 tauyz = tau2(i) + scale*(abs(epsyz(i)) - gamma2(i))
                 signyz(i) = sign(tauyz,signyz(i))

--- a/engine/source/materials/mat/mat125/sigeps125c.F90
+++ b/engine/source/materials/mat/mat125/sigeps125c.F90
@@ -549,7 +549,7 @@
               end if
               g12d = w12*g12
               signxy(i) = g12d*epsxy(i)
-              if(abs(signxy(i)) >= tau(i) .and. abs(signxy(i)) <  sc(i)) then
+              if(abs(signxy(i)) >= tau(i) .and. abs(signxy(i)) <  sc(i) .and. ems(i) > gamma(i)) then
                 scale =  (sc(i) - tau(i))/(ems(i) - gamma(i))
                 tauxy = tau(i) + scale*(abs(epsxy(i)) - gamma(i))
                 signxy(i) = sign(tauxy,signxy(i))

--- a/starter/source/materials/mat/mat125/hm_read_mat125.F90
+++ b/starter/source/materials/mat/mat125/hm_read_mat125.F90
@@ -213,6 +213,7 @@
 
           if(nu31 == zero) nu31 = nu21
           if(nu32 == zero) nu32 = nu21
+          if(fs /= -1) fs = -1  ! only this formulation implemented
 ! ----------------------------------------------------------------------------------------------------------------------
           !     check and default values
           !-----------------------------
@@ -290,7 +291,7 @@
           !     filling buffer tables
           !--------------------------
           ! number of material parameters
-          matparam%nuparam = 80
+          matparam%nuparam = 86
           allocate (matparam%uparam(matparam%nuparam))
           matparam%uparam(1:matparam%nuparam) = zero 
           ! number of functions
@@ -424,6 +425,7 @@
           if(ems <= gamma) ems = two*gamma
           if(ems13 <= gamma2) ems13 = two*gamma2
           if(ems23 <= gamma3) ems23 = two*gamma3
+          !
           if(sc == zero ) sc = ep10
           if(sc13 == zero) sc13 = ep10
           if(sc23 == zero) sc23 = ep10
@@ -528,6 +530,13 @@
           matparam%uparam(78)  = nu21
           matparam%uparam(79)  = nu31
           matparam%uparam(80)  = nu32
+          ! 3D Orthotropic for Isolid=24
+          matparam%uparam(81)  = d11
+          matparam%uparam(82)  = d22
+          matparam%uparam(83)  = d33
+          matparam%uparam(84)  = d12
+          matparam%uparam(85)  = d13
+          matparam%uparam(86)  = d23
           ! function ids
           ifunc(1)  = ifem11t
           ifunc(2)  = ifxt


### PR DESCRIPTION
…gidity for hourglasse for Isolid=24

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

For the D2R conversion of Mat58, for now we consider only Fs=-1 formulation and this could leads to NaN issue.
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

The problem is fixed by ignoring this option. 
I add also the update of orthotropic rigidity for computing the hourglass forces for Isolid=24
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
