### PR TITLE
replace Itetra4=1 by conversion from tet4 to tet10 w/ Itetra10=2

### DIFF
--- a/starter/source/properties/solid/hm_read_prop06.F
+++ b/starter/source/properties/solid/hm_read_prop06.F
@@ -126,6 +126,7 @@ C-----------------------------------------------
       INTEGER     IHBE_DS,ISST_DS,IFRAME_DS,
      .            ITET4_D,ITET10_D,ICPRE_D
       LOGICAL IS_AVAILABLE, IS_ENCRYPTED
+      CHARACTER(LEN=NCHARLINE) ::  MSGLINE
 C-----------------------------------------------
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
@@ -208,6 +209,12 @@ C-----removed flags:
 C----------------------
       IF(ITET4 == 0)  ITET4 = ITET4_D
       IF(ITET10 == 0) ITET10 = ITET10_D
+      IF(ITET4 == 1) THEN ! switched to tetra10 w/ itetra10=2
+        ITET10 = 2
+        ITET4 = 0  
+        MSGLINE='   ITETR4 IS CHANGED TO TETRA10'
+        CALL ANCMSG(MSGID=2027,MSGTYPE=MSGWARNING,ANMODE=ANINFO,I1=IG,C1=IDTITL,I2=2,C2=TRIM(MSGLINE))      
+      ENDIF
 C
 C
       IF (SUB_ID /= 0)

--- a/starter/source/properties/solid/hm_read_prop14.F
+++ b/starter/source/properties/solid/hm_read_prop14.F
@@ -174,7 +174,12 @@ C--------------------------------------------------
         ! use value from /DEF_SOLID (by default or in case of unexpected value) : and check it below
         ITET4 = ITET4_D
       ENDIF 
-      IF(ITET4 == 2) THEN
+      IF(ITET4 == 1) THEN ! switched to tetra10 w/ itetra10=2
+        ITET10 = 2
+        ITET4 = 0  
+        MSGLINE='   ITETR4 IS CHANGED TO TETRA10'
+        CALL ANCMSG(MSGID=2027,MSGTYPE=MSGWARNING,ANMODE=ANINFO,I1=IG,C1=TITR,I2=2,C2=TRIM(MSGLINE))      
+      ELSEIF(ITET4 == 2) THEN
         ! old single tetra4 & tetra10 formulation flag : set ITET4 to 1000
         ITET10 = 2
         ITET4 = 1000  

--- a/starter/source/starter/starter0.F
+++ b/starter/source/starter/starter0.F
@@ -105,6 +105,7 @@ C-----------------------------------------------
       use checksum_check_mod
       use th_mod , only : TH_HAS_NODA_PEXT
       use hm_rbodies_add_main_node_mod
+      use hm_convert_tetra4_to_tetra10_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -155,7 +156,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I,J,K, STAT,INP,OUT
+      INTEGER I,J,K, STAT,INP,OUT,itetra4
       INTEGER IFILNAM(2148),LEN,IDMAX_INTER,
      .        IDMAX_GRNOD,IDMAX_LINE,IDMAX_TABLE,IDMAX_FAIL,IDMAX_FUNCT,
      .        IDMAX_PART,IDMAX_PROP,IDMAX_MAT,IDMAX_ELEM,IDMAX_TH,
@@ -785,6 +786,11 @@ C-------------------------------------------------------------------
 C Add RBODY master node if not existing in /RBODY cards
 C------------------------------------------------------------------
       CALL hm_rbodies_add_main_node(LSUBMODEL)
+C-------------------------------------------------------------------
+C itetra4=1: convert tetra4 to tretra10 w/ itetra10=2
+C------------------------------------------------------------------
+      itetra4=1
+      CALL hm_convert_tetra4_to_tetra10(itetra4) 
 C------------------------------------------------------------------
       ! Initialisation of glob_therm module
 C------------------------------------------------------------------


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
actual Itetra4=1 (using rotational dofs to compute middle node moving) is not robust and accurate than tetra10 elements, and there is many remaining issues of it. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
we replace this option by the conversion automatic from tetra4 to tetra10 element w/ Itetra10=2

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
