### PR TITLE
Fix strain tensor output for ANIM with Itet4=3

### DIFF
--- a/engine/source/output/anim/generate/tensor6.F
+++ b/engine/source/output/anim/generate/tensor6.F
@@ -276,7 +276,7 @@ c-----------
                 ENDDO
               ENDIF
 c-----------
-            ELSEIF ((ISOLNOD==8 .OR. (ISOLNOD == 4 .AND. ISROT==0)) .AND. NPT==1 .AND. JHBE /= 14 .AND. JHBE /= 15) THEN
+            ELSEIF ((ISOLNOD==8 .OR. (ISOLNOD == 4 .AND. (ISROT==0 .OR. ISROT == 3))) .AND. NPT==1 .AND. JHBE /= 14 .AND. JHBE /= 15) THEN
               LBUF => ELBUF_TAB(NG)%BUFLY(1)%LBUF(1,1,1)                                           
               IF (ISORTH > 0) ISORTHG = 1
               IF (MLW>=28.AND.MLW /= 49) THEN
@@ -932,7 +932,7 @@ C-----------------------------------------------
               EVAR(6,I) = ZERO
             ENDDO
 c-----------
-            IF ((ISOLNOD == 8 .OR. (ISOLNOD == 4 .AND. ISROT == 0)) .AND. NPT == 1 .AND. JHBE /= 14   .AND. JHBE /= 15) THEN
+            IF ((ISOLNOD == 8 .OR. (ISOLNOD == 4 .AND. (ISROT==0 .OR. ISROT == 3))) .AND. NPT == 1 .AND. JHBE /= 14   .AND. JHBE /= 15) THEN
 c-----------
               LBUF => ELBUF_TAB(NG)%BUFLY(1)%LBUF(1,1,1)                                           
               IF (ISORTH > 0) ISORTHG = 1
@@ -2043,7 +2043,7 @@ C-----------------------------------------------
                 ENDDO
               ENDIF
 c-----------
-            ELSEIF ((ISOLNOD == 8 .OR. NPT == 1 .OR. (ISOLNOD == 4 .AND. ISROT == 0)) .AND.
+            ELSEIF ((ISOLNOD == 8 .OR. NPT == 1 .OR. (ISOLNOD == 4 .AND. (ISROT==0 .OR. ISROT == 3))) .AND.
      .               JHBE /= 14 .AND. JHBE /= 15 .AND. JHBE /= 17) THEN
 c-----------
               IR=ABS(PTI)/100


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

Strain tensor output was not working when using ANIM files with Itet4=3 flag for tetraedron. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

Allow the output with ISROT (ITET4) = 3. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
