### PR TITLE
Cleaning reset of PNEW array in mqviscb

### DIFF
--- a/engine/source/materials/mat_share/mmain.F90
+++ b/engine/source/materials/mat_share/mmain.F90
@@ -1760,7 +1760,7 @@
               &dt2t,     neltst,   ityptst,  aire,&
               &lbuf%off, geo,      pid,      voln,&
               &vd2,      deltax,   vis,      dxx,&
-              &dyy,      dzz,      pnew,     psh,&
+              &dyy,      dzz,      psh,&
               &mat,      ngl,      qvis,     ssp_eq,&
               &xk,       nel,      ity,      ismstr,&
               &jtur,     jthe)

--- a/engine/source/materials/mat_share/mqvisc26.F
+++ b/engine/source/materials/mat_share/mqvisc26.F
@@ -31,7 +31,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      3   DT2T,    NELTST,  ITYPTST, AIRE,
      4   OFFG,    GEO,     PID,     VOL,
      5   VD2,     DELTAX,  VIS,     D1,
-     6   D2,      D3,      PNEW,    PSH,
+     6   D2,      D3,      PSH,
      7   MAT,     NGL,     QVIS,    SSP_EQ,
      8   XK,      NEL,     ITY,     ISMSTR,
      9   JTUR,    JTHE)
@@ -72,7 +72,7 @@ C-----------------------------------------------
      .   PM(NPROPM,*), OFF(*), RHO(*), RK(*), T(*), RE(*),STI(*),
      .   OFFG(*),GEO(NPROPG,*),
      .   VOL(*), VD2(*), DELTAX(*), SSP(*), AIRE(*), VIS(*), 
-     .   PSH(*), PNEW(*),QVIS(*) ,SSP_EQ(*), 
+     .   PSH(*), QVIS(*) ,SSP_EQ(*),
      .   D1(*), D2(*), D3(*), XK(*)
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
@@ -138,7 +138,6 @@ C
         DO I=1,NEL
           CNS2=GEO(17,MX)*SSP(I)*AL(I)*RHO(I)
           PSH(I)=PM(88,MT)
-          PNEW(I)=0.
           QAA = QA*QA*AD(I)
           QX(I)=(QB+CNS1)*SSP(I)+AL(I) * QAA
      .     + VISI*(TWO*VIS(I)+CNS2) / MAX(EM20,RHO(I)*DELTAX(I))
@@ -152,7 +151,6 @@ C
         DO I=1,NEL
           CNS2=PM(94,MT)*SSP(I)*AL(I)*RHO(I)
           PSH(I)=PM(88,MT)
-          PNEW(I)=0.
           QAA = QA*QA*AD(I)
           QX(I)=(QB+CNS1)*SSP(I)+DELTAX(I) *QAA
      .     + VISI*(2.*VIS(I)+CNS2) / MAX(EM20,RHO(I)*DELTAX(I))

--- a/engine/source/materials/mat_share/mqviscb.F
+++ b/engine/source/materials/mat_share/mqviscb.F
@@ -202,7 +202,6 @@ C
         CNS1_0=FACPG*GEO(16,PID(1))
         CNS2_0=FACPG*GEO(17,PID(1))
         PSH(1:NEL)=PM(88,MT)
-        PNEW(1:NEL)=ZERO
         QAA_0 = QA*QA
         DTMIN(1:NEL) = GEO(172,PID(1)) 
         DO I=1,NEL
@@ -228,7 +227,6 @@ C           Same for VIS(I) since SOUNDSPEED is generally computed wrt RHO0, not
         QA =FACQ*GEO(14,PID(1))
         QB =FACQ*GEO(15,PID(1))
         PSH(1:NEL)=PM(88,MT)
-        PNEW(1:NEL)=ZERO
         QAA_0 = QA*QA
         DTMIN(1:NEL) = GEO(172,PID(1)) 
 


### PR DESCRIPTION
#### removing reset of PNEW array in mqviscb

#### Description of the changes
Resetting the _PNEW(:)_ array in _mqviscb_ subroutine is no longer necessary, since no equation of state (EoS) uses an incremental formulation anymore.
