### PR TITLE
Iremgap is set to 2 by default with Igap=5 

### DIFF
--- a/starter/source/interfaces/int25/hm_read_inter_type25.F
+++ b/starter/source/interfaces/int25/hm_read_inter_type25.F
@@ -371,6 +371,9 @@ C
         IF(IGAP==2) THEN
            FLAGREMNOD = 2
         ENDIF
+        IF(IGAP==5) THEN
+           FLAGREMNOD = 2
+        ENDIF
         IF (FLAGREMNOD == 0) FLAGREMNOD = 1
 
 C.....* Storage IPARI FRIGAP *........


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
Iremgap is set to 2 by default with Igap=5 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
Iremgap is set to 2 by default with Igap=5 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
