### PR TITLE
openreader : debug pb include transform

### DIFF
--- a/hm_cfg_files/config/CFG/Keyword971/INCLUDE/include_transform.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971/INCLUDE/include_transform.cfg
@@ -39,7 +39,7 @@ ATTRIBUTES(COMMON)
     INCOUT1     =  VALUE(INT, "Offset to function ID, table ID, and curve ID");
 
     //Card 4
-    TRANID = VALUE(STRING, "");
+    TRANID      =  VALUE(POSITION, "");
     
     fullfilepath   = VALUE(STRING, "Full File Path");
 

--- a/reader/source/cfgkernel/sdi/sdiModelViewPOLSDyna.h
+++ b/reader/source/cfgkernel/sdi/sdiModelViewPOLSDyna.h
@@ -1,0 +1,173 @@
+/*Copyright>    OpenRadioss
+//Copyright>    Copyright (C) 1986-2025 Altair Engineering Inc.
+//Copyright>
+//Copyright>    This program is free software: you can redistribute it and/or modify
+//Copyright>    it under the terms of the GNU Affero General Public License as published by
+//Copyright>    the Free Software Foundation, either version 3 of the License, or
+//Copyright>    (at your option) any later version.
+//Copyright>
+//Copyright>    This program is distributed in the hope that it will be useful,
+//Copyright>    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//Copyright>    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//Copyright>    GNU Affero General Public License for more details.
+//Copyright>
+//Copyright>    You should have received a copy of the GNU Affero General Public License
+//Copyright>    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//Copyright>
+//Copyright>
+//Copyright>    Commercial Alternative: Altair Radioss Software
+//Copyright>
+//Copyright>    As an alternative to this open-source version, Altair also offers Altair Radioss
+//Copyright>    software under a commercial license.  Contact Altair to discuss further if the
+//Copyright>    commercial version may interest you: https://www.altair.com/radioss/.*/
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////////
+
+#if !defined(SDIMODELVIEWPOLSDYNA__INCLUDED_)
+#define SDIMODELVIEWPOLSDYNA__INCLUDED_
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <set>
+
+#include <HCDI/hcdi_utils.h>
+#include <HCDI/hcdi_mv_descriptor.h>
+#include <HCDI/hcdi_multicfgkernelmgr.h>
+
+#include <sdiCFGTypeMapper.h>
+#include <sdiModelViewPO.h>
+
+namespace sdi
+{
+
+// forward declaration
+class SDIModelViewPOLSDyna;
+
+class SDISelectionDataPOLSDynaInclude: public SDISelectionDataPO<SPECIALIZATION_TYPE_GENERAL>
+{
+public:
+    SDISelectionDataPOLSDynaInclude(const sdiString& keyword,
+                                    const SDIModelViewPrivate* pModelView,
+                                    std::vector<IMECPreObject *> *pre_obj_lst,
+                                    const Filter* pFilter):
+        SDISelectionDataPO<SPECIALIZATION_TYPE_GENERAL>(
+            keyword, pModelView, pre_obj_lst, pFilter, false, 1)
+    {}
+
+    //! Advances to next entity, returning false if no such selectable entity
+    virtual bool Next()
+    {
+        // the preobject following the one of a *INCLUDE_TRANSFORM is an internal one
+        // and has to be skipped, so we call an additional Next() of the parent class
+        if(p_index != UINT_MAX && // not first call
+           p_pCurrentEntityData->GetKeyword() == "*INCLUDE_TRANSFORM")
+        {
+            SDISelectionDataPO<SPECIALIZATION_TYPE_GENERAL>::Next();
+        }
+
+        // now the "regular" call of Next() of the parent class
+        return SDISelectionDataPO<SPECIALIZATION_TYPE_GENERAL>::Next();
+    }
+
+    //! Count of number of possible entities accessible by selection data.
+    virtual unsigned int Count() const
+    {
+        return SDISelectionData::Count(); // default implementation, which uses Next()
+    }
+};
+
+class SDIModelViewPOLSDyna: public ModelViewPO
+{
+public:
+    SDIModelViewPOLSDyna(std::vector<IMECPreObject*> *preobjects) :
+        ModelViewPO(SDICFGTypeMapper(), preobjects, HCDI_OBJ_TYPE_HC_MAX,
+                    nullptr, {"*DEFINE_CURVE"})
+    {
+    }
+
+    virtual ~SDIModelViewPOLSDyna()
+    {
+    }
+
+    virtual SDISelectionData* CreateSelectionData(const sdiString& keyword,
+                                                  const Filter*   pselectionFilter = nullptr) const
+    {
+        EntityType type = GetEntityType(keyword);
+        unsigned int CFGType = GetCFGType(type);
+        if(HCDI_OBJ_TYPE_INCLUDEFILES == CFGType)
+        {
+            return new SDISelectionDataPOLSDynaInclude(
+                keyword, this, &(p_preobjects[CFGType]), pselectionFilter);
+        }
+        else
+        {
+            return ModelViewPO::CreateSelectionData(keyword, pselectionFilter);
+        }
+    }
+
+    virtual bool P_FindById(const unsigned int id, EntityType type, HandleRead& handle) const
+    {
+        if(myTypeInclude == type || HCDI_OBJ_TYPE_INCLUDEFILES == type)
+        {
+            if(p_preobjects[HCDI_OBJ_TYPE_INCLUDEFILES].size() > id)
+            {
+                handle.SetPointer(p_preobjects[HCDI_OBJ_TYPE_INCLUDEFILES][id]);
+                if(id > 1 &&
+                   p_preobjects[HCDI_OBJ_TYPE_INCLUDEFILES][id-1] != nullptr &&
+                   strcmp(p_preobjects[HCDI_OBJ_TYPE_INCLUDEFILES][id-1]->GetInputFullType(),
+                          "*INCLUDE_TRANSFORM") == 0)
+                {   // the preobject following the one of a *INCLUDE_TRANSFORM is an internal one,
+                    // so in this case we need the preceding one
+                    handle.SetPointer(p_preobjects[HCDI_OBJ_TYPE_INCLUDEFILES][id-1]);
+                }
+                return true;
+            }
+            else return false;
+        }
+        else
+        {
+            return ModelViewPO::P_FindById(id, type, handle);
+        }
+    }
+
+    virtual unsigned int P_GetId(const HandleRead& handle) const
+    {
+        EntityType type = handle.GetType();
+        if(myTypeInclude == type || HCDI_OBJ_TYPE_INCLUDEFILES == type)
+        {
+            auto it = std::find(p_preobjects[HCDI_OBJ_TYPE_INCLUDEFILES].begin(),
+                                p_preobjects[HCDI_OBJ_TYPE_INCLUDEFILES].end(),
+                                handle.GetPointer());
+            if(it != p_preobjects[HCDI_OBJ_TYPE_INCLUDEFILES].end())
+            {
+                unsigned int id = (unsigned int) (it - p_preobjects[HCDI_OBJ_TYPE_INCLUDEFILES].begin());
+                if(id > 0 &&
+                   id < p_preobjects[HCDI_OBJ_TYPE_INCLUDEFILES].size() - 1 &&
+                   p_preobjects[HCDI_OBJ_TYPE_INCLUDEFILES][id] != nullptr &&
+                   strcmp(p_preobjects[HCDI_OBJ_TYPE_INCLUDEFILES][id]->GetInputFullType(),
+                          "*INCLUDE_TRANSFORM") == 0)
+                {   // preobjects of *INCLUDE_TRANSFORM are followed by an internal one, which is
+                    // the owner of contained entities, so we need the "id" of that one
+                    return id + 1;
+                }
+                return id;
+            }
+            return 0;
+        }
+        else
+        {
+            return ModelViewPO::P_GetId(handle);
+        }
+    }
+};
+
+
+} // namespace sdi
+
+
+#endif // SDIMODELVIEWPOLSDYNA__INCLUDED_

--- a/reader/source/io/model_readers/ls-dyna/keyword/dynamain.cxx
+++ b/reader/source/io/model_readers/ls-dyna/keyword/dynamain.cxx
@@ -42,6 +42,7 @@ void DynakeyMessages::ShowMessage(const sdiMessageHandler::Level &level, int cod
  
 #include <sdiCFGTypeMapper.h> 
 #include <sdiModelViewPO.h>
+#include <sdiModelViewPOLSDyna.h>
 
 static std::vector<IMECPreObject *> pre_obj_lst[HCDI_OBJ_TYPE_HC_MAX];
 
@@ -78,12 +79,7 @@ sdi::ModelViewEdit* DynakeyReadModel(const char *filename)
     ModelFactoryReaderPOExprTk* model = new ModelFactoryReaderPOExprTk();
     CommonDataReaderCFG reader(model,"", str_version, "", true);
     reader.ReadModel(filename, pre_obj_lst);
-    const CFGKernel* cfgkernel = MultiCFGKernelMgr::getInstance().GetCurrentCFGKernel();
-    sdi::ModelViewPO* pModelViewSDI =  new sdi::ModelViewPO(
-        //sdi::SDICFGTypeMapper(cfgkernel, "*"),
-        sdi::SDICFGTypeMapper(),
-        pre_obj_lst, HCDI_OBJ_TYPE_HC_MAX, cfgkernel,
-        {"*DEFINE_CURVE"});
+    sdi::ModelViewPO* pModelViewSDI = new sdi::SDIModelViewPOLSDyna(pre_obj_lst);
     pModelViewSDI->ApplyIdOffsets("INCLUDE_TRANSFORM");
 
     return pModelViewSDI;


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to how preobject handling and entity data are managed in the configuration kernel, with a focus on better compatibility, code modularization, and more robust handling of nodes and elements. The most significant changes include refactoring object value setting logic, enhancing backward compatibility, and optimizing node management in preobjects.

**Refactoring and Modularization:**

* Extracted and refactored logic for setting single object values to a dedicated method `SetSingleObjectValueToPreObject`, making it virtual for easier extension and overriding in derived classes. This improves code maintainability and allows for special-case handling. [[1]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL3865-R3887) [[2]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL2198-R2228) [[3]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fR4127-R4167)

**Backward Compatibility and Robustness:**

* Improved backward compatibility for HM loads by explicitly handling the legacy `"displayname"` attribute when the standard name is empty, both in entity data and model view classes. [[1]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL222-R222) [[2]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL2014-R2029)

**Node and Element Handling Improvements:**

* Enhanced logic for node preobject management by tracking both `p_currentIncludeId` and `p_previousIncludeId`, ensuring correct association and avoiding duplication. Also, changed node addition logic to always use the last node preobject for updates. [[1]](diffhunk://#diff-1c2495a909f9fff4df90db999e114c392137bc7224c41e59fbedd00f744d08dfR298) [[2]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL1556-R1571) [[3]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fR1585-R1586) [[4]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL1586-R1605)
* Improved handling of elements without owners by adding a fallback for "collector" objects and clarifying the code path for ownerless elements.
* Added comments and minor optimizations for handling node arrays, with notes for future speed-ups and early termination in loops. [[1]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL493-L498) [[2]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL526-L532)

**Miscellaneous Improvements:**

* Updated attribute definition in `include_transform.cfg` to use `POSITION` type for `TRANID`, aligning with expected data types.
* Minor cleanups, comment updates, and type clarifications throughout the codebase to improve readability and maintainability. [[1]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL376-R387) [[2]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL967-R980) [[3]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL1342) [[4]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL1510-R1522) [[5]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL2363-R2388) [[6]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL2390) [[7]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL2917) [[8]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL3791) [[9]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL3825-R3847) [[10]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL1641)
