### PR TITLE
openreader: compilation issue with gcc13

### DIFF
--- a/reader/source/cfgkernel/UTILS/file_utils.cpp
+++ b/reader/source/cfgkernel/UTILS/file_utils.cpp
@@ -30,6 +30,7 @@
 #endif
 #include <sys/types.h>  // For stat().
 #include <sys/stat.h>   // For stat().
+#include <array> 
 
 #ifdef WIN32
 #include <direct.h>

--- a/reader/source/dyna2rad/dyna2rad/_private/convertsets.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/convertsets.cxx
@@ -25,6 +25,7 @@
 #include <dyna2rad/convertsets.h>
 #include <dyna2rad/dyna2rad.h>
 #include <dyna2rad/sdiUtils.h>
+#include <cstdint>
 
 using namespace std;
 using namespace sdi;


### PR DESCRIPTION
This pull request makes minor improvements to the codebase by adding necessary standard library includes to two source files. These changes help ensure proper type usage and compatibility.

Dependency and compatibility improvements:

* Added the `<array>` header to `file_utils.cpp` to support usage of the `std::array` container.
* Added the `<cstdint>` header to `convertsets.cxx` to provide fixed-width integer types.