### PR TITLE
/SET : enable option _E for the key PART and SUBM to get only node_from_external_surface

### DIFF
--- a/starter/source/model/sets/create_subm_clause.F
+++ b/starter/source/model/sets/create_subm_clause.F
@@ -160,7 +160,7 @@ C-----------------------------------------------
       INTEGER IWORK(70000)
 !
       INTEGER, ALLOCATABLE, DIMENSION(:) :: SUBM_READ_TMP,SORTED_SUBM,INDEXS,
-     . PART_READ_TMP,SORTED_PARTS,INDEXP,TAGNODSUB,NODE_READ_TMP,SORTED_NODES,INDEXN
+     . PART_READ_TMP,SORTED_PARTS,INDEXP,NODE_READ_TMP,SORTED_NODES,INDEXN
 C
       INTEGER SET_USRTOS
       EXTERNAL SET_USRTOS
@@ -179,14 +179,6 @@ C=======================================================================
 
       ALLOCATE(INDEXP(2*NPART)) ! parts of subsets
       INDEXP = 0
-
-      ALLOCATE(TAGNODSUB(NUMNOD))
-
-      ALLOCATE(NODE_READ_TMP(NUMNOD))
-!!      ALLOCATE(SORTED_NODES(NUMNOD))
-!!      ALLOCATE(INDEXN(2*NUMNOD)) ! nodes of subsets
-!!      INDEXN = 0
-
 
       NINDX = 0
       LIST_SIZE_S = 0
@@ -280,60 +272,6 @@ C=======================================================================
         CLAUSE%PART(I) = SORTED_PARTS(I)
       ENDDO
 !---
-
-
-      ! Tag & convert Nodes of Submodel
-      ! ---------------------
-      CALL CPP_NODE_SUB_TAG(TAGNODSUB)
-
-
-      NINDX = 0
-      DO I=1,LIST_SIZE_S
-        ISUB = SORTED_SUBM(I)
-        DO J=1,NUMNOD
-          SUB_INDEX = TAGNODSUB(J)
-          IF (ISUB == SUB_INDEX) THEN
-
-             NODE = J
-
-             NINDX=NINDX+1    !   nb of Nodes of CLAUSE subsets
-             NODE_READ_TMP(NINDX) = NODE
-
-          ENDIF
-        ENDDO
-      ENDDO
-
-
-      ! Sort of TAG Nodes from Readed SUBMODELs and remove eventual duplicates
-      ! ---------------------------------------------------- 
-
-      ALLOCATE(SORTED_NODES(NINDX))
-      ALLOCATE(INDEXN(2*NINDX))
-      INDEXN = 0
-
-      IWORK(:) = 0
-      DO I=1,NINDX
-        INDEXN(I) = I
-      ENDDO
-      CALL MY_ORDERS(0,IWORK,NODE_READ_TMP,INDEXN,NINDX,1)
-                
-      DO I=1,NINDX
-         SORTED_NODES(I) = NODE_READ_TMP(INDEXN(I))
-      ENDDO
-
-      LIST_SIZE_N = 0
-      CALL REMOVE_DUPLICATES(SORTED_NODES,NINDX,LIST_SIZE_N)
-
-
-      ! Copy in final SET
-      ! ------------------
-      CLAUSE%NB_NODE = LIST_SIZE_N  
-      ALLOCATE( CLAUSE%NODE( LIST_SIZE_N ) )
-
-      DO I=1,LIST_SIZE_N
-        CLAUSE%NODE(I) = SORTED_NODES(I)
-      ENDDO
-
 C-------------------------
        DEALLOCATE(SUBM_READ_TMP)
        DEALLOCATE(SORTED_SUBM)
@@ -341,10 +279,6 @@ C-------------------------
        DEALLOCATE(PART_READ_TMP)
        DEALLOCATE(SORTED_PARTS)
        DEALLOCATE(INDEXP)
-       DEALLOCATE(TAGNODSUB)
-       DEALLOCATE(NODE_READ_TMP)
-       DEALLOCATE(SORTED_NODES)
-       DEALLOCATE(INDEXN)
 C-------------------------
       RETURN
       END

--- a/starter/source/model/sets/hm_set.F
+++ b/starter/source/model/sets/hm_set.F
@@ -802,7 +802,13 @@ C-----------------------------------------------
                   CALL CREATE_LINE_FROM_SURFACE(CLAUSE,KEYSET,OPT_A,OPT_E,DELBUF    ,
      .                                          .FALSE.)
 
-
+                  ! Node from ELEMENT
+                  ! 1D - only, otherwise from SURFACE
+                  CALL CREATE_NODE_FROM_ELEMENT(
+     .                            IXS   ,IXS10  ,IXS20  ,IXS16  ,IXQ    ,
+     .                            IXC   ,IXTG   ,IXT    ,IXP    ,IXR    ,
+     .                            IXX   ,KXX    ,KXSP   ,CLAUSE ,GEO,
+     .                            DUMMY_ARRAY   ,DSZ    ,.FALSE.)
 
               CASE ( 'RBODY' )
 


### PR DESCRIPTION
…om external surface

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

Wrong construction of group of nodes from /SET with key SUBM_E. They are built from ALL instead of external surface.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

Rebuild group of nodes in /SET with key = SUBM_E.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
