### PR TITLE
Fix uninitialized variable for /FAIL/VISUAL

### DIFF
--- a/engine/source/materials/mat_share/mulawc.F90
+++ b/engine/source/materials/mat_share/mulawc.F90
@@ -658,8 +658,8 @@
                 do ifl = 1, nfail      ! loop over fail models in current layer
                   irupt  =  fbuf%floc(ifl)%ilawf
                   if(irupt== 4.or.irupt== 5.or.irupt== 6.or.irupt==7.or.   &
-                  &                 irupt==10.or.irupt==24.or.irupt==34.or.irupt==39.or.  &
-                  &                 irupt==43.or.irupt==47 ) flag_eps=.true.
+                  &  irupt==10.or.irupt==24.or.irupt==34.or.irupt==36.or.  &
+                  &  irupt==39.or.irupt==43.or.irupt==47 ) flag_eps=.true.
                 enddo
               enddo
             endif


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

FLAG_EPS for /FAIL/VISUAL was set to .false. but need to be true to trigger strain tensor computation in mulawc.F

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

Switch to true when using /FAIL/VISUAL 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
