### PR TITLE
Reapply "not set itetra10=2 in conversion tet4 to tet10 when AMS is u…

### DIFF
--- a/starter/source/properties/hm_read_properties.F
+++ b/starter/source/properties/hm_read_properties.F
@@ -76,7 +76,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .                  NPC   ,PLD   ,UNITAB ,RTRANS,LSUBMODEL  ,
      .                  PROP_TAG ,IPART ,KNOT,IDRAPEID,STACK_INFO,
      .                  NUMGEO_STACK,NPROP_STACK, MULTI_FVM,IADBUF,DEFAULTS,
-     .                  MAT_PARAM  )
+     .                  MAT_PARAM  ,ISMS )
 C============================================================================
 C-----------------------------------------------
 C   ROUTINE DESCRIPTION :
@@ -118,6 +118,7 @@ C-----------------------------------------------
      .        NPROP_STACK,IADBUF
       TYPE(SUBMODEL_DATA) LSUBMODEL(NSUBMOD)
       my_real GEO(NPROPG,NUMGEO), X(*), PM(NPROPM,NUMMAT),PLD(*),RTRANS(NTRANSF,*),KNOT(*)
+      INTEGER, INTENT(IN) :: ISMS
 
       DOUBLE PRECISION BUFGEO(*)
 
@@ -362,7 +363,8 @@ c------------------------------
              IGTYP=6
              CALL HM_READ_PROP06(GEO(1,I),IGEO(1,I),PROP_TAG ,MULTI_FVM,IGTYP  ,
      .                          PROP_ID  ,IDTITL   ,UNITAB   ,LSUBMODEL,RTRANS ,
-     .                          SUB_ID   ,ISKN     ,IPART    ,SUB_INDEX,DEFAULTS%SOLID)
+     .                          SUB_ID   ,ISKN     ,IPART    ,SUB_INDEX,DEFAULTS%SOLID,
+     .                          ISMS )
 
           CASE ('TYPE5','TYPE05','RIVET')
 c------------------------------
@@ -461,7 +463,7 @@ C--------------------------------------------------
             IGTYP=14
             IF (ALE%GLOBAL%ICAA == 0 .AND. IGFLU == 0) THEN
              CALL HM_READ_PROP14(GEO(1,I),IGEO(1,I),PROP_TAG ,MULTI_FVM,IGTYP,PROP_ID,IDTITL,UNITAB,LSUBMODEL,
-     .                          IPART ,DEFAULTS%SOLID)
+     .                          IPART ,DEFAULTS%SOLID,ISMS )
             ELSE
              CALL HM_READ_PROP14F(GEO(1,I),IGEO(1,I),PROP_TAG ,MULTI_FVM,IGTYP,PROP_ID,IDTITL,UNITAB,LSUBMODEL,
      .                            DEFAULTS%SOLID)

--- a/starter/source/properties/solid/hm_read_prop06.F
+++ b/starter/source/properties/solid/hm_read_prop06.F
@@ -40,7 +40,8 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !||====================================================================
       SUBROUTINE HM_READ_PROP06(GEO      ,IGEO    ,PROP_TAG,MULTI_FVM ,IGTYP   ,
      .                          IG       ,IDTITL  ,UNITAB  ,LSUBMODEL ,RTRANS  ,
-     .                          SUB_ID   ,ISKN    ,IPART   ,SUB_INDEX,DEFAULTS_SOLID)
+     .                          SUB_ID   ,ISKN    ,IPART   ,SUB_INDEX,DEFAULTS_SOLID,
+     .                          ISMS  )
 C-----------------------------------------------
 C   ROUTINE DESCRIPTION :
 C   ===================
@@ -102,6 +103,7 @@ C-----------------------------------------------
       INTEGER,INTENT(IN) :: IGTYP
       INTEGER,INTENT(IN) :: SUB_ID 
       INTEGER,INTENT(IN) :: SUB_INDEX 
+      INTEGER,INTENT(IN) :: ISMS
 C
       my_real,INTENT(INOUT) :: GEO(NPROPG)
       my_real,INTENT(IN) :: RTRANS(NTRANSF,NRTRANS)
@@ -126,6 +128,7 @@ C-----------------------------------------------
       INTEGER     IHBE_DS,ISST_DS,IFRAME_DS,
      .            ITET4_D,ITET10_D,ICPRE_D
       LOGICAL IS_AVAILABLE, IS_ENCRYPTED
+      CHARACTER(LEN=NCHARLINE) ::  MSGLINE
 C-----------------------------------------------
       IS_ENCRYPTED = .FALSE.
       IS_AVAILABLE = .FALSE.
@@ -208,6 +211,12 @@ C-----removed flags:
 C----------------------
       IF(ITET4 == 0)  ITET4 = ITET4_D
       IF(ITET10 == 0) ITET10 = ITET10_D
+      IF(ITET4 == 1) THEN ! switched to tetra10 w/ itetra10=2
+        IF (ISMS == 0) ITET10 = 2
+        ITET4 = 0  
+        MSGLINE='   ITETR4 IS CHANGED TO TETRA10'
+        CALL ANCMSG(MSGID=2027,MSGTYPE=MSGWARNING,ANMODE=ANINFO,I1=IG,C1=IDTITL,I2=2,C2=TRIM(MSGLINE))      
+      ENDIF
 C
 C
       IF (SUB_ID /= 0)

--- a/starter/source/properties/solid/hm_read_prop14.F
+++ b/starter/source/properties/solid/hm_read_prop14.F
@@ -38,7 +38,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !||    submodel_mod             ../starter/share/modules1/submodel_mod.F
 !||====================================================================
       SUBROUTINE HM_READ_PROP14(GEO,IGEO,PROP_TAG,MULTI_FVM,IGTYP,IG,TITR,UNITAB,
-     .                          LSUBMODEL,IPART,DEFAULTS_SOLID)
+     .                          LSUBMODEL,IPART,DEFAULTS_SOLID,ISMS )
 C-----------------------------------------------
 C   ROUTINE DESCRIPTION :
 C   ===================
@@ -94,6 +94,7 @@ C MODIFIED ARGUMENT
       my_real,INTENT(INOUT)::GEO(NPROPG)
       TYPE(PROP_TAG_) , DIMENSION(0:MAXPROP) :: PROP_TAG
       TYPE(SOLID_DEFAULTS_), INTENT(IN) :: DEFAULTS_SOLID
+      INTEGER, INTENT(IN) :: ISMS
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -174,7 +175,12 @@ C--------------------------------------------------
         ! use value from /DEF_SOLID (by default or in case of unexpected value) : and check it below
         ITET4 = ITET4_D
       ENDIF 
-      IF(ITET4 == 2) THEN
+      IF(ITET4 == 1) THEN ! switched to tetra10 w/ itetra10=2
+        IF (ISMS == 0) ITET10 = 2
+        ITET4 = 0  
+        MSGLINE='   ITETR4 IS CHANGED TO TETRA10'
+        CALL ANCMSG(MSGID=2027,MSGTYPE=MSGWARNING,ANMODE=ANINFO,I1=IG,C1=TITR,I2=2,C2=TRIM(MSGLINE))      
+      ELSEIF(ITET4 == 2) THEN
         ! old single tetra4 & tetra10 formulation flag : set ITET4 to 1000
         ITET10 = 2
         ITET4 = 1000  

--- a/starter/source/starter/lectur.F
+++ b/starter/source/starter/lectur.F
@@ -2361,7 +2361,7 @@ C
      .                          NPC        , TF          , UNITAB   , RTRANS   ,LSUBMODEL ,
      .                          PROP_TAG   , IPART       , KNOT     , IDRAPEID ,STACK_INFO,
      .                          NUMGEOSTACK, NPROP_STACK , MULTI_FVM, IADGEO   ,DEFAULTS  ,
-     .                          MAT_ELEM%MAT_PARAM)
+     .                          MAT_ELEM%MAT_PARAM,  ISMS)
 C
         ALLOCATE(BUFGEO(SBUFGEO)    ,STAT=stat)
         IF(STAT /= 0) CALL ANCMSG(MSGID=268,ANMODE=ANINFO,

--- a/starter/source/starter/starter0.F
+++ b/starter/source/starter/starter0.F
@@ -114,6 +114,7 @@ C-----------------------------------------------
       use analyse_arret_mod
       use hm_evaluate_rbodies_from_rigid_parts_mod
       use hm_create_rbodies_from_rigid_parts_mod
+      use hm_convert_tetra4_to_tetra10_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -164,7 +165,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I,J,K, STAT,INP,OUT
+      INTEGER I,J,K, STAT,INP,OUT,itetra4
       INTEGER IFILNAM(2148),LEN,IDMAX_INTER,
      .        IDMAX_GRNOD,IDMAX_LINE,IDMAX_TABLE,IDMAX_FAIL,IDMAX_FUNCT,
      .        IDMAX_PART,IDMAX_PROP,IDMAX_MAT,IDMAX_ELEM,IDMAX_TH,
@@ -817,6 +818,11 @@ C-------------------------------------------------------------------
 C Add RBODY master node if not existing in /RBODY cards
 C------------------------------------------------------------------
       CALL hm_rbodies_add_main_node(LSUBMODEL)
+C-------------------------------------------------------------------
+C itetra4=1: convert tetra4 to tretra10 w/ itetra10=2
+C------------------------------------------------------------------
+      itetra4=1
+      CALL hm_convert_tetra4_to_tetra10(itetra4) 
 C------------------------------------------------------------------
       ! Initialisation of glob_therm module
 C------------------------------------------------------------------


### PR DESCRIPTION
…sed"

This reverts commit db55719a9a3d594bcbd34679e38c7c30da52d1c4.

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
reapply the development of conversion tet4 to tet10 with itetra4=1 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
