### PR TITLE
Move Chaboche derivatives in /MAT/LAW87

### DIFF
--- a/engine/source/materials/mat/mat087/mat87c_hansel.F90
+++ b/engine/source/materials/mat/mat087/mat87c_hansel.F90
@@ -346,6 +346,20 @@
           !=========================================================================
           if (nindx > 0) then
 !
+            !< Computation of the derivative of backstress tensor w.r.t pl. strain
+            if ((ikin == 1).and.(fisokin > zero)) then
+#include "vectorize.inc"
+              do ii = 1, nindx
+                i = indx(ii)
+                dsigbxxdp(i) = ckh(1)*sigb(i,1) + ckh(2)*sigb(i,4) +               &
+                  ckh(3)*sigb(i,7) + ckh(4)*sigb(i,10)
+                dsigbyydp(i) = ckh(1)*sigb(i,2) + ckh(2)*sigb(i,5) +               &
+                  ckh(3)*sigb(i,8) + ckh(4)*sigb(i,11)
+                dsigbxydp(i) = ckh(1)*sigb(i,3) + ckh(2)*sigb(i,6) +               &
+                  ckh(3)*sigb(i,9) + ckh(4)*sigb(i,12)
+              end do
+            end if
+!
             !< Loop over the iterations
             do iter = 1, niter
 #include "vectorize.inc"
@@ -487,12 +501,6 @@
                 if (fisokin > zero) then
                   !<  -> Chaboche-Rousselier kinematic hardening
                   if (ikin == 1) then
-                    dsigbxxdp(i) = ckh(1)*sigb(i,1) + ckh(2)*sigb(i,4) +         &
-                                   ckh(3)*sigb(i,7) + ckh(4)*sigb(i,10)
-                    dsigbyydp(i) = ckh(1)*sigb(i,2) + ckh(2)*sigb(i,5) +         &
-                                   ckh(3)*sigb(i,8) + ckh(4)*sigb(i,11)
-                    dsigbxydp(i) = ckh(1)*sigb(i,3) + ckh(2)*sigb(i,6) +         &
-                                   ckh(3)*sigb(i,9) + ckh(4)*sigb(i,12)
                     dsigbxxdlam = fisokin*(akck*(two*normxx + normyy) - dsigbxxdp(i)*dpladlam)
                     dsigbyydlam = fisokin*(akck*(two*normyy + normxx) - dsigbyydp(i)*dpladlam)
                     dsigbxydlam = fisokin*(akck*normxy - dsigbxydp(i)*dpladlam)

--- a/engine/source/materials/mat/mat087/mat87c_swift_voce.F90
+++ b/engine/source/materials/mat/mat087/mat87c_swift_voce.F90
@@ -344,6 +344,20 @@
           !=========================================================================
           if (nindx > 0) then
 !
+            !< Computation of the derivative of backstress tensor w.r.t pl. strain
+            if ((ikin == 1).and.(fisokin > zero)) then
+#include "vectorize.inc"
+              do ii = 1, nindx
+                i = indx(ii)
+                dsigbxxdp(i) = ckh(1)*sigb(i,1) + ckh(2)*sigb(i,4) +               &
+                  ckh(3)*sigb(i,7) + ckh(4)*sigb(i,10)
+                dsigbyydp(i) = ckh(1)*sigb(i,2) + ckh(2)*sigb(i,5) +               &
+                  ckh(3)*sigb(i,8) + ckh(4)*sigb(i,11)
+                dsigbxydp(i) = ckh(1)*sigb(i,3) + ckh(2)*sigb(i,6) +               &
+                  ckh(3)*sigb(i,9) + ckh(4)*sigb(i,12)
+              end do
+            end if
+!
             !< Loop over the iterations
             do iter = 1, niter
 #include "vectorize.inc"
@@ -485,12 +499,6 @@
                 if (fisokin > zero) then
                   !<  -> Chaboche-Rousselier kinematic hardening
                   if (ikin == 1) then
-                    dsigbxxdp(i) = ckh(1)*sigb(i,1) + ckh(2)*sigb(i,4) +         &
-                                   ckh(3)*sigb(i,7) + ckh(4)*sigb(i,10)
-                    dsigbyydp(i) = ckh(1)*sigb(i,2) + ckh(2)*sigb(i,5) +         &
-                                   ckh(3)*sigb(i,8) + ckh(4)*sigb(i,11)
-                    dsigbxydp(i) = ckh(1)*sigb(i,3) + ckh(2)*sigb(i,6) +         &
-                                   ckh(3)*sigb(i,9) + ckh(4)*sigb(i,12)
                     dsigbxxdlam = fisokin*(akck*(two*normxx + normyy) - dsigbxxdp(i)*dpladlam)
                     dsigbyydlam = fisokin*(akck*(two*normyy + normxx) - dsigbyydp(i)*dpladlam)
                     dsigbxydlam = fisokin*(akck*normxy - dsigbxydp(i)*dpladlam)

--- a/engine/source/materials/mat/mat087/mat87c_tabulated.F90
+++ b/engine/source/materials/mat/mat087/mat87c_tabulated.F90
@@ -329,6 +329,20 @@
           !=========================================================================
           if (nindx > 0) then
 !
+            !< Computation of the derivative of backstress tensor w.r.t pl. strain
+            if ((ikin == 1).and.(fisokin > zero)) then
+#include "vectorize.inc"
+              do ii = 1, nindx
+                i = indx(ii)
+                dsigbxxdp(i) = ckh(1)*sigb(i,1) + ckh(2)*sigb(i,4) +               &
+                  ckh(3)*sigb(i,7) + ckh(4)*sigb(i,10)
+                dsigbyydp(i) = ckh(1)*sigb(i,2) + ckh(2)*sigb(i,5) +               &
+                  ckh(3)*sigb(i,8) + ckh(4)*sigb(i,11)
+                dsigbxydp(i) = ckh(1)*sigb(i,3) + ckh(2)*sigb(i,6) +               &
+                  ckh(3)*sigb(i,9) + ckh(4)*sigb(i,12)
+              end do
+            end if
+!
             !< Loop over the iterations
             do iter = 1, niter
 #include "vectorize.inc"
@@ -470,12 +484,6 @@
                 if (fisokin > zero) then
                   !<  -> Chaboche-Rousselier kinematic hardening
                   if (ikin == 1) then
-                    dsigbxxdp(i) = ckh(1)*sigb(i,1) + ckh(2)*sigb(i,4) +         &
-                                   ckh(3)*sigb(i,7) + ckh(4)*sigb(i,10)
-                    dsigbyydp(i) = ckh(1)*sigb(i,2) + ckh(2)*sigb(i,5) +         &
-                                   ckh(3)*sigb(i,8) + ckh(4)*sigb(i,11)
-                    dsigbxydp(i) = ckh(1)*sigb(i,3) + ckh(2)*sigb(i,6) +         &
-                                   ckh(3)*sigb(i,9) + ckh(4)*sigb(i,12)
                     dsigbxxdlam = fisokin*(akck*(two*normxx + normyy) - dsigbxxdp(i)*dpladlam)
                     dsigbyydlam = fisokin*(akck*(two*normyy + normxx) - dsigbyydp(i)*dpladlam)
                     dsigbxydlam = fisokin*(akck*normxy - dsigbxydp(i)*dpladlam)

--- a/engine/source/materials/mat/mat087/mat87c_tabulated_3dir_ortho.F90
+++ b/engine/source/materials/mat/mat087/mat87c_tabulated_3dir_ortho.F90
@@ -409,6 +409,20 @@
           !=========================================================================
           if (nindx > 0) then
 !
+            !< Computation of the derivative of backstress tensor w.r.t pl. strain
+            if ((ikin == 1).and.(fisokin > zero)) then
+#include "vectorize.inc"
+              do ii = 1, nindx
+                i = indx(ii)
+                dsigbxxdp(i) = ckh(1)*sigb(i,1) + ckh(2)*sigb(i,4) +               &
+                  ckh(3)*sigb(i,7) + ckh(4)*sigb(i,10)
+                dsigbyydp(i) = ckh(1)*sigb(i,2) + ckh(2)*sigb(i,5) +               &
+                  ckh(3)*sigb(i,8) + ckh(4)*sigb(i,11)
+                dsigbxydp(i) = ckh(1)*sigb(i,3) + ckh(2)*sigb(i,6) +               &
+                  ckh(3)*sigb(i,9) + ckh(4)*sigb(i,12)
+              end do
+            end if
+!
             !< Loop over the iterations
             do iter = 1, niter
 #include "vectorize.inc"
@@ -560,12 +574,6 @@
                 if (fisokin > zero) then
                   !<  -> Chaboche-Rousselier kinematic hardening
                   if (ikin == 1) then
-                    dsigbxxdp(i) = ckh(1)*sigb(i,1) + ckh(2)*sigb(i,4) +         &
-                                   ckh(3)*sigb(i,7) + ckh(4)*sigb(i,10)
-                    dsigbyydp(i) = ckh(1)*sigb(i,2) + ckh(2)*sigb(i,5) +         &
-                                   ckh(3)*sigb(i,8) + ckh(4)*sigb(i,11)
-                    dsigbxydp(i) = ckh(1)*sigb(i,3) + ckh(2)*sigb(i,6) +         &
-                                   ckh(3)*sigb(i,9) + ckh(4)*sigb(i,12)
                     dsigbxxdlam = fisokin*(akck*(two*normxx + normyy) - dsigbxxdp(i)*dpladlam)
                     dsigbyydlam = fisokin*(akck*(two*normyy + normxx) - dsigbyydp(i)*dpladlam)
                     dsigbxydlam = fisokin*(akck*normxy - dsigbxydp(i)*dpladlam)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

Recently added modification for plane stress condition in Chaboche kinematic hardening may affect the results convergence in time. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

Re-move the derivative of some variables outside the iterative procedure. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
