### PR TITLE
GCC 15 build was failing due to -Werror=maybe-uninitialized

### DIFF
--- a/engine/source/elements/spring/r23l135def3.F90
+++ b/engine/source/elements/spring/r23l135def3.F90
@@ -388,7 +388,7 @@
           do i = 1, nel  
             if (mat_param%iparam(1) == 1) then
               xk(i) = uvar(17,i)*mat_param%uparam(1)    
-            else if (mat_param%iparam(1) == 0) then 
+            else ! if (mat_param%iparam(1) == 0) then 
               xk(i) = zero
             end if  
             fx(i) = xk(i) * dx(i) 
@@ -403,7 +403,7 @@
           do i = 1, nel      
             if (mat_param%iparam(2) == 1) then
               yk(i) = uvar(17,i)*mat_param%uparam(1)       
-            else if (mat_param%iparam(2) == 0) then 
+            else !  if (mat_param%iparam(2) == 0) then 
               yk(i) = zero
             end if  
             fy(i) = yk(i) * dy(i)    
@@ -418,7 +418,7 @@
           do i = 1, nel      
             if (mat_param%iparam(3) == 1) then
               zk(i) = uvar(17,i)*mat_param%uparam(1)      
-            else if (mat_param%iparam(3) == 0) then 
+            else !if (mat_param%iparam(3) == 0) then 
               zk(i) = zero
             end if  
             fz(i) = zk(i) * dz(i) 


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

This pull request makes a minor update to the logic in the `r23l135def3` subroutine, simplifying conditional checks for setting spring force constants. The changes remove unnecessary explicit condition checks for zero values, relying instead on the default `else` branch.

Logic simplification in spring force calculations:

* In the `r23l135def3` subroutine in `r23l135def3.F90`, replaced explicit `else if (mat_param%iparam(n) == 0)` conditions with a simple `else` branch for each direction (x, y, z), streamlining the assignment of zero when the parameter is not 1. [[1]](diffhunk://#diff-a6fb83768ced111b5de88694cfd0894f684eef47f81ef33bd78a395208fb779bL391-R391) [[2]](diffhunk://#diff-a6fb83768ced111b5de88694cfd0894f684eef47f81ef33bd78a395208fb779bL406-R406) [[3]](diffhunk://#diff-a6fb83768ced111b5de88694cfd0894f684eef47f81ef33bd78a395208fb779bL421-R421)
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
