### PR TITLE
correction to fix issue of  imposed velocity/disp/acc using sensor

### DIFF
--- a/engine/source/constraints/general/impvel/fixvel.F
+++ b/engine/source/constraints/general/impvel/fixvel.F
@@ -272,7 +272,7 @@ C------- Second pass
             N = INDEX(JJ)
             L = IBFV(3,N)
             IF (L > 0) ISMOOTH = NPC(2*NFUNCT+L+1)
-            IF(NCYCLE == 0)THEN 
+            IF(NCYCLE == 0 .OR. (ISENS > 0 .AND. TSC(JJ)>ZERO))THEN 
                 IPOSC_WO_SMOOTH(II) = 0
             ELSE
                 IPOSC_WO_SMOOTH(II) = IBFV(5,N)
@@ -286,7 +286,7 @@ C------- Second pass
             N = INDEX(JJ)
             L = IBFV(3,N)
             IF (L > 0) ISMOOTH = NPC(2*NFUNCT+L+1)
-            IF(NCYCLE == 0)THEN 
+            IF(NCYCLE == 0 .OR. (ISENS > 0 .AND. TSC(JJ)>ZERO))THEN 
                 IPOSC_SMOOTH(II) = 0
             ELSE
                 IPOSC_SMOOTH(II) = IBFV(5,N)


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
When imposed velocity/acceleration/displacement uses sensor with delay times, the imposed time function should be shifted this delay time, it's not the case

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
correction to fix the issue of imposed velocity with sensor

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
