### PR TITLE
missing initialization in beam direction reading

### DIFF
--- a/reader/source/solver_interface/source/elements/cpp_beam_read.cpp
+++ b/reader/source/solver_interface/source/elements/cpp_beam_read.cpp
@@ -50,7 +50,9 @@ CDECL void cpp_beam_read_(int *IXP, int *NIXP, int *IPARTP, int *SUBID_BEAM, dou
     sdiIdentifier identifier_vx("Vx");
     sdiIdentifier identifier_vy("Vy");
     sdiIdentifier identifier_vz("Vz");
-    double dvx, dvy, dvz;
+    double dvx= 0.0;
+    double dvy= 0.0;
+    double dvz= 0.0;
 //
 // Elem loop
 //


### PR DESCRIPTION
This pull request makes a minor update to the initialization of variables in the `cpp_beam_read.cpp` file. The change ensures that the variables `dvx`, `dvy`, and `dvz` are explicitly initialized to `0.0` when declared, which helps prevent potential issues with uninitialized values.

* Explicitly initialized `dvx`, `dvy`, and `dvz` to `0.0` in `cpp_beam_read.cpp` to avoid usage of uninitialized variables.