### PR TITLE
make small strain option compatible to solid element deletion by geom…

### DIFF
--- a/engine/source/elements/solid/solide/s8dlenmax_sm.F90
+++ b/engine/source/elements/solid/solide/s8dlenmax_sm.F90
@@ -1,0 +1,118 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 1986-2026 Altair Engineering Inc.
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Altair Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+!Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+!Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+!||====================================================================
+      module s8dlenmax_sm_mod
+      implicit none
+      contains
+! ======================================================================================================================
+! \brief compute some geometric parameters of hexahedron in case of small strain
+! ======================================================================================================================
+        subroutine s8dlenmax_sm(                          &
+          nel      ,rho0     ,vol0       ,x       ,       &
+          nc1      ,nc2      ,nc3        ,nc4     ,       &
+          nc5      ,nc6      ,nc7        ,nc8     ,       &
+          l_max    ,rho      ,vol        ,l_min   ,       &
+          numnod )
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                        Modules
+! ----------------------------------------------------------------------------------------------------------------------
+          use constant_mod, only : em20
+          use precision_mod, only : WP
+          use mvsiz_mod , only : mvsiz
+! ----------------------------------------------------------------------------------------------------------------------
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          integer, intent(in)                                    :: nel             !< number of elements
+          integer, intent(in)                                    :: numnod          !< number of nodes
+          integer, dimension(mvsiz), intent(in   )               :: nc1             !< n1_id
+          integer, dimension(mvsiz), intent(in   )               :: nc2             !< n2_id
+          integer, dimension(mvsiz), intent(in   )               :: nc3             !< n3_id
+          integer, dimension(mvsiz), intent(in   )               :: nc4             !< n4_id
+          integer, dimension(mvsiz), intent(in   )               :: nc5             !< n5_id
+          integer, dimension(mvsiz), intent(in   )               :: nc6             !< n6_id
+          integer, dimension(mvsiz), intent(in   )               :: nc7             !< n7_id
+          integer, dimension(mvsiz), intent(in   )               :: nc8             !< n8_id
+          real(kind=WP), dimension(nel),   intent(in   )         :: rho             !< density
+          real(kind=WP), dimension(nel),   intent(in   )         :: vol0            !< initial volume
+          real(kind=WP), dimension(mvsiz), intent(inout)         :: vol             !< volume
+          real(kind=WP), dimension(mvsiz), intent(inout)         :: l_max           !< maximum length
+          real(kind=WP), dimension(mvsiz), intent(inout)         :: l_min           !< minimumlength
+          real(kind=WP), dimension(3,numnod), intent(in)         :: x               !< coordinates
+          real(kind=WP), intent(in   )                           :: rho0            !< initial density
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   local variables
+! ----------------------------------------------------------------------------------------------------------------------
+          integer :: i,j
+          real(kind=WP), dimension(mvsiz) ::                  &
+            x1,      x2,     x3,     x4,                      &
+            y1,      y2,     y3,     y4,                      &
+            z1,      z2,     z3,     z4,                      &
+            x5,      x6,     x7,     x8,                      &
+            y5,      y6,     y7,     y8,                      &
+            z5,      z6,     z7,     z8
+! ======================================================================================================================
+            do i=1,nel
+              x1(i) =x(1,nc1(i))
+              y1(i) =x(2,nc1(i))
+              z1(i) =x(3,nc1(i))
+              x2(i) =x(1,nc2(i))
+              y2(i) =x(2,nc2(i))
+              z2(i) =x(3,nc2(i))
+              x3(i) =x(1,nc3(i))
+              y3(i) =x(2,nc3(i))
+              z3(i) =x(3,nc3(i))
+              x4(i) =x(1,nc4(i))
+              y4(i) =x(2,nc4(i))
+              z4(i) =x(3,nc4(i))
+              x5(i) =x(1,nc5(i))
+              y5(i) =x(2,nc5(i))
+              z5(i) =x(3,nc5(i))
+              x6(i) =x(1,nc6(i))
+              y6(i) =x(2,nc6(i))
+              z6(i) =x(3,nc6(i))
+              x7(i) =x(1,nc7(i))
+              y7(i) =x(2,nc7(i))
+              z7(i) =x(3,nc7(i))
+              x8(i) =x(1,nc8(i))
+              y8(i) =x(2,nc8(i))
+              z8(i) =x(3,nc8(i))
+            enddo
+!
+           call sdlenmax(l_max,                                    &
+                         x1,      x2,      x3,      x4,            &
+                         x5,      x6,      x7,      x8,            &
+                         y1,      y2,      y3,      y4,            &
+                         y5,      y6,      y7,      y8,            &
+                         z1,      z2,      z3,      z4,            &
+                         z5,      z6,      z7,      z8,            &
+                         nel)
+            do i=1,nel
+              vol(i) = vol0(i)*rho0/max(em20,rho(i))
+              l_min(i) = vol(i)/l_max(i)**2
+            end do  
+!
+        end subroutine s8dlenmax_sm
+! ----------------------------------------------------------------------------------------------------------------------
+      end module s8dlenmax_sm_mod

--- a/engine/source/elements/solid/solide/sforc3.F
+++ b/engine/source/elements/solid/solide/sforc3.F
@@ -172,6 +172,7 @@ C-----------------------------------------------
       USE SDISTOR_INI_MOD, ONLY : SDISTOR_INI
       use glob_therm_mod
       use element_mod , only : nixs
+      use s8dlenmax_sm_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -422,7 +423,7 @@ C
       my_real, DIMENSION(:), ALLOCATABLE :: VAR_REG
       my_real :: CONDE(MVSIZ),AMU(MVSIZ),DIVDE(MVSIZ),L_MAX(MVSIZ),
      .           STI_C(MVSIZ),LL(MVSIZ),FLD(MVSIZ),OFFG11(MVSIZ),
-     .           CNS2,FQMAX
+     .           CNS2,FQMAX,VOLGS(MVSIZ),L_MIN(MVSIZ),RHO0
       my_real, DIMENSION(:), POINTER :: EINT
       my_real :: ELEM_MASS
       my_real :: SUM_EPS(9),SUM_M,SUM_VOL
@@ -1069,7 +1070,16 @@ C Compute Strains for output
       IF ((IMON_MAT==1).AND. ITASK == 0) CALL STOPTIME(TIMERS,35)
 C
       IF (NN_DEL >0) THEN
-        CALL SDLENMAX(L_MAX, 
+        IF (ISMSTR == 1 .OR. ISMSTR == 11) THEN 
+          RHO0 = PM(1,IMAT)
+          CALL S8DLENMAX_SM(                          
+     1           NEL      ,RHO0     ,GBUF%VOL    ,X      ,       
+     2           NC1      ,NC2      ,NC3        ,NC4     ,       
+     3           NC5      ,NC6      ,NC7        ,NC8     ,       
+     4           L_MAX    ,GBUF%RHO ,VOLGS      ,L_MIN   ,
+     5           NUMNOD )
+        ELSE
+          CALL SDLENMAX(L_MAX, 
      1   X1,      X2,      X3,      X4,      
      2   X5,      X6,      X7,      X8,      
      3   Y1,      Y2,      Y3,      Y4,      
@@ -1077,7 +1087,10 @@ C
      5   Z1,      Z2,      Z3,      Z4,      
      6   Z5,      Z6,      Z7,      Z8,      
      7   NEL)
-       CALL SGEODEL3(NGL,GBUF%OFF,VOLN,DELTAX,GBUF%VOL,GEO(1,NGEO(1)),L_MAX,DT,NEL,IDEL7NOK )
+         VOLGS(1:NEL) =VOLN(1:NEL)
+         L_MIN(1:NEL) =DELTAX(1:NEL)
+        END IF  
+       CALL SGEODEL3(NGL,GBUF%OFF,VOLGS,L_MIN,GBUF%VOL,GEO(1,NGEO(1)),L_MAX,DT,NEL,IDEL7NOK )
       END IF
 C Small Strain
       CALL SMALLB3(

--- a/engine/source/elements/solid/solide10/s10forc3.F
+++ b/engine/source/elements/solid/solide10/s10forc3.F
@@ -129,6 +129,7 @@ C-----------------------------------------------
       use glob_therm_mod
       USE S10GET_X0_MOD, ONLY : S10GET_X0
       use element_mod , only : nixs
+      use s4dlenmax_sm_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -257,12 +258,12 @@ C
      .    MFZZ(MVSIZ,5),MFZX(MVSIZ,5),MFXZ(MVSIZ,5),DIVDE(MVSIZ),
      .    NU(MVSIZ),FACP(MVSIZ),E0(MVSIZ),C1,DVM(MVSIZ),
      .    VISP(MVSIZ),FACDB,RBID(MVSIZ),SIGP(NEL,6),
-     .    FLD(MVSIZ),STI_C(MVSIZ),LL(MVSIZ),OFFG(MVSIZ),FQMAX
+     .    FLD(MVSIZ),STI_C(MVSIZ),LL(MVSIZ),OFFG(MVSIZ),FQMAX,VOLGS(MVSIZ)
 c
       my_real VARNL(NEL),DELTAX4(MVSIZ)
 c     Flag Bolt Preloading
       INTEGER IBOLTP,NBPRELD,ISCTL,ISTAB(MVSIZ)
-      INTEGER SZ_IX
+      INTEGER SZ_IX,NN_DEL,PID
       my_real, 
      .  DIMENSION(:), POINTER :: BPRELD
       my_real, dimension(mvsiz) :: fheat
@@ -371,9 +372,9 @@ C-----------
 C     
       IPLAW1 = 0
       CNS2 = ZERO
+      MX = IXS(1,NF1)
+      RHO0_1 =PM( 1,MX)
       IF (ISM12_11>0 .AND.IDTMIN(1)==3) THEN
-         MX = IXS(1,NF1)
-         RHO0_1 =PM( 1,MX)
          IF (PM(21,MX)>0.49) IPLAW1=1
          IF (IPLAW1==1) THEN
            FACDB = ONE- ZEP02
@@ -384,8 +385,6 @@ C
            IF (IGEO(35,NGEO(1))>0) CNS2=CNS2-ABS(GEO(17,NGEO(1)))
          END IF 
       ELSEIF (ISMSTR==10.AND.MTN==1) THEN
-         MX = IXS(1,NF1)
-         RHO0_1 =PM( 1,MX)
          IF (PM(21,MX)>0.49) THEN
            VISP(LFT:LLT)=TWO
            CNS2 = ZEP02
@@ -394,6 +393,10 @@ C
       END IF 
       ISCTL = IGEO(97,NGEO(1))
       IF (ISROT == 1) ISCTL = 0 ! uncompatible with itetra4=1
+      NN_DEL =0
+      PID  = NGEO(1)
+      IF (GEO(190,PID)+GEO(191,PID)+GEO(192,PID)+GEO(192,PID)>ZERO) NN_DEL=4
+      IF (NN_DEL ==0 .AND. DT%IDEL_BRICK>0) NN_DEL=4
 C     
       CALL S10NX3(
      1   NX,      NEL,     NPT)
@@ -815,8 +818,18 @@ c
      .                       SX , SY , SZ ,
      .                       TX , TY , TZ ,DELTAX4,GEO(1,NGEO(1)),
      .                       NEL,NPT,ISMSTR,ISROT,DT)
+      IF (NN_DEL >0) THEN
+        IF (ISMSTR == 1 .OR. ISMSTR == 11) THEN 
+          CALL S4DLENMAX_SM(                          
+     1           NEL      ,X        ,DELTAX4     ,VOLGS   ,       
+     2           NC(1,1)  ,NC(1,2)  ,NC(1,3)     ,NC(1,4) ,       
+     3           NUMNOD )
+        ELSE
+          VOLGS(1:NEL) =VOLG(1:NEL)
+        END IF  
         RBID(LFT:LLT)=ZERO
-        CALL SGEODEL3(NGL,GBUF%OFF,VOLG,DELTAX4,GBUF%VOL,GEO(1,NGEO(1)),RBID,DT,NEL,IDEL7NOK)
+        CALL SGEODEL3(NGL,GBUF%OFF,VOLGS,DELTAX4,GBUF%VOL,GEO(1,NGEO(1)),RBID,DT,NEL,IDEL7NOK)
+      END IF  
         CALL SMALLB3(GBUF%OFF,OFF,NEL,ISMSTR)
         CALL SMALLGEO3(NGL, GBUF%OFF ,VOLG ,DELTAX4, GBUF%VOL ,ITET, NEL, ISMSTR,DT)
 C-----------!!!-seperate LBUF%SIGL=LBUF%SIG,w/ npt>0 ISM12_11

--- a/engine/source/elements/solid/solide4/s4dlenmax_sm.F90
+++ b/engine/source/elements/solid/solide4/s4dlenmax_sm.F90
@@ -1,0 +1,135 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 1986-2026 Altair Engineering Inc.
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Altair Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+!Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+!Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+!||====================================================================
+      module s4dlenmax_sm_mod
+      implicit none
+      contains
+! ======================================================================================================================
+! \brief compute some geometric parameters of tetrahedron in case of small strain
+! ======================================================================================================================
+        subroutine s4dlenmax_sm(                          &
+          nel      ,x        ,l_min      ,vol     ,       &
+          nc1      ,nc2      ,nc3        ,nc4     ,       &
+          numnod )
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                        Modules
+! ----------------------------------------------------------------------------------------------------------------------
+          use constant_mod, only : one_over_6,six,em20
+          use precision_mod, only : WP
+          use mvsiz_mod , only : mvsiz
+! ----------------------------------------------------------------------------------------------------------------------
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          integer, intent(in)                                    :: nel             !< number of elements
+          integer, intent(in)                                    :: numnod          !< number of nodes
+          integer, dimension(mvsiz), intent(in   )               :: nc1             !< n1_id
+          integer, dimension(mvsiz), intent(in   )               :: nc2             !< n2_id
+          integer, dimension(mvsiz), intent(in   )               :: nc3             !< n3_id
+          integer, dimension(mvsiz), intent(in   )               :: nc4             !< n4_id
+          real(kind=WP), dimension(mvsiz), intent(inout)         :: vol             !< volume
+          real(kind=WP), dimension(mvsiz), intent(inout)         :: l_min           !< charactistic length
+          real(kind=WP), dimension(3,numnod), intent(in)         :: x               !< coordinates
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   local variables
+! ----------------------------------------------------------------------------------------------------------------------
+          integer :: i,j
+          real(kind=WP), dimension(mvsiz) ::                  &
+            x1,      x2,     x3,     x4,                      &
+            y1,      y2,     y3,     y4,                      &
+            z1,      z2,     z3,     z4,                      &
+            rx,      ry,     rz,                              &
+            sx,      sy,     sz,                              &
+            tx,      ty,     tz                             
+          real(kind=WP) :: a1x,a1y,a1z,a2x,a2y,a2z,a3x,a3y,a3z,a4x,a4y,a4z,a1,a2,a3,a4
+          real(kind=WP) :: x43,y43,z43,x41,y41,z41,x42,y42,z42,b1,c1,d1
+! ======================================================================================================================
+      do i=1,nel
+        x1(i) =x(1,nc1(i))
+        y1(i) =x(2,nc1(i))
+        z1(i) =x(3,nc1(i))
+        x2(i) =x(1,nc2(i))
+        y2(i) =x(2,nc2(i))
+        z2(i) =x(3,nc2(i))
+        x3(i) =x(1,nc3(i))
+        y3(i) =x(2,nc3(i))
+        z3(i) =x(3,nc3(i))
+        x4(i) =x(1,nc4(i))
+        y4(i) =x(2,nc4(i))
+        z4(i) =x(3,nc4(i))
+      end do
+!
+      do i=1,nel
+       x43 = x4(i) - x3(i)
+       y43 = y4(i) - y3(i)
+       z43 = z4(i) - z3(i)
+       x41 = x4(i) - x1(i)
+       y41 = y4(i) - y1(i)
+       z41 = z4(i) - z1(i)
+       x42 = x4(i) - x2(i)
+       y42 = y4(i) - y2(i)
+       z42 = z4(i) - z2(i)
+!
+       rx(i) =  -x41
+       ry(i) =  -y41
+       rz(i) =  -z41
+       sx(i) =  -x42
+       sy(i) =  -y42
+       sz(i) =  -z42
+       tx(i) =  -x43
+       ty(i) =  -y43
+       tz(i) =  -z43
+!
+       b1  =  y43*z42 - y42*z43
+       c1  =  z43*x42 - z42*x43
+       d1  =  x43*y42 - x42*y43
+       vol(i) = (x41*b1 + y41*c1 + z41*d1)*one_over_6
+      end do
+!      
+      do i=1,nel
+        a1x = ry(i)*sz(i)-rz(i)*sy(i)
+        a1y = rz(i)*sx(i)-rx(i)*sz(i)
+        a1z = rx(i)*sy(i)-ry(i)*sx(i)
+        a1 = a1x*a1x+a1y*a1y+a1z*a1z
+!      
+        a2x = sy(i)*tz(i)-sz(i)*ty(i)
+        a2y = sz(i)*tx(i)-sx(i)*tz(i)
+        a2z = sx(i)*ty(i)-sy(i)*tx(i)
+        a2 = a2x*a2x+a2y*a2y+a2z*a2z
+!      
+        a3x = ty(i)*rz(i)-tz(i)*ry(i)
+        a3y = tz(i)*rx(i)-tx(i)*rz(i)
+        a3z = tx(i)*ry(i)-ty(i)*rx(i)
+        a3 = a3x*a3x+a3y*a3y+a3z*a3z
+!      
+        a4x = a1x+a2x+a3x
+        a4y = a1y+a2y+a3y
+        a4z = a1z+a2z+a3z
+        a4 = a4x*a4x+a4y*a4y+a4z*a4z      
+        l_min(i) = six*vol(i)/sqrt(max(a1,a2,a3,a4))
+      end do
+!
+        end subroutine s4dlenmax_sm
+! ----------------------------------------------------------------------------------------------------------------------
+      end module s4dlenmax_sm_mod

--- a/engine/source/elements/solid/solide4/s4forc3.F
+++ b/engine/source/elements/solid/solide4/s4forc3.F
@@ -125,6 +125,7 @@ C-----------------------------------------------
       use glob_therm_mod
       USE SENSOR_MOD
       use element_mod , only : nixs
+      use s4dlenmax_sm_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -266,7 +267,7 @@ C-----------------------------------------------
      .  MFXX(MVSIZ),MFXY(MVSIZ),MFYX(MVSIZ),
      .  MFYY(MVSIZ),MFYZ(MVSIZ),MFZY(MVSIZ),
      .  MFZZ(MVSIZ),MFZX(MVSIZ),MFXZ(MVSIZ),BID(MVSIZ),AMU(MVSIZ),
-     .  FLD(MVSIZ),STI_C(MVSIZ),LL(MVSIZ),MU,FQMAX
+     .  FLD(MVSIZ),STI_C(MVSIZ),LL(MVSIZ),MU,FQMAX,VOLGS(MVSIZ),L_MIN(MVSIZ)
       my_real, 
      .  DIMENSION(:), POINTER :: EINT
       my_real, dimension(mvsiz) :: fheat
@@ -281,7 +282,7 @@ C
 
 C----- 
 c     Flag Bolt Preloading
-      INTEGER IBOLTP,NBPRELD,ISCTL,ISTAB(MVSIZ),PID,SZ_IX
+      INTEGER IBOLTP,NBPRELD,ISCTL,ISTAB(MVSIZ),PID,SZ_IX,NN_DEL
       my_real, 
      .  DIMENSION(:), POINTER :: BPRELD
 C-----------------------------------------------
@@ -308,6 +309,9 @@ C-----------
       PID = IXS(10,NF1)
       IGTYP = IGEO(11,PID)   
       ISCTL = IGEO(97,PID)
+      NN_DEL =0
+      IF (GEO(190,PID)+GEO(191,PID)+GEO(192,PID)+GEO(192,PID)>ZERO) NN_DEL=4
+      IF (NN_DEL ==0 .AND. DT%IDEL_BRICK>0) NN_DEL=4
 c
       CALL S4COOR3(
      1   X,         IXS(1,NF1),V,         W,
@@ -700,9 +704,20 @@ C--------------------------
       ENDIF
 C
       IF(JLAG+JALE+JEUL == 0)RETURN
+      IF (NN_DEL >0) THEN
+        IF (ISMSTR == 1 .OR. ISMSTR == 11) THEN 
+          CALL S4DLENMAX_SM(                          
+     1           NEL      ,X        ,L_MIN      ,VOLGS   ,            
+     2           NC1      ,NC2      ,NC3        ,NC4     ,       
+     3           NUMNOD )
+        ELSE
+          VOLGS(1:NEL) =VOLN(1:NEL)
+          L_MIN(1:NEL) =DELTAX(1:NEL)
+        END IF 
+        BID(LFT:LLT)=ZERO
+        CALL SGEODEL3(NGL,GBUF%OFF,VOLGS,L_MIN,GBUF%VOL,GEO(1,NGEO(1)),BID,DT,NEL,IDEL7NOK )
+      END IF !(NN_DEL >0) THEN
       ITET = 1
-      BID(LFT:LLT)=ZERO
-      CALL SGEODEL3(NGL,GBUF%OFF,VOLN,DELTAX,GBUF%VOL,GEO(1,NGEO(1)),BID,DT,NEL,IDEL7NOK )
 C-----------------------------
 C     SMALL STRAIN 
 C-----------------------------

--- a/engine/source/elements/solid/solide8e/s8eforc3.F
+++ b/engine/source/elements/solid/solide8e/s8eforc3.F
@@ -162,6 +162,7 @@ C-----------------------------------------------
       use glob_therm_mod
       USE sz_dt1_mod, only : sz_dt1
       use element_mod , only : nixs
+      use s8dlenmax_sm_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -416,7 +417,7 @@ C     variables used for the non-local
       my_real,
      .  DIMENSION(:), POINTER :: DNL
       my_real 
-     .  H(8),PS2(8),PR2(8),PT2(8),ZR,ZS,ZT
+     .  H(8),PS2(8),PR2(8),PT2(8),ZR,ZS,ZT,VOLGS(MVSIZ),L_MIN(MVSIZ)
 C
       my_real
      .  W_GAUSS(9,9),A_GAUSS(9,9)
@@ -647,10 +648,10 @@ c------ Sigy of GBUF%SIG is not good, take the ip of min(e_ps)
        ENDDO
       ENDIF 
       CNS2 = ZERO
+      RHO0_1 =PM( 1,MX)
       IF (IINT==2.AND.ICP==1.AND.MTN==1.AND.
      .               (ISMSTR==10.OR.ISMSTR==12)) THEN
         IF (ISMSTR==12) THEN
-          RHO0_1 =PM( 1,MX)
           CNS2 = ZEP02
           IF (IGEO(35,NGEO(1))>0) CNS2=CNS2-ABS(GEO(17,NGEO(1)))
         END IF
@@ -1797,7 +1798,15 @@ c-------------------
       ENDIF
       ITET = 0
       IF (NN_DEL >0) THEN
-        CALL SDLENMAX(L_MAX, 
+        IF (ISMSTR == 1 .OR. ISMSTR == 11) THEN 
+          CALL S8DLENMAX_SM(                          
+     1           NEL      ,RHO0_1   ,GBUF%VOL    ,X      ,       
+     2           NC1      ,NC2      ,NC3        ,NC4     ,       
+     3           NC5      ,NC6      ,NC7        ,NC8     ,       
+     4           L_MAX    ,GBUF%RHO ,VOLGS      ,L_MIN   ,
+     5           NUMNOD )
+        ELSE
+          CALL SDLENMAX(L_MAX, 
      1   X1,      X2,      X3,      X4,      
      2   X5,      X6,      X7,      X8,      
      3   Y1,      Y2,      Y3,      Y4,      
@@ -1805,7 +1814,10 @@ c-------------------
      5   Z1,      Z2,      Z3,      Z4,      
      6   Z5,      Z6,      Z7,      Z8,      
      7   NEL)
-       CALL SGEODEL3(NGL,GBUF%OFF,VOLG,DELTAX,GBUF%VOL,GEO(1,NGEO(1)),L_MAX,DT,NEL,IDEL7NOK)
+         VOLGS(1:NEL) =VOLG(1:NEL)
+         L_MIN(1:NEL) =DELTAX(1:NEL)
+        END IF
+        CALL SGEODEL3(NGL,GBUF%OFF,VOLGS,L_MIN,GBUF%VOL,GEO(1,NGEO(1)),L_MAX,DT,NEL,IDEL7NOK)
       END IF
 C-----------------------------
 C     SMALL STRAIN 

--- a/engine/source/elements/solid/solide8z/s8zforc3.F
+++ b/engine/source/elements/solid/solide8z/s8zforc3.F
@@ -137,6 +137,7 @@ C-----------------------------------------------
       use glob_therm_mod
       USE sz_dt1_mod, only : sz_dt1
       use element_mod , only : nixs
+      use s8dlenmax_sm_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -339,7 +340,7 @@ C   variables used only in solid routines (as arguments)
      .   G1Z(MVSIZ),G2Z(MVSIZ),G3Z(MVSIZ)
       my_real
      .   WI,SMAX(MVSIZ),VOLG(MVSIZ),NU(MVSIZ),PP(MVSIZ),USB(MVSIZ),
-     .   DTI,BID(MVSIZ),FAC_NU,NU_SP,NU0
+     .   DTI,BID(MVSIZ),FAC_NU,NU_SP,NU0,VOLGS(MVSIZ),L_MIN(MVSIZ),RHO0
       my_real
      .   SIGY(MVSIZ), SIGN(NEL,6),ET(MVSIZ), NU1(MVSIZ),
      . R1_FREE(MVSIZ),R3_FREE(MVSIZ),DELTAXI(MVSIZ)
@@ -1441,7 +1442,16 @@ c----------------------
       ENDIF
       ITET = 0
       IF (NN_DEL >0) THEN
-        CALL SDLENMAX(L_MAX, 
+        IF (ISMSTR == 1 .OR. ISMSTR == 11) THEN 
+          RHO0 = PM(1,IMAT)
+          CALL S8DLENMAX_SM(                          
+     1           NEL      ,RHO0     ,GBUF%VOL   ,X       ,       
+     2           NC1      ,NC2      ,NC3        ,NC4     ,       
+     3           NC5      ,NC6      ,NC7        ,NC8     ,       
+     4           L_MAX    ,GBUF%RHO ,VOLGS      ,L_MIN   ,
+     5           NUMNOD )
+        ELSE
+          CALL SDLENMAX(L_MAX, 
      1   X1,      X2,      X3,      X4,      
      2   X5,      X6,      X7,      X8,      
      3   Y1,      Y2,      Y3,      Y4,      
@@ -1449,7 +1459,10 @@ c----------------------
      5   Z1,      Z2,      Z3,      Z4,      
      6   Z5,      Z6,      Z7,      Z8,      
      7   NEL)
-       CALL SGEODEL3(NGL,GBUF%OFF,VOLG,DELTAX,GBUF%VOL,GEO(1,NGEO(1)),L_MAX,DT,NEL,IDEL7NOK)
+         VOLGS(1:NEL) =VOLG(1:NEL)
+         L_MIN(1:NEL) =DELTAX(1:NEL)
+       END IF
+       CALL SGEODEL3(NGL,GBUF%OFF,VOLGS,L_MIN,GBUF%VOL,GEO(1,NGEO(1)),L_MAX,DT,NEL,IDEL7NOK)
       END IF
 C-----------------------------
 C     SMALL STRAIN 

--- a/engine/source/elements/solid/solidez/szforc3.F
+++ b/engine/source/elements/solid/solidez/szforc3.F
@@ -142,6 +142,7 @@ C-----------------------------------------------
       USE SENSOR_MOD
       USE sz_dt1_mod, only : sz_dt1
       use element_mod , only : nixs
+      use s8dlenmax_sm_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -314,7 +315,7 @@ C 8-nodes Solid Connectivities
      .  XGXYA(MVSIZ),XGYZA(MVSIZ),XGZXA(MVSIZ),
      .  XGXA2(MVSIZ),XGYA2(MVSIZ),XGZA2(MVSIZ),
      .  STI_C(MVSIZ),LL(MVSIZ),L_MAX(MVSIZ),FLD(MVSIZ),
-     .  CNS2,RHO0_1,NU,FQMAX
+     .  CNS2,RHO0_1,NU,FQMAX,VOLGS(MVSIZ),L_MIN(MVSIZ)
       my_real, dimension(mvsiz) :: fheat
       my_real ,DIMENSION(:), POINTER :: EINT
 C-----
@@ -397,8 +398,8 @@ C
      .        NN_DEL=8
       IF (NN_DEL ==0 .AND. DT%IDEL_BRICK>0) NN_DEL=8
       CNS2 = ZERO
+      RHO0_1 =PM( 1,IMAT)
       IF (ICP==1.AND.MTN==1.AND.ISMSTR==12) THEN
-         RHO0_1 =PM( 1,IMAT)
          CNS2 = ZEP02
          IF (IGEO(35,NGEO(1))>0) CNS2=CNS2-ABS(GEO(17,NGEO(1)))
       END IF
@@ -805,7 +806,15 @@ C
 C
       ITET = 0
       IF (NN_DEL >0) THEN
-        CALL SDLENMAX(L_MAX, 
+        IF (ISMSTR == 1 .OR. ISMSTR == 11) THEN 
+          CALL S8DLENMAX_SM(                          
+     1           NEL      ,RHO0_1   ,GBUF%VOL   ,X       ,       
+     2           NC1      ,NC2      ,NC3        ,NC4     ,       
+     3           NC5      ,NC6      ,NC7        ,NC8     ,       
+     4           L_MAX    ,GBUF%RHO ,VOLGS      ,L_MIN   ,
+     5           NUMNOD )
+        ELSE
+          CALL SDLENMAX(L_MAX, 
      1   X1,      X2,      X3,      X4,      
      2   X5,      X6,      X7,      X8,      
      3   Y1,      Y2,      Y3,      Y4,      
@@ -813,7 +822,10 @@ C
      5   Z1,      Z2,      Z3,      Z4,      
      6   Z5,      Z6,      Z7,      Z8,      
      7   NEL)
-       CALL SGEODEL3(NGL,GBUF%OFF,VOLN,DELTAX,GBUF%VOL,GEO(1,NGEO(1)),L_MAX,DT,NEL,IDEL7NOK )
+         VOLGS(1:NEL) =VOLN(1:NEL)
+         L_MIN(1:NEL) =DELTAX(1:NEL)
+        END IF  
+       CALL SGEODEL3(NGL,GBUF%OFF,VOLGS,L_MIN,GBUF%VOL,GEO(1,NGEO(1)),L_MAX,DT,NEL,IDEL7NOK )
       END IF
 C
 C Small strain formulation is activated:


### PR DESCRIPTION
…etric criteria

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
solid element deletion by geometric criteria (Vdef_min...)can be defined either in /PROP or in Engine time step input, but when small strain options (Ismstr=1,11) are used, it doesn't work.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
make small strain options compatible to solid element deletion.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
