### PR TITLE
bug fix in /LAW2

### DIFF
--- a/engine/source/materials/mat/mat002/sigeps02g.F
+++ b/engine/source/materials/mat/mat002/sigeps02g.F
@@ -146,7 +146,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       Z3     = mat_param%uparam(10)
       Z4     = mat_param%uparam(11)                 
       ASRATE = mat_param%uparam(9)
-      ASRATE = MIN(ONE,ASRATE*DT1C(I))
+      ASRATE = MIN(ONE,ASRATE*DT1C(JFT))
 
       TREF  = mat_param%therm%tref                  
       TMELT = mat_param%therm%tmelt                 


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

This pull request makes a small change to the `SIGEPS02G` subroutine in the `sigeps02g.F` file. The modification updates the calculation of `ASRATE` to use `DT1C(JFT)` instead of `DT1C(I)`, because `I` was not initialized
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
