### PR TITLE
in 1.rad ( 2.rad ....)  files, comments with large numbers of characters

### DIFF
--- a/engine/source/engine/radioss2.F
+++ b/engine/source/engine/radioss2.F
@@ -599,7 +599,7 @@ c
         IF(OUTFILE_BOOL) BOOL_C = 1
 
         CALL LF_CONVERT_C_FLAT(GOT_INPUT,ROOTN,LENROOTN,FNAME,LFNAME,
-     .                         INAME, IERR,1024,LEN_TMP_NAME,TMP_NAME,
+     .                         INAME, IERR,65536,LEN_TMP_NAME,TMP_NAME,
      .                         LEN_TMP_NAME2,TMP_NAME2)
 
         IF (IERR == 0) THEN


### PR DESCRIPTION
This pull request makes a minor change to the `RADIOSS2` subroutine. The update increases the buffer size used in the `LF_CONVERT_C_FLAT` function call, which may help prevent issues with long file names or paths.

* Increased the buffer size parameter in the `LF_CONVERT_C_FLAT` call from `1024` to `65536` in the `RADIOSS2` subroutine, potentially improving support for longer file names.