### PR TITLE
/PART with Irigid , create /RBODY 

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2612/PART/part.cfg
+++ b/hm_cfg_files/config/CFG/radioss2612/PART/part.cfg
@@ -1,0 +1,86 @@
+//Copyright>    CFG Files and Library ("CFG")
+//Copyright>    Copyright (C) 1986-2026 Altair Engineering Inc.
+//Copyright>
+//Copyright>    Altair Engineering Inc. grants to third parties limited permission to
+//Copyright>    use and modify CFG solely in connection with OpenRadioss software, provided
+//Copyright>    that any modification to CFG by a third party must be provided back to
+//Copyright>    Altair Engineering Inc. and shall be deemed a Contribution under and therefore
+//Copyright>    subject to the CONTRIBUTOR LICENSE AGREEMENT for OpenRadioss software.
+//Copyright>
+//Copyright>    CFG IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//Copyright>    INCLUDING, BUT NOT LIMITED TO, THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+//Copyright>    A PARTICULAR PURPOSE, AND NONINFRINGEMENT.  IN NO EVENT SHALL ALTAIR ENGINEERING
+//Copyright>    INC. OR ITS AFFILIATES BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY,
+//Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
+//Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
+//
+// Part Setup File
+// 
+
+ATTRIBUTES {
+  materialid = VALUE(MATERIAL, "Material");
+  propertyid = VALUE(PROPERTY,"Property");
+  subsetid = VALUE(ASSEMBLY,"Subset");
+  THICK = VALUE(FLOAT,"Thickness");
+  IRIGID = VALUE(INT, "");
+  TITLE = VALUE(STRING, "");
+  Node_ID = VALUE(NODE, "Node ID");
+  Skew_ID = VALUE(SYSTEM, "Skew ID");
+  Mass = VALUE(FLOAT, "Mass");
+  Sens_ID = VALUE(SENSOR, "Sensitivity ID");
+  JXX = VALUE(FLOAT, "Jxx");
+  JYY = VALUE(FLOAT, "Jyy");
+  JZZ = VALUE(FLOAT, "Jzz");
+  JXY = VALUE(FLOAT, "Jxy");
+  JYZ = VALUE(FLOAT, "Jyz");
+  JXZ = VALUE(FLOAT, "Jxz");
+}
+
+GUI(COMMON) {
+  optional:  
+  SCALAR(THICK) {DIMENSION="l";}
+  SCALAR(Mass) {DIMENSION="m";}
+  SCALAR(JXX) {DIMENSION="massmi";}
+  SCALAR(JYY) {DIMENSION="massmi";}
+  SCALAR(JZZ) {DIMENSION="massmi";}
+  SCALAR(JXY) {DIMENSION="massmi";}
+  SCALAR(JYZ) {DIMENSION="massmi";}
+  SCALAR(JXZ) {DIMENSION="massmi";}
+}
+
+// File format for Radioss 2612
+FORMAT(radioss2612) 
+{
+    HEADER("/PART/%d",_ID_);
+    CARD("%-100s",TITLE);
+    COMMENT("#  prop_ID    mat_ID subset_ID               Thick    Irigid");
+    CARD("%10d%10d%10d%20lg%10d",propertyid,materialid,subsetid,THICK,IRIGID);
+
+    if (IRIGID == 1) {
+      COMMENT("#  Node_ID   Skew_ID                Mass   Sens_ID");
+      CARD("%10d%10d%20lg%10d",Node_ID,Skew_ID,Mass,Sens_ID);
+      COMMENT("#                Jxx                 Jyy                 Jzz");
+      CARD("%20lg%20lg%20lg",JXX,JYY,JZZ);
+      COMMENT("#                Jxy                 Jyz                 Jxz");
+      CARD("%20lg%20lg%20lg",JXY,JYZ,JXZ);
+    }
+}
+
+// File format for Radioss 51
+FORMAT(radioss51) 
+{
+    HEADER("/PART/%d",_ID_);
+    CARD("%-100s",TITLE);
+    COMMENT("#  prop_ID    mat_ID subset_ID               Thick");
+    CARD("%10d%10d%10d%20lg",propertyid,materialid,subsetid,THICK);
+}
+
+// File format for Radioss 41
+FORMAT(radioss41) 
+{
+    HEADER("/PART/%d/%-40s",_ID_,TITLE);
+    COMMENT("#prop_ID  mat_ID  subset           Thick");
+    CARD("%8d%8d%8d%16lg",propertyid,materialid,subsetid,THICK);
+}
+
+

--- a/starter/source/devtools/hm_reader/hm_create_rbodies_from_rigid_parts.F90
+++ b/starter/source/devtools/hm_reader/hm_create_rbodies_from_rigid_parts.F90
@@ -1,0 +1,59 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 1986-2026 Altair Engineering Inc.
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Altair Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+!Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+!Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+!||====================================================================
+!||    hm_create_rbodies_from_rigid_parts_mod   ../starter/source/devtools/hm_reader/hm_create_rbodies_from_rigid_parts.F90
+!||====================================================================
+      module hm_create_rbodies_from_rigid_parts_mod
+        implicit none
+      contains
+! ======================================================================================================================
+!                                                   procedures
+! ======================================================================================================================
+!! \brief create /RBODY for RIGID parts (/PART with Irigid)
+!! \details This routine create a /RBODY for each /PART with Irigid .
+!||====================================================================
+!||    hm_create_rbodies_from_rigid_parts    ../starter/source/devtools/hm_reader/hm_create_rbodies_from_rigid_parts.F90
+!||--- calls      -----------------------------------------------------
+!||====================================================================
+        subroutine hm_create_rbodies_from_rigid_parts(NB_NEWRBODIES,NEW_RBODY_TO_PART,NEW_RBODY_ID)
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Modules
+! ----------------------------------------------------------------------------------------------------------------------
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          integer, intent(in) :: NB_NEWRBODIES
+          integer, dimension(NB_NEWRBODIES), intent(out) :: NEW_RBODY_TO_PART
+          integer, dimension(NB_NEWRBODIES), intent(out) :: NEW_RBODY_ID
+! ----------------------------------------------------------------------------------------------------------------------
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Body
+! ----------------------------------------------------------------------------------------------------------------------
+          call cpp_create_rbodies_from_rigid_parts(NEW_RBODY_TO_PART,NEW_RBODY_ID)
+! ----------------------------------------------------------------------------------------------------------------------
+        end subroutine hm_create_rbodies_from_rigid_parts
+      end module hm_create_rbodies_from_rigid_parts_mod

--- a/starter/source/devtools/hm_reader/hm_evaluate_rbodies_from_rigid_parts.F90
+++ b/starter/source/devtools/hm_reader/hm_evaluate_rbodies_from_rigid_parts.F90
@@ -1,0 +1,58 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 1986-2026 Altair Engineering Inc.
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Altair Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+!Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+!Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+!||====================================================================
+!||    hm_evaluate_rbodies_from_rigid_parts_mod   ../starter/source/devtools/hm_reader/hm_evaluate_rbodies_from_rigid_parts.F90
+!||====================================================================
+      module hm_evaluate_rbodies_from_rigid_parts_mod
+        implicit none
+      contains
+! ======================================================================================================================
+!                                                   procedures
+! ======================================================================================================================
+!! \brief create /RBODY for RIGID parts (/PART with Irigid)
+!! \details This routine create a /RBODY for each /PART with Irigid .
+!||====================================================================
+!||    hm_evaluate_rbodies_from_rigid_parts    ../starter/source/devtools/hm_reader/hm_evaluate_rbodies_from_rigid_parts.F90
+!||--- calls      -----------------------------------------------------
+!||====================================================================
+        subroutine hm_evaluate_rbodies_from_rigid_parts(NPART,NBRBODIES_PER_PART)
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Modules
+! ----------------------------------------------------------------------------------------------------------------------
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          integer, intent(in) :: NPART
+          integer, dimension(NPART), intent(out) :: NBRBODIES_PER_PART
+! ----------------------------------------------------------------------------------------------------------------------
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Body
+! ----------------------------------------------------------------------------------------------------------------------
+          call cpp_evaluate_rbodies_number_from_rigid_parts(NBRBODIES_PER_PART)
+! ----------------------------------------------------------------------------------------------------------------------
+        end subroutine hm_evaluate_rbodies_from_rigid_parts
+      end module hm_evaluate_rbodies_from_rigid_parts_mod

--- a/starter/source/starter/starter0.F
+++ b/starter/source/starter/starter0.F
@@ -107,6 +107,8 @@ C-----------------------------------------------
       use th_mod , only : TH_HAS_NODA_PEXT
       use hm_rbodies_add_main_node_mod
       use analyse_arret_mod
+      use hm_evaluate_rbodies_from_rigid_parts_mod
+      use hm_create_rbodies_from_rigid_parts_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -170,6 +172,9 @@ C-----------------------------------------------
       INTEGER :: RADFLEX_PROCESS_PID
 C
       INTEGER, DIMENSION(:,:), ALLOCATABLE :: SEATBELT_CONVERTED_ELEMENTS
+      INTEGER, dimension(:), ALLOCATABLE :: NBRBODIES_PER_PART
+      INTEGER, DIMENSION(:), ALLOCATABLE :: NEW_RBODY_TO_PART
+      INTEGER, DIMENSION(:), ALLOCATABLE :: NEW_RBODY_ID
 C
       CHARACTER(LEN=2148) :: FILNAM  ! Maximum is SIZE(OUTFILE_CHAR_LEN) + 100
       CHARACTER CHRUN*4,CPUNAM*20,ROOTN*80,CHRUNR*4,ARCHTITLE*66
@@ -184,6 +189,7 @@ C
       CHARACTER(len=2048) :: TMP_NAME
       CHARACTER(len=2048) :: OUT_FILE_NAME
       INTEGER :: NB_DYNA_INCLUDE
+      INTEGER :: NB_NEWRBODIES
 C
       my_real UNITE, RTITR
 C
@@ -256,7 +262,7 @@ C CODVERS : VERSION CODE        = 2019 IF RELEASE 2019
 C IMINVER : MINOR VERSION CODE  = 1 IF MINOR RELEASE A(A~1) OF 4.4 RELEASE
 C ISRCVER : SOURCE VERSION CODE = 41*100+9
 C-------------------------------------------------------------------
-      CODVERS          = 2026
+      CODVERS          = 2612
       IMINVER          = 1
       ISRCVER          = 1
 C-------------------------------------------------------------------
@@ -788,6 +794,19 @@ c 2d seatbelt translation
      .  CALL HM_CONVERT_2D_ELEMENTS_SEATBELT(IDMAX_PART,IDMAX_PROP,IDMAX_MAT,IDMAX_ELEM,IDMAX_TH,
      .                                           SEATBELT_CONVERTED_ELEMENTS,NB_SEATBELT_SHELLS,LSUBMODEL)
 C-------------------------------------------------------------------
+C Build RBODY from PART with Irigid
+C------------------------------------------------------------------
+      CALL HM_OPTION_COUNT('/PART', NPART)
+      ALLOCATE(NBRBODIES_PER_PART(NPART))
+      NBRBODIES_PER_PART(1:NPART) = 0
+      CALL hm_evaluate_rbodies_from_rigid_parts(NPART,NBRBODIES_PER_PART)
+
+      NB_NEWRBODIES = SUM(NBRBODIES_PER_PART)
+
+      ALLOCATE(NEW_RBODY_TO_PART(NB_NEWRBODIES))
+      ALLOCATE(NEW_RBODY_ID(NB_NEWRBODIES))
+      CALL hm_create_rbodies_from_rigid_parts(NB_NEWRBODIES,NEW_RBODY_TO_PART,NEW_RBODY_ID)
+C-------------------------------------------------------------------
 C Add RBODY master node if not existing in /RBODY cards
 C------------------------------------------------------------------
       CALL hm_rbodies_add_main_node(LSUBMODEL)
@@ -863,6 +882,9 @@ C --------------------------------------------------
       ENDIF
 C
       IF(ALLOCATED(SEATBELT_CONVERTED_ELEMENTS)) DEALLOCATE(SEATBELT_CONVERTED_ELEMENTS)  
+      IF(ALLOCATED(NBRBODIES_PER_PART)) DEALLOCATE(NBRBODIES_PER_PART)  
+      IF(ALLOCATED(NEW_RBODY_ID)) DEALLOCATE(NEW_RBODY_ID)
+      IF(ALLOCATED(NEW_RBODY_TO_PART)) DEALLOCATE(NEW_RBODY_TO_PART)
       CALL USER_WINDOWS_CLEAN(USER_WINDOWS)
       CALL TH_CLEAN(OUTPUT%TH)
 C


### PR DESCRIPTION
This pull request introduces functionality to automatically create `/RBODY` entities for rigid parts (i.e., `/PART` entries with `Irigid` set) in the Radioss starter workflow. The implementation involves adding new modules for evaluating and creating these rigid bodies, updating the main starter routine to use them, and ensuring proper resource management. Additionally, there are updates to configuration files and versioning.

**New functionality for rigid body creation:**

* Added two new Fortran modules, `hm_evaluate_rbodies_from_rigid_parts_mod` and `hm_create_rbodies_from_rigid_parts_mod`, which provide procedures to evaluate the number of rigid bodies needed and to create `/RBODY` entities for `/PART` entries with `Irigid` set. [[1]](diffhunk://#diff-9ecc6cf97dca0000993ce263b621cdb15df8c386b914a42542342a0332aed926R1-R58) [[2]](diffhunk://#diff-61edacaa33f3d2e564738c1731feb7167e562e6e599f6a1fdf3b25ce891f17eeR1-R59)
* Integrated these modules into the main `starter0.F` routine: after counting `/PART` entries, the code now allocates arrays, evaluates how many `/RBODY` entities are needed, creates them, and ensures arrays are deallocated after use. [[1]](diffhunk://#diff-bfc6f515005dcd344b5789de2b4cff4fdc5158c3b36cff9889ff6c03a2622096R110-R111) [[2]](diffhunk://#diff-bfc6f515005dcd344b5789de2b4cff4fdc5158c3b36cff9889ff6c03a2622096R175-R177) [[3]](diffhunk://#diff-bfc6f515005dcd344b5789de2b4cff4fdc5158c3b36cff9889ff6c03a2622096R192) [[4]](diffhunk://#diff-bfc6f515005dcd344b5789de2b4cff4fdc5158c3b36cff9889ff6c03a2622096R797-R809) [[5]](diffhunk://#diff-bfc6f515005dcd344b5789de2b4cff4fdc5158c3b36cff9889ff6c03a2622096R885-R887)

**Configuration and versioning updates:**

* Added a new configuration file `part.cfg` for Radioss 2612, detailing attributes and formats for `/PART` entries, including handling of rigid parts.