### PR TITLE
openreader : CNODE reading Submodel management

### DIFF
--- a/reader/source/solver_interface/source/submodels/cpp_nodes_subtag.cpp
+++ b/reader/source/solver_interface/source/submodels/cpp_nodes_subtag.cpp
@@ -40,7 +40,7 @@ CDECL void cpp_node_sub_tag_(int *TAGNODSUB)
     SelectionRead nodes(g_pModelViewSDI,"/NODE");
     unsigned int submodelId=0;
     unsigned int includeId=0;
-    int i=0;
+    int cptNode=0;
 //
 // Nodes loop
 //
@@ -61,8 +61,33 @@ CDECL void cpp_node_sub_tag_(int *TAGNODSUB)
             hInclude.GetValue(g_pModelViewSDI, sdiIdentifier("shadow_submodelid"), value);
             value.GetValue(submodelId);
         }
-        TAGNODSUB[i] = includeId;
-        i++;
+        TAGNODSUB[cptNode] = includeId;
+        cptNode++;
+    }
+
+    SelectionRead cnodes(g_pModelViewSDI,"/CNODE");
+//
+// Nodes loop
+//
+    while(cnodes.Next())
+    {
+// Get Submodel Id
+        sdiValue value;
+        HandleRead hInclude(cnodes->GetInclude());
+        unsigned int submodelId = 0;
+        includeId = hInclude.GetId(g_pModelViewSDI);
+        hInclude.GetValue(g_pModelViewSDI, sdiIdentifier("shadow_submodelid"), value);
+        value.GetValue(submodelId);
+        while(0 == submodelId && hInclude.IsValid())
+        {
+            EntityRead include(g_pModelViewSDI, hInclude);
+            hInclude = include.GetInclude();
+            includeId = hInclude.GetId(g_pModelViewSDI);
+            hInclude.GetValue(g_pModelViewSDI, sdiIdentifier("shadow_submodelid"), value);
+            value.GetValue(submodelId);
+        }
+        TAGNODSUB[cptNode] = includeId;
+        cptNode++;
     }
 }
 


### PR DESCRIPTION
This pull request updates the logic in the `cpp_node_sub_tag_` function within `cpp_nodes_subtag.cpp` to extend support from just `/NODE` entries to also include `/CNODE` entries. The indexing variable was renamed for clarity, and a new loop was added to process the additional node type.

**Enhancements to node submodel tagging:**

* Renamed the node counter variable from `i` to `cptNode` for improved clarity and consistency throughout the function.
* Added a new loop to process `/CNODE` entries, mirroring the logic used for `/NODE` entries, so that both node types are now handled and their include IDs are stored in the `TAGNODSUB` array.