### PR TITLE
SET and GROUPS : issue with PART OFFSET with //SUBMODEL

### DIFF
--- a/hm_cfg_files/config/CFG/radioss110/SETS/beam.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/SETS/beam.cfg
@@ -113,7 +113,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -154,7 +154,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {

--- a/hm_cfg_files/config/CFG/radioss110/SETS/bric.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/SETS/bric.cfg
@@ -114,7 +114,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -155,7 +155,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {

--- a/hm_cfg_files/config/CFG/radioss110/SETS/line.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/SETS/line.cfg
@@ -112,7 +112,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -175,7 +175,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {

--- a/hm_cfg_files/config/CFG/radioss110/SETS/node.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/SETS/node.cfg
@@ -145,7 +145,7 @@ FORMAT(radioss41) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {
@@ -230,7 +230,7 @@ FORMAT(radioss51) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss110/SETS/part.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/SETS/part.cfg
@@ -103,7 +103,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -136,7 +136,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {

--- a/hm_cfg_files/config/CFG/radioss110/SETS/quad.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/SETS/quad.cfg
@@ -114,7 +114,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -155,7 +155,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {

--- a/hm_cfg_files/config/CFG/radioss110/SETS/sh3n.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/SETS/sh3n.cfg
@@ -114,7 +114,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -155,7 +155,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {

--- a/hm_cfg_files/config/CFG/radioss110/SETS/shell.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/SETS/shell.cfg
@@ -114,7 +114,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -155,7 +155,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {

--- a/hm_cfg_files/config/CFG/radioss110/SETS/spring.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/SETS/spring.cfg
@@ -114,7 +114,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -155,7 +155,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {

--- a/hm_cfg_files/config/CFG/radioss110/SETS/surf.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/SETS/surf.cfg
@@ -96,8 +96,8 @@ DEFAULTS(COMMON)
 {
     surfGenOpt = 0;
     ordered = 0;
-    ids_type ="/COMPONENT/PART";
-    negativeIds_type = "/COMPONENT/PART";
+    ids_type ="/COMPONENT";
+    negativeIds_type = "/COMPONENT";
     set_Type ="PART";
 }
 GUI(COMMON) 
@@ -183,7 +183,7 @@ FORMAT(radioss41) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {
@@ -266,7 +266,7 @@ FORMAT(radioss51) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {
@@ -351,7 +351,7 @@ FORMAT(radioss110) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss110/SETS/surf_all.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/SETS/surf_all.cfg
@@ -56,8 +56,8 @@ DEFAULTS(COMMON)
 {
     surfGenOpt = 0;
     ordered = 0;
-    ids_type ="/COMPONENT/PART";
-    negativeIds_type = "/COMPONENT/PART";
+    ids_type ="/COMPONENT";
+    negativeIds_type = "/COMPONENT";
     set_Type ="PART";
 }
 GUI(COMMON) 
@@ -91,7 +91,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -123,7 +123,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {

--- a/hm_cfg_files/config/CFG/radioss110/SETS/surf_ext.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/SETS/surf_ext.cfg
@@ -97,7 +97,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -133,7 +133,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {

--- a/hm_cfg_files/config/CFG/radioss110/SETS/truss.cfg
+++ b/hm_cfg_files/config/CFG/radioss110/SETS/truss.cfg
@@ -114,7 +114,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -155,7 +155,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {

--- a/hm_cfg_files/config/CFG/radioss2018/SETS/beam.cfg
+++ b/hm_cfg_files/config/CFG/radioss2018/SETS/beam.cfg
@@ -118,7 +118,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -159,7 +159,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -210,7 +210,7 @@ FORMAT(radioss2018) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss2018/SETS/bric.cfg
+++ b/hm_cfg_files/config/CFG/radioss2018/SETS/bric.cfg
@@ -118,7 +118,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -159,7 +159,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -210,7 +210,7 @@ FORMAT(radioss2018) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss2018/SETS/node.cfg
+++ b/hm_cfg_files/config/CFG/radioss2018/SETS/node.cfg
@@ -145,7 +145,7 @@ FORMAT(radioss41) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {
@@ -230,7 +230,7 @@ FORMAT(radioss51) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss2018/SETS/part.cfg
+++ b/hm_cfg_files/config/CFG/radioss2018/SETS/part.cfg
@@ -107,7 +107,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -140,7 +140,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -183,7 +183,7 @@ FORMAT(radioss2018) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss2018/SETS/quad.cfg
+++ b/hm_cfg_files/config/CFG/radioss2018/SETS/quad.cfg
@@ -118,7 +118,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -159,7 +159,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -210,7 +210,7 @@ FORMAT(radioss2018) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss2018/SETS/sh3n.cfg
+++ b/hm_cfg_files/config/CFG/radioss2018/SETS/sh3n.cfg
@@ -118,7 +118,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -159,7 +159,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -210,7 +210,7 @@ FORMAT(radioss2018) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss2018/SETS/shell.cfg
+++ b/hm_cfg_files/config/CFG/radioss2018/SETS/shell.cfg
@@ -118,7 +118,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -159,7 +159,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -210,7 +210,7 @@ FORMAT(radioss2018) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss2018/SETS/spring.cfg
+++ b/hm_cfg_files/config/CFG/radioss2018/SETS/spring.cfg
@@ -118,7 +118,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -159,7 +159,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -210,7 +210,7 @@ FORMAT(radioss2018) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss2018/SETS/truss.cfg
+++ b/hm_cfg_files/config/CFG/radioss2018/SETS/truss.cfg
@@ -118,7 +118,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -159,7 +159,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -210,7 +210,7 @@ FORMAT(radioss2018) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss2019/SETS/beam.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/SETS/beam.cfg
@@ -120,7 +120,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -161,7 +161,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -212,7 +212,7 @@ FORMAT(radioss2018) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {
@@ -274,7 +274,7 @@ FORMAT(radioss2019) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss2019/SETS/bric.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/SETS/bric.cfg
@@ -120,7 +120,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -161,7 +161,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -212,7 +212,7 @@ FORMAT(radioss2018) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {
@@ -274,7 +274,7 @@ FORMAT(radioss2019) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss2019/SETS/node.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/SETS/node.cfg
@@ -148,7 +148,7 @@ FORMAT(radioss41) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {
@@ -246,7 +246,7 @@ FORMAT(radioss51) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {
@@ -354,7 +354,7 @@ FORMAT(radioss2019) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss2019/SETS/part.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/SETS/part.cfg
@@ -109,7 +109,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -142,7 +142,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -185,7 +185,7 @@ FORMAT(radioss2018) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {
@@ -239,7 +239,7 @@ FORMAT(radioss2019) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss2019/SETS/quad.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/SETS/quad.cfg
@@ -120,7 +120,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -161,7 +161,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -212,7 +212,7 @@ FORMAT(radioss2018) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {
@@ -274,7 +274,7 @@ FORMAT(radioss2019) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss2019/SETS/sh3n.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/SETS/sh3n.cfg
@@ -120,7 +120,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -161,7 +161,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -212,7 +212,7 @@ FORMAT(radioss2018) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {
@@ -274,7 +274,7 @@ FORMAT(radioss2019) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss2019/SETS/shell.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/SETS/shell.cfg
@@ -120,7 +120,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -161,7 +161,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -212,7 +212,7 @@ FORMAT(radioss2018) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {
@@ -274,7 +274,7 @@ FORMAT(radioss2019) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss2019/SETS/spring.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/SETS/spring.cfg
@@ -120,7 +120,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -161,7 +161,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -212,7 +212,7 @@ FORMAT(radioss2018) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {
@@ -274,7 +274,7 @@ FORMAT(radioss2019) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss2019/SETS/tria.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/SETS/tria.cfg
@@ -117,7 +117,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -154,7 +154,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -201,7 +201,7 @@ FORMAT(radioss2018) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {
@@ -263,7 +263,7 @@ FORMAT(radioss2019) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss2019/SETS/truss.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/SETS/truss.cfg
@@ -120,7 +120,7 @@ FORMAT(radioss41) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -161,7 +161,7 @@ FORMAT(radioss51) {
     }
     else if(set_Type== "PART" )
     {
-        ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+        ASSIGN(ids_type, /COMPONENT, IMPORT);
     }
     else if(set_Type== "MAT" )
     {
@@ -212,7 +212,7 @@ FORMAT(radioss2018) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {
@@ -274,7 +274,7 @@ FORMAT(radioss2019) {
         }
         else if(set_Type== "PART" )
         {
-            ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+            ASSIGN(ids_type, /COMPONENT, IMPORT);
         }
         else if(set_Type== "MAT" )
         {

--- a/hm_cfg_files/config/CFG/radioss2021/SETS/set_support.cfg
+++ b/hm_cfg_files/config/CFG/radioss2021/SETS/set_support.cfg
@@ -28,7 +28,7 @@ ATTRIBUTES(COMMON) {
     opt_C         =  VALUE(INT, "add entities with at least 1 node inside the box defined by box_ID");
 // for list id
     idsmax        =  SIZE("No. Set item");
-    ids           =  ARRAY[idsmax](MULTIOBJECT, "Set list item") { SUBTYPES = ( /NODE , /ELEMS/SHELL , /ELEMS/SH3N, /ELEMS/BEAM, /ELEMS/SPRING, /ELEMS/TRUSS, /ELEMS/SOLID, /ELEMS/QUAD, /ELEMS/TRIA, /COMPONENT/PART , /BOX , /ASSEMBLY, /SOLVERSUBMODEL, /SETS/SET, /RIGIDBODY /*, /RBODY , /SEG? */) ; }   
+    ids           =  ARRAY[idsmax](MULTIOBJECT, "Set list item") { SUBTYPES = ( /NODE , /ELEMS/SHELL , /ELEMS/SH3N, /ELEMS/BEAM, /ELEMS/SPRING, /ELEMS/TRUSS, /ELEMS/SOLID, /ELEMS/QUAD, /ELEMS/TRIA, /COMPONENT , /BOX , /ASSEMBLY, /SOLVERSUBMODEL, /SETS/SET, /RIGIDBODY /*, /RBODY , /SEG? */) ; }   
     ids_type     =   VALUE(STRING, "Type of multi object");
 // for gene 
     genemax       =  SIZE("No. gene items "); 
@@ -348,7 +348,7 @@ FORMAT(radioss2021) {
    if(opt_== 1)
    {
        ASSIGN(KEY_type, PART,IMPORT);
-       ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+       ASSIGN(ids_type, /COMPONENT, IMPORT);
    }
    if(IO_FLAG == 2 && KEY_type== "PART")
    {

--- a/hm_cfg_files/config/CFG/radioss2024/SETS/set_support.cfg
+++ b/hm_cfg_files/config/CFG/radioss2024/SETS/set_support.cfg
@@ -28,7 +28,7 @@ ATTRIBUTES(COMMON) {
     opt_C         =  VALUE(INT, "add entities with at least 1 node inside the box defined by box_ID");
 // for list id
     idsmax        =  SIZE("No. Set item");
-    ids           =  ARRAY[idsmax](MULTIOBJECT, "Set list item") { SUBTYPES = ( /NODE , /ELEMS/SHELL , /ELEMS/SH3N, /ELEMS/BEAM, /ELEMS/SPRING, /ELEMS/TRUSS, /ELEMS/SOLID, /ELEMS/QUAD, /ELEMS/TRIA, /COMPONENT/PART , /BOX , /ASSEMBLY, /SOLVERSUBMODEL, /SETS/SET, /RIGIDBODY /*, /RBODY , /SEG? */) ; }   
+    ids           =  ARRAY[idsmax](MULTIOBJECT, "Set list item") { SUBTYPES = ( /NODE , /ELEMS/SHELL , /ELEMS/SH3N, /ELEMS/BEAM, /ELEMS/SPRING, /ELEMS/TRUSS, /ELEMS/SOLID, /ELEMS/QUAD, /ELEMS/TRIA, /COMPONENT , /BOX , /ASSEMBLY, /SOLVERSUBMODEL, /SETS/SET, /RIGIDBODY /*, /RBODY , /SEG? */) ; }   
     ids_type     =   VALUE(STRING, "Type of multi object");
 // for gene 
     genemax       =  SIZE("No. gene items "); 
@@ -364,7 +364,7 @@ FORMAT(radioss2024) {
    if(opt_== 1)
    {
        ASSIGN(KEY_type, PART,IMPORT);
-       ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+       ASSIGN(ids_type, /COMPONENT, IMPORT);
    }
    if(IO_FLAG == 2 && KEY_type== "PART")
    {
@@ -735,7 +735,7 @@ FORMAT(radioss2021) {
    if(opt_== 1)
    {
        ASSIGN(KEY_type, PART,IMPORT);
-       ASSIGN(ids_type, /COMPONENT/PART, IMPORT);
+       ASSIGN(ids_type, /COMPONENT, IMPORT);
    }
    if(IO_FLAG == 2 && KEY_type== "PART")
    {


### PR DESCRIPTION
This pull request standardizes the assignment of `ids_type` for PART set types across various Radioss configuration files. Specifically, it changes the assignment from `/COMPONENT/PART` to `/COMPONENT` in both the defaults and format sections of multiple SETS configuration files, ensuring consistency and simplifying the component referencing logic.

**Standardization of PART set type assignment:**

* Updated `ids_type` assignment for PART set types from `/COMPONENT/PART` to `/COMPONENT` in the following Radioss 110 SETS config files:
  - `beam.cfg` [[1]](diffhunk://#diff-61094a3e8c48af71b57aebe3758ce66fe1ba506621e0b8705b15e206555261bbL116-R116) [[2]](diffhunk://#diff-61094a3e8c48af71b57aebe3758ce66fe1ba506621e0b8705b15e206555261bbL157-R157)
  - `bric.cfg` [[1]](diffhunk://#diff-23b5c2495217c37e7e5e9cf2101eb826c298c73c9bc5bde5ac996edef41c21cfL117-R117) [[2]](diffhunk://#diff-23b5c2495217c37e7e5e9cf2101eb826c298c73c9bc5bde5ac996edef41c21cfL158-R158)
  - `line.cfg` [[1]](diffhunk://#diff-9a0e59c6058724e975d1946c1de7ddbae57447071c00d77e8807d22d4e475463L115-R115) [[2]](diffhunk://#diff-9a0e59c6058724e975d1946c1de7ddbae57447071c00d77e8807d22d4e475463L178-R178)
  - `node.cfg` [[1]](diffhunk://#diff-86d3c459d7312b1f9815d4bf0eff0c55020ff10651c4b281c096ecdcdac31847L148-R148) [[2]](diffhunk://#diff-86d3c459d7312b1f9815d4bf0eff0c55020ff10651c4b281c096ecdcdac31847L233-R233)
  - `part.cfg` [[1]](diffhunk://#diff-dc37458e6b50d553c3e7250856c6b3f762ef63a5b5d0b62d4d4fbff23a0bfbe2L106-R106) [[2]](diffhunk://#diff-dc37458e6b50d553c3e7250856c6b3f762ef63a5b5d0b62d4d4fbff23a0bfbe2L139-R139)
  - `quad.cfg` [[1]](diffhunk://#diff-082f219b2395ecad867c7aa3e18cef5b3de666460432868b96b44c14247d1945L117-R117) [[2]](diffhunk://#diff-082f219b2395ecad867c7aa3e18cef5b3de666460432868b96b44c14247d1945L158-R158)
  - `sh3n.cfg` [[1]](diffhunk://#diff-5089e164b50b284fabb591bcc9941de91c0e84c52934070900cc191b14b4723eL117-R117) [[2]](diffhunk://#diff-5089e164b50b284fabb591bcc9941de91c0e84c52934070900cc191b14b4723eL158-R158)
  - `shell.cfg` [[1]](diffhunk://#diff-738737b648333e4017596fd9c6ebd437e9bb45b1b2e276e96b82001027404e13L117-R117) [[2]](diffhunk://#diff-738737b648333e4017596fd9c6ebd437e9bb45b1b2e276e96b82001027404e13L158-R158)
  - `spring.cfg` [[1]](diffhunk://#diff-f512f7f79816b430079e4c55961edd0aedb35bef5242716af6376e2a8bfdcb11L117-R117) [[2]](diffhunk://#diff-f512f7f79816b430079e4c55961edd0aedb35bef5242716af6376e2a8bfdcb11L158-R158)
  - `surf.cfg` [[1]](diffhunk://#diff-0eea8b9c18aeeb4d515b559b705c1cf821402a802bc4a6a37ac08f84e0d919cbL99-R100) [[2]](diffhunk://#diff-0eea8b9c18aeeb4d515b559b705c1cf821402a802bc4a6a37ac08f84e0d919cbL186-R186) [[3]](diffhunk://#diff-0eea8b9c18aeeb4d515b559b705c1cf821402a802bc4a6a37ac08f84e0d919cbL269-R269) [[4]](diffhunk://#diff-0eea8b9c18aeeb4d515b559b705c1cf821402a802bc4a6a37ac08f84e0d919cbL354-R354)
  - `surf_all.cfg` [[1]](diffhunk://#diff-479811643710939ba0d3bfea1425b8006aadc798bf76e4793ac336919feeea90L59-R60) [[2]](diffhunk://#diff-479811643710939ba0d3bfea1425b8006aadc798bf76e4793ac336919feeea90L94-R94) [[3]](diffhunk://#diff-479811643710939ba0d3bfea1425b8006aadc798bf76e4793ac336919feeea90L126-R126)
  - `surf_ext.cfg` [[1]](diffhunk://#diff-421c35c153ca1a9adb631c46ac8977634d94ef3dee9e1a3354aa51e05f6d61a8L100-R100) [[2]](diffhunk://#diff-421c35c153ca1a9adb631c46ac8977634d94ef3dee9e1a3354aa51e05f6d61a8L136-R136)
  - `truss.cfg` [[1]](diffhunk://#diff-b501d91f34c4461ff4db7276d50cb2cfe71f1285fb6bbd131762f7ee5db77198L117-R117) [[2]](diffhunk://#diff-b501d91f34c4461ff4db7276d50cb2cfe71f1285fb6bbd131762f7ee5db77198L158-R158)

* Applied the same change for Radioss 2018 SETS config files:
  - `beam.cfg` [[1]](diffhunk://#diff-89139720cc246335d5ecaaf3a61f54a21214b935faf8281631edcbb5ef531a59L121-R121) [[2]](diffhunk://#diff-89139720cc246335d5ecaaf3a61f54a21214b935faf8281631edcbb5ef531a59L162-R162) [[3]](diffhunk://#diff-89139720cc246335d5ecaaf3a61f54a21214b935faf8281631edcbb5ef531a59L213-R213)
  - `bric.cfg` [[1]](diffhunk://#diff-bb150fe926e0a8d6e10c1149e7283a1c9b52d00172333b7fe7f43dad5b1461a7L121-R121) [[2]](diffhunk://#diff-bb150fe926e0a8d6e10c1149e7283a1c9b52d00172333b7fe7f43dad5b1461a7L162-R162) [[3]](diffhunk://#diff-bb150fe926e0a8d6e10c1149e7283a1c9b52d00172333b7fe7f43dad5b1461a7L213-R213)
  - `node.cfg` [[1]](diffhunk://#diff-9faee6ce7e555166b9e2980bfa452d870f8e1933cadb41d756a0c3be7596c7b9L148-R148) [[2]](diffhunk://#diff-9faee6ce7e555166b9e2980bfa452d870f8e1933cadb41d756a0c3be7596c7b9L233-R233)
  - `part.cfg` [[1]](diffhunk://#diff-6c208fd2352789a2b60fa6665120a9af496415ed05d98acd36d7c4154c466e71L110-R110) [[2]](diffhunk://#diff-6c208fd2352789a2b60fa6665120a9af496415ed05d98acd36d7c4154c466e71L143-R143) [[3]](diffhunk://#diff-6c208fd2352789a2b60fa6665120a9af496415ed05d98acd36d7c4154c466e71L186-R186)

These change corrects some issue with //SUBMODEL offset in SETs & GROUPs for referenced parts
