### PR TITLE
Fix typo issue about function ID and Chaboche kinematic hardening for /MAT/LAW87

### DIFF
--- a/engine/source/materials/mat/mat087/mat87c_hansel.F90
+++ b/engine/source/materials/mat/mat087/mat87c_hansel.F90
@@ -346,20 +346,6 @@
           !=========================================================================
           if (nindx > 0) then
 !
-            !< Computation of the derivative of backstress tensor w.r.t pl. strain
-            if ((ikin == 1).and.(fisokin > zero)) then
-#include "vectorize.inc"
-              do ii = 1, nindx
-                i = indx(ii)
-                dsigbxxdp(i) = ckh(1)*sigb(i,1) + ckh(2)*sigb(i,4) +               &
-                  ckh(3)*sigb(i,7) + ckh(4)*sigb(i,10)
-                dsigbyydp(i) = ckh(1)*sigb(i,2) + ckh(2)*sigb(i,5) +               &
-                  ckh(3)*sigb(i,8) + ckh(4)*sigb(i,11)
-                dsigbxydp(i) = ckh(1)*sigb(i,3) + ckh(2)*sigb(i,6) +               &
-                  ckh(3)*sigb(i,9) + ckh(4)*sigb(i,12)
-              end do
-            end if
-!
             !< Loop over the iterations
             do iter = 1, niter
 #include "vectorize.inc"
@@ -501,8 +487,14 @@
                 if (fisokin > zero) then
                   !<  -> Chaboche-Rousselier kinematic hardening
                   if (ikin == 1) then
-                    dsigbxxdlam = fisokin*(akck*normxx - dsigbxxdp(i)*dpladlam)
-                    dsigbyydlam = fisokin*(akck*normyy - dsigbyydp(i)*dpladlam)
+                    dsigbxxdp(i) = ckh(1)*sigb(i,1) + ckh(2)*sigb(i,4) +         &
+                                   ckh(3)*sigb(i,7) + ckh(4)*sigb(i,10)
+                    dsigbyydp(i) = ckh(1)*sigb(i,2) + ckh(2)*sigb(i,5) +         &
+                                   ckh(3)*sigb(i,8) + ckh(4)*sigb(i,11)
+                    dsigbxydp(i) = ckh(1)*sigb(i,3) + ckh(2)*sigb(i,6) +         &
+                                   ckh(3)*sigb(i,9) + ckh(4)*sigb(i,12)
+                    dsigbxxdlam = fisokin*(akck*(two*normxx + normyy) - dsigbxxdp(i)*dpladlam)
+                    dsigbyydlam = fisokin*(akck*(two*normyy + normxx) - dsigbyydp(i)*dpladlam)
                     dsigbxydlam = fisokin*(akck*normxy - dsigbxydp(i)*dpladlam)
                     !<  -> Prager kinematic hardening
                   else if (ikin == 2) then
@@ -566,27 +558,27 @@
                   if (ikin == 1) then
                     ! -> Update the all set of backstresses components
                     sigb(i, 1) = sigb(i, 1) +                                      &
-                      fisokin*(akh(1)*ckh(1)*normxx*dlam  - ckh(1)*sigb(i,1)*ddep)
+                      fisokin*(akh(1)*ckh(1)*(two*normxx + normyy)*dlam  - ckh(1)*sigb(i,1)*ddep)
                     sigb(i, 2) = sigb(i, 2) +                                      &
-                      fisokin*(akh(1)*ckh(1)*normyy*dlam  - ckh(1)*sigb(i,2)*ddep)
+                      fisokin*(akh(1)*ckh(1)*(two*normyy + normxx)*dlam  - ckh(1)*sigb(i,2)*ddep)
                     sigb(i, 3) = sigb(i, 3) +                                      &
                       fisokin*(akh(1)*ckh(1)*normxy*dlam  - ckh(1)*sigb(i,3)*ddep)
                     sigb(i, 4) = sigb(i, 4) +                                      &
-                      fisokin*(akh(2)*ckh(2)*normxx*dlam  - ckh(2)*sigb(i,4)*ddep)
+                      fisokin*(akh(2)*ckh(2)*(two*normxx + normyy)*dlam  - ckh(2)*sigb(i,4)*ddep)
                     sigb(i, 5) = sigb(i, 5) +                                      &
-                      fisokin*(akh(2)*ckh(2)*normyy*dlam  - ckh(2)*sigb(i,5)*ddep)
+                      fisokin*(akh(2)*ckh(2)*(two*normyy + normxx)*dlam  - ckh(2)*sigb(i,5)*ddep)
                     sigb(i, 6) = sigb(i, 6) +                                      &
                       fisokin*(akh(2)*ckh(2)*normxy*dlam  - ckh(2)*sigb(i,6)*ddep)
                     sigb(i, 7) = sigb(i, 7) +                                      &
-                      fisokin*(akh(3)*ckh(3)*normxx*dlam  - ckh(3)*sigb(i,7)*ddep)
+                      fisokin*(akh(3)*ckh(3)*(two*normxx + normyy)*dlam  - ckh(3)*sigb(i,7)*ddep)
                     sigb(i, 8) = sigb(i, 8) +                                      &
-                      fisokin*(akh(3)*ckh(3)*normyy*dlam  - ckh(3)*sigb(i,8)*ddep)
+                      fisokin*(akh(3)*ckh(3)*(two*normyy + normxx)*dlam  - ckh(3)*sigb(i,8)*ddep)
                     sigb(i, 9) = sigb(i, 9) +                                      &
                       fisokin*(akh(3)*ckh(3)*normxy*dlam  - ckh(3)*sigb(i,9)*ddep)
                     sigb(i,10) = sigb(i,10) +                                      &
-                      fisokin*(akh(4)*ckh(4)*normxx*dlam - ckh(4)*sigb(i,10)*ddep)
+                      fisokin*(akh(4)*ckh(4)*(two*normxx + normyy)*dlam - ckh(4)*sigb(i,10)*ddep)
                     sigb(i,11) = sigb(i,11) +                                      &
-                      fisokin*(akh(4)*ckh(4)*normyy*dlam - ckh(4)*sigb(i,11)*ddep)
+                      fisokin*(akh(4)*ckh(4)*(two*normyy + normxx)*dlam - ckh(4)*sigb(i,11)*ddep)
                     sigb(i,12) = sigb(i,12) +                                      &
                       fisokin*(akh(4)*ckh(4)*normxy*dlam - ckh(4)*sigb(i,12)*ddep)
                     !<  -> Prager kinematic hardening

--- a/engine/source/materials/mat/mat087/mat87c_swift_voce.F90
+++ b/engine/source/materials/mat/mat087/mat87c_swift_voce.F90
@@ -344,20 +344,6 @@
           !=========================================================================
           if (nindx > 0) then
 !
-            !< Computation of the derivative of backstress tensor w.r.t pl. strain
-            if ((ikin == 1).and.(fisokin > zero)) then
-#include "vectorize.inc"
-              do ii = 1, nindx
-                i = indx(ii)
-                dsigbxxdp(i) = ckh(1)*sigb(i,1) + ckh(2)*sigb(i,4) +               &
-                  ckh(3)*sigb(i,7) + ckh(4)*sigb(i,10)
-                dsigbyydp(i) = ckh(1)*sigb(i,2) + ckh(2)*sigb(i,5) +               &
-                  ckh(3)*sigb(i,8) + ckh(4)*sigb(i,11)
-                dsigbxydp(i) = ckh(1)*sigb(i,3) + ckh(2)*sigb(i,6) +               &
-                  ckh(3)*sigb(i,9) + ckh(4)*sigb(i,12)
-              end do
-            end if
-!
             !< Loop over the iterations
             do iter = 1, niter
 #include "vectorize.inc"
@@ -499,8 +485,14 @@
                 if (fisokin > zero) then
                   !<  -> Chaboche-Rousselier kinematic hardening
                   if (ikin == 1) then
-                    dsigbxxdlam = fisokin*(akck*normxx - dsigbxxdp(i)*dpladlam)
-                    dsigbyydlam = fisokin*(akck*normyy - dsigbyydp(i)*dpladlam)
+                    dsigbxxdp(i) = ckh(1)*sigb(i,1) + ckh(2)*sigb(i,4) +         &
+                                   ckh(3)*sigb(i,7) + ckh(4)*sigb(i,10)
+                    dsigbyydp(i) = ckh(1)*sigb(i,2) + ckh(2)*sigb(i,5) +         &
+                                   ckh(3)*sigb(i,8) + ckh(4)*sigb(i,11)
+                    dsigbxydp(i) = ckh(1)*sigb(i,3) + ckh(2)*sigb(i,6) +         &
+                                   ckh(3)*sigb(i,9) + ckh(4)*sigb(i,12)
+                    dsigbxxdlam = fisokin*(akck*(two*normxx + normyy) - dsigbxxdp(i)*dpladlam)
+                    dsigbyydlam = fisokin*(akck*(two*normyy + normxx) - dsigbyydp(i)*dpladlam)
                     dsigbxydlam = fisokin*(akck*normxy - dsigbxydp(i)*dpladlam)
                     !<  -> Prager kinematic hardening
                   else if (ikin == 2) then
@@ -564,27 +556,27 @@
                   if (ikin == 1) then
                     ! -> Update the all set of backstresses components
                     sigb(i, 1) = sigb(i, 1) +                                      &
-                      fisokin*(akh(1)*ckh(1)*normxx*dlam  - ckh(1)*sigb(i,1)*ddep)
+                      fisokin*(akh(1)*ckh(1)*(two*normxx + normyy)*dlam  - ckh(1)*sigb(i,1)*ddep)
                     sigb(i, 2) = sigb(i, 2) +                                      &
-                      fisokin*(akh(1)*ckh(1)*normyy*dlam  - ckh(1)*sigb(i,2)*ddep)
+                      fisokin*(akh(1)*ckh(1)*(two*normyy + normxx)*dlam  - ckh(1)*sigb(i,2)*ddep)
                     sigb(i, 3) = sigb(i, 3) +                                      &
                       fisokin*(akh(1)*ckh(1)*normxy*dlam  - ckh(1)*sigb(i,3)*ddep)
                     sigb(i, 4) = sigb(i, 4) +                                      &
-                      fisokin*(akh(2)*ckh(2)*normxx*dlam  - ckh(2)*sigb(i,4)*ddep)
+                      fisokin*(akh(2)*ckh(2)*(two*normxx + normyy)*dlam  - ckh(2)*sigb(i,4)*ddep)
                     sigb(i, 5) = sigb(i, 5) +                                      &
-                      fisokin*(akh(2)*ckh(2)*normyy*dlam  - ckh(2)*sigb(i,5)*ddep)
+                      fisokin*(akh(2)*ckh(2)*(two*normyy + normxx)*dlam  - ckh(2)*sigb(i,5)*ddep)
                     sigb(i, 6) = sigb(i, 6) +                                      &
                       fisokin*(akh(2)*ckh(2)*normxy*dlam  - ckh(2)*sigb(i,6)*ddep)
                     sigb(i, 7) = sigb(i, 7) +                                      &
-                      fisokin*(akh(3)*ckh(3)*normxx*dlam  - ckh(3)*sigb(i,7)*ddep)
+                      fisokin*(akh(3)*ckh(3)*(two*normxx + normyy)*dlam  - ckh(3)*sigb(i,7)*ddep)
                     sigb(i, 8) = sigb(i, 8) +                                      &
-                      fisokin*(akh(3)*ckh(3)*normyy*dlam  - ckh(3)*sigb(i,8)*ddep)
+                      fisokin*(akh(3)*ckh(3)*(two*normyy + normxx)*dlam  - ckh(3)*sigb(i,8)*ddep)
                     sigb(i, 9) = sigb(i, 9) +                                      &
                       fisokin*(akh(3)*ckh(3)*normxy*dlam  - ckh(3)*sigb(i,9)*ddep)
                     sigb(i,10) = sigb(i,10) +                                      &
-                      fisokin*(akh(4)*ckh(4)*normxx*dlam - ckh(4)*sigb(i,10)*ddep)
+                      fisokin*(akh(4)*ckh(4)*(two*normxx + normyy)*dlam - ckh(4)*sigb(i,10)*ddep)
                     sigb(i,11) = sigb(i,11) +                                      &
-                      fisokin*(akh(4)*ckh(4)*normyy*dlam - ckh(4)*sigb(i,11)*ddep)
+                      fisokin*(akh(4)*ckh(4)*(two*normyy + normxx)*dlam - ckh(4)*sigb(i,11)*ddep)
                     sigb(i,12) = sigb(i,12) +                                      &
                       fisokin*(akh(4)*ckh(4)*normxy*dlam - ckh(4)*sigb(i,12)*ddep)
                     !<  -> Prager kinematic hardening

--- a/engine/source/materials/mat/mat087/mat87c_tabulated.F90
+++ b/engine/source/materials/mat/mat087/mat87c_tabulated.F90
@@ -329,20 +329,6 @@
           !=========================================================================
           if (nindx > 0) then
 !
-            !< Computation of the derivative of backstress tensor w.r.t pl. strain
-            if ((ikin == 1).and.(fisokin > zero)) then
-#include "vectorize.inc"
-              do ii = 1, nindx
-                i = indx(ii)
-                dsigbxxdp(i) = ckh(1)*sigb(i,1) + ckh(2)*sigb(i,4) +               &
-                  ckh(3)*sigb(i,7) + ckh(4)*sigb(i,10)
-                dsigbyydp(i) = ckh(1)*sigb(i,2) + ckh(2)*sigb(i,5) +               &
-                  ckh(3)*sigb(i,8) + ckh(4)*sigb(i,11)
-                dsigbxydp(i) = ckh(1)*sigb(i,3) + ckh(2)*sigb(i,6) +               &
-                  ckh(3)*sigb(i,9) + ckh(4)*sigb(i,12)
-              end do
-            end if
-!
             !< Loop over the iterations
             do iter = 1, niter
 #include "vectorize.inc"
@@ -484,8 +470,14 @@
                 if (fisokin > zero) then
                   !<  -> Chaboche-Rousselier kinematic hardening
                   if (ikin == 1) then
-                    dsigbxxdlam = fisokin*(akck*normxx - dsigbxxdp(i)*dpladlam)
-                    dsigbyydlam = fisokin*(akck*normyy - dsigbyydp(i)*dpladlam)
+                    dsigbxxdp(i) = ckh(1)*sigb(i,1) + ckh(2)*sigb(i,4) +         &
+                                   ckh(3)*sigb(i,7) + ckh(4)*sigb(i,10)
+                    dsigbyydp(i) = ckh(1)*sigb(i,2) + ckh(2)*sigb(i,5) +         &
+                                   ckh(3)*sigb(i,8) + ckh(4)*sigb(i,11)
+                    dsigbxydp(i) = ckh(1)*sigb(i,3) + ckh(2)*sigb(i,6) +         &
+                                   ckh(3)*sigb(i,9) + ckh(4)*sigb(i,12)
+                    dsigbxxdlam = fisokin*(akck*(two*normxx + normyy) - dsigbxxdp(i)*dpladlam)
+                    dsigbyydlam = fisokin*(akck*(two*normyy + normxx) - dsigbyydp(i)*dpladlam)
                     dsigbxydlam = fisokin*(akck*normxy - dsigbxydp(i)*dpladlam)
                     !<  -> Prager kinematic hardening
                   else if (ikin == 2) then
@@ -549,27 +541,27 @@
                   if (ikin == 1) then
                     ! -> Update the all set of backstresses components
                     sigb(i, 1) = sigb(i, 1) +                                      &
-                      fisokin*(akh(1)*ckh(1)*normxx*dlam  - ckh(1)*sigb(i,1)*ddep)
+                      fisokin*(akh(1)*ckh(1)*(two*normxx + normyy)*dlam  - ckh(1)*sigb(i,1)*ddep)
                     sigb(i, 2) = sigb(i, 2) +                                      &
-                      fisokin*(akh(1)*ckh(1)*normyy*dlam  - ckh(1)*sigb(i,2)*ddep)
+                      fisokin*(akh(1)*ckh(1)*(two*normyy + normxx)*dlam  - ckh(1)*sigb(i,2)*ddep)
                     sigb(i, 3) = sigb(i, 3) +                                      &
                       fisokin*(akh(1)*ckh(1)*normxy*dlam  - ckh(1)*sigb(i,3)*ddep)
                     sigb(i, 4) = sigb(i, 4) +                                      &
-                      fisokin*(akh(2)*ckh(2)*normxx*dlam  - ckh(2)*sigb(i,4)*ddep)
+                      fisokin*(akh(2)*ckh(2)*(two*normxx + normyy)*dlam  - ckh(2)*sigb(i,4)*ddep)
                     sigb(i, 5) = sigb(i, 5) +                                      &
-                      fisokin*(akh(2)*ckh(2)*normyy*dlam  - ckh(2)*sigb(i,5)*ddep)
+                      fisokin*(akh(2)*ckh(2)*(two*normyy + normxx)*dlam  - ckh(2)*sigb(i,5)*ddep)
                     sigb(i, 6) = sigb(i, 6) +                                      &
                       fisokin*(akh(2)*ckh(2)*normxy*dlam  - ckh(2)*sigb(i,6)*ddep)
                     sigb(i, 7) = sigb(i, 7) +                                      &
-                      fisokin*(akh(3)*ckh(3)*normxx*dlam  - ckh(3)*sigb(i,7)*ddep)
+                      fisokin*(akh(3)*ckh(3)*(two*normxx + normyy)*dlam  - ckh(3)*sigb(i,7)*ddep)
                     sigb(i, 8) = sigb(i, 8) +                                      &
-                      fisokin*(akh(3)*ckh(3)*normyy*dlam  - ckh(3)*sigb(i,8)*ddep)
+                      fisokin*(akh(3)*ckh(3)*(two*normyy + normxx)*dlam  - ckh(3)*sigb(i,8)*ddep)
                     sigb(i, 9) = sigb(i, 9) +                                      &
                       fisokin*(akh(3)*ckh(3)*normxy*dlam  - ckh(3)*sigb(i,9)*ddep)
                     sigb(i,10) = sigb(i,10) +                                      &
-                      fisokin*(akh(4)*ckh(4)*normxx*dlam - ckh(4)*sigb(i,10)*ddep)
+                      fisokin*(akh(4)*ckh(4)*(two*normxx + normyy)*dlam - ckh(4)*sigb(i,10)*ddep)
                     sigb(i,11) = sigb(i,11) +                                      &
-                      fisokin*(akh(4)*ckh(4)*normyy*dlam - ckh(4)*sigb(i,11)*ddep)
+                      fisokin*(akh(4)*ckh(4)*(two*normyy + normxx)*dlam - ckh(4)*sigb(i,11)*ddep)
                     sigb(i,12) = sigb(i,12) +                                      &
                       fisokin*(akh(4)*ckh(4)*normxy*dlam - ckh(4)*sigb(i,12)*ddep)
                     !<  -> Prager kinematic hardening

--- a/engine/source/materials/mat/mat087/mat87c_tabulated_3dir_ortho.F90
+++ b/engine/source/materials/mat/mat087/mat87c_tabulated_3dir_ortho.F90
@@ -409,20 +409,6 @@
           !=========================================================================
           if (nindx > 0) then
 !
-            !< Computation of the derivative of backstress tensor w.r.t pl. strain
-            if ((ikin == 1).and.(fisokin > zero)) then
-#include "vectorize.inc"
-              do ii = 1, nindx
-                i = indx(ii)
-                dsigbxxdp(i) = ckh(1)*sigb(i,1) + ckh(2)*sigb(i,4) +               &
-                  ckh(3)*sigb(i,7) + ckh(4)*sigb(i,10)
-                dsigbyydp(i) = ckh(1)*sigb(i,2) + ckh(2)*sigb(i,5) +               &
-                  ckh(3)*sigb(i,8) + ckh(4)*sigb(i,11)
-                dsigbxydp(i) = ckh(1)*sigb(i,3) + ckh(2)*sigb(i,6) +               &
-                  ckh(3)*sigb(i,9) + ckh(4)*sigb(i,12)
-              end do
-            end if
-!
             !< Loop over the iterations
             do iter = 1, niter
 #include "vectorize.inc"
@@ -574,8 +560,14 @@
                 if (fisokin > zero) then
                   !<  -> Chaboche-Rousselier kinematic hardening
                   if (ikin == 1) then
-                    dsigbxxdlam = fisokin*(akck*normxx - dsigbxxdp(i)*dpladlam)
-                    dsigbyydlam = fisokin*(akck*normyy - dsigbyydp(i)*dpladlam)
+                    dsigbxxdp(i) = ckh(1)*sigb(i,1) + ckh(2)*sigb(i,4) +         &
+                                   ckh(3)*sigb(i,7) + ckh(4)*sigb(i,10)
+                    dsigbyydp(i) = ckh(1)*sigb(i,2) + ckh(2)*sigb(i,5) +         &
+                                   ckh(3)*sigb(i,8) + ckh(4)*sigb(i,11)
+                    dsigbxydp(i) = ckh(1)*sigb(i,3) + ckh(2)*sigb(i,6) +         &
+                                   ckh(3)*sigb(i,9) + ckh(4)*sigb(i,12)
+                    dsigbxxdlam = fisokin*(akck*(two*normxx + normyy) - dsigbxxdp(i)*dpladlam)
+                    dsigbyydlam = fisokin*(akck*(two*normyy + normxx) - dsigbyydp(i)*dpladlam)
                     dsigbxydlam = fisokin*(akck*normxy - dsigbxydp(i)*dpladlam)
                     !<  -> Prager kinematic hardening
                   else if (ikin == 2) then
@@ -639,27 +631,27 @@
                   if (ikin == 1) then
                     ! -> Update the all set of backstresses components
                     sigb(i, 1) = sigb(i, 1) +                                      &
-                      fisokin*(akh(1)*ckh(1)*normxx*dlam  - ckh(1)*sigb(i,1)*ddep)
+                      fisokin*(akh(1)*ckh(1)*(two*normxx + normyy)*dlam  - ckh(1)*sigb(i,1)*ddep)
                     sigb(i, 2) = sigb(i, 2) +                                      &
-                      fisokin*(akh(1)*ckh(1)*normyy*dlam  - ckh(1)*sigb(i,2)*ddep)
+                      fisokin*(akh(1)*ckh(1)*(two*normyy + normxx)*dlam  - ckh(1)*sigb(i,2)*ddep)
                     sigb(i, 3) = sigb(i, 3) +                                      &
                       fisokin*(akh(1)*ckh(1)*normxy*dlam  - ckh(1)*sigb(i,3)*ddep)
                     sigb(i, 4) = sigb(i, 4) +                                      &
-                      fisokin*(akh(2)*ckh(2)*normxx*dlam  - ckh(2)*sigb(i,4)*ddep)
+                      fisokin*(akh(2)*ckh(2)*(two*normxx + normyy)*dlam  - ckh(2)*sigb(i,4)*ddep)
                     sigb(i, 5) = sigb(i, 5) +                                      &
-                      fisokin*(akh(2)*ckh(2)*normyy*dlam  - ckh(2)*sigb(i,5)*ddep)
+                      fisokin*(akh(2)*ckh(2)*(two*normyy + normxx)*dlam  - ckh(2)*sigb(i,5)*ddep)
                     sigb(i, 6) = sigb(i, 6) +                                      &
                       fisokin*(akh(2)*ckh(2)*normxy*dlam  - ckh(2)*sigb(i,6)*ddep)
                     sigb(i, 7) = sigb(i, 7) +                                      &
-                      fisokin*(akh(3)*ckh(3)*normxx*dlam  - ckh(3)*sigb(i,7)*ddep)
+                      fisokin*(akh(3)*ckh(3)*(two*normxx + normyy)*dlam  - ckh(3)*sigb(i,7)*ddep)
                     sigb(i, 8) = sigb(i, 8) +                                      &
-                      fisokin*(akh(3)*ckh(3)*normyy*dlam  - ckh(3)*sigb(i,8)*ddep)
+                      fisokin*(akh(3)*ckh(3)*(two*normyy + normxx)*dlam  - ckh(3)*sigb(i,8)*ddep)
                     sigb(i, 9) = sigb(i, 9) +                                      &
                       fisokin*(akh(3)*ckh(3)*normxy*dlam  - ckh(3)*sigb(i,9)*ddep)
                     sigb(i,10) = sigb(i,10) +                                      &
-                      fisokin*(akh(4)*ckh(4)*normxx*dlam - ckh(4)*sigb(i,10)*ddep)
+                      fisokin*(akh(4)*ckh(4)*(two*normxx + normyy)*dlam - ckh(4)*sigb(i,10)*ddep)
                     sigb(i,11) = sigb(i,11) +                                      &
-                      fisokin*(akh(4)*ckh(4)*normyy*dlam - ckh(4)*sigb(i,11)*ddep)
+                      fisokin*(akh(4)*ckh(4)*(two*normyy + normxx)*dlam - ckh(4)*sigb(i,11)*ddep)
                     sigb(i,12) = sigb(i,12) +                                      &
                       fisokin*(akh(4)*ckh(4)*normxy*dlam - ckh(4)*sigb(i,12)*ddep)
                     !<  -> Prager kinematic hardening

--- a/starter/source/materials/mat/mat087/hm_read_mat87.F90
+++ b/starter/source/materials/mat/mat087/hm_read_mat87.F90
@@ -100,7 +100,7 @@
 !                                                   local variables
 ! ----------------------------------------------------------------------------------------------------------------------
           integer :: i,iflagsr,iflag,flag_fit,ilaw,nrate,offset,         &
-            ierr2,ifunc(maxfunc),itable(3),ikin,info
+            ierr2,ifunc(maxfunc),itable(3),ikin,info,ifunc_id(maxfunc)
           real(kind=WP) :: e,nu,g,bulk,fcut,al1,al2,al3,al4,al5,al6,al7,al8,           &
             fisokin,invp,invc,unspt,unsct,aswift,epso,qvoce,beta,           &
             ko,alpha,nexp,unsp,unsc,rho0,rhor,rate(maxfunc),yfac(maxfunc),       &
@@ -255,6 +255,8 @@
                 end if
               end do
             end if
+            !< Save user id for output
+            ifunc_id(1:maxfunc) = ifunc(1:maxfunc)
             !< - Swift-Voce
           else if (iflag == 1) then
             !< Yield criterion exponent
@@ -640,7 +642,7 @@
             end if
             if (iflag == 0) then
               write(iout,1007) nrate
-              if (nrate>0) write(iout,1008)(ifunc(i),yfac(i),rate(i),i=1,nrate)
+              if (nrate>0) write(iout,1008)(ifunc_id(i),yfac(i),rate(i),i=1,nrate)
             else if (iflag == 1) then
               write(iout,1009) invp,invc,qvoce,beta,ko,alpha,aswift,nexp,epso
             else if (iflag == 2) then


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

It was detected that Chaboche Rousselier kinematic hardening in /MAT/LAW87 was not fullfiling the plane stress assumption, and some typo issue in function ID in the starter. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

Add the plane stress condition in Chaboche kinematic hardening + fix the typo issue

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
