### PR TITLE
openReader CNODE handling

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2026/data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/radioss2026/data_hierarchy.cfg
@@ -20,11 +20,23 @@
 //========================================================================================
 
 HIERARCHY {
-    KEYWORD         = NODE;
+    KEYWORD         = NODES;
     TITLE           = "NODE";
     TYPE            = NODE;
-    FILE            = "NODE/node.cfg";
-    USER_NAMES      = (NODE);
+    //
+    HIERARCHY {
+        KEYWORD         = NODE;
+        TITLE           = "NODE";
+        FILE            = "NODE/node.cfg";
+        USER_NAMES      = (NODE);
+    }
+
+    HIERARCHY {
+        KEYWORD         = CNODE;
+        TITLE           = "CNODE";
+        FILE            = "NODE/cnode.cfg";
+        USER_NAMES      = (CNODE);
+    }
 }
 
 HIERARCHY {

--- a/hm_cfg_files/config/CFG/radioss41/NODE/cnode.cfg
+++ b/hm_cfg_files/config/CFG/radioss41/NODE/cnode.cfg
@@ -1,0 +1,113 @@
+//Copyright>    CFG Files and Library ("CFG")
+//Copyright>    Copyright (C) 1986-2026 Altair Engineering Inc.
+//Copyright>
+//Copyright>    Altair Engineering Inc. grants to third parties limited permission to
+//Copyright>    use and modify CFG solely in connection with OpenRadioss software, provided
+//Copyright>    that any modification to CFG by a third party must be provided back to
+//Copyright>    Altair Engineering Inc. and shall be deemed a Contribution under and therefore
+//Copyright>    subject to the CONTRIBUTOR LICENSE AGREEMENT for OpenRadioss software.
+//Copyright>
+//Copyright>    CFG IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//Copyright>    INCLUDING, BUT NOT LIMITED TO, THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+//Copyright>    A PARTICULAR PURPOSE, AND NONINFRINGEMENT.  IN NO EVENT SHALL ALTAIR ENGINEERING
+//Copyright>    INC. OR ITS AFFILIATES BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY,
+//Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
+//Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
+//
+//  Node Setup File
+// 
+
+ATTRIBUTES(COMMON) {
+// INPUT ATTRIBUTES
+    Search_Value                          = VALUE(FLOAT,  "Search_Value");
+    COUNT                                 = SIZE("Node Number");
+    //id                                  = ARRAY[COUNT](NODE,"Node identifier");
+    id                                    = ARRAY[COUNT](INT,"Node identifier");
+    globalx                               = ARRAY[COUNT](FLOAT,"X coordinate");
+    globaly                               = ARRAY[COUNT](FLOAT,"Y coordinate");
+    globalz                               = ARRAY[COUNT](FLOAT,"Z coordinate");
+
+// HM INTERNAL
+    KEYWORD_STR                           = VALUE(STRING, "Solver Keyword");
+    NUM_COMMENTS                          = SIZE("NUM_COMMENTS");
+    CommentEnumField                      = VALUE(INT,"User Comments");
+    COMMENTS                              = ARRAY[NUM_COMMENTS](STRING,"Entity Comments");
+}
+
+SKEYWORDS_IDENTIFIER(COMMON)
+{
+    Search_Value                       = 4805;
+    KEYWORD_STR                        = 9000;
+    COMMENTS                           = 5109;
+    CommentEnumField                   = 7951;
+    NUM_COMMENTS                       = 5110;
+//
+    COUNT                              = -1;
+    id                                 = -1;
+    globalx                            = -1;
+    globaly                            = -1;
+    globalz                            = -1;
+}
+
+CHECK(COMMON)
+{
+
+}
+
+DEFAULTS(COMMON)
+{
+
+}
+
+GUI(COMMON) {
+    RADIO(CommentEnumField)
+    {
+        ENUM_VALUE_FLAG=TRUE;
+        ADD(1, "Hide in Menu/Export");
+        ADD(2, "Show in Menu/Export");
+        ADD(3, "Do Not Export");
+    }
+    if(CommentEnumField == 2)
+    {  
+        SIZE(NUM_COMMENTS);
+        ARRAY(NUM_COMMENTS,"")
+        {
+            SCALAR(COMMENTS);
+        }   
+    }
+
+    ASSIGN(KEYWORD_STR, "/CNODE");
+
+    SCALAR(Search_Value) {DIMENSION="l";}
+    SIZE(COUNT) ;
+
+    ARRAY(COUNT,"Node data")
+    {
+         //DATA(id) ;
+         SCALAR(id) ;
+         SCALAR(globalx) {DIMENSION="l";}
+         SCALAR(globaly) {DIMENSION="l";}
+         SCALAR(globalz) {DIMENSION="l";}
+    }
+}
+
+// File format
+FORMAT(radioss110) 
+{
+    HEADER("/CNODE/%-20lf",Search_Value);
+    COMMENT("#  node_ID                 Xc                  Yc                  Zc");
+    FREE_CARD_LIST(COUNT)
+    {
+        CARD("%10d%20lg%20lg%20lg",id,globalx,globaly,globalz);
+    }
+}
+FORMAT(radioss51)
+{  
+    HEADER("/CNODE/%-20lf",Search_Value);
+    COMMENT("#  node_ID                 Xc                  Yc                  Zc");
+    FREE_CARD_LIST(COUNT)
+    {
+        CARD("%10d%20lg%20lg%20lg",id,globalx,globaly,globalz);
+    }
+}
+

--- a/reader/source/cfgkernel/sdi/sdiModelViewPO.h
+++ b/reader/source/cfgkernel/sdi/sdiModelViewPO.h
@@ -721,12 +721,18 @@ public:
 
             sdiString kernelFullType = this->p_pre_obj_lst->at(i)->GetKernelFullType();
 
-            bool isSame = true;
-            if (kernelFullType.find("/ELEMS") == 0) {
-                kernelFullType.erase(0, 6); // Remove "/ELEMS"
-                if (!(strcmp(this->p_keyword.c_str(), kernelFullType.c_str()) == 0)) {
-                    isSame = false;
+            sdiString inputFullType = this->p_pre_obj_lst->at(i)->GetInputFullType();
+            if (inputFullType.find('/') != std::string::npos) {
+                size_t secondSlashPos = inputFullType.find('/', inputFullType.find('/') + 1);
+                if (secondSlashPos != std::string::npos) {
+                    inputFullType = inputFullType.substr(0, secondSlashPos);
                 }
+            }
+
+            bool isSame = true;
+            
+            if (!(strcmp(this->p_keyword.c_str(), inputFullType.c_str()) == 0)) {
+                isSame = false;
             }
 
             if(this->p_pre_obj_lst->at(i) != nullptr && isSame)

--- a/reader/source/solver_interface/source/nodes/cpp_nodes_count.cpp
+++ b/reader/source/solver_interface/source/nodes/cpp_nodes_count.cpp
@@ -55,24 +55,9 @@ CDECL void cpp_nodes_count_(int *nbNodes, int *nbCnodes)
 {
     sdiValue search_value_val;
     SelectionNodeRead nodes(g_pModelViewSDI, "/NODE");
-    sdiIdentifier search_value_identifier("Search_Value");
-    bool is_cnode;
-    int cpt = 0;
-    int cpt1 = 0;
-    while(nodes.Next())
-    {
-        is_cnode = nodes->GetValue(search_value_identifier, search_value_val);
-        if(!is_cnode)
-        {
-            cpt = cpt + 1;
-        }
-        else
-        {
-            cpt1 = cpt1 + 1;
-        }
-    }
-    *nbNodes = cpt;
-    *nbCnodes = cpt1;
+    SelectionNodeRead cnodes(g_pModelViewSDI, "/CNODE");
+    *nbNodes = nodes.Count();
+    *nbCnodes = cnodes.Count();
 }
 CDECL void CPP_NODES_COUNT(int *nbNodes, int *nbCnodes)
 {cpp_nodes_count_ (nbNodes,nbCnodes);}


### PR DESCRIPTION
This pull request introduces significant improvements to how nodes and cnodes are handled in the Radioss configuration and solver interface code. The main changes include separating the treatment of nodes and cnodes, introducing a dedicated configuration for cnodes, and updating the logic throughout the codebase to reflect this separation. This enhances clarity, maintainability, and correctness when processing node and cnode data.

**Configuration and Data Hierarchy Updates:**

- Added a new `CNODE` hierarchy and configuration file (`cnode.cfg`) in the Radioss configuration, and updated the node hierarchy to distinguish between `NODE` and `CNODE` entries. (`hm_cfg_files/config/CFG/radioss2026/data_hierarchy.cfg`, `hm_cfg_files/config/CFG/radioss41/NODE/cnode.cfg`) [[1]](diffhunk://#diff-a363c0d8a651ff98903e29e2017b1b7de6bec2b0f30a751e6e3c427dc5495302L23-R41) [[2]](diffhunk://#diff-5abe5498c4668bd4b5d20df99c0873b68d519a99c8a35396ff59882f0c28c109R1-R113)

**Solver Interface and Node/Cnode Processing:**

- Refactored the node and cnode counting and reading functions to use separate selection queries for `/NODE` and `/CNODE`, eliminating the previous logic that distinguished cnodes based on attribute values. This simplifies and clarifies the code for counting and reading node and cnode data. (`cpp_nodes_count.cpp`, `cpp_nodes_read.cpp`) [[1]](diffhunk://#diff-9eeeb68ac6686cc09b5f1e633ed3b27eae3b1fbf3e33cd835ce9697fc6d96b62L58-R60) [[2]](diffhunk://#diff-aa23f19e28896428ebb51e60dff767418243545f39ec1a7637ffa402d23966d3L47-L58) [[3]](diffhunk://#diff-aa23f19e28896428ebb51e60dff767418243545f39ec1a7637ffa402d23966d3L88) [[4]](diffhunk://#diff-aa23f19e28896428ebb51e60dff767418243545f39ec1a7637ffa402d23966d3L120) [[5]](diffhunk://#diff-aa23f19e28896428ebb51e60dff767418243545f39ec1a7637ffa402d23966d3L148-R182) [[6]](diffhunk://#diff-aa23f19e28896428ebb51e60dff767418243545f39ec1a7637ffa402d23966d3L216-R244) [[7]](diffhunk://#diff-aa23f19e28896428ebb51e60dff767418243545f39ec1a7637ffa402d23966d3L229-R265) [[8]](diffhunk://#diff-aa23f19e28896428ebb51e60dff767418243545f39ec1a7637ffa402d23966d3L251-R283) [[9]](diffhunk://#diff-aa23f19e28896428ebb51e60dff767418243545f39ec1a7637ffa402d23966d3L268)

**SDI Model View and Attribute Access:**

- Updated the SDI model view classes to provide a more robust and flexible implementation of the `GetValue` method for entity arrays, ensuring correct attribute access for both nodes and cnodes. The method was moved from `SDIElementDataPO` to the templated `TSDIEntityDataPOArray` class for better generality. (`sdiModelViewPO.h`) [[1]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fR405-R407) [[2]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL497-L498) [[3]](diffhunk://#diff-86af87a5845c4b09edbd96fb553c68be9f68cfbef09c4f7a008c7f021c7bd35fL2649-R2666)

**Selection Logic Improvements:**

- Improved the selection logic to use the correct type string for distinguishing between nodes and cnodes, ensuring that entities are matched and processed accurately according to their type. (`sdiModelViewPO.h`)

These changes collectively improve the structure and reliability of node and cnode handling in the Radioss configuration and solver interface.