### PR TITLE
Add bimodular elasticity in /MAT/LAW131 + additional feature

### DIFF
--- a/engine/source/materials/mat/mat131/elasticity/elasticity_anisotropic.F90
+++ b/engine/source/materials/mat/mat131/elasticity/elasticity_anisotropic.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_trial_stress   ../engine/source/materials/mat/mat131/elasto_plastic_trial_stress.F90
 !||====================================================================
       module elasticity_anisotropic_mod
+! \brief Compute anisotropic elastic stress for /MAT/LAW131
+! \details Compute the elastic stress tensor using anisotropic elasticity
+!          for /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    elasticity_anisotropic        ../engine/source/materials/mat/mat131/elasticity/elasticity_anisotropic.F90

--- a/engine/source/materials/mat/mat131/elasticity/elasticity_bimod_isotropic.F90
+++ b/engine/source/materials/mat/mat131/elasticity/elasticity_bimod_isotropic.F90
@@ -20,42 +20,24 @@
 !Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
 !Copyright>        software under a commercial license.  Contact Altair to discuss further if the
 !Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
-!||====================================================================
-!||    elasticity_viscous_isotropic_mod   ../engine/source/materials/mat/mat131/elasticity/elasticity_viscous_isotropic.F90
-!||--- called by ------------------------------------------------------
-!||    elasto_plastic_trial_stress        ../engine/source/materials/mat/mat131/elasto_plastic_trial_stress.F90
-!||====================================================================
-      module elasticity_viscous_isotropic_mod
-! \brief Compute viscous isotropic elastic stress for /MAT/LAW131
-! \details Compute the elastic stress tensor using viscous isotropic elasticity
-!          for /MAT/LAW131 (elasto-plastic material law).
+      module elasticity_bimod_isotropic_mod
+! \brief Compute bimodular isotropic elastic stress for /MAT/LAW131
+! \details Compute the elastic stress tensor using bimodular isotropic elasticity
+!          (different moduli in tension and compression) for /MAT/LAW131.
       contains
-!||====================================================================
-!||    elasticity_viscous_isotropic   ../engine/source/materials/mat/mat131/elasticity/elasticity_viscous_isotropic.F90
-!||--- called by ------------------------------------------------------
-!||    elasto_plastic_trial_stress    ../engine/source/materials/mat/mat131/elasto_plastic_trial_stress.F90
-!||--- calls      -----------------------------------------------------
-!||    table_mat_vinterp              ../engine/source/materials/tools/table_mat_vinterp.F
-!||--- uses       -----------------------------------------------------
-!||    constant_mod                   ../common_source/modules/constant_mod.F
-!||    matparam_def_mod               ../common_source/modules/mat_elem/matparam_def_mod.F90
-!||    precision_mod                  ../common_source/modules/precision_mod.F90
-!||    table_mat_vinterp_mod          ../engine/source/materials/tools/table_mat_vinterp.F
-!||====================================================================
-      subroutine elasticity_viscous_isotropic(                                 &
+      subroutine elasticity_bimod_isotropic(                                   &
         matparam ,nel      ,eltype   ,ieos     ,rho      ,dpdm     ,           &
         depsxx   ,depsyy   ,depszz   ,depsxy   ,depsyz   ,depszx   ,           &
         sigoxx   ,sigoyy   ,sigozz   ,sigoxy   ,sigoyz   ,sigozx   ,           &
         signxx   ,signyy   ,signzz   ,signxy   ,signyz   ,signzx   ,           &
         shf      ,cstf     ,soundsp  ,s13      ,s23      ,s43      ,           &
-        epsd     ,nvartmp  ,vartmp   ,young    )
+        young    )
 !----------------------------------------------------------------
 !   M o d u l e s
 !----------------------------------------------------------------
         use matparam_def_mod
         use constant_mod
         use precision_mod, only : WP
-        use table_mat_vinterp_mod
 !----------------------------------------------------------------
 !   I m p l i c i t   T y p e s
 !----------------------------------------------------------------
@@ -93,70 +75,116 @@
         real(kind=WP), dimension(nel),     intent(inout) :: s13      !< Compliance matrix component for thickness update
         real(kind=WP), dimension(nel),     intent(inout) :: s23      !< Compliance matrix component for thickness update
         real(kind=WP), dimension(nel),     intent(inout) :: s43      !< Compliance matrix component for thickness update
-        real(kind=WP), dimension(nel),     intent(in)    :: epsd     !< Equivalent strain rate
-        integer,                           intent(in)    :: nvartmp  !< Number of temporary variables for table interpolation
-        integer,dimension(nel,nvartmp),    intent(inout) :: vartmp   !< Temporary variable array for table interpolation
         real(kind=WP), dimension(nel),     intent(inout) :: young    !< Young modulus
 !----------------------------------------------------------------
 !  L o c a l  V a r i a b l e s
 !----------------------------------------------------------------
         integer :: i
-        real(kind=WP), dimension(nel) :: young_fac,dyoung_fact
-        real(kind=WP), dimension(nel,1) :: xvec
+        real(kind=WP) :: et,ec,nu,tt,tc
+        real(kind=WP), dimension(nel) :: bulk,shear,lam,cii,cij,aii,aij,fac,p, &
+          svm,triax
 !===============================================================================
 !
         !=======================================================================
-        !< - Viscous isotropic elasticity
+        !< - Isotropic elasticity
         !=======================================================================
+        !< Recover elastic parameter
+        et = matparam%uparam(1)
+        ec = matparam%uparam(2)
+        nu = matparam%nu
+        tt = matparam%uparam(3)
+        tc = matparam%uparam(4)
+        bulk(1:nel) = et/three/(one - two*nu)
         !< Young modulus
-        young(1:nel) = matparam%young
-        !< Interpolation of the Young modulus viscous factor
-        xvec(1:nel,1) = epsd(1:nel)
-        call table_mat_vinterp(matparam%table(1),nel,nel,vartmp(1:nel,1),      &
-          xvec(1:nel,1),young_fac(1:nel),dyoung_fact(1:nel))
+        young(1:nel) = et
         !< Solids
-        if (eltype == 1) then     
+        if (eltype == 1) then
+          !< Young modulus update for bimodular behavior     
+          if (ec > zero) then
+            p(1:nel) = -third*(sigoxx(1:nel) + sigoyy(1:nel) + sigozz(1:nel))
+            svm(1:nel) =  half*(sigoyy(1:nel)-sigozz(1:nel))**2 +              &                 
+                          half*(sigozz(1:nel)-sigoxx(1:nel))**2 +              & 
+                          half*(sigoxx(1:nel)-sigoyy(1:nel))**2 +              &
+                         three*(sigoxy(1:nel))**2               +              &
+                         three*(sigoyz(1:nel))**2               +              &
+                         three*(sigozx(1:nel))**2 
+            svm(1:nel) = sqrt(svm(1:nel))
+            triax(1:nel) = -p(1:nel)/max(svm(1:nel),em20)
+            if (abs(tt - tc) < em20) then
+              where (abs(triax(1:nel)) < em10)
+                young(1:nel) = ec
+              end where
+            else
+              fac(1:nel) = (triax(1:nel) - tc)/(tt - tc)
+              fac(1:nel) = max(zero, min(one, fac(1:nel)))
+              young(1:nel) = fac(1:nel)*et + (one - fac(1:nel))*ec
+            endif
+          endif
+          !< Compute elastic stiffness matrix components
+          bulk(1:nel) = young(1:nel)/three/(one - two*nu)
+          shear(1:nel) = young(1:nel)/(two*(one + nu))
+          lam(1:nel) = young(1:nel)*nu/(one + nu)/(one - two*nu)
+          cii(1:nel) = lam(1:nel) + shear(1:nel)*two
+          cij(1:nel) = lam(1:nel)
           !< Elastic stiffness matrix
-          cstf(1:nel,1,1) = matparam%uparam(1)*young_fac(1:nel)
-          cstf(1:nel,2,2) = matparam%uparam(1)*young_fac(1:nel)
-          cstf(1:nel,3,3) = matparam%uparam(1)*young_fac(1:nel)
-          cstf(1:nel,1,2) = matparam%uparam(2)*young_fac(1:nel)
-          cstf(1:nel,1,3) = matparam%uparam(2)*young_fac(1:nel)
-          cstf(1:nel,2,1) = matparam%uparam(2)*young_fac(1:nel)
-          cstf(1:nel,2,3) = matparam%uparam(2)*young_fac(1:nel)
-          cstf(1:nel,3,1) = matparam%uparam(2)*young_fac(1:nel)
-          cstf(1:nel,3,2) = matparam%uparam(2)*young_fac(1:nel)
-          cstf(1:nel,4,4) = matparam%shear*young_fac(1:nel)
-          cstf(1:nel,5,5) = matparam%shear*young_fac(1:nel)
-          cstf(1:nel,6,6) = matparam%shear*young_fac(1:nel)
-          young(1:nel) = matparam%young*young_fac(1:nel)
+          cstf(1:nel,1,1) =   cii(1:nel)
+          cstf(1:nel,2,2) =   cii(1:nel)
+          cstf(1:nel,3,3) =   cii(1:nel)
+          cstf(1:nel,1,2) =   cij(1:nel)
+          cstf(1:nel,1,3) =   cij(1:nel)
+          cstf(1:nel,2,1) =   cij(1:nel)
+          cstf(1:nel,2,3) =   cij(1:nel)
+          cstf(1:nel,3,1) =   cij(1:nel)
+          cstf(1:nel,3,2) =   cij(1:nel)
+          cstf(1:nel,4,4) = shear(1:nel)
+          cstf(1:nel,5,5) = shear(1:nel)
+          cstf(1:nel,6,6) = shear(1:nel)
           !< Sound speed
           if (ieos > 0) then 
             soundsp(1:nel) = sqrt((dpdm(1:nel) +                               &
-                              four_over_3*matparam%shear*young_fac(1:nel))     &
-                                                               /rho(1:nel))
+                                    four_over_3*shear(1:nel))/rho(1:nel))
           else
-            soundsp(1:nel) = sqrt((matparam%bulk+                              &
-                              four_over_3*matparam%shear)*young_fac(1:nel)     &
-                                                               /rho(1:nel))
+            soundsp(1:nel) = sqrt((bulk(1:nel)+                                &
+                                    four_over_3*shear(1:nel))/rho(1:nel))
           endif
         !< Shells
         elseif (eltype == 2) then
+          !< Young modulus update for bimodular behavior     
+          if (ec > zero) then
+            p(1:nel) = -third*(sigoxx(1:nel) + sigoyy(1:nel))
+            svm(1:nel) = sigoxx(1:nel)**2 + sigoyy(1:nel)**2 -                 &
+                         sigoxx(1:nel)*sigoyy(1:nel) + three*(sigoxy(1:nel)**2)
+            svm(1:nel) = sqrt(svm(1:nel))
+            triax(1:nel) = -p(1:nel)/max(svm(1:nel),em20)
+            if (abs(tt - tc) < em20) then
+              where (abs(triax(1:nel)) < em10)
+                young(1:nel) = ec
+              end where
+            else
+              fac(1:nel) = (triax(1:nel) - tc)/(tt - tc)
+              fac(1:nel) = max(zero, min(one, fac(1:nel)))
+              young(1:nel) = fac(1:nel)*et + (one - fac(1:nel))*ec
+            endif
+          endif
+          !< Compute elastic stiffness matrix components
+          aii(1:nel) = young(1:nel)/(one - nu*nu)
+          aij(1:nel) = nu*aii(1:nel)
+          shear(1:nel) = young(1:nel)/(two*(one + nu))
           !< Elastic stiffness matrix
-          cstf(1:nel,1,1) = matparam%uparam(3)*young_fac(1:nel)
-          cstf(1:nel,2,2) = matparam%uparam(3)*young_fac(1:nel)
-          cstf(1:nel,1,2) = matparam%uparam(4)*young_fac(1:nel)
-          cstf(1:nel,2,1) = matparam%uparam(4)*young_fac(1:nel)
-          cstf(1:nel,4,4) = matparam%shear*young_fac(1:nel)
-          cstf(1:nel,5,5) = matparam%shear*shf(1:nel)*young_fac(1:nel)
-          cstf(1:nel,6,6) = matparam%shear*shf(1:nel)*young_fac(1:nel)
+          cstf(1:nel,1,1) = aii(1:nel)
+          cstf(1:nel,2,2) = aii(1:nel)
+          cstf(1:nel,1,2) = aij(1:nel)
+          cstf(1:nel,2,1) = aij(1:nel)
+          cstf(1:nel,4,4) = shear(1:nel)
+          cstf(1:nel,5,5) = shear(1:nel)*shf(1:nel)
+          cstf(1:nel,6,6) = shear(1:nel)*shf(1:nel)
           !< Compliance matrix components for thickness update
-          s13(1:nel) = - matparam%nu / (matparam%young * young_fac(1:nel))
-          s23(1:nel) = - matparam%nu / (matparam%young * young_fac(1:nel))
+          s13(1:nel) = - matparam%nu / young(1:nel)
+          s23(1:nel) = - matparam%nu / young(1:nel)
           s43(1:nel) = zero
           !< Sound speed
           soundsp(1:nel) = sqrt(cstf(1:nel,1,1)/rho(1:nel))
-        endif
+        endif 
 !
         !=======================================================================
         !< Elastic trial stress computation
@@ -177,5 +205,5 @@
           signzx(i) = sigozx(i) + cstf(i,6,6)*depszx(i)
         enddo
 !
-      end subroutine elasticity_viscous_isotropic
-      end module elasticity_viscous_isotropic_mod
+      end subroutine elasticity_bimod_isotropic
+      end module elasticity_bimod_isotropic_mod

--- a/engine/source/materials/mat/mat131/elasticity/elasticity_isotropic.F90
+++ b/engine/source/materials/mat/mat131/elasticity/elasticity_isotropic.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_trial_stress   ../engine/source/materials/mat/mat131/elasto_plastic_trial_stress.F90
 !||====================================================================
       module elasticity_isotropic_mod
+! \brief Compute isotropic elastic stress for /MAT/LAW131
+! \details Compute the elastic stress tensor using isotropic elasticity
+!          for /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    elasticity_isotropic          ../engine/source/materials/mat/mat131/elasticity/elasticity_isotropic.F90

--- a/engine/source/materials/mat/mat131/elasticity/elasticity_orthotropic.F90
+++ b/engine/source/materials/mat/mat131/elasticity/elasticity_orthotropic.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_trial_stress   ../engine/source/materials/mat/mat131/elasto_plastic_trial_stress.F90
 !||====================================================================
       module elasticity_orthotropic_mod
+! \brief Compute orthotropic elastic stress for /MAT/LAW131
+! \details Compute the elastic stress tensor using orthotropic elasticity
+!          for /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    elasticity_orthotropic        ../engine/source/materials/mat/mat131/elasticity/elasticity_orthotropic.F90

--- a/engine/source/materials/mat/mat131/elasticity/elasticity_temp_isotropic.F90
+++ b/engine/source/materials/mat/mat131/elasticity/elasticity_temp_isotropic.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_trial_stress     ../engine/source/materials/mat/mat131/elasto_plastic_trial_stress.F90
 !||====================================================================
       module elasticity_temp_isotropic_mod
+! \brief Compute temperature-dependent isotropic elastic stress for /MAT/LAW131
+! \details Compute the elastic stress tensor using temperature-dependent
+!          isotropic elasticity for /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    elasticity_temp_isotropic     ../engine/source/materials/mat/mat131/elasticity/elasticity_temp_isotropic.F90

--- a/engine/source/materials/mat/mat131/elasto_plastic_eq_stress.F90
+++ b/engine/source/materials/mat/mat131/elasto_plastic_eq_stress.F90
@@ -31,6 +31,9 @@
 !||    nice_solids                    ../engine/source/materials/mat/mat131/return_mapping/nice_solids.F90
 !||====================================================================
       module elasto_plastic_eq_stress_mod
+! \brief Compute elasto-plastic equivalent stress for /MAT/LAW131
+! \details Compute the equivalent stress from the deviatoric stress tensor
+!          for /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    elasto_plastic_eq_stress                    ../engine/source/materials/mat/mat131/elasto_plastic_eq_stress.F90

--- a/engine/source/materials/mat/mat131/elasto_plastic_kinematic_hardening.F90
+++ b/engine/source/materials/mat/mat131/elasto_plastic_kinematic_hardening.F90
@@ -31,6 +31,9 @@
 !||    nice_solids                              ../engine/source/materials/mat/mat131/return_mapping/nice_solids.F90
 !||====================================================================
       module elasto_plastic_kinematic_hardening_mod
+! \brief Compute elasto-plastic kinematic hardening for /MAT/LAW131
+! \details Compute the kinematic hardening contribution (backstress update)
+!          for /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    elasto_plastic_kinematic_hardening   ../engine/source/materials/mat/mat131/elasto_plastic_kinematic_hardening.F90

--- a/engine/source/materials/mat/mat131/elasto_plastic_second_order_numerical.F90
+++ b/engine/source/materials/mat/mat131/elasto_plastic_second_order_numerical.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_eq_stress                    ../engine/source/materials/mat/mat131/elasto_plastic_eq_stress.F90
 !||====================================================================
       module elasto_plastic_second_order_numerical_mod
+! \brief Compute second-order numerical approximation for /MAT/LAW131
+! \details Compute second-order numerical derivatives of the yield function
+!          for /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    elasto_plastic_second_order_numerical   ../engine/source/materials/mat/mat131/elasto_plastic_second_order_numerical.F90

--- a/engine/source/materials/mat/mat131/elasto_plastic_trial_stress.F90
+++ b/engine/source/materials/mat/mat131/elasto_plastic_trial_stress.F90
@@ -31,6 +31,9 @@
 !||    nice_solids                       ../engine/source/materials/mat/mat131/return_mapping/nice_solids.F90
 !||====================================================================
       module elasto_plastic_trial_stress_mod
+! \brief Compute elasto-plastic trial stress for /MAT/LAW131
+! \details Compute the elastic trial stress tensor (predictor step)
+!          for /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    elasto_plastic_trial_stress        ../engine/source/materials/mat/mat131/elasto_plastic_trial_stress.F90
@@ -76,6 +79,7 @@
         use elasticity_anisotropic_mod
         use elasticity_viscous_isotropic_mod
         use elasticity_temp_isotropic_mod
+        use elasticity_bimod_isotropic_mod
 !----------------------------------------------------------------
 !   I m p l i c i t   T y p e s
 !----------------------------------------------------------------
@@ -189,6 +193,17 @@
               signxx   ,signyy   ,signzz   ,signxy   ,signyz   ,signzx   ,     &
               shf      ,cstf     ,soundsp  ,s13      ,s23      ,s43      ,     &
               temp     ,nvartmp  ,vartmp   ,young    ,nuvar    ,uvar     )
+          !---------------------------------------------------------------------
+          !< Bimodular isotropic elastic model
+          !---------------------------------------------------------------------
+          case(6)
+            call elasticity_bimod_isotropic(                                   &
+              matparam ,nel      ,eltype   ,ieos     ,rho      ,dpdm     ,     &
+              depsxx   ,depsyy   ,depszz   ,depsxy   ,depsyz   ,depszx   ,     &
+              sigoxx   ,sigoyy   ,sigozz   ,sigoxy   ,sigoyz   ,sigozx   ,     &
+              signxx   ,signyy   ,signzz   ,signxy   ,signyz   ,signzx   ,     &
+              shf      ,cstf     ,soundsp  ,s13      ,s23      ,s43      ,     &
+              young    )
         end select
 !
       end subroutine elasto_plastic_trial_stress

--- a/engine/source/materials/mat/mat131/elasto_plastic_yield_stress.F90
+++ b/engine/source/materials/mat/mat131/elasto_plastic_yield_stress.F90
@@ -31,6 +31,9 @@
 !||    nice_solids                       ../engine/source/materials/mat/mat131/return_mapping/nice_solids.F90
 !||====================================================================
       module elasto_plastic_yield_stress_mod
+! \brief Compute elasto-plastic yield stress for /MAT/LAW131
+! \details Compute the yield stress including work hardening, strain rate
+!          dependency, and thermal softening for /MAT/LAW131.
       contains
 !||====================================================================
 !||    elasto_plastic_yield_stress          ../engine/source/materials/mat/mat131/elasto_plastic_yield_stress.F90

--- a/engine/source/materials/mat/mat131/kinematic_hardening/kinematic_hardening_chaboche.F90
+++ b/engine/source/materials/mat/mat131/kinematic_hardening/kinematic_hardening_chaboche.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_kinematic_hardening   ../engine/source/materials/mat/mat131/elasto_plastic_kinematic_hardening.F90
 !||====================================================================
       module kinematic_hardening_chaboche_mod
+! \brief Compute Chaboche kinematic hardening for /MAT/LAW131
+! \details Compute the Chaboche nonlinear kinematic hardening model
+!          (backstress evolution) for /MAT/LAW131.
       contains
 !||====================================================================
 !||    kinematic_hardening_chaboche         ../engine/source/materials/mat/mat131/kinematic_hardening/kinematic_hardening_chaboche.F90

--- a/engine/source/materials/mat/mat131/kinematic_hardening/kinematic_hardening_prager.F90
+++ b/engine/source/materials/mat/mat131/kinematic_hardening/kinematic_hardening_prager.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_kinematic_hardening   ../engine/source/materials/mat/mat131/elasto_plastic_kinematic_hardening.F90
 !||====================================================================
       module kinematic_hardening_prager_mod
+! \brief Compute Prager kinematic hardening for /MAT/LAW131
+! \details Compute the Prager linear kinematic hardening model
+!          (backstress evolution) for /MAT/LAW131.
       contains
 !||====================================================================
 !||    kinematic_hardening_prager           ../engine/source/materials/mat/mat131/kinematic_hardening/kinematic_hardening_prager.F90

--- a/engine/source/materials/mat/mat131/return_mapping/cppm_shells.F90
+++ b/engine/source/materials/mat/mat131/return_mapping/cppm_shells.F90
@@ -26,6 +26,9 @@
 !||    sigeps131c        ../engine/source/materials/mat/mat131/sigeps131c.F90
 !||====================================================================
       module cppm_shells_mod
+! \brief Closest Point Projection Method return mapping for shells in /MAT/LAW131
+! \details Perform the CPPM (Closest Point Projection Method) implicit return
+!          mapping algorithm for shell elements in /MAT/LAW131.
       contains
 !||====================================================================
 !||    cppm_shells                              ../engine/source/materials/mat/mat131/return_mapping/cppm_shells.F90

--- a/engine/source/materials/mat/mat131/return_mapping/cppm_solids.F90
+++ b/engine/source/materials/mat/mat131/return_mapping/cppm_solids.F90
@@ -26,6 +26,9 @@
 !||    sigeps131         ../engine/source/materials/mat/mat131/sigeps131.F90
 !||====================================================================
       module cppm_solids_mod
+! \brief Closest Point Projection Method return mapping for solids in /MAT/LAW131
+! \details Perform the CPPM (Closest Point Projection Method) implicit return
+!          mapping algorithm for solid elements in /MAT/LAW131.
       contains
 !||====================================================================
 !||    cppm_solids                              ../engine/source/materials/mat/mat131/return_mapping/cppm_solids.F90

--- a/engine/source/materials/mat/mat131/return_mapping/cutting_plane_shells.F90
+++ b/engine/source/materials/mat/mat131/return_mapping/cutting_plane_shells.F90
@@ -26,6 +26,9 @@
 !||    sigeps131c                 ../engine/source/materials/mat/mat131/sigeps131c.F90
 !||====================================================================
       module cutting_plane_shells_mod
+! \brief Cutting plane return mapping for shells in /MAT/LAW131
+! \details Perform the cutting plane semi-implicit return mapping algorithm
+!          for shell elements in /MAT/LAW131.
       contains
 !||====================================================================
 !||    cutting_plane_shells                     ../engine/source/materials/mat/mat131/return_mapping/cutting_plane_shells.F90

--- a/engine/source/materials/mat/mat131/return_mapping/cutting_plane_solids.F90
+++ b/engine/source/materials/mat/mat131/return_mapping/cutting_plane_solids.F90
@@ -26,6 +26,9 @@
 !||    sigeps131                  ../engine/source/materials/mat/mat131/sigeps131.F90
 !||====================================================================
       module cutting_plane_solids_mod
+! \brief Cutting plane return mapping for solids in /MAT/LAW131
+! \details Perform the cutting plane semi-implicit return mapping algorithm
+!          for solid elements in /MAT/LAW131.
       contains
 !||====================================================================
 !||    cutting_plane_solids                     ../engine/source/materials/mat/mat131/return_mapping/cutting_plane_solids.F90

--- a/engine/source/materials/mat/mat131/return_mapping/nice_shells.F90
+++ b/engine/source/materials/mat/mat131/return_mapping/nice_shells.F90
@@ -26,6 +26,9 @@
 !||    sigeps131c        ../engine/source/materials/mat/mat131/sigeps131c.F90
 !||====================================================================
       module nice_shells_mod
+! \brief NICE return mapping for shells in /MAT/LAW131
+! \details Perform the NICE (Next Increment Corrects Error) explicit return
+!          mapping algorithm for shell elements in /MAT/LAW131.
       contains
 !||====================================================================
 !||    nice_shells                              ../engine/source/materials/mat/mat131/return_mapping/nice_shells.F90

--- a/engine/source/materials/mat/mat131/return_mapping/nice_solids.F90
+++ b/engine/source/materials/mat/mat131/return_mapping/nice_solids.F90
@@ -26,6 +26,9 @@
 !||    sigeps131         ../engine/source/materials/mat/mat131/sigeps131.F90
 !||====================================================================
       module nice_solids_mod
+! \brief NICE return mapping for solids in /MAT/LAW131
+! \details Perform the NICE (Next Increment Corrects Error) explicit return
+!          mapping algorithm for solid elements in /MAT/LAW131.
       contains
 !||====================================================================
 !||    nice_solids                              ../engine/source/materials/mat/mat131/return_mapping/nice_solids.F90

--- a/engine/source/materials/mat/mat131/self_heating/self_heating_tabulated.F90
+++ b/engine/source/materials/mat/mat131/self_heating/self_heating_tabulated.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_yield_stress   ../engine/source/materials/mat/mat131/elasto_plastic_yield_stress.F90
 !||====================================================================
       module self_heating_tabulated_mod
+! \brief Compute tabulated self-heating for /MAT/LAW131
+! \details Compute the temperature rise due to plastic work dissipation
+!          using a tabulated Taylor-Quinney coefficient for /MAT/LAW131.
       contains
 !||====================================================================
 !||    self_heating_tabulated        ../engine/source/materials/mat/mat131/self_heating/self_heating_tabulated.F90

--- a/engine/source/materials/mat/mat131/self_heating/self_heating_taylor.F90
+++ b/engine/source/materials/mat/mat131/self_heating/self_heating_taylor.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_yield_stress   ../engine/source/materials/mat/mat131/elasto_plastic_yield_stress.F90
 !||====================================================================
       module self_heating_taylor_mod
+! \brief Compute Taylor-Quinney self-heating for /MAT/LAW131
+! \details Compute the temperature rise due to plastic work dissipation
+!          using a constant Taylor-Quinney coefficient for /MAT/LAW131.
       contains
 !||====================================================================
 !||    self_heating_taylor           ../engine/source/materials/mat/mat131/self_heating/self_heating_taylor.F90

--- a/engine/source/materials/mat/mat131/sigeps131.F90
+++ b/engine/source/materials/mat/mat131/sigeps131.F90
@@ -26,6 +26,9 @@
 !||    mulaw           ../engine/source/materials/mat_share/mulaw.F90
 !||====================================================================
       module sigeps131_mod
+! \brief Main stress computation for /MAT/LAW131 (solids)
+! \details Main routine for computing stresses and internal variables
+!          for solid elements using /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    sigeps131                  ../engine/source/materials/mat/mat131/sigeps131.F90

--- a/engine/source/materials/mat/mat131/sigeps131c.F90
+++ b/engine/source/materials/mat/mat131/sigeps131c.F90
@@ -26,6 +26,9 @@
 !||    mulawc           ../engine/source/materials/mat_share/mulawc.F90
 !||====================================================================
       module sigeps131c_mod
+! \brief Main stress computation for /MAT/LAW131 (shells)
+! \details Main routine for computing stresses and internal variables
+!          for shell elements using /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    sigeps131c                 ../engine/source/materials/mat/mat131/sigeps131c.F90

--- a/engine/source/materials/mat/mat131/srate_dependency/srate_dependency_cowpersymonds.F90
+++ b/engine/source/materials/mat/mat131/srate_dependency/srate_dependency_cowpersymonds.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_yield_stress          ../engine/source/materials/mat/mat131/elasto_plastic_yield_stress.F90
 !||====================================================================
       module srate_dependency_cowpersymonds_mod
+! \brief Compute Cowper-Symonds strain rate dependency for /MAT/LAW131
+! \details Compute the strain rate scaling factor using the Cowper-Symonds
+!          model for /MAT/LAW131.
       contains
 !||====================================================================
 !||    srate_dependency_cowpersymonds   ../engine/source/materials/mat/mat131/srate_dependency/srate_dependency_cowpersymonds.F90

--- a/engine/source/materials/mat/mat131/srate_dependency/srate_dependency_johnsoncook.F90
+++ b/engine/source/materials/mat/mat131/srate_dependency/srate_dependency_johnsoncook.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_yield_stress        ../engine/source/materials/mat/mat131/elasto_plastic_yield_stress.F90
 !||====================================================================
       module srate_dependency_johnsoncook_mod
+! \brief Compute Johnson-Cook strain rate dependency for /MAT/LAW131
+! \details Compute the strain rate scaling factor using the Johnson-Cook
+!          model for /MAT/LAW131.
       contains
 !||====================================================================
 !||    srate_dependency_johnsoncook   ../engine/source/materials/mat/mat131/srate_dependency/srate_dependency_johnsoncook.F90

--- a/engine/source/materials/mat/mat131/srate_dependency/srate_dependency_nonlinear.F90
+++ b/engine/source/materials/mat/mat131/srate_dependency/srate_dependency_nonlinear.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_yield_stress      ../engine/source/materials/mat/mat131/elasto_plastic_yield_stress.F90
 !||====================================================================
       module srate_dependency_nonlinear_mod
+! \brief Compute nonlinear strain rate dependency for /MAT/LAW131
+! \details Compute the strain rate scaling factor using a nonlinear model
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    srate_dependency_nonlinear    ../engine/source/materials/mat/mat131/srate_dependency/srate_dependency_nonlinear.F90

--- a/engine/source/materials/mat/mat131/srate_dependency/srate_dependency_tabulated.F90
+++ b/engine/source/materials/mat/mat131/srate_dependency/srate_dependency_tabulated.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_yield_stress      ../engine/source/materials/mat/mat131/elasto_plastic_yield_stress.F90
 !||====================================================================
       module srate_dependency_tabulated_mod
+! \brief Compute tabulated strain rate dependency for /MAT/LAW131
+! \details Compute the strain rate scaling factor using tabulated data
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    srate_dependency_tabulated    ../engine/source/materials/mat/mat131/srate_dependency/srate_dependency_tabulated.F90

--- a/engine/source/materials/mat/mat131/therm_softening/therm_softening_johnsoncook.F90
+++ b/engine/source/materials/mat/mat131/therm_softening/therm_softening_johnsoncook.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_yield_stress       ../engine/source/materials/mat/mat131/elasto_plastic_yield_stress.F90
 !||====================================================================
       module therm_softening_johnsoncook_mod
+! \brief Compute Johnson-Cook thermal softening for /MAT/LAW131
+! \details Compute the thermal softening factor using the Johnson-Cook
+!          model for /MAT/LAW131.
       contains
 !||====================================================================
 !||    therm_softening_johnsoncook   ../engine/source/materials/mat/mat131/therm_softening/therm_softening_johnsoncook.F90

--- a/engine/source/materials/mat/mat131/therm_softening/therm_softening_tabulated.F90
+++ b/engine/source/materials/mat/mat131/therm_softening/therm_softening_tabulated.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_yield_stress     ../engine/source/materials/mat/mat131/elasto_plastic_yield_stress.F90
 !||====================================================================
       module therm_softening_tabulated_mod
+! \brief Compute tabulated thermal softening for /MAT/LAW131
+! \details Compute the thermal softening factor using tabulated data
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    therm_softening_tabulated     ../engine/source/materials/mat/mat131/therm_softening/therm_softening_tabulated.F90

--- a/engine/source/materials/mat/mat131/therm_softening/therm_softening_zhao.F90
+++ b/engine/source/materials/mat/mat131/therm_softening/therm_softening_zhao.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_yield_stress   ../engine/source/materials/mat/mat131/elasto_plastic_yield_stress.F90
 !||====================================================================
       module therm_softening_zhao_mod
+! \brief Compute Zhao thermal softening for /MAT/LAW131
+! \details Compute the thermal softening factor using the Zhao model
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    therm_softening_zhao          ../engine/source/materials/mat/mat131/therm_softening/therm_softening_zhao.F90

--- a/engine/source/materials/mat/mat131/work_hardening/work_hardening_linearvoce.F90
+++ b/engine/source/materials/mat/mat131/work_hardening/work_hardening_linearvoce.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_yield_stress     ../engine/source/materials/mat/mat131/elasto_plastic_yield_stress.F90
 !||====================================================================
       module work_hardening_linearvoce_mod
+! \brief Compute linear Voce work hardening for /MAT/LAW131
+! \details Compute the isotropic work hardening stress using the linear
+!          Voce (saturation + linear) model for /MAT/LAW131.
       contains
 !||====================================================================
 !||    work_hardening_linearvoce     ../engine/source/materials/mat/mat131/work_hardening/work_hardening_linearvoce.F90

--- a/engine/source/materials/mat/mat131/work_hardening/work_hardening_powerlaw.F90
+++ b/engine/source/materials/mat/mat131/work_hardening/work_hardening_powerlaw.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_yield_stress   ../engine/source/materials/mat/mat131/elasto_plastic_yield_stress.F90
 !||====================================================================
       module work_hardening_powerlaw_mod
+! \brief Compute power law work hardening for /MAT/LAW131
+! \details Compute the isotropic work hardening stress using the power law
+!          (Hollomon/Ludwik) model for /MAT/LAW131.
       contains
 !||====================================================================
 !||    work_hardening_powerlaw       ../engine/source/materials/mat/mat131/work_hardening/work_hardening_powerlaw.F90
@@ -61,7 +64,7 @@
 !  L o c a l  V a r i a b l e s
 !----------------------------------------------------------------
         integer :: i
-        real(kind=WP) :: ca,cb,cn,eps0
+        real(kind=WP) :: ca,cb,cn,eps0,sigmax
         real(kind=WP), dimension(nel) :: pla_plus_eps0_pow_cn_minus_1
 !===============================================================================
 !
@@ -69,14 +72,19 @@
         !< - Power law work hardening model
         !=======================================================================
         !< Recover work hardening parameters
-        ca   = matparam%uparam(offset + 1) !< Initial yield stress
-        cb   = matparam%uparam(offset + 2) !< Hardening modulus
-        cn   = matparam%uparam(offset + 3) !< Hardening exponent
-        eps0 = matparam%uparam(offset + 4) !< Initial plastic strain
+        ca     = matparam%uparam(offset + 1) !< Initial yield stress
+        cb     = matparam%uparam(offset + 2) !< Hardening modulus
+        cn     = matparam%uparam(offset + 3) !< Hardening exponent
+        eps0   = matparam%uparam(offset + 4) !< Initial plastic strain
+        sigmax = matparam%uparam(offset + 5) !< Maximum yield stress
         pla_plus_eps0_pow_cn_minus_1(1:nel) = (pla(1:nel) + eps0)**(cn - one)
         sigy(1:nel) = ca + cb*(pla(1:nel) + eps0)*                             &
                               pla_plus_eps0_pow_cn_minus_1(1:nel)
         dsigy_dpla(1:nel) = cn*cb*pla_plus_eps0_pow_cn_minus_1(1:nel)
+        where (sigy(1:nel) > sigmax) 
+          sigy(1:nel) = sigmax
+          dsigy_dpla(1:nel) = zero
+        end where
 !
         end subroutine work_hardening_powerlaw
       end module work_hardening_powerlaw_mod

--- a/engine/source/materials/mat/mat131/work_hardening/work_hardening_tabulated.F90
+++ b/engine/source/materials/mat/mat131/work_hardening/work_hardening_tabulated.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_yield_stress    ../engine/source/materials/mat/mat131/elasto_plastic_yield_stress.F90
 !||====================================================================
       module work_hardening_tabulated_mod
+! \brief Compute tabulated work hardening for /MAT/LAW131
+! \details Compute the isotropic work hardening stress using tabulated
+!          stress-strain data for /MAT/LAW131.
       contains
 !||====================================================================
 !||    work_hardening_tabulated      ../engine/source/materials/mat/mat131/work_hardening/work_hardening_tabulated.F90

--- a/engine/source/materials/mat/mat131/work_hardening/work_hardening_voce.F90
+++ b/engine/source/materials/mat/mat131/work_hardening/work_hardening_voce.F90
@@ -26,6 +26,9 @@
 !||    elasto_plastic_yield_stress   ../engine/source/materials/mat/mat131/elasto_plastic_yield_stress.F90
 !||====================================================================
       module work_hardening_voce_mod
+! \brief Compute Voce work hardening for /MAT/LAW131
+! \details Compute the isotropic work hardening stress using the Voce
+!          (exponential saturation) model for /MAT/LAW131.
       contains
 !||====================================================================
 !||    work_hardening_voce           ../engine/source/materials/mat/mat131/work_hardening/work_hardening_voce.F90

--- a/engine/source/materials/mat/mat131/yield_criterion/yield_criterion_barlat1989.F90
+++ b/engine/source/materials/mat/mat131/yield_criterion/yield_criterion_barlat1989.F90
@@ -27,6 +27,10 @@
 !||    elasto_plastic_second_order_numerical   ../engine/source/materials/mat/mat131/elasto_plastic_second_order_numerical.F90
 !||====================================================================
       module yield_criterion_barlat1989_mod
+! \brief Compute Barlat 1989 yield criterion for /MAT/LAW131
+! \details Compute the equivalent stress and its first-order
+!          derivatives using the Barlat 1989 anisotropic yield criterion
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    yield_criterion_barlat1989              ../engine/source/materials/mat/mat131/yield_criterion/yield_criterion_barlat1989.F90

--- a/engine/source/materials/mat/mat131/yield_criterion/yield_criterion_barlat2000.F90
+++ b/engine/source/materials/mat/mat131/yield_criterion/yield_criterion_barlat2000.F90
@@ -27,6 +27,10 @@
 !||    elasto_plastic_second_order_numerical   ../engine/source/materials/mat/mat131/elasto_plastic_second_order_numerical.F90
 !||====================================================================
       module yield_criterion_barlat2000_mod
+! \brief Compute Barlat 2000 yield criterion for /MAT/LAW131
+! \details Compute the equivalent stress and its first-order
+!          derivatives using the Barlat 2000 (Yld2000-2d) anisotropic
+!          yield criterion for /MAT/LAW131.
       contains
 !||====================================================================
 !||    yield_criterion_barlat2000              ../engine/source/materials/mat/mat131/yield_criterion/yield_criterion_barlat2000.F90

--- a/engine/source/materials/mat/mat131/yield_criterion/yield_criterion_hershey.F90
+++ b/engine/source/materials/mat/mat131/yield_criterion/yield_criterion_hershey.F90
@@ -26,6 +26,10 @@
 !||    elasto_plastic_eq_stress      ../engine/source/materials/mat/mat131/elasto_plastic_eq_stress.F90
 !||====================================================================
       module yield_criterion_hershey_mod
+! \brief Compute Hershey yield criterion for /MAT/LAW131
+! \details Compute the equivalent stress and its first and second-order
+!          derivatives using the Hershey isotropic yield criterion
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    yield_criterion_hershey        ../engine/source/materials/mat/mat131/yield_criterion/yield_criterion_hershey.F90

--- a/engine/source/materials/mat/mat131/yield_criterion/yield_criterion_hill.F90
+++ b/engine/source/materials/mat/mat131/yield_criterion/yield_criterion_hill.F90
@@ -26,6 +26,10 @@
 !||    elasto_plastic_eq_stress   ../engine/source/materials/mat/mat131/elasto_plastic_eq_stress.F90
 !||====================================================================
       module yield_criterion_hill_mod
+! \brief Compute Hill yield criterion for /MAT/LAW131
+! \details Compute the equivalent stress and its first and second-order
+!          derivatives using the Hill 1948 anisotropic yield criterion
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    yield_criterion_hill           ../engine/source/materials/mat/mat131/yield_criterion/yield_criterion_hill.F90

--- a/engine/source/materials/mat/mat131/yield_criterion/yield_criterion_vonmises.F90
+++ b/engine/source/materials/mat/mat131/yield_criterion/yield_criterion_vonmises.F90
@@ -29,6 +29,10 @@
 !||    yield_criterion_hill           ../engine/source/materials/mat/mat131/yield_criterion/yield_criterion_hill.F90
 !||====================================================================
       module yield_criterion_vonmises_mod
+! \brief Compute von Mises yield criterion for /MAT/LAW131
+! \details Compute the equivalent stress and its first and second-order
+!          derivatives using the von Mises isotropic yield criterion
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    yield_criterion_vonmises   ../engine/source/materials/mat/mat131/yield_criterion/yield_criterion_vonmises.F90

--- a/hm_cfg_files/config/CFG/radioss2612/MAT/matl131_elasto_plastic_support.cfg
+++ b/hm_cfg_files/config/CFG/radioss2612/MAT/matl131_elasto_plastic_support.cfg
@@ -67,6 +67,12 @@ ATTRIBUTES(COMMON) {
     ELAS_TEMP_FCTH  = VALUE(FUNCT, "Young modulus temperature dependency function ID for heating");
     ELAS_TEMP_FCTC  = VALUE(FUNCT, "Young modulus temperature dependency function ID for cooling");
     ELAS_TEMP_FCTN  = VALUE(FUNCT, "Poisson ratio temperature dependency function ID");
+// for ELAS_BIMOD_ISOTROPIC
+    ELAS_BIMOD_ET    = VALUE(FLOAT, "Young modulus in tension");
+    ELAS_BIMOD_EC    = VALUE(FLOAT, "Young modulus in compression");
+    ELAS_BIMOD_NU    = VALUE(FLOAT, "Poisson ratio");
+    ELAS_BIMOD_TT    = VALUE(FLOAT, "Limit triaxiality in tension");
+    ELAS_BIMOD_TC    = VALUE(FLOAT, "Limit triaxiality in compression");
 // for CRIT_HERSHEY
     CRIT_HERSHEY_N  = VALUE(FLOAT, "Hershey criterion exponent n");
 // for CRIT_HILL
@@ -115,6 +121,10 @@ ATTRIBUTES(COMMON) {
     HARD_POWERLAW_B = VALUE(FLOAT, "Hardening modulus B");
     HARD_POWERLAW_N = VALUE(FLOAT, "Hardening exponent n");
     HARD_POWERLAW_EPS0 = VALUE(FLOAT,"Initial plastic strain EPS0");
+    HARD_POWERLAW_SIGY = VALUE(FLOAT,"Yield stress at zero plastic strain");
+    HARD_POWERLAW_UTS  = VALUE(FLOAT,"Ultimate tensile strength");
+    HARD_POWERLAW_EPSUTS= VALUE(FLOAT,"Engineering strain at UTS");
+    HARD_POWERLAW_SIGMAX = VALUE(FLOAT,"Maximum yield stress");
 // for HARD_VOCE
     HARD_VOCE_R0    = VALUE(FLOAT, "Initial yield stress R0");
     HARD_VOCE_Q1    = VALUE(FLOAT, "Voce 1 saturation stress Q1");
@@ -229,6 +239,12 @@ SKEYWORDS_IDENTIFIER(COMMON)
     ELAS_TEMP_E      = -1;
     ELAS_TEMP_NU     = -1;
     //
+    ELAS_BIMOD_ET  = -1;
+    ELAS_BIMOD_EC  = -1;
+    ELAS_BIMOD_NU  = -1;
+    ELAS_BIMOD_TT  = -1;
+    ELAS_BIMOD_TC  = -1;
+    //
     CRIT_HERSHEY_N = -1;
     //
     CRIT_HILL_R11 = -1;
@@ -276,6 +292,10 @@ SKEYWORDS_IDENTIFIER(COMMON)
     HARD_POWERLAW_B = -1;
     HARD_POWERLAW_N = -1;
     HARD_POWERLAW_EPS0 = -1;
+    HARD_POWERLAW_SIGY = -1;
+    HARD_POWERLAW_UTS  = -1;
+    HARD_POWERLAW_EPSUTS= -1;
+    HARD_POWERLAW_SIGMAX = -1;
     //
     HARD_VOCE_R0 = -1;
     HARD_VOCE_Q1 = -1;
@@ -386,6 +406,12 @@ GUI(COMMON)
     // for ELAS_TEMP_ISOTROPIC
     SCALAR(ELAS_TEMP_E)                {DIMENSION="pressure";     }
     SCALAR(ELAS_TEMP_NU)               {DIMENSION="DIMENSIONLESS";}
+    // for ELAS_BIMOD_ISOTROPIC
+    SCALAR(ELAS_BIMOD_ET)              {DIMENSION="pressure";     }
+    SCALAR(ELAS_BIMOD_EC)              {DIMENSION="pressure";     }
+    SCALAR(ELAS_BIMOD_NU)              {DIMENSION="DIMENSIONLESS";}
+    SCALAR(ELAS_BIMOD_TT)              {DIMENSION="DIMENSIONLESS";}
+    SCALAR(ELAS_BIMOD_TC)              {DIMENSION="DIMENSIONLESS";}
     // for CRIT_HERSHEY
     SCALAR(CRIT_HERSHEY_N)             {DIMENSION="DIMENSIONLESS";}
     // for CRIT_HILL
@@ -433,6 +459,10 @@ GUI(COMMON)
     SCALAR(HARD_POWERLAW_B)            {DIMENSION="pressure";     }
     SCALAR(HARD_POWERLAW_N)            {DIMENSION="DIMENSIONLESS";}
     SCALAR(HARD_POWERLAW_EPS0)         {DIMENSION="DIMENSIONLESS";}
+    SCALAR(HARD_POWERLAW_SIGY)         {DIMENSION="pressure";     }
+    SCALAR(HARD_POWERLAW_UTS)          {DIMENSION="pressure";     }
+    SCALAR(HARD_POWERLAW_EPSUTS)       {DIMENSION="DIMENSIONLESS";}
+    SCALAR(HARD_POWERLAW_SIGMAX)       {DIMENSION="pressure";     }
     // for HARD_VOCE
     SCALAR(HARD_VOCE_R0)               {DIMENSION="pressure";     }
     SCALAR(HARD_VOCE_Q1)               {DIMENSION="pressure";     }
@@ -547,6 +577,13 @@ FORMAT(radioss2612) {
         COMMENT("$                  E                  NU         FCT_ID_HEAT         FCT_ID_COOL           FCT_ID_NU");
         CARD("%20lg%20lg%10s%10d%10s%10d%10s%10d",ELAS_TEMP_E,ELAS_TEMP_NU,_BLANK_,ELAS_TEMP_FCTH,_BLANK_,ELAS_TEMP_FCTC,_BLANK_,ELAS_TEMP_FCTN);
    }
+   if (KEY_type == "ELAS_BIMOD_ISOTROPIC")
+   {
+        COMMENT("$           KEY_TYPE");
+        CARD("%-20s",KEY_type);
+        COMMENT("$                 ET                  EC                  NU                  TT                  TC");
+        CARD("%20lg%20lg%20lg%20lg%20lg",ELAS_BIMOD_ET,ELAS_BIMOD_EC,ELAS_BIMOD_NU,ELAS_BIMOD_TT,ELAS_BIMOD_TC);
+   }
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    if (KEY_type == "CRIT_VONMISES")
    {
@@ -615,8 +652,15 @@ FORMAT(radioss2612) {
    {
         COMMENT("$           KEY_TYPE");
         CARD("%-20s",KEY_type);
-        COMMENT("$                  A                   B                   N                EPS0");
-        CARD("%20lg%20lg%20lg%20lg",HARD_POWERLAW_A,HARD_POWERLAW_B,HARD_POWERLAW_N,HARD_POWERLAW_EPS0);
+        COMMENT("$                  A                   B                   N                EPS0              SIGMAX");
+        CARD("%20lg%20lg%20lg%20lg%20lg",HARD_POWERLAW_A,HARD_POWERLAW_B,HARD_POWERLAW_N,HARD_POWERLAW_EPS0,HARD_POWERLAW_SIGMAX);
+   }
+   if (KEY_type == "HARD_POWERLAW_ENG")
+   {
+        COMMENT("$           KEY_TYPE");
+        CARD("%-20s",KEY_type);
+        COMMENT("$               SIGY                 UTS             EPS_UTS                EPS0              SIGMAX");
+        CARD("%20lg%20lg%20lg%20lg%20lg",HARD_POWERLAW_SIGY,HARD_POWERLAW_UTS,HARD_POWERLAW_EPSUTS,HARD_POWERLAW_EPS0,HARD_POWERLAW_SIGMAX);
    }
    if (KEY_type == "HARD_VOCE")
    {

--- a/starter/source/materials/mat/mat131/elasticity/hm_read_elasticity.F90
+++ b/starter/source/materials/mat/mat131/elasticity/hm_read_elasticity.F90
@@ -27,6 +27,9 @@
 !||====================================================================
       module hm_read_elasticity_mod
         implicit none
+! \brief Read elasticity input data for /MAT/LAW131
+! \details Read and dispatch the elasticity model input data
+!          for /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    hm_read_elasticity                         ../starter/source/materials/mat/mat131/elasticity/hm_read_elasticity.F90
@@ -69,6 +72,7 @@
           use hm_read_elasticity_anisotropic_mod
           use hm_read_elasticity_viscous_isotropic_mod
           use hm_read_elasticity_temp_isotropic_mod
+          use hm_read_elasticity_bimod_isotropic_mod
 !----------------------------------------------------------------
 !   I m p l i c i t   T y p e s
 !----------------------------------------------------------------
@@ -150,6 +154,14 @@
                 is_encrypted,mat_id,titr      ,ntab_elas,itab_elas   ,         &
                 x2vect   ,x3vect   ,x4vect    ,fscale   ,nvartmp     ,         &
                 mtag     ,nuvar_elas)
+            !===================================================================
+            !< Bimodular isotropic elasticity parameters
+            !===================================================================
+            case('BIMO')
+              call hm_read_elasticity_bimod_isotropic(                         &
+                ikey     ,ielas    ,nupar_elas,upar_elas,is_available,         &
+                unitab   ,lsubmodel,matparam  ,parmat   ,iout        ,         &
+                is_encrypted,mat_id,titr      )
           end select
 ! -------------------------------------------------------------------------------
         end subroutine hm_read_elasticity

--- a/starter/source/materials/mat/mat131/elasticity/hm_read_elasticity_anisotropic.F90
+++ b/starter/source/materials/mat/mat131/elasticity/hm_read_elasticity_anisotropic.F90
@@ -27,6 +27,9 @@
 !||====================================================================
       module hm_read_elasticity_anisotropic_mod
         implicit none
+! \brief Read anisotropic elasticity input data for /MAT/LAW131
+! \details Read the anisotropic elasticity model parameters
+!          for /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    hm_read_elasticity_anisotropic   ../starter/source/materials/mat/mat131/elasticity/hm_read_elasticity_anisotropic.F90

--- a/starter/source/materials/mat/mat131/elasticity/hm_read_elasticity_bimod_isotropic.F90
+++ b/starter/source/materials/mat/mat131/elasticity/hm_read_elasticity_bimod_isotropic.F90
@@ -20,30 +20,13 @@
 !Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
 !Copyright>        software under a commercial license.  Contact Altair to discuss further if the
 !Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
-!||====================================================================
-!||    hm_read_elasticity_isotropic_mod   ../starter/source/materials/mat/mat131/elasticity/hm_read_elasticity_isotropic.F90
-!||--- called by ------------------------------------------------------
-!||    hm_read_elasticity                 ../starter/source/materials/mat/mat131/elasticity/hm_read_elasticity.F90
-!||====================================================================
-      module hm_read_elasticity_isotropic_mod
+      module hm_read_elasticity_bimod_isotropic_mod
         implicit none
-! \brief Read isotropic elasticity input data for /MAT/LAW131
-! \details Read the isotropic elasticity model parameters
-!          for /MAT/LAW131 (elasto-plastic material law).
+! \brief Read bimodular isotropic elasticity input data for /MAT/LAW131
+! \details Read the bimodular isotropic elasticity model parameters
+!          (different moduli in tension and compression) for /MAT/LAW131.
       contains
-!||====================================================================
-!||    hm_read_elasticity_isotropic   ../starter/source/materials/mat/mat131/elasticity/hm_read_elasticity_isotropic.F90
-!||--- called by ------------------------------------------------------
-!||    hm_read_elasticity             ../starter/source/materials/mat/mat131/elasticity/hm_read_elasticity.F90
-!||--- calls      -----------------------------------------------------
-!||    ancmsg                         ../starter/source/output/message/message.F
-!||    hm_get_float_array_index       ../starter/source/devtools/hm_reader/hm_get_float_array_index.F
-!||--- uses       -----------------------------------------------------
-!||    hm_option_read_mod             ../starter/share/modules1/hm_option_read_mod.F
-!||    message_mod                    ../starter/share/message_module/message_mod.F
-!||    submodel_mod                   ../starter/share/modules1/submodel_mod.F
-!||====================================================================
-        subroutine hm_read_elasticity_isotropic(                               &
+        subroutine hm_read_elasticity_bimod_isotropic(                         &
           ikey     ,ielas    ,nupar_elas,upar_elas,is_available,               &
           unitab   ,lsubmodel,matparam ,parmat    ,iout        ,is_encrypted,  &
           mat_id   ,titr     )
@@ -80,14 +63,17 @@
 !----------------------------------------------------------------
 !  L o c a l  V a r i a b l e s
 !----------------------------------------------------------------
-          real(kind=WP) :: young,nu,shear,lam,cii,cij,aii,aij
+          real(kind=WP) :: et,ec,nu,tt,tc
 !===============================================================================
 ! 
           !===================================================================
           !< Elastic isotropic parameters
           !===================================================================
-          call hm_get_float_array_index("ELAS_ISOT_E" ,young,ikey,is_available,lsubmodel,unitab)
-          call hm_get_float_array_index("ELAS_ISOT_NU",nu   ,ikey,is_available,lsubmodel,unitab)
+          call hm_get_float_array_index("ELAS_BIMOD_ET",et,ikey,is_available,lsubmodel,unitab)
+          call hm_get_float_array_index("ELAS_BIMOD_EC",ec,ikey,is_available,lsubmodel,unitab)
+          call hm_get_float_array_index("ELAS_BIMOD_NU",nu,ikey,is_available,lsubmodel,unitab)
+          call hm_get_float_array_index("ELAS_BIMOD_TT",tt,ikey,is_available,lsubmodel,unitab)
+          call hm_get_float_array_index("ELAS_BIMOD_TC",tc,ikey,is_available,lsubmodel,unitab)
           !< Check parameters values
           if (nu < zero .or. nu >= half) then
             call ancmsg(msgid=3131,                                            &
@@ -96,14 +82,27 @@
                         i1=mat_id,                                             &
                         c1="ERROR",                                            &
                         c2=titr,                                               &
-                        c3="ELAS_ISOTROPIC",                                   &
+                        c3="ELAS_BIMOD_ISOTROPIC",                             &
                         c4="POISSON'S RATIO MUST BE IN THE RANGE [0,0.5[.")
           endif
+          tt = min(max(tt,-one),one)
+          tc = min(max(tc,-one),one)
+          if (tt <= tc) then 
+            call ancmsg(msgid=3131,                                            &
+                        msgtype=msgerror,                                      &
+                        anmode=aninfo_blind_2,                                 &
+                        i1=mat_id,                                             &
+                        c1="ERROR",                                            &
+                        c2=titr,                                               &
+                        c3="ELAS_BIMOD_ISOTROPIC",                             &
+                        c4="LIMIT TRIAXIALITY IN TENSION MUST BE GREATER THAN  &
+                            OR EQUAL TO LIMIT TRIAXIALITY IN COMPRESSION.")
+          endif
           !< Fill MATPARAM values
-          matparam%young = young
+          matparam%young = max(et,ec)
           matparam%nu    = nu
-          matparam%shear = young/(two*(one + nu))
-          matparam%bulk  = young/(three*(one - two*nu))
+          matparam%shear = matparam%young/(two*(one + nu))
+          matparam%bulk  = matparam%young/(three*(one - two*nu))
           !< Fill PARMAT values
           parmat(1)  = matparam%bulk
           parmat(2)  = matparam%young
@@ -111,33 +110,30 @@
           parmat(16) = 2
           parmat(17) = (one - two*nu)/(one - nu)
           !< Elasticity type
-          ielas = 1
+          ielas = 6
           !< Number of parameters
           nupar_elas = 4
           !< Save elastic parameters
-          shear = young/(two*(one + nu))
-          lam = young*nu/(one + nu)/(one - two*nu)
-          cii = lam + shear*two
-          cij = lam
-          aii = young/(one - nu*nu)
-          aij = nu*aii
-          upar_elas(1) = cii
-          upar_elas(2) = cij
-          upar_elas(3) = aii
-          upar_elas(4) = aij
+          upar_elas(1) = et
+          upar_elas(2) = ec
+          upar_elas(3) = tt
+          upar_elas(4) = tc
           !< Printing elastic parameters
-          if (is_encrypted)then
+          if (is_encrypted) then
             write(iout,"(5X,A,//)") "CONFIDENTIAL DATA"
           else
-            write(iout,1000) young,nu
+            write(iout,1000) et,ec,nu,tt,tc
           endif
 ! ------------------------------------------------------------------------------
 1000 format(/                                                                  &
           5X,"-------------------------------------------------------",/       &
-          5X,"ISOTROPIC ELASTICITY                                   ",/,      &
+          5X,"ISOTROPIC BIMODULAR ELASTICITY                         ",/,      &
           5X,"-------------------------------------------------------",/,      &
-          5X,"YOUNG MODULUS (E). . . . . . . . . . . . . . . . . . .=",1PG20.13/&
-          5X,"POISSON RATIO (NU) . . . . . . . . . . . . . . . . . .=",1PG20.13/)
+          5X,"YOUNG MODULUS IN TENSION (ET). . . . . . . . . . . . .=",1PG20.13/&
+          5X,"YOUNG MODULUS IN COMPRESSION (EC). . . . . . . . . . .=",1PG20.13/&
+          5X,"POISSON RATIO (NU) . . . . . . . . . . . . . . . . . .=",1PG20.13/&
+          5X,"LIMIT TRIAXIALITY IN TENSION (TT). . . . . . . . . . .=",1PG20.13/&
+          5X,"LIMIT TRIAXIALITY IN COMPRESSION (TC). . . . . . . . .=",1PG20.13/)
 ! -------------------------------------------------------------------------------
-        end subroutine hm_read_elasticity_isotropic
-      end module hm_read_elasticity_isotropic_mod
+        end subroutine hm_read_elasticity_bimod_isotropic
+      end module hm_read_elasticity_bimod_isotropic_mod

--- a/starter/source/materials/mat/mat131/elasticity/hm_read_elasticity_orthotropic.F90
+++ b/starter/source/materials/mat/mat131/elasticity/hm_read_elasticity_orthotropic.F90
@@ -27,6 +27,9 @@
 !||====================================================================
       module hm_read_elasticity_orthotropic_mod
         implicit none
+! \brief Read orthotropic elasticity input data for /MAT/LAW131
+! \details Read the orthotropic elasticity model parameters
+!          for /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    hm_read_elasticity_orthotropic   ../starter/source/materials/mat/mat131/elasticity/hm_read_elasticity_orthotropic.F90

--- a/starter/source/materials/mat/mat131/elasticity/hm_read_elasticity_temp_isotropic.F90
+++ b/starter/source/materials/mat/mat131/elasticity/hm_read_elasticity_temp_isotropic.F90
@@ -27,6 +27,9 @@
 !||====================================================================
       module hm_read_elasticity_temp_isotropic_mod
         implicit none
+! \brief Read temperature-dependent isotropic elasticity input data for /MAT/LAW131
+! \details Read the temperature-dependent isotropic elasticity model
+!          parameters for /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    hm_read_elasticity_temp_isotropic   ../starter/source/materials/mat/mat131/elasticity/hm_read_elasticity_temp_isotropic.F90

--- a/starter/source/materials/mat/mat131/elasticity/hm_read_elasticity_viscous_isotropic.F90
+++ b/starter/source/materials/mat/mat131/elasticity/hm_read_elasticity_viscous_isotropic.F90
@@ -27,6 +27,9 @@
 !||====================================================================
       module hm_read_elasticity_viscous_isotropic_mod
         implicit none
+! \brief Read viscous isotropic elasticity input data for /MAT/LAW131
+! \details Read the viscous isotropic elasticity model parameters
+!          for /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    hm_read_elasticity_viscous_isotropic   ../starter/source/materials/mat/mat131/elasticity/hm_read_elasticity_viscous_isotropic.F90

--- a/starter/source/materials/mat/mat131/hm_read_elasto_plastic.F90
+++ b/starter/source/materials/mat/mat131/hm_read_elasto_plastic.F90
@@ -27,6 +27,9 @@
 !||====================================================================
       module hm_read_elasto_plastic_mod
         implicit none
+! \brief Read /MAT/LAW131 elasto-plastic material input data
+! \details Main reader routine for /MAT/LAW131 (elasto-plastic material law).
+!          Reads and dispatches all sub-model input data.
       contains
 !||====================================================================
 !||    hm_read_elasto_plastic            ../starter/source/materials/mat/mat131/hm_read_elasto_plastic.F90
@@ -310,7 +313,7 @@
                   itab_hard,x2vect_hard     ,x3vect_hard   ,x4vect_hard     ,  &
                   fscale_hard,nvartmp_hard  ,is_available  ,unitab,lsubmodel,  &
                   iout  ,is_encrypted       ,vpflag        ,israte          ,  &
-                  parmat   )   
+                  parmat   ,titr  ,mat_id   ,matparam      )   
               !< Strain rate dependency
               case ('SRAT')
                 if (iratedep /= 0) then 

--- a/starter/source/materials/mat/mat131/kinematic_hardening/hm_read_kinematic_hardening.F90
+++ b/starter/source/materials/mat/mat131/kinematic_hardening/hm_read_kinematic_hardening.F90
@@ -27,6 +27,9 @@
 !||====================================================================
       module hm_read_kinematic_hardening_mod
         implicit none
+! \brief Read kinematic hardening input data for /MAT/LAW131
+! \details Read and dispatch the kinematic hardening model input data
+!          for /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    hm_read_kinematic_hardening                ../starter/source/materials/mat/mat131/kinematic_hardening/hm_read_kinematic_hardening.F90

--- a/starter/source/materials/mat/mat131/kinematic_hardening/hm_read_kinematic_hardening_chaboche.F90
+++ b/starter/source/materials/mat/mat131/kinematic_hardening/hm_read_kinematic_hardening_chaboche.F90
@@ -26,6 +26,9 @@
 !||    hm_read_kinematic_hardening                ../starter/source/materials/mat/mat131/kinematic_hardening/hm_read_kinematic_hardening.F90
 !||====================================================================
       module hm_read_kinematic_hardening_chaboche_mod
+! \brief Read Chaboche kinematic hardening input data for /MAT/LAW131
+! \details Read the Chaboche nonlinear kinematic hardening model parameters
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_kinematic_hardening_chaboche   ../starter/source/materials/mat/mat131/kinematic_hardening/hm_read_kinematic_hardening_chaboche.F90

--- a/starter/source/materials/mat/mat131/kinematic_hardening/hm_read_kinematic_hardening_prager.F90
+++ b/starter/source/materials/mat/mat131/kinematic_hardening/hm_read_kinematic_hardening_prager.F90
@@ -26,6 +26,9 @@
 !||    hm_read_kinematic_hardening              ../starter/source/materials/mat/mat131/kinematic_hardening/hm_read_kinematic_hardening.F90
 !||====================================================================
       module hm_read_kinematic_hardening_prager_mod
+! \brief Read Prager kinematic hardening input data for /MAT/LAW131
+! \details Read the Prager linear kinematic hardening model parameters
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_kinematic_hardening_prager   ../starter/source/materials/mat/mat131/kinematic_hardening/hm_read_kinematic_hardening_prager.F90

--- a/starter/source/materials/mat/mat131/self_heating/hm_read_self_heating.F90
+++ b/starter/source/materials/mat/mat131/self_heating/hm_read_self_heating.F90
@@ -27,6 +27,9 @@
 !||====================================================================
       module hm_read_self_heating_mod
         implicit none
+! \brief Read self-heating input data for /MAT/LAW131
+! \details Read and dispatch the self-heating model input data
+!          for /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    hm_read_self_heating                 ../starter/source/materials/mat/mat131/self_heating/hm_read_self_heating.F90

--- a/starter/source/materials/mat/mat131/self_heating/hm_read_self_heating_tabulated.F90
+++ b/starter/source/materials/mat/mat131/self_heating/hm_read_self_heating_tabulated.F90
@@ -26,6 +26,9 @@
 !||    hm_read_self_heating                 ../starter/source/materials/mat/mat131/self_heating/hm_read_self_heating.F90
 !||====================================================================
       module hm_read_self_heating_tabulated_mod
+! \brief Read tabulated self-heating input data for /MAT/LAW131
+! \details Read the tabulated Taylor-Quinney self-heating model parameters
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_self_heating_tabulated   ../starter/source/materials/mat/mat131/self_heating/hm_read_self_heating_tabulated.F90

--- a/starter/source/materials/mat/mat131/self_heating/hm_read_self_heating_taylor.F90
+++ b/starter/source/materials/mat/mat131/self_heating/hm_read_self_heating_taylor.F90
@@ -26,6 +26,9 @@
 !||    hm_read_self_heating              ../starter/source/materials/mat/mat131/self_heating/hm_read_self_heating.F90
 !||====================================================================
       module hm_read_self_heating_taylor_mod
+! \brief Read Taylor-Quinney self-heating input data for /MAT/LAW131
+! \details Read the constant Taylor-Quinney self-heating model parameters
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_self_heating_taylor   ../starter/source/materials/mat/mat131/self_heating/hm_read_self_heating_taylor.F90

--- a/starter/source/materials/mat/mat131/srate_dependency/hm_read_srate_dependency.F90
+++ b/starter/source/materials/mat/mat131/srate_dependency/hm_read_srate_dependency.F90
@@ -27,6 +27,9 @@
 !||====================================================================
       module hm_read_srate_dependency_mod
         implicit none
+! \brief Read strain rate dependency input data for /MAT/LAW131
+! \details Read and dispatch the strain rate dependency model input data
+!          for /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    hm_read_srate_dependency                     ../starter/source/materials/mat/mat131/srate_dependency/hm_read_srate_dependency.F90

--- a/starter/source/materials/mat/mat131/srate_dependency/hm_read_srate_dependency_cowpersymonds.F90
+++ b/starter/source/materials/mat/mat131/srate_dependency/hm_read_srate_dependency_cowpersymonds.F90
@@ -26,6 +26,9 @@
 !||    hm_read_srate_dependency                     ../starter/source/materials/mat/mat131/srate_dependency/hm_read_srate_dependency.F90
 !||====================================================================
       module hm_read_srate_dependency_cowpersymonds_mod
+! \brief Read Cowper-Symonds strain rate dependency input data for /MAT/LAW131
+! \details Read the Cowper-Symonds strain rate dependency model parameters
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_srate_dependency_cowpersymonds   ../starter/source/materials/mat/mat131/srate_dependency/hm_read_srate_dependency_cowpersymonds.F90

--- a/starter/source/materials/mat/mat131/srate_dependency/hm_read_srate_dependency_johnsoncook.F90
+++ b/starter/source/materials/mat/mat131/srate_dependency/hm_read_srate_dependency_johnsoncook.F90
@@ -26,6 +26,9 @@
 !||    hm_read_srate_dependency                   ../starter/source/materials/mat/mat131/srate_dependency/hm_read_srate_dependency.F90
 !||====================================================================
       module hm_read_srate_dependency_johnsoncook_mod
+! \brief Read Johnson-Cook strain rate dependency input data for /MAT/LAW131
+! \details Read the Johnson-Cook strain rate dependency model parameters
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_srate_dependency_johnsoncook   ../starter/source/materials/mat/mat131/srate_dependency/hm_read_srate_dependency_johnsoncook.F90

--- a/starter/source/materials/mat/mat131/srate_dependency/hm_read_srate_dependency_nonlinear.F90
+++ b/starter/source/materials/mat/mat131/srate_dependency/hm_read_srate_dependency_nonlinear.F90
@@ -26,6 +26,9 @@
 !||    hm_read_srate_dependency                 ../starter/source/materials/mat/mat131/srate_dependency/hm_read_srate_dependency.F90
 !||====================================================================
       module hm_read_srate_dependency_nonlinear_mod
+! \brief Read nonlinear strain rate dependency input data for /MAT/LAW131
+! \details Read the nonlinear strain rate dependency model parameters
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_srate_dependency_nonlinear   ../starter/source/materials/mat/mat131/srate_dependency/hm_read_srate_dependency_nonlinear.F90

--- a/starter/source/materials/mat/mat131/srate_dependency/hm_read_srate_dependency_tabulated.F90
+++ b/starter/source/materials/mat/mat131/srate_dependency/hm_read_srate_dependency_tabulated.F90
@@ -26,6 +26,9 @@
 !||    hm_read_srate_dependency                 ../starter/source/materials/mat/mat131/srate_dependency/hm_read_srate_dependency.F90
 !||====================================================================
       module hm_read_srate_dependency_tabulated_mod
+! \brief Read tabulated strain rate dependency input data for /MAT/LAW131
+! \details Read the tabulated strain rate dependency model parameters
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_srate_dependency_tabulated   ../starter/source/materials/mat/mat131/srate_dependency/hm_read_srate_dependency_tabulated.F90

--- a/starter/source/materials/mat/mat131/therm_softening/hm_read_therm_softening.F90
+++ b/starter/source/materials/mat/mat131/therm_softening/hm_read_therm_softening.F90
@@ -27,6 +27,9 @@
 !||====================================================================
       module hm_read_therm_softening_mod
         implicit none
+! \brief Read thermal softening input data for /MAT/LAW131
+! \details Read and dispatch the thermal softening model input data
+!          for /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    hm_read_therm_softening                   ../starter/source/materials/mat/mat131/therm_softening/hm_read_therm_softening.F90

--- a/starter/source/materials/mat/mat131/therm_softening/hm_read_therm_softening_johnsoncook.F90
+++ b/starter/source/materials/mat/mat131/therm_softening/hm_read_therm_softening_johnsoncook.F90
@@ -26,6 +26,9 @@
 !||    hm_read_therm_softening                   ../starter/source/materials/mat/mat131/therm_softening/hm_read_therm_softening.F90
 !||====================================================================
       module hm_read_therm_softening_johnsoncook_mod
+! \brief Read Johnson-Cook thermal softening input data for /MAT/LAW131
+! \details Read the Johnson-Cook thermal softening model parameters
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_therm_softening_johnsoncook   ../starter/source/materials/mat/mat131/therm_softening/hm_read_therm_softening_johnsoncook.F90

--- a/starter/source/materials/mat/mat131/therm_softening/hm_read_therm_softening_tabulated.F90
+++ b/starter/source/materials/mat/mat131/therm_softening/hm_read_therm_softening_tabulated.F90
@@ -26,6 +26,9 @@
 !||    hm_read_therm_softening                 ../starter/source/materials/mat/mat131/therm_softening/hm_read_therm_softening.F90
 !||====================================================================
       module hm_read_therm_softening_tabulated_mod
+! \brief Read tabulated thermal softening input data for /MAT/LAW131
+! \details Read the tabulated thermal softening model parameters
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_therm_softening_tabulated   ../starter/source/materials/mat/mat131/therm_softening/hm_read_therm_softening_tabulated.F90

--- a/starter/source/materials/mat/mat131/therm_softening/hm_read_therm_softening_zhao.F90
+++ b/starter/source/materials/mat/mat131/therm_softening/hm_read_therm_softening_zhao.F90
@@ -26,6 +26,9 @@
 !||    hm_read_therm_softening            ../starter/source/materials/mat/mat131/therm_softening/hm_read_therm_softening.F90
 !||====================================================================
       module hm_read_therm_softening_zhao_mod
+! \brief Read Zhao thermal softening input data for /MAT/LAW131
+! \details Read the Zhao thermal softening model parameters
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_therm_softening_zhao   ../starter/source/materials/mat/mat131/therm_softening/hm_read_therm_softening_zhao.F90

--- a/starter/source/materials/mat/mat131/work_hardening/hm_read_work_hardening.F90
+++ b/starter/source/materials/mat/mat131/work_hardening/hm_read_work_hardening.F90
@@ -27,6 +27,9 @@
 !||====================================================================
       module hm_read_work_hardening_mod
         implicit none
+! \brief Read work hardening input data for /MAT/LAW131
+! \details Read and dispatch the work hardening model input data
+!          for /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    hm_read_work_hardening                  ../starter/source/materials/mat/mat131/work_hardening/hm_read_work_hardening.F90
@@ -49,7 +52,7 @@
           ikey     ,type     ,ihard    ,nupar_hard,upar_hard,ntab_hard,        &
           itab_hard,x2vect   ,x3vect   ,x4vect    ,fscale   ,nvartmp  ,        &
           is_available,unitab,lsubmodel,iout      ,is_encrypted,vpflag,        &
-          israte   ,parmat   )
+          israte   ,parmat   ,titr     ,mat_id    ,matparam    )
 !----------------------------------------------------------------
 !   M o d u l e s
 !----------------------------------------------------------------
@@ -90,42 +93,49 @@
           integer,                 intent(inout) :: vpflag                !< Strain rate flag
           integer,                 intent(inout) :: israte                !< Strain rate filtering flag
           real(kind=WP),dimension(100),intent(inout) :: parmat            !< Material parameters
+          character(len=nchartitle),intent(in)   :: titr                  !< Material law user title
+          integer,                 intent(in)    :: mat_id                !< Material law user ID
+          type(matparam_struct_),  intent(inout) :: matparam              !< Matparam data structure
 !===============================================================================
 !     
-          !< Select work hardening type
-          select case (type(1:4))
-            !===================================================================
-            !< Power law hardening parameters
-            !===================================================================
-            case ('POWE')
-              call hm_read_work_hardening_powerlaw(                            &
-                ikey     ,ihard    ,nupar_hard,upar_hard,is_available,         &
-                unitab   ,lsubmodel,iout     ,is_encrypted)
-            !===================================================================
-            !< Power law hardening parameters
-            !===================================================================
-            case ('VOCE')
-              call hm_read_work_hardening_voce(                                &
-                ikey     ,ihard    ,nupar_hard,upar_hard,is_available,         &
-                unitab   ,lsubmodel,iout     ,is_encrypted)
-            !===================================================================
-            !< Tabulated hardening parameters
-            !===================================================================
-            case ('TAB ')
-              call hm_read_work_hardening_tabulated(                           &
-                ikey     ,ihard    ,ntab_hard ,itab_hard   ,x2vect ,x3vect   , &
-                x4vect   ,fscale   ,nvartmp   ,is_available,unitab ,lsubmodel, &
-                iout     ,is_encrypted,vpflag ,israte      ,parmat ,nupar_hard,&
-                upar_hard)
-            !===================================================================
-            !< Linear-Voce hardening parameters
-            !===================================================================
-            case ('LINV')
-              call hm_read_work_hardening_linearvoce(                          &
-                ikey     ,ihard    ,nupar_hard,upar_hard,is_available,         &
-                unitab   ,lsubmodel,iout     ,is_encrypted)
-            !===================================================================
-          end select
-! -------------------------------------------------------------------------------
+          !=====================================================================
+          !< Power law hardening parameters
+          !=====================================================================
+          if (type(1:12) == 'POWERLAW_ENG') then
+            call hm_read_work_hardening_powerlaw(                              &
+              ikey     ,ihard    ,nupar_hard,upar_hard,is_available,           &
+              unitab   ,lsubmodel,iout     ,is_encrypted,         1,           &
+              titr     ,mat_id   ,matparam )          
+          elseif (type(1:8) == 'POWERLAW') then
+            call hm_read_work_hardening_powerlaw(                              &
+              ikey     ,ihard    ,nupar_hard,upar_hard,is_available,           &
+              unitab   ,lsubmodel,iout     ,is_encrypted,         2,           &
+              titr     ,mat_id   ,matparam )
+          !=====================================================================
+          !< Voce hardening parameters
+          !=====================================================================
+          elseif (type(1:4) == 'VOCE') then
+            call hm_read_work_hardening_voce(                                  &
+              ikey     ,ihard    ,nupar_hard,upar_hard,is_available,           &
+              unitab   ,lsubmodel,iout     ,is_encrypted)
+          !=====================================================================
+          !< Tabulated hardening parameters
+          !=====================================================================
+          elseif (type(1:3) == 'TAB') then
+            call hm_read_work_hardening_tabulated(                             &
+              ikey     ,ihard    ,ntab_hard ,itab_hard   ,x2vect ,x3vect   ,   &
+              x4vect   ,fscale   ,nvartmp   ,is_available,unitab ,lsubmodel,   &
+              iout     ,is_encrypted,vpflag ,israte      ,parmat ,nupar_hard,  &
+              upar_hard)
+          !=====================================================================
+          !< Linear-Voce hardening parameters
+          !=====================================================================
+          elseif (type(1:7) == 'LINVOCE') then
+            call hm_read_work_hardening_linearvoce(                            &
+              ikey     ,ihard    ,nupar_hard,upar_hard,is_available,           &
+              unitab   ,lsubmodel,iout     ,is_encrypted)
+          endif
+          !=====================================================================
+!-------------------------------------------------------------------------------
         end subroutine hm_read_work_hardening
       end module hm_read_work_hardening_mod

--- a/starter/source/materials/mat/mat131/work_hardening/hm_read_work_hardening_linearvoce.F90
+++ b/starter/source/materials/mat/mat131/work_hardening/hm_read_work_hardening_linearvoce.F90
@@ -26,6 +26,9 @@
 !||    hm_read_work_hardening                  ../starter/source/materials/mat/mat131/work_hardening/hm_read_work_hardening.F90
 !||====================================================================
       module hm_read_work_hardening_linearvoce_mod
+! \brief Read linear Voce work hardening input data for /MAT/LAW131
+! \details Read the linear Voce work hardening model parameters
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_work_hardening_linearvoce   ../starter/source/materials/mat/mat131/work_hardening/hm_read_work_hardening_linearvoce.F90

--- a/starter/source/materials/mat/mat131/work_hardening/hm_read_work_hardening_powerlaw.F90
+++ b/starter/source/materials/mat/mat131/work_hardening/hm_read_work_hardening_powerlaw.F90
@@ -26,6 +26,9 @@
 !||    hm_read_work_hardening                ../starter/source/materials/mat/mat131/work_hardening/hm_read_work_hardening.F90
 !||====================================================================
       module hm_read_work_hardening_powerlaw_mod
+! \brief Read power law work hardening input data for /MAT/LAW131
+! \details Read the power law (Hollomon/Ludwik) work hardening model
+!          parameters for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_work_hardening_powerlaw   ../starter/source/materials/mat/mat131/work_hardening/hm_read_work_hardening_powerlaw.F90
@@ -39,7 +42,8 @@
 !||====================================================================
         subroutine hm_read_work_hardening_powerlaw(                            &
           ikey     ,ihard    ,nupar_hard,upar_hard,is_available,               &
-          unitab   ,lsubmodel,iout     ,is_encrypted)
+          unitab   ,lsubmodel,iout     ,is_encrypted,iflag     ,               &
+          titr     ,mat_id   ,matparam )
 !----------------------------------------------------------------
 !   M o d u l e s
 !----------------------------------------------------------------
@@ -49,6 +53,7 @@
           use constant_mod
           use matparam_def_mod
           use precision_mod, only : WP
+          use message_mod
 !----------------------------------------------------------------
 !   I m p l i c i t   T y p e s
 !----------------------------------------------------------------
@@ -56,44 +61,107 @@
 !----------------------------------------------------------------
 !  I n p u t   A r g u m e n t s
 !----------------------------------------------------------------
-          integer,                 intent(in)    :: ikey                  !< material key
-          integer,                 intent(inout) :: ihard                 !< work hardening type
-          integer,                 intent(inout) :: nupar_hard            !< number of work hardening parameters
-          real(kind=WP),dimension(100),intent(inout) :: upar_hard         !< work hardening parameters
-          logical,                 intent(in)    :: is_available          !< availability flag
-          type(unit_type_),        intent(in)    :: unitab                !< units table
-          type(submodel_data),dimension(nsubmod),intent(in) :: lsubmodel  !< submodel data structure
-          integer,                 intent(in)    :: iout                  !< output unit
-          logical,                 intent(in)    :: is_encrypted          !< encryption flag
+          integer,                 intent(in)    :: ikey                  !< Material key
+          integer,                 intent(inout) :: ihard                 !< Work hardening type
+          integer,                 intent(inout) :: nupar_hard            !< Number of work hardening parameters
+          real(kind=WP),dimension(100),intent(inout) :: upar_hard         !< Work hardening parameters
+          logical,                 intent(in)    :: is_available          !< Availability flag
+          type(unit_type_),        intent(in)    :: unitab                !< Units table
+          type(submodel_data),dimension(nsubmod),intent(in) :: lsubmodel  !< Submodel data structure
+          integer,                 intent(in)    :: iout                  !< Output unit
+          logical,                 intent(in)    :: is_encrypted          !< Encryption flag
+          integer,                 intent(in)    :: iflag                 !< Flag for input format (1: simplified, 2: classic)
+          character(len=nchartitle),intent(in)   :: titr                  !< Material law user title
+          integer,                 intent(in)    :: mat_id                !< Material law user ID
+          type(matparam_struct_),  intent(inout) :: matparam              !< Matparam data structure
 !----------------------------------------------------------------
 !  L o c a l  V a r i a b l e s
 !----------------------------------------------------------------
-          real(kind=WP) :: ca,cb,cn,eps0
+          real(kind=WP) :: ca,cb,cn,eps0,sigmax,cb0,rm,ag,cn0,young
 !===============================================================================
 !            
-          !===================================================================
+          !=====================================================================
           !< Power law hardening parameters
-          !===================================================================
-          call hm_get_float_array_index("HARD_POWERLAW_A"   ,ca  ,ikey,is_available,lsubmodel,unitab)
-          call hm_get_float_array_index("HARD_POWERLAW_B"   ,cb  ,ikey,is_available,lsubmodel,unitab)
-          call hm_get_float_array_index("HARD_POWERLAW_N"   ,cn  ,ikey,is_available,lsubmodel,unitab)
-          call hm_get_float_array_index("HARD_POWERLAW_EPS0",eps0,ikey,is_available,lsubmodel,unitab)
+          !=====================================================================
+          if (iflag == 1) then 
+            call hm_get_float_array_index("HARD_POWERLAW_SIGY"  ,ca,ikey,is_available,lsubmodel,unitab)
+            call hm_get_float_array_index("HARD_POWERLAW_UTS"   ,cb,ikey,is_available,lsubmodel,unitab)
+            call hm_get_float_array_index("HARD_POWERLAW_EPSUTS",cn,ikey,is_available,lsubmodel,unitab)
+            cb0 = cb
+            rm  = cb *(one+cn)
+            ag  = log(one+cn)
+            cn0 = cn
+            cn  = rm*ag / max((rm-ca),em20)
+            cb  = rm/max((cn*ag**(cn-one)),em20)
+            young = matparam%young
+            if (young == zero) then 
+              call ancmsg(msgid=3131,                                          &
+                msgtype=msgerror,                                              &
+                anmode=aninfo_blind_2,                                         &
+                i1=mat_id,                                                     &
+                c1="ERROR",                                                    &
+                c2=titr,                                                       &
+                c3="HARD_POWERLAW_ENG",                                        &
+                c4="ELASTIC BEHAVIOR IS NOT DEFINED (YOUNG'S MODULUS IS ZERO)" //&
+                   " PLEASE DEFINE ELAS KEY TYPE PRIOR HARD KEY TYPE")
+            endif
+            if (cn > one) then
+              cn = one
+              cb = (cb0*(one+cn0)-ca)/(log(one+cn0)-cb0*(one+cn0)/young-ca/young)
+              call ancmsg(msgid=3131,                                          &
+                msgtype=msgwarning,                                            &
+                anmode=aninfo_blind_2,                                         &
+                i1=mat_id,                                                     &
+                c1="WARNING",                                                  &
+                c2=titr,                                                       &
+                c3="HARD_POWERLAW_ENG",                                        &
+                c4="INPUT DATA NOT VALID FOR AUTOMATIC PARAMETER FITTING" //   &
+                   " N IS SET TO 1.0 AND B IS RECOMPUTED ACCORDINGLY" //       &
+                   " RESULT WILL NOT FIT INPUT VALUES")
+            endif
+            if (cn < zero .and. cb < zero) then
+              cn = zero
+              cb = zero
+              call ancmsg(msgid=3131,                                          &
+                msgtype=msgwarning,                                            &
+                anmode=aninfo_blind_2,                                         &
+                i1=mat_id,                                                     &
+                c1="WARNING",                                                  &
+                c2=titr,                                                       &
+                c3="HARD_POWERLAW_ENG",                                        &
+                c4="INPUT DATA NOT VALID FOR AUTOMATIC PARAMETER FITTING " //  &
+                   " N IS SET TO 0.0 AND B IS SET TO 0.0 " //                  &
+                   " RESULT WILL NOT FIT INPUT VALUES")
+            endif            
+          elseif (iflag == 2) then
+            call hm_get_float_array_index("HARD_POWERLAW_A",ca,ikey,is_available,lsubmodel,unitab)
+            call hm_get_float_array_index("HARD_POWERLAW_B",cb,ikey,is_available,lsubmodel,unitab)
+            call hm_get_float_array_index("HARD_POWERLAW_N",cn,ikey,is_available,lsubmodel,unitab)
+          endif
+          call hm_get_float_array_index("HARD_POWERLAW_EPS0"  ,eps0  ,ikey,is_available,lsubmodel,unitab)
+          call hm_get_float_array_index("HARD_POWERLAW_SIGMAX",sigmax,ikey,is_available,lsubmodel,unitab)
           !< Work hardening type
           ihard = 1
           !< Default initial plastic strain
-          if (eps0 == zero) eps0 = em20
+          if (eps0   == zero) eps0 = em20
+          if (sigmax == zero) sigmax = infinity
           !< Number of parameters
-          nupar_hard = 4
+          nupar_hard = 5
           !< Save hardening parameters
           upar_hard(1) = ca
           upar_hard(2) = cb
           upar_hard(3) = cn
           upar_hard(4) = eps0
+          upar_hard(5) = sigmax
           !< Printing work hardening parameters
           if (is_encrypted)then
             write(iout,"(5X,A,//)") "CONFIDENTIAL DATA"
           else
-            write(iout,1000) ca,cb,cn,eps0
+            if (iflag == 2) then 
+              write(iout,1000) ca,cb,cn,eps0,sigmax
+            elseif (iflag == 1) then
+              write(iout,2000) ca,cb0,cn0,eps0,sigmax,cb,cn
+            endif
           endif
 ! ------------------------------------------------------------------------------
 1000 format(/                                                                  &
@@ -103,7 +171,19 @@
           5X,"INITIAL YIELD STRESS (A) . . . . . . . . . . . . . . .=",1PG20.13/&
           5X,"HARDENING MODULUS (B). . . . . . . . . . . . . . . . .=",1PG20.13/&
           5X,"HARDENING EXPONENT (N) . . . . . . . . . . . . . . . .=",1PG20.13/&
-          5X,"INITIAL PLASTIC STRAIN (EPS0). . . . . . . . . . . . .=",1PG20.13/)
+          5X,"INITIAL PLASTIC STRAIN (EPS0). . . . . . . . . . . . .=",1PG20.13/&
+          5X,"MAXIMUM YIELD STRESS (SIGMAX). . . . . . . . . . . . .=",1PG20.13/)
+2000 format(/                                                                  &
+          5X,"-------------------------------------------------------",/       &
+          5X,"POWER LAW WORK HARDENING                               ",/,      &
+          5X,"-------------------------------------------------------",/,      &
+          5X,"INITIAL YIELD STRESS (A) . . . . . . . . . . . . . . .=",1PG20.13/&
+          5X,"ULTIMATE TENSILE STRENGTH (UTS). . . . . . . . . . . .=",1PG20.13/&
+          5X,"ENGINEERING STRAIN AT UTS (EPS_UTS). . . . . . . . . .=",1PG20.13/&
+          5X,"INITIAL PLASTIC STRAIN (EPS0). . . . . . . . . . . . .=",1PG20.13/&
+          5X,"MAXIMUM YIELD STRESS (SIGMAX). . . . . . . . . . . . .=",1PG20.13/&
+          5X,"COMPUTED HARDENING MODULUS (B) . . . . . . . . . . . .=",1PG20.13/&
+          5X,"COMPUTED HARDENING EXPONENT (N). . . . . . . . . . . .=",1PG20.13/)
 ! -------------------------------------------------------------------------------
         end subroutine hm_read_work_hardening_powerlaw
       end module hm_read_work_hardening_powerlaw_mod

--- a/starter/source/materials/mat/mat131/work_hardening/hm_read_work_hardening_tabulated.F90
+++ b/starter/source/materials/mat/mat131/work_hardening/hm_read_work_hardening_tabulated.F90
@@ -26,6 +26,9 @@
 !||    hm_read_work_hardening                 ../starter/source/materials/mat/mat131/work_hardening/hm_read_work_hardening.F90
 !||====================================================================
       module hm_read_work_hardening_tabulated_mod
+! \brief Read tabulated work hardening input data for /MAT/LAW131
+! \details Read the tabulated work hardening model parameters
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_work_hardening_tabulated   ../starter/source/materials/mat/mat131/work_hardening/hm_read_work_hardening_tabulated.F90

--- a/starter/source/materials/mat/mat131/work_hardening/hm_read_work_hardening_voce.F90
+++ b/starter/source/materials/mat/mat131/work_hardening/hm_read_work_hardening_voce.F90
@@ -26,6 +26,9 @@
 !||    hm_read_work_hardening            ../starter/source/materials/mat/mat131/work_hardening/hm_read_work_hardening.F90
 !||====================================================================
       module hm_read_work_hardening_voce_mod
+! \brief Read Voce work hardening input data for /MAT/LAW131
+! \details Read the Voce work hardening model parameters
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_work_hardening_voce   ../starter/source/materials/mat/mat131/work_hardening/hm_read_work_hardening_voce.F90

--- a/starter/source/materials/mat/mat131/yield_criterion/hm_read_yield_criterion.F90
+++ b/starter/source/materials/mat/mat131/yield_criterion/hm_read_yield_criterion.F90
@@ -27,6 +27,9 @@
 !||====================================================================
       module hm_read_yield_criterion_mod
         implicit none
+! \brief Read yield criterion input data for /MAT/LAW131
+! \details Read and dispatch the yield criterion model input data
+!          for /MAT/LAW131 (elasto-plastic material law).
       contains
 !||====================================================================
 !||    hm_read_yield_criterion                  ../starter/source/materials/mat/mat131/yield_criterion/hm_read_yield_criterion.F90

--- a/starter/source/materials/mat/mat131/yield_criterion/hm_read_yield_criterion_barlat1989.F90
+++ b/starter/source/materials/mat/mat131/yield_criterion/hm_read_yield_criterion_barlat1989.F90
@@ -27,6 +27,9 @@
 !||====================================================================
       module hm_read_yield_criterion_barlat1989_mod
         implicit none
+! \brief Read Barlat 1989 yield criterion input data for /MAT/LAW131
+! \details Read the Barlat 1989 anisotropic yield criterion parameters
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_yield_criterion_barlat1989   ../starter/source/materials/mat/mat131/yield_criterion/hm_read_yield_criterion_barlat1989.F90

--- a/starter/source/materials/mat/mat131/yield_criterion/hm_read_yield_criterion_barlat2000.F90
+++ b/starter/source/materials/mat/mat131/yield_criterion/hm_read_yield_criterion_barlat2000.F90
@@ -27,6 +27,9 @@
 !||====================================================================
       module hm_read_yield_criterion_barlat2000_mod
         implicit none
+! \brief Read Barlat 2000 yield criterion input data for /MAT/LAW131
+! \details Read the Barlat 2000 (Yld2000-2d) anisotropic yield criterion
+!          parameters for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_yield_criterion_barlat2000   ../starter/source/materials/mat/mat131/yield_criterion/hm_read_yield_criterion_barlat2000.F90

--- a/starter/source/materials/mat/mat131/yield_criterion/hm_read_yield_criterion_hershey.F90
+++ b/starter/source/materials/mat/mat131/yield_criterion/hm_read_yield_criterion_hershey.F90
@@ -27,6 +27,9 @@
 !||====================================================================
       module hm_read_yield_criterion_hershey_mod
         implicit none
+! \brief Read Hershey yield criterion input data for /MAT/LAW131
+! \details Read the Hershey isotropic yield criterion parameters
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_yield_criterion_hershey   ../starter/source/materials/mat/mat131/yield_criterion/hm_read_yield_criterion_hershey.F90

--- a/starter/source/materials/mat/mat131/yield_criterion/hm_read_yield_criterion_hill.F90
+++ b/starter/source/materials/mat/mat131/yield_criterion/hm_read_yield_criterion_hill.F90
@@ -27,6 +27,9 @@
 !||====================================================================
       module hm_read_yield_criterion_hill_mod
         implicit none
+! \brief Read Hill yield criterion input data for /MAT/LAW131
+! \details Read the Hill 1948 anisotropic yield criterion parameters
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_yield_criterion_hill   ../starter/source/materials/mat/mat131/yield_criterion/hm_read_yield_criterion_hill.F90

--- a/starter/source/materials/mat/mat131/yield_criterion/hm_read_yield_criterion_vonmises.F90
+++ b/starter/source/materials/mat/mat131/yield_criterion/hm_read_yield_criterion_vonmises.F90
@@ -27,6 +27,9 @@
 !||====================================================================
       module hm_read_yield_criterion_vonmises_mod
         implicit none
+! \brief Read von Mises yield criterion input data for /MAT/LAW131
+! \details Read the von Mises isotropic yield criterion parameters
+!          for /MAT/LAW131.
       contains
 !||====================================================================
 !||    hm_read_yield_criterion_vonmises   ../starter/source/materials/mat/mat131/yield_criterion/hm_read_yield_criterion_vonmises.F90


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

Add a new ELAS keyword for /MAT/LAW131 to consider different Young moduli between tension and compression. 
In addition, a new input format for HARD_POWERLAW has been added to simplify the usage. Finally, all files of /MAT/LAW131 have now a /brief and /details comment section. 

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

Add a new ELAS keyword for /MAT/LAW131 to consider different Young moduli between tension and compression. 
In addition, a new input format for HARD_POWERLAW has been added to simplify the usage. Finally, all files of /MAT/LAW131 have now a /brief and /details comment section. 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
