### PR TITLE
0499699a4407dfe4506c2a7053a113576c694224 was buggy

### DIFF
--- a/starter/source/spmd/domain_decomposition/initwg_shell.F
+++ b/starter/source/spmd/domain_decomposition/initwg_shell.F
@@ -145,7 +145,7 @@ C-----------------------------------------------
         ! -----------------
         NPN = NINT(GEO(6,PID))
         NPT = ABS(NPN) ! get the number of integration points
-        if(iworksh(2,i)>0) npt = iworksh(2,i) ! if ply data is available, get the number of integration points from ply data (for composite materials)
+        if(iworksh(1,i)>0) npt = iworksh(1,i) ! if ply data is available, get the number of integration points from ply data (for composite materials)
         IHBE = NINT(GEO(171,PID))
         ITHK = NINT(GEO(35,PID))
         IPLA = NINT(GEO(39,PID))

--- a/starter/source/spmd/domain_decomposition/initwg_tri.F
+++ b/starter/source/spmd/domain_decomposition/initwg_tri.F
@@ -148,7 +148,7 @@ C-----------------------------------------------
         ITHK = NINT(GEO(35,PID))
         IPLA = NINT(GEO(39,PID))
         NPT = MAX(ABS(NPN),1)
-        if(iworksh(2,numelc+i)>0) npt = iworksh(2,i) ! if ply data is available, get the number of integration points from ply data (for composite materials)
+        if(iworksh(1,numelc+i)>0) npt = iworksh(1,numelc+i) ! if ply data is available, get the number of integration points from ply data (for composite materials)
         FLAG_NON_LOCAL = 0  
         SPECIAL_OPTION = 0
         SPE_I_1 = 1


### PR DESCRIPTION
The number of ply is defined by iworksh(1) instead of iworksh(2) 
For shell3n elements, there is an offset (numelc+...)

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
Fix the 2 issues

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
