### PR TITLE
array dimension correction in h3d output per layer

### DIFF
--- a/engine/source/output/h3d/h3d_build_fortran/lech3d.F
+++ b/engine/source/output/h3d/h3d_build_fortran/lech3d.F
@@ -1640,6 +1640,10 @@ C--------------------------------------------------
 C
             ENDIF
 C
+            DO NG=1,NGROUP
+               NLAY_MAX  = MAX(NLAY_MAX,ELBUF_STR(NG)%NLAY)
+            ENDDO
+            
             IF(.NOT.ALLOCATED(IS_LAYER_MAT))ALLOCATE(IS_LAYER_MAT(MAX(1,NUMMAT),MAX(1,NLAY_MAX)))
             IS_LAYER_MAT(1:MAX(1,NUMMAT),MAX(1,NLAY_MAX)) = 0
 C


### PR DESCRIPTION
This pull request introduces a minor change to the `LECH3D` subroutine in `lech3d.F` to ensure the correct calculation of the maximum number of layers (`NLAY_MAX`) across all groups before allocating the `IS_LAYER_MAT` array.

Array allocation fix:

* Added a loop over all groups (`NGROUP`) to determine the maximum number of layers (`NLAY_MAX`) by comparing each group's `ELBUF_STR(NG)%NLAY` value, ensuring the allocation of `IS_LAYER_MAT` uses the true maximum layer count.