### PR TITLE
Add new broken element behavior in /MAT/LAW126: ifailso = 5

### DIFF
--- a/engine/source/materials/mat/mat126/sigeps126.F90
+++ b/engine/source/materials/mat/mat126/sigeps126.F90
@@ -417,7 +417,7 @@
               if (off(i) <  one) off(i) = off(i)*four_over_5
               if ((noff(i) == 1).and.(off(i) == one)) off(i) = four_over_5
             end do
-            !< Set to zero the deviatoric stress tensor
+          !< Set to zero the deviatoric stress tensor
           else if (ifail == 2) then
             do i = 1,nel
               if (noff(i) == 1) then
@@ -429,8 +429,8 @@
                 signzx(i) = zero
               end if
             end do
-            !< Set to zero the deviatoric stress tensor
-            !< Keep pressure only in compression
+          !< Set to zero the deviatoric stress tensor
+          !< Keep pressure only in compression
           else if (ifail == 3) then
             do i = 1,nel
               if (noff(i) == 1) then
@@ -442,10 +442,22 @@
                 signzx(i) = zero
               end if
             end do
-            !< Set to zero the whole stress tensor
+          !< Set to zero the whole stress tensor
           else if (ifail == 4) then
             do i = 1,nel
               if (noff(i) == 1) then
+                signxx(i) = zero
+                signyy(i) = zero
+                signzz(i) = zero
+                signxy(i) = zero
+                signyz(i) = zero
+                signzx(i) = zero
+              end if
+            end do
+          !< Set stress tensor to zero only in tension (negative pressure)
+          elseif (ifail == 5) then 
+            do i = 1,nel
+              if ((noff(i) == 1).and.(pnew(i) < zero)) then
                 signxx(i) = zero
                 signyy(i) = zero
                 signzz(i) = zero

--- a/starter/source/materials/mat/mat126/hm_read_mat126.F90
+++ b/starter/source/materials/mat/mat126/hm_read_mat126.F90
@@ -154,7 +154,7 @@
           idel = min(idel,4)
           idel = max(0,idel)
           !< Check flag for post-failure behavior
-          ifailso = min(ifailso,4)
+          ifailso = min(ifailso,5)
           ifailso = max(1,ifailso)
           !< Default values
           if (efmin   == zero) efmin   = em20
@@ -352,7 +352,8 @@
             5X,"  IFAILSO = 2: DEVIATORIC STRESS TENSOR IS VANISHED ",/,  &
             5X,"  IFAILSO = 3: DEVIATORIC STRESS TENSOR IS VANISHED IN COMPR.",/,&
             5X,"               STRESS TENSOR IS VANISHED IN TENSION ",/,  &
-            5X,"  IFAILSO = 4: STRESS TENSOR IS VANISHED",/)
+            5X,"  IFAILSO = 4: STRESS TENSOR IS VANISHED",/,              &
+            5X,"  IFAILSO = 5: STRESS TENSOR IS VANISHED IN TENSION ONLY",/)
 !
         end subroutine hm_read_mat126
 ! ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

Add new broken element behavior in /MAT/LAW126: ifailso = 5
When ifailso = 5, the whole stress tensor is vanished in tension only. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

Add new ifailso value and treatment. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
