### PR TITLE
correction /INIVEL check with rigid parts

### DIFF
--- a/starter/source/constraints/general/rbody/rbody_part_modif.F90
+++ b/starter/source/constraints/general/rbody/rbody_part_modif.F90
@@ -580,7 +580,7 @@
           end do
           is_available = .false.
 !--------------------------------------------------
-          call hm_option_start('/inivel')
+          call hm_option_start('/INIVEL')
           i = 0
 
           do cpt=1,hm_ninvel


### PR DESCRIPTION
This pull request makes a small change to the `rbody_part_modif.F90` file, updating the argument to the `hm_option_start` subroutine from `'/inivel'` to `'/INIVEL'` to ensure consistency or correct case sensitivity.

- Changed the argument in the `hm_option_start` call from `'/inivel'` to `'/INIVEL'` in `rbody_part_modif.F90`.
