### PR TITLE
Sorting Algorithm performance for Eikonal solver initialization (SPMD)

### DIFF
--- a/common_source/tools/sort/insertion_sort.F90
+++ b/common_source/tools/sort/insertion_sort.F90
@@ -35,6 +35,8 @@
         ! insertion sort for real and integer arrays
         !    index array allows to determine the bijection between unsorted and sorted arrays
 
+        ! With long lists (n > ~1000) use stlsort
+
       implicit none
 
       contains

--- a/common_source/tools/sort/myqsort.F
+++ b/common_source/tools/sort/myqsort.F
@@ -62,20 +62,17 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-        INTEGER N,ERROR,PERM(N)
-C     REAL
-        my_real
-     .    A(N)
+        INTEGER,INTENT(IN) :: N           !< list size
+        INTEGER,INTENT(INOUT) :: ERROR    !< error code: 0 if no error, -1 if N < 1
+        INTEGER,INTENT(INOUT) :: PERM(N)  !< permutations indexes of the sorted list
+        my_real, INTENT(INOUT) :: A(N)    !< list to be sorted
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
         INTEGER :: STACKLEN
         INTEGER :: TRESHOLD
+        PARAMETER( STACKLEN = 128 ,TRESHOLD = 9 ) ! the max STACKLEN <= 1 + 2 x log2 (N+1)/(TRESHOLD + 2)
         INTEGER :: DONE
-C the max STACKLEN <= 1 + 2 x log2 (N+1)/(TRESHOLD + 2)
-        PARAMETER( STACKLEN = 128 ,
-     .             TRESHOLD   =  9 )
-C
         INTEGER :: I
         INTEGER :: IPLUS1
         INTEGER :: J
@@ -87,12 +84,10 @@ C
         INTEGER :: RLEN
         INTEGER :: TOP
         INTEGER :: STACK(STACKLEN)
-C     REAL
-        my_real
-     .          RK, RV
-C
+        my_real :: RK, RV
+C-----------------------------------------------
         ERROR = 0
-C
+
         IF  (N < 1)  THEN
           ERROR = -1
           RETURN
@@ -106,7 +101,7 @@ C
         DO  I = 1, N
           PERM(I) = I
         ENDDO
-C
+
         TOP = 1
         LEFT = 1
         RIGHT = N
@@ -116,13 +111,11 @@ C
           DONE = 0
         ENDIF
 
-c     QUICKSORT
-c
+       ! QUICKSORT
         DO WHILE (DONE /= 1)
           RK = A((LEFT+RIGHT)/2)
           A((LEFT+RIGHT)/2) = A(LEFT)
           A(LEFT) = RK
-C
           K = PERM((LEFT+RIGHT)/2)
           PERM((LEFT+RIGHT)/2) = PERM(LEFT)
           PERM(LEFT) = K
@@ -174,15 +167,15 @@ C
               PERM(J) = K
             ENDIF
           ENDDO
-C
+
           RK = A(LEFT)
           A(LEFT) = A(J)
           A(J) = RK
-C
+
           K = PERM(LEFT)
           PERM(LEFT) = PERM(J)
           PERM(J) = K
-C
+
           LLEN = J-LEFT
           RLEN = RIGHT - I + 1
 
@@ -213,9 +206,8 @@ C
             TOP = TOP + 2
           ENDIF
         END DO
-c
-c     INSERTION SORT
-c
+
+        ! INSERTION SORT
         I = N - 1
         IPLUS1 = N
         DO WHILE (I > 0)
@@ -234,13 +226,10 @@ c
             A(JMINUS1) = RK
             PERM(JMINUS1) = K
           ENDIF
-C
           IPLUS1 = I
           I = I - 1
         ENDDO
-c
+
         RETURN
-c
-c     -------------------
-c
+C-----------------------------------------------
       end

--- a/common_source/tools/sort/myqsort_int.F
+++ b/common_source/tools/sort/myqsort_int.F
@@ -43,21 +43,19 @@ C   I m p l i c i t   T y p e s
 C-----------------------------------------------
 #include      "implicit_f.inc"
 C-----------------------------------------------
-C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-        INTEGER N,ERROR,PERM(N)
-        INTEGER :: A(N)
+        INTEGER,INTENT(IN) :: N           !< list size
+        INTEGER,INTENT(INOUT) :: ERROR    !< error code: 0 if no error, -1 if N < 1
+        INTEGER,INTENT(OUT) :: PERM(N)  !< permutations indexes of the sorted list
+        INTEGER,INTENT(OUT) :: A(N)     !< integer list to be sorted
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
         INTEGER :: STACKLEN
         INTEGER :: TRESHOLD
+        PARAMETER( STACKLEN = 128, TRESHOLD =  9 ) !the max STACKLEN <= 1 + 2 x log2 (N+1)/(TRESHOLD + 2)
         INTEGER :: DONE
-C the max STACKLEN <= 1 + 2 x log2 (N+1)/(TRESHOLD + 2)
-        PARAMETER( STACKLEN = 128 ,
-     .             TRESHOLD   =  9 )
-C
         INTEGER :: I
         INTEGER :: IPLUS1
         INTEGER :: J
@@ -69,12 +67,10 @@ C
         INTEGER :: RLEN
         INTEGER :: TOP
         INTEGER :: STACK(STACKLEN)
-C     REAL ou REAL*8
-        my_real
-     .          RK, RV
-C
+        my_real :: RK, RV
+
         ERROR = 0
-C
+
         IF  (N < 1)  THEN
           ERROR = -1
           RETURN
@@ -88,7 +84,7 @@ C
         DO  I = 1, N
           PERM(I) = I
         ENDDO
-C
+
         TOP = 1
         LEFT = 1
         RIGHT = N
@@ -98,13 +94,12 @@ C
           DONE = 0
         ENDIF
 
-c     QUICKSORT
-c
+        ! QUICKSORT
         DO WHILE (DONE /= 1)
           RK = A((LEFT+RIGHT)/2)
           A((LEFT+RIGHT)/2) = A(LEFT)
           A(LEFT) = RK
-C
+
           K = PERM((LEFT+RIGHT)/2)
           PERM((LEFT+RIGHT)/2) = PERM(LEFT)
           PERM(LEFT) = K
@@ -156,15 +151,15 @@ C
               PERM(J) = K
             ENDIF
           ENDDO
-C
+
           RK = A(LEFT)
           A(LEFT) = A(J)
           A(J) = RK
-C
+
           K = PERM(LEFT)
           PERM(LEFT) = PERM(J)
           PERM(J) = K
-C
+
           LLEN = J-LEFT
           RLEN = RIGHT - I + 1
 
@@ -195,9 +190,8 @@ C
             TOP = TOP + 2
           ENDIF
         END DO
-c
-c     INSERTION SORT
-c
+
+        ! INSERTION SORT
         I = N - 1
         IPLUS1 = N
         DO WHILE (I > 0)
@@ -216,13 +210,11 @@ c
             A(JMINUS1) = RK
             PERM(JMINUS1) = K
           ENDIF
-C
+
           IPLUS1 = I
           I = I - 1
         ENDDO
-c
+
         RETURN
-c
-c     -------------------
-c
+C-----------------------------------------------
       end

--- a/starter/source/initial_conditions/detonation/eikonal_init_sorting.F90
+++ b/starter/source/initial_conditions/detonation/eikonal_init_sorting.F90
@@ -40,7 +40,6 @@
 !                                                   Modules
 ! ----------------------------------------------------------------------------------------------------------------------
           use constant_mod, only : zero, ep21
-          use insertion_sort_mod , only : integer_insertion_sort_with_index
           use precision_mod, only : WP
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Implicit none
@@ -73,7 +72,7 @@
           allocate(indx(neldet))
 
           indx(1:neldet) = [(kk, kk=1,neldet)]
-          call integer_insertion_sort_with_index(uelem_list, indx, neldet)
+          call stlsort_int_int(neldet, indx, uelem_list)
 
           !sort other arrays with same order usin indx array
           int_tmp_array(:)  = elem_list(:)     ; elem_list(:)    = int_tmp_array(indx(:))


### PR DESCRIPTION
#### Sorting Algorithm performance for Eikonal solver initialization (SPMD)

#### Description of the changes
Fix performance issue in SPMD (sorting).

With nspmd > 1, sorting time increased by up to +340% on a 0.5M-element simulation (Starter elapsed time: **nspmd=01 4.7 s** → **nspmd=02 20.7 s**). This was explained by the input list almost already sorted with nspmd=01. Replaced the previous sorting routine with STL introsort algorithm. Sorting is now fast when running Starter with nspmd > 1.

Performance verification (Total Starter elapsed time):

nspmd=01: 4.3 s
nspmd=02: 4.4 s
nspmd=03: 4.4 s
nspmd=24: 4.7 s

Elapsed times are now comparable

verification nspmd = 2
<img width="511" height="189" alt="image" src="https://github.com/user-attachments/assets/debcaba1-455d-48e5-81d4-f0dd5d4ec8f6" />

