### PR TITLE
INTER/SUB for E2E contact 1D elements

### DIFF
--- a/starter/source/interfaces/inter3d1/i25neigh.F
+++ b/starter/source/interfaces/inter3d1/i25neigh.F
@@ -109,7 +109,7 @@ C-----------------------------------------------
       INTEGER,  DIMENSION(:),ALLOCATABLE :: INDEX, ITAG, NTAG, ROOT,INDEX2
       INTEGER, DIMENSION(:), ALLOCATABLE :: MLOC,KAD,ADDSUBN,ADDSUBN_TMP,
      .                                      LISUBN,INFLG_SUBN,IXSUB,EBINFLG_TMP,
-     .                                      IIXYZ
+     .                                      IIXYZ , ADDSUBE_TMP,LISUBE_TMP,INFLG_SUBE_TMP
       INTEGER, DIMENSION(:,:,:),ALLOCATABLE :: MNEIGH_SOLID
 C-----------------------------------------------
 C   E x t e r n a l   F u n c t i o n s
@@ -566,6 +566,14 @@ C-----------------------------------------------------------------------
            ALLOCATE(EBINFLG_TMP(NEDGE_L))
             EBINFLG_TMP(1:NEDGE_L) =EBINFLG(1:NEDGE_L)
          ENDIF
+         IF(NISUB > 0) THEN
+           ALLOCATE(ADDSUBE_TMP(NEDGE_L+1))
+           ADDSUBE_TMP(1:NEDGE_L+1) =ADDSUBE(1:NEDGE_L+1)
+           ALLOCATE(LISUBE_TMP(NISUBE))
+           LISUBE_TMP(1:NISUBE) =LISUBE(1:NISUBE)
+           ALLOCATE(INFLG_SUBE_TMP(NISUBE))
+           INFLG_SUBE_TMP(1:NISUBE) =INFLG_SUBE(1:NISUBE) 
+         ENDIF
       ENDIF
 C
       DO I=1,NRTM
@@ -879,7 +887,6 @@ C-----1D element edges -----
       IF(NEDGE_L >0) THEN
          LEDGE(5:6,NEDGE+1:NEDGE+NEDGE_L) = LEDGE_TMP3(1:2,1:NEDGE_L)
          LEDGE(7,NEDGE+1:NEDGE+NEDGE_L) = 3
-         IF(ILEV==2)EBINFLG(NEDGE+1:NEDGE+NEDGE_L) =EBINFLG(1:NEDGE_L)
          NEDGE = NEDGE+NEDGE_L
       ENDIF
 
@@ -896,7 +903,6 @@ C-----1D element edges -----
          K=INDEX2(I)
          LEDGE(1:NLEDGE,I)=LEDGE_TMP(1:NLEDGE,K)
       ENDDO
-
 C
 c      DO I=1,NRTM
 c       print *,'I,MSEGTYP(I)=',I,MSEGTYP(I),itab(irect(1:4,i))
@@ -933,7 +939,7 @@ C-----------------------------------------
         END DO
       END IF
 C
-      IF(NEDGE/=0.AND.NISUB/=0)THEN
+      IF(NEDGE/=0.AND.NISUB/=0.AND.NEDGE /=NEDGE_L)THEN
 
         ALLOCATE (MLOC(NUMNOD),KAD(MAX(NMN,NEDGE)),STAT=stat)
         MLOC(1:NUMNOD)=0
@@ -1062,78 +1068,145 @@ C-----------------------------------------
         INFLG_SUBE(1:NISUBE)=0
 C
         DO NE=1,NEDGE
-          I1  =MLOC(LEDGE(5,NE))
-          I2  =MLOC(LEDGE(6,NE))
+          IF(LEDGE(7,NE)/=3) THEN
+            I1  =MLOC(LEDGE(5,NE))
+            I2  =MLOC(LEDGE(6,NE))
 
-          LL  =ADDSUBN(I1)
-          KK  =ADDSUBN(I2)
-          DO WHILE(LL<ADDSUBN(I1+1))
-            JSUB=LISUBN(LL)
-            DO WHILE(KK<ADDSUBN(I2+1))
-              KSUB=LISUBN(KK)   
-              IF(KSUB==JSUB)THEN
-                ADDSUBE(NE)=ADDSUBE(NE)+1
-                KK=KK+1
-              ELSE IF(KSUB<JSUB)THEN
-                KK=KK+1
-              ELSE
-                GO TO 100
-              END IF
+            LL  =ADDSUBN(I1)
+            KK  =ADDSUBN(I2)
+            DO WHILE(LL<ADDSUBN(I1+1))
+              JSUB=LISUBN(LL)
+              DO WHILE(KK<ADDSUBN(I2+1))
+                KSUB=LISUBN(KK)   
+                IF(KSUB==JSUB)THEN
+                  ADDSUBE(NE)=ADDSUBE(NE)+1
+                  KK=KK+1
+                ELSE IF(KSUB<JSUB)THEN
+                  KK=KK+1
+                ELSE
+                  GO TO 100
+                END IF
+              END DO
+ 100        CONTINUE
+            LL=LL+1
             END DO
- 100      CONTINUE
-          LL=LL+1
-          END DO
+          ELSEIF(NEDGE /=NEDGE_L) THEN
+            ADDSUBE(NE)=ADDSUBE(NE)+(ADDSUBE_TMP(INDEX2(NE)-(NEDGE-NEDGE_L)+1)-ADDSUBE_TMP(INDEX2(NE)-(NEDGE-NEDGE_L)))
+          ENDIF
         END DO
 C
         CUR=1
         DO NE=1,NEDGE
-          NEXT       = CUR+ADDSUBE(NE)
-          ADDSUBE(NE)= CUR
-          CUR        = NEXT
+           NEXT       = CUR+ADDSUBE(NE)
+           ADDSUBE(NE)= CUR
+           CUR        = NEXT
         END DO
         ADDSUBE(1+NEDGE)=CUR
 C
 C       Use Kad (1: Nedge) to fill Lisube, inflg_sube
         DO NE=1,NEDGE
-          KAD(NE)=ADDSUBE(NE)
+           KAD(NE)=ADDSUBE(NE)
         END DO
 
         DO NE=1,NEDGE
-          I1  =MLOC(LEDGE(5,NE))
-          I2  =MLOC(LEDGE(6,NE))
 
-          LL  =ADDSUBN(I1)
-          KK  =ADDSUBN(I2)
-          DO WHILE(LL<ADDSUBN(I1+1))
-            JSUB=LISUBN(LL)
-            IMS1 = BITGET(INFLG_SUBN(LL),0)
-            IMS2 = BITGET(INFLG_SUBN(LL),1)
-            DO WHILE(KK<ADDSUBN(I2+1))
-              KSUB=LISUBN(KK)   
-              IMS3 = BITGET(INFLG_SUBN(KK),0)
-              IMS4 = BITGET(INFLG_SUBN(KK),1)
-              IF(KSUB==JSUB)THEN
-                LISUBE(KAD(NE))=JSUB
-                IF(IMS1==1.AND.IMS3==1) ! edge belongs to S1 is I1 and I2 belong to S1
-     .           INFLG_SUBE(KAD(NE))=
-     .                BITSET(INFLG_SUBE(KAD(NE)),0)
-                IF(IMS2==1.AND.IMS4==1) ! edge belongs to S2 is I1 and I2 belong to S2
-     .           INFLG_SUBE(KAD(NE))=
-     .                BITSET(INFLG_SUBE(KAD(NE)),1)
-                KAD(NE)   =KAD(NE)+1
-                KK=KK+1
-              ELSE IF(KSUB<JSUB)THEN
-                KK=KK+1
-              ELSE
-                GO TO 200
-              END IF
+          IF(LEDGE(7,NE)/=3) THEN
+            I1  =MLOC(LEDGE(5,NE))
+            I2  =MLOC(LEDGE(6,NE))
+
+            LL  =ADDSUBN(I1)
+            KK  =ADDSUBN(I2)
+            DO WHILE(LL<ADDSUBN(I1+1))
+              JSUB=LISUBN(LL)
+              IMS1 = BITGET(INFLG_SUBN(LL),0)
+              IMS2 = BITGET(INFLG_SUBN(LL),1)
+              DO WHILE(KK<ADDSUBN(I2+1))
+                KSUB=LISUBN(KK)   
+                IMS3 = BITGET(INFLG_SUBN(KK),0)
+                IMS4 = BITGET(INFLG_SUBN(KK),1)
+                IF(KSUB==JSUB)THEN
+                  LISUBE(KAD(NE))=JSUB
+                  IF(IMS1==1.AND.IMS3==1) ! edge belongs to S1 is I1 and I2 belong to S1
+     .             INFLG_SUBE(KAD(NE))=
+     .                 BITSET(INFLG_SUBE(KAD(NE)),0)
+                  IF(IMS2==1.AND.IMS4==1) ! edge belongs to S2 is I1 and I2 belong to S2
+     .             INFLG_SUBE(KAD(NE))=
+     .                 BITSET(INFLG_SUBE(KAD(NE)),1)
+                  KAD(NE)   =KAD(NE)+1
+                  KK=KK+1
+                ELSE IF(KSUB<JSUB)THEN
+                  KK=KK+1
+                ELSE
+                  GO TO 200
+                END IF
+              END DO
+ 200        CONTINUE
+            LL=LL+1
             END DO
- 200      CONTINUE
-          LL=LL+1
-          END DO
+          ELSEIF(NEDGE /=NEDGE_L) THEN
+            KK  =ADDSUBE(NE)
+            LL = ADDSUBE_TMP(INDEX2(NE)-(NEDGE-NEDGE_L))
+            DO WHILE(KK<ADDSUBE(NE+1))
+              LISUBE(KK)=LISUBE_TMP(LL)
+              INFLG_SUBE(KK)=INFLG_SUBE_TMP(LL)
+              KK = KK +1
+              LL = LL +1
+            ENDDO
+          ENDIF
         END DO
 
         DEALLOCATE (MLOC,KAD,ADDSUBN_TMP,ADDSUBN,LISUBN,INFLG_SUBN,IXSUB)
+        IF(NISUB > 0.AND.NEDGE_L > 0) DEALLOCATE (ADDSUBE_TMP,INFLG_SUBE_TMP,LISUBE_TMP)
+
+C-------------------------------------
+        IF(IPRI>=6) THEN
+          WRITE(IOUT,1000)
+          WRITE(IOUT,1010)NOINT
+          WRITE(IOUT,'(10I10)')
+     .         (NOM_OPT(1,NINTER+LISUB(JSUB)),JSUB=1,NISUB)
+          WRITE(IOUT,1030)
+          DO NE=1,NEDGE
+            JSUB=ADDSUBE(NE)
+            N   =ADDSUBE(NE+1)-ADDSUBE(NE)
+            IF(N>0)THEN
+              WRITE(IOUT,'(3I10)')NE,ITAB(LEDGE(5,NE)),ITAB(LEDGE(6,NE))
+              WRITE(IOUT,'(30X,2I10)')
+     .          (LISUBE(JSUB-1+K),INFLG_SUBE(JSUB-1+K),K=1,N)
+            END IF
+          END DO
+        END IF
+      ELSEIF(NEDGE/=0.AND.NISUB/=0.AND.NEDGE ==NEDGE_L)THEN
+
+        ADDSUBE(1:NEDGE+1)  = 0 
+        LISUBE(1:NISUBE)=0
+        INFLG_SUBE(1:NISUBE)=0
+C-----------------------------------------
+C       Calculation of ADDSUBN, LISUBN, INFLG_SUBN for the main nodes
+C-----------------------------------------
+        ADDSUBE(1:NEDGE+1)=0
+        DO I=1,NEDGE
+           ADDSUBE(I)=ADDSUBE(I)+ADDSUBE_TMP(INDEX2(I)+1)-ADDSUBE_TMP(INDEX2(I))
+        END DO
+C
+        CUR=1
+        DO I=1,NEDGE
+          NEXT    = CUR+ADDSUBE(I)
+          ADDSUBE(I) = CUR
+          CUR     = NEXT
+        END DO
+        ADDSUBE(1+NEDGE)=CUR
+        DO NE=1,NEDGE
+           KK  =ADDSUBE(NE)
+           LL = ADDSUBE_TMP(INDEX2(NE))
+           DO WHILE(KK<ADDSUBE(NE+1))
+             LISUBE(KK)=LISUBE_TMP(LL)
+             INFLG_SUBE(KK)=INFLG_SUBE_TMP(LL)
+             KK = KK +1
+             LL = LL +1
+           ENDDO
+        ENDDO
+        IF(NISUB > 0.AND.NEDGE_L > 0) DEALLOCATE (ADDSUBE_TMP,INFLG_SUBE_TMP,LISUBE_TMP)
+ 
 C-------------------------------------
         IF(IPRI>=6) THEN
           WRITE(IOUT,1000)
@@ -1152,11 +1225,11 @@ C-------------------------------------
           END DO
         END IF
       END IF ! IF(NEDGE/=0.AND.NISUB/=0)THEN
-        IF(ALLOCATED(IIXYZ))DEALLOCATE(IIXYZ)
-        IF(ALLOCATED(INDEX2))DEALLOCATE(INDEX2)
-        IF(ALLOCATED(LEDGE_TMP))DEALLOCATE(LEDGE_TMP)
-        IF(ALLOCATED(LEDGE_TMP3))DEALLOCATE(LEDGE_TMP3)
-        IF(ALLOCATED(EBINFLG_TMP))DEALLOCATE(EBINFLG_TMP)
+      IF(ALLOCATED(IIXYZ))DEALLOCATE(IIXYZ)
+      IF(ALLOCATED(INDEX2))DEALLOCATE(INDEX2)
+      IF(ALLOCATED(LEDGE_TMP))DEALLOCATE(LEDGE_TMP)
+      IF(ALLOCATED(LEDGE_TMP3))DEALLOCATE(LEDGE_TMP3)
+      IF(ALLOCATED(EBINFLG_TMP))DEALLOCATE(EBINFLG_TMP)
 C-------------------------------------
  1000 FORMAT(    /1X,'   STRUCTURE OF SUB-INTERFACES OUTPUT TO TH'/
      .            1X,'   ----------------------------------------'// )

--- a/starter/source/interfaces/interf1/inintsub.F
+++ b/starter/source/interfaces/interf1/inintsub.F
@@ -69,13 +69,14 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER, DIMENSION(:), ALLOCATABLE :: NOD2NSV,NOD2RTM,NOD2RTMS,NOD2RTMM,KAD,TAGNOD,TAGRTM
-      INTEGER, DIMENSION(:), ALLOCATABLE :: TAGLINS,TAGLINM
+      INTEGER, DIMENSION(:), ALLOCATABLE :: TAGLINS,TAGLINM,TAGEDG,NOD2EDG
       TARGET NOD2NSV
        INTEGER, DIMENSION(:), POINTER :: IADD
       INTEGER J,K,
      .   NI,NOINT,NTY,NRTS,NRTM,NSN,NMN,MULTIMP,IFQ,NRTM_SH,NRTM0,
      .   NISUB, NISUBS, NISUBM, JSUB, IS,
-     .   IM, N,STAT,NT19,NSNE,NRTSE
+     .   IM, N,STAT,NT19,NSNE,NRTSE,
+     .   NEDGE_1D,MAXEDG,NEDGE,NISUBE
       CHARACTER MESS*40
       INTEGER ID
       CHARACTER(LEN=NCHARTITLE) :: TITR
@@ -97,11 +98,19 @@ C=======================================================================
       ALLOCATE (NOD2RTM(4*MAXRTM)      ,STAT=stat)
       ALLOCATE (NOD2RTMS(2*MAXRTMS)      ,STAT=stat)
       ALLOCATE (NOD2RTMM(2*MAXRTMS)      ,STAT=stat)  
-      ALLOCATE (KAD(MAX(NUMNOD+MAXNSNE,MAXRTM,MAXRTMS)),STAT=stat)
       ALLOCATE (TAGNOD(NUMNOD)      ,STAT=stat)
       ALLOCATE (TAGRTM(MAXRTM)      ,STAT=stat)
       ALLOCATE (TAGLINS(MAXRTMS)      ,STAT=stat)
       ALLOCATE (TAGLINM(MAXRTMS)      ,STAT=stat)
+      MAXEDG = 0
+      DO NI=1,NINTER
+        NTY  =IPARI(7,NI)
+        NEDGE_1D=IPARI(101,NI)
+        IF (NTY==25) MAXEDG = MAX(MAXEDG,NEDGE_1D)
+      ENDDO
+      ALLOCATE (NOD2EDG(2*MAXEDG)      ,STAT=stat)
+      ALLOCATE (TAGEDG(MAXEDG)      ,STAT=stat)
+      ALLOCATE (KAD(MAX(NUMNOD+MAXNSNE,MAXRTM,MAXRTMS,MAXEDG)),STAT=stat)
 C
       IADD => NOD2NSV(1:NUMNOD+1)
       DO NI=1,NINTER
@@ -134,13 +143,20 @@ C
                NSNE   = IPARI(55,NI)
                NRTSE  = IPARI(55,NI)
             ENDIF
+            NEDGE_1D = 0
+            IF(NTY==25) THEN
+              NEDGE_1D=IPARI(101,NI)
+            ENDIF
+            NEDGE = IPARI(68,NI)
+            NISUBE = IPARI(90,NI)
 C
             IF(NISUB/=0)THEN    
                CALL ININTSUB_25(ITAB      ,IGRNOD ,IGRSURF ,NOM_OPT ,INTBUF_TAB,
      .                        NRTM      ,NRTM0  ,NSN     ,NISUBS  ,NISUBM    ,
      .                        NOINT     ,NI     ,NOD2NSV ,NOD2RTM ,KAD       ,
      .                        TAGNOD    ,TAGRTM ,IADD    ,NSNE    ,NTY       ,
-     .                        NRTSE     )   
+     .                        NRTSE     ,NEDGE_1D,NOD2EDG,TAGEDG  ,MAXEDG    ,
+     .                        NEDGE     ,NISUBE  ,NLEDGE)   
             END IF
 
 C------------------------------------------
@@ -349,6 +365,7 @@ C
       DEALLOCATE (TAGRTM)
       DEALLOCATE (TAGNOD)
       DEALLOCATE (TAGLINS,TAGLINM)
+      DEALLOCATE (TAGEDG,NOD2EDG)
 C 
 C-------------------------------------
  1000 FORMAT(    /1X,'   STRUCTURE OF SUB-INTERFACES OUTPUT TO TH'/

--- a/starter/source/output/subinterface/inintsub_25.F
+++ b/starter/source/output/subinterface/inintsub_25.F
@@ -36,7 +36,8 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .                       NRTM      ,NRTM0  ,NSN     ,NISUBS  ,NISUBM    ,
      .                       NOINT     ,NI     ,NOD2NSV ,NOD2RTM ,KAD       ,
      .                       TAGNOD    ,TAGRTM ,IADD    ,NSNE    ,NTY       ,
-     .                       NRTSE     )   
+     .                       NRTSE     ,NEDGE_1D,NOD2EDG,TAGEDG  ,MAXEDG    ,
+     .                       NEDGE     ,NISUBE  ,NLEDGE )   
 
 C-----------------------------------------------
 C   M o d u l e s
@@ -63,6 +64,9 @@ C-----------------------------------------------
       INTEGER NRTM, NRTM0, NSN, NISUBS, NISUBM, NOINT, NI
       INTEGER NOM_OPT(LNOPT1,*)
       INTEGER ,INTENT(IN) :: NSNE, NTY, NRTSE
+      INTEGER ,INTENT(IN) :: NEDGE_1D, MAXEDG, NEDGE,NISUBE  ,NLEDGE
+      INTEGER ,INTENT(INOUT) :: NOD2EDG(2*MAXEDG)
+      INTEGER ,INTENT(INOUT) :: TAGEDG(MAXEDG)
 
       TYPE(INTBUF_STRUCT_) INTBUF_TAB(*)
 C-----------------------------------------------
@@ -87,9 +91,13 @@ C=======================================================================
 C
         INTBUF_TAB(NI)%ADDSUBS(1:NSN+1)  = 0   ! address of different subinter related to secondary node
         INTBUF_TAB(NI)%ADDSUBM(1:NRTM+1) = 0   ! address of different subinter related to main segment
+        IF(NEDGE_1D > 0) INTBUF_TAB(NI)%ADDSUBE(1:NEDGE+1) = 0   ! address of different subinter related to the edge
 
         INTBUF_TAB(NI)%INFLG_SUBS(1:NISUBS)=0  ! Flags for determining what is surface Surf1 or Surf2
         INTBUF_TAB(NI)%INFLG_SUBM(1:NISUBM)=0
+        IF(NEDGE_1D > 0) INTBUF_TAB(NI)%INFLG_SUBE(1:NISUBE) = 0   ! address of different subinter related to the edge
+
+        IF(NSN >0) THEN
 
 C----------------------------------------
 C  TAG nodes second calculate addresses
@@ -450,12 +458,12 @@ C
 
 
         END DO
-
+        ENDIF
 
 C----------------------------------------
 C  TAG main segments calculate addresses
 C---------------------------------------------
-
+        IF(NRTM > 0) THEN
 C
 C           Use IADD (1: Numnod+1)
         IADD(1:NUMNOD+1) = 0
@@ -499,7 +507,6 @@ C           utilise NOD2RTM(4*NRTM0)
            NOD2RTM(KAD(IN)) = IM
               KAD(IN) = KAD(IN) + 1
         ENDDO
-
 C
 C      prepare ADDSUBM : 
         KSUB=0
@@ -878,6 +885,410 @@ C
 C
            END IF
         END DO
+       ENDIF
+
+C----------------------------------------
+C  TAG edge 1D element  calculate addresses
+C---------------------------------------------
+       IF(NEDGE_1D > 0) THEN
+
+C
+C          Use IADD (1: Numnod+1)
+          IADD(1:NUMNOD+1) = 0
+
+          DO I=1,NEDGE_1D
+            IN       = INTBUF_TAB(NI)%LEDGE(NLEDGE*(I-1)+5)
+            IADD(IN) = IADD(IN)+1
+            IN       = INTBUF_TAB(NI)%LEDGE(NLEDGE*(I-1)+6)
+            IADD(IN) = IADD(IN)+1
+          END DO
+C
+          CUR=1
+          DO I=1,NUMNOD
+             NEXT     =CUR+IADD(I)
+             IADD(I)  =CUR
+             CUR      =NEXT
+          END DO
+          IADD(NUMNOD+1)=CUR
+C
+C           utilise KAD(NUMNOD)
+          DO I=1,NUMNOD
+             KAD(I)=IADD(I)
+          END DO
+C
+C           utilise NOD2RTM(4*NRTM0)
+          DO I=1,NEDGE_1D
+             IN       = INTBUF_TAB(NI)%LEDGE(NLEDGE*(I-1)+5)
+             NOD2EDG(KAD(IN)) = I
+             KAD(IN) = KAD(IN) + 1
+             IN       = INTBUF_TAB(NI)%LEDGE(NLEDGE*(I-1)+6)
+             NOD2EDG(KAD(IN)) = I
+             KAD(IN) = KAD(IN) + 1
+          ENDDO
+
+C
+C      prepare ADDSUBE : 
+          KSUB=0
+          DO JSUB=1,NINTSUB
+            ID1=NOM_OPT(1,NINTER+JSUB)
+            CALL FRETITL2(TITR1,
+     .                NOM_OPT(LNOPT1-LTITR+1,NINTER+JSUB),LTITR)
+
+            IF(NOM_OPT(2,NINTER+JSUB)==NOINT
+     .           .AND.NOM_OPT(5,NINTER+JSUB)==1)THEN
+                KSUB=KSUB+1
+C
+C      Lisub (ksub) = internal JSUB of the sub-interface
+               INTBUF_TAB(NI)%LISUB(KSUB) = JSUB
+               INTBUF_TAB(NI)%TYPSUB(KSUB) = 1
+C
+                TAGEDG(1:NEDGE_1D) = 0
+C
+                ISU1  =NOM_OPT(3,NINTER+JSUB)
+                NNE  =IGRSURF(ISU1)%NSEG
+                DO I=1,NNE
+                   IN=IGRSURF(ISU1)%NODES(I,1)
+                   KM=0
+                   DO JAD=IADD(IN),IADD(IN+1)-1
+                      IM = NOD2EDG(JAD)
+                      IFNRT = 0
+                      DO J=1,4
+                         II=IGRSURF(ISU1)%NODES(I,J)
+                         IF(II/=0)THEN
+                           DO K=5,6
+                              IF(INTBUF_TAB(NI)%LEDGE(NLEDGE*(IM-1)+K)==II) IFNRT = IFNRT + 1
+                           END DO
+                         ENDIF
+                      ENDDO
+                      IF(IFNRT >= 2) THEN
+                          KM=IM 
+                          EXIT
+                      ENDIF
+                   ENDDO
+
+                   IF(KM/=0)THEN
+                     IF(TAGEDG(KM)==0)THEN
+                       INTBUF_TAB(NI)%ADDSUBE(KM)=INTBUF_TAB(NI)%ADDSUBE(KM)+1
+                       TAGEDG(KM)=1
+                     ENDIF
+                   END IF
+                END DO
+C
+                ISU2  =NOM_OPT(6,NINTER+JSUB)
+                IF(ISU2/=0)THEN
+                   NNE  =IGRSURF(ISU2)%NSEG
+                   DO I=1,NNE
+                      IN=IGRSURF(ISU2)%NODES(I,1)
+                      KM=0
+  
+                      DO JAD=IADD(IN),IADD(IN+1)-1
+                         IM = NOD2EDG(JAD)
+                         IFNRT = 0
+                         DO J=1,4
+                            II=IGRSURF(ISU2)%NODES(I,J)
+                            IF(II/=0)THEN
+                               DO K=5,6
+                                  IF(INTBUF_TAB(NI)%LEDGE(NLEDGE*(IM-1)+K)==II) IFNRT = IFNRT + 1
+                               END DO
+                            ENDIF
+                          ENDDO
+                          IF(IFNRT >= 2) THEN
+                            KM=IM 
+                            EXIT
+                          ENDIF
+                      ENDDO
+
+                      IF(KM/=0)THEN
+                         IF(TAGEDG(KM)==0)THEN
+                           INTBUF_TAB(NI)%ADDSUBE(KM)=INTBUF_TAB(NI)%ADDSUBE(KM)+1
+                           TAGEDG(KM)=1
+                         ENDIF
+                      END IF
+                   END DO
+                END IF
+C
+C
+
+
+C
+C---------Case of subinter defined with inter 0 -------------
+C
+           ELSEIF(NOM_OPT(2,NINTER+JSUB) == 0 
+     .      .AND. NOM_OPT(5,NINTER+JSUB) == 1) THEN
+
+                KSUB=KSUB+1
+               INTBUF_TAB(NI)%LISUB (KSUB) = JSUB
+C
+                TAGEDG(1:NEDGE_1D) = 0
+C
+                ISU1  =NOM_OPT(3,NINTER+JSUB)
+                ISU2  =NOM_OPT(6,NINTER+JSUB)
+
+                IF(ISU2 > 0 ) INTBUF_TAB(NI)%TYPSUB(KSUB) = 2
+                IF(ISU1 > 0 ) THEN
+                  INTBUF_TAB(NI)%TYPSUB(KSUB) = 3
+                  NNE  =IGRSURF(ISU1)%NSEG
+                  DO I=1,NNE
+                     IN=IGRSURF(ISU1)%NODES(I,1)
+                     KM=0
+
+                     DO JAD=IADD(IN),IADD(IN+1)-1
+                       IM = NOD2EDG(JAD)
+                       IFNRT = 0
+                       DO J=1,4
+                         II=IGRSURF(ISU1)%NODES(I,J)
+                         IF(J/=4.OR.II/=0)THEN
+                           DO K=5,6
+                              IF(INTBUF_TAB(NI)%LEDGE(NLEDGE*(IM-1)+K)==II) IFNRT = IFNRT + 1
+                           END DO
+                         ENDIF
+                       ENDDO
+                       IF(IFNRT >= 2) THEN
+                          KM=IM 
+                          EXIT
+                       ENDIF
+                    ENDDO
+
+                    IF(KM/=0)THEN
+                      IF(TAGEDG(KM)==0)THEN
+                        INTBUF_TAB(NI)%ADDSUBE(KM)=INTBUF_TAB(NI)%ADDSUBE(KM)+1
+                        TAGEDG(KM)=1
+                      ENDIF
+                    END IF
+                  END DO
+                ENDIF
+C
+
+                IF(ISU2 > 0 ) THEN
+                  NNE  =IGRSURF(ISU2)%NSEG
+                  DO I=1,NNE
+                     IN=IGRSURF(ISU2)%NODES(I,1)
+                     KM=0
+
+                     DO JAD=IADD(IN),IADD(IN+1)-1
+                       IM = NOD2EDG(JAD)
+                       IFNRT = 0
+                       DO J=1,4
+                         II=IGRSURF(ISU2)%NODES(I,J)
+                         IF(J/=4.OR.II/=0)THEN
+                           DO K=5,6
+                              IF(INTBUF_TAB(NI)%LEDGE(NLEDGE*(IM-1)+K)==II) IFNRT = IFNRT + 1
+                           END DO
+                         ENDIF
+                       ENDDO
+                       IF(IFNRT >= 2) THEN
+                          KM=IM 
+                          EXIT
+                       ENDIF
+                    ENDDO
+
+                    IF(KM/=0)THEN
+                      IF(TAGEDG(KM)==0) THEN
+                         INTBUF_TAB(NI)%ADDSUBE(KM)=INTBUF_TAB(NI)%ADDSUBE(KM)+1
+                         TAGEDG(KM)=1
+                      ENDIF
+                    END IF
+                  END DO
+                ENDIF
+C
+           END IF
+
+          END DO
+C
+          CUR=1
+          DO IM=1,NEDGE_1D
+            NEXT                  =CUR+INTBUF_TAB(NI)%ADDSUBE(IM)
+            INTBUF_TAB(NI)%ADDSUBE(IM)=CUR
+            CUR                  =NEXT
+          END DO
+         INTBUF_TAB(NI)%ADDSUBE(NEDGE_1D+1)=CUR
+C
+C           utilise KAD(1:NRTM0)
+          DO IM=1,NEDGE_1D
+            KAD(IM)=INTBUF_TAB(NI)%ADDSUBE(IM)
+          END DO
+
+C
+C      prepare LISUBM : 
+C      LISUBM(ADDSUBM(IM):ADDSUBM(IM+1)-1) SS. INTERF CONTENANT LE SEG.MAIN IM
+          KSUB=0
+          DO JSUB=1,NINTSUB
+             IF(NOM_OPT(2,NINTER+JSUB)==NOINT
+     .           .AND.NOM_OPT(5,NINTER+JSUB)==1)THEN
+                KSUB=KSUB+1
+C
+                TAGEDG(1:NEDGE_1D) = 0
+C
+                ISU1 =NOM_OPT(3,NINTER+JSUB)
+                NNE  =IGRSURF(ISU1)%NSEG
+                DO I=1,NNE
+                   IN=IGRSURF(ISU1)%NODES(I,1)
+                   KM=0
+                   DO JAD=IADD(IN),IADD(IN+1)-1
+                      IM = NOD2EDG(JAD)
+                      IFNRT = 0
+                      DO J=1,4
+                         II=IGRSURF(ISU1)%NODES(I,J)
+                         IF(II/=0)THEN
+                           DO K=5,6
+                              IF(INTBUF_TAB(NI)%LEDGE(NLEDGE*(IM-1)+K)==II) IFNRT = IFNRT + 1
+                           END DO
+                         ENDIF
+                      ENDDO
+                      IF(IFNRT >= 2) THEN
+                          KM=IM 
+                          EXIT
+                      ENDIF
+                   ENDDO
+                   IF(KM/=0)THEN
+                     IF(TAGEDG(KM)==0)THEN
+                       INTBUF_TAB(NI)%INFLG_SUBE(KAD(IM))=
+     .                   IBSET(INTBUF_TAB(NI)%INFLG_SUBE(KAD(KM)),0)
+                       INTBUF_TAB(NI)%LISUBE(KAD(KM))=KSUB
+                       KAD(KM)=KAD(KM)+1
+                       TAGEDG(KM)=1
+C                   ELSE
+C                     INTBUF_TAB(NI)%INFLG_SUBM(KAD(IM)-1)=
+C    .                  IBSET(INTBUF_TAB(NI)%INFLG_SUBM(KAD(IM)-1),0)
+                     END IF
+                   END IF
+                END DO
+
+                ISU2  =NOM_OPT(6,NINTER+JSUB)
+                IF(ISU2/=0)THEN
+                  NNE  =IGRSURF(ISU2)%NSEG
+                  DO I=1,NNE
+                     IN=IGRSURF(ISU2)%NODES(I,1)
+                     KM=0
+                     DO JAD=IADD(IN),IADD(IN+1)-1
+                         IM = NOD2EDG(JAD)
+                         IFNRT = 0
+                         DO J=1,4
+                            II=IGRSURF(ISU2)%NODES(I,J)
+                            IF(II/=0)THEN
+                               DO K=5,6
+                                  IF(INTBUF_TAB(NI)%LEDGE(NLEDGE*(IM-1)+K)==II) IFNRT = IFNRT + 1
+                               END DO
+                            ENDIF
+                          ENDDO
+                          IF(IFNRT >= 2) THEN
+                            KM=IM 
+                            EXIT
+                          ENDIF
+                     ENDDO
+                     IF(KM/=0)THEN
+                       IF(TAGEDG(KM)==0)THEN
+                        INTBUF_TAB(NI)%INFLG_SUBE(KAD(KM))=
+     .                    IBSET(INTBUF_TAB(NI)%INFLG_SUBE(KAD(KM)),1)
+                        INTBUF_TAB(NI)%LISUBE(KAD(KM))=KSUB
+                        KAD(IM)=KAD(KM)+1
+                        TAGEDG(KM)=1
+                       ELSE
+                        INTBUF_TAB(NI)%INFLG_SUBE(KAD(IM)-1)=
+     .                    IBSET(INTBUF_TAB(NI)%INFLG_SUBE(KAD(IM)-1),1)
+                       END IF
+                     END IF
+                  END DO
+                END IF
+
+
+
+C
+C---------Case of subinter defined with inter 0 -------------
+C
+           ELSEIF(NOM_OPT(2,NINTER+JSUB) == 0 
+     .         .AND. NOM_OPT(5,NINTER+JSUB) == 1) THEN
+
+                KSUB=KSUB+1
+C
+                TAGEDG(1:NEDGE_1D) = 0
+C
+
+                ISU1 =NOM_OPT(3,NINTER+JSUB)
+                IF(ISU1 > 0 ) THEN
+
+                  NNE  =IGRSURF(ISU1)%NSEG
+                  DO I=1,NNE
+                    IN=IGRSURF(ISU1)%NODES(I,1)
+                    KM=0
+
+                    DO JAD=IADD(IN),IADD(IN+1)-1
+                      IM = NOD2EDG(JAD)
+                      IFNRT = 0
+                      DO J=1,4
+                         II=IGRSURF(ISU1)%NODES(I,J)
+                         IF(II/=0)THEN
+                           DO K=5,6
+                              IF(INTBUF_TAB(NI)%LEDGE(NLEDGE*(IM-1)+K)==II) IFNRT = IFNRT + 1
+                           END DO
+                         ENDIF
+                      ENDDO
+                      IF(IFNRT >= 2) THEN
+                          KM=IM 
+                          EXIT
+                      ENDIF
+                    ENDDO
+
+                    IF(KM/=0)THEN
+                      IF(TAGEDG(KM)==0)THEN
+                        INTBUF_TAB(NI)%INFLG_SUBE(KAD(KM))=
+     .                    IBSET(INTBUF_TAB(NI)%INFLG_SUBE(KAD(KM)),1)
+                        INTBUF_TAB(NI)%LISUBE(KAD(KM))=KSUB
+                        KAD(KM)=KAD(KM)+1
+                        TAGEDG(KM)=1
+                      ENDIF
+                    END IF
+
+                  END DO
+C
+                ENDIF
+C
+                ISU2 =NOM_OPT(6,NINTER+JSUB)
+                IF(ISU2 > 0 ) THEN
+
+                  NNE  =IGRSURF(ISU2)%NSEG
+                  DO I=1,NNE
+                    IN=IGRSURF(ISU2)%NODES(I,1)
+                    KM=0
+
+                    DO JAD=IADD(IN),IADD(IN+1)-1
+                       IM = NOD2EDG(JAD)
+                       IFNRT = 0
+                       DO J=1,4
+                         II=IGRSURF(ISU2)%NODES(I,J)
+                         IF(J/=4.OR.II/=0)THEN
+                           DO K=5,6
+                              IF(INTBUF_TAB(NI)%LEDGE(NLEDGE*(IM-1)+K)==II) IFNRT = IFNRT + 1
+                           END DO
+                         ENDIF
+                       ENDDO
+                       IF(IFNRT >= 2) THEN
+                          KM=IM 
+                          EXIT
+                       ENDIF
+                    ENDDO
+
+                    IF(KM/=0)THEN
+                      IF(TAGEDG(KM)==0)THEN
+                        INTBUF_TAB(NI)%INFLG_SUBE(KAD(KM))=
+     .                    IBSET(INTBUF_TAB(NI)%INFLG_SUBE(KAD(KM)),0)
+                        INTBUF_TAB(NI)%LISUBE(KAD(KM))=KSUB
+                        KAD(KM)=KAD(KM)+1
+                        TAGEDG(KM)=1
+                      ELSE
+                        INTBUF_TAB(NI)%INFLG_SUBE(KAD(KM)-1)=
+     .                    IBSET(INTBUF_TAB(NI)%INFLG_SUBE(KAD(KM)-1),0)
+                      END IF
+                    END IF
+
+                  END DO
+C
+                ENDIF
+C
+           END IF
+        END DO
+      ENDIF
+
 C-------------------------------------
       RETURN
       END

--- a/starter/source/restart/ddsplit/inter_tools.F
+++ b/starter/source/restart/ddsplit/inter_tools.F
@@ -2245,7 +2245,7 @@ C FREE EDGES
 C INTERNAL EDGES 
       NB_INTERNAL_EDGES = 0
       DO I=1, NEDGE
-        IF(INTBUF_TAB%LEDGE(7+(I-1)*NLEDGE)/=3) THEN
+        IF(IABS(INTBUF_TAB%LEDGE(7+(I-1)*NLEDGE))/=3) THEN
           E1=INTBUF_TAB%LEDGE(1+(I-1)*NLEDGE)
           K1=SEGLOC(E1)
           E2=INTBUF_TAB%LEDGE(3+(I-1)*NLEDGE)
@@ -2262,12 +2262,19 @@ C INTERNAL EDGES
             TAG_EDGE(ID) = I
             ID = ID + 1
           ENDIF
+        ELSE
+          E1=INTBUF_TAB%LEDGE(15+(I-1)*NLEDGE)
+          IF(CEP(E1)==PROC) THEN
+            NB_INTERNAL_EDGES = NB_INTERNAL_EDGES + 1
+            TAG_EDGE(ID) = I
+            ID = ID + 1
+          ENDIF
         ENDIF
       ENDDO
 
       NB_BOUNDARY_EDGES_LOCAL = 0
       DO I=1, NEDGE
-        IF(INTBUF_TAB%LEDGE(7+(I-1)*NLEDGE)/=3) THEN
+        IF(IABS(INTBUF_TAB%LEDGE(7+(I-1)*NLEDGE))/=3) THEN
           E1=INTBUF_TAB%LEDGE(1+(I-1)*NLEDGE)
           K1=SEGLOC(E1)
           E2=INTBUF_TAB%LEDGE(3+(I-1)*NLEDGE)
@@ -2288,7 +2295,7 @@ C INTERNAL EDGES
 
       NB_BOUNDARY_EDGES_REMOTE = 0
       DO I=1, NEDGE
-        IF(INTBUF_TAB%LEDGE(7+(I-1)*NLEDGE)/=3) THEN
+        IF(IABS(INTBUF_TAB%LEDGE(7+(I-1)*NLEDGE))/=3) THEN
           E1=INTBUF_TAB%LEDGE(1+(I-1)*NLEDGE)
           K1=SEGLOC(E1)
           E2=INTBUF_TAB%LEDGE(3+(I-1)*NLEDGE)
@@ -2307,22 +2314,10 @@ C INTERNAL EDGES
         ENDIF
       ENDDO
 
-C INTERNAL EDGES 
-      NB_1D_EDGES = 0
-      DO I=1,NEDGE
-        IF(INTBUF_TAB%LEDGE(7+(I-1)*NLEDGE)==3) THEN
-          E1=INTBUF_TAB%LEDGE(15+(I-1)*NLEDGE)
-          IF(CEP(E1)==PROC) THEN
-            NB_1D_EDGES = NB_1D_EDGES + 1
-            TAG_EDGE(ID) = I
-            ID = ID + 1
-          ENDIF
-        ENDIF
-      ENDDO
       ALLOCATE(TAG1D(NUMNOD))
       TAG1D(1:NUMNOD)=0
       DO I=1,NEDGE
-        IF(INTBUF_TAB%LEDGE(7+(I-1)*NLEDGE)==3) THEN
+        IF(IABS(INTBUF_TAB%LEDGE(7+(I-1)*NLEDGE))==3) THEN
           E1=INTBUF_TAB%LEDGE(15+(I-1)*NLEDGE)
           IF(CEP(E1)==PROC) THEN
             N=INTBUF_TAB%LEDGE(5+(I-1)*NLEDGE)
@@ -6194,7 +6189,7 @@ C-----------------------------------------------
       INTEGER :: ID
       INTEGER, DIMENSION(:),ALLOCATABLE :: IBUF
       INTEGER :: NB_FREE_EDGES
-      INTEGER :: NB_INTERNAL_EDGES,NB_1D_EDGES
+      INTEGER :: NB_INTERNAL_EDGES
       INTEGER :: NB_BOUNDARY_EDGES_LOCAL ! boundary edges treated by current domain 
       INTEGER :: NB_BOUNDARY_EDGES_REMOTE ! boundary edges treated by the other domain 
       INTEGER :: IAS,JAS,IS,N1,N2,I1,I2
@@ -6206,7 +6201,7 @@ C ----------------------------------------
       NB_FREE_EDGES = 0
 C FREE EDGES
       DO I=1, NEDGE
-        IF(LEDGE(7,I)/=3) THEN
+        IF(IABS(LEDGE(7,I))/=3) THEN
           E1=LEDGE(1,I)
           K1=SEGLOC(E1)
           E2=LEDGE(3,I)
@@ -6288,7 +6283,7 @@ C orientation segment 2
 C INTERNAL EDGES 
       NB_INTERNAL_EDGES = 0
       DO I=1, NEDGE
-        IF(LEDGE(7,I)/=3) THEN
+        IF(IABS(LEDGE(7,I))/=3) THEN
           E1=LEDGE(1,I)
           K1=SEGLOC(E1)
           E2=LEDGE(3,I)
@@ -6385,12 +6380,60 @@ C orientation segment 2
             ASSERT(TAG_SM(I2) > 0)
 
           END IF
+        ELSE
+          E1=LEDGE(15,I)
+          IF(CEP(E1)==PROC) THEN
+            NB_INTERNAL_EDGES = NB_INTERNAL_EDGES + 1
+
+! Internal edge 
+            TAG_EDGE(ID) = I
+C at starter phase 9 and 10 are used to save PROC and local ID
+            ASSERT(LEDGE(9,I) == PROC) 
+            ASSERT(LEDGE(10,I) == ID)
+            LEDGE(9,I) = PROC 
+            LEDGE(10,I) = ID
+
+            ID = ID + 1
+            CMPT=CMPT+1
+            IBUF(CMPT) = 0
+            CMPT=CMPT+1
+            IBUF(CMPT) = 0
+            CMPT=CMPT+1
+            IBUF(CMPT) = 0
+            CMPT=CMPT+1
+            IBUF(CMPT) = 0
+            CMPT=CMPT+1
+            IBUF(CMPT) = NODLOCAL(LEDGE(5,I))
+            CMPT=CMPT+1
+            IBUF(CMPT) = NODLOCAL(LEDGE(6,I))
+            CMPT=CMPT+1
+            IBUF(CMPT) = LEDGE(7,I)
+            CMPT=CMPT+1
+            IBUF(CMPT) = I !  + 10000* ITAB(LEDGE(6,I))
+            CMPT=CMPT+1
+            IBUF(CMPT) = 1 !  Weight                         
+C orientation  segment 1
+            CMPT=CMPT+1 
+            IBUF(CMPT) = 0
+            CMPT = CMPT +1 
+            IBUF(CMPT) = 0
+            CMPT=CMPT+1
+            IBUF(CMPT) = 0
+
+C orientation segment 2
+            CMPT=CMPT+1
+            IBUF(CMPT) = 0
+            CMPT = CMPT +1 
+            IBUF(CMPT) = 0
+            CMPT=CMPT+1
+            IBUF(CMPT) = 0
+          END IF
         ENDIF
       ENDDO
 
       NB_BOUNDARY_EDGES_LOCAL = 0
       DO I=1, NEDGE
-        IF(LEDGE(7,I)/=3) THEN
+        IF(IABS(LEDGE(7,I))/=3) THEN
           E1=LEDGE(1,I)
           K1=SEGLOC(E1)
           E2=LEDGE(3,I)
@@ -6492,7 +6535,7 @@ C orientation segment 2
 
       NB_BOUNDARY_EDGES_REMOTE = 0
       DO I=1, NEDGE
-        IF(LEDGE(7,I)/=3) THEN
+        IF(IABS(LEDGE(7,I))/=3) THEN
           E1=LEDGE(1,I)
           K1=SEGLOC(E1)
           E2=LEDGE(3,I)
@@ -6586,63 +6629,6 @@ C orientation segment 2
         ENDIF
       ENDDO
 
-C
-C 1D element EDGES
-C INTERNAL EDGES 
-      NB_1D_EDGES = 0
-      DO I=1, NEDGE
-        IF(LEDGE(7,I)==3) THEN
-          E1=LEDGE(15,I)
-          IF(CEP(E1)==PROC) THEN
-            NB_1D_EDGES = NB_1D_EDGES + 1
-
-! Internal edge 
-            TAG_EDGE(ID) = I
-C at starter phase 9 and 10 are used to save PROC and local ID
-            ASSERT(LEDGE(9,I) == PROC) 
-            ASSERT(LEDGE(10,I) == ID)
-            LEDGE(9,I) = PROC 
-            LEDGE(10,I) = ID
-
-            ID = ID + 1
-            CMPT=CMPT+1
-            IBUF(CMPT) = 0
-            CMPT=CMPT+1
-            IBUF(CMPT) = 0
-            CMPT=CMPT+1
-            IBUF(CMPT) = 0
-            CMPT=CMPT+1
-            IBUF(CMPT) = 0
-            CMPT=CMPT+1
-            IBUF(CMPT) = NODLOCAL(LEDGE(5,I))
-            CMPT=CMPT+1
-            IBUF(CMPT) = NODLOCAL(LEDGE(6,I))
-            CMPT=CMPT+1
-            IBUF(CMPT) = LEDGE(7,I)
-            CMPT=CMPT+1
-            IBUF(CMPT) = I !  + 10000* ITAB(LEDGE(6,I))
-            CMPT=CMPT+1
-            IBUF(CMPT) = 1 !  Weight                         
-C orientation  segment 1
-            CMPT=CMPT+1 
-            IBUF(CMPT) = 0
-            CMPT = CMPT +1 
-            IBUF(CMPT) = 0
-            CMPT=CMPT+1
-            IBUF(CMPT) = 0
-
-C orientation segment 2
-            CMPT=CMPT+1
-            IBUF(CMPT) = 0
-            CMPT = CMPT +1 
-            IBUF(CMPT) = 0
-            CMPT=CMPT+1
-            IBUF(CMPT) = 0
-
-
-          END IF
-        ENDIF
-      ENDDO
 C      WRITE(6,*) __FILE__,"NEDGE_L",NEDGE_L
 C      WRITE(6,*) "NB_FREE_EDGES=",NB_FREE_EDGES
 C      WRITE(6,*) "NB_INTERNAL_EDGES=",NB_INTERNAL_EDGES
@@ -6651,7 +6637,7 @@ C      WRITE(6,*) "NB_BOUNDARY_EDGES_REMOTE=",NB_BOUNDARY_EDGES_REMOTE
 
 
 
-      I = NB_FREE_EDGES+NB_INTERNAL_EDGES+NB_BOUNDARY_EDGES_LOCAL + NB_BOUNDARY_EDGES_REMOTE+ NB_1D_EDGES 
+      I = NB_FREE_EDGES+NB_INTERNAL_EDGES+NB_BOUNDARY_EDGES_LOCAL + NB_BOUNDARY_EDGES_REMOTE 
       ASSERT(NEDGE_L == I)
 
       CALL WRITE_I_C(IBUF,NLEDGE*NEDGE_L)
@@ -7382,7 +7368,7 @@ C---  Split of KERMNODE -> IBUF1
       DO IK=1,NEDGE_L
          K = TAG_EDGE(IK)
          IK_LOC = .FALSE.
-         IF(INTBUF_TAB%LEDGE(7+(K-1)*NLEDGE)/=3) THEN
+         IF(IABS(INTBUF_TAB%LEDGE(7+(K-1)*NLEDGE))/=3) THEN
            EM1=INTBUF_TAB%LEDGE(1+(K-1)*NLEDGE)
            KM1=0
            IF(EM1/=.0) KM1=SEGLOC(EM1)
@@ -7401,7 +7387,7 @@ C---  Split of KERMNODE -> IBUF1
             SIZ2 = 0
             DO M=1,SIZ
                N = INTBUF_TAB%REMNODE_EDG(L+M-1)
-               IF(INTBUF_TAB%LEDGE(7+(N-1)*NLEDGE)/=3) THEN
+               IF(IABS(INTBUF_TAB%LEDGE(7+(N-1)*NLEDGE))/=3) THEN
                   ES1=INTBUF_TAB%LEDGE(1+(N-1)*NLEDGE)
                   KS1=0
                   IF(ES1/=0) KS1=SEGLOC(ES1)
@@ -7415,7 +7401,7 @@ C--           Local segment - local id is stored
 C--           Remote segment - line is stored as ITAB1 / ITAB2 (2 values)
                     SIZ2 = SIZ2 + 2
                   ENDIF
-               ELSEIF(INTBUF_TAB%LEDGE(7+(N-1)*NLEDGE)==3) THEN
+               ELSEIF(IABS(INTBUF_TAB%LEDGE(7+(N-1)*NLEDGE))==3) THEN
                   ES1=INTBUF_TAB%LEDGE(15+(N-1)*NLEDGE)
                   IF(CEP(ES1)==PROC) THEN
 C--           Local segment - local id is stored
@@ -7441,7 +7427,7 @@ C---  Split of ERMNODE -> IBUF2
       DO IK=1,NEDGE_L
          K = TAG_EDGE(IK)
          IK_LOC = .FALSE.
-         IF(INTBUF_TAB%LEDGE(7+(K-1)*NLEDGE)/=3) THEN
+         IF(IABS(INTBUF_TAB%LEDGE(7+(K-1)*NLEDGE))/=3) THEN
             EM1=INTBUF_TAB%LEDGE(1+(K-1)*NLEDGE)
             KM1=0
             IF(EM1/=.0) KM1=SEGLOC(EM1)
@@ -7463,7 +7449,7 @@ C
 C
             DO M=1,SIZ
                N = INTBUF_TAB%REMNODE_EDG(L+M-1)
-               IF(INTBUF_TAB%LEDGE(7+(N-1)*NLEDGE)/=3) THEN
+               IF(IABS(INTBUF_TAB%LEDGE(7+(N-1)*NLEDGE))/=3) THEN
                  KS1=0
                  ES1=INTBUF_TAB%LEDGE(1+(N-1)*NLEDGE)
                  IF(ES1/=0) KS1=SEGLOC(ES1)
@@ -7480,7 +7466,7 @@ C-- Remote segment - line is stored as ITAB1 / ITAB2 (2 values)
                    IBUF2(SIZ2+1) = ITAB(INTBUF_TAB%LEDGE(6+(N-1)*NLEDGE))
                    SIZ2 = SIZ2+2
                  ENDIF
-               ELSEIF(INTBUF_TAB%LEDGE(7+(N-1)*NLEDGE)==3) THEN
+               ELSEIF(IABS(INTBUF_TAB%LEDGE(7+(N-1)*NLEDGE))==3) THEN
                  ES1=INTBUF_TAB%LEDGE(15+(N-1)*NLEDGE)
                  IF(CEP(ES1)==PROC) THEN
 C-- Local segment - local id is stored

--- a/starter/source/spmd/prepare_split_i25e2e.F
+++ b/starter/source/spmd/prepare_split_i25e2e.F
@@ -98,7 +98,7 @@ C         WRITE(6,*) NIN,NTY,IEDGE
      .                              LOCAL_ID_SEG,
      .                              CEP_EDGE,
      .                              LOCAL_ID_EDG,
-     .                              CEP,SCEP,IPARI(101,NIN))
+     .                              CEP,SCEP)
         
          nbCandE2E = INTBUF_TAB(NIN)%I_STOK_E(1)
          nbCandE2S = INTBUF_TAB(NIN)%I_STOK_E(2)
@@ -238,7 +238,7 @@ CC ==========
      .                                 LOCAL_ID_SEG,
      .                                 CEP_EDGE,
      .                                 LOCAL_ID_EDG,
-     .                                 CEP,SCEP,NEDGE_1D)
+     .                                 CEP,SCEP)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -256,7 +256,7 @@ C-----------------------------------------------
       INTEGER, INTENT(INOUT) ::  LOCAL_ID_SEG(NRTM)
       INTEGER, INTENT(INOUT) ::  CEP_EDGE(NEDGE)
       INTEGER, INTENT(INOUT) ::  LOCAL_ID_EDG(NEDGE)
-      INTEGER, INTENT(IN) ::  SCEP,NEDGE_1D
+      INTEGER, INTENT(IN) ::  SCEP
       INTEGER, DIMENSION(SCEP), INTENT(IN) :: CEP !< connectivity element --> processor
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
@@ -282,7 +282,7 @@ C FREE EDGES
       DO I=1, NEDGE
         E1=LEDGE(1,I)
         E2=LEDGE(3,I)
-        IF(E2 == 0.AND.LEDGE(7,I)/=3) THEN
+        IF(E2 == 0.AND.IABS(LEDGE(7,I))/=3) THEN
           ISPMD = CEP_SEG(E1)
           NB_FREE_EDGES(ISPMD) = NB_FREE_EDGES(ISPMD) + 1
           EDGE_LOCAL(ISPMD) = EDGE_LOCAL(ISPMD) + 1
@@ -296,7 +296,7 @@ C FREE EDGES
 
 C INTERNAL EDGES 
       DO I=1, NEDGE
-        IF(LEDGE(7,I)/=3) THEN
+        IF(IABS(LEDGE(7,I))/=3) THEN
           E1=LEDGE(1,I)
           E2=LEDGE(3,I)
           ISPMD = CEP_SEG(E1)
@@ -310,12 +310,24 @@ C INTERNAL EDGES
             LEDGE(9,I) = ISPMD - 1
             LEDGE(10,I) = LOCAL_ID_EDG(I)
           END IF
+        ELSE
+          E1=LEDGE(15,I)
+           IF(E1 /= 0) THEN
+              ISPMD = CEP(E1) + 1
+             NB_INTERNAL_EDGES(ISPMD) = NB_INTERNAL_EDGES(ISPMD) + 1
+              EDGE_LOCAL(ISPMD) = EDGE_LOCAL(ISPMD) + 1
+              CEP_EDGE(I) = ISPMD - 1
+              LOCAL_ID_EDG(I) = EDGE_LOCAL(ISPMD)
+              ASSERT(LEDGE(9,I) == 0)
+              LEDGE(9,I) = ISPMD - 1
+              LEDGE(10,I) = LOCAL_ID_EDG(I)
+           END IF
         ENDIF
       ENDDO
 
 C BOUNDARY EDGE LOCAL
       DO I=1, NEDGE
-        IF(LEDGE(7,I)/=3) THEN
+        IF(IABS(LEDGE(7,I))/=3) THEN
           E1=LEDGE(1,I)
           E2=LEDGE(3,I)
           ISPMD = CEP_SEG(E1)
@@ -331,23 +343,6 @@ C BOUNDARY EDGE LOCAL
           END IF
         ENDIF
       ENDDO
-C 1D element EDGES
-      IF(NEDGE_1D >0 ) THEN   
-        DO I=1, NEDGE
-          IF(LEDGE(7,I)==3) THEN
-           E1=LEDGE(15,I)
-           IF(LEDGE(7,I)==3) THEN
-              ISPMD = CEP(E1) + 1
-              EDGE_LOCAL(ISPMD) = EDGE_LOCAL(ISPMD) + 1
-              CEP_EDGE(I) = ISPMD - 1
-              LOCAL_ID_EDG(I) = EDGE_LOCAL(ISPMD)
-              ASSERT(LEDGE(9,I) == 0)
-              LEDGE(9,I) = ISPMD - 1
-              LEDGE(10,I) = LOCAL_ID_EDG(I)
-           END IF
-          ENDIF
-         ENDDO
-      ENDIF
 
 
 


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
Add /INTER/SUB output for 1D/1D edge to edge contact inter 25

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
Add /INTER/SUB output for 1D/1D edge to edge contact inter 25:
For E2E inter sub output tables where defined using tabs for N2S tabs
in case of only 1D edges or combination of surface and 1D edges needs to rebuild these tables 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
