### PR TITLE
openreader : correction /NODE using /UNIT

### DIFF
--- a/hm_cfg_files/config/CFG/radioss41/NODE/node.cfg
+++ b/hm_cfg_files/config/CFG/radioss41/NODE/node.cfg
@@ -19,6 +19,7 @@
 
 ATTRIBUTES(COMMON) {
 // INPUT ATTRIBUTES
+    unitid                                = VALUE(UNIT, "Unit ID");
     COUNT                               = SIZE("Node Number");
     //id                                    = ARRAY[COUNT](NODE,"Node identifier");
     id                                    = ARRAY[COUNT](INT,"Node identifier");
@@ -75,6 +76,7 @@ GUI(COMMON) {
     }
 
     ASSIGN(KEYWORD_STR, "/NODE");
+    DATA(unitid);
     SIZE(COUNT) ;
 
     ARRAY(COUNT,"Node data")
@@ -88,18 +90,13 @@ GUI(COMMON) {
 }
 
 // File format
-FORMAT(radioss110) 
+FORMAT(radioss51) 
 {
-    HEADER("/NODE");
-    COMMENT("#  node_ID                 Xc                  Yc                  Zc");
-    FREE_CARD_LIST(COUNT)
-    {
-        CARD("%10d%20lg%20lg%20lg",id,globalx,globaly,globalz);
-    }
-}
-FORMAT(radioss51)
-{  
-    HEADER("/NODE");
+    ASSIGN(_IOMODE_, 2, EXPORT);
+    if(_IOMODE_ != 2 || unitid != NONE)
+        HEADER("/NODE/%d", unitid);
+    else
+        HEADER("/NODE");
     COMMENT("#  node_ID                 Xc                  Yc                  Zc");
     FREE_CARD_LIST(COUNT)
     {


### PR DESCRIPTION
This pull request introduces support for handling a `unitid` attribute for nodes in the Radioss 51 format, including updates to both the configuration and the C++ backend. The changes ensure that node data can now include a unit identifier, which is integrated into both the configuration file and the serialization/deserialization logic.

**Configuration and Format Handling:**
- Added a `unitid` attribute to the node configuration (`node.cfg`), updated its GUI representation, and modified the Radioss 51 format export logic to include `/NODE/%d` with the unit ID when appropriate. [[1]](diffhunk://#diff-05cd38e93442ef2b2ea709276d877050f3e484af2e1ac101a4a3a5dd28ac1f19R22) [[2]](diffhunk://#diff-05cd38e93442ef2b2ea709276d877050f3e484af2e1ac101a4a3a5dd28ac1f19R79) [[3]](diffhunk://#diff-05cd38e93442ef2b2ea709276d877050f3e484af2e1ac101a4a3a5dd28ac1f19L91-R98)

**Backend Support in C++:**
- Introduced a new class `SDINodeDataPORadioss` inheriting from `SDINodeDataPO`, which adds logic for retrieving and caching the `unitid` for a node, and overrides `GetValue` to support fetching the unit ID. [[1]](diffhunk://#diff-0dbaa3d664e7055935cc404de56b4129aed0a77a6ae979baeedc98d4fa6a3d9dR71-R92) [[2]](diffhunk://#diff-0dbaa3d664e7055935cc404de56b4129aed0a77a6ae979baeedc98d4fa6a3d9dR373-R398)
- Updated `SDIModelViewRadiossblk` to instantiate `SDINodeDataPORadioss` for node data, ensuring the new logic is used throughout the codebase.
