### PR TITLE
open_reader : update 10022026

### DIFF
--- a/reader/source/dyna2rad/dyna2rad/_private/convertcards.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/convertcards.cxx
@@ -242,7 +242,6 @@ void sdiD2R::ConvertCard::p_ConvertCtrlTimeStep()
             lsdDTMIN = GetValue<double>(*selectCtrlTerm, "DTMIN");
             break;
         }
-        if (lsdDTMIN == 0.0) lsdDTMIN = 1.0; // by default
 
         lsdTSMIN =abs(lsdDT2MS)*lsdDTMIN;
         if (lsdTSMIN > 0.0)

--- a/reader/source/dyna2rad/dyna2rad/_private/convertmats.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/convertmats.cxx
@@ -90,6 +90,7 @@ void ConvertMat::ConvertMaterials()
 
 void ConvertMat::ConvertEntities()
 {
+    m_maxFailId = 1;
     p_ConvertAllMatsAssociatedWithParts();
     p_ConvertMatAddErosion();
     p_ConvertMatAddDamageDiem();
@@ -1036,6 +1037,7 @@ void ConvertMat::p_ConvertMatL15(const EntityRead& dynaMat, sdiString& destCard,
         {
             p_radiossModel->CreateEntity(failGene1HEdit, "/FAIL/GENE1", dynaMatName);
             failGene1HEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+            failGene1HEdit.SetId(p_radiossModel, m_maxFailId++);
             if (failGene1HEdit.IsValid())
             {
                 failGene1HEdit.SetEntityHandle(p_radiossModel, sdiIdentifier("mat_id"), radMat);
@@ -1054,6 +1056,7 @@ void ConvertMat::p_ConvertMatL15(const EntityRead& dynaMat, sdiString& destCard,
         HandleEdit failEdit;
         p_radiossModel->CreateEntity(failEdit, "/FAIL/JOHNSON", dynaMatName);
         failEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+        failEdit.SetId(p_radiossModel, m_maxFailId++);
         if (failEdit.IsValid())
         {
             failEdit.SetEntityHandle(p_radiossModel, sdiIdentifier("mat_id"), radMat);
@@ -1128,6 +1131,7 @@ void ConvertMat::p_ConvertMatL15EOS(const EntityRead& dynaMat, sdiString& destCa
         HandleEdit failEdit;
         p_radiossModel->CreateEntity(failEdit, "/FAIL/JOHNSON", dynaMatName);
         failEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+        failEdit.SetId(p_radiossModel, m_maxFailId++);
         if (failEdit.IsValid())
         {
             failEdit.SetEntityHandle(p_radiossModel, sdiIdentifier("mat_id"), radMat);
@@ -1187,6 +1191,7 @@ void ConvertMat::p_ConvertMatL18(const sdi::EntityRead& dynaMat, sdiString& dest
     {
         p_radiossModel->CreateEntity(failJohnsonEdit, "/FAIL/JOHNSON", dynaMatName);
         failJohnsonEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+        failJohnsonEdit.SetId(p_radiossModel, m_maxFailId++);
 
         failJohnsonEdit.SetEntityHandle(p_radiossModel, sdiIdentifier("mat_id"), radMat);
         failJohnsonEdit.SetValue(p_radiossModel, sdiIdentifier("D1"), sdiValue(lsdEPSF));
@@ -1479,7 +1484,8 @@ void ConvertMat::p_ConvertMatL24(const EntityRead& dynaMat,sdiString& destCard, 
             if (lsdFAIL > 0.0 && matLawNum == 24)
             {
                 p_radiossModel->CreateEntity(failJohnsonHEdit, "/FAIL/JOHNSON", dynaMatName);
-                //failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                failJohnsonHEdit.SetId(p_radiossModel, m_maxFailId++);
                 EntityEdit failJohnsonEntEdit(p_radiossModel, failJohnsonHEdit);
                 failJohnsonEntEdit.SetEntityHandle(sdiIdentifier("mat_id"), radMat);
                 p_ConvertUtils.CopyValue(dynaMat, failJohnsonEntEdit, "FAIL", "D1");
@@ -1523,7 +1529,8 @@ void ConvertMat::p_ConvertMatL24(const EntityRead& dynaMat,sdiString& destCard, 
         if (lsdFAIL > 0.0 && matLawNum == 24)
         {
             p_radiossModel->CreateEntity(failJohnsonHEdit, "/FAIL/JOHNSON", dynaMatName);
-            //failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+            failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+            failJohnsonHEdit.SetId(p_radiossModel, m_maxFailId++);
             EntityEdit failJohnsonEntEdit(p_radiossModel, failJohnsonHEdit);
             failJohnsonEntEdit.SetEntityHandle(sdiIdentifier("mat_id"), radMat);
             p_ConvertUtils.CopyValue(dynaMat, failJohnsonEntEdit, "FAIL", "D1");
@@ -1602,7 +1609,8 @@ void ConvertMat::p_ConvertMatL24(const EntityRead& dynaMat,sdiString& destCard, 
                     if (lsdFAIL > 0.0 && matLawNum == 24)
                     {
                          p_radiossModel->CreateEntity(failJohnsonHEdit, "/FAIL/JOHNSON", dynaMatName);
-                         //failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                         failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                         failJohnsonHEdit.SetId(p_radiossModel, m_maxFailId++);
                          EntityEdit failJohnsonEntEdit(p_radiossModel, failJohnsonHEdit);
                          failJohnsonEntEdit.SetEntityHandle(sdiIdentifier("mat_id"), radMat);
                          p_ConvertUtils.CopyValue(dynaMat, failJohnsonEntEdit, "FAIL", "D1");
@@ -1672,7 +1680,8 @@ void ConvertMat::p_ConvertMatL24(const EntityRead& dynaMat,sdiString& destCard, 
             if (lsdFAIL > 0.0 && matLawNum == 24)
             {
                 p_radiossModel->CreateEntity(failJohnsonHEdit, "/FAIL/JOHNSON", dynaMatName);
-                //failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                failJohnsonHEdit.SetId(p_radiossModel, m_maxFailId++);
                 EntityEdit failJohnsonEntEdit(p_radiossModel, failJohnsonHEdit);
                 failJohnsonEntEdit.SetEntityHandle(sdiIdentifier("mat_id"), radMat);
                 p_ConvertUtils.CopyValue(dynaMat, failJohnsonEntEdit, "FAIL", "D1");
@@ -1705,7 +1714,8 @@ void ConvertMat::p_ConvertMatL24(const EntityRead& dynaMat,sdiString& destCard, 
             if (lsdFAIL > 0.0 && matLawNum == 24)
             {
                 p_radiossModel->CreateEntity(failJohnsonHEdit, "/FAIL/JOHNSON", dynaMatName);
-                //failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                failJohnsonHEdit.SetId(p_radiossModel, m_maxFailId++);
                 EntityEdit failJohnsonEntEdit(p_radiossModel, failJohnsonHEdit);
                 failJohnsonEntEdit.SetEntityHandle(sdiIdentifier("mat_id"), radMat);
                 p_ConvertUtils.CopyValue(dynaMat, failJohnsonEntEdit, "FAIL", "D1");
@@ -4746,6 +4756,7 @@ void ConvertMat::p_ConvertMatL81(const sdi::EntityRead& dynaMat, sdiString& dest
         {
             p_radiossModel->CreateEntity(failTab1Edit, "/FAIL/TAB1", matName);
             failTab1Edit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+            failTab1Edit.SetId(p_radiossModel, m_maxFailId++);
         }
 
         EntityEdit failTab1EntEdit(p_radiossModel, failTab1Edit);
@@ -4769,6 +4780,7 @@ void ConvertMat::p_ConvertMatL81(const sdi::EntityRead& dynaMat, sdiString& dest
         {
             p_radiossModel->CreateEntity(failTab1Edit, "/FAIL/TAB1", matName);
             failTab1Edit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+            failTab1Edit.SetId(p_radiossModel, m_maxFailId++);
         }
 
         EntityEdit failTab1EntEdit(p_radiossModel, failTab1Edit);
@@ -5482,6 +5494,7 @@ void ConvertMat::p_ConvertMatL99(const EntityRead& dynaMat, sdiString& destCard,
         {
             p_radiossModel->CreateEntity(failFldEdit, "/FAIL/FLD", dynaMatName);
             failFldEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+            failFldEdit.SetId(p_radiossModel, m_maxFailId++);
 
             double ordinateVal = lsdPSFAIL + (lsdA / lsdE);
 
@@ -5613,6 +5626,7 @@ void ConvertMat::p_ConvertMatL100(const EntityRead& dynaMat,sdiString& destCard,
         HandleEdit failHandlEdit;
         p_radiossModel->CreateEntity(failHandlEdit, "/FAIL/CONNECT", dynaMatName);
         failHandlEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+        failHandlEdit.SetId(p_radiossModel, m_maxFailId++);
         failHandlEdit.SetValue(p_radiossModel, sdiIdentifier("EPSILON_MAXN"), sdiValue(lsdEFAIL));
         failHandlEdit.SetValue(p_radiossModel, sdiIdentifier("EPSILON_MAXT"), sdiValue(lsdEFAIL));
         failHandlEdit.SetValue(p_radiossModel, sdiIdentifier("mat_id"), sdiValue(sdiValueEntity(destEntityType, createdRadiossMatId)));
@@ -6181,6 +6195,7 @@ void ConvertMat::p_ConvertMatL123(const EntityRead& dynaMat, sdiString& destCard
 
         p_radiossModel->CreateEntity(failTab1Edit, "/FAIL/TAB1", matName);
         failTab1Edit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+        failTab1Edit.SetId(p_radiossModel, m_maxFailId++);
         if (failTab1Edit.IsValid())
         {
             EntityEdit failTab1EntEdit(p_radiossModel, failTab1Edit);
@@ -6211,6 +6226,7 @@ void ConvertMat::p_ConvertMatL123(const EntityRead& dynaMat, sdiString& destCard
         lsdEPSMAJ = abs(lsdEPSMAJ);
         p_radiossModel->CreateEntity(failFldEdit, "/FAIL/FLD", matName);
         failFldEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+        failFldEdit.SetId(p_radiossModel, m_maxFailId++);
         if (failFldEdit.IsValid())
         {
             failFldEdit.SetValue(p_radiossModel, sdiIdentifier("IFAIL_SH"), sdiValue(2));
@@ -6879,6 +6895,7 @@ void ConvertMat::p_ConvertMatAddErosion()
                 {
                     p_radiossModel->CreateEntity(failGene1HEdit, "/FAIL/GENE1", matAddErosionName);
                     failGene1HEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                    failGene1HEdit.SetId(p_radiossModel, m_maxFailId++);
 
                     EntityEdit failGene1Edit(p_radiossModel, failGene1HEdit);
                     p_ConvertUtils.CopyValue(*selMatAddErosion, failGene1Edit, "MXPRES", "Pmax");
@@ -7133,8 +7150,9 @@ void ConvertMat::p_ConvertMatAddErosion()
                 if (!faiTab2HEdit.IsValid())
                 {
 //---------------------
-                    p_radiossModel->CreateEntity(faiTab2HEdit, "/FAIL/TAB2", matAddErosionName);
+                    p_radiossModel->CreateEntity(faiTab2HEdit, "/FAIL/TAB2", matAddErosionName,lsdMIDEntity.GetId());
                     faiTab2HEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                    faiTab2HEdit.SetId(p_radiossModel, m_maxFailId++);
 
                     EntityEdit faiTab2Edit(p_radiossModel, faiTab2HEdit);
 
@@ -7343,6 +7361,7 @@ void ConvertMat::p_ConvertMatAddErosion()
 
                     p_radiossModel->CreateEntity(failInievoHEdit, "/FAIL/INIEVO", matAddErosionName,radMatConvertedHandles[i].GetId(p_radiossModel));
                     failInievoHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                    failInievoHEdit.SetId(p_radiossModel, m_maxFailId++);
 
                     EntityEdit failInievoEdit(p_radiossModel, failInievoHEdit);
 
@@ -7734,8 +7753,9 @@ void ConvertMat::p_ConvertMatAddErosion()
                 if (!faiTab2HEdit.IsValid())
                 {
 //---------------------
-                    p_radiossModel->CreateEntity(faiTab2HEdit, "/FAIL/TAB2", matAddErosionName);
+                    p_radiossModel->CreateEntity(faiTab2HEdit, "/FAIL/TAB2", matAddErosionName,lsdMIDEntity.GetId());
                     faiTab2HEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                    faiTab2HEdit.SetId(p_radiossModel, m_maxFailId++);
 
                     EntityEdit faiTab2Edit(p_radiossModel, faiTab2HEdit);
 
@@ -7930,6 +7950,7 @@ void ConvertMat::p_ConvertMatAddErosion()
                 {
                     p_radiossModel->CreateEntity(failGene1HEdit, "/FAIL/GENE1", matAddErosionName);
                     failGene1HEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                    failGene1HEdit.SetId(p_radiossModel, m_maxFailId++);
 
                     EntityEdit failGene1Edit(p_radiossModel, failGene1HEdit);
                     p_ConvertUtils.CopyValue(*selMatAddErosion, failGene1Edit, "MXPRES", "Pmax");
@@ -8199,6 +8220,7 @@ void ConvertMat::p_ConvertMatAddErosion()
 
                     p_radiossModel->CreateEntity(failInievoHEdit, "/FAIL/INIEVO", matAddErosionName,radMatConvertedHandles[i].GetId(p_radiossModel));
                     failInievoHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                    failInievoHEdit.SetId(p_radiossModel, m_maxFailId++);
 
                     EntityEdit failInievoEdit(p_radiossModel, failInievoHEdit);
 
@@ -8585,6 +8607,7 @@ void ConvertMat::p_ConvertMatAddErosion()
                 {
                     p_radiossModel->CreateEntity(failGene1HEdit, "/FAIL/GENE1", matAddErosionName);
                     failGene1HEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                    failGene1HEdit.SetId(p_radiossModel, m_maxFailId++);
 
                     EntityEdit failGene1Edit(p_radiossModel, failGene1HEdit);
                     p_ConvertUtils.CopyValue(*selMatAddErosion, failGene1Edit, "MXPRES", "Pmax");
@@ -10019,6 +10042,7 @@ void ConvertMat::p_ConvertMatL124(const EntityRead& dynaMat, sdiString& destCard
         HandleEdit failJohnsonHEdit;
         p_radiossModel->CreateEntity(failJohnsonHEdit, "/FAIL/JOHNSON", dynaMatName, radMatId);
         failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+        failJohnsonHEdit.SetId(p_radiossModel, m_maxFailId++);
         if (failJohnsonHEdit.IsValid())
         {
 
@@ -10055,6 +10079,7 @@ void ConvertMat::p_ConvertMatL124(const EntityRead& dynaMat, sdiString& destCard
           HandleEdit failTensStrainHEdit;
           p_radiossModel->CreateEntity(failTensStrainHEdit, "/FAIL/TENSSTRAIN", dynaMatName, radMatId);
           failTensStrainHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+          failTensStrainHEdit.SetId(p_radiossModel, m_maxFailId++);
           if (failTensStrainHEdit.IsValid())
           {
               failTensStrainHEdit.SetEntityHandle(p_radiossModel, sdiIdentifier("mat_id"), radMat);
@@ -10103,6 +10128,7 @@ void ConvertMat::p_ConvertMatAddDamageDiem()
         HandleEdit failInievoHEdit; // /FAIL/INIEVO/ //
         p_radiossModel->CreateEntity(failInievoHEdit, "/FAIL/INIEVO", matAddDamageDiemName,lsdMIDEntity.GetId());
         failInievoHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+        failInievoHEdit.SetId(p_radiossModel, m_maxFailId++);
 
         selMatAddDamageDiem->GetEntityHandle(sdiIdentifier("MID"), matHandle);
         sdiConvert::SDIHandlReadList radMatConvertedHandles;
@@ -10673,7 +10699,8 @@ void ConvertMat::p_ConvertMatL105(const EntityRead& dynaMat,sdiString& destCard,
                 if (lsdFAIL > 0.0)
                 {
                     p_radiossModel->CreateEntity(failJohnsonHEdit, "/FAIL/JOHNSON", dynaMatName);
-                    //failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                    failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                    failJohnsonHEdit.SetId(p_radiossModel, m_maxFailId++);
                     EntityEdit failJohnsonEntEdit(p_radiossModel, failJohnsonHEdit);
                     failJohnsonEntEdit.SetEntityHandle(sdiIdentifier("mat_id"), radMat);
                     p_ConvertUtils.CopyValue(dynaMat, failJohnsonEntEdit, "FAIL", "D1");
@@ -10717,7 +10744,8 @@ void ConvertMat::p_ConvertMatL105(const EntityRead& dynaMat,sdiString& destCard,
             if(lsdFAIL > 0.0)
             {
                 p_radiossModel->CreateEntity(failJohnsonHEdit, "/FAIL/JOHNSON", dynaMatName);
-                //failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                failJohnsonHEdit.SetId(p_radiossModel, m_maxFailId++);
                 EntityEdit failJohnsonEntEdit(p_radiossModel, failJohnsonHEdit);
                 failJohnsonEntEdit.SetEntityHandle(sdiIdentifier("mat_id"), radMat);
                 p_ConvertUtils.CopyValue(dynaMat, failJohnsonEntEdit, "FAIL", "D1");
@@ -10795,7 +10823,8 @@ void ConvertMat::p_ConvertMatL105(const EntityRead& dynaMat,sdiString& destCard,
                         if(lsdFAIL > 0.0)
                         {
                             p_radiossModel->CreateEntity(failJohnsonHEdit, "/FAIL/JOHNSON", dynaMatName);
-                            //failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                            failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                            failJohnsonHEdit.SetId(p_radiossModel, m_maxFailId++);
                             EntityEdit failJohnsonEntEdit(p_radiossModel, failJohnsonHEdit);
                             failJohnsonEntEdit.SetEntityHandle(sdiIdentifier("mat_id"), radMat);
                             p_ConvertUtils.CopyValue(dynaMat, failJohnsonEntEdit, "FAIL", "D1");
@@ -10866,7 +10895,8 @@ void ConvertMat::p_ConvertMatL105(const EntityRead& dynaMat,sdiString& destCard,
                 if(lsdFAIL > 0.0)               
                 {
                      p_radiossModel->CreateEntity(failJohnsonHEdit, "/FAIL/JOHNSON", dynaMatName);
-                    //failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                    failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                    failJohnsonHEdit.SetId(p_radiossModel, m_maxFailId++);
                     EntityEdit failJohnsonEntEdit(p_radiossModel, failJohnsonHEdit);
                     failJohnsonEntEdit.SetEntityHandle(sdiIdentifier("mat_id"), radMat);
                     p_ConvertUtils.CopyValue(dynaMat, failJohnsonEntEdit, "FAIL", "D1");
@@ -10898,7 +10928,8 @@ void ConvertMat::p_ConvertMatL105(const EntityRead& dynaMat,sdiString& destCard,
                 if (lsdFAIL > 0.0)
                 {
                     p_radiossModel->CreateEntity(failJohnsonHEdit, "/FAIL/JOHNSON", dynaMatName);
-                    //failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                    failJohnsonHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                    failJohnsonHEdit.SetId(p_radiossModel, m_maxFailId++);
                     EntityEdit failJohnsonEntEdit(p_radiossModel, failJohnsonHEdit);
                     failJohnsonEntEdit.SetEntityHandle(sdiIdentifier("mat_id"), radMat);
                     p_ConvertUtils.CopyValue(dynaMat, failJohnsonEntEdit, "FAIL", "D1");
@@ -11327,8 +11358,9 @@ void ConvertMat::p_ConvertMatL224(const EntityRead& dynaMat, sdiString& destCard
 
     HandleEdit faiTab2HEdit;
 
-    p_radiossModel->CreateEntity(faiTab2HEdit, "/FAIL/TAB2", dynaMatName);
+    p_radiossModel->CreateEntity(faiTab2HEdit, "/FAIL/TAB2", dynaMatName,radmatEntityEdit.GetId());
     faiTab2HEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+    faiTab2HEdit.SetId(p_radiossModel, m_maxFailId++);
 
     EntityEdit faiTab2Edit(p_radiossModel, faiTab2HEdit);
 
@@ -11998,6 +12030,7 @@ void ConvertMat::p_ConvertMatL187(const EntityRead& dynaMat, sdiString& destCard
 
                 p_radiossModel->CreateEntity(faiTab2HEdit, "/FAIL/TAB2", dynaMatName);
                 faiTab2HEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                faiTab2HEdit.SetId(p_radiossModel, m_maxFailId++);
 
                 EntityEdit faiTab2Edit(p_radiossModel, faiTab2HEdit);
 
@@ -12037,6 +12070,7 @@ void ConvertMat::p_ConvertMatL187(const EntityRead& dynaMat, sdiString& destCard
 
                 p_radiossModel->CreateEntity(failtensstrainHEdit, "/FAIL/TENSSTRAIN", dynaMatName);
                 failtensstrainHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+                failtensstrainHEdit.SetId(p_radiossModel, m_maxFailId++);
 
                 EntityEdit failtensstrainEdit(p_radiossModel, failtensstrainHEdit);
 
@@ -12223,7 +12257,7 @@ void ConvertMat::p_ConvertMatAddThermalExpansion()
 
                     EntityEdit thermStressEdit(p_radiossModel, thermStressHEdit);
                     thermStressHEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
-                                 
+
                     p_ConvertUtils.CopyValue(*selMatAddThermalExpansion, thermStressEdit, "MULT", "Fscale_x");
                     p_ConvertUtils.CopyValue(*selMatAddThermalExpansion, thermStressEdit, "MULTY", "Fscale_y");
                     p_ConvertUtils.CopyValue(*selMatAddThermalExpansion, thermStressEdit, "MULTZ", "Fscale_z");
@@ -12263,6 +12297,7 @@ void ConvertMat::p_ConvertMatAddDamageGissmo()
         HandleEdit failTAB2HEdit;
         p_radiossModel->CreateEntity(failTAB2HEdit, "/FAIL/TAB2", matAddDamageGissmoName,lsdMIDEntity.GetId());
         failTAB2HEdit.SetValue(p_radiossModel, sdiIdentifier("ID_CARD_EXIST"), sdiValue(true));
+        failTAB2HEdit.SetId(p_radiossModel, m_maxFailId++);
         EntityEdit failTAB2Edit(p_radiossModel, failTAB2HEdit);
 
         if(radMatConvertedHandles.size() == 0 ) return;

--- a/reader/source/dyna2rad/dyna2rad/_private/convertprops.cxx
+++ b/reader/source/dyna2rad/dyna2rad/_private/convertprops.cxx
@@ -219,8 +219,7 @@ void ConvertProp::ConvertEntities()
                     EntityRead controlHourglassEntRead(p_lsdynaModel, controlHourglassHRead);
                     if (!propCard.compare(0,9,"/PROP/SPH")) p_ConvertUtils.CopyValue(controlHourglassEntRead, radPropEntityEdit, "QH", "h");
                 }
-                
-                if (!propCard.compare(0,12,"/PROP/TYPE14") && elform != 2 && (rad_Isolid !=14 && rad_Isolid !=17 && rad_Isolid !=18))
+                if (!propCard.compare(0,12,"/PROP/TYPE14") && elform != 2 && elform != 13 && (rad_Isolid !=14 && rad_Isolid !=17 && rad_Isolid !=18))
                 {
                     EntityEdit radEntPropEdit(p_radiossModel, radPropEdit);
                     double rad_h = GetValue<double>(radEntPropEdit, "h");
@@ -316,6 +315,7 @@ void ConvertProp::p_ConvertPropBasedOnCard(const EntityRead& dynaProp, const sdi
             {
                 int isolid = 0;
                 int elform = 0;
+                int itetra4 = 0;
                 sdiValue queryValue(elform);
                 dynaProp.GetValue(sdiIdentifier("LSD_ELFORM"), queryValue);
                 queryValue.GetValue(elform);
@@ -325,7 +325,14 @@ void ConvertProp::p_ConvertPropBasedOnCard(const EntityRead& dynaProp, const sdi
                     destCard = "/PROP/TYPE14";
                     isolid = 1;
                 }
-                else if (elform == 13 && (
+                else if (elform == 13)
+                    {
+                        destCard = "/PROP/TYPE14";
+                        if(matCard.find("*MAT_ELASTIC_FLUID") != string::npos || matCard.find("*MAT_001_FLUID") != string::npos)
+                          {
+                            isolid = 1;
+                          }
+                        else if (
                           (matCard.find("*MAT_ELASTIC") != string::npos || matCard.find("*MAT_001") != string::npos) ||
                           (matCard.find("*MAT_PLASTIC_KINEMATIC") != string::npos || matCard.find("*MAT_003") != string::npos) ||
                           (matCard.find("*MAT_USER_DEFINED_MATERIAL_MODELS") != string::npos || matCard.find("*MAT_041-050") != string::npos) ||
@@ -338,7 +345,7 @@ void ConvertProp::p_ConvertPropBasedOnCard(const EntityRead& dynaProp, const sdi
                           (matCard.find("*MAT_LUNG_TISSUE") != string::npos || matCard.find("*MAT_129") != string::npos) ||
                           (matCard.find("*MAT_BARLAT_YLD2000") != string::npos || matCard.find("*MAT_133") != string::npos) ||
                           (matCard.find("*MAT_ANISOTROPIC_ELASTIC_PLASTIC") != string::npos || matCard.find("*MAT_157")!= string::npos) ||
-                          (matCard.find("*MAT_SIMPLIFIED_RUBBER/FOAM") != string::npos || matCard.find("*MAT_181")!= string::npos) ||
+                          (matCard.find("*MAT_SIMPLIFIED_RUBBER") != string::npos || matCard.find("*MAT_181")!= string::npos) ||
                           (matCard.find("*MAT_SIMPLIFIED_RUBBER_WITH_DAMAGE") != string::npos || matCard.find("*MAT_183")!= string::npos) ||
                           (matCard.find("*MAT_BARLAT_YLD2004") != string::npos || matCard.find("*MAT_199")!= string::npos) ||
                           (matCard.find("*MAT_VISCOPLASTIC_MIXED_HARDENING") != string::npos || matCard.find("*MAT_225")!= string::npos) ||
@@ -365,11 +372,16 @@ void ConvertProp::p_ConvertPropBasedOnCard(const EntityRead& dynaProp, const sdi
                           (matCard.find("*MAT_PLASTICITY_COMPRESSION_TENSION") != string::npos || matCard.find("*MAT_124") != string::npos) ||
                           (matCard.find("*MAT_SAMP-1") != string::npos || matCard.find("*MAT_187") != string::npos) ||
                           (matCard.find("*MAT_TABULATED_JOHNSON_COOK_LOG_INTERPOLATION") != string::npos || matCard.find("*MAT_224") != string::npos) )
-                        )
-                {
-                    destCard = "/PROP/TYPE14";
-                    isolid = 24;
-                }
+                          {
+                            isolid = 24;
+                            itetra4 = 3;
+                          }
+                        else if(matCard.find("*MAT_DAMAGE_2") != string::npos || matCard.find("*MAT_105") != string::npos)
+                          {
+                            isolid = 24;
+                          }
+                        
+                    }
                 else if ((matCard.find("*MAT_SPOTWELD") != string::npos) || 
                          (matCard.find("*MAT_ARUP_ADHESIVE") != string::npos) ||
                          (matCard.find("*MAT_COHESIVE_MIXED_MODE_ELASTOPLASTIC_RATE") != string::npos) ||
@@ -410,6 +422,7 @@ void ConvertProp::p_ConvertPropBasedOnCard(const EntityRead& dynaProp, const sdi
                     p_radiossModel->CreateEntity(radProp, destCard, dynaPropName, dynaPropId);
                 EntityEdit radPropEdit(p_radiossModel, radProp);
                 radPropEdit.SetValue(sdiIdentifier("ISOLID"), sdiValue(isolid));
+                radPropEdit.SetValue(sdiIdentifier("Itetra4"), sdiValue(itetra4));
                 if(matLawNum != 26 && matLawNum != 126 && matLawNum != 2)
                    UpdateSystemForOrthPropFromDynaMat(p_lsdynaModel, p_radiossModel, matEntityRead, p_ConvertUtils, radPropEdit);
 
@@ -437,11 +450,11 @@ void ConvertProp::p_ConvertPropBasedOnCard(const EntityRead& dynaProp, const sdi
                         nu = (3 * lsdKM - 2 * lsdG) / (6 * lsdKM + 2 * lsdG);
                         if (nu >= 0.25)
                         {
-                            radPropEdit.SetValue(sdiIdentifier("ISOLID"), sdiValue(5));
+                            if (elform != 13) radPropEdit.SetValue(sdiIdentifier("ISOLID"), sdiValue(5));
                             radPropEdit.SetValue(sdiIdentifier("Ihkt"), sdiValue(2));
                         }
                         else
-                            radPropEdit.SetValue(sdiIdentifier("ISOLID"), sdiValue(1));
+                            if (elform != 13) radPropEdit.SetValue(sdiIdentifier("ISOLID"), sdiValue(1));
                     }
 
                     double lsdMU = 0.0;
@@ -499,51 +512,6 @@ void ConvertProp::p_ConvertPropBasedOnCard(const EntityRead& dynaProp, const sdi
                     {
                         radPropEdit.SetValue(sdiIdentifier("Ismstr"), sdiValue(10));
                     }
-                }
-                else if (elform == 13 && ( 
-                                           (matCard.find("*MAT_ELASTIC") != string::npos || matCard.find("*MAT_001") != string::npos) ||
-                                           (matCard.find("*MAT_PLASTIC_KINEMATIC") != string::npos || matCard.find("*MAT_003") != string::npos) ||
-                                           (matCard.find("*MAT_USER_DEFINED_MATERIAL_MODELS") != string::npos || matCard.find("*MAT_041-050") != string::npos) ||
-                                           (matCard.find("*MAT_PLASTICITY_WITH_DAMAGE_ORTHO") != string::npos || matCard.find("*MAT_082") != string::npos) ||
-                                           (matCard.find("*MAT_PLASTICITY_POLYMER") != string::npos || matCard.find("*MAT_089") != string::npos) ||
-                                           (matCard.find("*MAT_SOFT_TISSUE_VISCO") != string::npos || matCard.find("*MAT_092") != string::npos) ||
-                                           (matCard.find("*MAT_ANISOTROPIC_VISCOPLASTIC") != string::npos || matCard.find("*MAT_103") != string::npos) ||
-                                           (matCard.find("*MAT_ELASTIC_VISCOPLASTIC_THERMAL") != string::npos || matCard.find("*MAT_106") != string::npos) ||
-                                           (matCard.find("*MAT_HEART_TISSUE") != string::npos || matCard.find("*MAT_128") != string::npos) ||
-                                           (matCard.find("*MAT_LUNG_TISSUE") != string::npos || matCard.find("*MAT_129") != string::npos) ||
-                                           (matCard.find("*MAT_BARLAT_YLD2000") != string::npos || matCard.find("*MAT_133") != string::npos) ||
-                                           (matCard.find("*MAT_ANISOTROPIC_ELASTIC_PLASTIC") != string::npos || matCard.find("*MAT_157")!= string::npos) ||
-                                           (matCard.find("*MAT_SIMPLIFIED_RUBBER/FOAM") != string::npos || matCard.find("*MAT_181")!= string::npos) ||
-                                           (matCard.find("*MAT_SIMPLIFIED_RUBBER_WITH_DAMAGE") != string::npos || matCard.find("*MAT_183")!= string::npos) ||
-                                           (matCard.find("*MAT_BARLAT_YLD2004") != string::npos || matCard.find("*MAT_199")!= string::npos) ||
-                                           (matCard.find("*MAT_VISCOPLASTIC_MIXED_HARDENING") != string::npos || matCard.find("*MAT_225")!= string::npos) ||
-                                           (matCard.find("*MAT_CAZACU_BARLAT") != string::npos || matCard.find("*MAT_233")!= string::npos) ||
-                                           (matCard.find("*MAT_UHS_STEEL") != string::npos || matCard.find("*MAT_244")!= string::npos) ||
-                                           (matCard.find("*MAT_LOU-YOON_ANISOTROPIC_PLASTICITY") != string::npos || matCard.find("*MAT_263")!= string::npos) ||
-                                           (matCard.find("*MAT_TISSUE_DISPERSED") != string::npos || matCard.find("*MAT_266")!= string::npos) ||
-                                           (matCard.find("*MAT_BERGSTROM_BOYCE_RUBBER") != string::npos || matCard.find("*MAT_269")!= string::npos) ||
-                                           (matCard.find("*MAT_POWDER") != string::npos || matCard.find("*MAT_271")!= string::npos) ||
-                                           (matCard.find("*MAT_RHT") != string::npos || matCard.find("*MAT_272")!= string::npos) ||
-                                           (matCard.find("*MAT_CONCRETE_DAMAGE_PLASTIC_MODEL") != string::npos || matCard.find("*MAT_273")!= string::npos) ||
-                                           (matCard.find("*MAT_VISCOELASTIC") != string::npos || matCard.find("*MAT_006") != string::npos) ||
-                                           (matCard.find("*MAT_BLATZ-KO_RUBBER") != string::npos || matCard.find("*MAT_007") != string::npos) ||
-                                           (matCard.find("*MAT_JOHNSON_COOK") != string::npos || matCard.find("*MAT_015") != string::npos) ||
-                                           (matCard.find("*MAT_PIECEWISE_LINEAR_PLASTICITY") != string::npos || matCard.find("*MAT_024") != string::npos) ||
-                                           (matCard.find("*MAT_MOONEY-RIVLIN_RUBBER") != string::npos || matCard.find("*MAT_027") != string::npos) ||
-                                           (matCard.find("*MAT_OGDEN_RUBBER") != string::npos || matCard.find("*MAT_077_O") != string::npos) ||
-                                           (matCard.find("*MAT_PLASTICITY_WITH_DAMAGE") != string::npos || matCard.find("*MAT_081") != string::npos)  ||
-                                           (matCard.find("MAT_SOFT_TISSUE") != string::npos || matCard.find("*MAT_091") != string::npos) ||
-                                           (matCard.find("*MAT_SIMPLIFIED_JOHNSON_COOK") != string::npos || matCard.find("*MAT_098") != string::npos) ||
-                                           (matCard.find("*MAT_GURSON") != string::npos || matCard.find("*MAT_120") != string::npos) ||
-                                           (matCard.find("*MAT_HILL_3R") != string::npos || matCard.find("*MAT_122") != string::npos) ||
-                                           (matCard.find("*MAT_MODIFIED_PIECEWISE_LINEAR_PLASTICITY") != string::npos || matCard.find("*MAT_123") != string::npos) ||
-                                           (matCard.find("*MAT_PLASTICITY_COMPRESSION_TENSION") != string::npos || matCard.find("*MAT_124") != string::npos) ||
-                                           (matCard.find("*MAT_SAMP-1") != string::npos || matCard.find("*MAT_187") != string::npos) ||
-                                           (matCard.find("*MAT_TABULATED_JOHNSON_COOK_LOG_INTERPOLATION") != string::npos || matCard.find("*MAT_224") != string::npos)
-                                         )
-                        )
-                {
-                    radPropEdit.SetValue(sdiIdentifier("Itetra4"), sdiValue(3));
                 }
             }
             else if (keyword == "*SECTION_SEATBELT")

--- a/reader/source/dyna2rad/dyna2rad/convertinitialstresses.h
+++ b/reader/source/dyna2rad/dyna2rad/convertinitialstresses.h
@@ -58,6 +58,8 @@ namespace sdiD2R
         void ConvertInitialStressesShell();
 
         void ConvertInitialStressesSolid();
+
+        void ConvertInitialStressSection();
     };
 }
 

--- a/reader/source/dyna2rad/dyna2rad/convertmats.h
+++ b/reader/source/dyna2rad/dyna2rad/convertmats.h
@@ -58,6 +58,7 @@ namespace sdiD2R
         ConvertUtils p_ConvertUtils;
         Units p_CurrentUnitSyst;
         std::map<unsigned int, std::map<unsigned int, sdi::HandleEdit>> mapMatIdVsMapPropIdNewMatHandle;
+        int m_maxFailId;
 
         void ConvertEntities() override;
 


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the material and initial stress conversion logic in the dyna2rad module. The main improvements include the implementation of a new conversion function for initial stress sections, systematic assignment of unique IDs to failure entities during material conversion, and minor code cleanups.

**Material Conversion Improvements:**

* Added systematic assignment of unique IDs to all failure entities (such as `/FAIL/JOHNSON`, `/FAIL/GENE1`, `/FAIL/TAB1`, `/FAIL/FLD`, `/FAIL/CONNECT`) using an incrementing `m_maxFailId` counter to ensure uniqueness and consistency across different material laws and conversion functions. [[1]](diffhunk://#diff-057825db09943f337c2ad0205e0bf7b46040bfa25a77a83b06aef49b48cd96f5R1040) [[2]](diffhunk://#diff-057825db09943f337c2ad0205e0bf7b46040bfa25a77a83b06aef49b48cd96f5R1059) [[3]](diffhunk://#diff-057825db09943f337c2ad0205e0bf7b46040bfa25a77a83b06aef49b48cd96f5R1134) [[4]](diffhunk://#diff-057825db09943f337c2ad0205e0bf7b46040bfa25a77a83b06aef49b48cd96f5R1194) [[5]](diffhunk://#diff-057825db09943f337c2ad0205e0bf7b46040bfa25a77a83b06aef49b48cd96f5L1482-R1488) [[6]](diffhunk://#diff-057825db09943f337c2ad0205e0bf7b46040bfa25a77a83b06aef49b48cd96f5L1526-R1533) [[7]](diffhunk://#diff-057825db09943f337c2ad0205e0bf7b46040bfa25a77a83b06aef49b48cd96f5L1605-R1613) [[8]](diffhunk://#diff-057825db09943f337c2ad0205e0bf7b46040bfa25a77a83b06aef49b48cd96f5L1675-R1684) [[9]](diffhunk://#diff-057825db09943f337c2ad0205e0bf7b46040bfa25a77a83b06aef49b48cd96f5L1708-R1718) [[10]](diffhunk://#diff-057825db09943f337c2ad0205e0bf7b46040bfa25a77a83b06aef49b48cd96f5R4759) [[11]](diffhunk://#diff-057825db09943f337c2ad0205e0bf7b46040bfa25a77a83b06aef49b48cd96f5R4783) [[12]](diffhunk://#diff-057825db09943f337c2ad0205e0bf7b46040bfa25a77a83b06aef49b48cd96f5R5497) [[13]](diffhunk://#diff-057825db09943f337c2ad0205e0bf7b46040bfa25a77a83b06aef49b48cd96f5R5629) [[14]](diffhunk://#diff-057825db09943f337c2ad0205e0bf7b46040bfa25a77a83b06aef49b48cd96f5R6198) [[15]](diffhunk://#diff-057825db09943f337c2ad0205e0bf7b46040bfa25a77a83b06aef49b48cd96f5R6229)
* Initialized `m_maxFailId` at the start of material conversion to ensure IDs start from 1 for each conversion run.

**Initial Stress Conversion Enhancements:**

* Implemented the `ConvertInitialStressSection()` function, which handles conversion of `*INITIAL_STRESS_SECTION` entities, including creation of `/PRELOAD` and `/SET/GENERAL` entities, association with cross-sections and part sets, and logging of conversion mappings. This improves coverage and fidelity of initial stress data conversion. [[1]](diffhunk://#diff-a902c351699766ea1bd046797d81e9b38fbfd715b36451d86bffff44056e70dfR43-R44) [[2]](diffhunk://#diff-a902c351699766ea1bd046797d81e9b38fbfd715b36451d86bffff44056e70dfR731-R892)
* Added missing include for `sdiUtils.h` to support new functionality.

**Other Fixes and Cleanups:**

* Removed the defaulting of `lsdDTMIN` to 1.0 if zero in `ConvertCtrlTimeStep`, allowing zero values to be preserved as intended.