### PR TITLE
openreader : correction deletion on TETRA4 Elements when convert TETRA4 with Itet=x to TETRA10

### DIFF
--- a/reader/source/cfgkernel/sdi/sdiModelViewPO.h
+++ b/reader/source/cfgkernel/sdi/sdiModelViewPO.h
@@ -469,6 +469,15 @@ public:
         return p_ptr->GetIntValue(att_index_id, p_index2);
     }
 
+    virtual Status SetId(const unsigned int id) const
+    {
+        if(!p_ptr) return false;
+        int att_index_id = p_ptr->GetIndex(IMECPreObject::ATY_ARRAY, IMECPreObject::VTY_INT, "id");
+        if(att_index_id < 0) return false;
+        p_ptr->SetIntValue(att_index_id, p_index2, id);
+        return true;
+    }
+
 
     virtual HandleRead GetOwner() const
     {

--- a/reader/source/solver_interface/source/cfg_reading/GlobalModelSdi.cpp
+++ b/reader/source/solver_interface/source/cfg_reading/GlobalModelSdi.cpp
@@ -2759,7 +2759,7 @@ void GlobalEntitySDIConvertTetra4ToTetra10(int *Itetra4ToConsider)
 {
     bool isOk = false;
     int elemId = 0;
-    SelectionElementRead tetElements(g_pModelViewSDI, "/TETRA4");
+    SelectionElementEdit tetElements(g_pModelViewSDI, "/TETRA4");
     // Create a map to store existing mid-edge nodes: key = pair of node IDs (sorted), value = mid-node ID
     std::map<std::pair<unsigned int, unsigned int>, int> edgeToMidNodeMap;
 
@@ -2881,13 +2881,12 @@ void GlobalEntitySDIConvertTetra4ToTetra10(int *Itetra4ToConsider)
                     tetra10Nodes[i] = aNodeId[i];
                 for(int i = 0; i < 6; i++)
                     tetra10Nodes[i+4] = midNodeIds[i];
-                
-                g_pModelViewSDI->CreateElement(radTetra10HEdit,"/TETRA10",tetra10Nodes,partHread,elemId);
 
+                g_pModelViewSDI->CreateElement(radTetra10HEdit,"/TETRA10",tetra10Nodes,partHread,elemId);
+                
                 // Delete the original TETRA4 element
-                HandleRead tetra4HRead = tetElements->GetHandle();
-                HandleEdit tetra4HEdit(tetra4HRead.GetType(), tetra4HRead.GetPointer());
-                tetra4HEdit.SetId(g_pModelViewSDI, -tetElements->GetId());
+                tetElements->SetId(0);
+                
             }
         }
     }


### PR DESCRIPTION
This pull request introduces changes to improve element editing and streamline the conversion process from TETRA4 to TETRA10 elements in the solver interface. The most important changes include switching to an editable selection class and adding a new method for setting element IDs.

Enhancements to element editing and conversion:

* Replaced `SelectionElementRead` with `SelectionElementEdit` in the `GlobalEntitySDIConvertTetra4ToTetra10` function, enabling direct modification of TETRA4 elements during conversion.
* Added a new `SetId` method to the `SDIElementDataPO` class in `sdiModelViewPO.h`, allowing element IDs to be updated programmatically.
* Updated the TETRA4 element deletion logic in the conversion function to use the new `SetId(0)` method, simplifying the process of marking elements for removal.