### PR TITLE
EOS, default untialization of eos_param_ real data

### DIFF
--- a/common_source/modules/mat_elem/eos_param_mod.F90
+++ b/common_source/modules/mat_elem/eos_param_mod.F90
@@ -98,12 +98,12 @@
         integer :: ntable                        !< number of local function tables
         integer :: isfluid                       !< indicated if EoS is designed for fluid
         integer :: eostype                       !< eos model type
-        real(kind=WP) :: cv                      !< specific heat capacity (constant volume)
-        real(kind=WP) :: cp                      !< specific heat capacity (constant pressure)
-        real(kind=WP) :: psh                     !< pressure shift
-        real(kind=WP) :: e0                      !< initial internal energy
-        real(kind=WP) :: p0                      !< initial pressure
-        real(kind=WP) :: pmin                    !< minimum pressure
+        real(kind=WP) :: cv    = HUGE(1.0)        !< specific heat capacity (constant volume)
+        real(kind=WP) :: cp    = HUGE(1.0)        !< specific heat capacity (constant pressure)
+        real(kind=WP) :: psh   = HUGE(1.0)        !< pressure shift
+        real(kind=WP) :: e0    = HUGE(1.0)        !< initial internal energy
+        real(kind=WP) :: p0    = HUGE(1.0)        !< initial pressure
+        real(kind=WP) :: pmin  = HUGE(1.0)        !< minimum pressure
 
         real(kind=WP)  ,dimension(:) ,allocatable :: uparam  !< real value eos parameter table
         integer        ,dimension(:) ,allocatable :: iparam  !< int  value eos parameter table


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
Valgrind detected the use of uninitialized variables during the writing of *rst files.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
This pull request updates the default initialization of several real-valued parameters in the `eos_param_mod` module to ensure they are set to a large, invalid value unless explicitly assigned. This helps prevent bugs caused by uninitialized variables.

Initialization improvements:

* Set default values of `cv`, `cp`, `psh`, `e0`, `p0`, and `pmin` to `HUGE(1.0)` to catch uninitialized usage in the `eos_param_mod` module (`common_source/modules/mat_elem/eos_param_mod.F90`).

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
