### PR TITLE
/EOS/TILLOTSON : fix for unit translation (Vs)

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2026/MAT/mat_EOS.cfg
+++ b/hm_cfg_files/config/CFG/radioss2026/MAT/mat_EOS.cfg
@@ -245,7 +245,7 @@ GUI(COMMON) {
         SCALAR(MAT_B)         { DIMENSION="DIMENSIONLESS"; }
         SCALAR(E_R)           { DIMENSION="energydensity"; }
         SCALAR(E_S)           { DIMENSION="energydensity"; }
-        SCALAR(Vs)            { DIMENSION="volume"; }
+        SCALAR(Vs)            { DIMENSION="DIMENSIONLESS"; }
         SCALAR(MAT_EA)        { DIMENSION="energydensity"; }
         SCALAR(Refer_Rho)     { DIMENSION="density"; }
         SCALAR(Alpha)         { DIMENSION="DIMENSIONLESS"; }


### PR DESCRIPTION
#### /EOS/TILLOTSON : fix for unit translation (Vs)

#### Description of the changes
Parameter “Vs” is unitless. When using /EOS/TILLOTSON with a defined unit system, it must not be converted, as it represents a relative volume.


<img width="750" height="260" alt="image" src="https://github.com/user-attachments/assets/e2aecb5d-1973-4bfc-9995-a7ec94e9841e" />
