### PR TITLE
/INIVOL, initilize suvolume  in multimat ale law51

### DIFF
--- a/starter/source/initial_conditions/inivol/inivol_set.F
+++ b/starter/source/initial_conditions/inivol/inivol_set.F
@@ -110,8 +110,9 @@ C-----------------------------------------------
           DO I=1,NEL
             IF(IPART(I+NFT) /= IDP)CYCLE
             RATIO = MIN(MAX(ZERO,KVOL(IMAT,I)), ONE)
-            UVAR(I,1+KK)   = RATIO
-            UVAR(I,23+KK)  = RATIO
+            UVAR(I,1+KK)   = RATIO                                 !Vfrac(t)
+            UVAR(I,11+KK)  = RATIO*ELBUF_TAB(NG)%GBUF%VOL(I)       !vol(t)  <=> LBUF%VOL(I) for MLW=151
+            UVAR(I,23+KK)  = RATIO                                 !vfrac(t=0) : if relaxation to initial state is required
           ENDDO
         ENDDO
         DO I=1,NEL


### PR DESCRIPTION
#### /INIVOL, initilize suvolume  in multimat ale law51

#### Description of the changes
This Step was missing in the Starter Side.
It was updated during Cycle 1 only using volume fractions and global volume. If they are required during cycle 0 they were not yet computed. This is now fixed and subvolumes are computed as expected even on cycle 0.