### PR TITLE
/EOS/COMPACTION_TAB : increasing maximum number of iterations for fixed point method

### DIFF
--- a/common_source/eos/compaction_tab.F90
+++ b/common_source/eos/compaction_tab.F90
@@ -148,7 +148,7 @@
        iform          = eos_struct%iparam(1)
        plasexp        = eos_struct%iparam(2)
 
-       niter = 20
+       niter = 30
        tol = em06
        IF(DT1 == zero) call compaction_tab_init(eos_struct,nel,nvartmp,vartmp,nvareos,vareos,rho,rho_tmd) ! initial condition : set vereos(1:nel,:)
 


### PR DESCRIPTION
#### Description of the feature or the bug
/EOS/COMPACTION_TAB : increasing maximum number of iterations for fixed point method

#### Description of the changes
The tabulated compaction EoS is ised to model soil such as sand.
In multimaterial-ALE formulation increasing the maximum number of iteration is recommanded to to get better pressure equilibrium between the submaterial sharing a given cell.

In this simulation below with Sjöbo dry sand model the feedback is to improve the iteration number :
<img width="400" height="250" alt="image" src="https://github.com/user-attachments/assets/a6a07cee-24e7-4062-ad4b-06591a000a75" />

Sjöbo dry Sand material parameters and EoS description : https://github.com/OpenRadioss/OpenRadioss/pull/3712
input file for simulation above : [validation_test.zip](https://github.com/user-attachments/files/26220918/validation_test.zip)

