### PR TITLE
LAW78 IFUNC(1) was used without being initialized

### DIFF
--- a/engine/source/materials/mat_share/mulawc.F90
+++ b/engine/source/materials/mat_share/mulawc.F90
@@ -639,6 +639,7 @@
             &            igtyp == 51 .or. igtyp == 52) then
               if (ilaw == 58 .or. ilaw == 158 .or. ilaw == 88) nfunc = ipm(10,imat)+ipm(6,imat)
             endif
+            ifunc(1) = 0 ! ifunc(1) may be used even when nfunc=0 (see sigeps78c)
             do i=1,nfunc
               ifunc(i)=ipm(10+i,imat)
             enddo


### PR DESCRIPTION


#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
This pull request makes a small but important change to the `mulawc.F90` file to improve code safety and prevent potential issues with uninitialized variables.

* Code safety improvement:
  * In the `mulawc` subroutine, explicitly initializes `ifunc(1)` to 0 to ensure it has a defined value, even when `nfunc=0`, addressing potential usage in `sigeps78c`.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
