### PR TITLE
Initialize R0 to 0 to avoid compiler-dependent uninitialized state

### DIFF
--- a/starter/source/initial_conditions/detonation/read_dfs_detpoint.F
+++ b/starter/source/initial_conditions/detonation/read_dfs_detpoint.F
@@ -143,6 +143,7 @@ C-----------------------------------------------
           YC=ZERO
           ZC=ZERO
         ELSE
+          R0 = ZERO
           I_SHADOW = 0
           MSG_C2 = '/DFS/DETPOINT'
           CALL HM_GET_FLOATV('rad_det_locationA_X', XC, IS_AVAILABLE, LSUBMODEL, UNITAB)


### PR DESCRIPTION
#### Initialize R0 to 0 to avoid compiler-dependent uninitialized state

#### Description of the changes
As introduced in 147319577f76c812a97c66a3b72d997d74c1cb0e, R0 must be explicitly set to 0 since some compilers do not guarantee default initialization, which may result in undefined or non-reproducible behavior.