### PR TITLE
Python calls in build procedure : force python3 usage on Linux 

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -9,6 +9,9 @@ project (Radioss_Engine)
 # --------------------------
 if (arch STREQUAL "win64")
    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+   set(PYTHON_EXEC "python")
+else()
+   set(PYTHON_EXEC "python3")
 endif()
 
 
@@ -256,7 +259,7 @@ message (" dir : ${Build_includes_directory} added")
 # Load external libraries
 add_custom_target(
     extlib ALL
-    COMMAND python ${source_directory}/../Compiling_tools/script/load_extlib.py
+    COMMAND ${PYTHON_EXEC} ${source_directory}/../Compiling_tools/script/load_extlib.py
     COMMENT "Loading extlib libraries"
 )
 
@@ -266,7 +269,7 @@ add_custom_command(
          OUTPUT 
             ${Build_includes_directory}/engine_message_description.inc
          COMMAND 
-         python ${source_directory}/../Compiling_tools/script/build_message.py -inputfile=${source_directory}/source/output/message/engine_message_description.txt -outfile=${Build_includes_directory}/engine_message_description.inc
+         ${PYTHON_EXEC} ${source_directory}/../Compiling_tools/script/build_message.py -inputfile=${source_directory}/source/output/message/engine_message_description.txt -outfile=${Build_includes_directory}/engine_message_description.inc
          DEPENDS 
               ${source_directory}/source/output/message/engine_message_description.txt
          )
@@ -277,7 +280,7 @@ add_custom_command(
             ${Build_includes_directory}/__foo.inc 
             ${Build_includes_directory}/build_info.inc
          COMMAND 
-            python ${source_directory}/../Compiling_tools/script/or_build_info.py -arch=${arch} -outfile=${Build_includes_directory}/build_info.inc
+            ${PYTHON_EXEC} ${source_directory}/../Compiling_tools/script/or_build_info.py -arch=${arch} -outfile=${Build_includes_directory}/build_info.inc
          )
 else()
 #include generated with a text files
@@ -285,7 +288,7 @@ add_custom_command(
          OUTPUT 
             ${Build_includes_directory}/engine_message_description.inc
          COMMAND 
-            python ${source_directory}/../Compiling_tools/script/build_message.py -inputfile=${source_directory}/source/output/message/engine_message_description.txt -outfile=${Build_includes_directory}/engine_message_description.inc
+            ${PYTHON_EXEC} ${source_directory}/../Compiling_tools/script/build_message.py -inputfile=${source_directory}/source/output/message/engine_message_description.txt -outfile=${Build_includes_directory}/engine_message_description.inc
          DEPENDS 
               ${source_directory}/source/output/message/engine_message_description.txt
          )
@@ -296,7 +299,7 @@ add_custom_command(
             ${Build_includes_directory}/__foo.inc 
             ${Build_includes_directory}/build_info.inc
          COMMAND 
-            python ${source_directory}/../Compiling_tools/script/build_info.py -version=${version} -titlevers=${titlevers} -arch=${arch} -solver=E -outfile=${Build_includes_directory}/build_info.inc
+            ${PYTHON_EXEC} ${source_directory}/../Compiling_tools/script/build_info.py -version=${version} -titlevers=${titlevers} -arch=${arch} -solver=E -outfile=${Build_includes_directory}/build_info.inc
          )
 endif()
 

--- a/reader/source/solver_interface/CMakeLists.txt
+++ b/reader/source/solver_interface/CMakeLists.txt
@@ -4,6 +4,12 @@ cmake_minimum_required (VERSION 3.15)
 project (solver_interface)
 enable_language (CXX)
 
+if (arch STREQUAL "win64")
+   set(PYTHON_EXEC "python")
+else()
+   set(PYTHON_EXEC "python3")
+endif()
+
 set (library_name "solver_interface_${arch}" )
 
 #set source directory
@@ -39,7 +45,7 @@ list (APPEND include_dir_list ${Build_includes_directory} )
 
 add_custom_target(    
             chglt_id ALL
-            COMMAND python ${open_reader_root_dir}/../Compiling_tools/script/reader_info.py -outfile=${Build_includes_directory}/chglt_id.h
+            COMMAND ${PYTHON_EXEC} ${open_reader_root_dir}/../Compiling_tools/script/reader_info.py -outfile=${Build_includes_directory}/chglt_id.h
 )
 
 
@@ -75,7 +81,7 @@ add_dependencies(${library_name}  chglt_id)
 
 add_custom_command(TARGET ${library_name}
                    PRE_BUILD
-                   COMMAND python ${open_reader_root_dir}/../Compiling_tools/script/reader_info.py -outfile=${Build_includes_directory}/chglt_id.h
+                   COMMAND ${PYTHON_EXEC} ${open_reader_root_dir}/../Compiling_tools/script/reader_info.py -outfile=${Build_includes_directory}/chglt_id.h
                    )
 
 

--- a/starter/CMakeLists.txt
+++ b/starter/CMakeLists.txt
@@ -13,6 +13,9 @@ project (Radioss_Starter)
 # --------------------------
 if (arch STREQUAL "win64")
    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+   set(PYTHON_EXEC "python")
+else()
+   set(PYTHON_EXEC "python3")
 endif()
 
 # Language settings & Compiler Settings
@@ -185,7 +188,7 @@ message (" dir : ${Build_includes_directory} added")
 # Load external libraries
 add_custom_target(
     extlib ALL
-    COMMAND python ${source_directory}/../Compiling_tools/script/load_extlib.py
+    COMMAND ${PYTHON_EXEC} ${source_directory}/../Compiling_tools/script/load_extlib.py
     COMMENT "Loading extlib libraries"
 )
 
@@ -194,9 +197,9 @@ add_custom_command(
          OUTPUT 
             ${Build_includes_directory}/starter_message_description.inc
          COMMAND 
-            python ${source_directory}/../Compiling_tools/script/merge_files.py -file1=${source_directory}/source/output/message/starter_message_description.txt -file2=${source_directory}/../hm_cfg_files/messages/CONFIG/msg_hw_radioss_reader.txt -outfile=${Build_includes_directory}/fullstarter_message_description.txt
+            ${PYTHON_EXEC} ${source_directory}/../Compiling_tools/script/merge_files.py -file1=${source_directory}/source/output/message/starter_message_description.txt -file2=${source_directory}/../hm_cfg_files/messages/CONFIG/msg_hw_radioss_reader.txt -outfile=${Build_includes_directory}/fullstarter_message_description.txt
          COMMAND
-            python ${source_directory}/../Compiling_tools/script/build_message.py -inputfile=${Build_includes_directory}/fullstarter_message_description.txt -outfile=${Build_includes_directory}/starter_message_description.inc
+            ${PYTHON_EXEC} ${source_directory}/../Compiling_tools/script/build_message.py -inputfile=${Build_includes_directory}/fullstarter_message_description.txt -outfile=${Build_includes_directory}/starter_message_description.inc
          DEPENDS 
               ${source_directory}/source/output/message/starter_message_description.txt ${source_directory}/../hm_cfg_files/messages/CONFIG/msg_hw_radioss_reader.txt
          )
@@ -209,7 +212,7 @@ add_custom_command(
          ${Build_includes_directory}/__foo.inc
          ${Build_includes_directory}/build_info.inc
          COMMAND
-            python ${source_directory}/../Compiling_tools/script/or_build_info.py -arch=${arch} -outfile=${Build_includes_directory}/build_info.inc
+            ${PYTHON_EXEC} ${source_directory}/../Compiling_tools/script/or_build_info.py -arch=${arch} -outfile=${Build_includes_directory}/build_info.inc
          DEPENDS 
          )
 else()
@@ -219,7 +222,7 @@ add_custom_command(
             ${Build_includes_directory}/__foo.inc 
             ${Build_includes_directory}/build_info.inc
          COMMAND 
-            python ${source_directory}/../Compiling_tools/script/build_info.py -version=${version} -titlevers=${titlevers} -arch=${arch} -solver=S -outfile=${Build_includes_directory}/build_info.inc
+            ${PYTHON_EXEC} ${source_directory}/../Compiling_tools/script/build_info.py -version=${version} -titlevers=${titlevers} -arch=${arch} -solver=S -outfile=${Build_includes_directory}/build_info.inc
          DEPENDS 
          )
 endif()


### PR DESCRIPTION
 Python calls in build procedure : force python3 usage on Linux but keep python on Windows.

On Linux python can still be python2

Linux: call python3
Windows: call python

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
