### PR TITLE
conflict (regression) between ioff in law25 and ifail from 672f5265aa…

### DIFF
--- a/starter/source/elements/solid/solide/sgrtails.F
+++ b/starter/source/elements/solid/solide/sgrtails.F
@@ -111,7 +111,7 @@ C-----------------------------------------------
       INTEGER, INTENT(IN) :: IDDLEVEL
       INTEGER, INTENT(IN) :: PRINT_FLAG                 !< flag to print the element group data
       INTEGER, INTENT(IN) :: DAMP_RANGE_PART(NPART)     !< flag to compute the damping range
-      TYPE(MATPARAM_STRUCT_) , TARGET, DIMENSION(NUMMAT),INTENT(IN) :: MATPARAM_TAB
+      TYPE(MATPARAM_STRUCT_) , TARGET, DIMENSION(NUMMAT),INTENT(INOUT) :: MATPARAM_TAB
       MY_REAL  PM(NPROPM,NUMMAT), GEO(NPROPG,NUMGEO), RNOISE(NPERTURB,NUMELS)
       INTEGER, DIMENSION(2,NUMPRELOAD),INTENT(IN) :: IPRELOAD_FUN
 C-----------------------------------------------
@@ -657,6 +657,8 @@ C
             DO IL=1,NLAY                        
               IMAT  = IGEO(100+IL,PID)           
               NFAIL = MAX(NFAIL,MATPARAM_TAB(IMAT)%NFAIL)
+              ILAW = IPM(2,IMAT)
+              IF(MATPARAM_TAB(IMAT)%NFAIL>0.AND.ILAW==25) MATPARAM_TAB(IMAT)%IPARAM(2)=1000   !IOFF
             ENDDO
           ELSE
             NFAIL = MATPARAM_TAB(MID)%NFAIL
@@ -670,7 +672,9 @@ c
                   IF  (IFAILMODEL == 10 .OR. IFAILMODEL == 4 
      .             .OR.IFAILMODEL == 5  .OR. IFAILMODEL == 6)ISTRAIN = 1
                 ENDDO
-             ENDIF   
+            ELSEIF( MLN == 25 ) THEN
+              MATPARAM_TAB(MID)%IPARAM(2) = 1000   !IOFF
+            ENDIF   
           ENDIF
           IF(IKSNOD0 == 10.OR.
      .      (IKSNOD0 == 4.AND.ITET4 == 1))THEN


### PR DESCRIPTION
…c2f9969845e3455a2da84fa4c4e02d

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
when the rupture criteria are defined both in law25 (Ioff) and /IFAIL , there is a regression from 672f5265aac2f9969845e3455a2da84fa4c4e02d

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
Correction to ignore Ioff in law25 when /IFAIL is defined with this law

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
