### PR TITLE
build fix for #4808 for version without mpi

### DIFF
--- a/engine/source/interfaces/int07/inter_sort_07.F
+++ b/engine/source/interfaces/int07/inter_sort_07.F
@@ -136,6 +136,7 @@ C-----------------------------------------------
         INTEGER :: FIRST, LAST
         INTEGER :: NSN,NMN,NTY,NRTM
         logical :: need_computation
+        real:: T1
 C-----------------------------------------------
         ! --------------
         ! check if the current interface needs to be sorted

--- a/engine/source/interfaces/intsort/i7main_tri.F
+++ b/engine/source/interfaces/intsort/i7main_tri.F
@@ -132,6 +132,7 @@ C-----------------------------------------------
      .   XMAXL, YMAXL, ZMAXL, XMINL, YMINL, ZMINL, GAPMIN, GAPMAX,
      .   C_MAXL,DRAD,MX,MY,MZ,DX,DY,DZ,SX,SY,SZ,SX2,SY2,SZ2,
      .   CURV_MAX(NRTM_T),RDUM1(1)
+      real T1
 
       LOGICAL TYPE18
       INTEGER :: NRTM,NSN,NMN,NTY


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
This pull request introduces minor changes to variable declarations in two Fortran subroutines. The main update is the addition of a new variable, `T1`, in both `inter_sort_07.F` and `i7main_tri.F`. No logic or functionality has been altered.

- Added a new variable `T1` of type `my_real` to the `INTER_SORT_07` subroutine in `inter_sort_07.F`.
- Added a new variable `T1` to the variable declaration list in the `I7MAIN_TRI` subroutine in `i7main_tri.F`.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
