### PR TITLE
/MAT/LAW2 on GPU (cuda)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ extlib.zip
 *.c.json
 .devcontainer/**
 .idea/
+*.s
+*.backup

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -53,6 +53,8 @@ file(GLOB_RECURSE source_files  ${source_directory}/source/*.F ${source_director
 file(GLOB_RECURSE c_source_files ${source_directory}/source/*.c ${source_directory}/stub/*.c ${source_directory}/share/*.c ${source_directory}/../common_source/*.c )
 #C++ source files
 file(GLOB_RECURSE cpp_source_files ${source_directory}/source/*.cpp ${source_directory}/stub/*.cpp ${source_directory}/share/*.cpp ${source_directory}/../common_source/*.cpp )
+#CUDA source files (.cu) - only compiled when NVIDIA HPC SDK is used
+file(GLOB_RECURSE cuda_source_files ${source_directory}/source/*.cu ${source_directory}/stub/*.cu ${source_directory}/share/*.cu ${source_directory}/../common_source/*.cu )
 file(GLOB_RECURSE include_files ${include_directory}/*.inc ${include_directory}/*.h ${source_directory}/../common_source/*.inc ${source_directory}/../common_source/*.h )
 
 # Get the Fortran compiler name
@@ -61,6 +63,8 @@ get_filename_component(Fortran_COMPILER_NAME ${CMAKE_Fortran_COMPILER} NAME)
 # Check if the Fortran compiler name contains "ifx" or "ifort"
 string(FIND "${Fortran_COMPILER_NAME}" "ifx" Fortran_COMPILER_CONTAINS_IFX)
 string(FIND "${Fortran_COMPILER_NAME}" "ifort" Fortran_COMPILER_CONTAINS_IFORT)
+# Check if the Fortran compiler name contains "nvfortran"
+string(FIND "${Fortran_COMPILER_NAME}" "nvfortran" Fortran_COMPILER_CONTAINS_NVFORTRAN)
 
 set(MUMPS_VERSION "5.5.1")
 
@@ -123,6 +127,8 @@ file(GLOB_RECURSE c_source_files ${source_directory}/source/*.c ${source_directo
 
 #C++ source files
 file(GLOB_RECURSE cpp_source_files ${source_directory}/source/*.cpp ${source_directory}/com/*.cpp ${source_directory}/share/*.cpp ${source_directory}/../common_source/*.cpp )
+#CUDA source files (.cu) - only compiled when NVIDIA HPC SDK is used
+file(GLOB_RECURSE cuda_source_files ${source_directory}/source/*.cu ${source_directory}/com/*.cu ${source_directory}/share/*.cu ${source_directory}/../common_source/*.cu )
 
 file(GLOB_RECURSE include_files ${include_directory}/*.inc ${include_directory}/*.h  ${include_directory}/com/*.inc ${include_directory}/com/*.h ${source_directory}/../common_source/*.inc ${source_directory}/../common_source/*.h ../thid_party_com/*.h )
 
@@ -323,8 +329,22 @@ else()
   message(STATUS "No coupling library selected")
 endif()
 
+# CUDA source files (.cu) — requires gpu_cc to be defined (NVIDIA HPC SDK builds).
+# For non-GPU builds, discard any .cu files found during globbing;
+# the Fortran module shell_gpu_mod provides stub implementations via #ifdef WITH_CUDA.
+if (NOT DEFINED gpu_cc OR gpu_cc STREQUAL "")
+  set(cuda_source_files "")
+endif()
 
-add_executable (${EXEC_NAME} ${source_files} ${source_files_common} ${c_source_files} ${cpp_source_files} ${Build_includes_directory}/engine_message_description.inc ${Build_includes_directory}/__foo.inc )
+# Always exclude the C stub; Fortran module stubs handle the non-CUDA case
+list(FILTER c_source_files EXCLUDE REGEX "shell_gpu_stub\\.c$")
+
+if (cuda_source_files)
+  message(STATUS "CUDA source files: ${cuda_source_files}")
+endif()
+
+
+add_executable (${EXEC_NAME} ${source_files} ${source_files_common} ${c_source_files} ${cpp_source_files} ${cuda_source_files} ${Build_includes_directory}/engine_message_description.inc ${Build_includes_directory}/__foo.inc )
 
 add_dependencies(${EXEC_NAME} extlib)
 
@@ -335,6 +355,11 @@ add_custom_command(TARGET ${EXEC_NAME}
                   )
 
 target_include_directories(${EXEC_NAME} PRIVATE ${include_dir_list}  )
+
+# Define WITH_CUDA preprocessor macro when CUDA source files are compiled
+if (cuda_source_files)
+  target_compile_definitions(${EXEC_NAME} PRIVATE WITH_CUDA)
+endif()
 
 if(precice STREQUAL "1")
   message(STATUS "Linking with preCICE libraries")

--- a/engine/CMake_Compilers/cmake_linux64_nvidia.txt
+++ b/engine/CMake_Compilers/cmake_linux64_nvidia.txt
@@ -16,39 +16,27 @@ if ( DEFINED MPI )
   if ( mpiver STREQUAL "smp")
      set (mpi_suf "" )
   elseif ( mpiver STREQUAL "ompi")
-
-    # Default: use HPC-X OpenMPI bundled with NVIDIA HPC SDK
-    # Override by setting NVHPC env var to the versioned SDK root
-    set (nvhpcx_root "/opt/nvidia/hpc_sdk/Linux_x86_64/26.3/comm_libs/13.1/hpcx/hpcx-2.25.1/ompi")
-    if (DEFINED ENV{NVHPC})
-      # Discover HPC-X path from NVHPC env variable
-      file(GLOB _hpcx_dirs "$ENV{NVHPC}/comm_libs/*/hpcx/*/ompi")
-      list(LENGTH _hpcx_dirs _hpcx_count)
-      if (_hpcx_count GREATER 0)
-        list(GET _hpcx_dirs -1 nvhpcx_root)
-      endif()
-    endif()
-
-    set (mpi_inc "-I${nvhpcx_root}/include/")
-    set (mpi_lib "-L${nvhpcx_root}/lib -lmpi -lmpi_mpifh" )
+      set( unused_dummy_arg "-Werror=unused-dummy-argument") 
+      set (mpi_inc "-I/opt/openmpi-nv/include/")
+      set (mpi_lib "-L/opt/openmpi-nv/lib -lmpi_mpifh -lmpi -lopen-rte -lopen-pal -lhwloc -levent -levent_pthreads -lpmix -libverbs -lnl-3 -lnl-route-3" )
 
     if (mpi_os STREQUAL "1")
-
+      
       set (mpi_inc " ")
-      set (mpi_lib "-lmpi -lmpi_mpifh" )
+      set (mpi_lib "-lmpi_mpifh -lmpi -lopen-rte -lopen-pal -lhwloc -levent -levent_pthreads -lpmix -libverbs -lnl-3 -lnl-route-3" )
     else()
       if ( DEFINED mpi_root )
         set (mpi_inc "-I${mpi_root}/include/")
-        set (mpi_lib "-L${mpi_root}/lib -lmpi -lmpi_mpifh" )
+        set (mpi_lib "-L${mpi_root}/lib -lmpi_mpifh -lmpi -lopen-rte -lopen-pal -lhwloc -levent -levent_pthreads -lpmix -libverbs -lnl-3 -lnl-route-3" )        
       else()
-        set (mpi_inc "-I${nvhpcx_root}/include/")
-        set (mpi_lib "-L${nvhpcx_root}/lib -lmpi -lmpi_mpifh" )
+        set (mpi_inc "-I/opt/openmpi-nv/include/")
+        set (mpi_lib "-L/opt/openmpi-nv/lib -lmpi_mpifh -lmpi -lopen-rte -lopen-pal -lhwloc -levent -levent_pthreads -lpmix -libverbs -lnl-3 -lnl-route-3" )
 
         if ( DEFINED mpi_incdir )
             set (mpi_inc "-I${mpi_incdir}")
         endif()
         if ( DEFINED mpi_libdir )
-            set (mpi_lib "-L${mpi_libdir} -lmpi -lmpi_mpifh")
+            set (mpi_lib "-L${mpi_libdir} -lmpi_mpifh -lmpi -lopen-rte -lopen-pal -lhwloc -levent -levent_pthreads -lpmix -libverbs -lnl-3 -lnl-route-3")
         endif()
 
       endif()
@@ -56,12 +44,109 @@ if ( DEFINED MPI )
 
     set (mpi_suf "_${mpiver}" )
     set (mpi_flag "-DMPI ${mpi_inc}")
+  elseif ( mpiver STREQUAL "impi")
+  # Intel MPI 
+  set (mpi_suf "_${mpiver}" )
+  #MPI     
+  set (mpi_flag "-DMPI -I$ENV{I_MPI_ROOT}/include/ ")
+  set (mpi_lib "-L$ENV{I_MPI_ROOT}/lib -L$ENV{I_MPI_ROOT}/lib/release  -lmpi -lmpifort")
   else()
     message( FATAL_ERROR "\n ERROR : -mpi=${mpiver} not available for this platform\n\n" )
   endif()
 endif ()
 
+#if ( DEFINED MPI )
+#  set ( mpiver "${MPI}" )
+#  if ( mpiver STREQUAL "smp")
+#     set (mpi_suf "" )
+#  elseif ( mpiver STREQUAL "ompi")
+#
+#    # Default: use HPC-X OpenMPI bundled with NVIDIA HPC SDK
+#    # Override by setting NVHPC env var to the versioned SDK root
+#    set (nvhpcx_root "/opt/nvidia/hpc_sdk/Linux_x86_64/26.3/comm_libs/13.1/hpcx/hpcx-2.25.1/ompi")
+#    if (DEFINED ENV{NVHPC})
+#      # Discover HPC-X path from NVHPC env variable
+#      file(GLOB _hpcx_dirs "$ENV{NVHPC}/comm_libs/*/hpcx/*/ompi")
+#      list(LENGTH _hpcx_dirs _hpcx_count)
+#      if (_hpcx_count GREATER 0)
+#        list(GET _hpcx_dirs -1 nvhpcx_root)
+#      endif()
+#    endif()
+#
+#    set (mpi_inc "-I${nvhpcx_root}/include/")
+#    set (mpi_lib "-L${nvhpcx_root}/lib -lmpi -lmpi_mpifh" )
+#
+#    if (mpi_os STREQUAL "1")
+#
+#      set (mpi_inc " ")
+#      set (mpi_lib "-lmpi -lmpi_mpifh" )
+#    else()
+#      if ( DEFINED mpi_root )
+#        set (mpi_inc "-I${mpi_root}/include/")
+#        set (mpi_lib "-L${mpi_root}/lib -lmpi -lmpi_mpifh" )
+#      else()
+#        set (mpi_inc "-I${nvhpcx_root}/include/")
+#        set (mpi_lib "-L${nvhpcx_root}/lib -lmpi -lmpi_mpifh" )
+#
+#        if ( DEFINED mpi_incdir )
+#            set (mpi_inc "-I${mpi_incdir}")
+#        endif()
+#        if ( DEFINED mpi_libdir )
+#            set (mpi_lib "-L${mpi_libdir} -lmpi -lmpi_mpifh")
+#        endif()
+#
+#      endif()
+#    endif()
+#
+#    set (mpi_suf "_${mpiver}" )
+#    set (mpi_flag "-DMPI ${mpi_inc}")
+#  else()
+#    message( FATAL_ERROR "\n ERROR : -mpi=${mpiver} not available for this platform\n\n" )
+#  endif()
+#endif ()
+
 set ( RELNAME ${arch}${mpi_suf} )
+
+
+# GPU compute capability target (e.g. cc80 for A100, cc90 for H100, cc120 for B200)
+# Override with -Dgpu_cc=ccXX on the cmake command line
+# Used for both OpenACC offloading and CUDA (.cu) source file compilation
+if ( NOT DEFINED gpu_cc )
+  set ( gpu_cc "cc80" )
+endif()
+
+# CUDA toolkit path discovery
+# Override by setting NVHPC_CUDA_HOME or CUDA_HOME env vars
+set ( cuda_home "/usr/local/cuda" )
+if (DEFINED ENV{NVHPC_CUDA_HOME})
+  set ( cuda_home "$ENV{NVHPC_CUDA_HOME}" )
+elseif (DEFINED ENV{CUDA_HOME})
+  set ( cuda_home "$ENV{CUDA_HOME}" )
+endif()
+
+
+# OpenACC GPU offloading
+# ----------------------
+if ( openacc STREQUAL "1" )
+
+  message (STATUS "OpenACC enabled  – GPU target: ${gpu_cc}")
+  message (STATUS "CUDA toolkit    : ${cuda_home}")
+
+  # Flags injected into Fortran and linker when OpenACC is active
+  # Note: -cuda / -cudaforlibs removed — they cause a deadlock with mem:managed
+  #       on Blackwell GPUs (cc120) and are not needed for pure OpenACC offloading.
+  #       Device data management is handled by !$ACC DATA directives.
+  set ( acc_fort_flags  "-acc -gpu=${gpu_cc} -Minfo=accel -Mdetail" )
+  set ( acc_c_flags     "" )
+  set ( acc_link_flags  "-acc -gpu=${gpu_cc}" )
+  set ( acc_link_libs   "-L${cuda_home}/lib64 -lnvToolsExt" )
+
+else()
+  set ( acc_fort_flags  "" )
+  set ( acc_c_flags     "" )
+  set ( acc_link_flags  "" )
+  set ( acc_link_libs   "" )
+endif()
 
 
 # Third party libraries
@@ -143,7 +228,13 @@ endif()
 #   -Munroll       Enable loop unrolling
 #   -Mvect=simd    Enable SIMD vectorization
 #   -Minform=warn  Report warnings and above
-set( fort_flags "-Mnofma -mp -traceback -Mextend -Munroll -Mvect=simd -Minform=warn -Mlarge_arrays  -I${nv_sdk_inc}")
+#   When OpenACC is enabled the following are appended:
+#   -acc           Enable OpenACC directives
+#   -gpu=ccXX      Target GPU compute capability
+#   -cuda          Enable CUDA interoperability
+#   -Minfo=accel   Print accelerator mapping information
+set( fort_flags "-Mnofma -mp -traceback -Mextend -Munroll -Mvect=simd -Minform=warn  -I${nv_sdk_inc} ${acc_fort_flags}")
+#set(GPUFLAGS "-O3   -Mextend -gpu=cc120,mem:managed -acc -cuda -cudaforlibs -Minline -Minfo=accel -Mextend -Mnofma -fopenmp -DMYREAL8 -DMPI -DNO_SERIALIZE -I${OMPI_ROOT}/include/ -DCPP_mach=CPP_p4linux964 -DCPP_rel=75 -g -traceback")
 
 
 if ( debug STREQUAL "1" )
@@ -160,32 +251,58 @@ set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS
 set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS
   "-g -O0 -mp ${h3d_inc} ${zlib_inc} ${md5_inc} ${precision_flag} ${cppmach} ${cpprel} -std=c++14 ${mpi_flag}" )
 
+# CUDA source files (.cu) - compiled as CXX with nvc++
+if (cuda_source_files)
+  set_source_files_properties(${cuda_source_files} PROPERTIES LANGUAGE CXX)
+  set_source_files_properties(${cuda_source_files} PROPERTIES COMPILE_FLAGS
+    "-g -O0 -cuda -gpu=${gpu_cc} -mp -Minfo=accel --diag_suppress cuda_compile ${h3d_inc} ${zlib_inc} ${md5_inc} ${precision_flag} ${cppmach} ${cpprel} -std=c++17 ${mpi_flag}" )
+endif()
+
 else ()
 
 # Fortran (optimized)
 set_source_files_properties( ${source_files} PROPERTIES COMPILE_FLAGS
-  "-O2 ${fort_flags} ${wo_linalg} ${precision_flag} ${cppmach} ${cpprel} -DCPP_comp=f90 -DCOMP_NVFORTRAN=1 ${mpi_flag} ${ADF}" )
+  "-O3 ${fort_flags} ${wo_linalg} ${precision_flag} ${cppmach} ${cpprel} -DCPP_comp=f90 -DCOMP_NVFORTRAN=1 ${mpi_flag} ${ADF}" )
 
 # C source files
 set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS
-  "-w -O2 -mp ${h3d_inc} ${zlib_inc} ${md5_inc} ${precision_flag} ${cppmach} ${cpprel} ${mpi_flag}" )
+  "-w -O3 -mp ${h3d_inc} ${zlib_inc} ${md5_inc} ${precision_flag} ${cppmach} ${cpprel} ${mpi_flag}" )
 
 # CXX source files
 set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS
-  "-w -O2 -mp ${h3d_inc} ${zlib_inc} ${md5_inc} ${precision_flag} ${cppmach} ${cpprel} -std=c++14 ${mpi_flag}" )
+  "-w -O3 -mp ${h3d_inc} ${zlib_inc} ${md5_inc} ${precision_flag} ${cppmach} ${cpprel} -std=c++14 ${mpi_flag}" )
+
+# CUDA source files (.cu) - compiled as CXX with nvc++
+if (cuda_source_files)
+  set_source_files_properties(${cuda_source_files} PROPERTIES LANGUAGE CXX)
+  set_source_files_properties(${cuda_source_files} PROPERTIES COMPILE_FLAGS
+    "-w -O3 -cuda -gpu=${gpu_cc} -mp -Minfo=accel --diag_suppress cuda_compile ${h3d_inc} ${zlib_inc} ${md5_inc} ${precision_flag} ${cppmach} ${cpprel} -std=c++17 ${mpi_flag}" )
+endif()
 
 endif()
 
 
+# CUDA (.cu) source file linking
+if (cuda_source_files)
+  set ( cuda_link_flags "-cuda -gpu=${gpu_cc}" )
+  set ( cuda_link_libs  "-L${cuda_home}/lib64 -lcudart" )
+  message (STATUS "CUDA sources detected – GPU target: ${gpu_cc}")
+  message (STATUS "CUDA toolkit: ${cuda_home}")
+else()
+  set ( cuda_link_flags "" )
+  set ( cuda_link_libs  "" )
+endif()
+
+
 # Linking flags
-set (CMAKE_EXE_LINKER_FLAGS "-Wl,--export-dynamic -Wl,-no-pie -mp" )
+set (CMAKE_EXE_LINKER_FLAGS "-Wl,--export-dynamic -Wl,-no-pie -mp ${acc_link_flags} ${cuda_link_flags}" )
 string(STRIP ${CMAKE_EXE_LINKER_FLAGS} CMAKE_EXE_LINKER_FLAGS)
 
 # Libraries
 if ( static_link STREQUAL "1" )
-  set (LINK "rt ${zlib_lib} ${md5_lib} ${mpi_lib} -ldl -Bstatic_pgi -Bstatic_c++libs" )
+  set (LINK "rt ${zlib_lib} ${md5_lib} ${mpi_lib} ${acc_link_libs} ${cuda_link_libs} -ldl -Bstatic_pgi -Bstatic_c++libs" )
 else()
-  set (LINK "rt ${zlib_lib} ${md5_lib} ${mpi_lib} -ldl" )
+  set (LINK "rt ${zlib_lib} ${md5_lib} ${mpi_lib} ${acc_link_libs} ${cuda_link_libs} -ldl" )
 endif()
 string(STRIP ${LINK} LINK)
 

--- a/engine/CMake_Compilers/legacy_fortran.cmake
+++ b/engine/CMake_Compilers/legacy_fortran.cmake
@@ -579,6 +579,7 @@ set_source_files_properties( ${source_directory}/source/output/restart/write_joi
 set_source_files_properties( ${source_directory}/source/output/restart/wrrest.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/output/restart/read_joint.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/output/restart/wrcomm.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
+set_source_files_properties( ${source_directory}/source/elements/shell/coque/shell_gpu_mod.F90 PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/elements/xelem/xforc3.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/elements/xelem/xanim28.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )
 set_source_files_properties( ${source_directory}/source/elements/xelem/xforc31.F PROPERTIES COMPILE_FLAGS "${legacy_flags}" )

--- a/engine/build_script.sh
+++ b/engine/build_script.sh
@@ -62,6 +62,11 @@ function my_help()
   echo " -cwipi=[path to cwipi root directory] : enable cwipi coupling"
   echo " "
   echo " -no-python : do not link with python"
+  echo " "
+  echo " -openacc                            : enable OpenACC GPU offloading (NVIDIA compiler only)"
+  echo "   -gpu-cc=[ccXX]                    : GPU compute capability target (default: cc80)"
+  echo "                                       e.g. cc80 (A100), cc90 (H100), cc120 (B200)"
+  echo "                                       Set NVHPC_CUDA_HOME or CUDA_HOME to override CUDA toolkit path"
   echo " " 
   echo " " 
 }
@@ -105,6 +110,8 @@ precice="0"
 coupling_exe=""
 cwipi=0
 cwipi_path=""
+openacc=0
+gpu_cc=""
 com=0
 release=0
 ad=none
@@ -259,6 +266,16 @@ else
        if [ "$arg" == "-no-python" ]
        then
          no_python=1
+       fi
+
+       if [ "$arg" == "-openacc" ]
+       then
+         openacc=1
+       fi
+
+       if [ "$arg" == "-gpu-cc" ]
+       then
+         gpu_cc=`echo $var|awk -F '=' '{print $2}'`
        fi
 
        if [ "$arg" == "-release" ]
@@ -452,7 +469,7 @@ then
   CXX_path_w=`cygpath.exe -m "${CXX_path}"`
   cmake.exe .. -G "Unix Makefiles" -Darch=${arch} -Dprecision=${prec} ${MPI} -Ddebug=${debug} -DEXEC_NAME=${engine_exec} -Dstatic_link=$static_link -Dmpi_os=${mpi_os} ${mpi_root} ${mpi_libdir} ${mpi_incdir} ${dc} ${mumps_root} ${scalapack_root} ${lapack_root} -DCMAKE_BUILD_TYPE=Release -Dno_python=${no_python}  -Dstatic_link=$static_link -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_COMPILER="${Fortran_path_w}" -DCMAKE_C_COMPILER="${C_path_w}" -DCMAKE_CPP_COMPILER="${CPP_path_w}" -DCMAKE_CXX_COMPILER="${CXX_path_w}" ${la}
 else
-  cmake .. -Darch=${arch} -Dprecision=${prec} ${MPI} -Ddebug=${debug} -DEXEC_NAME=${engine_exec} -Dstatic_link=$static_link -Dmpi_os=${mpi_os} -Dsanitize=${sanitize} ${mpi_root} ${mpi_libdir} ${mpi_incdir} ${dc} ${mumps_root} ${scalapack_root} ${lapack_root} -Dno_python=${no_python} -Dstatic_link=$static_link -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_COMPILER=${Fortran_path} -DCMAKE_C_COMPILER=${C_path} -DCMAKE_CPP_COMPILER=${CPP_path} -DCMAKE_CXX_COMPILER=${CXX_path}  ${la} -Dprecice=${precice} -Dcwipi=${cwipi} -Dcwipi_path=${cwipi_path}
+  cmake .. -Darch=${arch} -Dprecision=${prec} ${MPI} -Ddebug=${debug} -DEXEC_NAME=${engine_exec} -Dstatic_link=$static_link -Dmpi_os=${mpi_os} -Dsanitize=${sanitize} ${mpi_root} ${mpi_libdir} ${mpi_incdir} ${dc} ${mumps_root} ${scalapack_root} ${lapack_root} -Dno_python=${no_python} -Dstatic_link=$static_link -Dopenacc=${openacc} ${gpu_cc:+-Dgpu_cc=${gpu_cc}} -DCMAKE_BUILD_TYPE=Release -DCMAKE_Fortran_COMPILER=${Fortran_path} -DCMAKE_C_COMPILER=${C_path} -DCMAKE_CPP_COMPILER=${CPP_path} -DCMAKE_CXX_COMPILER=${CXX_path}  ${la} -Dprecice=${precice} -Dcwipi=${cwipi} -Dcwipi_path=${cwipi_path}
 
 fi
 

--- a/engine/share/includes/macro.inc
+++ b/engine/share/includes/macro.inc
@@ -130,6 +130,7 @@
 #define MACRO_TIMER_AMS            39
 #define MACRO_TIMER_TMP1          150
 #define MACRO_TIMER_TMP2          149
+#define MACRO_TIMER_GPU_SHELL     153
 
 #define MACRO_TIMER_ALEMAIN        110
 #define MACRO_TIMER_MULTIFVM       111

--- a/engine/share/includes/timerr_c.inc
+++ b/engine/share/includes/timerr_c.inc
@@ -23,4 +23,4 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 C PARASIZ defini dans task_c.inc
 C.../TIMERR/
       INTEGER NTIMAX,LTIMERR
-      PARAMETER(NTIMAX = 150)
+      PARAMETER(NTIMAX = 200)

--- a/engine/share/modules/command_line_args.F
+++ b/engine/share/modules/command_line_args.F
@@ -30,4 +30,5 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !||====================================================================
       MODULE COMMAND_LINE_ARGS_MOD
         INTEGER :: GOT_PREVIEW = 0
+        INTEGER :: GPU = 0
       END MODULE COMMAND_LINE_ARGS_MOD

--- a/engine/source/elements/forintc.F
+++ b/engine/source/elements/forintc.F
@@ -61,7 +61,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !||    timer_mod                   ../engine/source/system/timer_mod.F90
 !||    ush_force3_mod              ../engine/source/user_interface/ushforce3.F90
 !||====================================================================
-      SUBROUTINE FORINTC(TIMERS,
+      SUBROUTINE FORINTC(TIMERS, GPU, IPRI,
      1    PM        ,GEO       ,X         ,A         ,AR        ,
      2    V         ,VR        ,MS        ,IN        ,NLOC_DMG  ,
      3    WA        ,STIFN     ,STIFR     ,FSKY      ,CRKSKY    ,
@@ -138,6 +138,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
+      INTEGER , INTENT(IN) :: GPU
       TYPE(TIMER_), INTENT(INOUT) :: TIMERS
       INTEGER,INTENT(IN)    :: USERL_AVAIL ! Flag for User libraries availability
       INTEGER,INTENT(IN)    :: MAXFUNC     ! Maximum number of functions
@@ -172,6 +173,7 @@ C     REAL
      .   MS_PLY(*), ZI_PLY(*),GRESAV(*),
      .   MSTG(*), DMELTG(*), MSC(*), DMELC(*),CONDN(*),CONDNSKY(*),
      .   PTG(3,*),MSZ2(*),APINCH(3,*),STIFPINCH(*),VPINCH(3,*)
+      integer, intent(inout) :: ipri
       DOUBLE PRECISION :: XDP(3,*)
       TYPE (TTABLE) TABLE(*)
       TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP)      :: ELBUF_TAB
@@ -196,11 +198,9 @@ C-----------------------------------------------
       DOUBLE PRECISION, POINTER :: pFBSAV6
       INTEGER INDXOF(MVSIZ)
       INTEGER I,II,J,N, NG, NVC, MLW, JFT, JLT,ISOLNOD,ITHK,IPLA,
-     .    K2, NF1,IPRI, OFFSET,TYP,
+     .    K2, NF1, OFFSET,TYP,
      .   K0, K5, K9, NSG, NEL, KFTS,IOFC, ISTRA,
      .   ICNOD,NFT1,ISENS_ENERGY,
-     .   
-     .   
      .   IEXPAN, IG,ITG1,ITG2,ITG3,NLEVXF,ISEATBELT
       INTEGER IPARSENS,ISECT
       INTEGER ISH3N,ISHPLYXFEM,IXFEM
@@ -298,6 +298,24 @@ C---
             ACTIFXFEM=IPARG(70,NG)
             ISUBSTACK=IPARG(71,NG)
             ISEATBELT=IPARG(91,NG)
+            IF(GPU == 1 ) THEN
+              IF (ITY == 3  ! 4-node shell
+     .             .AND. MLW == 2  ! material law 2 (Johnson-Cook)
+     .             .AND. IPARG(8,NG) /= 1  ! group active
+     .             .AND. NPT > 0  ! through-thickness integration (not global)
+     .             .AND. JHBE < 11  ! standard formulation (not BATOZ, not QEPH)
+     .             .AND. IGTYP < 29  ! not user property
+     .             .AND. IXFEM == 0  ! no XFEM
+     .             .AND. IFAILURE == 0  ! no failure model (simplify for mockup)
+     .             .AND. NSECT == 0  ! no section (simplify for mockup)
+     .             .AND. NEXMAD == 0  ! no explicit mass scaling (simplify for mockup)
+     .             .AND. ICRACK3D == 0 .AND. IXFEM == 0 .AND. ACTIFXFEM == 0 
+     .             .AND. NSLIPRING == 0 .AND. ISEATBELT == 0  ! no slipring/seatbelt (simplify for mockup)
+     .             .AND. GPU == 1  ! GPU enabled
+     .             .AND. ISUBSTACK == 0 .AND. ISENS_ENERGY == 0) THEN
+                CYCLE
+              ENDIF
+            ENDIF
             LFT   = 1
             LLT   = MIN(NVSIZ,NEL)
             MTN   = MLW
@@ -711,5 +729,595 @@ C
 C----6---------------------------------------------------------------7---------8
       RETURN
       END
+
+
+!      SUBROUTINE FORINTC_PREPARE_GPU(TIMERS, GPU,  SHELLS,
+!     1    PM        ,GEO       ,X         ,A         ,AR        ,
+!     2    V         ,VR        ,MS        ,IN        ,NLOC_DMG  ,
+!     3    WA        ,STIFN     ,STIFR     ,FSKY      ,CRKSKY    ,
+!     4    TF        ,BUFMAT    ,PARTSAV   ,D         ,MAT_ELEM  ,
+!     5    DR        ,EANI      ,TANI      ,FANI      ,
+!     6    FSAV      ,SENSORS   ,SKEW      ,FAILWAVE  ,
+!     7    DT2T      ,THKE      ,BUFGEO    ,IADC      ,IADTG      ,
+!     8    IPARG     ,NPC       ,IXC       ,IXTG      ,NELTST    ,
+!     A    IPARI     ,ITYPTST   ,NSTRF     ,
+!     B    IPART     ,IPARTC    ,IPARTTG   ,SECFCUM   ,
+!     D    FSAVD     ,GROUP_PARAM_TAB,
+!     F    FZERO     ,IXTG1     ,IADTG1    ,IGEO      ,IPM       ,
+!     G    MADFAIL   ,XSEC      ,ITASK     ,MCP       ,
+!     H    TEMP      ,FTHE      ,FTHESKY   ,
+!     I    MS_PLY    ,ZI_PLY    ,INOD_PXFEM,XEDGE4N   ,XEDGE3N   ,
+!     J    IEL_PXFEM ,IADC_PXFEM,IGROUC    ,NGROUC    ,GRESAV    ,
+!     K    GRTH      ,IGRTH     ,MSTG      ,DMELTG    ,MSC       ,
+!     L    DMELC     ,TABLE     ,KNOD2ELC  ,PTG       ,MSZ2      ,
+!     M    INOD_CRK  ,IEL_CRK   ,IADC_CRK  ,ELCUTC    ,NODENR    ,
+!     N    IBORDNODE ,NODEDGE   ,CRKNODIAD ,ELBUF_TAB ,
+!     O    XFEM_TAB  ,CONDN     ,CONDNSKY  ,CRKEDGE   ,
+!     P    STACK     ,ITAB      ,GLOB_THERM,
+!     S    DRAPE_SH4N  ,DRAPE_SH3N  ,SUBSET    ,XDP       ,VPINCH,
+!     T    APINCH    ,STIFPINCH ,DRAPEG,OUTPUT ,DT        ,
+!     Y    SNPC      ,  STF, USERL_AVAIL,MAXFUNC,
+!     U    SBUFMAT   ,IPARIT    ,LSKY      ,NODADT )
+!C-----------------------------------------------
+!C   M o d u l e s
+!C-----------------------------------------------
+!      USE TIMER_MOD
+!      USE TABLE_MOD
+!      USE MAT_ELEM_MOD
+!      USE CRACKXFEM_MOD
+!      USE STACK_MOD
+!      USE FAILWAVE_MOD
+!      USE NLOCAL_REG_MOD
+!      USE GROUPDEF_MOD
+!      USE PINCHTYPE_MOD
+!      USE SENSOR_MOD
+!      USE RUPTURE_MOD
+!      USE DRAPE_MOD
+!      USE OUTPUT_MOD
+!      USE ELBUFDEF_MOD
+!      USE DT_MOD
+!      use glob_therm_mod
+!      use element_mod , only : nixc,nixtg
+!      use ush_force3_mod , only : ush_force3
+!      use shell_gpu_mod, only : SHELLS_,
+!     .  shell_gpu_data_create, shell_gpu_allocate,
+!     .  shell_gpu_set_mat_params
+!C-----------------------------------------------
+!C   I m p l i c i t   T y p e s
+!C-----------------------------------------------
+!#include      "implicit_f.inc"
+!#include      "comlock.inc"
+!C-----------------------------------------------
+!C   G l o b a l   P a r a m e t e r s
+!C-----------------------------------------------
+!#include      "mvsiz_p.inc"
+!#include      "param_c.inc"
+!C-----------------------------------------------
+!C   C o m m o n   B l o c k s
+!C-----------------------------------------------
+!#include      "com01_c.inc"
+!#include      "com04_c.inc"
+!#include      "com06_c.inc"
+!#include      "com08_c.inc"
+!#include      "com_xfem1.inc"
+!#include      "vect01_c.inc"
+!#include      "scr06_c.inc"
+!#include      "scr07_c.inc"
+!#include      "scr17_c.inc"
+!#include      "task_c.inc"
+!#include      "couple_c.inc"
+!#include      "impl1_c.inc"
+!#include      "stati_c.inc"
+!C-----------------------------------------------
+!C   D u m m y   A r g u m e n t s
+!C-----------------------------------------------
+!      TYPE(SHELLS_), INTENT(INOUT) :: SHELLS
+!      INTEGER , INTENT(IN) :: GPU
+!      TYPE(TIMER_), INTENT(INOUT) :: TIMERS
+!      INTEGER,INTENT(IN)    :: USERL_AVAIL ! Flag for User libraries availability
+!      INTEGER,INTENT(IN)    :: MAXFUNC     ! Maximum number of functions
+!      INTEGER,INTENT(IN)    :: SBUFMAT     ! Size of Bufmat
+!      INTEGER,INTENT(IN)    :: STF         ! Size of TF
+!      INTEGER,INTENT(IN)    :: SNPC        ! Size of NPC
+!      INTEGER,INTENT(IN)    :: IPARIT, LSKY, NODADT
+!      INTEGER IXC(NIXC,*), IXTG(NIXTG,*), IGEO(NPROPGI,*), IPM(NPROPMI,*),
+!     .   NPC(*), IPARG(NPARG,*), IPARI(NPARI,*), 
+!     .   NSTRF(*), IPART(LIPART1,*), IPARTC(*), IPARTTG(*),
+!     .   IADC(4,*), IADTG(3,*),NELTST,
+!     .   ITYPTST,IXTG1(4,*),XEDGE4N(4,*),XEDGE3N(3,*),
+!     .   IADTG1(3,*),MADFAIL(*),ITASK,
+!     .   INOD_PXFEM(*),IEL_PXFEM(*) ,IADC_PXFEM(4,*), IGROUC(*),
+!     .   NGROUC,GRTH(*),IGRTH(*),KNOD2ELC(*),
+!     .   INOD_CRK(*),IEL_CRK(*),IADC_CRK(*),ELCUTC(2,*),
+!     .   NODENR(*),IBORDNODE(*),NODEDGE(2,*),CRKNODIAD(*),
+!     .   ITAB(*)
+!C     REAL
+!      my_real
+!     .   X(3,*)    ,D(3,*)  ,V(3,*)   ,VR(3,*),
+!     .   MS(*)     ,IN(*)   ,PM(NPROPM,*),SKEW(LSKEW,*),
+!     .   GEO(NPROPG,*),BUFMAT(*) ,TF(STF) ,FSAV(NTHVKI,*) ,
+!     .   WA(*), THKE(*),
+!     .   A(3,*)    ,AR(3,*) ,FANI(3,*) ,PARTSAV(NPSAV,*)    ,
+!     .   STIFN(*) ,STIFR(*),FSKY(*) ,
+!     .   DR(3,*) ,TANI(*),EANI(*),
+!     .   BUFGEO(*) ,DT2T, SECFCUM(7,NUMNOD,NSECT),
+!     .   FSAVD(NTHVKI,*),
+!     .   FZERO(3,4,(NUMELC+NUMELTG)),XSEC(4,3,NSECT),
+!     .   MCP(*),TEMP(*),FTHE(*),FTHESKY(*),
+!     .   MS_PLY(*), ZI_PLY(*),GRESAV(*),
+!     .   MSTG(*), DMELTG(*), MSC(*), DMELC(*),CONDN(*),CONDNSKY(*),
+!     .   PTG(3,*),MSZ2(*),APINCH(3,*),STIFPINCH(*),VPINCH(3,*)
+!      DOUBLE PRECISION :: XDP(3,*)
+!      TYPE (TTABLE) TABLE(*)
+!      TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP)      :: ELBUF_TAB
+!      TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP,NXEL) :: XFEM_TAB
+!      TYPE (XFEM_EDGE_)   , DIMENSION(*)           :: CRKEDGE
+!      TYPE (XFEM_SKY_)    , DIMENSION(*) :: CRKSKY
+!      TYPE (STACK_PLY) :: STACK 
+!      TYPE (FAILWAVE_STR_) :: FAILWAVE 
+!      TYPE (NLOCAL_STR_)   :: NLOC_DMG 
+!      TYPE (GROUP_PARAM_) , DIMENSION(NGROUP) :: GROUP_PARAM_TAB
+!      TYPE (SUBSET_) , DIMENSION(NSUBS) :: SUBSET
+!      TYPE (DRAPE_)    :: DRAPE_SH4N(NUMELC_DRAPE),DRAPE_SH3N(NUMELTG_DRAPE)
+!      TYPE (DRAPEG_)               :: DRAPEG
+!      TYPE (SENSORS_) ,INTENT(INOUT) ,TARGET :: SENSORS
+!      TYPE(OUTPUT_), INTENT(INOUT) :: OUTPUT !< output structure
+!      TYPE (MAT_ELEM_) ,INTENT(INOUT) :: MAT_ELEM
+!      TYPE (DT_) ,INTENT(IN) :: DT
+!      type (glob_therm_) ,intent(inout) :: glob_therm
+!C-----------------------------------------------
+!C   L o c a l   V a r i a b l e s
+!C-----------------------------------------------
+!      DOUBLE PRECISION, POINTER :: pFBSAV6
+!      INTEGER INDXOF(MVSIZ)
+!      INTEGER I,II,J,N, NG, NVC, MLW, JFT, JLT,ISOLNOD,ITHK,IPLA,
+!     .    K2, NF1,IPRI, OFFSET,TYP,
+!     .   K0, K5, K9, NSG, NEL, KFTS,IOFC, ISTRA,
+!     .   ICNOD,NFT1,ISENS_ENERGY,
+!     .   IEXPAN, IG,ITG1,ITG2,ITG3,NLEVXF,ISEATBELT
+!      INTEGER IPARSENS,ISECT
+!      INTEGER ISH3N,ISHPLYXFEM,IXFEM
+!      INTEGER IXEL,ACTIFXFEM,ISUBSTACK
+!      my_real
+!     .   FX(MVSIZ,20),FY(MVSIZ,20),FZ(MVSIZ,20),
+!     .   MX(MVSIZ,4),MY(MVSIZ,4),MZ(MVSIZ,4)
+!
+!
+!      integer :: law2_counter(NGROUP)
+!      integer :: nod_counter(NGROUP)
+!      logical, dimension(:), allocatable :: node_mask
+!      integer, dimension(:), allocatable :: glob_2_gpu, gpu_2_glob, node_local_id
+!      integer :: SUPER_GROUP_ID(NGROUP)
+!      integer :: PREVIOUS_SUPER_GROUP_ID
+!      integer :: IPARG_PREVIOUS(NPARG)
+!      integer :: SU,nod,imat,ipid
+!      integer :: elem_counter(NGROUP)
+!      integer :: IT, gpu_offset, IJ1, IJ2, IJ3, IJ4, IJ5
+!      integer :: glob_id
+!C======================================================================|
+!
+!      allocate(node_mask(NUMNOD))
+!      allocate(glob_2_gpu(NUMNOD))
+!      allocate(gpu_2_glob(NUMNOD))
+!      allocate(node_local_id(NUMNOD))
+!      IPARG_PREVIOUS = 0
+!      glob_2_gpu = 0
+!      gpu_2_glob = 0
+!      node_mask = .false.
+!      ITG1 = 1+4*ECRKXFEC
+!      ITG2 = 2*NUMELC
+!      ITG3 = 1+NUMELC
+!      IPRI = 0
+!      ISENS_ENERGY = 0
+!      law2_counter = 0
+!      nod_counter = 0
+!      elem_counter = 0
+!      DO I=1,SENSORS%NSENSOR
+!        TYP = SENSORS%SENSOR_TAB(I)%TYPE
+!        IF (TYP == 14) ISENS_ENERGY = 1 ! save internal/kinetic energy (PARTSAV)
+!      ENDDO ! DO I=1,NSENSOR
+!      PREVIOUS_SUPER_GROUP_ID = 0
+!      DO IG = 1, NGROUC
+!            NG = IGROUC(IG)
+!            IF (IPARG(1, NG) == 151) THEN !  Bypass law 151
+!               CYCLE
+!            ENDIF
+!C---------temporarily used to avoid pass KTBUF_STR everywhere
+!            NG_IMP = NG
+!            IF(IPARG(8,NG)==1) CYCLE
+!            ITY   =IPARG(5,NG)
+!C            IF(ITY/=3.AND.ITY/=7)GOTO 250
+!            OFFSET  = 0
+!            MLW     = IPARG(1,NG)
+!C MLW= 0 ----> void
+!C MLW = 13 ----> rigid material
+!            IF (MLW == 0 .OR. MLW == 13) CYCLE
+!            NEL     = IPARG(2,NG)
+!            NFT     = IPARG(3,NG)
+!            NPT     = IPARG(6,NG)
+!            JALE    = IPARG(7,NG)
+!            ISMSTR  = IPARG(9,NG)
+!            NSG     = IPARG(10,NG)
+!            JEUL    = IPARG(11,NG)
+!            JTUR    = IPARG(12,NG)
+!            JTHE    = IPARG(13,NG)
+!            JLAG    = IPARG(14,NG)
+!            ISTRA   = IPARG(44,NG)
+!            NVC     = IPARG(19,NG)
+!            JMULT   = IPARG(20,NG)
+!            JHBE    = IPARG(23,NG)
+!            ISH3N   = IPARG(23,NG)
+!            JIVF    = IPARG(24,NG)
+!            JPOR    = IPARG(27,NG)
+!            ITHK    = IPARG(28,NG)
+!            ISOLNOD = IPARG(28,NG)
+!            IPLA    = IPARG(29,NG)
+!            ICNOD   = IPARG(11,NG)
+!            IREP    = IPARG(35,NG)
+!            IINT    = IPARG(36,NG)
+!            JCVT    = IPARG(37,NG)
+!            IGTYP   = IPARG(38,NG)
+!            ISORTH  = IPARG(42,NG)
+!            ISORTHG = ISORTH
+!            ISRAT   = IPARG(40,NG)
+!            ISROT   = IPARG(41,NG)
+!            IFAILURE= IPARG(43,NG)
+!            KFTS    = IPARG(30,NG)
+!            JCLOSE  = IPARG(33,NG)
+!            ICSEN   = IPARG(39,NG)
+!            IEXPAN  = IPARG(49,NG)
+!            ISHPLYXFEM  = IPARG(50,NG)
+!            IGRE    = IPARG(51,NG)
+!            JSMS    = IPARG(52,NG)
+!            IXFEM   = IPARG(54,NG)
+!            NLEVXF  = IPARG(65,NG)
+!            ACTIFXFEM=IPARG(70,NG)
+!            ISUBSTACK=IPARG(71,NG)
+!            ISEATBELT=IPARG(91,NG)
+!            IF (ITY == 3  ! 4-node shell
+!     .           .AND. MLW == 2  ! material law 2 (Johnson-Cook)
+!     .           .AND. IPARG(8,NG) /= 1  ! group active
+!     .           .AND. NPT > 0  ! through-thickness integration (not global)
+!     .           .AND. JHBE < 11  ! standard formulation (not BATOZ, not QEPH)
+!     .           .AND. IGTYP < 29  ! not user property
+!     .           .AND. IXFEM == 0  ! no XFEM
+!     .           .AND. IFAILURE == 0  ! no failure model (simplify for mockup)
+!     .           .AND. NSECT == 0  ! no section (simplify for mockup)
+!     .           .AND. NEXMAD == 0  ! no explicit mass scaling (simplify for mockup)
+!     .           .AND. ICRACK3D == 0 .AND. IXFEM == 0 .AND. ACTIFXFEM == 0 
+!     .           .AND. NSLIPRING == 0 .AND. ISEATBELT == 0  ! no slipring/seatbelt (simplify for mockup)
+!     .           .AND. GPU == 1  ! GPU enabled
+!     .           .AND. ISUBSTACK == 0 .AND. ISENS_ENERGY == 0) THEN
+!            IF(ALL(IPARG(6:71,NG) == IPARG_PREVIOUS(6:71))) THEN
+!             SUPER_GROUP_ID(NG) = PREVIOUS_SUPER_GROUP_ID
+!            ELSE
+!             PREVIOUS_SUPER_GROUP_ID = PREVIOUS_SUPER_GROUP_ID + 1
+!             SUPER_GROUP_ID(NG) = PREVIOUS_SUPER_GROUP_ID
+!             node_mask = .false.
+!            ENDIF
+!            IPARG_PREVIOUS = IPARG(:,NG) 
+!            IF(.TRUE.) THEN
+!              LFT   = 1
+!              LLT   = MIN(NVSIZ,NEL)
+!              MTN   = MLW
+!              JFT=LFT
+!              JLT=LLT
+!              NF1 = NFT+1
+!              SU = SUPER_GROUP_ID(NG)
+!              law2_counter(SU) = law2_counter(SU) + NEL
+!              do i=1,NEL
+!                do j=1,4
+!                  if (node_mask(IXC(1+j,NF1+i)) .eqv. .false.) then
+!                    nod_counter(SU) = nod_counter(SU) + 1
+!!                   gpu_2_glob(node_counter) = IXC(1+j,NF1+i)
+!!                   glob_2_gpu(IXC(1+j,NF1+i)) = node_counter
+!                    node_mask(IXC(1+j,NF1+i)) = .true.
+!                  end if
+!                end do
+!              end do
+!            ENDIF
+!C----6---------------------------------------------------------------7---------8
+!        ENDIF
+!      END DO
+!
+!
+!
+!
+!      ALLOCATE(SHELLS%LAW2(PREVIOUS_SUPER_GROUP_ID))
+!      PREVIOUS_SUPER_GROUP_ID = 0
+!      DO IG = 1, NGROUC
+!            NG = IGROUC(IG)
+!            NEL     = IPARG(2,NG)
+!            NFT     = IPARG(3,NG)
+!            NPT     = IPARG(6,NG)
+! 
+!            IF(SUPER_GROUP_ID(NG) == 0) CYCLE ! skip groups not selected for GPU
+!            IF(SUPER_GROUP_ID(NG) /= PREVIOUS_SUPER_GROUP_ID) THEN
+!              PREVIOUS_SUPER_GROUP_ID = SUPER_GROUP_ID(NG)
+!              SU = SUPER_GROUP_ID(NG)
+!              nod = nod_counter(SU)
+!              nod_counter(SU) = 0 ! reset for next super group
+!              SHELLS%LAW2(SU)%numelc = law2_counter(SU)
+!              SHELLS%LAW2(SU)%numnod = nod 
+!              allocate(SHELLS%LAW2(SU)%gpu_2_glob(nod))
+!              SHELLS%LAW2(SU)%npt = IPARG(6,NG)
+!              SHELLS%LAW2(SU)%ismstr = IPARG(9,NG)
+!              SHELLS%LAW2(SU)%ithk = IPARG(28,NG)
+!              SHELLS%LAW2(SU)%handle = shell_gpu_data_create()
+!              call shell_gpu_allocate(
+!     .          shells%LAW2(SU)%handle,
+!     .          SHELLS%LAW2(SU)%numelc,
+!     .          SHELLS%LAW2(SU)%numnod,
+!     .          SHELLS%LAW2(SU)%npt,
+!     .          SHELLS%LAW2(SU)%ismstr,
+!     .          SHELLS%LAW2(SU)%ithk)
+!C
+!C             Retrieve material index and property index
+!C
+!              imat = ELBUF_TAB(NG)%bufly(1)%imat
+!              NF1  = IPARG(3,NG) + 1
+!              ipid = IXC(6,NF1)
+!C
+!C             Elastic properties  (cf. sigeps02c / mat_param)
+!C
+!              SHELLS%LAW2(SU)%e_young = MAT_ELEM%mat_param(imat)%young
+!              SHELLS%LAW2(SU)%nu      = MAT_ELEM%mat_param(imat)%nu
+!              SHELLS%LAW2(SU)%g_shear = MAT_ELEM%mat_param(imat)%shear
+!              SHELLS%LAW2(SU)%a11     = MAT_ELEM%mat_param(imat)%young
+!     .                                / (ONE - MAT_ELEM%mat_param(imat)%nu**2)
+!              SHELLS%LAW2(SU)%a12     = SHELLS%LAW2(SU)%a11
+!     .                                * MAT_ELEM%mat_param(imat)%nu
+!C
+!C             Johnson-Cook / Zerilli-Armstrong hardening (uparam)
+!C
+!              SHELLS%LAW2(SU)%ca      = MAT_ELEM%mat_param(imat)%uparam(1)
+!              SHELLS%LAW2(SU)%cb      = MAT_ELEM%mat_param(imat)%uparam(2)
+!              SHELLS%LAW2(SU)%cn      = MAT_ELEM%mat_param(imat)%uparam(3)
+!              SHELLS%LAW2(SU)%epmx    = MAT_ELEM%mat_param(imat)%uparam(4)
+!              SHELLS%LAW2(SU)%ymax    = MAT_ELEM%mat_param(imat)%uparam(5)
+!              SHELLS%LAW2(SU)%cc      = MAT_ELEM%mat_param(imat)%uparam(6)
+!              SHELLS%LAW2(SU)%epdr    = MAT_ELEM%mat_param(imat)%uparam(7)
+!              SHELLS%LAW2(SU)%fisokin = MAT_ELEM%mat_param(imat)%uparam(8)
+!C
+!C             Thermal parameters
+!C
+!              SHELLS%LAW2(SU)%rhocp   = MAT_ELEM%mat_param(imat)%therm%rhocp
+!              SHELLS%LAW2(SU)%tref    = MAT_ELEM%mat_param(imat)%therm%tref
+!              SHELLS%LAW2(SU)%tmelt   = MAT_ELEM%mat_param(imat)%therm%tmelt
+!C
+!C             Formulation-dependent: m_exp / z3 / z4  (cf. sigeps02c)
+!C
+!              SHELLS%LAW2(SU)%iform   = MAT_ELEM%mat_param(imat)%iparam(1)
+!              IF (SHELLS%LAW2(SU)%iform == 1) THEN
+!C               Zerilli-Armstrong
+!                SHELLS%LAW2(SU)%z3    = MAT_ELEM%mat_param(imat)%uparam(10)
+!                SHELLS%LAW2(SU)%z4    = MAT_ELEM%mat_param(imat)%uparam(11)
+!                SHELLS%LAW2(SU)%m_exp = ONE
+!              ELSE
+!C               Johnson-Cook
+!                SHELLS%LAW2(SU)%z3    = ZERO
+!                SHELLS%LAW2(SU)%z4    = ZERO
+!                SHELLS%LAW2(SU)%m_exp = MAT_ELEM%mat_param(imat)%uparam(10)
+!              ENDIF
+!C
+!C             Integer flags (iparam)
+!C
+!              SHELLS%LAW2(SU)%icc     = MAT_ELEM%mat_param(imat)%iparam(2)
+!              SHELLS%LAW2(SU)%vp      = MAT_ELEM%mat_param(imat)%iparam(3)
+!C
+!C             Strain-rate filter coefficient (PM(9,imat) = 2*pi*fcut)
+!C
+!              SHELLS%LAW2(SU)%asrate  = PM(9,imat)
+!C
+!C             Density, sound speed, shear correction factor
+!C
+!              SHELLS%LAW2(SU)%rho      = MAT_ELEM%mat_param(imat)%rho
+!              SHELLS%LAW2(SU)%ssp      = PM(27,imat)
+!              SHELLS%LAW2(SU)%shf_coef = GEO(38,ipid)
+!C
+!C             Plasticity algorithm
+!C
+!              SHELLS%LAW2(SU)%ipla    = IPARG(29,NG)
+!
+!C             hourglass parameters (from GEO property array)
+!              SHELLS%LAW2(SU)%h1   = GEO(13,ipid)
+!              SHELLS%LAW2(SU)%h2   = GEO(14,ipid)
+!              SHELLS%LAW2(SU)%h3   = GEO(15,ipid)
+!              SHELLS%LAW2(SU)%srh1 = GEO(18,ipid)
+!              SHELLS%LAW2(SU)%srh2 = GEO(19,ipid)
+!              SHELLS%LAW2(SU)%srh3 = GEO(20,ipid)
+!
+!              call shell_gpu_set_mat_params(
+!     .          SHELLS%LAW2(SU)%handle,
+!     .          SHELLS%LAW2(SU)%e_young,
+!     .          SHELLS%LAW2(SU)%nu,
+!     .          SHELLS%LAW2(SU)%g_shear,
+!     .          SHELLS%LAW2(SU)%a11,
+!     .          SHELLS%LAW2(SU)%a12,
+!     .          SHELLS%LAW2(SU)%ca,
+!     .          SHELLS%LAW2(SU)%cb,
+!     .          SHELLS%LAW2(SU)%cn,
+!     .          SHELLS%LAW2(SU)%cc,
+!     .          SHELLS%LAW2(SU)%epdr,
+!     .          SHELLS%LAW2(SU)%epmx,
+!     .          SHELLS%LAW2(SU)%ymax,
+!     .          SHELLS%LAW2(SU)%m_exp,
+!     .          SHELLS%LAW2(SU)%fisokin,
+!     .          SHELLS%LAW2(SU)%rhocp,
+!     .          SHELLS%LAW2(SU)%tref,
+!     .          SHELLS%LAW2(SU)%tmelt,
+!     .          SHELLS%LAW2(SU)%asrate,
+!     .          SHELLS%LAW2(SU)%rho,
+!     .          SHELLS%LAW2(SU)%ssp,
+!     .          SHELLS%LAW2(SU)%shf_coef,
+!     .          SHELLS%LAW2(SU)%ipla,
+!     .          SHELLS%LAW2(SU)%vp,
+!     .          SHELLS%LAW2(SU)%iform,
+!     .          SHELLS%LAW2(SU)%icc,
+!     .          SHELLS%LAW2(SU)%z3,
+!     .          SHELLS%LAW2(SU)%z4)
+!
+!              allocate(SHELLS%LAW2(SU)%n1(nod))
+!              allocate(SHELLS%LAW2(SU)%n2(nod))
+!              allocate(SHELLS%LAW2(SU)%n3(nod))
+!              allocate(SHELLS%LAW2(SU)%n4(nod))
+!              allocate(SHELLS%LAW2(SU)%xx(nod))
+!              allocate(SHELLS%LAW2(SU)%xy(nod))
+!              allocate(SHELLS%LAW2(SU)%xz(nod))
+!              allocate(SHELLS%LAW2(SU)%vx(nod))
+!              allocate(SHELLS%LAW2(SU)%vy(nod))
+!              allocate(SHELLS%LAW2(SU)%vz(nod))
+!              allocate(SHELLS%LAW2(SU)%vrx(nod))
+!              allocate(SHELLS%LAW2(SU)%vry(nod))
+!              allocate(SHELLS%LAW2(SU)%vrz(nod))
+!              allocate(SHELLS%LAW2(SU)%fx(nod))
+!              allocate(SHELLS%LAW2(SU)%fy(nod))
+!              allocate(SHELLS%LAW2(SU)%fz(nod))
+!              allocate(SHELLS%LAW2(SU)%mx(nod))
+!              allocate(SHELLS%LAW2(SU)%my(nod))
+!              allocate(SHELLS%LAW2(SU)%mz(nod))
+!              allocate(SHELLS%LAW2(SU)%stifn(nod))
+!              allocate(SHELLS%LAW2(SU)%stifr(nod))
+!              !IP state arrays [NPT*NUMELC]
+!              allocate(SHELLS%LAW2(SU)%sigxx(NPT*SHELLS%LAW2(SU)%numelc))
+!              allocate(SHELLS%LAW2(SU)%sigyy(NPT*SHELLS%LAW2(SU)%numelc))
+!              allocate(SHELLS%LAW2(SU)%sigxy(NPT*SHELLS%LAW2(SU)%numelc))
+!              allocate(SHELLS%LAW2(SU)%sigyz(NPT*SHELLS%LAW2(SU)%numelc))
+!              allocate(SHELLS%LAW2(SU)%sigzx(NPT*SHELLS%LAW2(SU)%numelc))
+!              allocate(SHELLS%LAW2(SU)%pla(NPT*SHELLS%LAW2(SU)%numelc))
+!              allocate(SHELLS%LAW2(SU)%epsd_ip(NPT*SHELLS%LAW2(SU)%numelc))
+!              allocate(SHELLS%LAW2(SU)%sigbakxx(NPT*SHELLS%LAW2(SU)%numelc))
+!              allocate(SHELLS%LAW2(SU)%sigbakyy(NPT*SHELLS%LAW2(SU)%numelc))
+!              allocate(SHELLS%LAW2(SU)%sigbakxy(NPT*SHELLS%LAW2(SU)%numelc))
+!              allocate(SHELLS%LAW2(SU)%tempel(NPT*SHELLS%LAW2(SU)%numelc))
+!              allocate(SHELLS%LAW2(SU)%eint(2*SHELLS%LAW2(SU)%numelc))
+!              SHELLS%LAW2(SU)%eint = 0.0d0
+!              SHELLS%LAW2(SU)%sigxx = 0.0d0
+!              SHELLS%LAW2(SU)%sigyy = 0.0d0
+!              SHELLS%LAW2(SU)%sigxy = 0.0d0
+!              SHELLS%LAW2(SU)%sigyz = 0.0d0
+!              SHELLS%LAW2(SU)%sigzx = 0.0d0
+!              SHELLS%LAW2(SU)%pla = 0.0d0
+!              SHELLS%LAW2(SU)%epsd_ip = 0.0d0
+!              SHELLS%LAW2(SU)%sigbakxx = 0.0d0
+!              SHELLS%LAW2(SU)%sigbakyy = 0.0d0
+!              SHELLS%LAW2(SU)%sigbakxy = 0.0d0
+!              SHELLS%LAW2(SU)%tempel = 0.0d0
+!              elem_counter(SU) = 0
+!              node_mask = .false.
+!              node_local_id = 0
+!            endif
+!C
+!C           Copy per-IP state from ELBUF_TAB into flat GPU arrays
+!C           Layout in lbuf%sig: [sigxx(1:NEL), sigyy(1:NEL), sigxy(1:NEL), sigyz(1:NEL), sigzx(1:NEL)]
+!C           Layout in GPU arrays: (IT-1)*total_numelc + elem_counter + i
+!C
+!            NF1 = NFT + 1
+!            do IT = 1, NPT
+!              do i = 1, NEL
+!                gpu_offset = (IT-1)*SHELLS%LAW2(SU)%numelc
+!     .                     + elem_counter(SU) + i
+!C               Stress components from lbuf%sig (5*NEL flat array)
+!                IJ1 = 0
+!                IJ2 = NEL
+!                IJ3 = 2*NEL
+!                IJ4 = 3*NEL
+!                IJ5 = 4*NEL
+!                if (ELBUF_TAB(NG)%bufly(1)%l_sig > 0) then
+!                  SHELLS%LAW2(SU)%sigxx(gpu_offset) =
+!     .              ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%sig(IJ1+i)
+!                  SHELLS%LAW2(SU)%sigyy(gpu_offset) =
+!     .              ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%sig(IJ2+i)
+!                  SHELLS%LAW2(SU)%sigxy(gpu_offset) =
+!     .              ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%sig(IJ3+i)
+!                  SHELLS%LAW2(SU)%sigyz(gpu_offset) =
+!     .              ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%sig(IJ4+i)
+!                  SHELLS%LAW2(SU)%sigzx(gpu_offset) =
+!     .              ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%sig(IJ5+i)
+!                endif
+!C               Plastic strain
+!                if (ELBUF_TAB(NG)%bufly(1)%l_pla > 0) then
+!                  SHELLS%LAW2(SU)%pla(gpu_offset) =
+!     .              ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%pla(i)
+!                endif
+!C               Strain rate
+!                if (ELBUF_TAB(NG)%bufly(1)%l_epsd > 0) then
+!                  SHELLS%LAW2(SU)%epsd_ip(gpu_offset) =
+!     .              ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%epsd(i)
+!                endif
+!C               Back-stress components from lbuf%sigb (same layout as sig)
+!                if (ELBUF_TAB(NG)%bufly(1)%l_sigb > 0) then
+!                  SHELLS%LAW2(SU)%sigbakxx(gpu_offset) =
+!     .              ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%sigb(IJ1+i)
+!                  SHELLS%LAW2(SU)%sigbakyy(gpu_offset) =
+!     .              ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%sigb(IJ2+i)
+!                  SHELLS%LAW2(SU)%sigbakxy(gpu_offset) =
+!     .              ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%sigb(IJ3+i)
+!                endif
+!C               Temperature
+!                if (ELBUF_TAB(NG)%bufly(1)%l_temp > 0) then
+!                  SHELLS%LAW2(SU)%tempel(gpu_offset) =
+!     .              ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%temp(i)
+!                endif
+!              end do
+!            end do
+!C           Internal energy from global buffer: GBUF%EINT(1:2*NEL)
+!            do i = 1, NEL
+!              SHELLS%LAW2(SU)%eint(elem_counter(SU)+i) =
+!     .          ELBUF_TAB(NG)%gbuf%eint(i)
+!              SHELLS%LAW2(SU)%eint(
+!     .          SHELLS%LAW2(SU)%numelc+elem_counter(SU)+i) =
+!     .          ELBUF_TAB(NG)%gbuf%eint(NEL+i)
+!            end do
+!C           Advance element counter for this super-group
+!            elem_counter(SU) = elem_counter(SU) + NEL
+!C           Build node mapping
+!            do i=1,NEL
+!              do j=1,4
+!                if (node_mask(IXC(1+j,NF1+i)) .eqv. .false.) then
+!                  nod_counter(SU) = nod_counter(SU) + 1
+!                  SHELLS%LAW2(SU)%gpu_2_glob(nod_counter(SU)) = IXC(1+j,NF1+i)
+!                  node_mask(IXC(1+j,NF1+i)) = .true.
+!                  node_local_id(IXC(1+j,NF1+i)) = nod_counter(SU)
+!                end if
+!              end do
+!            end do
+!            do i=1,NEL
+!                SHELLS%LAW2(SU)%n1(elem_counter(SU)+i) = node_local_id(IXC(2,NF1+i))
+!                SHELLS%LAW2(SU)%n2(elem_counter(SU)+i) = node_local_id(IXC(3,NF1+i))
+!                SHELLS%LAW2(SU)%n3(elem_counter(SU)+i) = node_local_id(IXC(4,NF1+i))
+!                SHELLS%LAW2(SU)%n4(elem_counter(SU)+i) = node_local_id(IXC(5,NF1+i))
+!            enddo
+!            SHELLS%LAW2(SU)%numnod = nod_counter(SU)
+!            ! gather X and V for nodes in this super-group
+!            do i=1,nod_counter(SU)
+!              glob_id = SHELLS%LAW2(SU)%gpu_2_glob(i)
+!              SHELLS%LAW2(SU)%xx(i) = X(1,glob_id)
+!              SHELLS%LAW2(SU)%xy(i) = X(2,glob_id)
+!              SHELLS%LAW2(SU)%xz(i) = X(3,glob_id)
+!              SHELLS%LAW2(SU)%vx(i) = V(1,glob_id)
+!              SHELLS%LAW2(SU)%vy(i) = V(2,glob_id)
+!              SHELLS%LAW2(SU)%vz(i) = V(3,glob_id)
+!
+!              if(iroddl == 1) then
+!              SHELLS%LAW2(SU)%vrx(i) = VR(1,glob_id)
+!              SHELLS%LAW2(SU)%vry(i) = VR(2,glob_id)
+!              SHELLS%LAW2(SU)%vrz(i) = VR(3,glob_id)
+!              endif
+!            end do
+! 
+!
+!      ENDDO
+!
+!
+!      DEALLOCATE(node_mask)
+!      DEALLOCATE(node_local_id)
+!      DEALLOCATE(glob_2_gpu)
+!      DEALLOCATE(gpu_2_glob)
+!
+!C
+!C----6---------------------------------------------------------------7---------8
+!      RETURN
+!      END
 
 

--- a/engine/source/elements/shell/coque/real_type.h
+++ b/engine/source/elements/shell/coque/real_type.h
@@ -1,0 +1,34 @@
+//Copyright>    OpenRadioss
+//Copyright>    Copyright (C) 1986-2026 Altair Engineering Inc.
+//Copyright>
+//Copyright>    This program is free software: you can redistribute it and/or modify
+//Copyright>    it under the terms of the GNU Affero General Public License as published by
+//Copyright>    the Free Software Foundation, either version 3 of the License, or
+//Copyright>    (at your option) any later version.
+//Copyright>
+//Copyright>    This program is distributed in the hope that it will be useful,
+//Copyright>    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//Copyright>    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//Copyright>    GNU Affero General Public License for more details.
+//Copyright>
+//Copyright>    You should have received a copy of the GNU Affero General Public License
+//Copyright>    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//Copyright>
+//Copyright>
+//Copyright>    Commercial Alternative: Altair Radioss Software
+//Copyright>
+//Copyright>    As an alternative to this open-source version, Altair also offers Altair Radioss
+//Copyright>    software under a commercial license.  Contact Altair to discuss further if the
+//Copyright>    commercial version may interest you: https://www.altair.com/radioss/.
+
+
+#ifdef _SHELL_REAL_TYPE_H
+#else
+#define _SHELL_REAL_TYPE_H
+#ifdef MYREAL8
+using Real = double;
+#else
+using Real = float;
+#endif
+#endif
+

--- a/engine/source/elements/shell/coque/shell_force_assembly_kernel.cu
+++ b/engine/source/elements/shell/coque/shell_force_assembly_kernel.cu
@@ -1,0 +1,707 @@
+//Copyright>    OpenRadioss
+//Copyright>    Copyright (C) 1986-2026 Altair Engineering Inc.
+//Copyright>
+//Copyright>    This program is free software: you can redistribute it and/or modify
+//Copyright>    it under the terms of the GNU Affero General Public License as published by
+//Copyright>    the Free Software Foundation, either version 3 of the License, or
+//Copyright>    (at your option) any later version.
+//Copyright>
+//Copyright>    This program is distributed in the hope that it will be useful,
+//Copyright>    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//Copyright>    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//Copyright>    GNU Affero General Public License for more details.
+//Copyright>
+//Copyright>    You should have received a copy of the GNU Affero General Public License
+//Copyright>    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//Copyright>
+//Copyright>
+//Copyright>    Commercial Alternative: Altair Radioss Software
+//Copyright>
+//Copyright>    As an alternative to this open-source version, Altair also offers Altair Radioss
+//Copyright>    software under a commercial license.  Contact Altair to discuss further if the
+//Copyright>    commercial version may interest you: https://www.altair.com/radioss/.
+// ==============================================================================
+//  OpenRadioss GPU — Kernel 3 (Option C): Forces + Assembly
+//  Covers: CHVIS3  — hourglass forces  (ISMSTR=1, IHBE<=1)
+//          CFINT3  — internal force computation (local → global)
+//          CUPDT3  — atomic scatter to global nodal arrays
+//
+//  Scope: ISMSTR=1, IHBE<=1, ISHFRAM=0, standard formulation (no ISIGI=5)
+//         One thread per element, flat SoA layout.
+// ==============================================================================
+
+#ifndef SHELL_FORCE_ASSEMBLY_KERNEL_CU
+#define SHELL_FORCE_ASSEMBLY_KERNEL_CU
+
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <cfloat>
+#include <type_traits>
+
+// Use the canonical HourglassParams definition from the header
+#include "shell_force_assembly_kernel.h"
+#include "real_type.h"
+
+// ===========================================================================
+//  Kernel 3 — shell_force_assembly_kernel
+//
+//  Reads generalized forces/moments (FOR, MOM) from Kernel 2, plus local
+//  frame, shape functions, hourglass state.  Computes hourglass forces
+//  (CHVIS3), assembles nodal forces in local frame (CFINT3), rotates to
+//  global frame, and scatters to global arrays via atomicAdd (CUPDT3).
+//
+//  Thread mapping:  I = blockIdx.x * blockDim.x + threadIdx.x
+// ===========================================================================
+template <int ISMSTR>
+__global__ __launch_bounds__(256, 1) void shell_force_assembly_kernel(
+    // ---- Connectivity (read-only, SoA) ----
+    const int* __restrict__ d_N1,
+    const int* __restrict__ d_N2,
+    const int* __restrict__ d_N3,
+    const int* __restrict__ d_N4,
+    // ---- Local frame from Kernel 1 ----
+    const Real* __restrict__ d_E1x,
+    const Real* __restrict__ d_E1y,
+    const Real* __restrict__ d_E1z,
+    const Real* __restrict__ d_E2x,
+    const Real* __restrict__ d_E2y,
+    const Real* __restrict__ d_E2z,
+    const Real* __restrict__ d_E3x,
+    const Real* __restrict__ d_E3y,
+    const Real* __restrict__ d_E3z,
+    // ---- Shape-function derivatives & geometry from Kernel 1 ----
+    const Real* __restrict__ d_PX1,
+    const Real* __restrict__ d_PX2,
+    const Real* __restrict__ d_PY1,
+    const Real* __restrict__ d_PY2,
+    const Real* __restrict__ d_AREA,
+    // ---- Hourglass volume ratios (for non-uniform GAMA) ----
+    const Real* __restrict__ d_VHX,
+    const Real* __restrict__ d_VHY,
+
+    // ---- Local velocities (for hourglass, from Kernel 2 intermediates) ----
+    //   These are the local-frame projected velocities VX1..VZ4 and RX1..RY4.
+    //   For the 3-kernel split, Kernel 2 must write them out.
+    //   Alternatively, we re-project from gathered velocities + local frame.
+    //   Here we choose to re-project (avoids extra arrays).
+    const Real* __restrict__ d_VL1x,
+    const Real* __restrict__ d_VL1y,
+    const Real* __restrict__ d_VL1z,
+    const Real* __restrict__ d_VL2x,
+    const Real* __restrict__ d_VL2y,
+    const Real* __restrict__ d_VL2z,
+    const Real* __restrict__ d_VL3x,
+    const Real* __restrict__ d_VL3y,
+    const Real* __restrict__ d_VL3z,
+    const Real* __restrict__ d_VL4x,
+    const Real* __restrict__ d_VL4y,
+    const Real* __restrict__ d_VL4z,
+    const Real* __restrict__ d_VRL1x,
+    const Real* __restrict__ d_VRL1y,
+    const Real* __restrict__ d_VRL1z,
+    const Real* __restrict__ d_VRL2x,
+    const Real* __restrict__ d_VRL2y,
+    const Real* __restrict__ d_VRL2z,
+    const Real* __restrict__ d_VRL3x,
+    const Real* __restrict__ d_VRL3y,
+    const Real* __restrict__ d_VRL3z,
+    const Real* __restrict__ d_VRL4x,
+    const Real* __restrict__ d_VRL4y,
+    const Real* __restrict__ d_VRL4z,
+    // ---- Element state ----
+    const Real* __restrict__ d_OFF,
+    const Real* __restrict__ d_THK0,      // [NUMELC] reference thickness
+    const Real* __restrict__ d_THK02,     // [NUMELC] thk0^2
+    // ---- Generalized forces/moments from Kernel 2 ----
+    const Real* __restrict__ d_FORxx,     // FOR(1) = Nxx / thk
+    const Real* __restrict__ d_FORyy,     // FOR(2) = Nyy / thk
+    const Real* __restrict__ d_FORxy,     // FOR(3) = Nxy / thk
+    const Real* __restrict__ d_FORyz,     // FOR(4) = Nyz / thk
+    const Real* __restrict__ d_FORzx,     // FOR(5) = Nxz / thk
+    const Real* __restrict__ d_MOMxx,     // MOM(1) = Mxx/thk^2
+    const Real* __restrict__ d_MOMyy,     // MOM(2) = Myy/thk^2
+    const Real* __restrict__ d_MOMxy,     // MOM(3) = Mxy/thk^2
+    // ---- Hourglass state (read/write) ----
+    Real* __restrict__ d_HOUR,            // [NUMELC*5] hourglass energy integrals
+    // ---- Material scalars for hourglass ----
+    Real* __restrict__ d_STI,             // [NUMELC] nodal stiffness (write)
+    Real* __restrict__ d_STIR,            // [NUMELC] rotational stiffness (write)
+    const Real* __restrict__ d_SSP,       // [NUMELC] sound speed
+    const Real* __restrict__ d_RHO,       // [NUMELC] density
+    const Real* __restrict__ d_YM,        // [NUMELC] Young's modulus
+    const Real* __restrict__ d_NU,        // [NUMELC] Poisson's ratio
+    const Real* __restrict__ d_A11,       // [NUMELC] plane-stress stiffness
+    const Real* __restrict__ d_G,         // [NUMELC] shear modulus
+    const Real* __restrict__ d_SHF,       // [NUMELC] shear factor
+    // ---- Internal energy (read/write) ----
+    Real* __restrict__ d_EINT,            // [NUMELC*2]
+    // ---- Global nodal arrays (atomic write) ----
+    Real* __restrict__ d_Fx,              // [NUMNOD]
+    Real* __restrict__ d_Fy,
+    Real* __restrict__ d_Fz,
+    Real* __restrict__ d_Mx,
+    Real* __restrict__ d_My,
+    Real* __restrict__ d_Mz,
+    Real* __restrict__ d_STIFN,           // [NUMNOD]
+    Real* __restrict__ d_STIFR,           // [NUMNOD]
+    // ---- Scalars ----
+    HourglassParams hg_params,
+    Real dt,
+    int    NPT,
+    int    NUMELC,
+    int    compute_sti,
+    int    IHBE
+)
+{
+    // ======================================================================
+    //  Thread mapping
+    // ======================================================================
+    int I = blockIdx.x * blockDim.x + threadIdx.x;
+    if (I >= NUMELC) return;
+
+    // ======================================================================
+    //  Load inputs
+    // ======================================================================
+    Real e1x = d_E1x[I]; Real e1y = d_E1y[I]; Real e1z = d_E1z[I];
+    Real e2x = d_E2x[I]; Real e2y = d_E2y[I]; Real e2z = d_E2z[I];
+    Real e3x = d_E3x[I]; Real e3y = d_E3y[I]; Real e3z = d_E3z[I];
+
+    Real px1  = d_PX1[I];   Real px2  = d_PX2[I];
+    Real py1  = d_PY1[I];   Real py2  = d_PY2[I];
+    Real area = d_AREA[I];
+
+    Real off_i  = d_OFF[I];
+    Real thk0   = d_THK0[I];
+    Real thk02  = thk0 * thk0;  // THK0 squared (matches CPU CCOEF3: THK02=THK0*THK0)
+
+    //  ALDT² stored in d_STI by kernel 1 — read before overwriting
+    Real aldt_sq = d_STI[I];
+
+    int n1 = d_N1[I]; int n2 = d_N2[I]; int n3 = d_N3[I]; int n4 = d_N4[I];
+
+    // Generalized forces (already stored as FOR/thk and MOM/thk^2)
+    Real for1 = d_FORxx[I];   // Nxx / thk
+    Real for2 = d_FORyy[I];   // Nyy / thk
+    Real for3 = d_FORxy[I];   // Nxy / thk
+    Real for4 = d_FORyz[I];   // Nyz / thk
+    Real for5 = d_FORzx[I];   // Nxz / thk
+    Real mom1 = d_MOMxx[I];   // Mxx/thk^2
+    Real mom2 = d_MOMyy[I];   // Myy/thk^2
+    Real mom3 = d_MOMxy[I];   // Mxy/thk^2
+
+    Real off_val = fmin(1.0, fabs(off_i));
+
+    // ======================================================================
+    //  1.  CHVIS3 — Hourglass forces  (ISMSTR=1, IHBE<=1 path)
+    //      Simplified: GAMA = ±OFF (uniform hourglass base vectors)
+    // ======================================================================
+
+    //  Re-project gathered velocities to local frame for hourglass
+    Real vl1x = d_VL1x[I]; Real vl1y = d_VL1y[I]; Real vl1z = d_VL1z[I];
+    Real vl2x = d_VL2x[I]; Real vl2y = d_VL2y[I]; Real vl2z = d_VL2z[I];
+    Real vl3x = d_VL3x[I]; Real vl3y = d_VL3y[I]; Real vl3z = d_VL3z[I];
+    Real vl4x = d_VL4x[I]; Real vl4y = d_VL4y[I]; Real vl4z = d_VL4z[I];
+
+    //  Staged FMA waves: 12 independent ops per wave to fill DP pipeline
+    //  Wave 1: initial products (12 independent DMULs)
+    Real vx1_l = e1x*vl1x;  Real vx2_l = e1x*vl2x;
+    Real vx3_l = e1x*vl3x;  Real vx4_l = e1x*vl4x;
+    Real vy1_l = e2x*vl1x;  Real vy2_l = e2x*vl2x;
+    Real vy3_l = e2x*vl3x;  Real vy4_l = e2x*vl4x;
+    Real vz1_l = e3x*vl1x;  Real vz2_l = e3x*vl2x;
+    Real vz3_l = e3x*vl3x;  Real vz4_l = e3x*vl4x;
+    //  Wave 2: second component FMAs (12 independent)
+    vx1_l = fma(e1y, vl1y, vx1_l);  vx2_l = fma(e1y, vl2y, vx2_l);
+    vx3_l = fma(e1y, vl3y, vx3_l);  vx4_l = fma(e1y, vl4y, vx4_l);
+    vy1_l = fma(e2y, vl1y, vy1_l);  vy2_l = fma(e2y, vl2y, vy2_l);
+    vy3_l = fma(e2y, vl3y, vy3_l);  vy4_l = fma(e2y, vl4y, vy4_l);
+    vz1_l = fma(e3y, vl1y, vz1_l);  vz2_l = fma(e3y, vl2y, vz2_l);
+    vz3_l = fma(e3y, vl3y, vz3_l);  vz4_l = fma(e3y, vl4y, vz4_l);
+    //  Wave 3: third component FMAs (12 independent)
+    vx1_l = fma(e1z, vl1z, vx1_l);  vx2_l = fma(e1z, vl2z, vx2_l);
+    vx3_l = fma(e1z, vl3z, vx3_l);  vx4_l = fma(e1z, vl4z, vx4_l);
+    vy1_l = fma(e2z, vl1z, vy1_l);  vy2_l = fma(e2z, vl2z, vy2_l);
+    vy3_l = fma(e2z, vl3z, vy3_l);  vy4_l = fma(e2z, vl4z, vy4_l);
+    vz1_l = fma(e3z, vl1z, vz1_l);  vz2_l = fma(e3z, vl2z, vz2_l);
+    vz3_l = fma(e3z, vl3z, vz3_l);  vz4_l = fma(e3z, vl4z, vz4_l);
+
+    //  Rotational velocities in local frame
+    Real vrl1x = d_VRL1x[I]; Real vrl1y = d_VRL1y[I]; Real vrl1z = d_VRL1z[I];
+    Real vrl2x = d_VRL2x[I]; Real vrl2y = d_VRL2y[I]; Real vrl2z = d_VRL2z[I];
+    Real vrl3x = d_VRL3x[I]; Real vrl3y = d_VRL3y[I]; Real vrl3z = d_VRL3z[I];
+    Real vrl4x = d_VRL4x[I]; Real vrl4y = d_VRL4y[I]; Real vrl4z = d_VRL4z[I];
+
+    //  Staged FMA waves for rotational velocity projections (8 per wave)
+    //  Wave 1: initial products
+    Real rx1 = e1x*vrl1x;  Real rx2 = e1x*vrl2x;
+    Real rx3 = e1x*vrl3x;  Real rx4 = e1x*vrl4x;
+    Real ry1 = e2x*vrl1x;  Real ry2 = e2x*vrl2x;
+    Real ry3 = e2x*vrl3x;  Real ry4 = e2x*vrl4x;
+    //  Wave 2: second component FMAs
+    rx1 = fma(e1y, vrl1y, rx1);  rx2 = fma(e1y, vrl2y, rx2);
+    rx3 = fma(e1y, vrl3y, rx3);  rx4 = fma(e1y, vrl4y, rx4);
+    ry1 = fma(e2y, vrl1y, ry1);  ry2 = fma(e2y, vrl2y, ry2);
+    ry3 = fma(e2y, vrl3y, ry3);  ry4 = fma(e2y, vrl4y, ry4);
+    //  Wave 3: third component FMAs
+    rx1 = fma(e1z, vrl1z, rx1);  rx2 = fma(e1z, vrl2z, rx2);
+    rx3 = fma(e1z, vrl3z, rx3);  rx4 = fma(e1z, vrl4z, rx4);
+    ry1 = fma(e2z, vrl1z, ry1);  ry2 = fma(e2z, vrl2z, ry2);
+    ry3 = fma(e2z, vrl3z, ry3);  ry4 = fma(e2z, vrl4z, ry4);
+
+    //  Material values for hourglass
+    Real rho_v   = d_RHO[I];
+    Real ssp_v   = d_SSP[I];
+    Real ym_v    = d_YM[I];
+    Real nu_v    = d_NU[I];
+    Real shf_v   = d_SHF[I];
+
+    //  Hourglass coefficients (from CHVIS3)
+    //  HVISC, HVLIN, HELAS from common /SCR06R/ (set in radioss2.F)
+    const Real HVISC = hg_params.HVISC;
+    const Real HVLIN = hg_params.HVLIN;
+    const Real HELAS = hg_params.HELAS;
+    const Real SR2D2 = 0.70710678118654752;  // sqrt(2)/2
+
+    Real shfpr3 = shf_v / (3.0 * (1.0 + nu_v));
+    Real r0 = 0.25 * rho_v;
+    Real r1 = r0 * 100.0;
+    r0 = r0 * HVLIN;
+
+    Real a1_hg = r1 * HVISC * hg_params.H1;
+    Real a2_hg = r0 * SR2D2 * hg_params.SRH1;
+    Real srshfpr3 = sqrt(fmax(shfpr3, 0.0));
+    Real a3_hg = r1 * HVISC * hg_params.H2 * srshfpr3;
+    Real a4_hg = r0 * SR2D2 * hg_params.SRH2 * srshfpr3;
+    Real a5_hg = HELAS * hg_params.H3 * r1 * 0.072169;
+    Real a6_hg = SR2D2 * hg_params.SRH3 * r0 * 0.072169;
+    Real r0_ym = 0.25 * ym_v * HELAS;
+    Real a7_hg = hg_params.H1 * r0_ym;
+    Real a8_hg = hg_params.H2 * r0_ym * shfpr3;
+
+    Real t2a = thk02 * area;
+    Real tsa = sqrt(fmax(t2a, 0.0));
+    Real h1q = a1_hg * tsa;
+    Real h1l = a2_hg * ssp_v * tsa;
+    Real h2q = a3_hg * thk02;
+    Real h2l = a4_hg * ssp_v * thk02;
+    Real h3q = a5_hg * t2a;
+    Real h3l = a6_hg * ssp_v * t2a;
+    Real td  = thk0 * dt;
+    Real hh1 = a7_hg * td;
+    Real b1v = fma(py1, py1, px1 * px1);
+    Real b2v = fma(py2, py2, px2 * px2);
+    Real hh2 = a8_hg * thk02 * td / fmax(b1v + b2v, 1.0e-20);
+
+    //  GAMA vectors — non-uniform when ISMSTR!=1,!=11 and IHBE>=1 (cf. CHVIS3)
+    Real gama1, gama2, gama3, gama4;
+    if (ISMSTR != 1 && ISMSTR != 11 && IHBE >= 1) {
+        Real vhx = d_VHX[I];
+        Real vhy = d_VHY[I];
+        Real px1v = px1 * vhx;
+        Real px2v = px2 * vhx;
+        Real py1v = py1 * vhy;
+        Real py2v = py2 * vhy;
+        gama1 = off_val * ( 1.0 - px1v - py1v);
+        gama3 = off_val * ( 1.0 + px1v + py1v);
+        gama2 = off_val * (-1.0 - px2v - py2v);
+        gama4 = off_val * (-1.0 + px2v + py2v);
+    } else {
+        gama1 =  off_val;
+        gama2 = -off_val;
+        gama3 =  off_val;
+        gama4 = -off_val;
+    }
+
+    //  Detect degenerate triangle (node 3 == node 4)
+    if (n3 == n4) {
+        h1q = 0.0; h1l = 0.0; h2q = 0.0; h2l = 0.0;
+        h3q = 0.0; h3l = 0.0; hh1 = 0.0; hh2 = 0.0;
+    }
+
+    // --- Anti-hourglass membrane forces ---
+    // Use GAMA-weighted velocities (matches CHVIS3 non-uniform path) — FMA chains
+    Real hg1_m = fma(vx4_l, gama4, fma(vx3_l, gama3, fma(vx2_l, gama2, vx1_l*gama1)));
+    Real hg2_m = fma(vy4_l, gama4, fma(vy3_l, gama3, fma(vy2_l, gama2, vy1_l*gama1)));
+
+    //  Read & update hourglass state (HOUR(I,1:2) → membrane)
+    Real hour1_state = fma(hg1_m, hh1, d_HOUR[0 * NUMELC + I]);
+    Real hour2_state = fma(hg2_m, hh1, d_HOUR[1 * NUMELC + I]);
+    d_HOUR[0 * NUMELC + I] = hour1_state;
+    d_HOUR[1 * NUMELC + I] = hour2_state;
+
+    Real hour1a = fma(hg1_m, fma(h1q, fabs(hg1_m), h1l), hour1_state);
+    Real hour2a = fma(hg2_m, fma(h1q, fabs(hg2_m), h1l), hour2_state);
+
+    Real h11 = hour1a * gama1;
+    Real h12 = hour1a * gama2;
+    Real h13 = hour1a * gama3;
+    Real h21 = hour2a * gama1;
+    Real h22 = hour2a * gama2;
+    Real h23 = hour2a * gama3;
+
+    Real ehou = fma(hour2a, hg2_m, hour1a * hg1_m);
+
+    // --- Anti-hourglass bending forces ---
+    // Use GAMA-weighted velocity (matches CHVIS3 non-uniform path)
+    Real hg1_b = fma(vz4_l, gama4, fma(vz3_l, gama3, fma(vz2_l, gama2, vz1_l*gama1)));
+
+    Real hour3_state = fma(hg1_b, hh2, d_HOUR[2 * NUMELC + I]);
+    d_HOUR[2 * NUMELC + I] = hour3_state;
+
+    Real hour3a = fma(hg1_b, fma(h2q, fabs(hg1_b), h2l), hour3_state);
+    Real h31 = hour3a * gama1;
+    Real h32 = hour3a * gama2;
+    Real h33 = hour3a * gama3;
+
+    ehou = fma(hour3a, hg1_b, ehou);
+
+    // --- Anti-hourglass moments ---
+    Real hg1_r = rx1 - rx2 + rx3 - rx4;
+    Real hg2_r = ry1 - ry2 + ry3 - ry4;
+
+    Real hour4 = hg1_r * fma(h3q, fabs(hg1_r), h3l);
+    Real hour5 = hg2_r * fma(h3q, fabs(hg2_r), h3l);
+
+    d_HOUR[3 * NUMELC + I] = hour4;
+    d_HOUR[4 * NUMELC + I] = hour5;
+
+    ehou = fma(hour4, hg1_r, fma(hour5, hg2_r, ehou));
+    ehou *= dt * off_val;
+
+    Real b11 =  hour4 * off_val;
+    Real b12 = -hour4 * off_val;
+    Real b13 =  hour4 * off_val;
+    Real b14 = -hour4 * off_val;
+    Real b21 =  hour5 * off_val;
+    Real b22 = -hour5 * off_val;
+    Real b23 =  hour5 * off_val;
+    Real b24 = -hour5 * off_val;
+
+    // ======================================================================
+    //  Stiffness for time step (STI, STIR) — compute_sti == 1 path
+    //
+    //  CPU flow for ISMSTR /= 3 (our case):
+    //    CDERI3:  STI = 0   (CPXPY3 is only called when ISMSTR==3)
+    //    CHVIS3:  SCALE = max(gamma²) * DT * max(HH1+H1L, HH2+H2L, H3L)
+    //                     / max(DT², EM20)
+    //             STI += SCALE
+    //             STI += max(B1,B2) * THK0 * A11 / (AREA * VISCMX² * ALPE)
+    //             STIR = STI * (THK02/12 + AREA/9)
+    //
+    //  HH1, HH2, H1L, H2L, H3L are already computed in the hourglass
+    //  section above and are still in scope.
+    //
+    //  VV = VISCMX² * ALPE.  For law 2: VISCMX=0 → transformed to 1.0,
+    //  ALPE=1.0 (ccoef3.F).  So VV = 1.0.
+    // ======================================================================
+    // b1v, b2v already computed above in hourglass section
+    Real pxx = fmax(b1v, b2v);
+
+    //  STI starts at zero for ISMSTR /= 3  (CDERI3 path, no CPXPY3)
+    Real sti_i = 0.0;
+
+    //  CHVIS3 hourglass stiffness contribution (SCALE term)
+    //  SCALE = max(gamma²) * DT * max(HH1+H1L, HH2+H2L, H3L) / max(DT², eps)
+    //  For ISMSTR=1/IHBE<=1: gamma = ±OFF, so max(gamma²) = off²
+    //  Reuse hh1, hh2, h1l, h2l, h3l from hourglass section (correct coefficients).
+    Real off2 = off_val * off_val;
+    Real hg_max  = fmax(hh1 + h1l, fmax(hh2 + h2l, h3l));
+    Real scale_hg = off2 * dt * hg_max / fmax(dt * dt, 1.0e-20);
+    sti_i += scale_hg;
+
+    //  CHSTI3 material stiffness: MAX(B1,B2)*THK0*A11 / (AREA * VV)
+    //  VV = VISCMX² * ALPE.  For law 2: VISCMX = sqrt(1+DM²)-DM ≈ 1.0
+    //  (DM = membrane viscosity coef, typically 0.0 for IHBE<=1).
+    //  ALPE = 1.0 (from CCOEF3).  So VV ≈ 1.0.
+    Real a11_v = d_A11[I];
+    Real vv = 1.0;  // VV = VISCMX² * ALPE ≈ 1.0 for law 2
+    Real sti_mat = pxx * thk0 * a11_v / fmax(area * vv, 1.0e-20);
+    sti_i += sti_mat;
+
+    //  STIR = STI * (THK02/12 + AREA/9)  where THK02 = THK0² (cf. ccoef3.F line 80)
+    Real vol0 = area * thk0;
+    Real stir_i = sti_i * (thk02 / 12.0 + area / 9.0);
+
+    //  compute_sti modes:
+    //    0 = no STI for STIFN (NODADT=0 AND IDTMIN3=0: CDT3 returns early)
+    //    1 = CPXPY3+CHSTI3 formula (NODADT/=0 OR IDT1SH=1 OR IDTMINS=2)
+    //    2 = CDT3 formula: 0.81*0.5*VOL0*YM/ALDT^2 (NODADT=0 AND IDTMIN3/=0)
+    if (compute_sti == 0) {
+        sti_i  = 0.0;
+        stir_i = 0.0;
+    } else if (compute_sti == 2) {
+        //  CDT3-style STI:  STI = ZEP81 * HALF * VOL0 * YM / ALDT^2
+        //  For law 2: VISCMX = sqrt(1+DM^2)-DM = 1.0 (DM=0), ALPE=1.0
+        //  so ALDT_modified = ALDT * VISCMX/sqrt(ALPE) = ALDT
+        Real divm = fmax(aldt_sq, 1.0e-20);
+        sti_i  = 0.81 * 0.5 * vol0 * ym_v / divm;
+        stir_i = 0.0;
+    }
+    // else compute_sti == 1: keep CPXPY3+CHSTI3 values computed above
+
+    //  Apply OFF
+    sti_i  *= off_val;
+    stir_i *= off_val;
+
+    // ======================================================================
+    //  2.  CFINT3 — Internal force computation
+    //      (ISIGI /= 5 standard path)
+    // ======================================================================
+
+    //  Scale generalized forces by thickness
+    Real f1a = for1 * thk0;   // Nxx
+    Real f2a = for2 * thk0;   // Nyy
+    Real f3a = for3 * thk0;   // Nxy
+    Real f4a = for4 * thk0;   // Nyz  (transverse shear)
+    Real f5a = for5 * thk0;   // Nxz  (transverse shear)
+
+    Real m4  = f4a * area;    // transverse shear resultant Y
+    Real m5  = f5a * area;    // transverse shear resultant X
+
+    //  Local nodal forces from B-matrix (membrane + transverse shear)
+    //  Node pairing via PX1/PY1 (diag 1-3) and PX2/PY2 (diag 2-4)
+    //  Use FMA: 6 independent FMAs in one wave
+    Real fl12 = fma(f3a, py2, f1a * px2);       // node 2, local x
+    Real fl22 = fma(f3a, px2, f2a * py2);       // node 2, local y
+    Real fl32 = fma(f4a, py2, f5a * px2);       // node 2, local z
+    Real fl11 = fma(f3a, py1, f1a * px1);       // node 1 contrib
+    Real fl21 = fma(f3a, px1, f2a * py1);
+    Real fl31 = fma(f4a, py1, f5a * px1);
+
+    //  Combine with hourglass forces (H arrays)
+    Real g11 = fl11 + h11;    Real g13 = h13 - fl11;
+    Real g21 = fl21 + h21;    Real g23 = h23 - fl21;
+    Real g31 = fl31 + h31;    Real g33 = h33 - fl31;
+    Real g12 = fl12 + h12;
+    Real g22 = fl22 + h22;
+    Real g32 = fl32 + h32;
+
+    //  Rotate to global frame (nodes 1,2,3) — staged FMA for ILP + fusion
+    //  Wave 1: 9 independent MULs (e_x * g_local)
+    Real f11_g = e1x*g11;  Real f12_g = e1x*g12;  Real f13_g = e1x*g13;
+    Real f21_g = e1y*g11;  Real f22_g = e1y*g12;  Real f23_g = e1y*g13;
+    Real f31_g = e1z*g11;  Real f32_g = e1z*g12;  Real f33_g = e1z*g13;
+    //  Wave 2: 9 independent FMAs
+    f11_g = fma(e2x, g21, f11_g);  f12_g = fma(e2x, g22, f12_g);  f13_g = fma(e2x, g23, f13_g);
+    f21_g = fma(e2y, g21, f21_g);  f22_g = fma(e2y, g22, f22_g);  f23_g = fma(e2y, g23, f23_g);
+    f31_g = fma(e2z, g21, f31_g);  f32_g = fma(e2z, g22, f32_g);  f33_g = fma(e2z, g23, f33_g);
+    //  Wave 3: 9 independent FMAs
+    f11_g = fma(e3x, g31, f11_g);  f12_g = fma(e3x, g32, f12_g);  f13_g = fma(e3x, g33, f13_g);
+    f21_g = fma(e3y, g31, f21_g);  f22_g = fma(e3y, g32, f22_g);  f23_g = fma(e3y, g33, f23_g);
+    f31_g = fma(e3z, g31, f31_g);  f32_g = fma(e3z, g32, f32_g);  f33_g = fma(e3z, g33, f33_g);
+
+    //  Node 4 by equilibrium: F4 = -(F1 + F2 + F3)
+    Real f14_g = -f11_g - f12_g - f13_g;
+    Real f24_g = -f21_g - f22_g - f23_g;
+    Real f34_g = -f31_g - f32_g - f33_g;
+
+    // --- Moments (from bending) ---
+    Real m1a = mom1 * thk02;   // MOM*THK02:  (Mxx/thk0²)*thk0² = Mxx
+    Real m2a = mom2 * thk02;   // Myy
+    Real m3a = mom3 * thk02;   // Mxy
+    m4 *= 0.25;                  // transverse shear moment contribution
+    m5 *= 0.25;
+
+    //  Local moment nodal forces (FMA: 4 independent)
+    Real ml11 = fma(-m3a, px1, -m2a * py1);
+    Real ml21 = fma( m3a, py1,  m1a * px1);
+    Real ml12 = fma(-m3a, px2, -m2a * py2);
+    Real ml22 = fma( m3a, py2,  m1a * px2);
+
+    //  Combine with hourglass moment forces (B arrays) and transverse shear moments
+    Real gm11 = ml11 - m4 + b11;     Real gm13 = -ml11 - m4 + b13;
+    Real gm12 = ml12 - m4 + b12;     Real gm14 = -ml12 - m4 + b14;
+    Real gm21 = ml21 + m5 + b21;     Real gm23 = -ml21 + m5 + b23;
+    Real gm22 = ml22 + m5 + b22;     Real gm24 = -ml22 + m5 + b24;
+
+    //  Rotate moments to global frame (only E1, E2 needed) — staged FMA
+    //  Wave 1: 12 independent MULs
+    Real m11_g = e1x*gm11;  Real m12_g = e1x*gm12;
+    Real m13_g = e1x*gm13;  Real m14_g = e1x*gm14;
+    Real m21_g = e1y*gm11;  Real m22_g = e1y*gm12;
+    Real m23_g = e1y*gm13;  Real m24_g = e1y*gm14;
+    Real m31_g = e1z*gm11;  Real m32_g = e1z*gm12;
+    Real m33_g = e1z*gm13;  Real m34_g = e1z*gm14;
+    //  Wave 2: 12 independent FMAs
+    m11_g = fma(e2x, gm21, m11_g);  m12_g = fma(e2x, gm22, m12_g);
+    m13_g = fma(e2x, gm23, m13_g);  m14_g = fma(e2x, gm24, m14_g);
+    m21_g = fma(e2y, gm21, m21_g);  m22_g = fma(e2y, gm22, m22_g);
+    m23_g = fma(e2y, gm23, m23_g);  m24_g = fma(e2y, gm24, m24_g);
+    m31_g = fma(e2z, gm21, m31_g);  m32_g = fma(e2z, gm22, m32_g);
+    m33_g = fma(e2z, gm23, m33_g);  m34_g = fma(e2z, gm24, m34_g);
+
+    // ======================================================================
+    //  Zero forces/moments for deleted elements (OFFG < 0)
+    // ======================================================================
+    if (off_i < 0.0) {
+        f11_g = 0.0; f21_g = 0.0; f31_g = 0.0;
+        f12_g = 0.0; f22_g = 0.0; f32_g = 0.0;
+        f13_g = 0.0; f23_g = 0.0; f33_g = 0.0;
+        f14_g = 0.0; f24_g = 0.0; f34_g = 0.0;
+        m11_g = 0.0; m21_g = 0.0; m31_g = 0.0;
+        m12_g = 0.0; m22_g = 0.0; m32_g = 0.0;
+        m13_g = 0.0; m23_g = 0.0; m33_g = 0.0;
+        m14_g = 0.0; m24_g = 0.0; m34_g = 0.0;
+        sti_i = 0.0; stir_i = 0.0;
+    }
+
+    // ======================================================================
+    //  3.  CUPDT3 — Atomic scatter to global nodal arrays
+    // Inefficient due to atomics, but straightforward and safe for parallelism.
+    // Coloring or other techniques should be used to reduce contention
+    // ======================================================================
+    //  Node 1
+    atomicAdd(&d_Fx[n1], -f11_g);
+    atomicAdd(&d_Fy[n1], -f21_g);
+    atomicAdd(&d_Fz[n1], -f31_g);
+    atomicAdd(&d_Mx[n1], -m11_g);
+    atomicAdd(&d_My[n1], -m21_g);
+    atomicAdd(&d_Mz[n1], -m31_g);
+    atomicAdd(&d_STIFN[n1], sti_i);
+    atomicAdd(&d_STIFR[n1], stir_i);
+
+    //  Node 2
+    atomicAdd(&d_Fx[n2], -f12_g);
+    atomicAdd(&d_Fy[n2], -f22_g);
+    atomicAdd(&d_Fz[n2], -f32_g);
+    atomicAdd(&d_Mx[n2], -m12_g);
+    atomicAdd(&d_My[n2], -m22_g);
+    atomicAdd(&d_Mz[n2], -m32_g);
+    atomicAdd(&d_STIFN[n2], sti_i);
+    atomicAdd(&d_STIFR[n2], stir_i);
+
+    //  Node 3
+    atomicAdd(&d_Fx[n3], -f13_g);
+    atomicAdd(&d_Fy[n3], -f23_g);
+    atomicAdd(&d_Fz[n3], -f33_g);
+    atomicAdd(&d_Mx[n3], -m13_g);
+    atomicAdd(&d_My[n3], -m23_g);
+    atomicAdd(&d_Mz[n3], -m33_g);
+    atomicAdd(&d_STIFN[n3], sti_i);
+    atomicAdd(&d_STIFR[n3], stir_i);
+
+    //  Node 4
+    atomicAdd(&d_Fx[n4], -f14_g);
+    atomicAdd(&d_Fy[n4], -f24_g);
+    atomicAdd(&d_Fz[n4], -f34_g);
+    atomicAdd(&d_Mx[n4], -m14_g);
+    atomicAdd(&d_My[n4], -m24_g);
+    atomicAdd(&d_Mz[n4], -m34_g);
+    atomicAdd(&d_STIFN[n4], sti_i);
+    atomicAdd(&d_STIFR[n4], stir_i);
+
+    // ======================================================================
+    //  4.  Energy update
+    //      Hourglass energy contribution into EINT (component 2 = bending)
+    // ======================================================================
+    d_EINT[1 * NUMELC + I] += ehou;
+}
+
+// ===========================================================================
+//  Host-side launcher
+// ===========================================================================
+extern "C"
+void launch_shell_force_assembly_kernel(
+    // Connectivity
+    const int* d_N1, const int* d_N2, const int* d_N3, const int* d_N4,
+    // Local frame
+    const Real* d_E1x, const Real* d_E1y, const Real* d_E1z,
+    const Real* d_E2x, const Real* d_E2y, const Real* d_E2z,
+    const Real* d_E3x, const Real* d_E3y, const Real* d_E3z,
+    // Shape functions
+    const Real* d_PX1, const Real* d_PX2,
+    const Real* d_PY1, const Real* d_PY2,
+    const Real* d_AREA,
+    // Hourglass volume ratios (for non-uniform GAMA)
+    const Real* d_VHX, const Real* d_VHY,
+    // Gathered velocities
+    const Real* d_VL1x,  const Real* d_VL1y,  const Real* d_VL1z,
+    const Real* d_VL2x,  const Real* d_VL2y,  const Real* d_VL2z,
+    const Real* d_VL3x,  const Real* d_VL3y,  const Real* d_VL3z,
+    const Real* d_VL4x,  const Real* d_VL4y,  const Real* d_VL4z,
+    const Real* d_VRL1x, const Real* d_VRL1y, const Real* d_VRL1z,
+    const Real* d_VRL2x, const Real* d_VRL2y, const Real* d_VRL2z,
+    const Real* d_VRL3x, const Real* d_VRL3y, const Real* d_VRL3z,
+    const Real* d_VRL4x, const Real* d_VRL4y, const Real* d_VRL4z,
+    // Element state
+    const Real* d_OFF, const Real* d_THK0, const Real* d_THK02,
+    // Generalized forces/moments
+    const Real* d_FORxx, const Real* d_FORyy, const Real* d_FORxy,
+    const Real* d_FORyz, const Real* d_FORzx,
+    const Real* d_MOMxx, const Real* d_MOMyy, const Real* d_MOMxy,
+    // Hourglass state
+    Real* d_HOUR,
+    // Stiffness outputs
+    Real* d_STI, Real* d_STIR,
+    // Material
+    const Real* d_SSP, const Real* d_RHO, const Real* d_YM,
+    const Real* d_NU,  const Real* d_A11, const Real* d_G,
+    const Real* d_SHF,
+    // Internal energy
+    Real* d_EINT,
+    // Global nodal arrays
+    Real* d_Fx, Real* d_Fy, Real* d_Fz,
+    Real* d_Mx, Real* d_My, Real* d_Mz,
+    Real* d_STIFN, Real* d_STIFR,
+    // Scalars
+    HourglassParams hg_params,
+    Real dt, int NPT, int NUMELC,
+    int compute_sti,
+    int ISMSTR, int IHBE,
+    cudaStream_t stream)
+{
+    const int BLOCK_SIZE = 256;
+    int grid_size = (NUMELC + BLOCK_SIZE - 1) / BLOCK_SIZE;
+
+    auto launch = [&](auto ismstr_tag) {
+        constexpr int ISMSTR_V = decltype(ismstr_tag)::value;
+        shell_force_assembly_kernel<ISMSTR_V><<<grid_size, BLOCK_SIZE, 0, stream>>>(
+            d_N1, d_N2, d_N3, d_N4,
+            d_E1x, d_E1y, d_E1z,
+            d_E2x, d_E2y, d_E2z,
+            d_E3x, d_E3y, d_E3z,
+            d_PX1, d_PX2, d_PY1, d_PY2, d_AREA,
+            d_VHX, d_VHY,
+            d_VL1x, d_VL1y, d_VL1z,
+            d_VL2x, d_VL2y, d_VL2z,
+            d_VL3x, d_VL3y, d_VL3z,
+            d_VL4x, d_VL4y, d_VL4z,
+            d_VRL1x, d_VRL1y, d_VRL1z,
+            d_VRL2x, d_VRL2y, d_VRL2z,
+            d_VRL3x, d_VRL3y, d_VRL3z,
+            d_VRL4x, d_VRL4y, d_VRL4z,
+            d_OFF, d_THK0, d_THK02,
+            d_FORxx, d_FORyy, d_FORxy, d_FORyz, d_FORzx,
+            d_MOMxx, d_MOMyy, d_MOMxy,
+            d_HOUR,
+            d_STI, d_STIR,
+            d_SSP, d_RHO, d_YM, d_NU, d_A11, d_G, d_SHF,
+            d_EINT,
+            d_Fx, d_Fy, d_Fz,
+            d_Mx, d_My, d_Mz,
+            d_STIFN, d_STIFR,
+            hg_params, dt, NPT, NUMELC, compute_sti, IHBE);
+    };
+
+    switch (ISMSTR) {
+        case 1:  launch(std::integral_constant<int,1>{});  break;
+        case 2:  launch(std::integral_constant<int,2>{});  break;
+        case 11: launch(std::integral_constant<int,11>{}); break;
+        default:
+            fprintf(stderr, "Unsupported ISMSTR=%d in shell_force_assembly_kernel\n", ISMSTR);
+            exit(EXIT_FAILURE);
+    }
+
+    // Check for kernel launch errors
+    {
+        cudaError_t err = cudaPeekAtLastError();
+        if (err != cudaSuccess) {
+            fprintf(stderr, "CUDA kernel launch error (force+assembly): %s\n",
+                    cudaGetErrorString(err));
+            exit(EXIT_FAILURE);
+        }
+    }
+}
+
+#endif // SHELL_FORCE_ASSEMBLY_KERNEL_CU

--- a/engine/source/elements/shell/coque/shell_force_assembly_kernel.h
+++ b/engine/source/elements/shell/coque/shell_force_assembly_kernel.h
@@ -1,0 +1,120 @@
+//Copyright>    OpenRadioss
+//Copyright>    Copyright (C) 1986-2026 Altair Engineering Inc.
+//Copyright>
+//Copyright>    This program is free software: you can redistribute it and/or modify
+//Copyright>    it under the terms of the GNU Affero General Public License as published by
+//Copyright>    the Free Software Foundation, either version 3 of the License, or
+//Copyright>    (at your option) any later version.
+//Copyright>
+//Copyright>    This program is distributed in the hope that it will be useful,
+//Copyright>    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//Copyright>    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//Copyright>    GNU Affero General Public License for more details.
+//Copyright>
+//Copyright>    You should have received a copy of the GNU Affero General Public License
+//Copyright>    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//Copyright>
+//Copyright>
+//Copyright>    Commercial Alternative: Altair Radioss Software
+//Copyright>
+//Copyright>    As an alternative to this open-source version, Altair also offers Altair Radioss
+//Copyright>    software under a commercial license.  Contact Altair to discuss further if the
+//Copyright>    commercial version may interest you: https://www.altair.com/radioss/.
+// ==============================================================================
+//  OpenRadioss GPU — Kernel 3 (Option C): Forces + Assembly
+//  Host-side header for shell_force_assembly_kernel
+// ==============================================================================
+
+#ifndef SHELL_FORCE_ASSEMBLY_KERNEL_H
+#define SHELL_FORCE_ASSEMBLY_KERNEL_H
+
+#include <cuda_runtime.h>
+#include "real_type.h"
+
+// ---------------------------------------------------------------------------
+//  Hourglass parameter structure
+// ---------------------------------------------------------------------------
+struct HourglassParams {
+    Real H1;          // membrane hourglass coefficient (from GEO(13,PID))
+    Real H2;          // bending hourglass coefficient  (from GEO(14,PID))
+    Real H3;          // rotational hourglass coefficient (from GEO(15,PID))
+    Real SRH1;        // sqrt scale for H1              (from GEO(18,PID))
+    Real SRH2;        // sqrt scale for H2              (from GEO(19,PID))
+    Real SRH3;        // sqrt scale for H3              (from GEO(20,PID))
+    Real HVISC;       // viscous hourglass scaling (from common /SCR06R/, typically 0.5)
+    Real HELAS;       // elastic hourglass scaling (from common /SCR06R/, typically 0.5)
+    Real HVLIN;       // linear  hourglass scaling (from common /SCR06R/, typically 0.0)
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ---------------------------------------------------------------------------
+//  Launch the force computation + atomic assembly kernel
+//  (CHVIS3 + CFINT3 + CUPDT3)
+//
+//  All pointer arguments are device pointers.
+//  d_Fx..d_STIFR are global nodal arrays — written with atomicAdd.
+//  d_HOUR is per-element hourglass state [NUMELC * 5], read/write.
+//  d_EINT is per-element internal energy  [NUMELC * 2], read/write.
+//
+//  The global nodal force/moment arrays MUST be zeroed before calling
+//  this kernel (or use a Real-buffer scheme).
+// ---------------------------------------------------------------------------
+void launch_shell_force_assembly_kernel(
+    // Connectivity  [NUMELC] each
+    const int* d_N1, const int* d_N2, const int* d_N3, const int* d_N4,
+    // Local frame from Kernel 1  [NUMELC] each
+    const Real* d_E1x, const Real* d_E1y, const Real* d_E1z,
+    const Real* d_E2x, const Real* d_E2y, const Real* d_E2z,
+    const Real* d_E3x, const Real* d_E3y, const Real* d_E3z,
+    // Shape-function derivatives & area  [NUMELC] each
+    const Real* d_PX1, const Real* d_PX2,
+    const Real* d_PY1, const Real* d_PY2,
+    const Real* d_AREA,
+    // Hourglass volume ratios [NUMELC] each (for non-uniform GAMA)
+    const Real* d_VHX, const Real* d_VHY,
+    // Gathered velocities from Kernel 1  [NUMELC] each
+    const Real* d_VL1x,  const Real* d_VL1y,  const Real* d_VL1z,
+    const Real* d_VL2x,  const Real* d_VL2y,  const Real* d_VL2z,
+    const Real* d_VL3x,  const Real* d_VL3y,  const Real* d_VL3z,
+    const Real* d_VL4x,  const Real* d_VL4y,  const Real* d_VL4z,
+    const Real* d_VRL1x, const Real* d_VRL1y, const Real* d_VRL1z,
+    const Real* d_VRL2x, const Real* d_VRL2y, const Real* d_VRL2z,
+    const Real* d_VRL3x, const Real* d_VRL3y, const Real* d_VRL3z,
+    const Real* d_VRL4x, const Real* d_VRL4y, const Real* d_VRL4z,
+    // Element state  [NUMELC] each
+    const Real* d_OFF,
+    const Real* d_THK0,
+    const Real* d_THK02,
+    // Generalized forces/moments from Kernel 2  [NUMELC] each
+    const Real* d_FORxx, const Real* d_FORyy, const Real* d_FORxy,
+    const Real* d_FORyz, const Real* d_FORzx,
+    const Real* d_MOMxx, const Real* d_MOMyy, const Real* d_MOMxy,
+    // Hourglass state  [NUMELC * 5]
+    Real* d_HOUR,
+    // Stiffness outputs [NUMELC]
+    Real* d_STI, Real* d_STIR,
+    // Per-element material scalars [NUMELC] each
+    const Real* d_SSP, const Real* d_RHO, const Real* d_YM,
+    const Real* d_NU,  const Real* d_A11, const Real* d_G,
+    const Real* d_SHF,
+    // Internal energy  [NUMELC * 2]
+    Real* d_EINT,
+    // Global nodal arrays [NUMNOD] each — ATOMICALLY written
+    Real* d_Fx, Real* d_Fy, Real* d_Fz,
+    Real* d_Mx, Real* d_My, Real* d_Mz,
+    Real* d_STIFN, Real* d_STIFR,
+    // Scalars
+    HourglassParams hg_params,
+    Real dt, int NPT, int NUMELC,
+    int compute_sti,
+    int ISMSTR, int IHBE,
+    cudaStream_t stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SHELL_FORCE_ASSEMBLY_KERNEL_H

--- a/engine/source/elements/shell/coque/shell_geometry_kernel.cu
+++ b/engine/source/elements/shell/coque/shell_geometry_kernel.cu
@@ -1,0 +1,550 @@
+//Copyright>    OpenRadioss
+//Copyright>    Copyright (C) 1986-2026 Altair Engineering Inc.
+//Copyright>
+//Copyright>    This program is free software: you can redistribute it and/or modify
+//Copyright>    it under the terms of the GNU Affero General Public License as published by
+//Copyright>    the Free Software Foundation, either version 3 of the License, or
+//Copyright>    (at your option) any later version.
+//Copyright>
+//Copyright>    This program is distributed in the hope that it will be useful,
+//Copyright>    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//Copyright>    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//Copyright>    GNU Affero General Public License for more details.
+//Copyright>
+//Copyright>    You should have received a copy of the GNU Affero General Public License
+//Copyright>    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//Copyright>
+//Copyright>
+//Copyright>    Commercial Alternative: Altair Radioss Software
+//Copyright>
+//Copyright>    As an alternative to this open-source version, Altair also offers Altair Radioss
+//Copyright>    software under a commercial license.  Contact Altair to discuss further if the
+//Copyright>    commercial version may interest you: https://www.altair.com/radioss/.
+// ==============================================================================
+//  OpenRadioss GPU — Kernel 1 (Option C): Geometry
+//  Covers: CCOOR3 (gather) → CNVEC3 (convected frame) → CDERI3 (shape funcs)
+//
+//  Scope: ISMSTR=1, IHBE<=1, ISHFRAM=0 (symmetric convected frame)
+//         One thread per element, flat SoA layout.
+// ==============================================================================
+
+#ifndef SHELL_GEOMETRY_KERNEL_CU
+#define SHELL_GEOMETRY_KERNEL_CU
+
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <cfloat>
+#include <type_traits>
+#include "real_type.h"
+
+// ---------------------------------------------------------------------------
+//  Small helpers
+// ---------------------------------------------------------------------------
+__device__ __forceinline__ Real safe_inv_norm(Real x, Real y, Real z)
+{
+    Real n2 = x * x + y * y + z * z;
+    return (n2 > 1.0e-40) ? rsqrt(n2) : 0.0;
+}
+
+// ===========================================================================
+//  Kernel 1 — shell_geometry_kernel
+//
+//  Per-element outputs written to global memory so that Kernel 2 (strains +
+//  material) and Kernel 3 (forces + assembly) can consume them.
+//
+//  Thread mapping:  I = blockIdx.x * blockDim.x + threadIdx.x
+//                   if (I >= NUMELC) return;
+// ===========================================================================
+template <int ISMSTR>
+__global__ __launch_bounds__(256, 2) void shell_geometry_kernel(
+    // ---- Global node arrays (read-only) ----
+    const Real* __restrict__ d_X,    // [3*NUMNOD] node X-coordinates
+    const Real* __restrict__ d_V,    // [3*NUMNOD] translational velocity X
+    const Real* __restrict__ d_VR,   // [3*NUMNOD] rotational velocity X
+    // ---- Connectivity (read-only, SoA) ----
+    const int* __restrict__ d_N1,       // [NUMELC] node-1 index
+    const int* __restrict__ d_N2,       // [NUMELC] node-2 index
+    const int* __restrict__ d_N3,       // [NUMELC] node-3 index
+    const int* __restrict__ d_N4,       // [NUMELC] node-4 index
+    // ---- Element state (read/write) ----
+    Real* __restrict__ d_OFF,         // [NUMELC] element activity flag
+    Real* __restrict__ d_SMSTR,       // [NUMELC*6] reference local coords
+    // ---- Per-element outputs for Kernel 2 & 3 (write) ----
+    //  Local frame vectors (9 components)
+    Real* __restrict__ d_E1x,         // [NUMELC]
+    Real* __restrict__ d_E1y,
+    Real* __restrict__ d_E1z,
+    Real* __restrict__ d_E2x,
+    Real* __restrict__ d_E2y,
+    Real* __restrict__ d_E2z,
+    Real* __restrict__ d_E3x,
+    Real* __restrict__ d_E3y,
+    Real* __restrict__ d_E3z,
+    //  Gathered translational velocities  (4 nodes × 3 = 12)
+    Real* __restrict__ d_VL1x,
+    Real* __restrict__ d_VL1y,
+    Real* __restrict__ d_VL1z,
+    Real* __restrict__ d_VL2x,
+    Real* __restrict__ d_VL2y,
+    Real* __restrict__ d_VL2z,
+    Real* __restrict__ d_VL3x,
+    Real* __restrict__ d_VL3y,
+    Real* __restrict__ d_VL3z,
+    Real* __restrict__ d_VL4x,
+    Real* __restrict__ d_VL4y,
+    Real* __restrict__ d_VL4z,
+    //  Gathered rotational velocities  (4 nodes × 3 = 12)
+    Real* __restrict__ d_VRL1x,
+    Real* __restrict__ d_VRL1y,
+    Real* __restrict__ d_VRL1z,
+    Real* __restrict__ d_VRL2x,
+    Real* __restrict__ d_VRL2y,
+    Real* __restrict__ d_VRL2z,
+    Real* __restrict__ d_VRL3x,
+    Real* __restrict__ d_VRL3y,
+    Real* __restrict__ d_VRL3z,
+    Real* __restrict__ d_VRL4x,
+    Real* __restrict__ d_VRL4y,
+    Real* __restrict__ d_VRL4z,
+    //  Shape-function derivatives & geometry
+    Real* __restrict__ d_PX1,         // [NUMELC]
+    Real* __restrict__ d_PX2,
+    Real* __restrict__ d_PY1,
+    Real* __restrict__ d_PY2,
+    Real* __restrict__ d_AREA,        // [NUMELC] element area
+    Real* __restrict__ d_A_I,         // [NUMELC] 1/area
+    Real* __restrict__ d_VHX,         // [NUMELC] hourglass vector X
+    Real* __restrict__ d_VHY,         // [NUMELC] hourglass vector Y
+    Real* __restrict__ d_Z2,          // [NUMELC] warping indicator
+    //  Displacement increments (ISMSTR=11 only, zeroed for ISMSTR=1)
+    Real* __restrict__ d_UX1,
+    Real* __restrict__ d_UY1,
+    Real* __restrict__ d_UX2,
+    Real* __restrict__ d_UY2,
+    Real* __restrict__ d_UX3,
+    Real* __restrict__ d_UY3,
+    Real* __restrict__ d_UX4,
+    Real* __restrict__ d_UY4,
+    //  Stiffness outputs (CPXPY3-style, written here because we have local coords)
+    Real* __restrict__ d_STI,         // [NUMELC] translational stiffness
+    Real* __restrict__ d_STIR,        // [NUMELC] rotational stiffness
+    //  Per-element material scalars (read-only, for stiffness)
+    const Real* __restrict__ d_YM,    // [NUMELC] Young's modulus
+    const Real* __restrict__ d_THK0,  // [NUMELC] reference thickness
+    const int* __restrict__ d_N3_conn,  // [NUMELC] node 3 connectivity (for triangle check)
+    const int* __restrict__ d_N4_conn,  // [NUMELC] node 4 connectivity (for triangle check)
+    //  Scalars
+    int   NUMELC,
+    Real H1,                          // membrane hourglass coefficient (GEO(13))
+    Real H2                           // bending hourglass coefficient (GEO(14))
+)
+{
+    // ======================================================================
+    //  Thread mapping — one thread per element
+    // ======================================================================
+    int I = blockIdx.x * blockDim.x + threadIdx.x;
+    if (I >= NUMELC) return;
+
+    // ======================================================================
+    //  1.  CCOOR3 — Gather nodal coordinates & velocities
+    // ======================================================================
+    int n1 = d_N1[I];
+    int n2 = d_N2[I];
+    int n3 = d_N3[I];
+    int n4 = d_N4[I];
+
+    // --- Global positions (XkG, YkG, ZkG) — AoS layout {x0,y0,z0,x1,y1,z1,...} ---
+    Real x1g = __ldg(&d_X[3*n1]);    Real y1g = __ldg(&d_X[3*n1+1]);    Real z1g = __ldg(&d_X[3*n1+2]);
+    Real x2g = __ldg(&d_X[3*n2]);    Real y2g = __ldg(&d_X[3*n2+1]);    Real z2g_nd = __ldg(&d_X[3*n2+2]);
+    Real x3g = __ldg(&d_X[3*n3]);    Real y3g = __ldg(&d_X[3*n3+1]);    Real z3g = __ldg(&d_X[3*n3+2]);
+    Real x4g = __ldg(&d_X[3*n4]);    Real y4g = __ldg(&d_X[3*n4+1]);    Real z4g = __ldg(&d_X[3*n4+2]);
+
+    // --- Translational velocities — AoS layout ---
+    Real vl1x = __ldg(&d_V[3*n1]);   Real vl1y = __ldg(&d_V[3*n1+1]);   Real vl1z = __ldg(&d_V[3*n1+2]);
+    Real vl2x = __ldg(&d_V[3*n2]);   Real vl2y = __ldg(&d_V[3*n2+1]);   Real vl2z = __ldg(&d_V[3*n2+2]);
+    Real vl3x = __ldg(&d_V[3*n3]);   Real vl3y = __ldg(&d_V[3*n3+1]);   Real vl3z = __ldg(&d_V[3*n3+2]);
+    Real vl4x = __ldg(&d_V[3*n4]);   Real vl4y = __ldg(&d_V[3*n4+1]);   Real vl4z = __ldg(&d_V[3*n4+2]);
+
+    // --- Rotational velocities — AoS layout ---
+    Real vrl1x = __ldg(&d_VR[3*n1]);  Real vrl1y = __ldg(&d_VR[3*n1+1]);  Real vrl1z = __ldg(&d_VR[3*n1+2]);
+    Real vrl2x = __ldg(&d_VR[3*n2]);  Real vrl2y = __ldg(&d_VR[3*n2+1]);  Real vrl2z = __ldg(&d_VR[3*n2+2]);
+    Real vrl3x = __ldg(&d_VR[3*n3]);  Real vrl3y = __ldg(&d_VR[3*n3+1]);  Real vrl3z = __ldg(&d_VR[3*n3+2]);
+    Real vrl4x = __ldg(&d_VR[3*n4]);  Real vrl4y = __ldg(&d_VR[3*n4+1]);  Real vrl4z = __ldg(&d_VR[3*n4+2]);
+
+    // --- Element activity ---
+    Real off_i = d_OFF[I];
+
+    // Zero velocities if element is being deleted (OFFG < 0)
+    if (off_i < 0.0) {
+        vl1x = 0.0;  vl1y = 0.0;  vl1z = 0.0;
+        vl2x = 0.0;  vl2y = 0.0;  vl2z = 0.0;
+        vl3x = 0.0;  vl3y = 0.0;  vl3z = 0.0;
+        vl4x = 0.0;  vl4y = 0.0;  vl4z = 0.0;
+        vrl1x = 0.0;  vrl1y = 0.0;  vrl1z = 0.0;
+        vrl2x = 0.0;  vrl2y = 0.0;  vrl2z = 0.0;
+        vrl3x = 0.0;  vrl3y = 0.0;  vrl3z = 0.0;
+        vrl4x = 0.0;  vrl4y = 0.0;  vrl4z = 0.0;
+    }
+
+    // ======================================================================
+    //  2.  CNVEC3 — Convected orthonormal frame (ISHFRAM=0, default)
+    // ======================================================================
+    //  Edge vectors in global frame
+    Real x21 = x2g - x1g;   Real y21 = y2g - y1g;   Real z21 = z2g_nd - z1g;
+    Real x32 = x3g - x2g;   Real y32 = y3g - y2g;   Real z32 = z3g - z2g_nd;
+    Real x34 = x3g - x4g;   Real y34 = y3g - y4g;   Real z34 = z3g - z4g;
+    Real x41 = x4g - x1g;   Real y41 = y4g - y1g;   Real z41 = z4g - z1g;
+
+    //  Initial E1 = (edge 2-1) + (edge 3-4)   — "diagonal" direction
+    Real e1x = x21 + x34;
+    Real e1y = y21 + y34;
+    Real e1z = z21 + z34;
+
+    //  Initial E2 = (edge 3-2) + (edge 4-1)   — other "diagonal"
+    Real e2x = x32 + x41;
+    Real e2y = y32 + y41;
+    Real e2z = z32 + z41;
+
+    //  E3 = E1 × E2  (shell normal, un-normalized)
+    Real e3x = e1y * e2z - e1z * e2y;
+    Real e3y = e1z * e2x - e1x * e2z;
+    Real e3z = e1x * e2y - e1y * e2x;
+
+    //  Normalize E3
+    Real inv_n = safe_inv_norm(e3x, e3y, e3z);
+    e3x *= inv_n;
+    e3y *= inv_n;
+    e3z *= inv_n;
+
+    //  Symmetrize E1 (ISHFRAM=0):  ratio = |E1| / |E2|
+    Real s1 = e1x * e1x + e1y * e1y + e1z * e1z;
+    Real s2 = e2x * e2x + e2y * e2y + e2z * e2z;
+    Real ratio = sqrt(s1 / fmax(s2, 1.0e-40));
+
+    //  E1 += (E2 × E3) * ratio
+    e1x += (e2y * e3z - e2z * e3y) * ratio;
+    e1y += (e2z * e3x - e2x * e3z) * ratio;
+    e1z += (e2x * e3y - e2y * e3x) * ratio;
+
+    //  Normalize E1
+    inv_n = safe_inv_norm(e1x, e1y, e1z);
+    e1x *= inv_n;
+    e1y *= inv_n;
+    e1z *= inv_n;
+
+    //  E2 = E3 × E1 (complete orthogonal triad)
+    e2x = e3y * e1z - e3z * e1y;
+    e2y = e3z * e1x - e3x * e1z;
+    e2z = e3x * e1y - e3y * e1x;
+
+    // ======================================================================
+    //  3.  CDERI3 — Shape-function derivatives & local coordinates
+    //              (ISMSTR = 1 or 2, co-rotational small strain)
+    // ======================================================================
+
+    // --- Step 1: Global relative vectors (nodes 2,3,4 w.r.t. node 1) ---
+    Real x21g = x2g - x1g;   Real y21g = y2g - y1g;   Real z21g = z2g_nd - z1g;
+    Real x31g = x3g - x1g;   Real y31g = y3g - y1g;   Real z31g = z3g - z1g;
+    Real x41g = x4g - x1g;   Real y41g = y4g - y1g;   Real z41g = z4g - z1g;
+
+    // --- Step 2: Project to local frame (E1, E2, E3) ---
+    Real xl2 = e1x * x21g + e1y * y21g + e1z * z21g;
+    Real yl2 = e2x * x21g + e2y * y21g + e2z * z21g;
+    Real xl3 = e1x * x31g + e1y * y31g + e1z * z31g;
+    Real yl3 = e2x * x31g + e2y * y31g + e2z * z31g;
+    Real xl4 = e1x * x41g + e1y * y41g + e1z * z41g;
+    Real yl4 = e2x * x41g + e2y * y41g + e2z * z41g;
+    Real zl2 = e3x * x21g + e3y * y21g + e3z * z21g;   // warping indicator
+
+    // --- Step 3: ISMSTR logic — reference geometry management ---
+    //  Displacement increments (default zero for ISMSTR=1,2)
+    Real ux1 = 0.0, uy1 = 0.0;
+    Real ux2 = 0.0, uy2 = 0.0;
+    Real ux3 = 0.0, uy3 = 0.0;
+    Real ux4 = 0.0, uy4 = 0.0;
+
+    //  SMSTR offsets:  component c for element I  →  d_SMSTR[c * NUMELC + I]
+    //  c = 0..5  maps to  X2_ref, Y2_ref, X3_ref, Y3_ref, X4_ref, Y4_ref
+
+    Real abs_off = fabs(off_i);
+
+    if (ISMSTR == 11) {
+        // ------------------------------------------------------------------
+        //  ISMSTR = 11:  incremental small-strain formulation
+        //  First cycle: |OFF|==1 → mark as 2, store reference, zero displ.
+        //  Later:       |OFF|==2 → compute displacement increments from ref.
+        // ------------------------------------------------------------------
+        if (abs_off == 1.0) {
+            // First cycle — store reference local coords, set flag to 2
+            off_i = copysign(2.0, off_i);
+
+            d_SMSTR[0 * NUMELC + I] = xl2;
+            d_SMSTR[1 * NUMELC + I] = yl2;
+            d_SMSTR[2 * NUMELC + I] = xl3;
+            d_SMSTR[3 * NUMELC + I] = yl3;
+            d_SMSTR[4 * NUMELC + I] = xl4;
+            d_SMSTR[5 * NUMELC + I] = yl4;
+            // ux*, uy* remain zero; xl*, yl* are the reference (no displacement)
+        }
+        else if (abs_off == 2.0) {
+            // Subsequent cycles — compute displacement increments
+            Real sm0 = d_SMSTR[0 * NUMELC + I];
+            Real sm1 = d_SMSTR[1 * NUMELC + I];
+            Real sm2 = d_SMSTR[2 * NUMELC + I];
+            Real sm3 = d_SMSTR[3 * NUMELC + I];
+            Real sm4 = d_SMSTR[4 * NUMELC + I];
+            Real sm5 = d_SMSTR[5 * NUMELC + I];
+
+            ux2 = xl2 - sm0;   uy2 = yl2 - sm1;
+            ux3 = xl3 - sm2;   uy3 = yl3 - sm3;
+            ux4 = xl4 - sm4;   uy4 = yl4 - sm5;
+            // ux1, uy1 stay zero (node 1 is origin in local frame)
+
+            // Use reference geometry for shape functions
+            xl2 = sm0;  yl2 = sm1;
+            xl3 = sm2;  yl3 = sm3;
+            xl4 = sm4;  yl4 = sm5;
+            zl2 = 0.0;
+        }
+    }
+    else if (ISMSTR == 1 || ISMSTR == 2) {
+        // ------------------------------------------------------------------
+        //  ISMSTR = 1 or 2:  co-rotational, reference frozen after 1st cycle
+        //  |OFF|==2  → read reference from SMSTR, replace local coords.
+        //  otherwise → store current local coords into SMSTR.
+        //  ISMSTR=1 additionally transitions OFF from 1 → 2 on first cycle.
+        // ------------------------------------------------------------------
+        if (abs_off == 2.0) {
+            // Use stored reference geometry
+            xl2 = d_SMSTR[0 * NUMELC + I];
+            yl2 = d_SMSTR[1 * NUMELC + I];
+            xl3 = d_SMSTR[2 * NUMELC + I];
+            yl3 = d_SMSTR[3 * NUMELC + I];
+            xl4 = d_SMSTR[4 * NUMELC + I];
+            yl4 = d_SMSTR[5 * NUMELC + I];
+            zl2 = 0.0;
+        } else {
+            // Store current geometry as reference
+            d_SMSTR[0 * NUMELC + I] = xl2;
+            d_SMSTR[1 * NUMELC + I] = yl2;
+            d_SMSTR[2 * NUMELC + I] = xl3;
+            d_SMSTR[3 * NUMELC + I] = yl3;
+            d_SMSTR[4 * NUMELC + I] = xl4;
+            d_SMSTR[5 * NUMELC + I] = yl4;
+        }
+        // ISMSTR=1: mark element as "initialized" on first cycle
+        if (ISMSTR == 1 && off_i == 1.0) {
+            off_i = 2.0;
+        }
+    }
+
+    // --- Step 4: Shape-function derivatives (1-point quad at center) ---
+    //     PX1 = ∂N/∂x diagonal 1-3,  PX2 = ∂N/∂x diagonal 2-4
+    Real px1 = 0.5 * (yl2 - yl4);
+    Real py1 = 0.5 * (xl4 - xl2);
+    Real px2 = 0.5 * yl3;
+    Real py2 = -0.5 * xl3;
+
+    // --- Step 5: Element area ---
+    Real area = 2.0 * (py2 * px1 - py1 * px2);
+    area = fmax(area, 1.0e-20);
+    Real a_i = 1.0 / area;
+
+    // --- Step 6: Hourglass vectors ---
+    Real vhx = (-xl2 + xl3 - xl4) * a_i;
+    Real vhy = (-yl2 + yl3 - yl4) * a_i;
+
+    // ======================================================================
+    //  4.  Write all outputs to global memory
+    // ======================================================================
+
+    // Activity flag (may have been updated by ISMSTR logic)
+    d_OFF[I] = off_i;
+
+    // Local frame
+    d_E1x[I] = e1x;   d_E1y[I] = e1y;   d_E1z[I] = e1z;
+    d_E2x[I] = e2x;   d_E2y[I] = e2y;   d_E2z[I] = e2z;
+    d_E3x[I] = e3x;   d_E3y[I] = e3y;   d_E3z[I] = e3z;
+
+    // Gathered translational velocities
+    d_VL1x[I] = vl1x;   d_VL1y[I] = vl1y;   d_VL1z[I] = vl1z;
+    d_VL2x[I] = vl2x;   d_VL2y[I] = vl2y;   d_VL2z[I] = vl2z;
+    d_VL3x[I] = vl3x;   d_VL3y[I] = vl3y;   d_VL3z[I] = vl3z;
+    d_VL4x[I] = vl4x;   d_VL4y[I] = vl4y;   d_VL4z[I] = vl4z;
+
+    // Gathered rotational velocities
+    d_VRL1x[I] = vrl1x;   d_VRL1y[I] = vrl1y;   d_VRL1z[I] = vrl1z;
+    d_VRL2x[I] = vrl2x;   d_VRL2y[I] = vrl2y;   d_VRL2z[I] = vrl2z;
+    d_VRL3x[I] = vrl3x;   d_VRL3y[I] = vrl3y;   d_VRL3z[I] = vrl3z;
+    d_VRL4x[I] = vrl4x;   d_VRL4y[I] = vrl4y;   d_VRL4z[I] = vrl4z;
+
+    // Shape-function derivatives & geometry
+    d_PX1[I]  = px1;
+    d_PX2[I]  = px2;
+    d_PY1[I]  = py1;
+    d_PY2[I]  = py2;
+    d_AREA[I] = area;
+    d_A_I[I]  = a_i;
+    d_VHX[I]  = vhx;
+    d_VHY[I]  = vhy;
+    d_Z2[I]   = zl2;
+
+    // Displacement increments (non-zero only for ISMSTR=11)
+    d_UX1[I] = ux1;   d_UY1[I] = uy1;
+    d_UX2[I] = ux2;   d_UY2[I] = uy2;
+    d_UX3[I] = ux3;   d_UY3[I] = uy3;
+    d_UX4[I] = ux4;   d_UY4[I] = uy4;
+
+    // ======================================================================
+    //  5.  CDLEN3 — Characteristic length for time-step stiffness
+    //      Compute ALDT² (squared characteristic length) from local coords
+    //      and store in d_STI[I] as scratch for Kernel 3 (CDT3 STI formula).
+    //      d_STIR[I] is zeroed.
+    //
+    //  CDLEN3 computes:
+    //    AL1 = X2²+Y2²,  AL2 = (X3-X2)²+(Y3-Y2)²,  AL6 = X3²+Y3²
+    //    AL3 = (X4-X3)²+(Y4-Y3)²,  AL4 = X4²+Y4²,  AL5 = (X4-X2)²+(Y4-Y2)²
+    //    ALMIN = min(AL1,AL2,AL4[,AL3,AL5,AL6 if quad])
+    //    DTDYN = AREA² / max(AL5,AL6)
+    //    ALDT  = max(DTDYN, ALMIN)
+    //    With hourglass correction: min(ALDT, 0.5*(ALMIN+ALDT)/max(H1,H2))
+    //    Final: ALDT² is stored (before sqrt).
+    // ======================================================================
+    {
+        // Use REFERENCE local coords for CDLEN3 (matching CPU CDERI3→CDLEN3 flow).
+        // After ISMSTR logic, xl2/yl2/... contain frozen reference coords (ISMSTR=1,2)
+        // and 'area' was computed from those reference coords.
+        Real al1 = xl2*xl2 + yl2*yl2;
+        Real al2 = (xl3-xl2)*(xl3-xl2) + (yl3-yl2)*(yl3-yl2);
+        Real al6 = xl3*xl3 + yl3*yl3;
+        Real al3 = (xl4-xl3)*(xl4-xl3) + (yl4-yl3)*(yl4-yl3);
+        Real al4 = xl4*xl4 + yl4*yl4;
+        Real al5 = (xl4-xl2)*(xl4-xl2) + (yl4-yl2)*(yl4-yl2);
+
+        Real almin = fmin(al1, fmin(al2, al4));
+        //  If node3 != node4 (quad), include al3, al5, al6
+        if (al3 > 0.0) {
+            Real alquad = fmin(al3, fmin(al5, al6));
+            almin = fmin(almin, alquad);
+        }
+
+        // DTDYN uses reference AREA (already computed from reference coords above)
+        Real dtdyn = (area * area) / fmax(fmax(al5, al6), 1.0e-20);
+        Real aldt_sq = fmax(dtdyn, almin);
+
+        //  Hourglass correction on dt: DTHOUR = 0.5*(ALMIN+ALDT)/max(H1,H2)
+        //  CPU CDLEN3 uses SQUARED values: DTHOUR = 0.5*(almin_sq + aldt_sq) / hmax
+        //  Then: if DTHOUR < ALDT_sq, ALDT_sq = DTHOUR
+        Real hmax = fmax(H1, H2);
+        if (hmax > 0.0) {
+            Real dthour = 0.5 * (almin + aldt_sq) / hmax;
+            if (dthour < aldt_sq) {
+                aldt_sq = dthour;
+            }
+        }
+
+        d_STI[I]  = aldt_sq;   // scratch: ALDT² for K3 CDT3 formula
+        d_STIR[I] = 0.0;
+    }
+}
+
+// ===========================================================================
+//  Host-side launcher
+// ===========================================================================
+extern "C"
+void launch_shell_geometry_kernel(
+    // Node arrays (AoS: {x0,y0,z0,x1,y1,z1,...})
+    const Real* d_X,
+    const Real* d_V,
+    const Real* d_VR,
+    // Connectivity
+    const int* d_N1, const int* d_N2, const int* d_N3, const int* d_N4,
+    // Element state
+    Real* d_OFF,   Real* d_SMSTR,
+    // Outputs: local frame
+    Real* d_E1x, Real* d_E1y, Real* d_E1z,
+    Real* d_E2x, Real* d_E2y, Real* d_E2z,
+    Real* d_E3x, Real* d_E3y, Real* d_E3z,
+    // Outputs: gathered velocities
+    Real* d_VL1x,  Real* d_VL1y,  Real* d_VL1z,
+    Real* d_VL2x,  Real* d_VL2y,  Real* d_VL2z,
+    Real* d_VL3x,  Real* d_VL3y,  Real* d_VL3z,
+    Real* d_VL4x,  Real* d_VL4y,  Real* d_VL4z,
+    Real* d_VRL1x, Real* d_VRL1y, Real* d_VRL1z,
+    Real* d_VRL2x, Real* d_VRL2y, Real* d_VRL2z,
+    Real* d_VRL3x, Real* d_VRL3y, Real* d_VRL3z,
+    Real* d_VRL4x, Real* d_VRL4y, Real* d_VRL4z,
+    // Outputs: shape functions & geometry
+    Real* d_PX1,  Real* d_PX2,
+    Real* d_PY1,  Real* d_PY2,
+    Real* d_AREA, Real* d_A_I,
+    Real* d_VHX,  Real* d_VHY,
+    Real* d_Z2,
+    // Outputs: displacement increments
+    Real* d_UX1,  Real* d_UY1,
+    Real* d_UX2,  Real* d_UY2,
+    Real* d_UX3,  Real* d_UY3,
+    Real* d_UX4,  Real* d_UY4,
+    // Outputs: stiffness (CPXPY3-style)
+    Real* d_STI,  Real* d_STIR,
+    // Per-element material scalars (for stiffness)
+    const Real* d_YM,   const Real* d_THK0,
+    const int* d_N3_stiff, const int* d_N4_stiff,
+    // Scalars
+    int NUMELC, int ISMSTR,
+    Real H1, Real H2,
+    // CUDA launch config
+    cudaStream_t stream)
+{
+    const int BLOCK_SIZE = 256;
+    int grid_size = (NUMELC + BLOCK_SIZE - 1) / BLOCK_SIZE;
+
+    auto launch = [&](auto ismstr_tag) {
+        constexpr int ISMSTR_V = decltype(ismstr_tag)::value;
+        shell_geometry_kernel<ISMSTR_V><<<grid_size, BLOCK_SIZE, 0, stream>>>(
+            d_X,
+            d_V,
+            d_VR,
+            d_N1, d_N2, d_N3, d_N4,
+            d_OFF, d_SMSTR,
+            d_E1x, d_E1y, d_E1z,
+            d_E2x, d_E2y, d_E2z,
+            d_E3x, d_E3y, d_E3z,
+            d_VL1x, d_VL1y, d_VL1z,
+            d_VL2x, d_VL2y, d_VL2z,
+            d_VL3x, d_VL3y, d_VL3z,
+            d_VL4x, d_VL4y, d_VL4z,
+            d_VRL1x, d_VRL1y, d_VRL1z,
+            d_VRL2x, d_VRL2y, d_VRL2z,
+            d_VRL3x, d_VRL3y, d_VRL3z,
+            d_VRL4x, d_VRL4y, d_VRL4z,
+            d_PX1, d_PX2, d_PY1, d_PY2,
+            d_AREA, d_A_I, d_VHX, d_VHY, d_Z2,
+            d_UX1, d_UY1, d_UX2, d_UY2,
+            d_UX3, d_UY3, d_UX4, d_UY4,
+            d_STI, d_STIR, d_YM, d_THK0, d_N3_stiff, d_N4_stiff,
+            NUMELC, H1, H2);
+    };
+
+    switch (ISMSTR) {
+        case 1:  launch(std::integral_constant<int,1>{});  break;
+        case 2:  launch(std::integral_constant<int,2>{});  break;
+        case 11: launch(std::integral_constant<int,11>{}); break;
+        default:
+            fprintf(stderr, "Unsupported ISMSTR=%d in shell_geometry_kernel\n", ISMSTR);
+            exit(EXIT_FAILURE);
+    }
+
+    // Check for kernel launch errors
+    {
+        cudaError_t err = cudaPeekAtLastError();
+        if (err != cudaSuccess) {
+            fprintf(stderr, "CUDA kernel launch error (geometry): %s\n",
+                    cudaGetErrorString(err));
+            exit(EXIT_FAILURE);
+        }
+    }
+}
+
+#endif // SHELL_GEOMETRY_KERNEL_CU

--- a/engine/source/elements/shell/coque/shell_geometry_kernel.h
+++ b/engine/source/elements/shell/coque/shell_geometry_kernel.h
@@ -1,0 +1,96 @@
+//Copyright>    OpenRadioss
+//Copyright>    Copyright (C) 1986-2026 Altair Engineering Inc.
+//Copyright>
+//Copyright>    This program is free software: you can redistribute it and/or modify
+//Copyright>    it under the terms of the GNU Affero General Public License as published by
+//Copyright>    the Free Software Foundation, either version 3 of the License, or
+//Copyright>    (at your option) any later version.
+//Copyright>
+//Copyright>    This program is distributed in the hope that it will be useful,
+//Copyright>    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//Copyright>    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//Copyright>    GNU Affero General Public License for more details.
+//Copyright>
+//Copyright>    You should have received a copy of the GNU Affero General Public License
+//Copyright>    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//Copyright>
+//Copyright>
+//Copyright>    Commercial Alternative: Altair Radioss Software
+//Copyright>
+//Copyright>    As an alternative to this open-source version, Altair also offers Altair Radioss
+//Copyright>    software under a commercial license.  Contact Altair to discuss further if the
+//Copyright>    commercial version may interest you: https://www.altair.com/radioss/.
+// ==============================================================================
+//  OpenRadioss GPU — Kernel 1 (Option C): Geometry
+//  Host-side header for shell_geometry_kernel
+// ==============================================================================
+
+#ifndef SHELL_GEOMETRY_KERNEL_H
+#define SHELL_GEOMETRY_KERNEL_H
+
+
+#include <cuda_runtime.h>
+#include "real_type.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ---------------------------------------------------------------------------
+//  Launch the geometry kernel (CCOOR3 + CNVEC3 + CDERI3)
+//
+//  All pointer arguments are device pointers.
+//  NUMELC = total number of 4-node shell elements.
+//  ISMSTR = small-strain flag (1, 2, or 11).
+//  stream = CUDA stream (0 for default stream).
+// ---------------------------------------------------------------------------
+void launch_shell_geometry_kernel(
+    // Node arrays  [3,NUMNOD] each, {x1 y1 z1|x2 y2 z2|...}, contiguous in memory
+    const Real* d_X,
+    const Real* d_V,
+    const Real* d_VR,
+    // Connectivity  [NUMELC] each
+    const int* d_N1, const int* d_N2, const int* d_N3, const int* d_N4,
+    // Element state  (read/write)
+    Real* d_OFF,          // [NUMELC]          activity flag
+    Real* d_SMSTR,        // [NUMELC*6]        reference coords (ISMSTR)
+    // Outputs: local frame  [NUMELC] each
+    Real* d_E1x, Real* d_E1y, Real* d_E1z,
+    Real* d_E2x, Real* d_E2y, Real* d_E2z,
+    Real* d_E3x, Real* d_E3y, Real* d_E3z,
+    // Outputs: gathered translational velocities  [NUMELC] each
+    Real* d_VL1x,  Real* d_VL1y,  Real* d_VL1z,
+    Real* d_VL2x,  Real* d_VL2y,  Real* d_VL2z,
+    Real* d_VL3x,  Real* d_VL3y,  Real* d_VL3z,
+    Real* d_VL4x,  Real* d_VL4y,  Real* d_VL4z,
+    // Outputs: gathered rotational velocities  [NUMELC] each
+    Real* d_VRL1x, Real* d_VRL1y, Real* d_VRL1z,
+    Real* d_VRL2x, Real* d_VRL2y, Real* d_VRL2z,
+    Real* d_VRL3x, Real* d_VRL3y, Real* d_VRL3z,
+    Real* d_VRL4x, Real* d_VRL4y, Real* d_VRL4z,
+    // Outputs: shape-function derivatives & geometry  [NUMELC] each
+    Real* d_PX1,  Real* d_PX2,
+    Real* d_PY1,  Real* d_PY2,
+    Real* d_AREA, Real* d_A_I,
+    Real* d_VHX,  Real* d_VHY,
+    Real* d_Z2,
+    // Outputs: displacement increments  [NUMELC] each
+    Real* d_UX1,  Real* d_UY1,
+    Real* d_UX2,  Real* d_UY2,
+    Real* d_UX3,  Real* d_UY3,
+    Real* d_UX4,  Real* d_UY4,
+    // Outputs: stiffness (CPXPY3-style)
+    Real* d_STI,  Real* d_STIR,
+    // Per-element material scalars (for stiffness)
+    const Real* d_YM,   const Real* d_THK0,
+    const int* d_N3_stiff, const int* d_N4_stiff,
+    // Scalars
+    int NUMELC, int ISMSTR,
+    Real H1, Real H2,
+    cudaStream_t stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SHELL_GEOMETRY_KERNEL_H

--- a/engine/source/elements/shell/coque/shell_gpu_data.h
+++ b/engine/source/elements/shell/coque/shell_gpu_data.h
@@ -1,0 +1,231 @@
+//Copyright>    OpenRadioss
+//Copyright>    Copyright (C) 1986-2026 Altair Engineering Inc.
+//Copyright>
+//Copyright>    This program is free software: you can redistribute it and/or modify
+//Copyright>    it under the terms of the GNU Affero General Public License as published by
+//Copyright>    the Free Software Foundation, either version 3 of the License, or
+//Copyright>    (at your option) any later version.
+//Copyright>
+//Copyright>    This program is distributed in the hope that it will be useful,
+//Copyright>    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//Copyright>    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//Copyright>    GNU Affero General Public License for more details.
+//Copyright>
+//Copyright>    You should have received a copy of the GNU Affero General Public License
+//Copyright>    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//Copyright>
+//Copyright>
+//Copyright>    Commercial Alternative: Altair Radioss Software
+//Copyright>
+//Copyright>    As an alternative to this open-source version, Altair also offers Altair Radioss
+//Copyright>    software under a commercial license.  Contact Altair to discuss further if the
+//Copyright>    commercial version may interest you: https://www.altair.com/radioss/.
+// ==============================================================================
+//  OpenRadioss GPU — Shell Element GPU Data Structures
+//  Structure-of-Arrays (SoA) layout for all device arrays
+// ==============================================================================
+
+#ifndef SHELL_GPU_DATA_H
+#define SHELL_GPU_DATA_H
+
+#include <cuda_runtime.h>
+#include "shell_strain_material_kernel.h"   // JohnsonCookParams
+#include "shell_force_assembly_kernel.h"    // HourglassParams
+#include "real_type.h"
+
+
+// ---------------------------------------------------------------------------
+//  Global (shared across all SUs) node/force arrays on the device.
+//  Allocated once for the full mesh; each SU's kernels index into these
+//  using global 0-based node IDs in their connectivity arrays.
+//
+//  Workflow per time step:
+//    1. Host uploads NODES%X/V/VR → d_X/d_V/d_VR on global_stream
+//    2. Zero d_raw_d2h on global_stream, record upload_done event
+//    3. Each SU stream waits on upload_done, then runs 3 kernels
+//       (K3 atomicAdd's into d_Fx..d_STIFR — safe across streams)
+//    4. Each SU stream records kernels_done event
+//    5. global_stream waits on all kernels_done, then D2H of d_raw_d2h
+// ---------------------------------------------------------------------------
+struct ShellGPUGlobal {
+    int NUMNOD;             // global node count
+
+    // --- Device node arrays (H2D each step) ---
+    // d_raw_h2d [9*NUMNOD] = {x0,y0,z0, x1,y1,z1, ...} | V | VR  (AoS)
+    Real* d_raw_h2d;
+    Real* d_X;            // = d_raw_h2d + 0            [3*NUMNOD]
+    Real* d_V;            // = d_raw_h2d + 3*NUMNOD     [3*NUMNOD]
+    Real* d_VR;           // = d_raw_h2d + 6*NUMNOD     [3*NUMNOD]
+
+    // --- Device force arrays (D2H after all kernels) ---
+    // d_raw_d2h [8*NUMNOD] = Fx|Fy|Fz|Mx|My|Mz|STIFN|STIFR  (SoA)
+    Real* d_raw_d2h;
+    Real* d_Fx;   Real* d_Fy;   Real* d_Fz;
+    Real* d_Mx;   Real* d_My;   Real* d_Mz;
+    Real* d_STIFN;
+    Real* d_STIFR;
+
+    // --- Synchronization ---
+    cudaStream_t stream;        // for H2D upload, zero, and D2H download
+    cudaEvent_t  upload_done;   // recorded after H2D + zero; SU streams wait on this
+};
+
+// ---------------------------------------------------------------------------
+//  Device memory pool for 4-node shell (COQUE) GPU computation.
+//  All arrays use SoA layout for coalesced memory access.
+//  Sizes: [NUMELC] per-element, [NPT*NUMELC] per-integration-point,
+//         [NUMNOD] per-node (global).
+// ---------------------------------------------------------------------------
+struct ShellGPUData {
+
+    // -----------------------------------------------------------------------
+    //  Mesh dimensions
+    // -----------------------------------------------------------------------
+    int NUMELC;         // total number of 4-node shell elements
+    int NUMNOD;         // total number of nodes
+    int NPT;            // number of through-thickness integration points
+    int ISMSTR;         // small-strain flag (1, 2, or 11)
+    int ITHK;           // thickness update flag (>0 enables)
+    int IHBE;           // hourglass formulation flag (>=1 needs non-uniform GAMA)
+    int compute_sti;    // 1 = compute STI for STIFN (NODADT/=0 etc.), 0 = skip
+
+    // -----------------------------------------------------------------------
+    //  Material & hourglass parameters (passed by value to kernels)
+    // -----------------------------------------------------------------------
+    JohnsonCookParams mat;
+    HourglassParams   hg;
+
+    // -----------------------------------------------------------------------
+    //  Global node arrays  [NUMNOD]
+    //  Persistent on device, updated each time step by H2D transfer.
+    //  d_Xx..d_VRz point into d_raw_h2d (contiguous 9*NUMNOD block).
+    //  d_Fx..d_STIFR point into d_raw_d2h (contiguous 8*NUMNOD block).
+    // -----------------------------------------------------------------------
+    // Contiguous device buffers for single-memcpy transfers
+    Real* d_raw_h2d;  // [9*NUMNOD] = Xx|Xy|Xz|Vx|Vy|Vz|VRx|VRy|VRz
+    Real* d_raw_d2h;  // [8*NUMNOD] = Fx|Fy|Fz|Mx|My|Mz|STIFN|STIFR
+    // Positions (pointers into d_raw_h2d)
+    Real* d_X; // 3 x NUMNOD
+    // Translational velocities (pointers into d_raw_h2d)
+    Real* d_V;
+    // Rotational velocities (pointers into d_raw_h2d)
+    Real* d_VR;
+    // Forces (pointers into d_raw_d2h, written by kernel, D2H each step)
+    Real* d_Fx;   Real* d_Fy;   Real* d_Fz;
+    // Moments (pointers into d_raw_d2h)
+    Real* d_Mx;   Real* d_My;   Real* d_Mz;
+    // Nodal stiffness (pointers into d_raw_d2h)
+    Real* d_STIFN;
+    Real* d_STIFR;
+
+    // -----------------------------------------------------------------------
+    //  Element connectivity  [NUMELC]  (read-only, uploaded once)
+    // -----------------------------------------------------------------------
+    int* d_N1;  int* d_N2;  int* d_N3;  int* d_N4;
+
+    // -----------------------------------------------------------------------
+    //  Element state  [NUMELC]  (persistent on device)
+    // -----------------------------------------------------------------------
+    Real* d_OFF;          // activity flag
+    Real* d_THK;          // current thickness
+    Real* d_THK0;         // initial thickness
+    Real* d_THK02;        // initial thickness 2
+    Real* d_SMSTR;        // reference coords [NUMELC*6]
+    Real* d_GSTR;         // global strains   [NUMELC*8]
+    Real* d_EINT;         // internal energy   [NUMELC*2]
+    Real* d_EPSD_elem;    // element strain rate
+    Real* d_HOUR;         // hourglass state   [NUMELC*5]
+
+    // Per-element stiffness outputs
+    Real* d_STI;
+    Real* d_STIR;
+
+    // Min-timestep reduction scalar (1 Real on device)
+    Real* d_dt_min;
+
+    // Per-element material scalars [NUMELC] (read-only, uploaded once)
+    Real* d_SSP;
+    Real* d_RHO;
+    Real* d_YM;
+    Real* d_NU;
+    Real* d_A11;
+    Real* d_G;
+    Real* d_SHF;
+
+    // -----------------------------------------------------------------------
+    //  Per-integration-point state  [NPT * NUMELC]  (persistent)
+    // -----------------------------------------------------------------------
+    Real* d_SIGxx;     Real* d_SIGyy;     Real* d_SIGxy;
+    Real* d_SIGyz;     Real* d_SIGzx;
+    Real* d_PLA;
+    Real* d_EPSD_ip;
+    Real* d_SIGBAKxx;  Real* d_SIGBAKyy;  Real* d_SIGBAKxy;
+    Real* d_DPLA;
+    Real* d_TEMPEL;
+    Real* d_SIGY;       // yield stress output [NUMELC]
+
+
+
+    // -----------------------------------------------------------------------
+    //  Intermediate arrays (Kernel 1 → Kernel 2 → Kernel 3)
+    //  Allocated once, reused every time step.  [NUMELC] each.
+    // -----------------------------------------------------------------------
+    // Local frame (Kernel 1 output, Kernel 2 & 3 input)
+    Real* d_E1x;  Real* d_E1y;  Real* d_E1z;
+    Real* d_E2x;  Real* d_E2y;  Real* d_E2z;
+    Real* d_E3x;  Real* d_E3y;  Real* d_E3z;
+
+    // Gathered translational velocities (Kernel 1 → 2 & 3)
+    Real* d_VL1x;  Real* d_VL1y;  Real* d_VL1z;
+    Real* d_VL2x;  Real* d_VL2y;  Real* d_VL2z;
+    Real* d_VL3x;  Real* d_VL3y;  Real* d_VL3z;
+    Real* d_VL4x;  Real* d_VL4y;  Real* d_VL4z;
+
+    // Gathered rotational velocities (Kernel 1 → 2 & 3)
+    Real* d_VRL1x;  Real* d_VRL1y;  Real* d_VRL1z;
+    Real* d_VRL2x;  Real* d_VRL2y;  Real* d_VRL2z;
+    Real* d_VRL3x;  Real* d_VRL3y;  Real* d_VRL3z;
+    Real* d_VRL4x;  Real* d_VRL4y;  Real* d_VRL4z;
+
+    // Shape-function derivatives & geometry (Kernel 1 → 2 & 3)
+    Real* d_PX1;   Real* d_PX2;
+    Real* d_PY1;   Real* d_PY2;
+    Real* d_AREA;  Real* d_A_I;
+    Real* d_VHX;   Real* d_VHY;
+    Real* d_Z2;
+
+    // Displacement increments (Kernel 1 → 2)
+    Real* d_UX1;  Real* d_UY1;
+    Real* d_UX2;  Real* d_UY2;
+    Real* d_UX3;  Real* d_UY3;
+    Real* d_UX4;  Real* d_UY4;
+
+    // Generalized forces / moments (Kernel 2 → 3)
+    Real* d_FORxx;  Real* d_FORyy;  Real* d_FORxy;
+    Real* d_FORyz;  Real* d_FORzx;
+    Real* d_MOMxx;  Real* d_MOMyy;  Real* d_MOMxy;
+
+    // -----------------------------------------------------------------------
+    //  Per-SU cycle counter (for debug prints)
+    // -----------------------------------------------------------------------
+    int ncycle;
+
+    // -----------------------------------------------------------------------
+    //  CUDA stream for asynchronous execution
+    // -----------------------------------------------------------------------
+    cudaStream_t stream;
+
+    // -----------------------------------------------------------------------
+    //  Back-pointer to global (shared) node/force arrays
+    //  Set by shell_gpu_set_global() after allocation.
+    // -----------------------------------------------------------------------
+    ShellGPUGlobal* global;
+
+    // -----------------------------------------------------------------------
+    //  Event recorded after this SU's K3 completes.
+    //  The global stream waits on all SU events before D2H of forces.
+    // -----------------------------------------------------------------------
+    cudaEvent_t kernels_done;
+};
+
+#endif                    

--- a/engine/source/elements/shell/coque/shell_gpu_driver.cu
+++ b/engine/source/elements/shell/coque/shell_gpu_driver.cu
@@ -1,0 +1,1314 @@
+//Copyright>    OpenRadioss
+//Copyright>    Copyright (C) 1986-2026 Altair Engineering Inc.
+//Copyright>
+//Copyright>    This program is free software: you can redistribute it and/or modify
+//Copyright>    it under the terms of the GNU Affero General Public License as published by
+//Copyright>    the Free Software Foundation, either version 3 of the License, or
+//Copyright>    (at your option) any later version.
+//Copyright>
+//Copyright>    This program is distributed in the hope that it will be useful,
+//Copyright>    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//Copyright>    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//Copyright>    GNU Affero General Public License for more details.
+//Copyright>
+//Copyright>    You should have received a copy of the GNU Affero General Public License
+//Copyright>    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//Copyright>
+//Copyright>
+//Copyright>    Commercial Alternative: Altair Radioss Software
+//Copyright>
+//Copyright>    As an alternative to this open-source version, Altair also offers Altair Radioss
+//Copyright>    software under a commercial license.  Contact Altair to discuss further if the
+//Copyright>    commercial version may interest you: https://www.altair.com/radioss/.
+// ==============================================================================
+//  OpenRadioss GPU — Shell Element GPU Driver
+//  Allocates device memory, manages host↔device transfers,
+//  and launches the three Option C kernels in sequence.
+// ==============================================================================
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cmath>
+
+#include <cuda_runtime.h>
+
+#include "shell_gpu_data.h"
+#include "shell_geometry_kernel.h"
+#include "shell_strain_material_kernel.h"
+#include "shell_force_assembly_kernel.h"
+#include "real_type.h"
+
+
+// ===========================================================================
+//  CUDA error-checking helper
+// ===========================================================================
+#define CUDA_CHECK(call)                                                      \
+    do {                                                                      \
+        cudaError_t err = (call);                                             \
+        if (err != cudaSuccess) {                                             \
+            fprintf(stderr, "CUDA error at %s:%d — %s\n",                    \
+                    __FILE__, __LINE__, cudaGetErrorString(err));             \
+            exit(EXIT_FAILURE);                                               \
+        }                                                                     \
+    } while (0)
+
+// ===========================================================================
+//  Helper: allocate a Real array on device and zero it
+// ===========================================================================
+static inline Real* alloc_d(int n)
+{
+    Real* ptr = nullptr;
+    CUDA_CHECK(cudaMalloc(&ptr, (size_t)n * sizeof(Real)));
+    CUDA_CHECK(cudaMemset(ptr, 0, (size_t)n * sizeof(Real)));
+    return ptr;
+}
+
+static inline int* alloc_i(int n)
+{
+    int* ptr = nullptr;
+    CUDA_CHECK(cudaMalloc(&ptr, (size_t)n * sizeof(int)));
+    CUDA_CHECK(cudaMemset(ptr, 0, (size_t)n * sizeof(int)));
+    return ptr;
+}
+
+// ===========================================================================
+//  Helper: safe free
+// ===========================================================================
+static inline void free_d(Real*& p) { if (p) { cudaFree(p); p = nullptr; } }
+static inline void free_i(int*& p)    { if (p) { cudaFree(p); p = nullptr; } }
+
+// ===========================================================================
+//  0. GLOBAL NODE/FORCE HANDLE — shared across all SU streams
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+//  Create and allocate the global handle for NUMNOD nodes.
+//  Allocates d_raw_h2d [9*NUMNOD] and d_raw_d2h [8*NUMNOD] on device,
+//  creates a dedicated CUDA stream and event.
+// ---------------------------------------------------------------------------
+extern "C"
+ShellGPUGlobal* shell_gpu_global_create(int NUMNOD)
+{
+    ShellGPUGlobal* gh = (ShellGPUGlobal*)calloc(1, sizeof(ShellGPUGlobal));
+    gh->NUMNOD = NUMNOD;
+    const int NN = NUMNOD;
+
+    // H2D buffer: 9*NN Reals = X(3*NN) | V(3*NN) | VR(3*NN)  (AoS)
+    gh->d_raw_h2d = alloc_d(9 * NN);
+    gh->d_X  = gh->d_raw_h2d;
+    gh->d_V  = gh->d_raw_h2d + 3 * NN;
+    gh->d_VR = gh->d_raw_h2d + 6 * NN;
+
+    // D2H buffer: 8*NN Reals = Fx|Fy|Fz|Mx|My|Mz|STIFN|STIFR  (SoA)
+    gh->d_raw_d2h = alloc_d(8 * NN);
+    gh->d_Fx    = gh->d_raw_d2h + 0 * NN;
+    gh->d_Fy    = gh->d_raw_d2h + 1 * NN;
+    gh->d_Fz    = gh->d_raw_d2h + 2 * NN;
+    gh->d_Mx    = gh->d_raw_d2h + 3 * NN;
+    gh->d_My    = gh->d_raw_d2h + 4 * NN;
+    gh->d_Mz    = gh->d_raw_d2h + 5 * NN;
+    gh->d_STIFN = gh->d_raw_d2h + 6 * NN;
+    gh->d_STIFR = gh->d_raw_d2h + 7 * NN;
+
+    CUDA_CHECK(cudaStreamCreate(&gh->stream));
+    CUDA_CHECK(cudaEventCreateWithFlags(&gh->upload_done, cudaEventDisableTiming));
+
+    fprintf(stdout, " [GPU-GLOBAL] Created global handle: NUMNOD=%d, "
+            "d_raw_h2d=%zu MB, d_raw_d2h=%zu MB\n",
+            NN,
+            (size_t)(9*NN)*sizeof(Real) / (1024*1024),
+            (size_t)(8*NN)*sizeof(Real) / (1024*1024));
+
+    return gh;
+}
+
+// ---------------------------------------------------------------------------
+//  Destroy the global handle — free device arrays, stream, event.
+// ---------------------------------------------------------------------------
+extern "C"
+void shell_gpu_global_destroy(ShellGPUGlobal* gh)
+{
+    if (!gh) return;
+    free_d(gh->d_raw_h2d);
+    free_d(gh->d_raw_d2h);
+    if (gh->stream)      { cudaStreamDestroy(gh->stream);  gh->stream = nullptr; }
+    if (gh->upload_done) { cudaEventDestroy(gh->upload_done); gh->upload_done = nullptr; }
+    free(gh);
+}
+
+// ---------------------------------------------------------------------------
+//  Upload global node positions/velocities (H2D) and zero force arrays.
+//  Records upload_done event so that SU streams can wait on it.
+//
+//  X, V, VR are Fortran (3, NUMNOD) column-major = AoS in memory:
+//    {x0,y0,z0, x1,y1,z1, ...}  — matches d_X[3*n + {0,1,2}] access
+// ---------------------------------------------------------------------------
+extern "C"
+void shell_gpu_global_upload_nodes(ShellGPUGlobal* gh,
+                                   const Real* X,
+                                   const Real* V,
+                                   const Real* VR)
+{
+    const int NN = gh->NUMNOD;
+    const size_t s3n = (size_t)(3 * NN) * sizeof(Real);
+    const size_t s8n = (size_t)(8 * NN) * sizeof(Real);
+    cudaStream_t s = gh->stream;
+
+    // H2D: X, V, VR → d_raw_h2d
+    CUDA_CHECK(cudaMemcpyAsync(gh->d_X,  X,  s3n, cudaMemcpyHostToDevice, s));
+    CUDA_CHECK(cudaMemcpyAsync(gh->d_V,  V,  s3n, cudaMemcpyHostToDevice, s));
+    CUDA_CHECK(cudaMemcpyAsync(gh->d_VR, VR, s3n, cudaMemcpyHostToDevice, s));
+
+    // Zero force accumulation arrays (Fx..STIFR) — contiguous block
+    CUDA_CHECK(cudaMemsetAsync(gh->d_raw_d2h, 0, s8n, s));
+
+    // Signal that upload + zero is complete — SU streams will wait on this
+    CUDA_CHECK(cudaEventRecord(gh->upload_done, s));
+}
+
+// ---------------------------------------------------------------------------
+//  Download global force arrays (D2H) into a pinned host buffer.
+//  raw_gpu_to_cpu is [8*NUMNOD]: Fx|Fy|Fz|Mx|My|Mz|STIFN|STIFR
+// ---------------------------------------------------------------------------
+extern "C"
+void shell_gpu_global_download_forces(ShellGPUGlobal* gh,
+                                      Real* raw_gpu_to_cpu)
+{
+    const size_t s8n = (size_t)(8 * gh->NUMNOD) * sizeof(Real);
+    CUDA_CHECK(cudaMemcpyAsync(raw_gpu_to_cpu, gh->d_raw_d2h, s8n,
+                               cudaMemcpyDeviceToHost, gh->stream));
+}
+
+// ---------------------------------------------------------------------------
+//  Block CPU until global stream (upload or download) completes.
+// ---------------------------------------------------------------------------
+extern "C"
+void shell_gpu_global_synchronize(ShellGPUGlobal* gh)
+{
+    CUDA_CHECK(cudaStreamSynchronize(gh->stream));
+}
+
+// ---------------------------------------------------------------------------
+//  Make an SU stream wait until the global upload is done.
+//  Call this before launching SU kernels.
+// ---------------------------------------------------------------------------
+extern "C"
+void shell_gpu_global_wait_upload(ShellGPUGlobal* gh, ShellGPUData* g)
+{
+    CUDA_CHECK(cudaStreamWaitEvent(g->stream, gh->upload_done, 0));
+}
+
+// ---------------------------------------------------------------------------
+//  Make the global stream wait until an SU's kernels are done.
+//  Call this after all SU kernel launches, before global D2H.
+// ---------------------------------------------------------------------------
+extern "C"
+void shell_gpu_global_wait_su(ShellGPUGlobal* gh, ShellGPUData* g)
+{
+    CUDA_CHECK(cudaStreamWaitEvent(gh->stream, g->kernels_done, 0));
+}
+
+// ---------------------------------------------------------------------------
+//  Pin Fortran NODES%X, %V, %VR for truly async H2D.
+//  Also pin the D2H force result buffer.
+//  Call once after Fortran arrays are allocated.
+// ---------------------------------------------------------------------------
+extern "C"
+void shell_gpu_global_pin_host(const Real* X, const Real* V,
+                               const Real* VR, Real* raw_gpu_to_cpu,
+                               int NUMNOD)
+{
+    const size_t s3n = (size_t)(3 * NUMNOD) * sizeof(Real);
+    const size_t s8n = (size_t)(8 * NUMNOD) * sizeof(Real);
+    CUDA_CHECK(cudaHostRegister((void*)X,  s3n, cudaHostRegisterDefault));
+    CUDA_CHECK(cudaHostRegister((void*)V,  s3n, cudaHostRegisterDefault));
+    CUDA_CHECK(cudaHostRegister((void*)VR, s3n, cudaHostRegisterDefault));
+    CUDA_CHECK(cudaHostRegister(raw_gpu_to_cpu, s8n, cudaHostRegisterDefault));
+}
+
+// ---------------------------------------------------------------------------
+//  Set the back-pointer from a per-SU handle to the global handle.
+//  Also aliases the node/force pointers for convenience.
+// ---------------------------------------------------------------------------
+extern "C"
+void shell_gpu_set_global(ShellGPUData* g, ShellGPUGlobal* gh)
+{
+    g->global = gh;
+
+    // Alias device node arrays (read-only for K1)
+    g->d_X  = gh->d_X;
+    g->d_V  = gh->d_V;
+    g->d_VR = gh->d_VR;
+
+    // Alias device force arrays (atomicAdd by K3)
+    g->d_Fx    = gh->d_Fx;
+    g->d_Fy    = gh->d_Fy;
+    g->d_Fz    = gh->d_Fz;
+    g->d_Mx    = gh->d_Mx;
+    g->d_My    = gh->d_My;
+    g->d_Mz    = gh->d_Mz;
+    g->d_STIFN = gh->d_STIFN;
+    g->d_STIFR = gh->d_STIFR;
+}
+
+// ===========================================================================
+//  0a. CREATE / DESTROY the host-side ShellGPUData handle
+//      These are needed because the Fortran side cannot sizeof() a C struct.
+// ===========================================================================
+extern "C"
+ShellGPUData* shell_gpu_data_create()
+{
+    ShellGPUData* g = (ShellGPUData*)calloc(1, sizeof(ShellGPUData));
+    return g;
+}
+
+extern "C"
+void shell_gpu_data_destroy(ShellGPUData* g)
+{
+    if (g) free(g);
+}
+
+// ===========================================================================
+//  0b. SET material (Johnson-Cook) and hourglass parameters on the handle
+//      These are by-value structs inside ShellGPUData, passed to kernels 2&3.
+//      They must be set after shell_gpu_allocate() and before the first
+//      call to shell_gpu_run_kernels() / shell_gpu_full_step().
+// ===========================================================================
+extern "C"
+void shell_gpu_set_mat_params(ShellGPUData* g,
+    Real E,  Real nu, Real G,  Real A11, Real A12,
+    Real CA, Real CB, Real CN, Real CC,  Real EPDR,
+    Real EPMX, Real YMAX,  Real M_EXP,
+    Real FISOKIN, Real RHOCP, Real TREF, Real TMELT, Real ASRATE,
+    Real RHO, Real SSP, Real SHF_COEF,
+    int IPLA, int VP, int IFORM, int ICC,
+    Real Z3, Real Z4)
+{
+    g->mat.E        = E;
+    g->mat.nu       = nu;
+    g->mat.G        = G;
+    g->mat.A11      = A11;
+    g->mat.A12      = A12;
+    g->mat.CA       = CA;
+    g->mat.CB       = CB;
+    g->mat.CN       = CN;
+    g->mat.CC       = CC;
+    g->mat.EPDR     = EPDR;
+    g->mat.EPMX     = EPMX;
+    g->mat.YMAX     = YMAX;
+    g->mat.M_EXP    = M_EXP;
+    g->mat.FISOKIN  = FISOKIN;
+    g->mat.RHOCP    = RHOCP;
+    g->mat.TREF     = TREF;
+    g->mat.TMELT    = TMELT;
+    g->mat.ASRATE   = ASRATE;
+    g->mat.RHO      = RHO;
+    g->mat.SSP      = SSP;
+    g->mat.SHF_COEF = SHF_COEF;
+    g->mat.IPLA     = IPLA;
+    g->mat.VP       = VP;
+    g->mat.IFORM    = IFORM;
+    g->mat.ICC      = ICC;
+    g->mat.Z3       = Z3;
+    g->mat.Z4       = Z4;
+}
+
+extern "C"
+void shell_gpu_set_hg_params(ShellGPUData* g,
+    Real H1,  Real H2,  Real H3,
+    Real SRH1, Real SRH2, Real SRH3,
+    Real HVISC, Real HELAS, Real HVLIN)
+{
+    g->hg.H1   = H1;
+    g->hg.H2   = H2;
+    g->hg.H3   = H3;
+    g->hg.SRH1 = SRH1;
+    g->hg.SRH2 = SRH2;
+    g->hg.SRH3 = SRH3;
+    g->hg.HVISC = HVISC;
+    g->hg.HELAS = HELAS;
+    g->hg.HVLIN = HVLIN;
+}
+
+// ---------------------------------------------------------------------------
+//  Set compute_sti flag: 1 = compute element stiffness for STIFN (NODADT/=0),
+//                        0 = skip (NODADT==0 and IDT1SH!=1 and IDTMINS!=2)
+// ---------------------------------------------------------------------------
+extern "C"
+void shell_gpu_set_compute_sti(ShellGPUData* g, int flag)
+{
+    g->compute_sti = flag;
+}
+
+extern "C"
+void shell_gpu_set_ihbe(ShellGPUData* g, int ihbe)
+{
+    g->IHBE = ihbe;
+}
+
+// ===========================================================================
+//  1. ALLOCATE all device arrays
+// ===========================================================================
+extern "C"
+void shell_gpu_allocate(ShellGPUData* g,
+                        int NUMELC, int NUMNOD, int NPT,
+                        int ISMSTR, int ITHK)
+{
+    memset(g, 0, sizeof(ShellGPUData));
+
+    g->NUMELC = NUMELC;
+    g->NUMNOD = NUMNOD;
+    g->NPT    = NPT;
+    g->ISMSTR = ISMSTR;
+    g->ITHK   = ITHK;
+
+    CUDA_CHECK(cudaStreamCreate(&g->stream));
+    CUDA_CHECK(cudaEventCreateWithFlags(&g->kernels_done, cudaEventDisableTiming));
+
+    const int NE  = NUMELC;
+    const int NN  = NUMNOD;
+    const int NIP = NPT * NUMELC;
+
+    // ----- Global node / force arrays are NOT allocated here -----
+    // They live on ShellGPUGlobal and are aliased via shell_gpu_set_global().
+    // d_raw_h2d, d_raw_d2h, d_X, d_V, d_VR, d_Fx..d_STIFR are set later.
+    g->d_raw_h2d = nullptr;
+    g->d_raw_d2h = nullptr;
+    g->d_X = g->d_V = g->d_VR = nullptr;
+    g->d_Fx = g->d_Fy = g->d_Fz = nullptr;
+    g->d_Mx = g->d_My = g->d_Mz = nullptr;
+    g->d_STIFN = g->d_STIFR = nullptr;
+    g->global = nullptr;
+
+    // ----- Connectivity [NUMELC] -----
+    g->d_N1 = alloc_i(NE);  g->d_N2 = alloc_i(NE);
+    g->d_N3 = alloc_i(NE);  g->d_N4 = alloc_i(NE);
+
+    // ----- Element state [NUMELC] -----
+    g->d_OFF       = alloc_d(NE);
+    g->d_THK       = alloc_d(NE);
+    g->d_THK0      = alloc_d(NE);
+    g->d_THK02     = alloc_d(NE);
+    g->d_SMSTR     = alloc_d(NE * 6);
+    g->d_GSTR      = alloc_d(NE * 8);
+    g->d_EINT      = alloc_d(NE * 2);
+    g->d_EPSD_elem = alloc_d(NE);
+    g->d_HOUR      = alloc_d(NE * 5);
+    g->d_STI       = alloc_d(NE);
+    g->d_STIR      = alloc_d(NE);
+    g->d_dt_min    = alloc_d(1);
+
+    // Per-element material scalars (read-only on device)
+    g->d_SSP = alloc_d(NE);
+    g->d_RHO = alloc_d(NE);
+    g->d_YM  = alloc_d(NE);
+    g->d_NU  = alloc_d(NE);
+    g->d_A11 = alloc_d(NE);
+    g->d_G   = alloc_d(NE);
+    g->d_SHF = alloc_d(NE);
+
+    // ----- Per-integration-point state [NPT * NUMELC] -----
+    g->d_SIGxx    = alloc_d(NIP);  g->d_SIGyy    = alloc_d(NIP);
+    g->d_SIGxy    = alloc_d(NIP);  g->d_SIGyz    = alloc_d(NIP);
+    g->d_SIGzx    = alloc_d(NIP);
+    g->d_PLA      = alloc_d(NIP);
+    g->d_EPSD_ip  = alloc_d(NIP);
+    g->d_SIGBAKxx = alloc_d(NIP);  g->d_SIGBAKyy = alloc_d(NIP);
+    g->d_SIGBAKxy = alloc_d(NIP);
+    g->d_DPLA     = alloc_d(NIP);
+    g->d_TEMPEL   = alloc_d(NIP);
+    g->d_SIGY     = alloc_d(NE);
+
+    // ----- Intermediate arrays [NUMELC] -----
+    // Local frame
+    g->d_E1x = alloc_d(NE);  g->d_E1y = alloc_d(NE);  g->d_E1z = alloc_d(NE);
+    g->d_E2x = alloc_d(NE);  g->d_E2y = alloc_d(NE);  g->d_E2z = alloc_d(NE);
+    g->d_E3x = alloc_d(NE);  g->d_E3y = alloc_d(NE);  g->d_E3z = alloc_d(NE);
+
+    // Gathered translational velocities (4 nodes × 3 components)
+    g->d_VL1x = alloc_d(NE);  g->d_VL1y = alloc_d(NE);  g->d_VL1z = alloc_d(NE);
+    g->d_VL2x = alloc_d(NE);  g->d_VL2y = alloc_d(NE);  g->d_VL2z = alloc_d(NE);
+    g->d_VL3x = alloc_d(NE);  g->d_VL3y = alloc_d(NE);  g->d_VL3z = alloc_d(NE);
+    g->d_VL4x = alloc_d(NE);  g->d_VL4y = alloc_d(NE);  g->d_VL4z = alloc_d(NE);
+
+    // Gathered rotational velocities
+    g->d_VRL1x = alloc_d(NE);  g->d_VRL1y = alloc_d(NE);  g->d_VRL1z = alloc_d(NE);
+    g->d_VRL2x = alloc_d(NE);  g->d_VRL2y = alloc_d(NE);  g->d_VRL2z = alloc_d(NE);
+    g->d_VRL3x = alloc_d(NE);  g->d_VRL3y = alloc_d(NE);  g->d_VRL3z = alloc_d(NE);
+    g->d_VRL4x = alloc_d(NE);  g->d_VRL4y = alloc_d(NE);  g->d_VRL4z = alloc_d(NE);
+
+    // Shape functions & geometry
+    g->d_PX1  = alloc_d(NE);  g->d_PX2 = alloc_d(NE);
+    g->d_PY1  = alloc_d(NE);  g->d_PY2 = alloc_d(NE);
+    g->d_AREA = alloc_d(NE);  g->d_A_I = alloc_d(NE);
+    g->d_VHX  = alloc_d(NE);  g->d_VHY = alloc_d(NE);
+    g->d_Z2   = alloc_d(NE);
+
+    // Displacement increments
+    g->d_UX1 = alloc_d(NE);  g->d_UY1 = alloc_d(NE);
+    g->d_UX2 = alloc_d(NE);  g->d_UY2 = alloc_d(NE);
+    g->d_UX3 = alloc_d(NE);  g->d_UY3 = alloc_d(NE);
+    g->d_UX4 = alloc_d(NE);  g->d_UY4 = alloc_d(NE);
+
+    // Generalized forces / moments  (Kernel 2 → 3)
+    g->d_FORxx = alloc_d(NE);  g->d_FORyy = alloc_d(NE);
+    g->d_FORxy = alloc_d(NE);  g->d_FORyz = alloc_d(NE);
+    g->d_FORzx = alloc_d(NE);
+    g->d_MOMxx = alloc_d(NE);  g->d_MOMyy = alloc_d(NE);
+    g->d_MOMxy = alloc_d(NE);
+}
+
+// ===========================================================================
+//  2. DEALLOCATE all device arrays
+// ===========================================================================
+extern "C"
+void shell_gpu_deallocate(ShellGPUData* g)
+{
+    // Global node/force arrays are NOT freed here — they belong to ShellGPUGlobal.
+    // Just null out the aliased pointers.
+    g->d_raw_h2d = nullptr;
+    g->d_raw_d2h = nullptr;
+    g->d_X = g->d_V = g->d_VR = nullptr;
+    g->d_Fx = g->d_Fy = g->d_Fz = nullptr;
+    g->d_Mx = g->d_My = g->d_Mz = nullptr;
+    g->d_STIFN = g->d_STIFR = nullptr;
+    g->global = nullptr;
+
+    // Connectivity
+    free_i(g->d_N1);  free_i(g->d_N2);  free_i(g->d_N3);  free_i(g->d_N4);
+
+    // Element state
+    free_d(g->d_OFF);   free_d(g->d_THK);
+    free_d(g->d_THK0);  free_d(g->d_THK02);
+    free_d(g->d_SMSTR); free_d(g->d_GSTR);
+    free_d(g->d_EINT);  free_d(g->d_EPSD_elem);
+    free_d(g->d_HOUR);
+    free_d(g->d_STI);   free_d(g->d_STIR);
+    free_d(g->d_dt_min);
+    free_d(g->d_SSP);   free_d(g->d_RHO);  free_d(g->d_YM);
+    free_d(g->d_NU);    free_d(g->d_A11);  free_d(g->d_G);
+    free_d(g->d_SHF);
+
+    // Per-integration-point state
+    free_d(g->d_SIGxx);    free_d(g->d_SIGyy);    free_d(g->d_SIGxy);
+    free_d(g->d_SIGyz);    free_d(g->d_SIGzx);
+    free_d(g->d_PLA);      free_d(g->d_EPSD_ip);
+    free_d(g->d_SIGBAKxx); free_d(g->d_SIGBAKyy); free_d(g->d_SIGBAKxy);
+    free_d(g->d_DPLA);     free_d(g->d_TEMPEL);
+    free_d(g->d_SIGY);
+
+    // Intermediate arrays
+    free_d(g->d_E1x);  free_d(g->d_E1y);  free_d(g->d_E1z);
+    free_d(g->d_E2x);  free_d(g->d_E2y);  free_d(g->d_E2z);
+    free_d(g->d_E3x);  free_d(g->d_E3y);  free_d(g->d_E3z);
+
+    free_d(g->d_VL1x); free_d(g->d_VL1y); free_d(g->d_VL1z);
+    free_d(g->d_VL2x); free_d(g->d_VL2y); free_d(g->d_VL2z);
+    free_d(g->d_VL3x); free_d(g->d_VL3y); free_d(g->d_VL3z);
+    free_d(g->d_VL4x); free_d(g->d_VL4y); free_d(g->d_VL4z);
+
+    free_d(g->d_VRL1x); free_d(g->d_VRL1y); free_d(g->d_VRL1z);
+    free_d(g->d_VRL2x); free_d(g->d_VRL2y); free_d(g->d_VRL2z);
+    free_d(g->d_VRL3x); free_d(g->d_VRL3y); free_d(g->d_VRL3z);
+    free_d(g->d_VRL4x); free_d(g->d_VRL4y); free_d(g->d_VRL4z);
+
+    free_d(g->d_PX1);  free_d(g->d_PX2);
+    free_d(g->d_PY1);  free_d(g->d_PY2);
+    free_d(g->d_AREA); free_d(g->d_A_I);
+    free_d(g->d_VHX);  free_d(g->d_VHY);
+    free_d(g->d_Z2);
+
+    free_d(g->d_UX1);  free_d(g->d_UY1);
+    free_d(g->d_UX2);  free_d(g->d_UY2);
+    free_d(g->d_UX3);  free_d(g->d_UY3);
+    free_d(g->d_UX4);  free_d(g->d_UY4);
+
+    free_d(g->d_FORxx); free_d(g->d_FORyy); free_d(g->d_FORxy);
+    free_d(g->d_FORyz); free_d(g->d_FORzx);
+    free_d(g->d_MOMxx); free_d(g->d_MOMyy); free_d(g->d_MOMxy);
+
+    if (g->stream) {
+        cudaStreamDestroy(g->stream);
+        g->stream = nullptr;
+    }
+    if (g->kernels_done) {
+        cudaEventDestroy(g->kernels_done);
+        g->kernels_done = nullptr;
+    }
+
+    memset(g, 0, sizeof(ShellGPUData));
+}
+
+// ===========================================================================
+//  3. HOST → DEVICE TRANSFERS
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+//  Upload constant data (called once at initialization)
+//  - Connectivity, initial thickness, material scalars, initial state
+// ---------------------------------------------------------------------------
+extern "C"
+void shell_gpu_upload_constant(ShellGPUData*  g,
+                               const int*     h_N1,   const int*     h_N2,
+                               const int*     h_N3,   const int*     h_N4,
+                               const Real*  h_THK0,
+                               const Real*  h_OFF,
+                               const Real*  h_SSP,  const Real*  h_RHO,
+                               const Real*  h_YM,   const Real*  h_NU,
+                               const Real*  h_A11,  const Real*  h_G,
+                               const Real*  h_SHF)
+{
+    const int NE = g->NUMELC;
+    const size_t se = (size_t)NE * sizeof(Real);
+    const size_t si = (size_t)NE * sizeof(int);
+
+    // Connectivity (never changes)
+    CUDA_CHECK(cudaMemcpyAsync(g->d_N1, h_N1, si, cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_N2, h_N2, si, cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_N3, h_N3, si, cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_N4, h_N4, si, cudaMemcpyHostToDevice, g->stream));
+
+    // Initial thickness → THK0 and THK02 = THK0/2
+    CUDA_CHECK(cudaMemcpyAsync(g->d_THK0, h_THK0, se, cudaMemcpyHostToDevice, g->stream));
+    // THK = THK0 initially
+    CUDA_CHECK(cudaMemcpyAsync(g->d_THK, h_THK0, se, cudaMemcpyHostToDevice, g->stream));
+
+    // Compute THK02 = THK0^2 on host and upload
+    //   (CPU ccoef3.F:  THK02(I) = THK0(I)*THK0(I))
+    {
+        Real* tmp = (Real*)malloc(se);
+        for (int i = 0; i < NE; ++i) tmp[i] = h_THK0[i] * h_THK0[i];
+        CUDA_CHECK(cudaMemcpyAsync(g->d_THK02, tmp, se, cudaMemcpyHostToDevice, g->stream));
+        cudaStreamSynchronize(g->stream);
+        free(tmp);
+    }
+
+    // Element activity
+    CUDA_CHECK(cudaMemcpyAsync(g->d_OFF, h_OFF, se, cudaMemcpyHostToDevice, g->stream));
+
+    // Material scalars per element
+    CUDA_CHECK(cudaMemcpyAsync(g->d_SSP, h_SSP, se, cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_RHO, h_RHO, se, cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_YM,  h_YM,  se, cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_NU,  h_NU,  se, cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_A11, h_A11, se, cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_G,   h_G,   se, cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_SHF, h_SHF, se, cudaMemcpyHostToDevice, g->stream));
+
+    CUDA_CHECK(cudaStreamSynchronize(g->stream));
+}
+
+// ---------------------------------------------------------------------------
+//  Upload per-integration-point initial state (called once)
+// ---------------------------------------------------------------------------
+extern "C"
+void shell_gpu_upload_ip_state(ShellGPUData*  g,
+                               const Real*  h_SIGxx,    const Real*  h_SIGyy,
+                               const Real*  h_SIGxy,    const Real*  h_SIGyz,
+                               const Real*  h_SIGzx,
+                               const Real*  h_PLA,      const Real*  h_EPSD_ip,
+                               const Real*  h_SIGBAKxx, const Real*  h_SIGBAKyy,
+                               const Real*  h_SIGBAKxy,
+                               const Real*  h_TEMPEL)
+{
+    const size_t sip = (size_t)(g->NPT * g->NUMELC) * sizeof(Real);
+
+    CUDA_CHECK(cudaMemcpyAsync(g->d_SIGxx,    h_SIGxx,    sip, cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_SIGyy,    h_SIGyy,    sip, cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_SIGxy,    h_SIGxy,    sip, cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_SIGyz,    h_SIGyz,    sip, cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_SIGzx,    h_SIGzx,    sip, cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_PLA,      h_PLA,      sip, cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_EPSD_ip,  h_EPSD_ip,  sip, cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_SIGBAKxx, h_SIGBAKxx, sip, cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_SIGBAKyy, h_SIGBAKyy, sip, cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_SIGBAKxy, h_SIGBAKxy, sip, cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_TEMPEL,   h_TEMPEL,   sip, cudaMemcpyHostToDevice, g->stream));
+
+    CUDA_CHECK(cudaStreamSynchronize(g->stream));
+}
+
+// ---------------------------------------------------------------------------
+//  Upload node positions and velocities (called each time step before kernels)
+// ---------------------------------------------------------------------------
+//  PROFILING (nsys, 28440 steps):
+//    1 H2D per step → 28,648 total H2D calls, 278 MB total.
+//    GPU-side H2D: 17.5ms total (30.8% of GPU memops). ~0.6µs avg per call.
+//    CPU-side cudaMemcpyAsync: 47µs avg — the high avg is because host memory
+//    is NOT pinned, so cudaMemcpyAsync falls back to synchronous staging.
+//
+//  CRITICAL OPTIMIZATION — PIN HOST MEMORY:
+//    cudaHostRegister(raw_cpu_to_gpu, 9*NUMNOD*8, cudaHostRegisterDefault)
+//    once at init time.  This would:
+//    a) Make cudaMemcpyAsync truly asynchronous (~2µs CPU time per call)
+//    b) Allow the 3-pass SU pipeline to actually overlap CPU gather of
+//       SU(k+1) with GPU execution of SU(k)
+//    c) Reduce the 4.07s cudaMemcpyAsync total by ~3x
+//    This is THE single most impactful remaining optimization.
+//
+//  Long-term: keep node data GPU-resident (GPU time integration).
+// ---------------------------------------------------------------------------
+extern "C"
+void shell_gpu_upload_nodes(ShellGPUData*  g,
+                            const Real*  X,
+                            const Real*  V,
+                            const Real*  VR)
+{
+    const size_t s3n = (size_t)(3 * g->NUMNOD) * sizeof(Real);
+
+    // ONE H2D transfer: host raw_cpu_to_gpu[9*NUMNOD] → device d_raw_h2d[9*NUMNOD]
+    // Both sides have identical SoA layout: [Xx|Xy|Xz|Vx|Vy|Vz|VRx|VRy|VRz]
+    CUDA_CHECK(cudaMemcpyAsync(g->d_raw_h2d, X, s3n,
+                               cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_raw_h2d + 3 * g->NUMNOD, V, s3n,
+                               cudaMemcpyHostToDevice, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(g->d_raw_h2d + 6 * g->NUMNOD, VR, s3n,
+                               cudaMemcpyHostToDevice, g->stream));
+
+    // No cudaStreamSynchronize needed: run_kernels uses the same stream,
+    // so the H2D will complete before any kernel reads the data.
+}
+
+// ===========================================================================
+//  4. DEVICE → HOST TRANSFERS
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+//  Download nodal forces, moments, stiffness (synchronous variant)
+// ---------------------------------------------------------------------------
+//  PROFILING (nsys, 28440 steps):
+//    1 D2H per step → ~28K of the 57,712 D2H calls, ~10 KB avg.
+//    GPU-side D2H: ~11ms total.  CPU-side: ~47µs avg (unpinned memory).
+//    With pinned memory this would drop to ~2µs avg.
+//
+//  NOTE: The 3-pass SU pipeline (shell_gpu_full_step_async) avoids this
+//  synchronous variant entirely. This function is kept for non-pipelined
+//  callers (shell_gpu_full_step). Prefer the async path.
+// ---------------------------------------------------------------------------
+extern "C"
+void shell_gpu_download_nodal_forces(const ShellGPUData* g,
+                                     Real* raw_gpu_to_cpu)
+{
+    const size_t s8n = (size_t)(8 * g->NUMNOD) * sizeof(Real);
+
+    // ONE D2H transfer: device d_raw_d2h[8*NUMNOD] → host raw_gpu_to_cpu[8*NUMNOD]
+    CUDA_CHECK(cudaMemcpyAsync(raw_gpu_to_cpu, g->d_raw_d2h, s8n,
+                               cudaMemcpyDeviceToHost, g->stream));
+
+    // COST: ~5-10µs per call × 28K steps ≈ 140-280ms of CPU stall
+    CUDA_CHECK(cudaStreamSynchronize(g->stream));
+}
+
+// ---------------------------------------------------------------------------
+//  Download element energy (for output / energy balance checking)
+// ---------------------------------------------------------------------------
+extern "C"
+void shell_gpu_download_energy(const ShellGPUData* g,
+                               Real* h_EINT)
+{
+    const size_t se2 = (size_t)(g->NUMELC * 2) * sizeof(Real);
+    CUDA_CHECK(cudaMemcpyAsync(h_EINT, g->d_EINT, se2, cudaMemcpyDeviceToHost, g->stream));
+    CUDA_CHECK(cudaStreamSynchronize(g->stream));
+}
+
+// ---------------------------------------------------------------------------
+//  Download per-element ALDT² (synchronous variant)
+//  Kernel 1 writes ALDT² into d_STI[]; Kernel 3 only reads it.
+// ---------------------------------------------------------------------------
+//  PROFILING (nsys, 28440 steps):
+//    1 D2H per step → ~28K of the 57,712 D2H calls, ~1 KB avg.
+//    With the 3-pass pipeline, prefer shell_gpu_download_aldt_sq_async
+//    + deferred shell_gpu_synchronize to avoid per-SU sync.
+//
+//  OPTIMIZATION:  Replace with a GPU reduction kernel computing
+//    min(sqrt(aldt_sq) * dtfac / ssp) and download a single scalar.
+// ---------------------------------------------------------------------------
+extern "C"
+void shell_gpu_download_aldt_sq(const ShellGPUData* g,
+                                Real* h_aldt_sq)
+{
+    const size_t se = (size_t)g->NUMELC * sizeof(Real);
+    CUDA_CHECK(cudaMemcpyAsync(h_aldt_sq, g->d_STI, se, cudaMemcpyDeviceToHost, g->stream));
+
+    // COST: blocks CPU until all prior GPU work completes.  ~5-10µs × 28K steps
+    CUDA_CHECK(cudaStreamSynchronize(g->stream));
+}
+
+// ---------------------------------------------------------------------------
+//  Download full element + IP state (for output / restart)
+// ---------------------------------------------------------------------------
+extern "C"
+void shell_gpu_download_state(const ShellGPUData* g,
+                              Real* h_OFF,   Real* h_THK,
+                              Real* h_GSTR,  Real* h_EPSD_elem,
+                              Real* h_SIGxx, Real* h_SIGyy,
+                              Real* h_SIGxy, Real* h_SIGyz,
+                              Real* h_SIGzx,
+                              Real* h_PLA,   Real* h_EPSD_ip,
+                              Real* h_SIGBAKxx, Real* h_SIGBAKyy,
+                              Real* h_SIGBAKxy,
+                              Real* h_TEMPEL)
+{
+    const int NE  = g->NUMELC;
+    const int NIP = g->NPT * NE;
+    const size_t se  = (size_t)NE  * sizeof(Real);
+    const size_t sip = (size_t)NIP * sizeof(Real);
+
+    CUDA_CHECK(cudaMemcpyAsync(h_OFF,       g->d_OFF,       se,  cudaMemcpyDeviceToHost, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(h_THK,       g->d_THK,       se,  cudaMemcpyDeviceToHost, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(h_GSTR,      g->d_GSTR,  (size_t)(NE*8)*sizeof(Real), cudaMemcpyDeviceToHost, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(h_EPSD_elem, g->d_EPSD_elem, se,  cudaMemcpyDeviceToHost, g->stream));
+
+    CUDA_CHECK(cudaMemcpyAsync(h_SIGxx,    g->d_SIGxx,    sip, cudaMemcpyDeviceToHost, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(h_SIGyy,    g->d_SIGyy,    sip, cudaMemcpyDeviceToHost, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(h_SIGxy,    g->d_SIGxy,    sip, cudaMemcpyDeviceToHost, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(h_SIGyz,    g->d_SIGyz,    sip, cudaMemcpyDeviceToHost, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(h_SIGzx,    g->d_SIGzx,    sip, cudaMemcpyDeviceToHost, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(h_PLA,      g->d_PLA,      sip, cudaMemcpyDeviceToHost, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(h_EPSD_ip,  g->d_EPSD_ip,  sip, cudaMemcpyDeviceToHost, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(h_SIGBAKxx, g->d_SIGBAKxx, sip, cudaMemcpyDeviceToHost, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(h_SIGBAKyy, g->d_SIGBAKyy, sip, cudaMemcpyDeviceToHost, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(h_SIGBAKxy, g->d_SIGBAKxy, sip, cudaMemcpyDeviceToHost, g->stream));
+    CUDA_CHECK(cudaMemcpyAsync(h_TEMPEL,   g->d_TEMPEL,   sip, cudaMemcpyDeviceToHost, g->stream));
+
+    CUDA_CHECK(cudaStreamSynchronize(g->stream));
+}
+
+// ===========================================================================
+//  5. ZERO NODAL ACCUMULATION ARRAYS
+//     Must be called once per time step before running the kernels
+//     (forces/moments/stiffness are accumulated via atomicAdd).
+// ===========================================================================
+//  PROFILING (nsys, 28440 steps):
+//    1 memset per step → 28,440 calls (+ 760 from init = 29,200 total).
+//    CPU-side: 139ms total (2.8% of CUDA API), avg 4.9µs. Negligible.
+//    GPU-side: 16.4ms total (28.9% of GPU memops), avg 0.56µs.
+//  Could be folded into Kernel 1 as first-touch writes to eliminate.
+// ===========================================================================
+extern "C"
+void shell_gpu_zero_nodal_arrays(ShellGPUData* g)
+{
+    // Force arrays now live on ShellGPUGlobal and are zeroed there
+    // (inside shell_gpu_global_upload_nodes).  This is a no-op.
+    (void)g;
+}
+
+// ===========================================================================
+//  6. RUN ALL THREE KERNELS FOR ONE TIME STEP
+//     This is the main entry point called by the Fortran time-stepping loop.
+//
+//     Sequence:
+//       a) Zero nodal F/M/STIF arrays
+//       b) Kernel 1: Geometry  (CCOOR3 + CNVEC3 + CDERI3)
+//       c) Kernel 2: Strains + Material  (CCOEF3 + CDEFO3 + CCURV3 +
+//                                         CSTRA3 + CMAIN3/SIGEPS02C/M2CPLR)
+//       d) Kernel 3: Forces + Assembly  (CHVIS3 + CFINT3 + CUPDT3)
+//
+//     The three kernel launches are enqueued into the same CUDA stream,
+//     so they execute in order. No explicit synchronization between them
+//     is needed; the stream guarantees ordering.
+// ===========================================================================
+extern "C"
+void shell_gpu_run_kernels(ShellGPUData* g, Real dt)
+{
+    const int NE     = g->NUMELC;
+    const int NPT    = g->NPT;
+    const int ISMSTR = g->ISMSTR;
+    const int ITHK   = g->ITHK;
+    cudaStream_t s   = g->stream;
+
+    // --- Per-SU cycle counter (stored in ShellGPUData, not static) ---
+    g->ncycle++;
+    const int ncycle_gpu = g->ncycle;
+
+    // (a) Zero nodal accumulation arrays
+    shell_gpu_zero_nodal_arrays(g);
+
+    // ------------------------------------------------------------------
+    //  (b) Kernel 1: Geometry
+    //      Gathers node coords/velocities, builds convected frame,
+    //      computes shape-function derivatives.
+    //  PROFILING: 9.8% GPU compute, 176ms / 28K steps, avg 6.2µs.
+    //             CPU launch cost: avg 5.5µs (471ms / 85K launches / 3).
+    //             Memory-bound (many global reads via connectivity).
+    // ------------------------------------------------------------------
+    launch_shell_geometry_kernel(
+        // Global node arrays
+        g->d_X,  
+        g->d_V,  
+        g->d_VR, 
+        // Connectivity
+        g->d_N1, g->d_N2, g->d_N3, g->d_N4,
+        // Element state (read/write)
+        g->d_OFF,  g->d_SMSTR,
+        // Outputs: local frame
+        g->d_E1x, g->d_E1y, g->d_E1z,
+        g->d_E2x, g->d_E2y, g->d_E2z,
+        g->d_E3x, g->d_E3y, g->d_E3z,
+        // Outputs: gathered translational velocities
+        g->d_VL1x, g->d_VL1y, g->d_VL1z,
+        g->d_VL2x, g->d_VL2y, g->d_VL2z,
+        g->d_VL3x, g->d_VL3y, g->d_VL3z,
+        g->d_VL4x, g->d_VL4y, g->d_VL4z,
+        // Outputs: gathered rotational velocities
+        g->d_VRL1x, g->d_VRL1y, g->d_VRL1z,
+        g->d_VRL2x, g->d_VRL2y, g->d_VRL2z,
+        g->d_VRL3x, g->d_VRL3y, g->d_VRL3z,
+        g->d_VRL4x, g->d_VRL4y, g->d_VRL4z,
+        // Outputs: shape functions & geometry
+        g->d_PX1,  g->d_PX2,
+        g->d_PY1,  g->d_PY2,
+        g->d_AREA, g->d_A_I,
+        g->d_VHX,  g->d_VHY,
+        g->d_Z2,
+        // Outputs: displacement increments
+        g->d_UX1, g->d_UY1,
+        g->d_UX2, g->d_UY2,
+        g->d_UX3, g->d_UY3,
+        g->d_UX4, g->d_UY4,
+        // Outputs: stiffness (CPXPY3-style, computed here with local coords)
+        g->d_STI, g->d_STIR,
+        // Per-element material scalars (for stiffness)
+        g->d_YM, g->d_THK0,
+        g->d_N3, g->d_N4,
+        // Scalars
+        NE, ISMSTR,
+        g->hg.H1, g->hg.H2,
+        s);
+
+    // ------------------------------------------------------------------
+    //  (c) Kernel 2: Strains + Material
+    //      Computes membrane/bending strains, runs Johnson-Cook material
+    //      law with radial return, outputs generalized forces/moments.
+    //  PROFILING: 71.2% GPU compute, 1.276s / 28K steps, avg 44.9µs.
+    //             THE dominant GPU hotspot.
+    //             High register pressure from radial-return limits occupancy.
+    //             Optimization: reduce registers, increase block size,
+    //             explore shared-memory caching of per-IP state.
+    // ------------------------------------------------------------------
+
+    // NOTE: d_FORxx..d_MOMxy are NOT zeroed here — Kernel 2 overwrites them
+    // with direct assignment (=), not atomicAdd.  The old FOR/MOM values from
+    // the previous time step must survive until Kernel 2 reads them for the
+    // trapezoidal stress-work energy calculation (degmb/degfx).
+    // d_SIGY and d_DPLA are also overwritten by direct assignment.
+
+    // ------------------------------------------------------------------
+    //  CCOEF3 equivalent:  THK0 = THK  (snapshot current thickness)
+    //  When ITHK>0 and ISMSTR/=3, the reference thickness used for
+    //  force/moment normalization, integration weights, and z-coordinates
+    //  must be updated to the current physical thickness each cycle.
+    //  Without this, forces drift as thickness evolves.
+    // ------------------------------------------------------------------
+    if (ITHK > 0 && ISMSTR != 3) {
+        const size_t se = (size_t)NE * sizeof(Real);
+        CUDA_CHECK(cudaMemcpyAsync(g->d_THK0, g->d_THK, se,
+                                   cudaMemcpyDeviceToDevice, s));
+    }
+
+    launch_shell_strain_material_kernel(
+        // Kernel 1 outputs (read-only)
+        g->d_E1x, g->d_E1y, g->d_E1z,
+        g->d_E2x, g->d_E2y, g->d_E2z,
+        g->d_E3x, g->d_E3y, g->d_E3z,
+        g->d_VL1x, g->d_VL1y, g->d_VL1z,
+        g->d_VL2x, g->d_VL2y, g->d_VL2z,
+        g->d_VL3x, g->d_VL3y, g->d_VL3z,
+        g->d_VL4x, g->d_VL4y, g->d_VL4z,
+        g->d_VRL1x, g->d_VRL1y, g->d_VRL1z,
+        g->d_VRL2x, g->d_VRL2y, g->d_VRL2z,
+        g->d_VRL3x, g->d_VRL3y, g->d_VRL3z,
+        g->d_VRL4x, g->d_VRL4y, g->d_VRL4z,
+        g->d_PX1,  g->d_PX2,
+        g->d_PY1,  g->d_PY2,
+        g->d_AREA, g->d_A_I,
+        g->d_UX1,  g->d_UY1,
+        g->d_UX2,  g->d_UY2,
+        g->d_UX3,  g->d_UY3,
+        g->d_UX4,  g->d_UY4,
+        // Element state
+        g->d_OFF, g->d_THK, g->d_THK0,
+        g->d_GSTR, g->d_EINT, g->d_EPSD_elem,
+        // Per-integration-point state
+        g->d_SIGxx, g->d_SIGyy, g->d_SIGxy,
+        g->d_SIGyz, g->d_SIGzx,
+        g->d_PLA,   g->d_EPSD_ip,
+        g->d_SIGBAKxx, g->d_SIGBAKyy, g->d_SIGBAKxy,
+        g->d_DPLA,  g->d_TEMPEL,
+        // Outputs: generalized forces/moments
+        g->d_FORxx, g->d_FORyy, g->d_FORxy,
+        g->d_FORyz, g->d_FORzx,
+        g->d_MOMxx, g->d_MOMyy, g->d_MOMxy,
+        g->d_SIGY,
+        // Scalars
+        g->mat, dt, NPT, NE, ISMSTR, ITHK, ncycle_gpu, s);
+
+    // ------------------------------------------------------------------
+    //  (d) Kernel 3: Forces + Assembly
+    //      Computes hourglass forces, transforms to global, atomicAdd
+    //      to nodal force/moment arrays.
+    //  PROFILING: 19.0% GPU compute, 341ms / 28K steps, avg 12.0µs.
+    //             atomicAdd contention on shared nodes.
+    // ------------------------------------------------------------------
+    launch_shell_force_assembly_kernel(
+        // Connectivity
+        g->d_N1, g->d_N2, g->d_N3, g->d_N4,
+        // Local frame
+        g->d_E1x, g->d_E1y, g->d_E1z,
+        g->d_E2x, g->d_E2y, g->d_E2z,
+        g->d_E3x, g->d_E3y, g->d_E3z,
+        // Shape functions
+        g->d_PX1, g->d_PX2,
+        g->d_PY1, g->d_PY2,
+        g->d_AREA,
+        // Hourglass volume ratios (for non-uniform GAMA)
+        g->d_VHX, g->d_VHY,
+        // Gathered velocities
+        g->d_VL1x, g->d_VL1y, g->d_VL1z,
+        g->d_VL2x, g->d_VL2y, g->d_VL2z,
+        g->d_VL3x, g->d_VL3y, g->d_VL3z,
+        g->d_VL4x, g->d_VL4y, g->d_VL4z,
+        g->d_VRL1x, g->d_VRL1y, g->d_VRL1z,
+        g->d_VRL2x, g->d_VRL2y, g->d_VRL2z,
+        g->d_VRL3x, g->d_VRL3y, g->d_VRL3z,
+        g->d_VRL4x, g->d_VRL4y, g->d_VRL4z,
+        // Element state
+        g->d_OFF, g->d_THK0, g->d_THK02,
+        // Generalized forces/moments
+        g->d_FORxx, g->d_FORyy, g->d_FORxy,
+        g->d_FORyz, g->d_FORzx,
+        g->d_MOMxx, g->d_MOMyy, g->d_MOMxy,
+        // Hourglass state
+        g->d_HOUR,
+        // Stiffness outputs
+        g->d_STI, g->d_STIR,
+        // Material
+        g->d_SSP, g->d_RHO, g->d_YM, g->d_NU, g->d_A11, g->d_G, g->d_SHF,
+        // Internal energy
+        g->d_EINT,
+        // Global nodal arrays (atomicAdd)
+        g->d_Fx, g->d_Fy, g->d_Fz,
+        g->d_Mx, g->d_My, g->d_Mz,
+        g->d_STIFN, g->d_STIFR,
+        // Scalars
+        g->hg, dt, NPT, NE, g->compute_sti, ISMSTR, g->IHBE, s);
+
+    // Record event: this SU's kernels are done.
+    // The global stream will wait on this before D2H of forces.
+    CUDA_CHECK(cudaEventRecord(g->kernels_done, s));
+}
+
+// ===========================================================================
+//  7. SYNCHRONIZE
+//     Block CPU until all GPU work on this stream has completed.
+// ===========================================================================
+extern "C"
+void shell_gpu_synchronize(ShellGPUData* g)
+{
+    CUDA_CHECK(cudaStreamSynchronize(g->stream));
+}
+
+// ===========================================================================
+//  7b. PIN / UNPIN HOST MEMORY
+//      Page-lock the Fortran raw transfer buffers so that cudaMemcpyAsync
+//      becomes truly asynchronous instead of falling back to synchronous
+//      staging through an internal bounce buffer.
+//
+//      Must be called ONCE after the Fortran buffers are allocated and
+//      ONCE before they are deallocated.  The pointers must remain valid
+//      (not reallocated/moved) between pin and unpin.
+//
+//      Expected impact: cudaMemcpyAsync avg drops from ~47µs to ~2µs,
+//      saving ~3s of CPU API time over 28K steps and enabling true
+//      overlap of CPU gather with GPU execution in the 3-pass pipeline.
+// ===========================================================================
+extern "C"
+void shell_gpu_pin_host_memory(const ShellGPUData* g,
+                               Real* raw_cpu_to_gpu,
+                               Real* raw_gpu_to_cpu)
+{
+    const size_t s_h2d = (size_t)(9 * g->NUMNOD) * sizeof(Real);
+    const size_t s_d2h = (size_t)(8 * g->NUMNOD) * sizeof(Real);
+
+    CUDA_CHECK(cudaHostRegister(raw_cpu_to_gpu, s_h2d, cudaHostRegisterDefault));
+    CUDA_CHECK(cudaHostRegister(raw_gpu_to_cpu, s_d2h, cudaHostRegisterDefault));
+}
+
+extern "C"
+void shell_gpu_unpin_host_memory(Real* raw_cpu_to_gpu,
+                                 Real* raw_gpu_to_cpu)
+{
+    // cudaHostUnregister is safe even if the pointer was never registered
+    // (it returns cudaErrorHostMemoryNotRegistered which we ignore).
+    cudaHostUnregister(raw_cpu_to_gpu);
+    cudaHostUnregister(raw_gpu_to_cpu);
+}
+
+// ===========================================================================
+//  8. FULL TIME STEP — synchronous convenience wrapper
+//     (Prefer shell_gpu_full_step_async + deferred sync for production.)
+// ===========================================================================
+//
+//  PROFILING SUMMARY (nsys, 28440 steps, pipelined 3-pass SU loop):
+//
+//    Total CUDA API time: 4.89s  (was 14.1s before batching — 2.9x speedup)
+//
+//    cudaMemcpyAsync:    4.07s  83.3%  86,360 calls  avg 47µs
+//    cudaLaunchKernel:   0.47s   9.6%  85,320 calls  avg 5.5µs
+//    cudaMemsetAsync:    0.14s   2.8%  28,440 calls  avg 4.9µs
+//    cudaStreamSync:     0.015s  0.3%  29,296 calls  avg 0.5µs  ← was 987ms!
+//
+//    GPU compute: 1.793s  (geometry 176ms + strain 1276ms + assembly 341ms)
+//    GPU memops:  57ms    (H2D 17.5ms + D2H 23ms + memset 16.4ms)
+//
+//  PER-STEP CALL COUNT:  1 H2D + 1 memset + 3 launches + 1 D2D + 2 D2H
+//                         + 1 sync = 9 CUDA calls  (was 28, then 8)
+//
+//  KEY INSIGHT — UNPINNED MEMORY DOMINATES:
+//    cudaMemcpyAsync averages 47µs because host memory (Fortran pointer)
+//    is NOT page-locked.  The CUDA runtime falls back to internal staging
+//    through a pinned bounce buffer, making each "async" call synchronous.
+//    Over 86K calls × 47µs = 4.07s of CPU stall in the memcpy driver.
+//
+//  REMAINING BOTTLENECKS (in priority order):
+//
+//    1. PINNED HOST MEMORY (highest impact, ~3x reduction in API time).
+//       cudaHostRegister(raw_cpu_to_gpu) and cudaHostRegister(raw_gpu_to_cpu)
+//       once at init.  Turns 47µs avg memcpy into ~2µs truly-async calls.
+//       Enables real overlap of CPU gather(SU+1) with GPU compute(SU).
+//       Expected savings: ~3s of CPU API time.
+//
+//    2. Kernel 2 optimization (71.2% of GPU compute, 1.276s).
+//       Radial-return loop has high register pressure → low occupancy.
+//       Profile with ncu --set full to identify register spills.
+//
+//    3. Fortran gather/scatter loops: scalar indirect-indexed O(NUMNOD)
+//       CPU work between GPU launches.  Move to GPU or vectorize.
+//
+//    4. GPU reduction for min-timestep: eliminate the ALDT² D2H + CPU
+//       reduction loop.  Download a single scalar instead.
+//
+// ===========================================================================
+extern "C"
+void shell_gpu_full_step(ShellGPUData* g, Real dt,
+                         const Real* raw_cpu_to_gpu,
+                         Real* raw_gpu_to_cpu)
+{
+    // 1. Upload current node positions/velocities
+    //    Legacy path: raw_cpu_to_gpu is [9*NUMNOD] = X|V|VR contiguous
+    shell_gpu_upload_nodes(g,
+                           raw_cpu_to_gpu,
+                           raw_cpu_to_gpu + 3 * g->NUMNOD,
+                           raw_cpu_to_gpu + 6 * g->NUMNOD);
+
+    // 2. Run the three kernels
+    shell_gpu_run_kernels(g, dt);
+
+    // 3. Download results (single contiguous buffer)
+    shell_gpu_download_nodal_forces(g, raw_gpu_to_cpu);
+}
+
+// ===========================================================================
+//  9. ASYNC VARIANTS — for pipelined SU iteration
+//
+//     The Fortran time-step loop is split into 3 passes over SU groups:
+//
+//       Pass 1: gather nodes (CPU) + upload + run_kernels + D2H (all async)
+//       Pass 2: start async D2H of ALDT² per SU
+//       Pass 3: synchronize each SU stream, scatter forces, reduce ALDT
+//
+//     PROFILING IMPACT:
+//       cudaStreamSynchronize dropped from 987ms (3/step) to 15.5ms (1/step).
+//       The one remaining sync per SU in pass 3 finds work already completed
+//       in most cases → avg sync 0.5µs (was ~11µs pipeline-drain).
+//
+//     LIMITATION:
+//       The SU pipelining benefit is currently limited because host memory
+//       is not pinned — cudaMemcpyAsync blocks internally anyway.
+//       With cudaHostRegister, pass 1 would truly overlap CPU/GPU work.
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+//  Async full step: H2D + 3 kernels + D2H of forces, NO synchronization.
+//  The caller must call shell_gpu_synchronize() later before reading results.
+// ---------------------------------------------------------------------------
+extern "C"
+void shell_gpu_full_step_async(ShellGPUData* g, Real dt,
+                               const Real* X,
+                               const Real* V,
+                               const Real* VR,
+                               Real* raw_gpu_to_cpu)
+{
+    // With global node/force arrays:
+    //   - H2D and D2H are handled by the global handle, NOT here.
+    //   - This SU stream waits on the global upload_done event,
+    //     runs the 3 kernels, and records kernels_done.
+    //   - The caller (gpu_shell_launch_async) is responsible for
+    //     calling shell_gpu_global_upload_nodes beforehand and
+    //     shell_gpu_global_download_forces afterwards.
+
+    // 1. Wait for global node upload + force zeroing to complete
+    if (g->global) {
+        CUDA_CHECK(cudaStreamWaitEvent(g->stream, g->global->upload_done, 0));
+    } else {
+        // Fallback: per-SU upload (legacy path, should not be reached)
+        shell_gpu_upload_nodes(g, X, V, VR);
+    }
+
+    // 2. Run the three kernels (uses aliased global node/force pointers)
+    shell_gpu_run_kernels(g, dt);
+
+    // Note: shell_gpu_run_kernels already records g->kernels_done event.
+    // No D2H here — the global handle does it after all SUs complete.
+}
+
+// ---------------------------------------------------------------------------
+//  Async ALDT² download: enqueues D2H, NO synchronization.
+//  The caller must call shell_gpu_synchronize() before reading h_aldt_sq.
+// ---------------------------------------------------------------------------
+extern "C"
+void shell_gpu_download_aldt_sq_async(const ShellGPUData* g,
+                                      Real* h_aldt_sq)
+{
+    const size_t se = (size_t)g->NUMELC * sizeof(Real);
+    CUDA_CHECK(cudaMemcpyAsync(h_aldt_sq, g->d_STI, se,
+                               cudaMemcpyDeviceToHost, g->stream));
+}
+
+// ===========================================================================
+//  10. GPU MIN-DT REDUCTION
+//      Replaces the host-side pattern of:
+//        download_aldt_sq (NUMELC Reals D2H) + Fortran min-loop
+//      with:
+//        1 kernel launch (reduction) + 1 D2H of 8 bytes (single scalar)
+//
+//      d_STI[i] = ALDT² (from Kernel 1).
+//      d_SSP[i] = sound speed (uploaded once at init).
+//      d_OFF[i] = element activity flag.
+//
+//      Element timestep:  dt_elem = dtfac * sqrt(ALDT²) / SSP
+//      Result:            min over all active elements.
+//
+//      PROFILING IMPACT (expected):
+//        Eliminates 28K unpinned D2H calls (~1.2s cudaMemcpyAsync CPU time)
+//        and 28K × NUMELC host-side iterations.
+//        Replaces with 28K kernel launches (~5µs each) + 28K × 8-byte D2H.
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+//  Device helper: atomicMin for Real (CUDA does not provide one natively).
+//  Uses CAS loop on the underlying integer representation.
+// ---------------------------------------------------------------------------
+#ifdef MYREAL8
+__device__ __forceinline__
+Real atomicMin_Real(Real* addr, Real val)
+{
+    unsigned long long int* addr_ull = (unsigned long long int*)addr;
+    unsigned long long int old = *addr_ull;
+    unsigned long long int assumed;
+    do {
+        assumed = old;
+        Real old_val = __longlong_as_double(assumed);
+        if (val >= old_val) break;
+        old = atomicCAS(addr_ull, assumed, __double_as_longlong(val));
+    } while (assumed != old);
+    return __longlong_as_double(old);
+}
+#else
+__device__ __forceinline__
+Real atomicMin_Real(Real* addr, Real val)
+{
+    unsigned int* addr_ui = (unsigned int*)addr;
+    unsigned int old = *addr_ui;
+    unsigned int assumed;
+    do {
+        assumed = old;
+        Real old_val = __int_as_float(assumed);
+        if (val >= old_val) break;
+        old = atomicCAS(addr_ui, assumed, __float_as_int(val));
+    } while (assumed != old);
+    return __int_as_float(old);
+}
+#endif
+
+// ---------------------------------------------------------------------------
+//  Reduction kernel: each block reduces a tile, writes partial min
+//  via atomicMin_Real to d_result (pre-initialized to +inf by the host).
+// ---------------------------------------------------------------------------
+__global__
+void shell_min_dt_kernel(const Real* __restrict__ d_STI,
+                         const Real* __restrict__ d_SSP,
+                         const Real* __restrict__ d_OFF,
+                         Real dtfac,
+                         int    NE,
+                         Real* __restrict__ d_result)
+{
+    __shared__ Real sdata[256];  // fixed size = BLOCK (avoids ptxas bounds warning)
+
+    const int tid = threadIdx.x;
+    const int gid = blockIdx.x * blockDim.x + tid;
+
+    // Each thread computes its element's dt, or +inf if inactive / out of range
+    Real my_dt = 1.0e30;
+    if (gid < NE) {
+        Real off = d_OFF[gid];
+        if (off > 0.0) {
+            Real aldt_sq = d_STI[gid];
+            Real ssp     = d_SSP[gid];
+            if (aldt_sq > 1.0e-20 && ssp > 1.0e-20) {
+                my_dt = dtfac * sqrt(aldt_sq) / ssp;
+            }
+        }
+    }
+
+    sdata[tid] = my_dt;
+    __syncthreads();
+
+    // Tree reduction within block
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (tid < s && sdata[tid + s] < sdata[tid]) {
+            sdata[tid] = sdata[tid + s];
+        }
+        __syncthreads();
+    }
+
+    // Block leader: atomic min into global result
+    if (tid == 0) {
+        atomicMin_Real(d_result, sdata[0]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+//  Host launcher: enqueues init + kernel + D2H onto the SU stream.
+//  Caller must call shell_gpu_synchronize() before reading *h_dt_min.
+// ---------------------------------------------------------------------------
+extern "C"
+void shell_gpu_min_dt(ShellGPUData* g,
+                      Real        dtfac,
+                      Real*       h_dt_min)
+{
+    const int NE    = g->NUMELC;
+    const int BLOCK = 256;
+    const int GRID  = (NE + BLOCK - 1) / BLOCK;
+
+    // Initialize device result to +inf using memset (avoids unpinned H2D).
+    // 0x7F repeated 8 times → 0x7F7F7F7F7F7F7F7F ≈ 1.7e306 (IEEE 754),
+    // safely above any real dt_elem.  Uses cudaMemsetAsync (no host memory).
+    CUDA_CHECK(cudaMemsetAsync(g->d_dt_min, 0x7F, sizeof(Real), g->stream));
+
+    shell_min_dt_kernel<<<GRID, BLOCK, 0, g->stream>>>(g->d_STI, g->d_SSP, g->d_OFF, dtfac, NE, g->d_dt_min);
+
+    {
+        cudaError_t err = cudaPeekAtLastError();
+        if (err != cudaSuccess) {
+            fprintf(stderr, "CUDA kernel launch error (min_dt reduction): %s\n",
+                    cudaGetErrorString(err));
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    // Download single scalar (8 bytes)
+    CUDA_CHECK(cudaMemcpyAsync(h_dt_min, g->d_dt_min, sizeof(Real),
+                               cudaMemcpyDeviceToHost, g->stream));
+}

--- a/engine/source/elements/shell/coque/shell_gpu_driver.h
+++ b/engine/source/elements/shell/coque/shell_gpu_driver.h
@@ -1,0 +1,211 @@
+//Copyright>    OpenRadioss
+//Copyright>    Copyright (C) 1986-2026 Altair Engineering Inc.
+//Copyright>
+//Copyright>    This program is free software: you can redistribute it and/or modify
+//Copyright>    it under the terms of the GNU Affero General Public License as published by
+//Copyright>    the Free Software Foundation, either version 3 of the License, or
+//Copyright>    (at your option) any later version.
+//Copyright>
+//Copyright>    This program is distributed in the hope that it will be useful,
+//Copyright>    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//Copyright>    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//Copyright>    GNU Affero General Public License for more details.
+//Copyright>
+//Copyright>    You should have received a copy of the GNU Affero General Public License
+//Copyright>    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//Copyright>
+//Copyright>
+//Copyright>    Commercial Alternative: Altair Radioss Software
+//Copyright>
+//Copyright>    As an alternative to this open-source version, Altair also offers Altair Radioss
+//Copyright>    software under a commercial license.  Contact Altair to discuss further if the
+//Copyright>    commercial version may interest you: https://www.altair.com/radioss/.
+// ==============================================================================
+//  OpenRadioss GPU — Shell Element GPU Driver
+//  C-linkage header for host-side orchestration functions
+// ==============================================================================
+
+#ifndef SHELL_GPU_DRIVER_H
+#define SHELL_GPU_DRIVER_H
+
+#include "shell_gpu_data.h"
+#include "real_type.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ---------------------------------------------------------------------------
+//  Global (shared) node/force handle — one per SHELLS_ instance
+// ---------------------------------------------------------------------------
+
+// Create global handle: allocate device node/force arrays for NUMNOD nodes.
+ShellGPUGlobal* shell_gpu_global_create(int NUMNOD);
+
+// Destroy global handle: free device arrays, stream, event.
+void shell_gpu_global_destroy(ShellGPUGlobal* gh);
+
+// Upload NODES%X/V/VR (H2D) + zero force arrays + record upload_done event.
+void shell_gpu_global_upload_nodes(ShellGPUGlobal* gh,
+                                   const Real* X,
+                                   const Real* V,
+                                   const Real* VR);
+
+// Download force arrays (D2H) after all SU kernels complete.
+void shell_gpu_global_download_forces(ShellGPUGlobal* gh,
+                                      Real* raw_gpu_to_cpu);
+
+// Block CPU until global stream completes.
+void shell_gpu_global_synchronize(ShellGPUGlobal* gh);
+
+// Make SU stream wait for global upload to finish.
+void shell_gpu_global_wait_upload(ShellGPUGlobal* gh, ShellGPUData* g);
+
+// Make global stream wait for SU kernels to finish.
+void shell_gpu_global_wait_su(ShellGPUGlobal* gh, ShellGPUData* g);
+
+// Pin Fortran NODES%X/V/VR and the D2H force buffer for async memcpy.
+void shell_gpu_global_pin_host(const Real* X, const Real* V,
+                               const Real* VR, Real* raw_gpu_to_cpu,
+                               int NUMNOD);
+
+// Set back-pointer from per-SU handle to global handle (aliases pointers).
+void shell_gpu_set_global(ShellGPUData* g, ShellGPUGlobal* gh);
+
+// ---------------------------------------------------------------------------
+//  Per-SU Lifecycle
+// ---------------------------------------------------------------------------
+
+// Allocate all device arrays.  Call once during initialization.
+void shell_gpu_allocate(ShellGPUData* g,
+                        int NUMELC, int NUMNOD, int NPT,
+                        int ISMSTR, int ITHK);
+
+// Free all device arrays and destroy the CUDA stream.
+void shell_gpu_deallocate(ShellGPUData* g);
+
+// ---------------------------------------------------------------------------
+//  One-time uploads (called once after allocation)
+// ---------------------------------------------------------------------------
+
+// Upload connectivity, initial thickness, activity flags, material scalars.
+void shell_gpu_upload_constant(ShellGPUData*  g,
+                               const int*     h_N1,   const int*     h_N2,
+                               const int*     h_N3,   const int*     h_N4,
+                               const Real*  h_THK0,
+                               const Real*  h_OFF,
+                               const Real*  h_SSP,  const Real*  h_RHO,
+                               const Real*  h_YM,   const Real*  h_NU,
+                               const Real*  h_A11,  const Real*  h_G,
+                               const Real*  h_SHF);
+
+// Upload per-integration-point initial state.
+void shell_gpu_upload_ip_state(ShellGPUData*  g,
+                               const Real*  h_SIGxx,    const Real*  h_SIGyy,
+                               const Real*  h_SIGxy,    const Real*  h_SIGyz,
+                               const Real*  h_SIGzx,
+                               const Real*  h_PLA,      const Real*  h_EPSD_ip,
+                               const Real*  h_SIGBAKxx, const Real*  h_SIGBAKyy,
+                               const Real*  h_SIGBAKxy,
+                               const Real*  h_TEMPEL);
+
+// ---------------------------------------------------------------------------
+//  Per-time-step transfers
+// ---------------------------------------------------------------------------
+
+// Upload node positions + velocities (H2D, before kernel launch).
+// raw_cpu_to_gpu is a single contiguous buffer of 9*NUMNOD Reals:
+//   [Xx|Xy|Xz|Vx|Vy|Vz|VRx|VRy|VRz], each sub-array of size NUMNOD.
+void shell_gpu_upload_nodes(ShellGPUData*  g,
+                            const Real*  raw_cpu_to_gpu);
+
+// Download nodal forces, moments, stiffness (D2H, after kernel launch).
+// raw_gpu_to_cpu is a single contiguous buffer of 8*NUMNOD Reals:
+//   [Fx|Fy|Fz|Mx|My|Mz|STIFN|STIFR], each sub-array of size NUMNOD.
+void shell_gpu_download_nodal_forces(const ShellGPUData* g,
+                                     Real* raw_gpu_to_cpu);
+
+// Download element internal energy (D2H).
+void shell_gpu_download_energy(const ShellGPUData* g, Real* h_EINT);
+
+// Download full element + IP state (D2H, for output / restart).
+void shell_gpu_download_state(const ShellGPUData* g,
+                              Real* h_OFF,   Real* h_THK,
+                              Real* h_GSTR,  Real* h_EPSD_elem,
+                              Real* h_SIGxx, Real* h_SIGyy,
+                              Real* h_SIGxy, Real* h_SIGyz,
+                              Real* h_SIGzx,
+                              Real* h_PLA,   Real* h_EPSD_ip,
+                              Real* h_SIGBAKxx, Real* h_SIGBAKyy,
+                              Real* h_SIGBAKxy,
+                              Real* h_TEMPEL);
+
+// ---------------------------------------------------------------------------
+//  Kernel execution
+// ---------------------------------------------------------------------------
+
+// Set the compute_sti mode (0=skip, 1=CPXPY3+CHSTI3, 2=CDT3).
+void shell_gpu_set_compute_sti(ShellGPUData* g, int flag);
+
+// Set the IHBE (hourglass formulation) flag.
+void shell_gpu_set_ihbe(ShellGPUData* g, int ihbe);
+
+// Zero nodal force/moment/stiffness arrays (must precede each kernel run).
+void shell_gpu_zero_nodal_arrays(ShellGPUData* g);
+
+// Launch all three kernels sequentially on the device stream.
+// Does NOT upload nodes or download forces — call wrappers for that.
+void shell_gpu_run_kernels(ShellGPUData* g, Real dt);
+
+// Wait for all GPU work to complete.
+void shell_gpu_synchronize(ShellGPUData* g);
+
+// Pin (page-lock) host transfer buffers for truly async cudaMemcpyAsync.
+// Call once after Fortran allocates raw_cpu_to_gpu / raw_gpu_to_cpu.
+void shell_gpu_pin_host_memory(const ShellGPUData* g,
+                               Real* raw_cpu_to_gpu,
+                               Real* raw_gpu_to_cpu);
+
+// Unpin host buffers. Call before deallocating the Fortran arrays.
+void shell_gpu_unpin_host_memory(Real* raw_cpu_to_gpu,
+                                 Real* raw_gpu_to_cpu);
+
+// ---------------------------------------------------------------------------
+//  Convenience: one-call full time step
+//  (upload nodes → zero arrays → 3 kernels → download forces)
+// ---------------------------------------------------------------------------
+void shell_gpu_full_step(ShellGPUData* g, Real dt,
+                         const Real* raw_cpu_to_gpu,
+                         Real* raw_gpu_to_cpu);
+
+// ---------------------------------------------------------------------------
+//  Async variants — for pipelined SU iteration (no synchronization)
+// ---------------------------------------------------------------------------
+
+// Async full step: H2D + 3 kernels + D2H enqueued, caller must sync later.
+void shell_gpu_full_step_async(ShellGPUData* g, Real dt,
+                               const Real* X,
+                               const Real* V,
+                               const Real* VR,
+                               Real* raw_gpu_to_cpu);
+
+// Async ALDT² download: D2H enqueued, caller must sync before reading.
+void shell_gpu_download_aldt_sq_async(const ShellGPUData* g,
+                                      Real* h_aldt_sq);
+
+// Download per-element ALDT² (synchronous — kept for backward compat).
+void shell_gpu_download_aldt_sq(const ShellGPUData* g, Real* h_aldt_sq);
+
+// Compute min element timestep on GPU via reduction kernel.
+// Result = min over active elements of: dtfac * sqrt(d_STI[i]) / d_SSP[i].
+// Downloads a single scalar (8 bytes) instead of NUMELC Reals.
+// The result is available after shell_gpu_synchronize().
+void shell_gpu_min_dt(ShellGPUData* g,
+                      Real dtfac,
+                      Real* h_dt_min);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SHELL_GPU_DRIVER_H

--- a/engine/source/elements/shell/coque/shell_gpu_mod.F90
+++ b/engine/source/elements/shell/coque/shell_gpu_mod.F90
@@ -1,0 +1,928 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 1986-2026 Altair Engineering Inc.
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Altair Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+!Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+!Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+      module shell_gpu_mod
+! ======================================================================================================================
+!! \brief  Fortran interfaces for the CUDA shell element GPU driver
+!! \details
+!!   This module provides ISO_C_BINDING interfaces to the C functions
+!!   defined in shell_gpu_driver.cu.  The GPU handle (ShellGPUData) is
+!!   treated as an opaque C pointer (type(c_ptr)).
+!!
+!!   LIFECYCLE — full calling sequence from Fortran:
+!!
+!!   1. INITIALISATION (once)
+!!      gpu_handle = shell_gpu_data_create()          ! allocate C struct on host heap
+!!      call shell_gpu_allocate(gpu_handle, ...)       ! allocate all device arrays
+!!      call shell_gpu_set_mat_params(gpu_handle, ...) ! set Johnson-Cook material params
+!!      call shell_gpu_set_hg_params(gpu_handle, ...)  ! set hourglass params
+!!      call shell_gpu_upload_constant(gpu_handle, ..) ! H2D: connectivity, thickness, per-elem scalars
+!!      call shell_gpu_upload_ip_state(gpu_handle, ..) ! H2D: initial stress / strain state
+!!
+!!   2. TIME STEPPING (each cycle)
+!!      call shell_gpu_full_step(gpu_handle, dt, &
+!!                               Xx, Xy, Xz, Vx, Vy, Vz, VRx, VRy, VRz, &
+!!                               Fx, Fy, Fz, Mx, My, Mz, STIFN, STIFR)
+!!
+!!      Or equivalently, the three sub-steps:
+!!        call shell_gpu_upload_nodes(gpu_handle, Xx, ...)
+!!        call shell_gpu_run_kernels(gpu_handle, dt)
+!!        call shell_gpu_download_nodal_forces(gpu_handle, Fx, ...)
+!!
+!!   3. OUTPUT / RESTART (as needed)
+!!      call shell_gpu_download_energy(gpu_handle, EINT)
+!!      call shell_gpu_download_state(gpu_handle,  ...)
+!!
+!!   4. CLEANUP (once)
+!!      call shell_gpu_deallocate(gpu_handle)          ! free device arrays
+!!      call shell_gpu_data_destroy(gpu_handle)        ! free the C struct itself
+!!
+!!   IMPORTANT NOTES:
+!!   - gpu_handle is NOT populated by shell_gpu_full_step. It must be
+!!     fully initialised (steps 1a–1f) before the first time-step call.
+!!   - shell_gpu_full_step only uploads node positions / velocities,
+!!     runs the 3 kernels, and downloads the resulting nodal forces.
+!!   - All host arrays passed to these routines must be contiguous.
+!!   - The GPU code always operates in double precision regardless of
+!!     the build precision setting (WP).
+! ======================================================================================================================
+
+        use, intrinsic :: iso_c_binding, only : c_ptr , c_null_ptr ,  c_int
+        use precision_mod, only : WP
+        implicit none
+
+
+        ! GPU_SHELL(COLOUR)%LAW2(GROUP) is a convenient Fortran-side mirror of the GPU data, used for
+        type GPU_SHELL_LAW2
+          ! sizes
+          integer(c_int) :: numelc    !< Number of 4-node shell elements
+          integer(c_int) :: numnod    !< Number of nodes
+          integer(c_int) :: npt       !< Through-thickness integration points
+          integer(c_int) :: ismstr    !< Small-strain flag (1, 2, or 11)
+          integer(c_int) :: ithk      !< Thickness update flag (>0 enables)
+          integer(c_int) :: ihbe      !< Hourglass formulation flag (>=1: non-uniform GAMA)
+          ! mapping arrays
+          integer(c_int), dimension(:), allocatable :: glob_2_gpu !< Maps global node ID to GPU node index
+          integer(c_int), dimension(:), allocatable :: gpu_2_glob !< Maps GPU node index to global node ID
+          type(c_ptr) :: handle = c_null_ptr
+
+          integer(c_int), dimension(:), allocatable  :: n1     !< Connectivity node 1 [NUMELC]
+          integer(c_int), dimension(:), allocatable  :: n2     !< Connectivity node 2 [NUMELC]
+          integer(c_int), dimension(:), allocatable  :: n3     !< Connectivity node 3 [NUMELC]
+          integer(c_int), dimension(:), allocatable  :: n4     !< Connectivity node 4 [NUMELC]
+          integer(c_int), dimension(:), allocatable  :: ngl    !< Global element ID [NUMELC]
+          integer(c_int), dimension(:), allocatable  :: part_id !< Part ID for each element [NUMELC]
+
+          ! Host to Device: node data [NUMNOD]
+          real(WP), dimension(:), pointer :: raw_cpu_to_gpu => null()
+          ! These are pointers into a single contiguous buffer for optimized GPU transfers
+          real(WP), dimension(:), pointer :: xx  => null() !< Node X coordinates
+          real(WP), dimension(:), pointer :: xy  => null() !< Node Y coordinates
+          real(WP), dimension(:), pointer :: xz  => null() !< Node Z coordinates
+          real(WP), dimension(:), pointer :: vx  => null() !< Translational velocity X
+          real(WP), dimension(:), pointer :: vy  => null() !< Translational velocity Y
+          real(WP), dimension(:), pointer :: vz  => null() !< Translational velocity Z
+          real(WP), dimension(:), pointer :: vrx => null() !< Rotational velocity X
+          real(WP), dimension(:), pointer :: vry => null() !< Rotational velocity Y
+          real(WP), dimension(:), pointer :: vrz => null() !< Rotational velocity Z
+          ! Device to Host: nodal results [NUMNOD]
+          real(WP), dimension(:), pointer :: raw_gpu_to_cpu => null()
+          real(WP), dimension(:), pointer :: fx    => null() !< Nodal force X
+          real(WP), dimension(:), pointer :: fy    => null() !< Nodal force Y
+          real(WP), dimension(:), pointer :: fz    => null() !< Nodal force Z
+          real(WP), dimension(:), pointer :: mx    => null() !< Nodal moment X
+          real(WP), dimension(:), pointer :: my    => null() !< Nodal moment Y
+          real(WP), dimension(:), pointer :: mz    => null() !< Nodal moment Z
+          real(WP), dimension(:), pointer :: stifn => null() !< Nodal translational stiffness
+          real(WP), dimension(:), pointer :: stifr => null() !< Nodal rotational stiffness
+          ! Temporary per-element ALDT² buffer for async download (legacy)
+          real(WP), dimension(:), allocatable :: aldt_sq
+          ! Result scalar for GPU min-dt reduction (written by shell_gpu_min_dt)
+          real(WP) :: dt_min_result = 0.0d0
+          ! IP state arrays [NPT*NUMELC]
+          real(WP), dimension(:), allocatable :: sigxx    !< Stress xx
+          real(WP), dimension(:), allocatable :: sigyy    !< Stress yy
+          real(WP), dimension(:), allocatable :: sigxy    !< Stress xy
+          real(WP), dimension(:), allocatable :: sigyz    !< Stress yz
+          real(WP), dimension(:), allocatable :: sigzx    !< Stress zx
+          real(WP), dimension(:), allocatable :: pla      !< Plastic strain
+          real(WP), dimension(:), allocatable :: epsd_ip  !< Strain rate
+          real(WP), dimension(:), allocatable :: sigbakxx !< Back-stress xx
+          real(WP), dimension(:), allocatable :: sigbakyy !< Back-stress yy
+          real(WP), dimension(:), allocatable :: sigbakxy !< Back-stress xy
+          real(WP), dimension(:), allocatable :: tempel    !< Temperature
+          real(WP), dimension(:), allocatable :: eint      !< Internal energy
+
+          ! Material parameters (stored by value in the handle)
+          real(WP) :: e_young   !< Young's modulus
+          real(WP) :: nu        !< Poisson's ratio
+          real(WP) :: g_shear   !< Shear modulus
+          real(WP) :: a11       !< Plane-stress stiffness E/(1-nu^2)
+          real(WP) :: a12       !< Coupling  nu * A11
+          real(WP) :: ca        !< J-C param A (initial yield)
+          real(WP) :: cb        !< J-C param B (hardening modulus)
+          real(WP) :: cn        !< J-C param n (hardening exponent)
+          real(WP) :: cc        !< J-C param C (strain-rate sensitivity)
+          real(WP) :: epdr      !< Reference strain rate
+          real(WP) :: epmx      !< Max plastic strain for rupture
+          real(WP) :: ymax      !< Yield stress cap
+          real(WP) :: m_exp     !< Thermal exponent m
+          real(WP) :: fisokin   !< Isotropic/kinematic ratio
+          real(WP) :: rhocp     !< rho * Cp (adiabatic heating)
+          real(WP) :: tref      !< Reference temperature
+          real(WP) :: tmelt     !< Melting temperature
+          real(WP) :: asrate    !< Strain-rate filter coefficient
+          real(WP) :: rho       !< Density
+          real(WP) :: ssp       !< Sound speed
+          real(WP) :: shf_coef  !< Shear correction factor
+          integer(c_int) :: ipla      !< Plasticity algorithm (0, 1, or 2)
+          integer(c_int) :: vp        !< Strain-rate type
+          integer(c_int) :: iform     !< 0=Johnson-Cook, 1=Zerilli-Armstrong
+          integer(c_int) :: icc       !< Cowper-Symonds flag
+          real(WP) :: z3        !< Zerilli-Armstrong param
+          real(WP) :: z4        !< Zerilli-Armstrong param
+
+          real(WP) :: h1    !< Membrane hourglass coeff
+          real(WP) :: h2    !< Bending hourglass coeff
+          real(WP) :: h3    !< Rotational hourglass coeff
+          real(WP) :: srh1  !< sqrt scale for h1
+          real(WP) :: srh2  !< sqrt scale for h2
+          real(WP) :: srh3  !< sqrt scale for h3
+          real(WP) :: dtfac !< Timestep scale factor DTFAC1(3)
+
+          real(WP), dimension(:), allocatable   :: el_thk0   !< Initial thickness [NUMELC]
+          real(WP), dimension(:), allocatable   :: el_off   !< Element activity [NUMELC]
+          real(WP), dimension(:), allocatable   :: el_ssp    !< Sound speed [NUMELC]
+          real(WP), dimension(:), allocatable   :: el_rho    !< Density [NUMELC]
+          real(WP), dimension(:), allocatable   :: el_ym    !< Young's modulus [NUMELC]
+          real(WP), dimension(:), allocatable   :: el_nu     !< Poisson's ratio [NUMELC]
+          real(WP), dimension(:), allocatable   :: el_a11    !< Plane-stress stiffness [NUMELC]
+          real(WP), dimension(:), allocatable   :: el_g_shear !< Shear modulus [NUMELC]
+          real(WP), dimension(:), allocatable   :: el_shf    !< Shear correction factor [NUMELC]
+
+
+
+        end type GPU_SHELL_LAW2
+
+        ! SHELLS(COLOUR)%LAW2(SUPER_GROUP) is a convenient Fortran-side mirror of the GPU data, used for
+        type SHELLS_
+          !type(GPU_SHELL_LAW1), dimension(:), allocatable :: law1 !< Array of LAW structs, one per color
+          type(GPU_SHELL_LAW2), dimension(:), allocatable :: law2 !
+          !type(GPU_SHELL_LAW3), dimension(:), allocatable :: law3 !< Future expansion for additional material models
+          !...
+          !type(GPU_SHELL_LAW132), dimension(:), allocatable :: law132 !< Future expansion for additional material models
+          ! GPU element dt should reduce DT2T only when the CPU CDT3 would
+          ! do the same: NODADT=0 AND IDTMIN3/=0 (compute_sti==2).
+          ! With NODADT/=0 the timestep is controlled by DTNODA from STIFN,
+          ! not by element-level dt.
+          logical :: reduce_elem_dt = .false.
+          ! Global (shared) node/force handle — one per SHELLS_ instance
+          type(c_ptr) :: global_handle = c_null_ptr
+          ! Host-side D2H force buffer [8*NUMNOD_GLOBAL] — pinned memory
+          real(WP), dimension(:), allocatable :: raw_gpu_to_cpu_global
+          ! Global node count for the shared arrays
+          integer(c_int) :: numnod_global = 0
+        end type SHELLS_
+
+
+
+        private
+        ! Derived types
+        public :: GPU_SHELL_LAW2
+        public :: SHELLS_
+        ! Opaque handle
+        public :: c_ptr
+
+        ! Lifecycle
+        public :: shell_gpu_data_create
+        public :: shell_gpu_data_destroy
+        public :: shell_gpu_allocate
+        public :: shell_gpu_deallocate
+
+        ! Parameter setters
+        public :: shell_gpu_set_mat_params
+        public :: shell_gpu_set_hg_params
+        public :: shell_gpu_set_compute_sti
+        public :: shell_gpu_set_ihbe
+
+        ! Data transfers
+        public :: shell_gpu_upload_constant
+        public :: shell_gpu_upload_ip_state
+        public :: shell_gpu_upload_nodes
+        public :: shell_gpu_download_nodal_forces
+        public :: shell_gpu_download_energy
+        public :: shell_gpu_download_aldt_sq
+        public :: shell_gpu_download_state
+
+        ! Kernel execution
+        public :: shell_gpu_run_kernels
+        public :: shell_gpu_zero_nodal_arrays
+        public :: shell_gpu_synchronize
+        public :: shell_gpu_pin_host_memory
+        public :: shell_gpu_unpin_host_memory
+
+        ! Convenience wrapper
+        public :: shell_gpu_full_step
+
+        ! Async variants for pipelined SU iteration
+        public :: shell_gpu_full_step_async
+        public :: shell_gpu_download_aldt_sq_async
+
+        ! GPU min-dt reduction (replaces ALDT download + host loop)
+        public :: shell_gpu_min_dt
+
+        ! Global (shared) node/force handle
+        public :: shell_gpu_global_create
+        public :: shell_gpu_global_destroy
+        public :: shell_gpu_global_upload_nodes
+        public :: shell_gpu_global_download_forces
+        public :: shell_gpu_global_synchronize
+        public :: shell_gpu_global_wait_upload
+        public :: shell_gpu_global_wait_su
+        public :: shell_gpu_global_pin_host
+        public :: shell_gpu_set_global
+
+#ifdef WITH_CUDA
+        ! ======================================================================================================================
+        !                                                   INTERFACES
+        ! ======================================================================================================================
+
+        interface
+
+          ! ----------------------------------------------------------------------------------------------------------------------
+          !  0. Handle creation / destruction
+          ! ----------------------------------------------------------------------------------------------------------------------
+
+          !! \brief Allocate a ShellGPUData structure on the host heap.
+          !! \return Opaque C pointer to the newly allocated handle (all fields zeroed).
+          function shell_gpu_data_create() result(g) bind(c, name='shell_gpu_data_create')
+            import :: c_ptr
+            type(c_ptr) :: g
+          end function shell_gpu_data_create
+
+          !! \brief Free the host-side ShellGPUData structure.
+          !!        Must be called AFTER shell_gpu_deallocate.
+          subroutine shell_gpu_data_destroy(g) bind(c, name='shell_gpu_data_destroy')
+            import :: c_ptr
+            type(c_ptr), value, intent(in) :: g
+          end subroutine shell_gpu_data_destroy
+
+          ! ----------------------------------------------------------------------------------------------------------------------
+          !  1. Device memory allocation / deallocation
+          ! ----------------------------------------------------------------------------------------------------------------------
+
+          !! \brief Allocate all device arrays and create the CUDA stream.
+          !! \details This sets mesh dimensions in the handle and allocates
+          !!          device memory for nodes, elements, and integration points.
+          subroutine shell_gpu_allocate(g, numelc, numnod, npt, ismstr, ithk) &
+            bind(c, name='shell_gpu_allocate')
+            import :: c_ptr , c_int
+            type(c_ptr),       value, intent(in) :: g         !< GPU handle
+            integer(c_int),    value, intent(in) :: numelc    !< Number of 4-node shell elements
+            integer(c_int),    value, intent(in) :: numnod    !< Number of nodes
+            integer(c_int),    value, intent(in) :: npt       !< Through-thickness integration points
+            integer(c_int),    value, intent(in) :: ismstr    !< Small-strain flag (1, 2, or 11)
+            integer(c_int),    value, intent(in) :: ithk      !< Thickness update flag (>0 enables)
+          end subroutine shell_gpu_allocate
+
+          !! \brief Free all device arrays and destroy the CUDA stream.
+          subroutine shell_gpu_deallocate(g) bind(c, name='shell_gpu_deallocate')
+            import :: c_ptr
+            type(c_ptr), value, intent(in) :: g
+          end subroutine shell_gpu_deallocate
+
+          ! ----------------------------------------------------------------------------------------------------------------------
+          !  2. Material and hourglass parameter setters
+          ! ----------------------------------------------------------------------------------------------------------------------
+
+          !! \brief Set Johnson-Cook material parameters on the GPU handle.
+          !! \details These are stored by value in the handle and passed to
+          !!          kernel 2 (strain + material law) at each time step.
+          subroutine shell_gpu_set_mat_params(g, &
+            e_young, nu, g_shear, a11, a12, &
+            ca, cb, cn, cc, epdr, epmx, ymax, m_exp, &
+            fisokin, rhocp, tref, tmelt, asrate, &
+            rho, ssp, shf_coef, &
+            ipla, vp, iform, icc, &
+            z3, z4) &
+            bind(c, name='shell_gpu_set_mat_params')
+            import :: c_ptr , c_int , WP
+            type(c_ptr),       value, intent(in) :: g
+            real(WP),    value, intent(in) :: e_young   !< Young's modulus
+            real(WP),    value, intent(in) :: nu        !< Poisson's ratio
+            real(WP),    value, intent(in) :: g_shear   !< Shear modulus
+            real(WP),    value, intent(in) :: a11       !< Plane-stress stiffness E/(1-nu^2)
+            real(WP),    value, intent(in) :: a12       !< Coupling  nu * A11
+            real(WP),    value, intent(in) :: ca        !< J-C param A (initial yield)
+            real(WP),    value, intent(in) :: cb        !< J-C param B (hardening modulus)
+            real(WP),    value, intent(in) :: cn        !< J-C param n (hardening exponent)
+            real(WP),    value, intent(in) :: cc        !< J-C param C (strain-rate sensitivity)
+            real(WP),    value, intent(in) :: epdr      !< Reference strain rate
+            real(WP),    value, intent(in) :: epmx      !< Max plastic strain for rupture
+            real(WP),    value, intent(in) :: ymax      !< Yield stress cap
+            real(WP),    value, intent(in) :: m_exp     !< Thermal exponent m
+            real(WP),    value, intent(in) :: fisokin   !< Isotropic/kinematic ratio
+            real(WP),    value, intent(in) :: rhocp     !< rho * Cp (adiabatic heating)
+            real(WP),    value, intent(in) :: tref      !< Reference temperature
+            real(WP),    value, intent(in) :: tmelt     !< Melting temperature
+            real(WP),    value, intent(in) :: asrate    !< Strain-rate filter coefficient
+            real(WP),    value, intent(in) :: rho       !< Density
+            real(WP),    value, intent(in) :: ssp       !< Sound speed
+            real(WP),    value, intent(in) :: shf_coef  !< Shear correction factor
+            integer(c_int),    value, intent(in) :: ipla      !< Plasticity algorithm (0, 1, or 2)
+            integer(c_int),    value, intent(in) :: vp        !< Strain-rate type
+            integer(c_int),    value, intent(in) :: iform     !< 0=Johnson-Cook, 1=Zerilli-Armstrong
+            integer(c_int),    value, intent(in) :: icc       !< Cowper-Symonds flag
+            real(WP),    value, intent(in) :: z3        !< Zerilli-Armstrong param
+            real(WP),    value, intent(in) :: z4        !< Zerilli-Armstrong param
+          end subroutine shell_gpu_set_mat_params
+
+          !! \brief Set hourglass parameters on the GPU handle.
+          !! \details These are stored by value and passed to kernel 3
+          !!          (force + assembly) at each time step.
+          subroutine shell_gpu_set_hg_params(g, h1, h2, h3, srh1, srh2, srh3, &
+            hvisc_in, helas_in, hvlin_in) &
+            bind(c, name='shell_gpu_set_hg_params')
+            import :: c_ptr , WP
+            type(c_ptr),       value, intent(in) :: g
+            real(WP),    value, intent(in) :: h1    !< Membrane hourglass coeff
+            real(WP),    value, intent(in) :: h2    !< Bending hourglass coeff
+            real(WP),    value, intent(in) :: h3    !< Rotational hourglass coeff
+            real(WP),    value, intent(in) :: srh1  !< sqrt scale for h1
+            real(WP),    value, intent(in) :: srh2  !< sqrt scale for h2
+            real(WP),    value, intent(in) :: srh3  !< sqrt scale for h3
+            real(WP),    value, intent(in) :: hvisc_in !< viscous hg scaling (common SCR06R)
+            real(WP),    value, intent(in) :: helas_in !< elastic hg scaling (common SCR06R)
+            real(WP),    value, intent(in) :: hvlin_in !< linear  hg scaling (common SCR06R)
+          end subroutine shell_gpu_set_hg_params
+
+          !! \brief Set compute_sti flag: 1 = compute element stiffness for
+          !!        STIFN (NODADT/=0), 0 = skip (matches CPU NODADT=0 behavior)
+          subroutine shell_gpu_set_compute_sti(g, flag) &
+            bind(c, name='shell_gpu_set_compute_sti')
+            import :: c_ptr , c_int
+            type(c_ptr),       value, intent(in) :: g
+            integer(c_int),    value, intent(in) :: flag  !< 0=skip, 1=compute
+          end subroutine shell_gpu_set_compute_sti
+
+          !! \brief Set IHBE flag: hourglass formulation (>=1 needs non-uniform GAMA)
+          subroutine shell_gpu_set_ihbe(g, ihbe) &
+            bind(c, name='shell_gpu_set_ihbe')
+            import :: c_ptr , c_int
+            type(c_ptr),       value, intent(in) :: g
+            integer(c_int),    value, intent(in) :: ihbe
+          end subroutine shell_gpu_set_ihbe
+
+          ! ----------------------------------------------------------------------------------------------------------------------
+          !  3. Host to Device transfers
+          ! ----------------------------------------------------------------------------------------------------------------------
+
+          !! \brief Upload constant (one-time) data: connectivity, thickness,
+          !!        element activity, per-element material scalars.
+          subroutine shell_gpu_upload_constant(g, &
+            h_n1, h_n2, h_n3, h_n4, &
+            h_thk0, h_off, &
+            h_ssp, h_rho, h_ym, h_nu, h_a11, h_g_shear, h_shf) &
+            bind(c, name='shell_gpu_upload_constant')
+            import :: c_ptr , c_int , WP
+            type(c_ptr),       value, intent(in) :: g
+            integer(c_int),    intent(in)        :: h_n1(*)     !< Connectivity node 1 [NUMELC]
+            integer(c_int),    intent(in)        :: h_n2(*)     !< Connectivity node 2 [NUMELC]
+            integer(c_int),    intent(in)        :: h_n3(*)     !< Connectivity node 3 [NUMELC]
+            integer(c_int),    intent(in)        :: h_n4(*)     !< Connectivity node 4 [NUMELC]
+            real(WP),    intent(in)        :: h_thk0(*)   !< Initial thickness [NUMELC]
+            real(WP),    intent(in)        :: h_off(*)    !< Element activity [NUMELC]
+            real(WP),    intent(in)        :: h_ssp(*)    !< Sound speed [NUMELC]
+            real(WP),    intent(in)        :: h_rho(*)    !< Density [NUMELC]
+            real(WP),    intent(in)        :: h_ym(*)     !< Young's modulus [NUMELC]
+            real(WP),    intent(in)        :: h_nu(*)     !< Poisson's ratio [NUMELC]
+            real(WP),    intent(in)        :: h_a11(*)    !< Plane-stress stiffness [NUMELC]
+            real(WP),    intent(in)        :: h_g_shear(*) !< Shear modulus [NUMELC]
+            real(WP),    intent(in)        :: h_shf(*)    !< Shear correction factor [NUMELC]
+          end subroutine shell_gpu_upload_constant
+
+          !! \brief Upload per-integration-point initial state (called once).
+          subroutine shell_gpu_upload_ip_state(g, &
+            h_sigxx, h_sigyy, h_sigxy, h_sigyz, h_sigzx, &
+            h_pla, h_epsd_ip, &
+            h_sigbakxx, h_sigbakyy, h_sigbakxy, &
+            h_tempel) &
+            bind(c, name='shell_gpu_upload_ip_state')
+            import :: c_ptr , WP
+            type(c_ptr),       value, intent(in) :: g
+            real(WP),    intent(in)        :: h_sigxx(*)    !< Stress xx [NPT*NUMELC]
+            real(WP),    intent(in)        :: h_sigyy(*)    !< Stress yy
+            real(WP),    intent(in)        :: h_sigxy(*)    !< Stress xy
+            real(WP),    intent(in)        :: h_sigyz(*)    !< Stress yz
+            real(WP),    intent(in)        :: h_sigzx(*)    !< Stress zx
+            real(WP),    intent(in)        :: h_pla(*)      !< Plastic strain
+            real(WP),    intent(in)        :: h_epsd_ip(*)  !< Strain rate
+            real(WP),    intent(in)        :: h_sigbakxx(*) !< Back-stress xx
+            real(WP),    intent(in)        :: h_sigbakyy(*) !< Back-stress yy
+            real(WP),    intent(in)        :: h_sigbakxy(*) !< Back-stress xy
+            real(WP),    intent(in)        :: h_tempel(*)   !< Temperature
+          end subroutine shell_gpu_upload_ip_state
+
+          !! \brief Upload node positions and velocities (called each time step).
+          subroutine shell_gpu_upload_nodes(g, raw_cpu_to_gpu) &
+            bind(c, name='shell_gpu_upload_nodes')
+            import :: c_ptr , WP
+            type(c_ptr),       value, intent(in) :: g
+            real(WP),    intent(in)        :: raw_cpu_to_gpu(*)  !< Node X coords [NUMNOD]
+          end subroutine shell_gpu_upload_nodes
+
+          ! ----------------------------------------------------------------------------------------------------------------------
+          !  4. Device to Host transfers
+          ! ----------------------------------------------------------------------------------------------------------------------
+
+          !! \brief Download nodal forces, moments and stiffness (each time step).
+          subroutine shell_gpu_download_nodal_forces(g, raw_gpu_to_cpu) &
+            bind(c, name='shell_gpu_download_nodal_forces')
+            import :: c_ptr , WP
+            type(c_ptr),       value, intent(in) :: g
+            real(WP),    intent(inout)     :: raw_gpu_to_cpu(*)    !< Nodal force X [NUMNOD]
+          end subroutine shell_gpu_download_nodal_forces
+
+          !! \brief Download element internal energy (for output / energy balance).
+          subroutine shell_gpu_download_energy(g, h_eint) &
+            bind(c, name='shell_gpu_download_energy')
+            import :: c_ptr , WP
+            type(c_ptr),       value, intent(in) :: g
+            real(WP),    intent(inout)     :: h_eint(*) !< Internal energy [NUMELC*2]
+          end subroutine shell_gpu_download_energy
+
+          !! \brief Download per-element ALDT² (characteristic length squared).
+          !! \details Kernel 1 stores ALDT² in d_STI[]; Kernel 3 only reads it.
+          !!          Used by host-side element timestep so it uses frozen-reference
+          !!          geometry (ISMSTR=1/2) instead of recomputing from current coords.
+          subroutine shell_gpu_download_aldt_sq(g, h_aldt_sq) &
+            bind(c, name='shell_gpu_download_aldt_sq')
+            import :: c_ptr , WP
+            type(c_ptr),       value, intent(in) :: g
+            real(WP),    intent(inout)     :: h_aldt_sq(*) !< ALDT² per element [NUMELC]
+          end subroutine shell_gpu_download_aldt_sq
+
+          !! \brief Download full element + integration-point state (output/restart).
+          subroutine shell_gpu_download_state(g, &
+            h_off, h_thk, h_gstr, h_epsd_elem, &
+            h_sigxx, h_sigyy, h_sigxy, h_sigyz, h_sigzx, &
+            h_pla, h_epsd_ip, &
+            h_sigbakxx, h_sigbakyy, h_sigbakxy, &
+            h_tempel) &
+            bind(c, name='shell_gpu_download_state')
+            import :: c_ptr , WP
+            type(c_ptr),       value, intent(in) :: g
+            real(WP),    intent(inout)     :: h_off(*)       !< Element activity [NUMELC]
+            real(WP),    intent(inout)     :: h_thk(*)       !< Current thickness [NUMELC]
+            real(WP),    intent(inout)     :: h_gstr(*)      !< Global strains [NUMELC*8]
+            real(WP),    intent(inout)     :: h_epsd_elem(*) !< Element strain rate [NUMELC]
+            real(WP),    intent(inout)     :: h_sigxx(*)     !< Stress xx [NPT*NUMELC]
+            real(WP),    intent(inout)     :: h_sigyy(*)
+            real(WP),    intent(inout)     :: h_sigxy(*)
+            real(WP),    intent(inout)     :: h_sigyz(*)
+            real(WP),    intent(inout)     :: h_sigzx(*)
+            real(WP),    intent(inout)     :: h_pla(*)
+            real(WP),    intent(inout)     :: h_epsd_ip(*)
+            real(WP),    intent(inout)     :: h_sigbakxx(*)
+            real(WP),    intent(inout)     :: h_sigbakyy(*)
+            real(WP),    intent(inout)     :: h_sigbakxy(*)
+            real(WP),    intent(inout)     :: h_tempel(*)
+          end subroutine shell_gpu_download_state
+
+          ! ----------------------------------------------------------------------------------------------------------------------
+          !  5. Kernel execution
+          ! ----------------------------------------------------------------------------------------------------------------------
+
+          !! \brief Zero the nodal force/moment/stiffness arrays on device.
+          subroutine shell_gpu_zero_nodal_arrays(g) &
+            bind(c, name='shell_gpu_zero_nodal_arrays')
+            import :: c_ptr
+            type(c_ptr), value, intent(in) :: g
+          end subroutine shell_gpu_zero_nodal_arrays
+
+          !! \brief Run all three GPU kernels for one time step.
+          !! \details Sequence: zero nodal arrays, geometry, strain+material,
+          !!          force+assembly.  The handle g must be fully initialised.
+          subroutine shell_gpu_run_kernels(g, dt) &
+            bind(c, name='shell_gpu_run_kernels')
+            import :: c_ptr , WP
+            type(c_ptr),       value, intent(in) :: g
+            real(WP),    value, intent(in) :: dt   !< Current time step
+          end subroutine shell_gpu_run_kernels
+
+          !! \brief Block the CPU until all GPU work on this handle's stream completes.
+          subroutine shell_gpu_synchronize(g) &
+            bind(c, name='shell_gpu_synchronize')
+            import :: c_ptr
+            type(c_ptr), value, intent(in) :: g
+          end subroutine shell_gpu_synchronize
+
+          ! ----------------------------------------------------------------------------------------------------------------------
+          !  6. Convenience wrapper — full time step in one call
+          ! ----------------------------------------------------------------------------------------------------------------------
+
+          !! \brief Perform a complete GPU shell time step:
+          !!        upload nodes → run 3 kernels → download forces.
+          !! \details The GPU handle (g) must have been fully initialised before the
+          !!          first call:
+          !!          - shell_gpu_data_create
+          !!          - shell_gpu_allocate
+          !!          - shell_gpu_set_mat_params / shell_gpu_set_hg_params
+          !!          - shell_gpu_upload_constant / shell_gpu_upload_ip_state
+          !!
+          !!          This routine only transfers the per-step node data (positions
+          !!          and velocities) to the device, executes the three kernels, and
+          !!          copies the resulting nodal forces / moments / stiffness back.
+          !!
+          !!          raw_cpu_to_gpu is [9*NUMNOD]: Xx|Xy|Xz|Vx|Vy|Vz|VRx|VRy|VRz
+          !!          raw_gpu_to_cpu is [8*NUMNOD]: Fx|Fy|Fz|Mx|My|Mz|STIFN|STIFR
+          subroutine shell_gpu_full_step(g, dt, &
+            raw_cpu_to_gpu, raw_gpu_to_cpu) &
+            bind(c, name='shell_gpu_full_step')
+            import :: c_ptr , WP
+            type(c_ptr),       value, intent(in) :: g
+            real(WP),    value, intent(in) :: dt             !< Current time step
+            real(WP),    intent(in)        :: raw_cpu_to_gpu(*) !< H2D: 9*NUMNOD contiguous
+            real(WP),    intent(inout)     :: raw_gpu_to_cpu(*) !< D2H: 8*NUMNOD contiguous
+          end subroutine shell_gpu_full_step
+
+          ! --------------------------------------------------------------------------------------------------------------------
+          !  9. Async variants for pipelined SU iteration
+          ! --------------------------------------------------------------------------------------------------------------------
+
+          !! \brief Pin (page-lock) the Fortran host transfer buffers.
+          !! \details Enables truly asynchronous cudaMemcpyAsync. Call once
+          !!          after allocating raw_cpu_to_gpu and raw_gpu_to_cpu.
+          subroutine shell_gpu_pin_host_memory(g, raw_cpu_to_gpu, raw_gpu_to_cpu) &
+            bind(c, name='shell_gpu_pin_host_memory')
+            import :: c_ptr , WP
+            type(c_ptr),       value, intent(in) :: g
+            real(WP),    intent(in)        :: raw_cpu_to_gpu(*)
+            real(WP),    intent(in)        :: raw_gpu_to_cpu(*)
+          end subroutine shell_gpu_pin_host_memory
+
+          !! \brief Unpin host transfer buffers. Call before deallocation.
+          subroutine shell_gpu_unpin_host_memory(raw_cpu_to_gpu, raw_gpu_to_cpu) &
+            bind(c, name='shell_gpu_unpin_host_memory')
+            import :: WP
+            real(WP),    intent(in)        :: raw_cpu_to_gpu(*)
+            real(WP),    intent(in)        :: raw_gpu_to_cpu(*)
+          end subroutine shell_gpu_unpin_host_memory
+
+          ! --------------------------------------------------------------------------------------------------------------------
+
+          !! \brief Async full step: H2D + 3 kernels + D2H enqueued, NO sync.
+          !! \details The caller must call shell_gpu_synchronize(handle) before
+          !!          reading the force/moment/stiffness arrays.
+          subroutine shell_gpu_full_step_async(g, dt, X, V, VR, raw_gpu_to_cpu) &
+            bind(c, name='shell_gpu_full_step_async')
+            import :: c_ptr , WP
+            type(c_ptr),       value, intent(in) :: g
+            real(WP),    value, intent(in) :: dt             !< Current time step
+            real(WP),    intent(in)        :: X(3,*), V(3,*), VR(3,*) !< H2D: 9*NUMNOD contiguous
+            real(WP),    intent(inout)     :: raw_gpu_to_cpu(*) !< D2H: 8*NUMNOD contiguous
+          end subroutine shell_gpu_full_step_async
+
+          !! \brief Async ALDT² download: D2H enqueued, NO sync.
+          !! \details The caller must call shell_gpu_synchronize(handle) before
+          !!          reading h_aldt_sq.
+          subroutine shell_gpu_download_aldt_sq_async(g, h_aldt_sq) &
+            bind(c, name='shell_gpu_download_aldt_sq_async')
+            import :: c_ptr , WP
+            type(c_ptr),       value, intent(in) :: g
+            real(WP),    intent(inout)     :: h_aldt_sq(*) !< ALDT² per element [NUMELC]
+          end subroutine shell_gpu_download_aldt_sq_async
+
+          !! \brief Compute min element timestep via GPU reduction kernel.
+          !! \details Replaces the pattern of downloading NUMELC doubles
+          !!          (shell_gpu_download_aldt_sq_async) + Fortran reduction loop.
+          !!          Downloads a single scalar (8 bytes) instead.
+          !!          The caller must call shell_gpu_synchronize() before reading
+          !!          h_dt_min.
+          subroutine shell_gpu_min_dt(g, dtfac, h_dt_min) &
+            bind(c, name='shell_gpu_min_dt')
+            import :: c_ptr , WP
+            type(c_ptr),       value, intent(in)    :: g
+            real(WP),    value, intent(in)    :: dtfac     !< Timestep scale factor
+            real(WP),           intent(inout) :: h_dt_min  !< Result: min element dt
+          end subroutine shell_gpu_min_dt
+
+          ! --------------------------------------------------------------------------------------------------------------------
+          !  Global (shared) node/force handle
+          ! --------------------------------------------------------------------------------------------------------------------
+
+          !! \brief Create global handle: allocate device node/force arrays for NUMNOD nodes.
+          function shell_gpu_global_create(numnod) result(gh) bind(c, name='shell_gpu_global_create')
+            import :: c_ptr , c_int
+            integer(c_int), value, intent(in) :: numnod
+            type(c_ptr) :: gh
+          end function shell_gpu_global_create
+
+          !! \brief Destroy global handle: free device arrays, stream, event.
+          subroutine shell_gpu_global_destroy(gh) bind(c, name='shell_gpu_global_destroy')
+            import :: c_ptr
+            type(c_ptr), value, intent(in) :: gh
+          end subroutine shell_gpu_global_destroy
+
+          !! \brief Upload NODES%X/V/VR (H2D) + zero force arrays + record event.
+          subroutine shell_gpu_global_upload_nodes(gh, X, V, VR) &
+            bind(c, name='shell_gpu_global_upload_nodes')
+            import :: c_ptr , WP
+            type(c_ptr),    value, intent(in) :: gh
+            real(WP), intent(in)        :: X(3,*), V(3,*), VR(3,*)
+          end subroutine shell_gpu_global_upload_nodes
+
+          !! \brief Download force arrays (D2H) after all SU kernels complete.
+          subroutine shell_gpu_global_download_forces(gh, raw_gpu_to_cpu) &
+            bind(c, name='shell_gpu_global_download_forces')
+            import :: c_ptr , WP
+            type(c_ptr),    value, intent(in) :: gh
+            real(WP), intent(inout)     :: raw_gpu_to_cpu(*)
+          end subroutine shell_gpu_global_download_forces
+
+          !! \brief Block CPU until global stream completes.
+          subroutine shell_gpu_global_synchronize(gh) bind(c, name='shell_gpu_global_synchronize')
+            import :: c_ptr
+            type(c_ptr), value, intent(in) :: gh
+          end subroutine shell_gpu_global_synchronize
+
+          !! \brief Make SU stream wait for global upload to finish.
+          subroutine shell_gpu_global_wait_upload(gh, g) &
+            bind(c, name='shell_gpu_global_wait_upload')
+            import :: c_ptr
+            type(c_ptr), value, intent(in) :: gh
+            type(c_ptr), value, intent(in) :: g
+          end subroutine shell_gpu_global_wait_upload
+
+          !! \brief Make global stream wait for SU kernels to finish.
+          subroutine shell_gpu_global_wait_su(gh, g) &
+            bind(c, name='shell_gpu_global_wait_su')
+            import :: c_ptr
+            type(c_ptr), value, intent(in) :: gh
+            type(c_ptr), value, intent(in) :: g
+          end subroutine shell_gpu_global_wait_su
+
+          !! \brief Pin Fortran NODES%X/V/VR and force buffer for async memcpy.
+          subroutine shell_gpu_global_pin_host(X, V, VR, raw_gpu_to_cpu, numnod) &
+            bind(c, name='shell_gpu_global_pin_host')
+            import :: WP , c_int
+            real(WP), intent(in)    :: X(3,*), V(3,*), VR(3,*)
+            real(WP), intent(inout) :: raw_gpu_to_cpu(*)
+            integer(c_int), value, intent(in) :: numnod
+          end subroutine shell_gpu_global_pin_host
+
+          !! \brief Set back-pointer from per-SU handle to global handle.
+          subroutine shell_gpu_set_global(g, gh) bind(c, name='shell_gpu_set_global')
+            import :: c_ptr
+            type(c_ptr), value, intent(in) :: g
+            type(c_ptr), value, intent(in) :: gh
+          end subroutine shell_gpu_set_global
+
+        end interface
+
+#else
+      contains
+
+        ! ======================================================================================================================
+        !  Stub implementations — used when building without CUDA (WITH_CUDA not defined).
+        !  These empty procedures satisfy the linker; they are never called at runtime
+        !  because the GPU code path is guarded by the gpu_shell_available flag.
+        ! ======================================================================================================================
+
+        ! --- Lifecycle ---
+
+        function shell_gpu_data_create() result(g)
+          type(c_ptr) :: g
+          g = c_null_ptr
+        end function shell_gpu_data_create
+
+        subroutine shell_gpu_data_destroy(g)
+          type(c_ptr), value, intent(in) :: g
+        end subroutine shell_gpu_data_destroy
+
+        subroutine shell_gpu_allocate(g, numelc, numnod, npt, ismstr, ithk)
+          type(c_ptr),    value, intent(in) :: g
+          integer(c_int), value, intent(in) :: numelc, numnod, npt, ismstr, ithk
+        end subroutine shell_gpu_allocate
+
+        subroutine shell_gpu_deallocate(g)
+          type(c_ptr), value, intent(in) :: g
+        end subroutine shell_gpu_deallocate
+
+        ! --- Parameter setters ---
+
+        subroutine shell_gpu_set_mat_params(g, &
+          e_young, nu, g_shear, a11, a12, &
+          ca, cb, cn, cc, epdr, epmx, ymax, m_exp, &
+          fisokin, rhocp, tref, tmelt, asrate, &
+          rho, ssp, shf_coef, &
+          ipla, vp, iform, icc, z3, z4)
+          type(c_ptr),    value, intent(in) :: g
+          real(WP), value, intent(in) :: e_young, nu, g_shear, a11, a12
+          real(WP), value, intent(in) :: ca, cb, cn, cc, epdr, epmx, ymax, m_exp
+          real(WP), value, intent(in) :: fisokin, rhocp, tref, tmelt, asrate
+          real(WP), value, intent(in) :: rho, ssp, shf_coef
+          integer(c_int), value, intent(in) :: ipla, vp, iform, icc
+          real(WP), value, intent(in) :: z3, z4
+        end subroutine shell_gpu_set_mat_params
+
+        subroutine shell_gpu_set_hg_params(g, h1, h2, h3, srh1, srh2, srh3, &
+          hvisc_in, helas_in, hvlin_in)
+          type(c_ptr),    value, intent(in) :: g
+          real(WP), value, intent(in) :: h1, h2, h3, srh1, srh2, srh3
+          real(WP), value, intent(in) :: hvisc_in, helas_in, hvlin_in
+        end subroutine shell_gpu_set_hg_params
+
+        subroutine shell_gpu_set_compute_sti(g, flag)
+          type(c_ptr),    value, intent(in) :: g
+          integer(c_int), value, intent(in) :: flag
+        end subroutine shell_gpu_set_compute_sti
+
+        subroutine shell_gpu_set_ihbe(g, ihbe)
+          type(c_ptr),    value, intent(in) :: g
+          integer(c_int), value, intent(in) :: ihbe
+        end subroutine shell_gpu_set_ihbe
+
+        ! --- Data transfers ---
+
+        subroutine shell_gpu_upload_constant(g, &
+          h_n1, h_n2, h_n3, h_n4, &
+          h_thk0, h_off, h_ssp, h_rho, h_ym, h_nu, h_a11, h_g_shear, h_shf)
+          type(c_ptr),    value, intent(in) :: g
+          integer(c_int), intent(in) :: h_n1(*), h_n2(*), h_n3(*), h_n4(*)
+          real(WP), intent(in) :: h_thk0(*), h_off(*)
+          real(WP), intent(in) :: h_ssp(*), h_rho(*), h_ym(*), h_nu(*)
+          real(WP), intent(in) :: h_a11(*), h_g_shear(*), h_shf(*)
+        end subroutine shell_gpu_upload_constant
+
+        subroutine shell_gpu_upload_ip_state(g, &
+          h_sigxx, h_sigyy, h_sigxy, h_sigyz, h_sigzx, &
+          h_pla, h_epsd_ip, h_sigbakxx, h_sigbakyy, h_sigbakxy, h_tempel)
+          type(c_ptr),    value, intent(in) :: g
+          real(WP), intent(in) :: h_sigxx(*), h_sigyy(*), h_sigxy(*)
+          real(WP), intent(in) :: h_sigyz(*), h_sigzx(*)
+          real(WP), intent(in) :: h_pla(*), h_epsd_ip(*)
+          real(WP), intent(in) :: h_sigbakxx(*), h_sigbakyy(*), h_sigbakxy(*)
+          real(WP), intent(in) :: h_tempel(*)
+        end subroutine shell_gpu_upload_ip_state
+
+        subroutine shell_gpu_upload_nodes(g, raw_cpu_to_gpu)
+          type(c_ptr),    value, intent(in) :: g
+          real(WP), intent(in) :: raw_cpu_to_gpu(*)
+        end subroutine shell_gpu_upload_nodes
+
+        subroutine shell_gpu_download_nodal_forces(g, raw_gpu_to_cpu)
+          type(c_ptr),    value, intent(in) :: g
+          real(WP), intent(inout) :: raw_gpu_to_cpu(*)
+        end subroutine shell_gpu_download_nodal_forces
+
+        subroutine shell_gpu_download_energy(g, h_eint)
+          type(c_ptr),    value, intent(in) :: g
+          real(WP), intent(inout) :: h_eint(*)
+        end subroutine shell_gpu_download_energy
+
+        subroutine shell_gpu_download_aldt_sq(g, h_aldt_sq)
+          type(c_ptr),    value, intent(in) :: g
+          real(WP), intent(inout) :: h_aldt_sq(*)
+        end subroutine shell_gpu_download_aldt_sq
+
+        subroutine shell_gpu_download_state(g, &
+          h_off, h_thk, h_gstr, h_epsd_elem, &
+          h_sigxx, h_sigyy, h_sigxy, h_sigyz, h_sigzx, &
+          h_pla, h_epsd_ip, h_sigbakxx, h_sigbakyy, h_sigbakxy, h_tempel)
+          type(c_ptr),    value, intent(in) :: g
+          real(WP), intent(inout) :: h_off(*), h_thk(*), h_gstr(*), h_epsd_elem(*)
+          real(WP), intent(inout) :: h_sigxx(*), h_sigyy(*), h_sigxy(*)
+          real(WP), intent(inout) :: h_sigyz(*), h_sigzx(*)
+          real(WP), intent(inout) :: h_pla(*), h_epsd_ip(*)
+          real(WP), intent(inout) :: h_sigbakxx(*), h_sigbakyy(*), h_sigbakxy(*)
+          real(WP), intent(inout) :: h_tempel(*)
+        end subroutine shell_gpu_download_state
+
+        ! --- Kernel execution ---
+
+        subroutine shell_gpu_zero_nodal_arrays(g)
+          type(c_ptr), value, intent(in) :: g
+        end subroutine shell_gpu_zero_nodal_arrays
+
+        subroutine shell_gpu_run_kernels(g, dt)
+          type(c_ptr),    value, intent(in) :: g
+          real(WP), value, intent(in) :: dt
+        end subroutine shell_gpu_run_kernels
+
+        subroutine shell_gpu_synchronize(g)
+          type(c_ptr), value, intent(in) :: g
+        end subroutine shell_gpu_synchronize
+
+        ! --- Host pinning ---
+
+        subroutine shell_gpu_pin_host_memory(g, raw_cpu_to_gpu, raw_gpu_to_cpu)
+          type(c_ptr),    value, intent(in) :: g
+          real(WP), intent(in) :: raw_cpu_to_gpu(*)
+          real(WP), intent(in) :: raw_gpu_to_cpu(*)
+        end subroutine shell_gpu_pin_host_memory
+
+        subroutine shell_gpu_unpin_host_memory(raw_cpu_to_gpu, raw_gpu_to_cpu)
+          real(WP), intent(in) :: raw_cpu_to_gpu(*)
+          real(WP), intent(in) :: raw_gpu_to_cpu(*)
+        end subroutine shell_gpu_unpin_host_memory
+
+        ! --- Full step ---
+
+        subroutine shell_gpu_full_step(g, dt, raw_cpu_to_gpu, raw_gpu_to_cpu)
+          type(c_ptr),    value, intent(in) :: g
+          real(WP), value, intent(in) :: dt
+          real(WP), intent(in)    :: raw_cpu_to_gpu(*)
+          real(WP), intent(inout) :: raw_gpu_to_cpu(*)
+        end subroutine shell_gpu_full_step
+
+        ! --- Async variants ---
+
+        subroutine shell_gpu_full_step_async(g, dt, X, V, VR, raw_gpu_to_cpu)
+          type(c_ptr),    value, intent(in) :: g
+          real(WP), value, intent(in) :: dt
+          real(WP), intent(in)    :: X(3,*), V(3,*), VR(3,*)
+          real(WP), intent(inout) :: raw_gpu_to_cpu(*)
+        end subroutine shell_gpu_full_step_async
+
+        subroutine shell_gpu_download_aldt_sq_async(g, h_aldt_sq)
+          type(c_ptr),    value, intent(in) :: g
+          real(WP), intent(inout) :: h_aldt_sq(*)
+        end subroutine shell_gpu_download_aldt_sq_async
+
+        subroutine shell_gpu_min_dt(g, dtfac, h_dt_min)
+          type(c_ptr),    value, intent(in)    :: g
+          real(WP), value, intent(in)    :: dtfac
+          real(WP),        intent(inout) :: h_dt_min
+        end subroutine shell_gpu_min_dt
+
+        ! --- Global (shared) node/force handle ---
+
+        function shell_gpu_global_create(numnod) result(gh)
+          integer(c_int), value, intent(in) :: numnod
+          type(c_ptr) :: gh
+          gh = c_null_ptr
+        end function shell_gpu_global_create
+
+        subroutine shell_gpu_global_destroy(gh)
+          type(c_ptr), value, intent(in) :: gh
+        end subroutine shell_gpu_global_destroy
+
+        subroutine shell_gpu_global_upload_nodes(gh, X, V, VR)
+          type(c_ptr),    value, intent(in) :: gh
+          real(WP), intent(in) :: X(3,*), V(3,*), VR(3,*)
+        end subroutine shell_gpu_global_upload_nodes
+
+        subroutine shell_gpu_global_download_forces(gh, raw_gpu_to_cpu)
+          type(c_ptr),    value, intent(in) :: gh
+          real(WP), intent(inout) :: raw_gpu_to_cpu(*)
+        end subroutine shell_gpu_global_download_forces
+
+        subroutine shell_gpu_global_synchronize(gh)
+          type(c_ptr), value, intent(in) :: gh
+        end subroutine shell_gpu_global_synchronize
+
+        subroutine shell_gpu_global_wait_upload(gh, g)
+          type(c_ptr), value, intent(in) :: gh
+          type(c_ptr), value, intent(in) :: g
+        end subroutine shell_gpu_global_wait_upload
+
+        subroutine shell_gpu_global_wait_su(gh, g)
+          type(c_ptr), value, intent(in) :: gh
+          type(c_ptr), value, intent(in) :: g
+        end subroutine shell_gpu_global_wait_su
+
+        subroutine shell_gpu_global_pin_host(X, V, VR, raw_gpu_to_cpu, numnod)
+          real(WP), intent(in)    :: X(3,*), V(3,*), VR(3,*)
+          real(WP), intent(inout) :: raw_gpu_to_cpu(*)
+          integer(c_int), value, intent(in) :: numnod
+        end subroutine shell_gpu_global_pin_host
+
+        subroutine shell_gpu_set_global(g, gh)
+          type(c_ptr), value, intent(in) :: g
+          type(c_ptr), value, intent(in) :: gh
+        end subroutine shell_gpu_set_global
+
+#endif
+
+      end module shell_gpu_mod
+

--- a/engine/source/elements/shell/coque/shell_internal_forces.F90
+++ b/engine/source/elements/shell/coque/shell_internal_forces.F90
@@ -1,0 +1,949 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 1986-2026 Altair Engineering Inc.
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Altair Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+!Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+!Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+      module shell_internal_forces_mod
+      contains
+
+! ======================================================================================================================
+!! \brief  Gather node data and launch GPU shell pipeline asynchronously
+!! \details Gathers node positions/velocities from NODES into per-SU
+!!          contiguous SoA buffers, then enqueues H2D + 3 kernels + D2H
+!!          and (optionally) the min-dt reduction onto each SU's CUDA stream.
+!!          Returns immediately — NO synchronization.  The caller must
+!!          call gpu_shell_sync_scatter() later to collect results.
+!!
+!!          Intended usage in resol.F:
+!!            CALL gpu_shell_launch_async(...)   ! enqueue GPU work
+!!            CALL FORINTC(...)                  ! CPU shell forces  (hides GPU latency)
+!!            CALL FORINT(...)                   ! CPU solid forces  (hides GPU latency)
+!!            CALL gpu_shell_sync_scatter(...)   ! collect GPU results
+! ======================================================================================================================
+        subroutine gpu_shell_launch_async(NODES, SHELLS, dt1)
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   MODULES
+! ----------------------------------------------------------------------------------------------------------------------
+          use precision_mod, only: WP
+          use nodal_arrays_mod
+          use shell_gpu_mod
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   IMPLICIT NONE
+! ----------------------------------------------------------------------------------------------------------------------
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   ARGUMENTS
+! ----------------------------------------------------------------------------------------------------------------------
+          type(nodal_arrays_), intent(inout) :: NODES    !< Global nodal arrays (positions, velocities)
+          type(SHELLS_), intent(inout) :: SHELLS         !< GPU shell super-group data
+          real(WP), intent(in) :: dt1                    !< Current cycle time step
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   LOCAL VARIABLES
+! ----------------------------------------------------------------------------------------------------------------------
+          integer :: SU, NSU
+          integer, save :: icall = 0
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   BODY
+! ----------------------------------------------------------------------------------------------------------------------
+          icall = icall + 1
+          NSU = size(SHELLS%LAW2)
+
+          ! One-time summary: print GPU super-group element counts and ISMSTR
+          if (icall == 1) then
+            do SU = 1, NSU
+              write(6,"(A,I5,A,I6,A,I6,A,I5)") &
+              &" [GPU-CFG] SU=", SU, &
+              &"  NUMELC=", SHELLS%LAW2(SU)%numelc, &
+              &"  NUMNOD=", SHELLS%LAW2(SU)%numnod, &
+              &"  ISMSTR=", SHELLS%LAW2(SU)%ismstr
+            end do
+          end if
+
+          ! ==================================================================
+          ! STEP 1: Upload NODES%X/V/VR to device ONCE via global handle.
+          !   Also zeros the global force accumulation arrays and records
+          !   the upload_done event so that SU streams can wait on it.
+          ! ==================================================================
+          call shell_gpu_global_upload_nodes(SHELLS%global_handle, NODES%X, NODES%V, NODES%VR)
+
+          ! ==================================================================
+          ! STEP 2: Launch each SU's 3 kernels asynchronously.
+          !   Each SU stream waits on the global upload_done event, runs
+          !   K1→K2→K3, and records its kernels_done event.
+          !   The SUs can potentially overlap on the GPU.
+          ! ==================================================================
+          do SU = 1, NSU
+            if (SHELLS%LAW2(SU)%numelc > 0) then
+              ! shell_gpu_full_step_async now waits on global upload_done
+              ! and runs kernels only — no per-SU H2D or D2H.
+              call shell_gpu_full_step_async(SHELLS%LAW2(SU)%handle, dt1, &
+                NODES%X, NODES%V, NODES%VR, &
+                SHELLS%raw_gpu_to_cpu_global)
+            end if
+          end do
+
+          ! ==================================================================
+          ! STEP 3: Make global stream wait for all SU kernels to complete,
+          !   then start the single D2H of the global force arrays.
+          ! ==================================================================
+          do SU = 1, NSU
+            if (SHELLS%LAW2(SU)%numelc > 0) then
+              call shell_gpu_global_wait_su(SHELLS%global_handle, &
+                SHELLS%LAW2(SU)%handle)
+            end if
+          end do
+          call shell_gpu_global_download_forces(SHELLS%global_handle, &
+            SHELLS%raw_gpu_to_cpu_global)
+
+          ! ==================================================================
+          ! STEP 4: START ASYNC MIN-DT REDUCTION PER SU
+          !   Only when the CPU CDT3 would also reduce DT2T from element dt
+          !   (i.e. NODADT=0 AND IDTMIN3/=0, mapped to compute_sti==2).
+          ! ==================================================================
+          if (SHELLS%reduce_elem_dt) then
+            do SU = 1, NSU
+              if (SHELLS%LAW2(SU)%numelc > 0) then
+                call shell_gpu_min_dt(SHELLS%LAW2(SU)%handle, &
+                  SHELLS%LAW2(SU)%dtfac, SHELLS%LAW2(SU)%dt_min_result)
+              end if
+            end do
+          end if
+! ----------------------------------------------------------------------------------------------------------------------
+        end subroutine gpu_shell_launch_async
+
+! ======================================================================================================================
+!! \brief  Synchronize GPU streams and scatter results into global nodal arrays
+!! \details For each SU: blocks until the CUDA stream finishes, then
+!!          scatters GPU-computed forces/moments/stiffness into NODES,
+!!          collects min-dt results, and (if ipri>0) downloads internal
+!!          energy for PARTSAV accumulation.
+!!
+!!          Must be called AFTER gpu_shell_launch_async() and after any
+!!          CPU work that should overlap with GPU execution.
+! ======================================================================================================================
+        subroutine gpu_shell_sync_scatter(NODES, SHELLS, dt2t, partsav, npsav, npart, ipri)
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   MODULES
+! ----------------------------------------------------------------------------------------------------------------------
+          use precision_mod, only: WP
+          use nodal_arrays_mod
+          use shell_gpu_mod
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   IMPLICIT NONE
+! ----------------------------------------------------------------------------------------------------------------------
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   ARGUMENTS
+! ----------------------------------------------------------------------------------------------------------------------
+          type(nodal_arrays_), intent(inout) :: NODES    !< Global nodal arrays (forces accumulated here)
+          type(SHELLS_), intent(inout) :: SHELLS         !< GPU shell super-group data
+          integer, intent(in) :: npsav, npart
+          real(WP), intent(inout) :: dt2t                !< Accumulator for next cycle time step
+          real(WP), intent(inout) :: partsav(npsav,npart)
+          integer, intent(in) :: ipri                    !< Print level for diagnostic
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   LOCAL VARIABLES
+! ----------------------------------------------------------------------------------------------------------------------
+          integer :: SU, i, j, NSU, NN
+          integer, save :: icall = 0
+          real(WP) :: dt_gpu_min, eint_total
+          integer :: part_id
+          ! Diagnostic variables for controlling element
+          integer  :: dt_min_su, dt_min_j, dt_min_ngl
+          real(WP) :: dt_min_aldt, dt_min_ssp, dt_min_area
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   BODY
+! ----------------------------------------------------------------------------------------------------------------------
+          icall = icall + 1
+          dt_gpu_min = huge(1.0_WP)
+          dt_min_su  = 0
+          dt_min_j   = 0
+          dt_min_aldt = 0.0_WP
+          dt_min_ssp  = 0.0_WP
+          dt_min_area = 0.0_WP
+
+          NSU = size(SHELLS%LAW2)
+          NN  = SHELLS%numnod_global
+
+          ! ==================================================================
+          ! STEP 1: Synchronize the global stream.
+          !   The global stream's last operation was the D2H of the force
+          !   arrays (enqueued by gpu_shell_launch_async after all SU
+          !   kernels_done events).  This blocks until the download completes.
+          ! ==================================================================
+          call shell_gpu_global_synchronize(SHELLS%global_handle)
+
+          ! Also synchronize each SU stream (for min-dt results)
+          do SU = 1, NSU
+            if (SHELLS%LAW2(SU)%numelc > 0) then
+              call shell_gpu_synchronize(SHELLS%LAW2(SU)%handle)
+            end if
+          end do
+
+          ! ==================================================================
+          ! STEP 2: Scatter global force buffer into NODES%A / AR / stifn / stifr.
+          !   The D2H buffer is [8*NUMNOD] = Fx|Fy|Fz|Mx|My|Mz|STIFN|STIFR
+          !   indexed by global node ID (0-based in CUDA, 1-based in Fortran).
+          !   We add directly: only shell-connected nodes have nonzero values,
+          !   and the arrays were zeroed before kernel launch.
+          ! ==================================================================
+          do i = 1, NN
+            NODES%A(1,i) = NODES%A(1,i) + SHELLS%raw_gpu_to_cpu_global(i)
+            NODES%A(2,i) = NODES%A(2,i) + SHELLS%raw_gpu_to_cpu_global(NN + i)
+            NODES%A(3,i) = NODES%A(3,i) + SHELLS%raw_gpu_to_cpu_global(2*NN + i)
+            NODES%AR(1,i) = NODES%AR(1,i) + SHELLS%raw_gpu_to_cpu_global(3*NN + i)
+            NODES%AR(2,i) = NODES%AR(2,i) + SHELLS%raw_gpu_to_cpu_global(4*NN + i)
+            NODES%AR(3,i) = NODES%AR(3,i) + SHELLS%raw_gpu_to_cpu_global(5*NN + i)
+            NODES%stifn(i) = NODES%stifn(i) + SHELLS%raw_gpu_to_cpu_global(6*NN + i)
+            NODES%stifr(i) = NODES%stifr(i) + SHELLS%raw_gpu_to_cpu_global(7*NN + i)
+          end do
+
+          ! ==================================================================
+          ! STEP 3: Collect min-dt from GPU reduction per SU
+          ! ==================================================================
+          do SU = 1, NSU
+            if (SHELLS%LAW2(SU)%numelc > 0) then
+              if (SHELLS%reduce_elem_dt) then
+                if (SHELLS%LAW2(SU)%dt_min_result < dt_gpu_min) then
+                  dt_gpu_min = SHELLS%LAW2(SU)%dt_min_result
+                  dt_min_su  = SU
+                  dt_min_j   = 0
+                  dt_min_aldt = 0.0_WP
+                  dt_min_ssp  = SHELLS%LAW2(SU)%ssp
+                  dt_min_area = 0.0_WP
+                end if
+              end if
+            end if
+          end do
+
+          ! Download internal energy from GPU and accumulate into PARTSAV
+          if(ipri > 0) then
+            do SU = 1, NSU
+              call shell_gpu_download_energy(SHELLS%LAW2(SU)%handle, SHELLS%LAW2(SU)%eint)
+              do j = 1, SHELLS%LAW2(SU)%numelc
+                eint_total = SHELLS%LAW2(SU)%eint(j) &
+                  + SHELLS%LAW2(SU)%eint(SHELLS%LAW2(SU)%numelc + j)
+                part_id = SHELLS%LAW2(SU)%part_id(j)
+                PARTSAV(1, part_id) = PARTSAV(1, part_id) + eint_total
+              end do
+            end do
+          end if
+
+          ! Reduce DT2T with the GPU element time step
+          if (SHELLS%reduce_elem_dt .and. dt_gpu_min < dt2t) then
+            if (icall-1 <= 5) then
+              write(6,"(A,ES12.4,A,ES12.4)") &
+              &" [GPU] dt_elem_min = ", dt_gpu_min, " reducing dt2t from ", dt2t
+            endif
+            dt2t = dt_gpu_min
+          endif
+
+          ! Periodic diagnostic: print controlling element details
+          if (mod(icall-1, 100) == 0 .or. icall-1 <= 20) then
+            dt_min_ngl = 0
+            if (dt_min_su > 0 .and. dt_min_j > 0) then
+              dt_min_ngl = SHELLS%LAW2(dt_min_su)%ngl(dt_min_j)
+            end if
+            write(6,"(A,I6,A,ES14.6,A,I10,A,I6,A,I8,A,ES14.6,A,ES14.6)") &
+            &" [GPU-DT] CYC=", icall-1, &
+            &"  dt_min=", dt_gpu_min, &
+            &"  SU=", dt_min_su, &
+            &"  elem=", dt_min_j, &
+            &"  NGL=", dt_min_ngl, &
+            &"  ALDT=", dt_min_aldt, &
+            &"  SSP=", dt_min_ssp
+          end if
+! ----------------------------------------------------------------------------------------------------------------------
+        end subroutine gpu_shell_sync_scatter
+
+! ======================================================================================================================
+!! \brief  Legacy convenience wrapper — launch + sync in a single call
+!! \details Kept for backward compatibility.  Equivalent to calling
+!!          gpu_shell_launch_async() followed immediately by
+!!          gpu_shell_sync_scatter(), with no CPU work in between.
+! ======================================================================================================================
+        subroutine gpu_shell_internal_forces(NODES, SHELLS, dt1, dt2t, partsav, npsav, npart, ipri)
+          use precision_mod, only: WP
+          use nodal_arrays_mod
+          use shell_gpu_mod
+          implicit none
+          type(nodal_arrays_), intent(inout) :: NODES
+          type(SHELLS_), intent(inout) :: SHELLS
+          integer, intent(in) :: npsav, npart
+          real(WP), intent(in) :: dt1
+          real(WP), intent(inout) :: dt2t
+          real(WP), intent(inout) :: partsav(npsav,npart)
+          integer, intent(in) :: ipri
+
+          call gpu_shell_launch_async(NODES, SHELLS, dt1)
+          call gpu_shell_sync_scatter(NODES, SHELLS, dt2t, partsav, npsav, npart, ipri)
+
+        end subroutine gpu_shell_internal_forces
+
+        SUBROUTINE FORINTC_PREPARE_GPU( GPU, SHELLS, NUMELC,&
+        &PM , NPROPM,       GEO, NPROPG,  &
+        &NODES, MAT_ELEM  , NSECT, NSLIPRING, NEXMAD, &
+        &IPARG, nparg     ,IXC, IPARTC,      &
+        &IGROUC    ,NGROUC, NGROUP, NIXC    ,&
+        &ELBUF_TAB, DTFAC1_3, &
+        &NODADT_IN, IDT1SH_IN, IDTMINS_IN, IDTMIN3_IN, &
+        &HVISC_IN, HELAS_IN, HVLIN_IN )
+!-----------------------------------------------
+!   M o d u l e s
+!-----------------------------------------------
+          use constant_mod
+          USE MAT_ELEM_MOD
+          USE ELBUFDEF_MOD
+          use shell_gpu_mod, only : SHELLS_,&
+          &shell_gpu_data_create, shell_gpu_allocate,&
+          &shell_gpu_set_mat_params, shell_gpu_set_hg_params,&
+          &shell_gpu_set_compute_sti, shell_gpu_set_ihbe,&
+          &shell_gpu_upload_constant, shell_gpu_upload_ip_state,&
+          &shell_gpu_pin_host_memory,&
+          &shell_gpu_global_create, shell_gpu_global_pin_host,&
+          &shell_gpu_set_global
+          use precision_mod, only : WP
+          use nodal_arrays_mod
+          implicit none
+!-----------------------------------------------
+!   D u m m y   A r g u m e n t s
+!-----------------------------------------------
+          INTEGER , INTENT(IN) :: GPU
+          TYPE(SHELLS_), INTENT(INOUT) :: SHELLS
+          TYPE(nodal_arrays_), intent(inout) :: NODES
+          integer, intent(in) :: NPROPM, NPROPG,nparg,NGROUP, NIXC, NUMELC, NSECT
+          integer, intent(in) :: NSLIPRING
+          real(wp), intent(in) :: PM(NPROPM,*), GEO(NPROPG,*)
+          TYPE (MAT_ELEM_) ,INTENT(INOUT) :: MAT_ELEM
+          INTEGER, intent(in) :: IPARG(NPARG,*), IXC(NIXC,*)
+          INTEGER, intent(in) :: IGROUC(*), NGROUC
+          integer, intent(in) :: IPARTC(*)
+          TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP) :: ELBUF_TAB
+          real(wp), intent(in) :: DTFAC1_3  !< Timestep scale factor DTFAC1(3)
+          integer, intent(in) :: NODADT_IN   !< Nodal dt flag (from /SCR02/)
+          integer, intent(in) :: IDT1SH_IN   !< Shell dt flag (from /SCR17/)
+          integer, intent(in) :: IDTMINS_IN  !< SMS shell dt flag (from /SMS/)
+          integer, intent(in) :: IDTMIN3_IN  !< Shell dt control IDTMIN(3)
+          real(wp), intent(in) :: HVISC_IN    !< Viscous hourglass scaling (from /SCR06R/)
+          real(wp), intent(in) :: HELAS_IN    !< Elastic hourglass scaling (from /SCR06R/)
+          real(wp), intent(in) :: HVLIN_IN    !< Linear  hourglass scaling (from /SCR06R/)
+!-----------------------------------------------
+!   L o c a l   V a r i a b l e s
+!-----------------------------------------------
+          INTEGER :: I, J, NG, NVC, MLW, JFT, JLT, ISOLNOD, ITHK, IPLA,&
+          &NF1, IPRI, OFFSET, NSG, NEL, KFTS, ISTRA,&
+          &ICNOD, ISENS_ENERGY, IEXPAN, IG, ITG1, ITG2, ITG3,&
+          &NLEVXF, ISEATBELT
+          INTEGER :: ISH3N, ISHPLYXFEM, IXFEM
+          INTEGER :: ACTIFXFEM, ISUBSTACK
+          integer super_group_size
+
+
+          integer :: IFAILURE, JCVT, IGTYP, ISORTH, ISORTHG, ISRAT, ISROT, JCLOSE, JSMS
+          integer :: IINT, ISMSTR, JEUL, JTUR, JTHE, JLAG, IREP,ITY,JALE, JHBE
+          integer :: NPT,JIVF, JMULT,JPOR, NEXMAD
+          integer :: LFT,NFT, LLT, MTN
+          integer :: NUMNOD
+
+
+          integer :: law2_counter(NGROUP)
+          integer :: nod_counter(NGROUP)
+          logical, dimension(:), allocatable :: node_mask
+          integer, dimension(:), allocatable :: glob_2_gpu, gpu_2_glob, node_local_id
+          integer :: SUPER_GROUP_ID(NGROUP)
+          integer :: PREVIOUS_SUPER_GROUP_ID
+          integer :: IPARG_PREVIOUS(NPARG)
+          integer :: SU,nod,imat,ipid
+          integer :: elem_counter(NGROUP)
+          integer :: IT, gpu_offset, IJ1, IJ2, IJ3, IJ4, IJ5
+          integer :: glob_id
+          integer :: i_compute_sti
+!======================================================================|
+          NUMNOD = NODES%numnod
+          allocate(node_mask(NUMNOD))
+          allocate(glob_2_gpu(NUMNOD))
+          allocate(gpu_2_glob(NUMNOD))
+          allocate(node_local_id(NUMNOD))
+          IPARG_PREVIOUS = 0
+          glob_2_gpu = 0
+          gpu_2_glob = 0
+          node_mask = .false.
+          ITG2 = 2*NUMELC
+          ITG3 = 1+NUMELC
+          IPRI = 0
+          ISENS_ENERGY = 0
+          law2_counter = 0
+          nod_counter = 0
+          elem_counter = 0
+          SUPER_GROUP_ID = 0
+          PREVIOUS_SUPER_GROUP_ID = 0
+          super_group_size = 0
+          DO IG = 1, NGROUC
+            NG = IGROUC(IG)
+            IF (IPARG(1, NG) == 151) THEN !  Bypass law 151
+              CYCLE
+            ENDIF
+!---------temporarily used to avoid pass KTBUF_STR everywhere
+            IF(IPARG(8,NG)==1) CYCLE
+            ITY   =IPARG(5,NG)
+!            IF(ITY/=3.AND.ITY/=7)GOTO 250
+            OFFSET  = 0
+            MLW     = IPARG(1,NG)
+! MLW= 0 ----> void
+! MLW = 13 ----> rigid material
+            IF (MLW == 0 .OR. MLW == 13) CYCLE
+            NEL     = IPARG(2,NG)
+            NFT     = IPARG(3,NG)
+            NPT     = IPARG(6,NG)
+            JALE    = IPARG(7,NG)
+            ISMSTR  = IPARG(9,NG)
+            NSG     = IPARG(10,NG)
+            JEUL    = IPARG(11,NG)
+            JTUR    = IPARG(12,NG)
+            JTHE    = IPARG(13,NG)
+            JLAG    = IPARG(14,NG)
+            ISTRA   = IPARG(44,NG)
+            NVC     = IPARG(19,NG)
+            JMULT   = IPARG(20,NG)
+            JHBE    = IPARG(23,NG)
+            ISH3N   = IPARG(23,NG)
+            JIVF    = IPARG(24,NG)
+            JPOR    = IPARG(27,NG)
+            ITHK    = IPARG(28,NG)
+            ISOLNOD = IPARG(28,NG)
+            IPLA    = IPARG(29,NG)
+            ICNOD   = IPARG(11,NG)
+            IREP    = IPARG(35,NG)
+            IINT    = IPARG(36,NG)
+            JCVT    = IPARG(37,NG)
+            IGTYP   = IPARG(38,NG)
+            ISORTH  = IPARG(42,NG)
+            ISORTHG = ISORTH
+            ISRAT   = IPARG(40,NG)
+            ISROT   = IPARG(41,NG)
+            IFAILURE= IPARG(43,NG)
+            KFTS    = IPARG(30,NG)
+            JCLOSE  = IPARG(33,NG)
+            IEXPAN  = IPARG(49,NG)
+            ISHPLYXFEM  = IPARG(50,NG)
+            JSMS    = IPARG(52,NG)
+            IXFEM   = IPARG(54,NG)
+            NLEVXF  = IPARG(65,NG)
+            ACTIFXFEM=IPARG(70,NG)
+            ISUBSTACK=IPARG(71,NG)
+            ISEATBELT=IPARG(91,NG)
+            IF (ITY == 3&  ! 4-node shell
+            &.AND. MLW == 2&  ! material law 2 (Johnson-Cook)
+            &.AND. IPARG(8,NG) /= 1&  ! group active
+            &.AND. NPT > 0&  ! through-thickness integration (not global)
+            &.AND. JHBE < 11&  ! standard formulation (not BATOZ, not QEPH)
+            &.AND. IGTYP < 29&  ! not user property
+            &.AND. IXFEM == 0&  ! no XFEM
+            &.AND. IFAILURE == 0&  ! no failure model (simplify for mockup)
+            &.AND. NSECT == 0&  ! no section (simplify for mockup)
+            &.AND. NEXMAD == 0&  ! no explicit mass scaling (simplify for mockup)
+            &.AND. NSLIPRING == 0 .AND. ISEATBELT == 0&  ! no slipring/seatbelt (simplify for mockup)
+            &.AND. GPU == 1&  ! GPU enabled
+            &.AND. ISUBSTACK == 0 .AND. ISENS_ENERGY == 0) THEN
+              ! ---------------------------------------------------------
+              ! Super-group homogeneity check: only compare IPARG indices
+              ! that actually affect GPU kernel behavior.
+              !   IPARG(6)  = NPT    : integration point count (all kernels)
+              !   IPARG(9)  = ISMSTR : small-strain flag (all kernels)
+              !   IPARG(23) = JHBE   : hourglass formulation (kernel 3)
+              !   IPARG(28) = ITHK   : thickness update flag (kernel 2)
+              !   IPARG(29) = IPLA   : plasticity algorithm (kernel 2)
+              ! The previous comparison IPARG(6:71) was buggy because many
+              ! indices in that range are uninitialized or irrelevant to
+              ! the GPU code path, causing spurious super-group splits.
+              ! ---------------------------------------------------------
+              IF(super_group_size < 10000000 .AND. &
+              & IPARG(6,NG)  == IPARG_PREVIOUS(6)  .AND. &
+              &  IPARG(9,NG)  == IPARG_PREVIOUS(9)  .AND. &
+              &  IPARG(23,NG) == IPARG_PREVIOUS(23) .AND. &
+              &  IPARG(28,NG) == IPARG_PREVIOUS(28) .AND. &
+              &  IPARG(29,NG) == IPARG_PREVIOUS(29)) THEN
+                SUPER_GROUP_ID(NG) = PREVIOUS_SUPER_GROUP_ID
+                super_group_size = super_group_size + NEL
+              ELSE
+                super_group_size = NEL
+                PREVIOUS_SUPER_GROUP_ID = PREVIOUS_SUPER_GROUP_ID + 1
+                SUPER_GROUP_ID(NG) = PREVIOUS_SUPER_GROUP_ID
+                node_mask = .false.
+                ! Print which GPU-relevant IPARG values changed (diagnostic)
+                write(700,"(A,I6,A,I6,A,I6)") " [GPU-GROUP] NG=", NG, "  NPT=",    IPARG(6,NG), "  previous=", IPARG_PREVIOUS(6)
+                write(700,"(A,I6,A,I6,A,I6)") " [GPU-GROUP] NG=", NG, "  ISMSTR=", IPARG(9,NG), "  previous=", IPARG_PREVIOUS(9)
+                write(700,"(A,I6,A,I6)") " [GPU-GROUP] NG=", NG, "  JHBE=",   IPARG(23,NG), "  previous=", IPARG_PREVIOUS(23)
+                write(700,"(A,I6,A,I6,A,I6)") " [GPU-GROUP] NG=", NG, "  ITHK=",   IPARG(28,NG), "  previous=", IPARG_PREVIOUS(28)
+                write(700,"(A,I6,A,I6,A,I6)") " [GPU-GROUP] NG=", NG, "  IPLA=",   IPARG(29,NG), "  previous=", IPARG_PREVIOUS(29)
+              ENDIF
+              IPARG_PREVIOUS = IPARG(:,NG)
+              IF(.TRUE.) THEN
+                LFT   = 1
+                LLT   = MIN(128,NEL)
+                MTN   = MLW
+                JFT=LFT
+                JLT=LLT
+                NF1 = NFT+1
+                SU = SUPER_GROUP_ID(NG)
+                law2_counter(SU) = law2_counter(SU) + NEL
+                do i=1,NEL
+                  do j=1,4
+                    if (node_mask(IXC(1+j,NFT+i)) .eqv. .false.) then
+                      nod_counter(SU) = nod_counter(SU) + 1
+                      node_mask(IXC(1+j,NFT+i)) = .true.
+                    end if
+                  end do
+                end do
+              ENDIF
+!----6---------------------------------------------------------------7---------8
+            ENDIF
+          END DO
+
+
+
+
+          ALLOCATE(SHELLS%LAW2(PREVIOUS_SUPER_GROUP_ID))
+
+          ! Create global (shared) node/force handle — sized for full mesh NUMNOD
+          SHELLS%numnod_global = NUMNOD
+          SHELLS%global_handle = shell_gpu_global_create(NUMNOD)
+          ! Allocate host-side D2H force buffer [8*NUMNOD] and pin it
+          allocate(SHELLS%raw_gpu_to_cpu_global(8*NUMNOD))
+          SHELLS%raw_gpu_to_cpu_global = 0.0d0
+          call shell_gpu_global_pin_host(NODES%X, NODES%V, NODES%VR, &
+            SHELLS%raw_gpu_to_cpu_global, NUMNOD)
+          write(6,*) " [GPU-GLOBAL] Pinned NODES%X/V/VR and force buffer, NUMNOD=", NUMNOD
+
+          PREVIOUS_SUPER_GROUP_ID = 0
+          DO IG = 1, NGROUC
+            NG = IGROUC(IG)
+            NEL     = IPARG(2,NG)
+            NFT     = IPARG(3,NG)
+            NPT     = IPARG(6,NG)
+            NF1   = NFT+1
+
+            IF(SUPER_GROUP_ID(NG) == 0) CYCLE ! skip groups not selected for GPU
+            IF(SUPER_GROUP_ID(NG) /= PREVIOUS_SUPER_GROUP_ID) THEN
+              PREVIOUS_SUPER_GROUP_ID = SUPER_GROUP_ID(NG)
+              SU = SUPER_GROUP_ID(NG)
+              nod = nod_counter(SU)
+              nod_counter(SU) = 0 ! reset for next super group
+              SHELLS%LAW2(SU)%numelc = law2_counter(SU)
+              SHELLS%LAW2(SU)%numnod = nod
+              allocate(SHELLS%LAW2(SU)%gpu_2_glob(nod))
+              SHELLS%LAW2(SU)%npt = IPARG(6,NG)
+              SHELLS%LAW2(SU)%ismstr = IPARG(9,NG)
+              SHELLS%LAW2(SU)%ithk = IPARG(28,NG)
+              SHELLS%LAW2(SU)%ihbe = IPARG(23,NG)
+              SHELLS%LAW2(SU)%handle = shell_gpu_data_create()
+              write(6,*) "Allocating GPU data for SG ", SU, " with ", SHELLS%LAW2(SU)%numelc, " elements and ", nod, " nodes."
+              call shell_gpu_allocate(&
+              &shells%LAW2(SU)%handle,&
+              &SHELLS%LAW2(SU)%numelc,&
+              &SHELLS%LAW2(SU)%numnod,&
+              &SHELLS%LAW2(SU)%npt,&
+              &SHELLS%LAW2(SU)%ismstr,&
+              &SHELLS%LAW2(SU)%ithk)
+              ! Link per-SU handle to the global node/force arrays
+              call shell_gpu_set_global(SHELLS%LAW2(SU)%handle, SHELLS%global_handle)
+              ! Set compute_sti mode: match CPU cforc3→chsti3→cdt3 STI flow
+              !   0 = no STI (NODADT=0 AND IDTMIN3=0: CDT3 returns early)
+              !   1 = CPXPY3+CHSTI3 formula (NODADT/=0 OR IDT1SH=1 OR IDTMINS=2)
+              !   2 = CDT3 formula (NODADT=0, IDTMIN3/=0, IDT1SH=0)
+              if (NODADT_IN /= 0 .or. IDT1SH_IN == 1 .or. IDTMINS_IN == 2) then
+                i_compute_sti = 1
+              else if (IDTMIN3_IN /= 0) then
+                i_compute_sti = 2
+              else
+                i_compute_sti = 0
+              end if
+              call shell_gpu_set_compute_sti(SHELLS%LAW2(SU)%handle, i_compute_sti)
+              ! GPU element dt should reduce DT2T only when the CPU CDT3 would
+              ! do the same.  In CDT3, DT2T is reduced only when:
+              !   - CDT3 is called: ISMSTR/=3 AND (NODADT==0 OR IDTMIN3/=0)
+              !   - CDT3 doesn't return early: NODADT==0 AND NOT (IDTMINS==2 AND JSMS/=0)
+              ! For the GPU (no SMS/JSMS), this simplifies to:
+              !   NODADT==0 AND IDTMIN3/=0  ↔  compute_sti==2
+              SHELLS%reduce_elem_dt = (i_compute_sti == 2)
+              ! Set IHBE for non-uniform GAMA in hourglass computation
+              call shell_gpu_set_ihbe(SHELLS%LAW2(SU)%handle, SHELLS%LAW2(SU)%ihbe)
+              write(6,*) "Completed allocation of GPU data for super-group ", SU
+!
+!             Retrieve material index and property index
+!
+              imat = ELBUF_TAB(NG)%bufly(1)%imat
+              NF1  = IPARG(3,NG) + 1
+              ipid = IXC(6,NF1)
+!
+!             Elastic properties  (cf. sigeps02c / mat_param)
+!
+              SHELLS%LAW2(SU)%e_young = MAT_ELEM%mat_param(imat)%young
+              SHELLS%LAW2(SU)%nu      = MAT_ELEM%mat_param(imat)%nu
+              SHELLS%LAW2(SU)%g_shear = MAT_ELEM%mat_param(imat)%shear
+              SHELLS%LAW2(SU)%a11     = MAT_ELEM%mat_param(imat)%young&
+              &/ (ONE - MAT_ELEM%mat_param(imat)%nu**2)
+              SHELLS%LAW2(SU)%a12     = SHELLS%LAW2(SU)%a11&
+              &* MAT_ELEM%mat_param(imat)%nu
+!
+!             Johnson-Cook / Zerilli-Armstrong hardening (uparam)
+!
+              SHELLS%LAW2(SU)%ca      = MAT_ELEM%mat_param(imat)%uparam(1)
+              SHELLS%LAW2(SU)%cb      = MAT_ELEM%mat_param(imat)%uparam(2)
+              SHELLS%LAW2(SU)%cn      = MAT_ELEM%mat_param(imat)%uparam(3)
+              SHELLS%LAW2(SU)%epmx    = MAT_ELEM%mat_param(imat)%uparam(4)
+              SHELLS%LAW2(SU)%ymax    = MAT_ELEM%mat_param(imat)%uparam(5)
+              SHELLS%LAW2(SU)%cc      = MAT_ELEM%mat_param(imat)%uparam(6)
+              SHELLS%LAW2(SU)%epdr    = MAT_ELEM%mat_param(imat)%uparam(7)
+              SHELLS%LAW2(SU)%fisokin = MAT_ELEM%mat_param(imat)%uparam(8)
+!
+!             Thermal parameters
+!
+              SHELLS%LAW2(SU)%rhocp   = MAT_ELEM%mat_param(imat)%therm%rhocp
+              SHELLS%LAW2(SU)%tref    = MAT_ELEM%mat_param(imat)%therm%tref
+              SHELLS%LAW2(SU)%tmelt   = MAT_ELEM%mat_param(imat)%therm%tmelt
+!
+!             Formulation-dependent: m_exp / z3 / z4  (cf. sigeps02c)
+!
+              SHELLS%LAW2(SU)%iform   = MAT_ELEM%mat_param(imat)%iparam(1)
+              IF (SHELLS%LAW2(SU)%iform == 1) THEN
+!               Zerilli-Armstrong
+                SHELLS%LAW2(SU)%z3    = MAT_ELEM%mat_param(imat)%uparam(10)
+                SHELLS%LAW2(SU)%z4    = MAT_ELEM%mat_param(imat)%uparam(11)
+                SHELLS%LAW2(SU)%m_exp = ONE
+              ELSE
+!               Johnson-Cook
+                SHELLS%LAW2(SU)%z3    = ZERO
+                SHELLS%LAW2(SU)%z4    = ZERO
+                SHELLS%LAW2(SU)%m_exp = MAT_ELEM%mat_param(imat)%uparam(10)
+              ENDIF
+!
+!             Integer flags (iparam)
+!
+              SHELLS%LAW2(SU)%icc     = MAT_ELEM%mat_param(imat)%iparam(2)
+              SHELLS%LAW2(SU)%vp      = MAT_ELEM%mat_param(imat)%iparam(3)
+!
+!             Strain-rate filter coefficient (PM(9,imat) = 2*pi*fcut)
+!
+              SHELLS%LAW2(SU)%asrate  = PM(9,imat)
+!
+!             Density, sound speed, shear correction factor
+!             Note: CPU ccoef3.F sets SHF=0 for NPT==1 (no bending HG
+!             for single through-thickness integration point).
+!
+              SHELLS%LAW2(SU)%rho      = MAT_ELEM%mat_param(imat)%rho
+              SHELLS%LAW2(SU)%ssp      = PM(27,imat)
+              if (NPT == 1) then
+                SHELLS%LAW2(SU)%shf_coef = 0.0_WP
+              else
+                SHELLS%LAW2(SU)%shf_coef = GEO(38,ipid)
+              endif
+!
+!             Plasticity algorithm
+!
+              SHELLS%LAW2(SU)%ipla    = IPARG(29,NG)
+
+!             hourglass parameters (from GEO property array)
+              SHELLS%LAW2(SU)%h1   = GEO(13,ipid)
+              SHELLS%LAW2(SU)%h2   = GEO(14,ipid)
+              SHELLS%LAW2(SU)%h3   = GEO(15,ipid)
+              SHELLS%LAW2(SU)%srh1 = GEO(18,ipid)
+              SHELLS%LAW2(SU)%srh2 = GEO(19,ipid)
+              SHELLS%LAW2(SU)%srh3 = GEO(20,ipid)
+              SHELLS%LAW2(SU)%dtfac = DTFAC1_3
+
+              write(6,*) "Setting GPU material parameters for super-group ", SU
+              call shell_gpu_set_mat_params(&
+              &SHELLS%LAW2(SU)%handle,&
+              &SHELLS%LAW2(SU)%e_young,&
+              &SHELLS%LAW2(SU)%nu,&
+              &SHELLS%LAW2(SU)%g_shear,&
+              &SHELLS%LAW2(SU)%a11,&
+              &SHELLS%LAW2(SU)%a12,&
+              &SHELLS%LAW2(SU)%ca,&
+              &SHELLS%LAW2(SU)%cb,&
+              &SHELLS%LAW2(SU)%cn,&
+              &SHELLS%LAW2(SU)%cc,&
+              &SHELLS%LAW2(SU)%epdr,&
+              &SHELLS%LAW2(SU)%epmx,&
+              &SHELLS%LAW2(SU)%ymax,&
+              &SHELLS%LAW2(SU)%m_exp,&
+              &SHELLS%LAW2(SU)%fisokin,&
+              &SHELLS%LAW2(SU)%rhocp,&
+              &SHELLS%LAW2(SU)%tref,&
+              &SHELLS%LAW2(SU)%tmelt,&
+              &SHELLS%LAW2(SU)%asrate,&
+              &SHELLS%LAW2(SU)%rho,&
+              &SHELLS%LAW2(SU)%ssp,&
+              &SHELLS%LAW2(SU)%shf_coef,&
+              &SHELLS%LAW2(SU)%ipla,&
+              &SHELLS%LAW2(SU)%vp,&
+              &SHELLS%LAW2(SU)%iform,&
+              &SHELLS%LAW2(SU)%icc,&
+              &SHELLS%LAW2(SU)%z3,&
+              &SHELLS%LAW2(SU)%z4)
+              write(6,*) "Completed setting GPU material parameters for super-group ", SU
+
+              allocate(SHELLS%LAW2(SU)%n1(SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%n2(SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%n3(SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%n4(SHELLS%LAW2(SU)%numelc))
+              ! Per-element material arrays [NUMELC]
+              allocate(SHELLS%LAW2(SU)%el_thk0(SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%el_off(SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%el_ssp(SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%el_rho(SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%el_ym(SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%el_nu(SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%el_a11(SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%el_g_shear(SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%el_shf(SHELLS%LAW2(SU)%numelc))
+              ! Per-SU H2D/D2H buffers are no longer needed — node/force
+              ! arrays now live on the global handle (ShellGPUGlobal).
+              ! The old raw_cpu_to_gpu / raw_gpu_to_cpu / pointer aliases
+              ! are kept but not allocated (they remain null).
+              !IP state arrays [NPT*NUMELC]
+              allocate(SHELLS%LAW2(SU)%sigxx(NPT*SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%sigyy(NPT*SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%sigxy(NPT*SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%sigyz(NPT*SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%sigzx(NPT*SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%pla(NPT*SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%epsd_ip(NPT*SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%sigbakxx(NPT*SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%sigbakyy(NPT*SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%sigbakxy(NPT*SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%tempel(NPT*SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%eint(2*SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%part_id(SHELLS%LAW2(SU)%numelc))
+              allocate(SHELLS%LAW2(SU)%ngl(SHELLS%LAW2(SU)%numelc))
+              SHELLS%LAW2(SU)%eint = 0.0d0
+              SHELLS%LAW2(SU)%sigxx = 0.0d0
+              SHELLS%LAW2(SU)%sigyy = 0.0d0
+              SHELLS%LAW2(SU)%sigxy = 0.0d0
+              SHELLS%LAW2(SU)%sigyz = 0.0d0
+              SHELLS%LAW2(SU)%sigzx = 0.0d0
+              SHELLS%LAW2(SU)%pla = 0.0d0
+              SHELLS%LAW2(SU)%epsd_ip = 0.0d0
+              SHELLS%LAW2(SU)%sigbakxx = 0.0d0
+              SHELLS%LAW2(SU)%sigbakyy = 0.0d0
+              SHELLS%LAW2(SU)%sigbakxy = 0.0d0
+              SHELLS%LAW2(SU)%tempel = 0.0d0
+              elem_counter(SU) = 0
+              node_mask = .false.
+              node_local_id = 0
+            endif
+!
+!           Copy per-IP state from ELBUF_TAB into flat GPU arrays
+!           Layout in lbuf%sig: [sigxx(1:NEL), sigyy(1:NEL), sigxy(1:NEL), sigyz(1:NEL), sigzx(1:NEL)]
+!           Layout in GPU arrays: (IT-1)*total_numelc + elem_counter + i
+!
+            NF1 = NFT + 1
+            do IT = 1, NPT
+              do i = 1, NEL
+                gpu_offset = (IT-1)*SHELLS%LAW2(SU)%numelc&
+                &+ elem_counter(SU) + i
+!               Stress components from lbuf%sig (5*NEL flat array)
+                IJ1 = 0
+                IJ2 = NEL
+                IJ3 = 2*NEL
+                IJ4 = 3*NEL
+                IJ5 = 4*NEL
+                if (ELBUF_TAB(NG)%bufly(1)%l_sig > 0) then
+                  SHELLS%LAW2(SU)%sigxx(gpu_offset) =&
+                  &ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%sig(IJ1+i)
+                  SHELLS%LAW2(SU)%sigyy(gpu_offset) =&
+                  &ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%sig(IJ2+i)
+                  SHELLS%LAW2(SU)%sigxy(gpu_offset) =&
+                  &ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%sig(IJ3+i)
+                  SHELLS%LAW2(SU)%sigyz(gpu_offset) =&
+                  &ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%sig(IJ4+i)
+                  SHELLS%LAW2(SU)%sigzx(gpu_offset) =&
+                  &ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%sig(IJ5+i)
+                endif
+!               Plastic strain
+                if (ELBUF_TAB(NG)%bufly(1)%l_pla > 0) then
+                  SHELLS%LAW2(SU)%pla(gpu_offset) =&
+                  &ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%pla(i)
+                endif
+!               Strain rate
+                if (ELBUF_TAB(NG)%bufly(1)%l_epsd > 0) then
+                  SHELLS%LAW2(SU)%epsd_ip(gpu_offset) =&
+                  &ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%epsd(i)
+                endif
+!               Back-stress components from lbuf%sigb (same layout as sig)
+                if (ELBUF_TAB(NG)%bufly(1)%l_sigb > 0) then
+                  SHELLS%LAW2(SU)%sigbakxx(gpu_offset) =&
+                  &ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%sigb(IJ1+i)
+                  SHELLS%LAW2(SU)%sigbakyy(gpu_offset) =&
+                  &ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%sigb(IJ2+i)
+                  SHELLS%LAW2(SU)%sigbakxy(gpu_offset) =&
+                  &ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%sigb(IJ3+i)
+                endif
+!               Temperature
+                if (ELBUF_TAB(NG)%bufly(1)%l_temp > 0) then
+                  SHELLS%LAW2(SU)%tempel(gpu_offset) =&
+                  &ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)%temp(i)
+                endif
+              end do
+            end do
+!           Internal energy from global buffer: GBUF%EINT(1:2*NEL)
+            do i = 1, NEL
+              SHELLS%LAW2(SU)%part_id(elem_counter(SU)+i) = IPARTC(NFT+1)
+              SHELLS%LAW2(SU)%ngl(elem_counter(SU)+i) = IXC(NIXC,NFT+i)
+              SHELLS%LAW2(SU)%eint(elem_counter(SU)+i) =&
+              &ELBUF_TAB(NG)%gbuf%eint(i)
+              SHELLS%LAW2(SU)%eint(&
+              &SHELLS%LAW2(SU)%numelc+elem_counter(SU)+i) =&
+              &ELBUF_TAB(NG)%gbuf%eint(NEL+i)
+            end do
+!           Build node mapping
+            !do i=1,NEL
+            !  do j=1,4
+            !    if (node_mask(IXC(1+j,NFT+i)) .eqv. .false.) then
+            !      nod_counter(SU) = nod_counter(SU) + 1
+            !      SHELLS%LAW2(SU)%gpu_2_glob(nod_counter(SU)) = IXC(1+j,NFT+i)
+            !      node_mask(IXC(1+j,NFT+i)) = .true.
+            !      node_local_id(IXC(1+j,NFT+i)) = nod_counter(SU)
+            !    end if
+            !  end do
+            !end do
+!           Fill connectivity (before advancing elem_counter)
+!           Subtract 1 for C/CUDA 0-based indexing
+            do i=1,NEL
+              SHELLS%LAW2(SU)%n1(elem_counter(SU)+i) = IXC(2,NFT+i) - 1
+              SHELLS%LAW2(SU)%n2(elem_counter(SU)+i) = IXC(3,NFT+i) - 1
+              SHELLS%LAW2(SU)%n3(elem_counter(SU)+i) = IXC(4,NFT+i) - 1
+              SHELLS%LAW2(SU)%n4(elem_counter(SU)+i) = IXC(5,NFT+i) - 1
+            enddo
+!           Fill per-element material arrays (uniform within super-group)
+            do i = 1, NEL
+              SHELLS%LAW2(SU)%el_thk0(elem_counter(SU)+i) =&
+              &ELBUF_TAB(NG)%gbuf%thk(i)
+              SHELLS%LAW2(SU)%el_off(elem_counter(SU)+i) =&
+              &ELBUF_TAB(NG)%gbuf%off(i)
+              SHELLS%LAW2(SU)%el_ssp(elem_counter(SU)+i) =&
+              &SHELLS%LAW2(SU)%ssp
+              SHELLS%LAW2(SU)%el_rho(elem_counter(SU)+i) =&
+              &SHELLS%LAW2(SU)%rho
+              SHELLS%LAW2(SU)%el_ym(elem_counter(SU)+i) =&
+              &SHELLS%LAW2(SU)%e_young
+              SHELLS%LAW2(SU)%el_nu(elem_counter(SU)+i) =&
+              &SHELLS%LAW2(SU)%nu
+              SHELLS%LAW2(SU)%el_a11(elem_counter(SU)+i) =&
+              &SHELLS%LAW2(SU)%a11
+              SHELLS%LAW2(SU)%el_g_shear(elem_counter(SU)+i) =&
+              &SHELLS%LAW2(SU)%g_shear
+              SHELLS%LAW2(SU)%el_shf(elem_counter(SU)+i) =&
+              &SHELLS%LAW2(SU)%shf_coef
+            end do
+!           Advance element counter for this super-group
+            elem_counter(SU) = elem_counter(SU) + NEL
+            SHELLS%LAW2(SU)%numnod = numnod
+            ! gather X and V for nodes in this super-group
+!           do i=1,nod_counter(SU)
+!             glob_id = SHELLS%LAW2(SU)%gpu_2_glob(i)
+!             SHELLS%LAW2(SU)%xx(i) = NODES%X(1,glob_id)
+!             SHELLS%LAW2(SU)%xy(i) = NODES%X(2,glob_id)
+!             SHELLS%LAW2(SU)%xz(i) = NODES%X(3,glob_id)
+!             SHELLS%LAW2(SU)%vx(i) = NODES%V(1,glob_id)
+!             SHELLS%LAW2(SU)%vy(i) = NODES%V(2,glob_id)
+!             SHELLS%LAW2(SU)%vz(i) = NODES%V(3,glob_id)
+
+!             if(NODES%iroddl == 1) then
+!               SHELLS%LAW2(SU)%vrx(i) = NODES%VR(1,glob_id)
+!               SHELLS%LAW2(SU)%vry(i) = NODES%VR(2,glob_id)
+!               SHELLS%LAW2(SU)%vrz(i) = NODES%VR(3,glob_id)
+!             endif
+!           end do
+
+
+          ENDDO
+
+!
+!         Upload all constant data to the GPU for each super-group
+!
+          do SU = 1, size(SHELLS%LAW2)
+            if (SHELLS%LAW2(SU)%numelc <= 0) cycle
+!
+!            Set hourglass parameters
+!
+            call shell_gpu_set_hg_params(&
+            &SHELLS%LAW2(SU)%handle,&
+            &SHELLS%LAW2(SU)%h1,&
+            &SHELLS%LAW2(SU)%h2,&
+            &SHELLS%LAW2(SU)%h3,&
+            &SHELLS%LAW2(SU)%srh1,&
+            &SHELLS%LAW2(SU)%srh2,&
+            &SHELLS%LAW2(SU)%srh3,&
+            &HVISC_IN, HELAS_IN, HVLIN_IN)
+!
+!            Upload connectivity, thickness, element activity, per-element scalars
+!
+!           write(6,*) "Uploading constant data to GPU for super-group ", SU
+!           write(6,*) "n1,n2,n3,n4: ", SHELLS%LAW2(SU)%n1(1), SHELLS%LAW2(SU)%n2(1), SHELLS%LAW2(SU)%n3(1), SHELLS%LAW2(SU)%n4(1)
+            call shell_gpu_upload_constant(&
+            &SHELLS%LAW2(SU)%handle,&
+            &SHELLS%LAW2(SU)%n1,&
+            &SHELLS%LAW2(SU)%n2,&
+            &SHELLS%LAW2(SU)%n3,&
+            &SHELLS%LAW2(SU)%n4,&
+            &SHELLS%LAW2(SU)%el_thk0,&
+            &SHELLS%LAW2(SU)%el_off,&
+            &SHELLS%LAW2(SU)%el_ssp,&
+            &SHELLS%LAW2(SU)%el_rho,&
+            &SHELLS%LAW2(SU)%el_ym,&
+            &SHELLS%LAW2(SU)%el_nu,&
+            &SHELLS%LAW2(SU)%el_a11,&
+            &SHELLS%LAW2(SU)%el_g_shear,&
+            &SHELLS%LAW2(SU)%el_shf)
+!
+!            Upload initial integration-point state
+!
+            write(6,*) "Uploading IP state to GPU for super-group ", SU
+            call shell_gpu_upload_ip_state(&
+            &SHELLS%LAW2(SU)%handle,&
+            &SHELLS%LAW2(SU)%sigxx,&
+            &SHELLS%LAW2(SU)%sigyy,&
+            &SHELLS%LAW2(SU)%sigxy,&
+            &SHELLS%LAW2(SU)%sigyz,&
+            &SHELLS%LAW2(SU)%sigzx,&
+            &SHELLS%LAW2(SU)%pla,&
+            &SHELLS%LAW2(SU)%epsd_ip,&
+            &SHELLS%LAW2(SU)%sigbakxx,&
+            &SHELLS%LAW2(SU)%sigbakyy,&
+            &SHELLS%LAW2(SU)%sigbakxy,&
+            &SHELLS%LAW2(SU)%tempel)
+            write(6,*) "Completed GPU upload for super-group ", SU
+          end do
+
+          if(allocated(node_mask)) deallocate(node_mask)
+          if(allocated(node_local_id)) deallocate(node_local_id)
+          if(allocated(glob_2_gpu)) deallocate(glob_2_gpu)
+          if(allocated(gpu_2_glob)) deallocate(gpu_2_glob)
+
+!
+!----6---------------------------------------------------------------7---------8
+          RETURN
+        END
+      end module shell_internal_forces_mod
+
+
+

--- a/engine/source/elements/shell/coque/shell_strain_material_kernel.cu
+++ b/engine/source/elements/shell/coque/shell_strain_material_kernel.cu
@@ -1,0 +1,993 @@
+//Copyright>    OpenRadioss
+//Copyright>    Copyright (C) 1986-2026 Altair Engineering Inc.
+//Copyright>
+//Copyright>    This program is free software: you can redistribute it and/or modify
+//Copyright>    it under the terms of the GNU Affero General Public License as published by
+//Copyright>    the Free Software Foundation, either version 3 of the License, or
+//Copyright>    (at your option) any later version.
+//Copyright>
+//Copyright>    This program is distributed in the hope that it will be useful,
+//Copyright>    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//Copyright>    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//Copyright>    GNU Affero General Public License for more details.
+//Copyright>
+//Copyright>    You should have received a copy of the GNU Affero General Public License
+//Copyright>    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//Copyright>
+//Copyright>
+//Copyright>    Commercial Alternative: Altair Radioss Software
+//Copyright>
+//Copyright>    As an alternative to this open-source version, Altair also offers Altair Radioss
+//Copyright>    software under a commercial license.  Contact Altair to discuss further if the
+//Copyright>    commercial version may interest you: https://www.altair.com/radioss/.
+// ==============================================================================
+//  OpenRadioss GPU — Kernel 2 (Option C): Strains + Material
+//  Covers: CCOEF3  — material / geometry coefficients (simplified, uniform mat)
+//          CDEFO3  — membrane strain rates         (IHBE <= 1)
+//          CCURV3  — curvature rates (bending)
+//          CSTRA3  — strain increments & accumulation
+//          CMAIN3 / SIGEPS02C / M2CPLR — through-thickness material integration
+//                   (Johnson-Cook law 02, radial-return plasticity)
+//
+//  Scope: ISMSTR=1, IHBE<=1, ISHFRAM=0, MTN=2 (Johnson-Cook)
+//         One thread per element, flat SoA layout.
+// ==============================================================================
+
+#ifndef SHELL_STRAIN_MATERIAL_KERNEL_CU
+#define SHELL_STRAIN_MATERIAL_KERNEL_CU
+
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <cfloat>
+#include <type_traits>
+#include "real_type.h"
+
+// ===========================================================================
+//  Johnson-Cook material parameters — passed via constant memory or struct
+// ===========================================================================
+struct JohnsonCookParams {
+    Real E;           // Young's modulus
+    Real nu;          // Poisson's ratio
+    Real G;           // Shear modulus  E/(2(1+nu))
+    Real A11;         // plane-stress stiffness  E/(1-nu^2)
+    Real A12;         // coupling  nu*A11
+    Real CA;          // J-C param A  (initial yield)
+    Real CB;          // J-C param B  (hardening modulus)
+    Real CN;          // J-C param n  (hardening exponent)
+    Real CC;          // J-C param C  (strain-rate sensitivity)
+    Real EPDR;        // reference strain rate  (before dt scaling)
+    Real EPMX;        // max plastic strain for ductile rupture
+    Real YMAX;        // yield stress cap
+    Real M_EXP;       // thermal exponent m
+    Real FISOKIN;     // isotropic/kinematic ratio (1=iso, 0=kin)
+    Real RHOCP;       // rho * Cp  (adiabatic heating)
+    Real TREF;        // reference temperature
+    Real TMELT;       // melting temperature
+    Real ASRATE;      // strain-rate filter coefficient
+    Real RHO;         // density
+    Real SSP;         // sound speed
+    Real SHF_COEF;    // shear factor (from GEO, typically 5/6)
+    int    IPLA;        // plasticity algorithm (0,1,2)
+    int    VP;          // strain-rate mode (1=plastic, 2=total, 3=deviatoric)
+    int    IFORM;       // 0=Johnson-Cook, 1=Zerilli-Armstrong
+    int    ICC;         // Cowper-Symonds flag
+    Real Z3, Z4;      // Zerilli-Armstrong params (zero for J-C)
+};
+
+// ===========================================================================
+//  Device helper: M2CPLR-equivalent radial-return for a SINGLE integration pt
+//  Implements IPLA=0 (simple radial), IPLA=1 (plane-stress Newton, 3 iter),
+//  and IPLA=2 (normal projection + radial return).
+//  Kinematic hardening included when FISOKIN > 0.
+// ===========================================================================
+template <int IPLA>
+__device__ __forceinline__ void m2cplr_device(
+    // Material constants
+    Real A1, Real A2, Real G_mod, Real GS_val,
+    Real nu, Real E_mod,
+    Real CA_eff, Real CB_eff, Real CN, Real YMAX_eff,
+    Real CC_val, Real EPDR_scaled, Real FISOKIN,
+    // Strain increments (combined membrane + bending)
+    Real depsxx, Real depsyy, Real depsxy, Real depsyz, Real depszx,
+    // Old stress (input)
+    Real sigoxx, Real sigoyy, Real sigoxy, Real sigoyz, Real sigozx,
+    // Backstress (in/out)
+    Real &sigbakxx, Real &sigbakyy, Real &sigbakxy,
+    // Strain rate * dt
+    Real epsdot,
+    // State (in/out)
+    Real &pla, Real off,
+    // Outputs
+    Real &signxx, Real &signyy, Real &signxy, Real &signyz, Real &signzx,
+    Real &dpla, Real &ezz, Real &yld_out, Real &hardm, Real &etse)
+{
+    const Real SMALL = 1.0e-7;
+    const int NMAX = 3;
+    Real H_val = 0.0;
+
+    // --- Initialize new stress = old stress ---
+    signxx = sigoxx;
+    signyy = sigoyy;
+    signxy = sigoxy;
+    signyz = sigoyz;
+    signzx = sigozx;
+    etse   = 1.0;
+
+    // --- Kinematic hardening: subtract backstress ---
+    if (FISOKIN > 0.0) {
+        signxx -= sigbakxx;
+        signyy -= sigbakyy;
+        signxy -= sigbakxy;
+    }
+
+    // --- Elastic predictor ---
+    signxx += A1 * depsxx + A2 * depsyy;
+    signyy += A2 * depsxx + A1 * depsyy;
+    signxy += G_mod * depsxy;
+    signyz += GS_val * depsyz;
+    signzx += GS_val * depszx;
+
+    // --- Strain rate effect on yield parameters ---
+    Real ca_loc = CA_eff;
+    Real cb_loc = CB_eff;
+    Real ymax_loc = YMAX_eff;
+
+    // (logep computed from epsdot already scaled by dt)
+    Real logep = 0.0;
+    if (CC_val != 0.0) {
+        Real epsp_use = fmax(epsdot, EPDR_scaled);
+        logep = log(epsp_use / EPDR_scaled);
+        // Johnson-Cook strain-rate + thermal is already folded into CA_eff, CB_eff externally
+        // but for IFORM=0 (J-C) we apply the (1 + C*ln) factor here
+        Real q = (1.0 + CC_val * logep);
+        q = fmax(q, 1.0e-20);
+        ca_loc *= q;
+        cb_loc *= q;
+    }
+
+    // --- Yield stress ---
+    dpla = 0.0;
+    ezz  = 0.0;
+    Real yld;
+    if (pla == 0.0) {
+        yld = ca_loc;
+    } else {
+        Real beta = cb_loc * (1.0 - FISOKIN);
+        yld = ca_loc + beta * pow(pla, CN);
+    }
+    yld = fmin(yld, ymax_loc);
+    yld_out = yld;
+
+    // =================================================================
+    //  IPLA = 0: Simple radial return
+    // =================================================================
+    if (IPLA == 0) {
+        Real svm = sqrt(signxx * signxx + signyy * signyy - signxx * signyy + 3.0 * signxy * signxy);
+        Real r = fmin(1.0, yld / (svm + 1.0e-15));
+        if (r < 1.0) {
+            signxx *= r;
+            signyy *= r;
+            signxy *= r;
+            dpla = off * fmax(0.0, (svm - yld) / E_mod);
+            Real s1 = 0.5 * (signxx + signyy);
+            ezz = dpla * s1 / yld;
+            pla += dpla;
+            if (yld >= ymax_loc)
+                H_val = 0.0;
+            else
+                H_val = CN * cb_loc * pow(pla + SMALL, CN - 1.0);
+            etse = H_val / (H_val + E_mod);
+        }
+    }
+    // =================================================================
+    //  IPLA = 1: Plane-stress corrected Newton iteration (3 iterations)
+    // =================================================================
+    else if (IPLA == 1) {
+        Real s1_val = signxx + signyy;
+        Real s2_val = signxx - signyy;
+        Real s3_val = signxy;
+        Real Av = 0.25 * s1_val * s1_val;
+        Real Bv = 0.75 * s2_val * s2_val + 3.0 * s3_val * s3_val;
+        Real svm = sqrt(Av + Bv);
+
+        if (svm > yld && off == 1.0) {
+            Real nu1 = 1.0 / (1.0 - nu);
+            Real nu2 = 1.0 / (1.0 + nu);
+            if (yld >= ymax_loc)
+                H_val = 0.0;
+            else
+                H_val = CN * cb_loc * pow(pla + SMALL, CN - 1.0);
+            etse = H_val / (H_val + E_mod);
+
+            Real dpla_j = (svm - yld) / (3.0 * G_mod + H_val);
+            Real Anu1 = Av * nu1;
+            Real Bnu2 = 3.0 * Bv * nu2;
+            Real H2 = 2.0 * H_val;
+
+            Real P_val, Q_val;
+
+            if (FISOKIN == 0.0) {
+                // Pure isotropic hardening path
+                for (int n = 0; n < NMAX; n++) {
+                    Real dpla_i = dpla_j;
+                    Real pla_i = pla + dpla_i;
+                    dpla = dpla_j;
+                    Real yld_i;
+                    if (pla_i == 0.0)
+                        yld_i = fmin(ymax_loc, ca_loc);
+                    else
+                        yld_i = fmin(ymax_loc, ca_loc + cb_loc * pow(pla_i, CN));
+                    Real DR = 0.5 * E_mod * dpla_i / yld_i;
+                    P_val = 1.0 / (1.0 + DR * nu1);
+                    Q_val = 1.0 / (1.0 + 3.0 * DR * nu2);
+                    Real P2 = P_val * P_val;
+                    Real Q2 = Q_val * Q_val;
+                    Real F_val = Av * P2 + Bv * Q2 - yld_i * yld_i;
+                    Real DF_val = -(Anu1 * P2 * P_val + Bnu2 * Q2 * Q_val)
+                                    * (E_mod - DR * H2) / yld_i
+                                    - H2 * yld_i;
+                    if (dpla_i > 0.0)
+                        dpla_j = fmax(0.0, dpla_i - F_val / DF_val);
+                    else
+                        dpla_j = 0.0;
+                }
+            } else {
+                // Mixed isotropic/kinematic hardening
+                Real beta_h = H_val * FISOKIN;
+                Real HI = H_val - beta_h;
+                Real HK = (2.0 / 3.0) * beta_h;
+                Real aaa = 3.0 * HK / E_mod;
+                Real nu11 = nu1 + aaa;
+                Real nu21 = 3.0 * nu2 + aaa;
+                Anu1 = Av * nu11;
+                Bnu2 = Bv * nu21;
+                H2 = 2.0 * HI;
+
+                for (int n = 0; n < NMAX; n++) {
+                    Real dpla_i = dpla_j;
+                    Real pla_i = pla + dpla_i;
+                    dpla = dpla_j;
+                    Real beta = 1.0 - FISOKIN;
+                    Real yld_i;
+                    if (pla_i == 0.0)
+                        yld_i = fmin(ymax_loc, ca_loc);
+                    else
+                        yld_i = fmin(ymax_loc, ca_loc + beta * cb_loc * pow(pla_i, CN));
+                    Real DR = 0.5 * E_mod * dpla_i / yld_i;
+                    P_val = 1.0 / (1.0 + DR * nu11);
+                    Q_val = 1.0 / (1.0 + DR * nu21);
+                    Real P2 = P_val * P_val;
+                    Real Q2 = Q_val * Q_val;
+                    Real F_val = Av * P2 + Bv * Q2 - yld_i * yld_i;
+                    Real DF_val = -(Anu1 * P2 * P_val + Bnu2 * Q2 * Q_val)
+                                    * (E_mod - DR * H2) / yld_i
+                                    - H2 * yld_i;
+                    if (dpla_i > 0.0)
+                        dpla_j = fmax(0.0, dpla_i - F_val / DF_val);
+                    else
+                        dpla_j = 0.0;
+                }
+            }
+
+            // --- Plastically admissible stresses ---
+            pla += dpla;
+            Real S1 = (signxx + signyy) * P_val;
+            Real S2 = (signxx - signyy) * Q_val;
+            signxx = 0.5 * (S1 + S2);
+            signyy = 0.5 * (S1 - S2);
+            signxy = signxy * Q_val;
+            Real DR_final = 0.5 * E_mod * dpla / yld;
+            ezz = DR_final * S1 / E_mod;
+        }
+    }
+    // =================================================================
+    //  IPLA = 2: Normal projection + radial return
+    // =================================================================
+    else if (IPLA == 2) {
+        Real svm2 = signxx * signxx + signyy * signyy
+                      - signxx * signyy + 3.0 * signxy * signxy;
+        Real svm = sqrt(svm2);
+        Real yld2 = yld * yld;
+
+        if (svm2 > yld2 && off == 1.0) {
+            if (yld >= ymax_loc)
+                H_val = 0.0;
+            else
+                H_val = CN * cb_loc * pow(pla + SMALL, CN - 1.0);
+            etse = H_val / (H_val + E_mod);
+
+            // Normal projection
+            Real aa = (svm2 - yld2)
+                        / (5.0 * svm2 + 3.0 * (-signxx * signyy + signxy * signxy));
+            Real s1n = (1.0 - 2.0 * aa) * signxx + aa * signyy;
+            Real s2n = aa * signxx + (1.0 - 2.0 * aa) * signyy;
+            Real s3n = (1.0 - 3.0 * aa) * signxy;
+            signxx = s1n;
+            signyy = s2n;
+            signxy = s3n;
+
+            dpla = off * (svm - yld) / (3.0 * G_mod + H_val);
+            pla += dpla;
+            yld += H_val * dpla;
+
+            // Radial return
+            svm = sqrt(signxx * signxx + signyy * signyy
+                       - signxx * signyy + 3.0 * signxy * signxy);
+            Real r = fmin(1.0, yld / fmax(1.0e-20, svm));
+            signxx *= r;
+            signyy *= r;
+            signxy *= r;
+            ezz = dpla * 0.5 * (signxx + signyy) / yld;
+        }
+    }
+
+    yld_out = yld;
+    hardm = H_val;
+
+    // --- Kinematic hardening: update backstress, re-add ---
+    if (FISOKIN > 0.0) {
+        Real hkin = FISOKIN * H_val;
+        Real alpha = (yld > 0.0) ? hkin * dpla / yld : 0.0;
+        sigbakxx += alpha * signxx;
+        sigbakyy += alpha * signyy;
+        sigbakxy += alpha * signxy;
+
+        signxx += sigbakxx;
+        signyy += sigbakyy;
+        signxy += sigbakxy;
+    }
+}
+
+// ===========================================================================
+//  Kernel 2 — shell_strain_material_kernel
+//
+//  Reads outputs of Kernel 1 (local frame, velocities, shape functions).
+//  Produces generalized forces FOR(5) and moments MOM(3), updated element
+//  state (GSTR, THK, OFF, PLA, SIG, EPSD, SIGBAK, EINT …).
+//
+//  Thread mapping:  I = blockIdx.x * blockDim.x + threadIdx.x
+// ===========================================================================
+template <int IPLA, int NPT, int ISMSTR>
+__global__ __launch_bounds__(256, 1) void shell_strain_material_kernel(
+    // ---- Inputs from Kernel 1 (per-element, read-only) ----
+    const Real* __restrict__ d_E1x,
+    const Real* __restrict__ d_E1y,
+    const Real* __restrict__ d_E1z,
+    const Real* __restrict__ d_E2x,
+    const Real* __restrict__ d_E2y,
+    const Real* __restrict__ d_E2z,
+    const Real* __restrict__ d_E3x,
+    const Real* __restrict__ d_E3y,
+    const Real* __restrict__ d_E3z,
+    // Gathered translational velocities  (4 nodes × 3)
+    const Real* __restrict__ d_VL1x,
+    const Real* __restrict__ d_VL1y,
+    const Real* __restrict__ d_VL1z,
+    const Real* __restrict__ d_VL2x,
+    const Real* __restrict__ d_VL2y,
+    const Real* __restrict__ d_VL2z,
+    const Real* __restrict__ d_VL3x,
+    const Real* __restrict__ d_VL3y,
+    const Real* __restrict__ d_VL3z,
+    const Real* __restrict__ d_VL4x,
+    const Real* __restrict__ d_VL4y,
+    const Real* __restrict__ d_VL4z,
+    // Gathered rotational velocities  (4 nodes × 3)
+    const Real* __restrict__ d_VRL1x,
+    const Real* __restrict__ d_VRL1y,
+    const Real* __restrict__ d_VRL1z,
+    const Real* __restrict__ d_VRL2x,
+    const Real* __restrict__ d_VRL2y,
+    const Real* __restrict__ d_VRL2z,
+    const Real* __restrict__ d_VRL3x,
+    const Real* __restrict__ d_VRL3y,
+    const Real* __restrict__ d_VRL3z,
+    const Real* __restrict__ d_VRL4x,
+    const Real* __restrict__ d_VRL4y,
+    const Real* __restrict__ d_VRL4z,
+    // Shape-function derivatives & geometry from Kernel 1
+    const Real* __restrict__ d_PX1,
+    const Real* __restrict__ d_PX2,
+    const Real* __restrict__ d_PY1,
+    const Real* __restrict__ d_PY2,
+    const Real* __restrict__ d_AREA,
+    const Real* __restrict__ d_A_I,
+    // Displacement increments (ISMSTR=11 only; zero otherwise)
+    const Real* __restrict__ d_UX1,
+    const Real* __restrict__ d_UY1,
+    const Real* __restrict__ d_UX2,
+    const Real* __restrict__ d_UY2,
+    const Real* __restrict__ d_UX3,
+    const Real* __restrict__ d_UY3,
+    const Real* __restrict__ d_UX4,
+    const Real* __restrict__ d_UY4,
+    // ---- Element state (read/write) ----
+    Real* __restrict__ d_OFF,         // [NUMELC]
+    Real* __restrict__ d_THK,         // [NUMELC] current thickness
+    const Real* __restrict__ d_THK0,  // [NUMELC] reference thickness
+    Real* __restrict__ d_GSTR,        // [NUMELC*8] accumulated strains
+    Real* __restrict__ d_EINT,        // [NUMELC*2] internal energy
+    Real* __restrict__ d_EPSD_elem,   // [NUMELC]   element strain rate
+    // ---- Per-integration-point state [NPT * NUMELC] each ----
+    Real* __restrict__ d_SIGxx,
+    Real* __restrict__ d_SIGyy,
+    Real* __restrict__ d_SIGxy,
+    Real* __restrict__ d_SIGyz,
+    Real* __restrict__ d_SIGzx,
+    Real* __restrict__ d_PLA,
+    Real* __restrict__ d_EPSD_ip,
+    Real* __restrict__ d_SIGBAKxx,
+    Real* __restrict__ d_SIGBAKyy,
+    Real* __restrict__ d_SIGBAKxy,
+    Real* __restrict__ d_DPLA,
+    Real* __restrict__ d_TEMPEL,      // [NPT*NUMELC] temperature
+    // ---- Outputs: generalized forces/moments for Kernel 3 ----
+    Real* __restrict__ d_FORxx,       // [NUMELC] FOR(1)= Nxx/thk
+    Real* __restrict__ d_FORyy,       // [NUMELC] FOR(2)= Nyy/thk
+    Real* __restrict__ d_FORxy,       // [NUMELC] FOR(3)= Nxy/thk
+    Real* __restrict__ d_FORyz,       // [NUMELC] FOR(4)= Nyz/thk
+    Real* __restrict__ d_FORzx,       // [NUMELC] FOR(5)= Nxz/thk
+    Real* __restrict__ d_MOMxx,       // [NUMELC] MOM(1)= Mxx/thk^2
+    Real* __restrict__ d_MOMyy,       // [NUMELC] MOM(2)= Myy/thk^2
+    Real* __restrict__ d_MOMxy,       // [NUMELC] MOM(3)= Mxy/thk^2
+    // Output SIGY (average yield)
+    Real* __restrict__ d_SIGY,        // [NUMELC]
+    // ---- Scalars & material ----
+    JohnsonCookParams mat,
+    Real dt,
+    int    NUMELC,
+    int    ITHK,                        // thickness update flag
+    int    NCYCLE_DBG                    // cycle number for debug prints
+)
+{
+    // ======================================================================
+    //  Thread mapping
+    // ======================================================================
+    int I = blockIdx.x * blockDim.x + threadIdx.x;
+    if (I >= NUMELC) return;
+
+    // ======================================================================
+    //  Load Kernel 1 outputs (all register-resident after this)
+    // ======================================================================
+    Real e1x = d_E1x[I]; Real e1y = d_E1y[I]; Real e1z = d_E1z[I];
+    Real e2x = d_E2x[I]; Real e2y = d_E2y[I]; Real e2z = d_E2z[I];
+    Real e3x = d_E3x[I]; Real e3y = d_E3y[I]; Real e3z = d_E3z[I];
+
+    Real vl1x = d_VL1x[I]; Real vl1y = d_VL1y[I]; Real vl1z = d_VL1z[I];
+    Real vl2x = d_VL2x[I]; Real vl2y = d_VL2y[I]; Real vl2z = d_VL2z[I];
+    Real vl3x = d_VL3x[I]; Real vl3y = d_VL3y[I]; Real vl3z = d_VL3z[I];
+    Real vl4x = d_VL4x[I]; Real vl4y = d_VL4y[I]; Real vl4z = d_VL4z[I];
+
+    Real vrl1x = d_VRL1x[I]; Real vrl1y = d_VRL1y[I]; Real vrl1z = d_VRL1z[I];
+    Real vrl2x = d_VRL2x[I]; Real vrl2y = d_VRL2y[I]; Real vrl2z = d_VRL2z[I];
+    Real vrl3x = d_VRL3x[I]; Real vrl3y = d_VRL3y[I]; Real vrl3z = d_VRL3z[I];
+    Real vrl4x = d_VRL4x[I]; Real vrl4y = d_VRL4y[I]; Real vrl4z = d_VRL4z[I];
+
+    Real px1  = d_PX1[I];   Real px2  = d_PX2[I];
+    Real py1  = d_PY1[I];   Real py2  = d_PY2[I];
+    Real area = d_AREA[I];  Real a_i  = d_A_I[I];
+
+    Real off_i  = d_OFF[I];
+    Real thk_i  = d_THK[I];
+    Real thk0_i = d_THK0[I];
+
+    // ======================================================================
+    //  1.  CCOEF3 — Material/geometry coefficients (simplified: uniform mat)
+    // ======================================================================
+    Real ym   = mat.E;
+    Real nu_v = mat.nu;
+    Real g_v  = mat.G;
+    Real a11  = mat.A11;
+    Real a12  = mat.A12;
+    Real shf;
+
+    Real thk02 = thk0_i * thk0_i;
+    Real vol0  = thk0_i * area;
+
+    // Shear factor: SHF logic from CCOEF3  (NPT==1 → shf=0, else from GEO)
+    if (NPT == 1) {
+        shf = 0.0;
+    } else {
+        shf = mat.SHF_COEF;
+    }
+    Real gs_val = g_v * shf;
+
+    // ======================================================================
+    //  2.  CDEFO3 — Membrane strain rates × area  (IHBE <= 1)
+    // ======================================================================
+    //  Project nodal velocities → local frame
+    //  Staged FMA waves: 12 independent ops per wave to fill DP pipeline
+    //  (6-cycle DP latency needs ≥6 independent insns; 12 per wave is ideal)
+
+    //  Wave 1: initial products (12 independent DMULs)
+    Real vx1 = e1x * vl1x;  Real vx2 = e1x * vl2x;
+    Real vx3 = e1x * vl3x;  Real vx4 = e1x * vl4x;
+    Real vy1 = e2x * vl1x;  Real vy2 = e2x * vl2x;
+    Real vy3 = e2x * vl3x;  Real vy4 = e2x * vl4x;
+    Real vz1 = e3x * vl1x;  Real vz2 = e3x * vl2x;
+    Real vz3 = e3x * vl3x;  Real vz4 = e3x * vl4x;
+
+    //  Wave 2: second component FMAs (12 independent, each depends on one Wave 1 result)
+    vx1 = fma(e1y, vl1y, vx1);  vx2 = fma(e1y, vl2y, vx2);
+    vx3 = fma(e1y, vl3y, vx3);  vx4 = fma(e1y, vl4y, vx4);
+    vy1 = fma(e2y, vl1y, vy1);  vy2 = fma(e2y, vl2y, vy2);
+    vy3 = fma(e2y, vl3y, vy3);  vy4 = fma(e2y, vl4y, vy4);
+    vz1 = fma(e3y, vl1y, vz1);  vz2 = fma(e3y, vl2y, vz2);
+    vz3 = fma(e3y, vl3y, vz3);  vz4 = fma(e3y, vl4y, vz4);
+
+    //  Wave 3: third component FMAs (12 independent, each depends on one Wave 2 result)
+    vx1 = fma(e1z, vl1z, vx1);  vx2 = fma(e1z, vl2z, vx2);
+    vx3 = fma(e1z, vl3z, vx3);  vx4 = fma(e1z, vl4z, vx4);
+    vy1 = fma(e2z, vl1z, vy1);  vy2 = fma(e2z, vl2z, vy2);
+    vy3 = fma(e2z, vl3z, vy3);  vy4 = fma(e2z, vl4z, vy4);
+    vz1 = fma(e3z, vl1z, vz1);  vz2 = fma(e3z, vl2z, vz2);
+    vz3 = fma(e3z, vl3z, vz3);  vz4 = fma(e3z, vl4z, vz4);
+
+    Real vz13 = vz1 - vz3;
+    Real vz24 = vz2 - vz4;
+
+    //  Transverse shear strain rates × area
+    Real eyz = py1 * vz13 + py2 * vz24;
+    Real exz = px1 * vz13 + px2 * vz24;
+
+    //  IHBE <= 1: Z2 set to zero, membrane warping correction
+    Real dt1v4 = 0.25 * dt;
+
+    Real tmp2a = py2 + py1;
+    Real tmp3a = copysign(fmax(fabs(tmp2a), 1.0e-20), tmp2a);
+    Real tmp1a = dt1v4 * (vz13 - vz24) * (vz13 - vz24) / tmp3a;
+
+    Real vx13 = vx1 - vx3 - tmp1a;
+    Real vx24 = vx2 - vx4 + tmp1a;
+
+    Real exx = px1 * vx13 + px2 * vx24;  // ε̇_xx × area
+    Real exy = py1 * vx13 + py2 * vx24;  // partial γ̇_xy × area
+
+    Real tmp1b = px2 - px1;
+    Real tmp3b = copysign(fmax(fabs(tmp1b), 1.0e-20), tmp1b);
+    Real tmp2b = dt1v4 * (vz13 + vz24) * (vz13 + vz24) / tmp3b;
+
+    Real vy13 = vy1 - vy3 + tmp2b;
+    Real vy24 = vy2 - vy4 + tmp2b;
+
+    exy += px1 * vy13 + px2 * vy24;        // complete γ̇_xy × area
+    Real eyy = py1 * vy13 + py2 * vy24;  // ε̇_yy × area
+
+    // ======================================================================
+    //  3.  CCURV3 — Curvature rates × area
+    // ======================================================================
+    //  Project rotational velocities → local frame (staged FMA waves, 8 per wave)
+    //  Wave 1: initial products
+    Real rx1 = e1x * vrl1x;  Real rx2 = e1x * vrl2x;
+    Real rx3 = e1x * vrl3x;  Real rx4 = e1x * vrl4x;
+    Real ry1 = e2x * vrl1x;  Real ry2 = e2x * vrl2x;
+    Real ry3 = e2x * vrl3x;  Real ry4 = e2x * vrl4x;
+
+    //  Wave 2: second component FMAs
+    rx1 = fma(e1y, vrl1y, rx1);  rx2 = fma(e1y, vrl2y, rx2);
+    rx3 = fma(e1y, vrl3y, rx3);  rx4 = fma(e1y, vrl4y, rx4);
+    ry1 = fma(e2y, vrl1y, ry1);  ry2 = fma(e2y, vrl2y, ry2);
+    ry3 = fma(e2y, vrl3y, ry3);  ry4 = fma(e2y, vrl4y, ry4);
+
+    //  Wave 3: third component FMAs
+    rx1 = fma(e1z, vrl1z, rx1);  rx2 = fma(e1z, vrl2z, rx2);
+    rx3 = fma(e1z, vrl3z, rx3);  rx4 = fma(e1z, vrl4z, rx4);
+    ry1 = fma(e2z, vrl1z, ry1);  ry2 = fma(e2z, vrl2z, ry2);
+    ry3 = fma(e2z, vrl3z, ry3);  ry4 = fma(e2z, vrl4z, ry4);
+
+    Real rx13 = rx1 - rx3;
+    Real rx24 = rx2 - rx4;
+    Real ry13 = ry1 - ry3;
+    Real ry24 = ry2 - ry4;
+
+    //  Curvature rates × area
+    Real kyy = -(py1 * rx13 + py2 * rx24);
+    Real kxx =   px1 * ry13 + px2 * ry24;
+    Real kxy = (py1 * ry13 + py2 * ry24) - (px1 * rx13 + px2 * rx24);
+
+
+    //  Update transverse shear from average rotation
+    Real rxav = rx1 + rx2 + rx3 + rx4;
+    Real ryav = ry1 + ry2 + ry3 + ry4;
+    exz += ryav * 0.25 * area;
+    eyz -= rxav * 0.25 * area;
+
+    // ======================================================================
+    //  4.  CSTRA3 — Strain increments (dt / area scaling) & accumulation
+    // ======================================================================
+    Real fac1 = dt / area;
+    exx *= fac1;   // Δε_xx
+    eyy *= fac1;   // Δε_yy
+    exy *= fac1;   // Δγ_xy
+    exz *= fac1;   // Δγ_xz
+    eyz *= fac1;   // Δγ_yz
+    kxx *= fac1;   // Δκ_xx
+    kyy *= fac1;   // Δκ_yy
+    kxy *= fac1;   // Δκ_xy
+
+    //  GSTR accumulation (ISMSTR /= 11 path — standard incremental)
+    if (ISMSTR != 11) {
+        d_GSTR[0 * NUMELC + I] += exx;
+        d_GSTR[1 * NUMELC + I] += eyy;
+        d_GSTR[2 * NUMELC + I] += exy;
+        d_GSTR[3 * NUMELC + I] += eyz;
+        d_GSTR[4 * NUMELC + I] += exz;
+        d_GSTR[5 * NUMELC + I] += kxx;
+        d_GSTR[6 * NUMELC + I] += kyy;
+        d_GSTR[7 * NUMELC + I] += kxy;
+    } else {
+        //  ISMSTR=11: membrane strains from displacement increments
+        Real ux1_v = d_UX1[I]; Real uy1_v = d_UY1[I];
+        Real ux2_v = d_UX2[I]; Real uy2_v = d_UY2[I];
+        Real ux3_v = d_UX3[I]; Real uy3_v = d_UY3[I];
+        Real ux4_v = d_UX4[I]; Real uy4_v = d_UY4[I];
+
+        Real fac_a = a_i;  // 1/area
+        Real ux13d = ux1_v - ux3_v;
+        Real ux24d = ux2_v - ux4_v;
+        Real uy13d = uy1_v - uy3_v;
+        Real uy24d = uy2_v - uy4_v;
+
+        d_GSTR[0 * NUMELC + I] = (px1 * ux13d + px2 * ux24d) * fac_a;
+        d_GSTR[1 * NUMELC + I] = (py1 * uy13d + py2 * uy24d) * fac_a;
+        d_GSTR[2 * NUMELC + I] = (py1 * ux13d + py2 * ux24d
+                                 + px1 * uy13d + px2 * uy24d) * fac_a;
+        d_GSTR[3 * NUMELC + I] += eyz;
+        d_GSTR[4 * NUMELC + I] += exz;
+        d_GSTR[5 * NUMELC + I] += kxx;
+        d_GSTR[6 * NUMELC + I] += kyy;
+        d_GSTR[7 * NUMELC + I] += kxy;
+    }
+
+    // ======================================================================
+    //  4b. Stress-work internal energy — trapezoidal rule, part 1
+    //      Read generalized forces from PREVIOUS timestep (still in d_FOR/MOM).
+    //      degmb = FOR_old · Δε,  degfx = MOM_old · Δκ
+    // ======================================================================
+    Real for_old_xx = d_FORxx[I];
+    Real for_old_yy = d_FORyy[I];
+    Real for_old_xy = d_FORxy[I];
+    Real for_old_yz = d_FORyz[I];
+    Real for_old_zx = d_FORzx[I];
+    Real mom_old_xx = d_MOMxx[I];
+    Real mom_old_yy = d_MOMyy[I];
+    Real mom_old_xy = d_MOMxy[I];
+
+    Real degmb = for_old_xx * exx + for_old_yy * eyy + for_old_xy * exy
+                 + for_old_yz * eyz + for_old_zx * exz;
+    Real degfx = mom_old_xx * kxx + mom_old_yy * kyy + mom_old_xy * kxy;
+
+    // ======================================================================
+    //  5.  Equivalent strain rate for element (energy-equivalent)
+    //      CPU formula (cforc3.F lines 564-568):
+    //        eps_m2 = 4/3*(exx²+eyy²+exx*eyy+¼*exy²)
+    //        eps_k2 = 1/9*thk²*(kxx²+kyy²+kxx*kyy+¼*kxy²)
+    //        epsd_pg = sqrt(eps_m2 + eps_k2) / dt
+    // ======================================================================
+    Real eps_m2 = (4.0/3.0) * (exx*exx + eyy*eyy + exx*eyy + 0.25*exy*exy);
+    Real eps_k2 = (1.0/9.0) * thk_i * thk_i
+                  * (kxx*kxx + kyy*kyy + kxx*kyy + 0.25*kxy*kxy);
+    Real epsd_eq = sqrt(eps_m2 + eps_k2) / fmax(dt, 1.0e-30);
+
+    // ======================================================================
+    //  6.  CMAIN3 / SIGEPS02C — Through-thickness material integration
+    //      Gauss quadrature over NPT points.
+    //      Accumulate generalized forces (Nij) and moments (Mij).
+    // ======================================================================
+    Real nxx = 0.0, nyy = 0.0, nxy = 0.0, nyz_f = 0.0, nxz_f = 0.0;
+    Real mxx = 0.0, myy = 0.0, mxy = 0.0;
+    Real sigy_acc = 0.0;
+
+    Real off_old = fabs(off_i);  // store for rupture check
+    Real thk_updated = thk_i;
+
+    //  EPDR scaled by dt (as in SIGEPS02C)
+    Real epdr_scaled = fmax(mat.EPDR * dt, 1.0e-20);
+
+    //  Pre-compute thermal factor for J-C (IFORM=0)
+    //  (Zerilli not implemented in this mockup for simplicity)
+
+    for (int ipt = 0; ipt < NPT; ipt++) {
+        // --- Gauss point z-coordinate in [-0.5, +0.5] of unit thickness ---
+        //     For NPT points, Simpson-like spacing:
+        //     zeta = (-0.5 + (ipt + 0.5) / NPT)  →  maps to [-0.5, +0.5]
+        Real zeta = -0.5 + ((Real)ipt + 0.5) / (Real)NPT;
+        Real z_pos = zeta * thk0_i;  // physical z-coordinate
+
+        //  Integration weight  (trapezoidal / equal spacing):
+        //  wt = thk0 / NPT   (equal weight for each point)
+        Real wt = thk0_i / (Real)NPT;
+
+        // --- Combined strain increment at this z-point ---
+        Real deps_xx = exx + z_pos * kxx;
+        Real deps_yy = eyy + z_pos * kyy;
+        Real deps_xy = exy + z_pos * kxy;
+        Real deps_yz = eyz;
+        Real deps_zx = exz;
+
+        // --- Read old stress & state for this integration point ---
+        int idx = ipt * NUMELC + I;
+        Real sigo_xx = d_SIGxx[idx];
+        Real sigo_yy = d_SIGyy[idx];
+        Real sigo_xy = d_SIGxy[idx];
+        Real sigo_yz = d_SIGyz[idx];
+        Real sigo_zx = d_SIGzx[idx];
+        Real pla_ip  = d_PLA[idx];
+        Real epsd_ip = d_EPSD_ip[idx];
+        Real sbak_xx = d_SIGBAKxx[idx];
+        Real sbak_yy = d_SIGBAKyy[idx];
+        Real sbak_xy = d_SIGBAKxy[idx];
+        Real temp_ip = d_TEMPEL[idx];
+
+        // --- Strain rate for this integration point ---
+        Real epsdot_ip;
+        if (mat.VP == 1) {
+            epsdot_ip = epsd_ip * dt;  // stored filtered plastic rate
+        } else if (mat.VP == 2) {
+            epsd_ip = mat.ASRATE * epsd_eq + (1.0 - mat.ASRATE) * epsd_ip;
+            epsdot_ip = epsd_ip * dt;
+        } else {
+            epsdot_ip = epsd_ip * dt;  // VP=3 (simplified)
+        }
+
+        // --- Homologous temperature (J-C, IFORM=0) ---
+        Real tstar = 0.0;
+        if (mat.IFORM == 0 && mat.TMELT > mat.TREF) {
+            tstar = fmax(0.0, (temp_ip - mat.TREF) / (mat.TMELT - mat.TREF));
+        }
+
+        // --- Effective yield parameters with thermal softening ---
+        Real ca_eff = mat.CA;
+        Real cb_eff = mat.CB;
+        Real ymax_eff = mat.YMAX;
+        if (mat.IFORM == 0 && tstar > 0.0) {
+            Real tfac = 1.0 - pow(tstar, mat.M_EXP);
+            tfac = fmax(tfac, 1.0e-20);
+            ca_eff *= tfac;
+            cb_eff *= tfac;
+        }
+
+        // --- Radial return (M2CPLR equivalent) ---
+        Real sign_xx, sign_yy, sign_xy, sign_yz, sign_zx;
+        Real dpla_ip, ezz_ip, yld_ip, hardm_ip, etse_ip;
+        Real off_val = fmin(1.0, fabs(off_i));
+
+        m2cplr_device<IPLA>(
+            a11, a12, g_v, gs_val, nu_v, ym,
+            ca_eff, cb_eff, mat.CN, ymax_eff,
+            mat.CC, epdr_scaled, mat.FISOKIN,
+            deps_xx, deps_yy, deps_xy, deps_yz, deps_zx,
+            sigo_xx, sigo_yy, sigo_xy, sigo_yz, sigo_zx,
+            sbak_xx, sbak_yy, sbak_xy,
+            epsdot_ip,
+            pla_ip, off_val,
+            sign_xx, sign_yy, sign_xy, sign_yz, sign_zx,
+            dpla_ip, ezz_ip, yld_ip, hardm_ip, etse_ip);
+
+        // --- VP=1: post-update filtered plastic strain rate ---
+        if (mat.VP == 1) {
+            Real actual_rate = dpla_ip / fmax(dt, 1.0e-20);
+            epsd_ip = mat.ASRATE * actual_rate + (1.0 - mat.ASRATE) * epsd_ip;
+        }
+
+        // --- Yield stress accumulation ---
+        sigy_acc += yld_ip / (Real)NPT;
+
+        // --- Ductile rupture check ---
+        if (off_val == off_old && off_val > 0.0) {
+            if (off_val == 1.0 && pla_ip >= mat.EPMX && mat.EPMX > 0.0) {
+                off_val = 0.8;
+            } else if (off_val < 1.0) {
+                off_val *= 0.8;
+            }
+        }
+
+        // --- Thickness update (physical layer thickness = thk0/NPT) ---
+        // CPU MULAWGLC updates thickness unconditionally (ITHK not passed to mulawglc)
+        // ITHK only controls THK0=THK snapshot in CCOEF3, not physical THK evolution
+        Real thk_layer = thk0_i / (Real)NPT;
+        Real ezz_ps = -(deps_xx + deps_yy) * nu_v - (1.0 - 2.0 * nu_v) * ezz_ip;
+        ezz_ps /= (1.0 - nu_v);
+        thk_updated += ezz_ps * thk_layer * off_val;
+
+        // --- Temperature update (adiabatic) ---
+        if (mat.RHOCP > 0.0) {
+            temp_ip += yld_ip * dpla_ip / mat.RHOCP;
+        }
+
+        // --- Write updated state for this integration point ---
+        d_SIGxx[idx]    = sign_xx;
+        d_SIGyy[idx]    = sign_yy;
+        d_SIGxy[idx]    = sign_xy;
+        d_SIGyz[idx]    = sign_yz;
+        d_SIGzx[idx]    = sign_zx;
+        d_PLA[idx]      = pla_ip;
+        d_EPSD_ip[idx]  = epsd_ip;
+        d_SIGBAKxx[idx] = sbak_xx;
+        d_SIGBAKyy[idx] = sbak_yy;
+        d_SIGBAKxy[idx] = sbak_xy;
+        d_DPLA[idx]     = dpla_ip;
+        d_TEMPEL[idx]   = temp_ip;
+
+        // --- Accumulate generalized forces & moments (numerical integration) ---
+        nxx  += sign_xx * wt;
+        nyy  += sign_yy * wt;
+        nxy  += sign_xy * wt;
+        nyz_f += sign_yz * wt;
+        nxz_f += sign_zx * wt;
+        mxx  += sign_xx * z_pos * wt;
+        myy  += sign_yy * z_pos * wt;
+        mxy  += sign_xy * z_pos * wt;
+
+    } // end through-thickness loop
+
+    // ======================================================================
+    //  7.  Store generalized forces normalized by thickness
+    //      FOR = N / thk,  MOM = M / thk^2
+    // ======================================================================
+    Real inv_thk  = 1.0 / fmax(thk0_i, 1.0e-20);
+    Real inv_thk2 = inv_thk * inv_thk;  // MOM = M / thk0² (cf. CPU mulawc: mom = sum(wmc*sig))
+
+    // ======================================================================
+    //  7b. Stress-work internal energy — trapezoidal rule, part 2
+    //      degmb += FOR_new · Δε,  degfx += MOM_new · Δκ
+    //      then  eint(1) += degmb * ½ * vol0
+    //            eint(2) += degfx * thk0 * ½ * vol0
+    // ======================================================================
+    {
+        Real fnxx = nxx * inv_thk;
+        Real fnyy = nyy * inv_thk;
+        Real fnxy = nxy * inv_thk;
+        Real fnyz = nyz_f * inv_thk;
+        Real fnzx = nxz_f * inv_thk;
+        Real mnxx = mxx * inv_thk2;
+        Real mnyy = myy * inv_thk2;
+        Real mnxy = mxy * inv_thk2;
+
+        degmb += fnxx * exx + fnyy * eyy + fnxy * exy
+               + fnyz * eyz + fnzx * exz;
+        degfx += mnxx * kxx + mnyy * kyy + mnxy * kxy;
+
+        Real half_vol0 = 0.5 * vol0;
+        d_EINT[0 * NUMELC + I] += degmb * half_vol0;
+        d_EINT[1 * NUMELC + I] += degfx * thk0_i * half_vol0;
+    }
+
+    d_FORxx[I] = nxx * inv_thk;
+    d_FORyy[I] = nyy * inv_thk;
+    d_FORxy[I] = nxy * inv_thk;
+    d_FORyz[I] = nyz_f * inv_thk;
+    d_FORzx[I] = nxz_f * inv_thk;
+    d_MOMxx[I] = mxx * inv_thk2;
+    d_MOMyy[I] = myy * inv_thk2;
+    d_MOMxy[I] = mxy * inv_thk2;
+
+    // ======================================================================
+    //  8.  Update element-level state
+    // ======================================================================
+    d_THK[I]       = thk_updated;
+    d_SIGY[I]      = sigy_acc;
+    //  Element-level strain rate filtering (cf. cforc3.F line 570):
+    //    gbuf%epsd = asrate * epsd_pg + (1-asrate) * gbuf%epsd
+    //  For now asrate=1 (no filtering at element level), same as CPU default.
+    d_EPSD_elem[I] = epsd_eq;
+    // OFF is written back (may be modified by rupture at last ipt)
+    // For simplicity, we use the last-layer off_val; a more rigorous
+    // approach would track across all points.
+    // d_OFF[I] is already current (rupture is per-element, tracked externally).
+}
+
+// ===========================================================================
+//  Host-side launcher
+// ===========================================================================
+extern "C"
+void launch_shell_strain_material_kernel(
+    // Kernel 1 outputs (read-only)
+    const Real* d_E1x, const Real* d_E1y, const Real* d_E1z,
+    const Real* d_E2x, const Real* d_E2y, const Real* d_E2z,
+    const Real* d_E3x, const Real* d_E3y, const Real* d_E3z,
+    const Real* d_VL1x,  const Real* d_VL1y,  const Real* d_VL1z,
+    const Real* d_VL2x,  const Real* d_VL2y,  const Real* d_VL2z,
+    const Real* d_VL3x,  const Real* d_VL3y,  const Real* d_VL3z,
+    const Real* d_VL4x,  const Real* d_VL4y,  const Real* d_VL4z,
+    const Real* d_VRL1x, const Real* d_VRL1y, const Real* d_VRL1z,
+    const Real* d_VRL2x, const Real* d_VRL2y, const Real* d_VRL2z,
+    const Real* d_VRL3x, const Real* d_VRL3y, const Real* d_VRL3z,
+    const Real* d_VRL4x, const Real* d_VRL4y, const Real* d_VRL4z,
+    const Real* d_PX1,  const Real* d_PX2,
+    const Real* d_PY1,  const Real* d_PY2,
+    const Real* d_AREA, const Real* d_A_I,
+    const Real* d_UX1,  const Real* d_UY1,
+    const Real* d_UX2,  const Real* d_UY2,
+    const Real* d_UX3,  const Real* d_UY3,
+    const Real* d_UX4,  const Real* d_UY4,
+    // Element state
+    Real* d_OFF, Real* d_THK, const Real* d_THK0,
+    Real* d_GSTR, Real* d_EINT, Real* d_EPSD_elem,
+    // Per-integration-point state
+    Real* d_SIGxx, Real* d_SIGyy, Real* d_SIGxy,
+    Real* d_SIGyz, Real* d_SIGzx,
+    Real* d_PLA, Real* d_EPSD_ip,
+    Real* d_SIGBAKxx, Real* d_SIGBAKyy, Real* d_SIGBAKxy,
+    Real* d_DPLA, Real* d_TEMPEL,
+    // Outputs: generalized forces/moments
+    Real* d_FORxx, Real* d_FORyy, Real* d_FORxy,
+    Real* d_FORyz, Real* d_FORzx,
+    Real* d_MOMxx, Real* d_MOMyy, Real* d_MOMxy,
+    Real* d_SIGY,
+    // Scalars
+    JohnsonCookParams mat,
+    Real dt, int NPT, int NUMELC, int ISMSTR, int ITHK,
+    int NCYCLE_DBG,
+    cudaStream_t stream)
+{
+    const int BLOCK_SIZE = 256;
+    int grid_size = (NUMELC + BLOCK_SIZE - 1) / BLOCK_SIZE;
+
+    // -----------------------------------------------------------------------
+    //  Helper: launch kernel for a given (IPLA, NPT) pair
+    //  Common args block to avoid massive duplication
+    // -----------------------------------------------------------------------
+    auto launch = [&](auto ipla_tag, auto npt_tag, auto ismstr_tag) {
+        constexpr int IPLA_V   = decltype(ipla_tag)::value;
+        constexpr int NPT_V    = decltype(npt_tag)::value;
+        constexpr int ISMSTR_V = decltype(ismstr_tag)::value;
+        shell_strain_material_kernel<IPLA_V, NPT_V, ISMSTR_V><<<grid_size, BLOCK_SIZE, 0, stream>>>(
+            d_E1x, d_E1y, d_E1z, d_E2x, d_E2y, d_E2z, d_E3x, d_E3y, d_E3z,
+            d_VL1x, d_VL1y, d_VL1z, d_VL2x, d_VL2y, d_VL2z,
+            d_VL3x, d_VL3y, d_VL3z, d_VL4x, d_VL4y, d_VL4z,
+            d_VRL1x, d_VRL1y, d_VRL1z, d_VRL2x, d_VRL2y, d_VRL2z,
+            d_VRL3x, d_VRL3y, d_VRL3z, d_VRL4x, d_VRL4y, d_VRL4z,
+            d_PX1, d_PX2, d_PY1, d_PY2, d_AREA, d_A_I,
+            d_UX1, d_UY1, d_UX2, d_UY2, d_UX3, d_UY3, d_UX4, d_UY4,
+            d_OFF, d_THK, d_THK0, d_GSTR, d_EINT, d_EPSD_elem,
+            d_SIGxx, d_SIGyy, d_SIGxy, d_SIGyz, d_SIGzx,
+            d_PLA, d_EPSD_ip,
+            d_SIGBAKxx, d_SIGBAKyy, d_SIGBAKxy, d_DPLA, d_TEMPEL,
+            d_FORxx, d_FORyy, d_FORxy, d_FORyz, d_FORzx,
+            d_MOMxx, d_MOMyy, d_MOMxy, d_SIGY,
+            mat, dt, NUMELC, ITHK, NCYCLE_DBG);
+    };
+
+    // Dispatch on (IPLA, NPT, ISMSTR)
+    auto dispatch_ismstr = [&](auto ipla_tag, auto npt_tag) {
+        switch (ISMSTR) {
+            case 1:  launch(ipla_tag, npt_tag, std::integral_constant<int,1>{});  break;
+            case 2:  launch(ipla_tag, npt_tag, std::integral_constant<int,2>{});  break;
+            case 11: launch(ipla_tag, npt_tag, std::integral_constant<int,11>{}); break;
+            default:
+                fprintf(stderr, "Unsupported ISMSTR=%d in shell_strain_material_kernel\n", ISMSTR);
+                exit(EXIT_FAILURE);
+        }
+    };
+
+    auto dispatch_npt = [&](auto ipla_tag) {
+        switch (NPT) {
+            case 1:  dispatch_ismstr(ipla_tag, std::integral_constant<int,1>{}); break;
+            case 3:  dispatch_ismstr(ipla_tag, std::integral_constant<int,3>{}); break;
+            case 5:  dispatch_ismstr(ipla_tag, std::integral_constant<int,5>{}); break;
+            default:
+                fprintf(stderr, "Unsupported NPT=%d in shell_strain_material_kernel\n", NPT);
+                exit(EXIT_FAILURE);
+        }
+    };
+
+    switch (mat.IPLA) {
+        case 1:  dispatch_npt(std::integral_constant<int,1>{}); break;
+        case 2:  dispatch_npt(std::integral_constant<int,2>{}); break;
+        default: dispatch_npt(std::integral_constant<int,0>{}); break;
+    }
+
+    // Check for kernel launch errors
+    {
+        cudaError_t err = cudaPeekAtLastError();
+        if (err != cudaSuccess) {
+            fprintf(stderr, "CUDA kernel launch error (strain+material): %s\n",
+                    cudaGetErrorString(err));
+            exit(EXIT_FAILURE);
+        }
+    }
+}
+
+#endif // SHELL_STRAIN_MATERIAL_KERNEL_CU

--- a/engine/source/elements/shell/coque/shell_strain_material_kernel.h
+++ b/engine/source/elements/shell/coque/shell_strain_material_kernel.h
@@ -1,0 +1,127 @@
+//Copyright>    OpenRadioss
+//Copyright>    Copyright (C) 1986-2026 Altair Engineering Inc.
+//Copyright>
+//Copyright>    This program is free software: you can redistribute it and/or modify
+//Copyright>    it under the terms of the GNU Affero General Public License as published by
+//Copyright>    the Free Software Foundation, either version 3 of the License, or
+//Copyright>    (at your option) any later version.
+//Copyright>
+//Copyright>    This program is distributed in the hope that it will be useful,
+//Copyright>    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//Copyright>    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//Copyright>    GNU Affero General Public License for more details.
+//Copyright>
+//Copyright>    You should have received a copy of the GNU Affero General Public License
+//Copyright>    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//Copyright>
+//Copyright>
+//Copyright>    Commercial Alternative: Altair Radioss Software
+//Copyright>
+//Copyright>    As an alternative to this open-source version, Altair also offers Altair Radioss
+//Copyright>    software under a commercial license.  Contact Altair to discuss further if the
+//Copyright>    commercial version may interest you: https://www.altair.com/radioss/.
+// ==============================================================================
+//  OpenRadioss GPU — Kernel 2 (Option C): Strains + Material
+//  Host-side header for shell_strain_material_kernel
+// ==============================================================================
+
+#ifndef SHELL_STRAIN_MATERIAL_KERNEL_H
+#define SHELL_STRAIN_MATERIAL_KERNEL_H
+
+#include <cuda_runtime.h>
+#include "real_type.h"
+
+// ---------------------------------------------------------------------------
+//  Johnson-Cook material parameter structure
+// ---------------------------------------------------------------------------
+struct JohnsonCookParams {
+    Real E;           // Young's modulus
+    Real nu;          // Poisson's ratio
+    Real G;           // Shear modulus  E/(2(1+nu))
+    Real A11;         // plane-stress stiffness  E/(1-nu^2)
+    Real A12;         // coupling  nu * A11
+    Real CA;          // J-C param A  (initial yield)
+    Real CB;          // J-C param B  (hardening modulus)
+    Real CN;          // J-C param n  (hardening exponent)
+    Real CC;          // J-C param C  (strain-rate sensitivity)
+    Real EPDR;        // reference strain rate (before dt scaling)
+    Real EPMX;        // max plastic strain for ductile rupture
+    Real YMAX;        // yield stress cap
+    Real M_EXP;       // thermal exponent m
+    Real FISOKIN;     // isotropic/kinematic ratio (1=iso, 0=kin)
+    Real RHOCP;       // rho * Cp  (adiabatic heating)
+    Real TREF;        // reference temperature
+    Real TMELT;       // melting temperature
+    Real ASRATE;      // strain-rate exponential filter coefficient
+    Real RHO;         // density
+    Real SSP;         // sound speed
+    Real SHF_COEF;    // shear correction factor (e.g. 5/6)
+    int    IPLA;        // plasticity algorithm (0, 1, or 2)
+    int    VP;          // strain-rate type (1=plastic, 2=total, 3=deviatoric)
+    int    IFORM;       // 0=Johnson-Cook, 1=Zerilli-Armstrong
+    int    ICC;         // Cowper-Symonds flag
+    Real Z3, Z4;      // Zerilli-Armstrong thermal params (0 for J-C)
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ---------------------------------------------------------------------------
+//  Launch the strain + material kernel  (CCOEF3 + CDEFO3 + CCURV3 + CSTRA3
+//                                        + CMAIN3 / SIGEPS02C / M2CPLR)
+//
+//  All pointer arguments are device pointers.
+//  mat         = material parameter struct (passed by value to kernel)
+//  dt          = current time step
+//  NPT         = number of through-thickness integration points
+//  NUMELC      = total number of 4-node shell elements
+//  ISMSTR      = small-strain flag (1, 2, or 11)
+//  ITHK        = thickness-update flag (>0 enables)
+//  stream      = CUDA stream (0 for default)
+// ---------------------------------------------------------------------------
+void launch_shell_strain_material_kernel(
+    // Kernel 1 outputs (read-only)
+    const Real* d_E1x, const Real* d_E1y, const Real* d_E1z,
+    const Real* d_E2x, const Real* d_E2y, const Real* d_E2z,
+    const Real* d_E3x, const Real* d_E3y, const Real* d_E3z,
+    const Real* d_VL1x,  const Real* d_VL1y,  const Real* d_VL1z,
+    const Real* d_VL2x,  const Real* d_VL2y,  const Real* d_VL2z,
+    const Real* d_VL3x,  const Real* d_VL3y,  const Real* d_VL3z,
+    const Real* d_VL4x,  const Real* d_VL4y,  const Real* d_VL4z,
+    const Real* d_VRL1x, const Real* d_VRL1y, const Real* d_VRL1z,
+    const Real* d_VRL2x, const Real* d_VRL2y, const Real* d_VRL2z,
+    const Real* d_VRL3x, const Real* d_VRL3y, const Real* d_VRL3z,
+    const Real* d_VRL4x, const Real* d_VRL4y, const Real* d_VRL4z,
+    const Real* d_PX1,  const Real* d_PX2,
+    const Real* d_PY1,  const Real* d_PY2,
+    const Real* d_AREA, const Real* d_A_I,
+    const Real* d_UX1,  const Real* d_UY1,
+    const Real* d_UX2,  const Real* d_UY2,
+    const Real* d_UX3,  const Real* d_UY3,
+    const Real* d_UX4,  const Real* d_UY4,
+    // Element state
+    Real* d_OFF, Real* d_THK, const Real* d_THK0,
+    Real* d_GSTR, Real* d_EINT, Real* d_EPSD_elem,
+    // Per-integration-point state  [NPT * NUMELC]
+    Real* d_SIGxx, Real* d_SIGyy, Real* d_SIGxy,
+    Real* d_SIGyz, Real* d_SIGzx,
+    Real* d_PLA, Real* d_EPSD_ip,
+    Real* d_SIGBAKxx, Real* d_SIGBAKyy, Real* d_SIGBAKxy,
+    Real* d_DPLA, Real* d_TEMPEL,
+    // Outputs: generalized forces/moments  [NUMELC]
+    Real* d_FORxx, Real* d_FORyy, Real* d_FORxy,
+    Real* d_FORyz, Real* d_FORzx,
+    Real* d_MOMxx, Real* d_MOMyy, Real* d_MOMxy,
+    Real* d_SIGY,
+    // Scalars
+    JohnsonCookParams mat,
+    Real dt, int NPT, int NUMELC, int ISMSTR, int ITHK,
+    int NCYCLE_DBG,
+    cudaStream_t stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SHELL_STRAIN_MATERIAL_KERNEL_H

--- a/engine/source/engine/execargcheck.F
+++ b/engine/source/engine/execargcheck.F
@@ -115,6 +115,7 @@ C-----------------------------------------------
        MDS_PATHI = 0
        MDS_DIRI = 0
        GOT_PREVIEW= 0
+       GPU = 0
 
        ! Initialize MDS_PATH Array
        MDS_PATH=''
@@ -221,6 +222,8 @@ C -MEM-MAP
              GOT_INSPIRE_ALM=1
           CASE ( '-INSPIRE')
              GOT_INSPIRE=1
+          CASE ( '-GPU')
+             GPU=1
 C------------------------------------------------
 C -NORST : no restart file command
           CASE ( '-NORST')

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -656,6 +656,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
+              USE COMMAND_LINE_ARGS_MOD
               USE SPMD_EXCH_WAVE_MOD
               USE GHOST_SHELLS_MOD
               USE CONNECTIVITY_MOD
@@ -776,6 +777,8 @@ C-----------------------------------------------
               use sfem_mod
               use init_global_boundary_list_mod , only : init_global_boundary_list
               use sfem_init_mod , only : sfem_init
+              use shell_internal_forces_mod
+              use shell_gpu_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -1369,6 +1372,11 @@ C coupling coupling
               logical :: ongoing
               double precision :: dt2max_coupling
 C-----------------------------------------------------------------------------------
+C GPU
+              type(SHELLS_) :: SHELLS
+              integer :: ipri
+C             
+
               call resol_alloc_phase1(rby6,dxancg,nb25_candt,nb25_impct,nb25_dst1,nb25_dst2,igrouc,igrounc, 
      .                                interfaces,int18add,idamp_rdof_tab,icontact_old, 
      .                                nrbykin,numnod,parasiz,ngroup,ninter,sicontact,nodes,
@@ -2609,6 +2617,18 @@ C
 C===========================================================================
 C                 BEGINNING OF EXPLICIT ITERATION LOOP
 C===========================================================================
+              IF(GPU == 1) THEN
+               CALL FORINTC_PREPARE_GPU( GPU, SHELLS, NUMELC,
+     .           PM , NPROPM,       GEO, NPROPG,  
+     .           NODES, MAT_ELEM  , NSECT, NSLIPRING, NEXMAD, 
+     .           IPARG, nparg     ,ELEMENT%SHELL%IXC       , IPART(K3),
+     .           IGROUC    ,NGROUC, NGROUP, NIXC    ,
+     .           ELBUF_TAB, DTFAC1(3),
+     .           NODADT, IDT1SH, IDTMINS, IDTMIN(3),
+     .           HVISC, HELAS, HVLIN )
+              ENDIF
+
+
  100          CONTINUE
 
               NCYCLE_DEBUG = NCYCLE
@@ -3163,6 +3183,9 @@ C----------------------------------------
                   NATIV_SMS_SIZ = 0
                 ENDIF
 
+C
+
+
 C========================================================================================
 C                                     PARALLEL SECTION (SMP)
 C========================================================================================
@@ -3638,6 +3661,16 @@ C----------------------------------------
                   ITYPTST= ITYPTSTT
                 ENDIF
 
+             IF(GPU == 1) THEN
+C     GPU SHELL: launch async pipeline BEFORE CPU element work
+C     so that GPU kernels execute while FORINTC + FORINT run on CPU.
+C     Results are collected later by gpu_shell_sync_scatter.
+                CALL STARTIME(TIMERS,TIMER_GPU_SHELL)
+                CALL gpu_shell_launch_async(NODES,SHELLS,DT1)
+                CALL STOPTIME(TIMERS,TIMER_GPU_SHELL)
+              ENDIF
+
+
 
 C=======================================================================================
 C                                     PARALLEL SECTION (SMP)
@@ -4023,7 +4056,6 @@ C     INTERNAL FORCES OF SHELLS, 3-NODE SHELLS
 C-------------------------------
               CALL TRACE_IN(14,0,ZERO)
               IF (IMON>0) CALL STARTIME(TIMERS,TIMER_ELEMENT)
-
 C -------------------------------------------------------------------
 C   User Libraries get the possibility to use GET_U_NOD_X & GET_U_NOD_V in user elements properties (Solids & Springs)
               GETUNOD_NOCOM=1
@@ -4055,7 +4087,7 @@ C Init var parallel SMP
 
               NDTSKR=NDTSK ; IF(IRODDL == 0)NDTSKR=1
 
-              CALL FORINTC(TIMERS,
+              CALL FORINTC(TIMERS, GPU, IPRI,
      1           PM           ,GEO             ,NODES%X               ,NODES%A(1,NDTSK)     ,NODES%AR(1,NDTSK)  ,
      2           NODES%V            ,NODES%VR              ,NODES%MS              ,NODES%IN             ,NLOC_DMG     ,
      3           WA(NWAFTSK)  ,NODES%STIFN(NDTSK)    ,NODES%STIFR(NDTSKR)    ,ELEMENT%PON%FSKY           ,CRKSKY       ,
@@ -4090,6 +4122,7 @@ C Init var parallel SMP
               END IF
 #include "lockoff.inc"
 !$OMP END PARALLEL
+
               CALL PYTHON_END_OPENMP(PYTHON)
               CALL TRACE_OUT(14)
               IF (IMON>0) CALL STOPTIME(TIMERS,TIMER_ELEMENT)
@@ -4188,8 +4221,19 @@ C
 !$OMP END PARALLEL
               CALL PYTHON_END_OPENMP(PYTHON)
               CALL TRACE_OUT(14)
-
               IF (IMON>0) CALL STOPTIME(TIMERS,TIMER_ELEMENT)
+
+              IF(GPU == 1) THEN
+C     GPU SHELL: synchronize + scatter results now that FORINTC + FORINT
+C     have completed on the CPU.  By this point the GPU pipeline has had
+C     time to finish, so the sync call should return near-instantly.
+                CALL STARTIME(TIMERS,TIMER_GPU_SHELL)
+                CALL gpu_shell_sync_scatter(
+     .           NODES,SHELLS,DT2T,PARTSAV,NPSAV,NPART,IPRI)
+                CALL STOPTIME(TIMERS,TIMER_GPU_SHELL)
+              ENDIF
+
+
 C-----
               IF(NUMSPHG/=0)THEN
                 IF (IMONM > 0) CALL STARTIME(TIMERS,48)

--- a/engine/source/interfaces/int07/inter7_gather_cand.F90
+++ b/engine/source/interfaces/int07/inter7_gather_cand.F90
@@ -26,7 +26,7 @@
 !||    inter7_filter_cand       ../engine/source/interfaces/intsort/inter7_filter_cand.F90
 !||====================================================================
       MODULE INTER7_GATHER_CAND_MOD
-      implicit none
+        implicit none
       CONTAINS
 !||====================================================================
 !||    inter7_gather_cand   ../engine/source/interfaces/int07/inter7_gather_cand.F90

--- a/engine/source/interfaces/intsort/inter7_candidate_pairs.F90
+++ b/engine/source/interfaces/intsort/inter7_candidate_pairs.F90
@@ -27,7 +27,7 @@
 !||    main                         ../engine/unit_test/unit_test1.F
 !||====================================================================
       MODULE INTER7_CANDIDATE_PAIRS_MOD
-      implicit none
+        implicit none
       CONTAINS
 
 !! \brief get the list of candidates pairs for all main segments
@@ -175,11 +175,11 @@
           real(kind=WP) :: xmin, xmax, ymin, ymax, zmin, zmax
           real(kind=WP) :: xx1, xx2, xx3, xx4, yy1, yy2, yy3, yy4, zz1, zz2, zz3, zz4
           real(kind=WP) :: d1x, d1y, d1z, d2x, d2y, d2z, dd1, dd2, d2, a2
- 
+
           integer :: ix, iy, iz, m1, m2, m3, m4, ix1, iy1, iz1, ix2, iy2, iz2
- 
+
           real(kind=WP) :: xminb, yminb, zminb, xmaxb, ymaxb, zmaxb, xmine, ymine, zmine, xmaxe, ymaxe, zmaxe, aaa
- 
+
           integer, dimension(GROUP_SIZE) :: prov_n, prov_e !< temporary list of candidates
           integer :: cellid
 
@@ -611,7 +611,7 @@
 !                                                   local variables
 ! ----------------------------------------------------------------------------------------------------------------------
           integer :: i, j, iostat, unitNum
- 
+
 
           open(NEWUNIT=unitNum, FILE=filename, FORM="UNFORMATTED", STATUS="REPLACE", IOSTAT=iostat)
           if (iostat /= 0) then
@@ -813,7 +813,7 @@
 !                                                   local variables
 ! ----------------------------------------------------------------------------------------------------------------------
           integer :: i, j, iostat, unitNum
- 
+
           open(NEWUNIT=unitNum, FILE=filename, FORM="UNFORMATTED", STATUS="OLD", IOSTAT=iostat)
           if (iostat /= 0) then
             write(6,*) "error opening file: ", filename

--- a/engine/source/interfaces/intsort/inter7_collision_detection.F90
+++ b/engine/source/interfaces/intsort/inter7_collision_detection.F90
@@ -26,7 +26,7 @@
 !||    inter_sort_07                    ../engine/source/interfaces/int07/inter_sort_07.F
 !||====================================================================
       MODULE INTER7_COLLISION_DETECTION_MOD
-      implicit none
+        implicit none
       CONTAINS
 !||====================================================================
 !||    inter7_collision_detection   ../engine/source/interfaces/intsort/inter7_collision_detection.F90

--- a/engine/source/interfaces/intsort/inter7_filter_cand.F90
+++ b/engine/source/interfaces/intsort/inter7_filter_cand.F90
@@ -26,7 +26,7 @@
 !||    inter7_candidate_pairs   ../engine/source/interfaces/intsort/inter7_candidate_pairs.F90
 !||====================================================================
       MODULE INTER7_FILTER_CAND_MOD
-      implicit none
+        implicit none
       contains
 !! \brief broad phase filtering of candidate pairs
 !! \details input: nodes and segment sharing the same voxel, output: filtered candidate pairs

--- a/engine/source/interfaces/intsort/inter7_penetration.F90
+++ b/engine/source/interfaces/intsort/inter7_penetration.F90
@@ -27,7 +27,7 @@
 !||    inter7_filter_cand       ../engine/source/interfaces/intsort/inter7_filter_cand.F90
 !||====================================================================
       MODULE INTER7_PENETRATION_MOD
-      implicit none
+        implicit none
       contains
 !! \brief computes the penetration between a chuck of secondary nodes and a main surface/segment
 !! \details the candidate for penetration are couple of secondary nodes and the main surface/segment

--- a/engine/source/system/timer.F
+++ b/engine/source/system/timer.F
@@ -86,6 +86,12 @@ c       IF(IMONM >= 1)THEN
          ENDIF
          FIELDS(NF) = MACRO_TIMER_ELEMENT
          NF = NF + 1
+         IF(TABTIME(MACRO_TIMER_GPU_SHELL,1) > 0) THEN
+           FIELDS(NF) = MACRO_TIMER_GPU_SHELL
+           NF = NF + 1
+           TITLES(MACRO_TIMER_GPU_SHELL) = 'GPU_SHELL'
+         ENDIF
+
          FIELDS(NF) = MACRO_TIMER_KIN
          NF = NF + 1
          FIELDS(NF) = MACRO_TIMER_INTEG

--- a/engine/source/system/timer_mod.F90
+++ b/engine/source/system/timer_mod.F90
@@ -146,13 +146,14 @@
         integer, parameter :: TIMER_EXRBYV    =     12
         integer, parameter :: TIMER_EXSPMDV   =     13
         integer, parameter :: TIMER_MADYMO    =     14
-        integer, parameter :: TIMER_CONT_CRIT =     15  
+        integer, parameter :: TIMER_CONT_CRIT =     15
         integer, parameter :: TIMER_COMM_CRIT =     16
         integer, parameter :: TIMER_CONT_BUK  =     17
         integer, parameter :: TIMER_CONT_GFRONT=    18
         integer, parameter :: TIMER_CONT_OPT  =     19
+        integer, parameter :: TIMER_GPU_SHELL     =   153
         integer, parameter :: TIMER_AMS       =     39
-        integer, parameter :: TIMER_BEG_CRIT  =     56        
+        integer, parameter :: TIMER_BEG_CRIT  =     56
         integer, parameter :: TIMER_EOF_CRIT  =     57
         integer, parameter :: TIMER_EOF_SORT  =     58
         integer, parameter :: TIMER_TMP1      =    150
@@ -183,8 +184,8 @@
         integer, parameter :: TIMER_T25BUC    =      136
         integer, parameter :: TIMER_T25BUCE2E =      137
         integer, parameter :: TIMER_T25TRCE   =      138
-        integer, parameter :: timer_ale_elm   =      151  
-        integer, parameter :: timer_sfem      =      152           
+        integer, parameter :: timer_ale_elm   =      151
+        integer, parameter :: timer_sfem      =      152
         type timer_
           real, dimension(:,:), allocatable :: timer
           real, dimension(:), allocatable :: cputime

--- a/scripts/copyright/addcopyright.py
+++ b/scripts/copyright/addcopyright.py
@@ -6,7 +6,7 @@ import shutil
 
 fortran_ext = ['.F']
 fortran90_ext = ['.F90']
-cpp_ext = ['.h', '.cpp', '.c','.hpp','.cxx']
+cpp_ext = ['.h', '.cpp', '.c','.hpp','.cxx', '.cu']
 cfg_ext = ['.cfg']
 starter_deck_ext = ['_0000.rad']
 engine_deck_ext = ['_0001.rad']


### PR DESCRIPTION
# OpenRadioss 4-Node Shell Element (COQUE) — GPU/CUDA Porting Guide

**Material Law 02 (Johnson-Cook), IHBE≤1**

---

## 0. Building

The GPU build requires a CUDA-capable compiler (nvcc) and is integrated into the
OpenRadioss build system.  Standard build command:

```bash
cd engine
./build_script.sh -arch=linux64_nvidia  -openacc -gpu-cc=cc120 -nt=8 
```

The CUDA sources (`.cu` files) must be compiled with `nvcc` and linked with the
Fortran executable.  The ISO_C_BINDING interfaces in `shell_gpu_mod.F90` ensure
seamless interoperability between Fortran and C/CUDA.

For MPI, a dedicated OpenMPI build is needed.  Some tuning may be needed in  `./engine/CMake_Compilers/cmake_linux64_nvidia.txt`

To activate the LAW2 computations on the GPU, add -gpu to the engine command line such as

```bash
 ~/OpenRadioss/exec/engine_linux64_nvidia  -i *1.rad -notrap
```

---


## 1. Overview & Scope

This document describes the GPU (CUDA) port of the OpenRadioss 4-node shell element
internal force computation, targeting the following restricted configuration:

| Parameter | Value | Meaning |
|-----------|-------|---------|
| ITY | 3 | 4-node shell (coque) |
| MLW / MTN | 2 | Material law 02 — Johnson-Cook / Zerilli-Armstrong |
| ISMSTR | 1 (or 2, 11) | Small-strain co-rotational formulation |
| IHBE | ≤ 1 | Standard Belytschko-Tsay hourglass formulation |
| ISHFRAM | 0 | Symmetric convected frame (default) |
| IXFEM | 0 | No XFEM |
| IFAILURE | 0 | No failure model |
| NSECT | 0 | No section forces |
Each kernel fuses multiple CPU subroutines, and intermediate data stays resident in GPU
global memory between kernel launches (no host round-trips within a step).

This guide is intended for developers who know the CPU code and want to understand
how each CPU subroutine maps to the GPU implementation.

---

## 2. Architecture Comparison

### CPU Architecture

Elements are grouped into **vector groups** of up to `MVSIZ` elements (typically
`NVSIZ=128` elements + 1 padding = 129).  The outer loop iterates over groups
sequentially.  Within each group, all subroutines operate on SIMD-like vectorized
loops:

```
DO I = JFT, JLT      ! typically 1..128
    ... per-element computation ...
ENDDO
```

All intermediate work arrays are stack-allocated with dimension `(MVSIZ)`, live only
for the duration of one group, and are reused across groups.

### GPU Architecture

All elements in a "super-group" (see §4) are processed **simultaneously** — one
CUDA thread per element.  There is no vector-group concept.  Arrays that were
`(MVSIZ)` on the CPU become `(NUMELC)` on the GPU, persistently allocated in
device memory.

| Aspect | CPU (Fortran) | GPU (CUDA) |
|--------|--------------|------------|
| Parallelism unit | Vector group (128 elems) | Thread (1 element) |
| Work arrays | Stack `(MVSIZ)`, reused | Device global `(NUMELC)`, persistent |
| Memory layout | Array-of-Structures / mixed | Structure-of-Arrays (SoA) |
| Element loop | `DO I=JFT,JLT` | `I = blockIdx.x * blockDim.x + threadIdx.x` |
| Force assembly | Direct write (no race) | `atomicAdd` to global nodal arrays |
| Group iteration | Sequential `DO IG=1,NGROUC` | Single kernel launch over all elements |
| Material params | Read from `PM()`, `GEO()` each group | Passed as struct (by value) to kernel |

---

## 3. Integration into the Time-Step Loop

### Where the GPU code fits in `resol.F`

The GPU integration consists of two call sites in `resol.F`:

#### 3.1 One-time initialization (before the time loop)

```fortran
! resol.F, line ~2614 — before the explicit time-step loop
IF(GPU == 1) THEN
    CALL FORINTC_PREPARE_GPU(GPU, SHELLS, NUMELC, ...)
ENDIF
```

This scans all shell element groups, identifies those eligible for GPU offload,
builds **super-groups**, allocates device memory, uploads constant data and initial
state.  See §4 for details.

#### 3.2 Per-cycle GPU computation (inside the time loop)

The per-cycle GPU work is split into two calls placed to maximize GPU/CPU overlap:

```fortran
! resol.F — BEFORE CPU element forces (FORINTC/FORINT)
IF(GPU == 1) THEN
    CALL gpu_shell_launch_async(NODES, SHELLS, DT1)
ENDIF

! ... CPU does FORINTC + FORINT (shell + solid forces) concurrently ...

! resol.F — AFTER CPU element forces
IF(GPU == 1) THEN
    CALL gpu_shell_sync_scatter(NODES, SHELLS, DT2T, PARTSAV, NPSAV, NPART, IPRI)
ENDIF
```

`gpu_shell_launch_async` uploads `NODES%X/V/VR` to a **global device handle**
(shared across all SUs), launches each SU's 3 kernels asynchronously, and
enqueues a single D2H of the global force arrays.  It returns immediately.

`gpu_shell_sync_scatter` blocks until the GPU pipeline completes, then scatters
the downloaded forces/moments/stiffness into `NODES%A`, `NODES%AR`, `STIFN`,
`STIFR`.  It also collects min-dt results and (optionally) downloads internal
energy for `PARTSAV`.

This placement allows the GPU kernels to execute **concurrently** with the CPU
element force computation (`FORINTC` + `FORINT`), hiding GPU latency.

A legacy synchronous wrapper `gpu_shell_internal_forces` (= launch + sync in one
call) is preserved for backward compatibility.

#### 3.3 CPU bypass in `forintc.F`

When `GPU==1`, the per-group driver `FORINTC` **skips** (via `CYCLE`) any element
group that matches the GPU eligibility criteria.  This prevents double-counting:

```fortran
! forintc.F
IF (ITY == 3                                     &  ! 4-node shell
    .AND. MLW == 2                               &  ! material law 2 (Johnson-Cook)
    .AND. IPARG(8,NG) /= 1                       &  ! group active
    .AND. NPT > 0                                &  ! through-thickness integration
    .AND. JHBE < 11                              &  ! standard formulation
    .AND. IGTYP < 29                             &  ! not user property
    .AND. IXFEM == 0                             &  ! no XFEM
    .AND. IFAILURE == 0                          &  ! no failure model
    .AND. NSECT == 0                             &  ! no section forces
    .AND. NEXMAD == 0                            &  ! no mass scaling
    .AND. ICRACK3D == 0 .AND. ACTIFXFEM == 0    &  ! no crack / XFEM
    .AND. NSLIPRING == 0 .AND. ISEATBELT == 0   &  ! no slipring/seatbelt
    .AND. GPU == 1                               &  ! GPU enabled
    .AND. ISUBSTACK == 0 .AND. ISENS_ENERGY == 0) THEN
    CYCLE                      ! skip — GPU handles this group
ENDIF
```

The net effect: eligible law-2 shell elements are computed **only** on the GPU;
all other elements continue to be processed on the CPU by `FORINTC` → `CFORC3`.

### Call flow diagram

```
resol.F (time-step loop)
│
├── FORINTC_PREPARE_GPU()          ← once, before time loop
│   └── scans groups → builds super-groups
│       → creates global node/force handle (ShellGPUGlobal)
│       → pins host NODES%X/V/VR + global D2H force buffer
│       → allocates per-SU device arrays, links to global handle
│       → uploads connectivity, material, initial state per SU
│
├── ... time loop begins ...
│
├── gpu_shell_launch_async()       ← GPU shell forces (every cycle, BEFORE CPU)
│   ├── shell_gpu_global_upload_nodes()  (H2D: X, V, VR + zero forces, global stream)
│   │   └── records upload_done event
│   ├── DO SU = 1, NSU              (per-SU kernel launch)
│   │   └── shell_gpu_full_step_async()
│   │       ├── SU stream waits on upload_done
│   │       ├── Kernel 1 (Geometry)
│   │       ├── Kernel 2 (Strain+Material)
│   │       ├── Kernel 3 (Force+Assembly → atomicAdd to global)
│   │       └── records kernels_done event
│   ├── DO SU = 1, NSU
│   │   └── shell_gpu_global_wait_su()  (global stream waits for each SU)
│   ├── shell_gpu_global_download_forces()  (1 D2H of 8*NUMNOD, global stream)
│   └── [optional] DO SU: shell_gpu_min_dt()  (reduction kernel + 8B D2H)
│
├── FORINTC()                      ← CPU shell forces (concurrent with GPU)
│   ├── DO IG = 1, NGROUC
│   │   ├── [GPU-eligible group?] → CYCLE (skip)
│   │   └── [CPU group] → CFORC3() → full CPU pipeline
│   └── END DO
│
├── FORINT()                       ← CPU solid forces (concurrent with GPU)
│
└── gpu_shell_sync_scatter()       ← collect GPU results (every cycle, AFTER CPU)
    ├── shell_gpu_global_synchronize()  (block until global D2H completes)
    ├── shell_gpu_synchronize() per SU  (for min-dt results)
    ├── scatter raw_gpu_to_cpu_global → NODES%A, NODES%AR, STIFN, STIFR
    ├── collect dt_min_result → reduce DT2T
    └── (if output step) download EINT → accumulate PARTSAV
```

---

## 4. GPU Initialization (One-Time Setup)

The initialization is performed by `FORINTC_PREPARE_GPU` in
`shell_internal_forces.F90`.

### 4.1 Super-Group Construction

On the CPU, elements are organized into **element groups** (NG), each with uniform
properties stored in `IPARG(:,NG)`.  A single material/property combination may
span multiple groups (each capped at 128 elements for vectorization).

The GPU merges consecutive compatible groups into **super-groups** (SU).  Two groups
are compatible if a set of GPU-relevant `IPARG` indices are identical for both.
Specifically, only the following five indices are compared:

| Index | IPARG field | Affects |
|-------|------------|--------|
| 6 | `NPT` | Integration point count (all kernels) |
| 9 | `ISMSTR` | Small-strain flag (all kernels) |
| 23 | `JHBE` | Hourglass formulation (Kernel 3) |
| 28 | `ITHK` | Thickness update flag (Kernel 2) |
| 29 | `IPLA` | Plasticity algorithm (Kernel 2) |

The previous check compared the full `IPARG(6:71)` range, which included
uninitialized or GPU-irrelevant indices and caused spurious super-group splits.

A super-group contains all elements from its constituent groups — typically
thousands of elements instead of 128.

```
CPU groups:     [NG=5, 128 elems] [NG=6, 128 elems] [NG=7, 64 elems]
                ←── same IPARG(6:71) ──→
GPU super-group:  SU=1, 320 elements, single kernel launch
```

### 4.2 Eligibility Criteria

A group is eligible for GPU offload if ALL of the following hold:

| Criterion | Check |
|-----------|-------|
| 4-node shell | `ITY == 3` |
| Johnson-Cook law | `MLW == 2` |
| Group active | `IPARG(8) /= 1` |
| Through-thickness IPs | `NPT > 0` |
| Standard HG formulation | `JHBE < 11` |
| Standard property | `IGTYP < 29` |
| No XFEM / cracks | `IXFEM == 0 .AND. ICRACK3D == 0 .AND. ACTIFXFEM == 0` |
| No failure model | `IFAILURE == 0` |
| No sections | `NSECT == 0` |
| No mass scaling | `NEXMAD == 0` |
| No slipring/seatbelt | `NSLIPRING == 0 .AND. ISEATBELT == 0` |
| GPU flag | `GPU == 1` |
| No substacking/sensors | `ISUBSTACK == 0 .AND. ISENS_ENERGY == 0` |

### 4.3 Initialization Lifecycle

First, a **global** shared node/force handle is created for the full mesh:

| Step | Fortran Call | C/CUDA Function | Purpose |
|------|-------------|-----------------|---------|
| G1 | `shell_gpu_global_create(NUMNOD)` | allocate `ShellGPUGlobal` | Alloc device node/force arrays `[9*NUMNOD]` + `[8*NUMNOD]`, create stream/event |
| G2 | `shell_gpu_global_pin_host(X, V, VR, buf, NN)` | `cudaHostRegister` | Pin `NODES%X`, `NODES%V`, `NODES%VR`, and `raw_gpu_to_cpu_global` |

Then, for each super-group:

| Step | Fortran Call | C/CUDA Function | Purpose |
|------|-------------|-----------------|---------|
| 1 | `shell_gpu_data_create()` | `calloc(ShellGPUData)` | Allocate opaque C handle on host |
| 2 | `shell_gpu_allocate()` | `cudaMalloc` (per-SU arrays) | Allocate element/IP state and intermediate arrays |
| 3 | `shell_gpu_set_global()` | alias pointers | Link per-SU handle to global node/force arrays |
| 4 | `shell_gpu_set_compute_sti()` | — | Set stiffness computation mode (0/1/2) |
| 5 | `shell_gpu_set_ihbe()` | — | Set hourglass formulation flag |
| 6 | `shell_gpu_set_mat_params()` | — | Set Johnson-Cook material parameters |
| 7 | `shell_gpu_set_hg_params()` | — | Set hourglass control parameters |
| 8 | `shell_gpu_upload_constant()` | `cudaMemcpyAsync H2D` | Upload connectivity, thickness, per-element scalars |
| 9 | `shell_gpu_upload_ip_state()` | `cudaMemcpyAsync H2D` | Upload initial stress, plastic strain, temperature |

### 4.4 Node Numbering (Global 0-Based)

The GPU uses **global 0-based** node IDs rather than per-SU local renumbering.
Connectivity arrays `n1..n4` store `IXC(j, NFT+i) - 1` (i.e., the Fortran
1-based global node ID minus one for C/CUDA 0-based indexing).

All SU kernels index into the **same** global device node arrays
`d_X[3*NUMNOD]`, `d_V[3*NUMNOD]`, `d_VR[3*NUMNOD]` (owned by
`ShellGPUGlobal`) and atomicAdd into the same global force arrays
`d_Fx[NUMNOD]..d_STIFR[NUMNOD]`.  This eliminates per-SU gather/scatter
and local renumbering overhead.

Since all SUs share the same global arrays, multiple SU streams can
run concurrently on the GPU — Kernel 3's `atomicAdd` is safe across streams.

> **Note:** The Fortran-side `GPU_SHELL_LAW2` type still declares `glob_2_gpu`
> and `gpu_2_glob` mapping arrays, but these are vestigial from an earlier
> design and are no longer used in the per-step workflow.  The scatter in
> `gpu_shell_sync_scatter` iterates over all `NUMNOD_GLOBAL` nodes directly.

### 4.5 State Extraction from ELBUF_TAB

The initial integration-point state is extracted from the CPU element buffer structure
(`ELBUF_TAB(NG)%bufly(1)%lbuf(1,1,IT)`) and reorganized into flat SoA arrays:

| CPU Layout (per group, per IP) | GPU Layout (flat SoA) |
|-------------------------------|-----------------------|
| `lbuf(1,1,IT)%sig(i)` (stride NEL) | `d_SIGxx[(IT-1)*NUMELC + elem]` |
| `lbuf(1,1,IT)%pla(i)` | `d_PLA[(IT-1)*NUMELC + elem]` |
| `lbuf(1,1,IT)%epsd(i)` | `d_EPSD_ip[(IT-1)*NUMELC + elem]` |
| `lbuf(1,1,IT)%sigb(i)` (stride NEL) | `d_SIGBAKxx[(IT-1)*NUMELC + elem]` |
| `lbuf(1,1,IT)%temp(i)` | `d_TEMPEL[(IT-1)*NUMELC + elem]` |

### 4.6 Global Shared Node/Force Buffers & Pinned Host Memory

To minimize per-step CUDA API call overhead, all node-level H2D and D2H data is
managed by a **single global handle** (`ShellGPUGlobal`) shared across all SUs.

#### Device-side global buffers

Allocated once in `shell_gpu_global_create()`:

| Buffer | Size | Layout | Sub-pointers |
|--------|------|--------|--------------|
| `d_raw_h2d` | `9 × NUMNOD` Reals | AoS: `{x0,y0,z0,x1,y1,z1,...}|V|VR` | `d_X`, `d_V`, `d_VR` (3*NUMNOD each) |
| `d_raw_d2h` | `8 × NUMNOD` Reals | SoA: `[Fx\|Fy\|Fz\|Mx\|My\|Mz\|STIFN\|STIFR]` | `d_Fx..d_STIFR` (NUMNOD each) |

The sub-pointers are set once at allocation time.  Each per-SU `ShellGPUData` handle
gets aliased copies (via `shell_gpu_set_global`) so that kernels read/write through
these shared arrays — no per-SU node/force buffers exist on the device.

The H2D layout matches the Fortran `NODES%X(3,NUMNOD)` column-major storage (AoS).
The D2H layout uses SoA because Kernel 3 atomicAdds into separate component arrays.

#### Host-side buffers

| Buffer | Owner | Size | Purpose |
|--------|-------|------|---------|
| `NODES%X`, `NODES%V`, `NODES%VR` | Fortran (NODES) | `3*NUMNOD` each | H2D source (pinned) |
| `SHELLS%raw_gpu_to_cpu_global` | Fortran (SHELLS_) | `8*NUMNOD` | D2H destination (pinned) |

#### Pinned (page-locked) host memory

During initialization, `shell_gpu_global_pin_host()` pins `NODES%X`, `NODES%V`,
`NODES%VR`, and the global D2H buffer via `cudaHostRegister`.  This enables truly
asynchronous `cudaMemcpyAsync` (DMA without internal bounce buffer).

Without pinning, `cudaMemcpyAsync` on pageable memory falls back to synchronous
staging through an internal pinned buffer, averaging ~47 µs per call.  With pinning,
the average drops to ~2 µs, and the CPU is free to proceed immediately.

#### Per-step transfer summary

| Direction | Calls/step | Size | Source → Destination |
|-----------|-----------|------|---------------------|
| H2D | 3 (X, V, VR) | 3×`3*NUMNOD` Reals | `NODES%X/V/VR` → `d_X/d_V/d_VR` |
| Zero | 1 memset | `8*NUMNOD` Reals | `d_raw_d2h = 0` |
| D2H | 1 | `8*NUMNOD` Reals | `d_raw_d2h` → `raw_gpu_to_cpu_global` |

---

## 5. Per-Cycle Workflow: CPU vs GPU

### CPU: Per-Cycle Flow

```
FORINTC (loop over NGROUC groups)
└── for each group NG:
    └── CFORC3 (per-group driver, work arrays on stack)
        ├── CCOOR3      gather coords & velocities
        ├── CNVEC3      convected frame (e1, e2, e3)
        ├── CDERI3      shape function derivatives, area, HG vectors
        ├── CCOEF3      material/geometry coefficients
        ├── CDLEN3      characteristic length
        ├── CDEFO3      membrane strain rates
        ├── CCURV3      curvature rates
        ├── CSTRA3      strain increments, accumulate GSTR
        ├── CMAIN3      through-thickness material loop
        │   └── SIGEPS02C → M2CPLR  (per integration point)
        ├── CHVIS3      hourglass forces
        ├── CDT3        element time step
        ├── CFINT3      nodal forces (local → global)
        └── CUPDT3      scatter to global arrays
```

### GPU: Per-Cycle Flow (Global Shared Handle)

The per-cycle GPU workflow uses the global shared handle architecture.
`NODES%X/V/VR` are uploaded **once** for all SUs, and the results are downloaded
**once** after all SUs complete.  Per-SU kernels run on independent CUDA streams,
enabling concurrent execution on the GPU.

```
gpu_shell_launch_async  (called BEFORE FORINTC/FORINT)
├── shell_gpu_global_upload_nodes(gh, NODES%X, NODES%V, NODES%VR)
│   ├── H2D: X(3,NUMNOD), V(3,NUMNOD), VR(3,NUMNOD)  ← 3 memcpy, AoS
│   ├── memset d_raw_d2h = 0   (Fx..STIFR zeroed)
│   └── record upload_done event on global stream
│
├── DO SU = 1, NSU   (per-SU kernel launch — independent streams)
│   └── shell_gpu_full_step_async()
│       ├── SU stream waits on upload_done event
│       ├── shell_gpu_run_kernels()
│       │   ├── [optional] d2d copy: d_THK0 ← d_THK  (if ITHK>0)
│       │   ├── Kernel 1 (Geometry):   CCOOR3 + CNVEC3 + CDERI3 + CDLEN3
│       │   ├── Kernel 2 (Strain+Mat): CCOEF3 + CDEFO3 + CCURV3 + CSTRA3 + CMAIN3
│       │   └── Kernel 3 (Force+Asm):  CHVIS3 + CFINT3 + CUPDT3 (atomicAdd)
│       └── record kernels_done event on SU stream
│
├── DO SU = 1, NSU
│   └── shell_gpu_global_wait_su(gh, su_handle)
│       └── global stream waits on each SU's kernels_done
│
├── shell_gpu_global_download_forces(gh, raw_gpu_to_cpu_global)
│   └── D2H: d_raw_d2h → raw_gpu_to_cpu_global  (8*NUMNOD Reals)
│
└── [optional] DO SU = 1, NSU
    └── shell_gpu_min_dt(su_handle, dtfac, dt_min_result)
        ├── memset d_dt_min = +inf
        ├── shell_min_dt_kernel  (GPU tree reduction)
        └── D2H: 1 scalar (8 bytes)

gpu_shell_sync_scatter  (called AFTER FORINTC/FORINT complete)
├── shell_gpu_global_synchronize(gh)   ← block until D2H done
├── shell_gpu_synchronize() per SU     ← for min-dt results
├── scatter raw_gpu_to_cpu_global → NODES%A, NODES%AR, STIFN, STIFR
│   (loop over NUMNOD_GLOBAL, direct addition by global index)
├── collect dt_min_result → reduce DT2T (when reduce_elem_dt is true)
└── (if ipri>0) download EINT → accumulate PARTSAV per part
```

> **Key optimization:** With pinned host memory (§4.6), `cudaMemcpyAsync` returns
> immediately (~2 µs), so the CPU proceeds directly to `FORINTC` + `FORINT` while
> the GPU is computing.  The `gpu_shell_sync_scatter` call typically finds the GPU
> work already done by the time it synchronizes.

### Side-by-Side Comparison

| Step | CPU Subroutine | GPU Kernel | GPU Function |
|------|---------------|------------|--------------|
| Gather X/V/VR | `CCOOR3` | Kernel 1 | Coalesced reads via connectivity |
| Convected frame | `CNVEC3` | Kernel 1 | Register arithmetic |
| Shape derivatives | `CDERI3` | Kernel 1 | Register + SMSTR global R/W |
| Char. length | `CDLEN3` | Kernel 1 | Writes ALDT² to `d_STI` |
| Mat. coefficients | `CCOEF3` | Kernel 2 | From `JohnsonCookParams` struct |
| Membrane strains | `CDEFO3` | Kernel 2 | Register arithmetic |
| Curvature rates | `CCURV3` | Kernel 2 | Register arithmetic |
| Strain accumulation | `CSTRA3` | Kernel 2 | Global R/W on `d_GSTR` |
| Material law | `CMAIN3`→`SIGEPS02C`→`M2CPLR` | Kernel 2 | `m2cplr_device()` per IP |
| Hourglass | `CHVIS3` | Kernel 3 | Re-projects velocities locally |
| Element dt | `CDT3` | Kernel 1 + reduction kernel | ALDT² in K1, min-dt via GPU reduction |
| Internal forces | `CFINT3` | Kernel 3 | Local→global rotation in registers |
| Assembly | `CUPDT3` | Kernel 3 | `atomicAdd` to nodal arrays |

---

## 6. Subroutine-by-Subroutine Mapping

### 6.1 CCOOR3 — Gather Coordinates & Velocities

**CPU file:** `ccoor3.F`
**GPU location:** Kernel 1 (`shell_geometry_kernel.cu`), lines ~130–190

**Purpose:** For each element, gather the 4 nodal coordinates `(X,Y,Z)`,
translational velocities `(Vx,Vy,Vz)`, and rotational velocities `(VRx,VRy,VRz)`
from the global arrays using the element connectivity.

**CPU algorithm:**
```fortran
DO I = JFT, JLT
    ! N1..N4 from IXC(2:5, NFT+I)
    X1(I) = X(1, N1)  ;  Y1(I) = X(2, N1)  ;  Z1(I) = X(3, N1)
    ...                                        ! same for nodes 2, 3, 4
    VL1(I,1) = V(1, N1) ; VL1(I,2) = V(2, N1) ; VL1(I,3) = V(3, N1)
    ...                                        ! same for VR
ENDDO
```

**GPU equivalent:**
```c
int n1 = d_N1[I], n2 = d_N2[I], n3 = d_N3[I], n4 = d_N4[I];
Real x1 = d_X[3*n1], y1 = d_X[3*n1+1], z1 = d_X[3*n1+2];
...
// Writes to d_VL1x[I], d_VL1y[I], d_VL1z[I], etc.
```

**Key differences:**
- CPU: Array-of-Structures `X(3,node)` → loop stride across nodes
- GPU: Node data is uploaded in its native Fortran `X(3,NUMNOD)` AoS layout.
  Kernel 1 gathers via connectivity: `d_X[3*n1 + 0]`, `d_X[3*n1 + 1]`, etc.
- CPU: connectivity from `IXC(2:5, NFT+I)` with 1-based global node IDs
- GPU: connectivity from `d_N1[I]..d_N4[I]` with **0-based global** node IDs
- CPU: `VL1(I,3)` is `(MVSIZ,3)` — stack local, reused per group
- GPU: `d_VL1x[I]` is `[NUMELC]` — persistent device memory, written once, read by K2 & K3

---

### 6.2 CNVEC3 — Convected Orthonormal Frame

**CPU file:** `cnvec3.F`
**GPU location:** Kernel 1 (`shell_geometry_kernel.cu`), lines ~200–270

**Purpose:** Build an orthonormal local coordinate system `{E1, E2, E3}` from the
current element nodal coordinates.  E3 is the shell normal, E1/E2 span the
mid-surface.

**Algorithm (ISHFRAM=0, symmetric convected frame):**

1. Compute edge-sum diagonals:
   - `r = (X21+X34, Y21+Y34, Z21+Z34)` → initial E1 direction
   - `s = (X32+X41, Y32+Y41, Z32+Z41)` → initial E2 direction

2. Normal: `E3 = r × s`, normalize

3. Symmetrize E1: `E1 = r + sqrt(|r|²/|s|²) · (s × E3)`, normalize

4. Complete: `E2 = E3 × E1`

**GPU:** Identical arithmetic in registers.  No global memory beyond the gathered
coordinates (input) and the frame vectors `d_E1x..d_E3z` (output).  ~50 flops
per element.

**CPU outputs:** `E1X(MVSIZ)..E3Z(MVSIZ)` — stack arrays, consumed by subsequent subroutines within the same `CFORC3` call.

**GPU outputs:** `d_E1x[NUMELC]..d_E3z[NUMELC]` — persistent device arrays, consumed by Kernel 2 and Kernel 3.

---

### 6.3 CDERI3 — Shape Function Derivatives

**CPU file:** `cderi3.F`
**GPU location:** Kernel 1 (`shell_geometry_kernel.cu`), lines ~270–380

**Purpose:** Project the element nodes into the local frame, compute the one-point
quadrature shape function derivatives `(PX1, PX2, PY1, PY2)`, element area,
hourglass vectors, and handle small-strain reference geometry management.

**Algorithm:**

1. **Local projection:** For nodes 2,3,4 relative to node 1:
   ```
   X2 = E1·(X2g−X1g),  Y2 = E2·(X2g−X1g)
   X3 = E1·(X3g−X1g),  Y3 = E2·(X3g−X1g)
   X4 = E1·(X4g−X1g),  Y4 = E2·(X4g−X1g)
   Z2 = E3·(X2g−X1g)               ← warping indicator
   ```

2. **ISMSTR logic:**
   - `ISMSTR=1,2`: On first call (SMSTR uninitialized), store reference local
     coords in `SMSTR[I*6 + 0..5]`.  On subsequent calls, use stored reference
     geometry; set `Z2=0`.
   - `ISMSTR=11`: Compute incremental displacements `UX,UY` relative to stored
     reference.

3. **Shape function derivatives** (bilinear quad, 1-point integration):
   ```
   PX1 = ½(Y24),   PY1 = ½(X42)
   PX2 = ½Y3,      PY2 = −½X3
   ```

4. **Area:** `AREA = max(2·(PY2·PX1 − PY1·PX2), 1e-20)`

5. **Hourglass vectors:** `VHX = (−X2+X3−X4)/AREA`, `VHY = (−Y2+Y3−Y4)/AREA`

**GPU:** Same arithmetic. `d_SMSTR[I*6]` stored in device global memory for
ISMSTR reference geometry persistence across cycles.

**CPU Stiffness:** Also initializes `STI(I)=0, STIR(I)=0`.
**GPU Stiffness:** Additionally computes `ALDT²` (characteristic length squared)
for the CDT3 time step and writes it to `d_STI[I]` for later download.

---

### 6.4 CCOEF3 — Material/Geometry Coefficients

**CPU file:** `ccoef3.F`
**GPU location:** Kernel 2 (`shell_strain_material_kernel.cu`), beginning of kernel body

**Purpose:** Extract material properties (Young's modulus, Poisson's ratio, shear
modulus, density, sound speed) and property parameters (hourglass coefficients,
shear correction factor) from `PM()` and `GEO()`.

**CPU:** Reads from global arrays `PM(NPROPM, imat)` and `GEO(NPROPG, ipid)` for
each group, computing derived quantities:
```fortran
A11 = E / (1 - nu²)       ! plane-stress membrane stiffness
A12 = nu * A11             ! coupling term
G   = E / (2*(1+nu))       ! shear modulus
```

**GPU:** All material coefficients are pre-computed during initialization and stored
in the `JohnsonCookParams` struct, which is passed **by value** to Kernel 2.
Per-element scalars like `YM`, `NU`, `RHO`, `SSP`, `SHF` are stored in flat
`[NUMELC]` arrays uploaded once.

**Key difference:** On the CPU, `CCOEF3` runs per-group every cycle.  On the GPU,
this is **amortized** — the parameters are set once at initialization, and only the
derived quantities (like `gs_val = G * SHF`, `vol = AREA * THK0`) are computed
per-element in Kernel 2.

---

### 6.5 CDEFO3 — Membrane Strain Rates

**CPU file:** `cdefo3.F`
**GPU location:** Kernel 2 (`shell_strain_material_kernel.cu`), "CDEFO3" section

**Purpose:** Compute the membrane strain rate × area from local velocities.

**Algorithm (IHBE ≤ 1):**

1. Project gathered velocities to local frame:
   ```
   VX1 = E1·VL1,   VY1 = E2·VL1,   VZ1 = E3·VL1    (for all 4 nodes)
   ```

2. Velocity differences:
   ```
   VX13 = VX1−VX3,   VX24 = VX2−VX4
   VZ13 = VZ1−VZ3,   VZ24 = VZ2−VZ4
   ```

3. Strain rates × area:
   ```
   EXX = PX1·VX13 + PX2·VX24                 (εxx · A)
   EYY = PY1·VY13 + PY2·VY24                 (εyy · A)
   EXY = PY1·VX13 + PY2·VX24 + PX1·VY13 + PX2·VY24   (2εxy · A)
   EXZ = PX1·VZ13 + PX2·VZ24                 (transverse shear)
   EYZ = PY1·VZ13 + PY2·VZ24
   ```

4. Warping correction (IHBE ≤ 1):
   ```
   Z2 *= 0.25 * AREA
   VX13 += Z2·(EXZ·PY1 − EYZ·PX1)    (and similar adjustments)
   ```

**GPU:** Identical arithmetic, all in registers.  The local-frame projected
velocities (`VX1..VZ4`) are kept in registers (not written to global memory).
~60 flops per element.

---

### 6.6 CCURV3 — Curvature Rates (Bending)

**CPU file:** `ccurv3.F`
**GPU location:** Kernel 2 (`shell_strain_material_kernel.cu`), "CCURV3" section

**Purpose:** Compute curvature change rates × area from rotational velocities.

**Algorithm:**

1. Project rotational velocities to local frame:
   ```
   RX1 = E1·VRL1,  RY1 = E2·VRL1     (for all 4 nodes)
   ```

2. Curvature rates:
   ```
   KXX =  PX1·(RY1−RY3) + PX2·(RY2−RY4)      (κxx · A)
   KYY = −PY1·(RX1−RX3) − PY2·(RX2−RX4)       (κyy · A)
   KXY =  PY1·(RY1−RY3) + PY2·(RY2−RY4)
        − PX1·(RX1−RX3) − PX2·(RX2−RX4)       (κxy · A)
   ```

3. Transverse shear update from average rotation:
   ```
   RXAV = (RX1+RX2+RX3+RX4)/4
   RYAV = (RY1+RY2+RY3+RY4)/4
   EXZ += RYAV · (0.25·AREA)
   EYZ −= RXAV · (0.25·AREA)
   ```

**GPU:** ~45 flops per element.  Register arithmetic only.

---

### 6.7 CSTRA3 — Strain Increments & Accumulation

**CPU file:** `cstra3.F`
**GPU location:** Kernel 2 (`shell_strain_material_kernel.cu`), "CSTRA3" section

**Purpose:** Convert strain rate × area quantities to strain increments by
multiplying by `Δt/AREA`, and accumulate them into the global strain tensor
`GSTR(8)`.

**Algorithm:**
```fortran
FAC1 = DT1C / AREA
EXX  = EXX * FAC1      ! now these are strain increments
EYY  = EYY * FAC1
EXY  = EXY * FAC1
...
GSTR(1) += EXX          ! accumulated membrane strains
GSTR(2) += EYY
...
GSTR(6) += KXX          ! accumulated curvatures
GSTR(7) += KYY
GSTR(8) += KXY
```

**CPU:** `GSTR` is from `ELBUF_STR%GBUF%STRA` — read/write per group.
**GPU:** `d_GSTR[I*8 + k]` — persistent device memory, read/write per element.

---

### 6.8 CMAIN3 / SIGEPS02C / M2CPLR — Through-Thickness Material Integration

**CPU files:** `cmain3.F` → `mulawc.F90` → `sigeps02c.F` → `m2cplr.F`
**GPU location:** Kernel 2 (`shell_strain_material_kernel.cu`), through-thickness
loop + `m2cplr_device()` device function

**Purpose:** For each through-thickness integration point, combine membrane strains
with bending contribution (`ε = ε_membrane + z·κ`), apply the constitutive law
(Johnson-Cook elasto-plastic radial return), and integrate stress resultants
(forces N and moments M) across the thickness.

**CPU algorithm:**
```fortran
DO IT = 1, NPT
    Z = zeta(IT) * THK/2          ! distance from mid-surface
    DEPS = EPS_membrane + Z * KAPPA
    CALL SIGEPS02C(...)           ! constitutive update
    ! Accumulate:
    FOR(1:5) += sigma(1:5) * dz   ! membrane forces
    MOM(1:3) += sigma(1:3) * z*dz ! bending moments
ENDDO
FOR = FOR / THK                   ! normalize
MOM = MOM * 12 / THK²
```

**GPU — `m2cplr_device()`:**

This is a `__device__` function that implements the same radial-return plasticity
algorithm as the CPU `M2CPLR` subroutine, for a single integration point:

| CPU (M2CPLR) | GPU (m2cplr_device) |
|--------------|---------------------|
| `IPLA=0`: simple radial return | Same algorithm |
| `IPLA=1`: plane-stress Newton (3 iterations) | Same, with `NMAX=3` |
| `IPLA=2`: normal projection + radial | Same algorithm |
| Kinematic hardening (FISOKIN) | Backstress subtract/update |
| Ductile rupture (EPMX) | `OFF` flag reduction |
| Thickness update (plane-stress εzz) | `THK += ezz * THK` |
| Adiabatic temperature | `TEMPEL += dpla·yld / RHOCP` |

**Johnson-Cook yield function (IFORM=0):**

$$\sigma_y = (A + B \cdot \varepsilon_p^n)(1 + C \cdot \ln(\dot\varepsilon / \dot\varepsilon_0))(1 - T^{*m})$$

**Zerilli-Armstrong yield function (IFORM=1):**

$$\sigma_y = A + B \cdot \exp(-Z_3 T + Z_4 T \ln(\dot\varepsilon)) + C \cdot \varepsilon_p^n$$

**Key differences:**
- CPU: `SIGEPS02C` processes vectors of `NEL` elements at once, within the
  `DO IT=1,NPT` loop inside `CMAIN3`
- GPU: Each thread handles its own element, looping over `NPT` integration points
  serially.  The IP loop is inside the kernel, not outside.
- CPU: Old/new stress in `SIG(NEL,5)`, backstress in `SIGB(NEL,3)` — flat within group
- GPU: IP state in `d_SIGxx[(IT-1)*NUMELC + I]` — flat SoA across all elements

---

### 6.9 CHVIS3 — Hourglass Forces

**CPU file:** `chvis3.F`
**GPU location:** Kernel 3 (`shell_force_assembly_kernel.cu`), "CHVIS3" section

**Purpose:** Compute anti-hourglass forces to suppress the zero-energy hourglass
mode inherent in 1-point quadrature shell elements.

**Algorithm:**

The hourglass mode vector `GAMMA` (with signs `{+1,−1,+1,−1}` for uniform elements,
or non-uniform from `VHX/VHY` for distorted elements) extracts the hourglass
velocity:

```
HV_membrane = GAMMA · VX   (hourglass velocity, membrane)
HV_bending  = GAMMA · RX   (hourglass velocity, bending)
```

Three components of anti-hourglass force:
- **Viscous** (H1Q): proportional to `ρ·SSP·AREA·HV` — damps hourglass oscillation
- **Elastic** (HH1): Flanagan-Belytschko stiffness = `YM·THK·HGamma` (state-dependent, stored in `HOUR[0..2]`)
- **Linear** (H1L): proportional to `A11·THK/AREA·HV`

The hourglass energy `ehou` is accumulated into `EINT(2)`.

**GPU:** Same algorithm, but velocities are re-projected from gathered global
velocities (rather than reading pre-computed local velocities), to avoid storing
additional intermediate arrays.  Hourglass state `d_HOUR[I*5 + 0..4]` persists across
cycles via device global memory.

**CPU parameters from GEO():** `H1=GEO(13)`, `H2=GEO(14)`, `H3=GEO(15)`,
`SRH1=GEO(18)`, `SRH2=GEO(19)`, `SRH3=GEO(20)`.
**GPU:** Stored in `HourglassParams` struct, passed by value to Kernel 3.

---

### 6.10 CFINT3 — Internal Force Computation

**CPU file:** `cfint3.F`
**GPU location:** Kernel 3 (`shell_force_assembly_kernel.cu`), "CFINT3" section

**Purpose:** Convert stress resultants (FOR, MOM) into nodal forces using the
B-matrix, add hourglass contributions, and rotate from local to global frame.

**Algorithm:**

1. Scale generalized forces by thickness:
   ```
   F1A = FOR(1)·THK0,  F2A = FOR(2)·THK0, ...
   ```

2. Membrane nodal forces (local frame):
   ```
   F11 = F1A·PX1 + F3A·PY1    (node 1, local X)
   F21 = F2A·PY1 + F3A·PX1    (node 1, local Y)
   F31 = F5A·PX1 + F4A·PY1    (node 1, local Z)
   ```
   (Similarly for nodes 2, 3.  Node 4 by equilibrium: `F4 = −(F1+F2+F3)`)

3. Add hourglass contributions (`H11..H33` from CHVIS3)

4. Rotate to global frame:
   ```
   F1_global = E1X·F_localX + E2X·F_localY + E3X·F_localZ
   F2_global = E1Y·F_localX + E2Y·F_localY + E3Y·F_localZ
   F3_global = E1Z·F_localX + E2Z·F_localY + E3Z·F_localZ
   ```

5. Bending: scale MOM by `THK0²/12`, apply B-matrix for moments, add bending
   hourglass, rotate to global.

**GPU:** Same computation in registers.  The combined F+H result is directly passed
to the assembly stage (next section) within the same thread — no intermediate
global memory write needed.

---

### 6.11 CDT3 — Element Time Step

**CPU file:** `cdt3.F`
**GPU location:** Kernel 1 (ALDT² computation) + `shell_min_dt_kernel` reduction
kernel in `shell_gpu_driver.cu`

**Purpose:** Compute the element stable time step for the explicit time integration:

$$\Delta t_{elem} = \text{DTFAC} \cdot \frac{\ell_{char}}{c}$$

where $\ell_{char}$ is a characteristic element length and $c$ is the sound speed.

**CPU:** `CDT3` computes the characteristic length from the element edge lengths,
divides by sound speed, and reduces to find the controlling element.

**GPU:** The characteristic length squared (`ALDT²`) is computed **in Kernel 1**
(which has access to the local coordinates and area) and stored in `d_STI[I]`.
The minimum element time step is then computed by a dedicated **GPU reduction
kernel** (`shell_min_dt_kernel`):

1. Each thread computes `dt_elem = dtfac * sqrt(d_STI[i]) / d_SSP[i]` for its
   element (skipping inactive elements where `d_OFF ≤ 0`).
2. A shared-memory tree reduction finds the block minimum.
3. Block leaders write their result via `atomicMin_double` (CAS loop on 64-bit
   integer representation) to a single device scalar `d_dt_min`.
4. The result (8 bytes) is downloaded to the host via `cudaMemcpyAsync`.

This replaces the previous pattern of downloading the entire `ALDT²` array
(`NUMELC` doubles) to the host and performing a Fortran reduction loop.

> **Note:** The element-level dt reduces `DT2T` only when the CPU `CDT3` would do
> the same: `NODADT==0` and `IDTMIN3/=0` (mapped to `compute_sti==2`).  When
> `NODADT/=0`, the timestep is controlled by `DTNODA` from nodal stiffness
> (`STIFN`), not by element-level dt.  This is tracked by the `reduce_elem_dt`
> flag in `SHELLS_`.

---

### 6.12 CUPDT3 — Force Assembly (Scatter)

**CPU file:** `cupdt3.F`
**GPU location:** Kernel 3 (`shell_force_assembly_kernel.cu`), "CUPDT3" section

**Purpose:** Scatter the per-element nodal forces/moments to the global nodal arrays
and accumulate stiffness.

**CPU (direct scatter):**
```fortran
DO I = JFT, JLT
    A(1, N1) = A(1, N1) + F11(I)    ! no race condition: groups don't share nodes
    A(2, N1) = A(2, N1) + F21(I)
    ...
ENDDO
```

**GPU (atomic scatter):**
```c
atomicAdd(&d_Fx[n1], f11);
atomicAdd(&d_Fy[n1], f21);
atomicAdd(&d_Fz[n1], f31);
...   // same for nodes 2, 3, 4; moments; stiffness
```

**Key difference:** On the CPU, groups are processed sequentially and elements
within a group don't share boundary nodes, so no race conditions arise.  On the
GPU, all elements across all SUs execute simultaneously (potentially on overlapping
streams), so shared boundary nodes require `atomicAdd` to prevent data races.
Since all SUs write to the **same global** force arrays, this is correct even
when multiple SU streams overlap.

> **Performance note:** `atomicAdd` on double precision is supported on all modern
> NVIDIA GPUs (compute capability ≥ 6.0) but can be a bottleneck when many elements
> share the same node.  Future optimization: graph coloring to eliminate atomics.

---

## 7. Data Layout Transformation

The fundamental data layout change between CPU and GPU:

### CPU (Fortran, vector groups)

```
Work arrays:   dimension(MVSIZ)     — e.g., EXX(129), PX1(129)
Element state:  ELBUF_TAB(NG)%GBUF%array(NEL)       — per-group
IP state:       ELBUF_TAB(NG)%BUFLY(1)%LBUF(1,1,IT)%sig(NEL*5) — per-group, per-IP
Global nodes:   X(3, NUMNOD), V(3, NUMNOD)           — AoS
```

### GPU (CUDA, flat SoA)

```
Work arrays:   [NUMELC]             — e.g., d_EXX[NUMELC] (or registers)
Element state:  d_array[NUMELC]     — single flat array
IP state:       d_SIGxx[NPT * NUMELC]  — flat, IT-major: offset = (IT-1)*NUMELC + I
Global nodes:   d_X[3*NUMNOD] (AoS, matches Fortran layout), d_V[3*NUMNOD], d_VR[3*NUMNOD]
                (sub-pointers into ShellGPUGlobal.d_raw_h2d[9*NUMNOD])
Nodal results:  d_Fx[NUMNOD] ... d_STIFR[NUMNOD]  — SoA, sub-pointers into d_raw_d2h[8*NUMNOD]
```

### Indexing correspondence

| CPU | GPU | Notes |
|-----|-----|-------|
| `X(1, global_node_id)` | `d_X[3*node_id]` | Node ID 0-based global (AoS layout) |
| `IXC(2, NFT+I)` | `d_N1[I]` | Connectivity, 0-based global |
| `EXX(I)` within DO loop | register `exx` | No global memory needed |
| `GBUF%OFF(I)` | `d_OFF[elem_counter + I]` | Flat across super-group |
| `LBUF(1,1,IT)%sig(IJ1+I)` | `d_SIGxx[(IT-1)*NUMELC + I]` | ip-major flat layout |
| `FOR(I,1)` where `I ∈ [1,NEL]` | `d_FORxx[I]` | Kernel 2 → Kernel 3 |

---

## 8. GPU Data Structures

### 8.1 ShellGPUGlobal (C struct — `shell_gpu_data.h`)

Global (shared) node/force handle — one per `SHELLS_` instance.  All SUs read from
and write to these arrays:

| Category | Fields | Size |
|----------|--------|------|
| Dimension | `NUMNOD` | scalar |
| H2D buffer | `d_raw_h2d` → `d_X`, `d_V`, `d_VR` | `[9*NUMNOD]` |
| D2H buffer | `d_raw_d2h` → `d_Fx..d_STIFR` | `[8*NUMNOD]` |
| Synchronization | `stream`, `upload_done` (event) | — |

### 8.2 ShellGPUData (C struct — `shell_gpu_data.h`)

Per-super-group device memory pool.  Contains:

| Category | Example Fields | Size |
|----------|---------------|------|
| Mesh dimensions | `NUMELC`, `NUMNOD`, `NPT`, `ISMSTR`, `ITHK`, `IHBE` | scalars |
| Material params | `JohnsonCookParams mat` (E, ν, A, B, n, C, ...) | struct |
| Hourglass params | `HourglassParams hg` (H1, H2, H3, HVISC, ...) | struct |
| Global node/force aliases | `d_X`, `d_V`, `d_VR`, `d_Fx..d_STIFR` (aliased from ShellGPUGlobal) | — |
| Connectivity | `d_N1..d_N4` | `[NUMELC]` (int) |
| Element state | `d_OFF`, `d_THK`, `d_THK0`, `d_THK02`, `d_SMSTR[*6]`, `d_GSTR[*8]`, `d_HOUR[*5]`, `d_EINT[*2]` | `[NUMELC]` |
| Per-element material | `d_YM`, `d_NU`, `d_RHO`, `d_SSP`, `d_A11`, `d_G`, `d_SHF` | `[NUMELC]` |
| Min-dt reduction | `d_dt_min` | `[1]` (scalar) |
| Per-IP state | `d_SIGxx..zx`, `d_PLA`, `d_EPSD_ip`, `d_SIGBAKxx/yy/xy`, `d_TEMPEL`, `d_DPLA` | `[NPT*NUMELC]` |
| Intermediates K1→K2→K3 | `d_E1x..E3z`, `d_VL1x..VRL4z`, `d_PX1/2`, `d_PY1/2`, `d_AREA`, `d_A_I`, `d_FORxx..MOMxy` | `[NUMELC]` |
| Synchronization | `stream`, `kernels_done` (event), `global` (back-pointer) | — |

### 8.3 GPU_SHELL_LAW2 (Fortran type — `shell_gpu_mod.F90`)

The Fortran-side mirror for each super-group.  Contains:

- The opaque C handle: `type(c_ptr) :: handle`
- Node mapping arrays: `glob_2_gpu(:)`, `gpu_2_glob(:)` (vestigial, not used per-step)
- Connectivity: `n1(:)..n4(:)` — 0-based global node IDs
- Material parameters: all Johnson-Cook, Zerilli-Armstrong, and hourglass fields
- Per-element arrays: `el_thk0`, `el_off`, `el_ssp`, `el_rho`, `el_ym`, etc.
- Per-IP state arrays: `sigxx..sigzx`, `pla`, `epsd_ip`, `sigbakxx/yy/xy`, `tempel`
- Internal energy: `eint(2*NUMELC)`
- Element IDs: `ngl(:)` (global element ID), `part_id(:)` (part assignment)
- Min-dt result: `dt_min_result` — single scalar written by `shell_gpu_min_dt`
- Timestep factor: `dtfac` — DTFAC1(3) for min-dt computation

### 8.4 SHELLS_ (Fortran type — `shell_gpu_mod.F90`)

Top-level container:
```fortran
type SHELLS_
    type(GPU_SHELL_LAW2), dimension(:), allocatable :: law2
    logical :: reduce_elem_dt = .false.   ! True when NODADT==0 AND IDTMIN3/=0
    type(c_ptr) :: global_handle = c_null_ptr         ! ShellGPUGlobal pointer
    real(WP), dimension(:), allocatable :: raw_gpu_to_cpu_global  ! [8*NUMNOD]
    integer(c_int) :: numnod_global = 0               ! full-mesh node count
end type
```

`SHELLS%LAW2(SU)` gives access to super-group `SU`.

The `reduce_elem_dt` flag controls whether the GPU min-dt reduction (§6.11) is
performed and whether the result reduces `DT2T`.  It is set during initialization
based on `compute_sti==2` (equivalent to `NODADT==0 .AND. IDTMIN3/=0`).  When
`NODADT/=0`, the timestep is controlled by `DTNODA` via nodal stiffness, and
element-level dt is not needed.

---

## 9. GPU Kernel Architecture (Option C)

The implementation follows **Option C**: three fused kernels with intermediate data
resident in device global memory, plus a min-dt reduction kernel.

```
┌─────────────────────────────────────────────────────────┐
│ Kernel 1: shell_geometry_kernel                         │
│ ┌─────────┐  ┌─────────┐  ┌─────────┐  ┌──────────┐   │
│ │ CCOOR3  │→ │ CNVEC3  │→ │ CDERI3  │→ │ CDLEN3   │   │
│ │(gather) │  │(frame)  │  │(derivs) │  │(char len)│   │
│ └─────────┘  └─────────┘  └─────────┘  └──────────┘   │
│ Output: E1/E2/E3, VL, VRL, PX/PY, AREA, VHX/VHY, Z2  │
└────────────────────────┬────────────────────────────────┘
                         │ device global memory
┌────────────────────────▼────────────────────────────────┐
│ Kernel 2: shell_strain_material_kernel                  │
│ ┌─────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌──────┐ │
│ │ CCOEF3  │→│ CDEFO3 │→│ CCURV3 │→│ CSTRA3 │→│CMAIN3│ │
│ │(coeffs) │ │(membr) │ │(curv)  │ │(strain)│ │(mat) │ │
│ └─────────┘ └────────┘ └────────┘ └────────┘ └──────┘ │
│ Output: FOR(5), MOM(3), updated SIG, PLA, THK, GSTR   │
└────────────────────────┬────────────────────────────────┘
                         │ device global memory
┌────────────────────────▼────────────────────────────────┐
│ Kernel 3: shell_force_assembly_kernel                   │
│ ┌─────────┐  ┌─────────┐  ┌──────────────────┐         │
│ │ CHVIS3  │→ │ CFINT3  │→ │ CUPDT3           │         │
│ │(hglass) │  │(forces) │  │(atomicAdd scatter)│         │
│ └─────────┘  └─────────┘  └──────────────────┘         │
│ Output: global Fx/Fy/Fz, Mx/My/Mz, STIFN, STIFR      │
└────────────────────────┬────────────────────────────────┘
                         │ device global memory (d_STI)
┌────────────────────────▼────────────────────────────────┐
│ Kernel 4: shell_min_dt_kernel        (optional)        │
│ ┌───────────────────────────────────────────────────┐   │
│ │ Shared-memory tree reduction over NUMELC elements   │   │
│ │ dt_elem = dtfac * sqrt(d_STI[i]) / d_SSP[i]        │   │
│ │ Block leaders: atomicMin_double → d_dt_min (1 scalar)│   │
│ └───────────────────────────────────────────────────┘   │
│ Output: d_dt_min (single scalar, downloaded via D2H)   │
└─────────────────────────────────────────────────────────┘
```

All four kernels are launched into the **same CUDA stream**, ensuring sequential
execution without explicit synchronization between them.  The stream-ordered
execution guarantees that each kernel sees the outputs of the previous one.

Kernel 4 (`shell_min_dt_kernel`) is launched separately in pass 2 of the pipelined
SU loop (§5), only when `reduce_elem_dt` is true.  It reads `d_STI` (written by
Kernel 1) and `d_SSP`/`d_OFF` (uploaded once at init).

**Launch configuration:** Block size = 256 threads, grid = `ceil(NUMELC / 256)`.

---

## 10. File Inventory

### GPU-specific files (in `engine/source/elements/shell/coque/`)

| File | Language | Purpose |
|------|----------|---------|
| `shell_gpu_data.h` | C/CUDA | `ShellGPUData` and `ShellGPUGlobal` struct definitions |
| `shell_gpu_driver.h` | C/CUDA | C-linkage header for all driver functions |
| `shell_geometry_kernel.h` | C/CUDA | Kernel 1 launcher declaration |
| `shell_geometry_kernel.cu` | CUDA | Kernel 1: CCOOR3 + CNVEC3 + CDERI3 + CDLEN3 |
| `shell_strain_material_kernel.h` | C/CUDA | `JohnsonCookParams` struct + Kernel 2 launcher declaration |
| `shell_strain_material_kernel.cu` | CUDA | Kernel 2: CCOEF3 + CDEFO3 + CCURV3 + CSTRA3 + CMAIN3 (incl. `m2cplr_device`) |
| `shell_force_assembly_kernel.h` | C/CUDA | `HourglassParams` struct + Kernel 3 launcher declaration |
| `shell_force_assembly_kernel.cu` | CUDA | Kernel 3: CHVIS3 + CFINT3 + CUPDT3 |
| `shell_gpu_driver.cu` | CUDA | Allocate, upload, download, kernel orchestration, global handle, min-dt reduction, host memory pinning |
| `real_type.h` | C/CUDA | `Real` typedef (double or float depending on `MYREAL8`) |
| `shell_gpu_mod.F90` | Fortran 90 | ISO_C_BINDING interfaces, `GPU_SHELL_LAW2` / `SHELLS_` types |
| `shell_internal_forces.F90` | Fortran 90 | `FORINTC_PREPARE_GPU` (init) + `gpu_shell_launch_async` / `gpu_shell_sync_scatter` (per-cycle) |

### CPU reference files (for comparison)

| File | Purpose |
|------|---------|
| `forintc.F` | Top-level loop over element groups (now with GPU bypass) |
| `cforc3.F` | Per-group shell element driver (orchestrates all subroutines) |
| `ccoor3.F` | Gather nodal coordinates & velocities |
| `cnvec3.F` | Convected orthonormal frame |
| `cderi3.F` | Shape function derivatives, area, HG vectors |
| `ccoef3.F` | Material/geometry coefficient extraction |
| `cdefo3.F` | Membrane strain rates |
| `ccurv3.F` | Curvature rates (bending) |
| `cstra3.F` | Strain increment accumulation |
| `cmain3.F` → `sigeps02c.F` → `m2cplr.F` | Through-thickness material integration |
| `chvis3.F` | Hourglass forces |
| `cfint3.F` | Internal force computation |
| `cdt3.F` | Element time step |
| `cupdt3.F` | Force assembly (scatter to global) |

---

## 11. Current Limitations

This is a **proof of concept**.  The following features are not yet supported on the
GPU path:

| Feature | Notes |
|---------|-------|
| Material laws other than law 2 | Only Johnson-Cook / Zerilli-Armstrong |
| IHBE ≥ 2 | Batoz (IHBE ≥ 11), QEPH (IHBE ≥ 21) formulations |
| XFEM | Crack modeling |
| Failure models | Element deletion criteria |
| Section forces | `/SECT` outputs |
| Seatbelt / slipring | Contact-related features |
| Explicit mass scaling | `/DT/NODA/CST` |
| Non-local regularization | INLOC > 0 |
| Coupled thermal | JTHE /= 0 (adiabatic temperature still works) |
| Multiple materials per SU | All elements in a super-group must share the same material |
| OpenMP + GPU | Currently sequential across super-groups on host side (pipelined, but single-threaded) |
| State download for restart | `shell_gpu_download_state` exists but is not called regularly |
| MPI decomposition | GPU super-groups are domain-local |

---





