### PR TITLE
Change duplicated subroutine names

### DIFF
--- a/common_source/tools/memory/extend_array.F90
+++ b/common_source/tools/memory/extend_array.F90
@@ -52,7 +52,7 @@
         private :: extend_array_real_2d
         private :: extend_array_real_3d
         private :: reallocate_array_integer_1d
-        private :: check_error_and_write
+        private :: extend_check
         public :: extend_array
 
         !\extend the array, copy the values
@@ -99,7 +99,7 @@
         end function build_error_message
 
 !||====================================================================
-!||    check_error_and_write         ../common_source/tools/memory/my_alloc.F90
+!||    extend_check         ../common_source/tools/memory/my_alloc.F90
 !||--- called by ------------------------------------------------------
 !||    extend_array_double_1d        ../common_source/tools/memory/extend_array.F90
 !||    extend_array_double_2d        ../common_source/tools/memory/extend_array.F90
@@ -165,7 +165,7 @@
 !||--- calls      -----------------------------------------------------
 !||    arret                         ../engine/source/system/arret.F
 !||====================================================================
-        subroutine check_error_and_write(stat,msg)
+        subroutine extend_check(stat,msg)
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                     Arguments
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -182,14 +182,14 @@
             end if
             call arret(2)
           end if
-        end subroutine check_error_and_write
+        end subroutine extend_check
 
 
 !! \brief resize a 1D array of integer, copy the values
 !||====================================================================
 !||    extend_array_integer_1d   ../common_source/tools/memory/extend_array.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write     ../common_source/tools/memory/my_alloc.F90
+!||    extend_check     ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine extend_array_integer_1d(a, oldsize, newsize, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -212,7 +212,7 @@
           if (.not. allocated(a)) then
             allocate(a(newsize), stat=ierr)
             if (ierr /= 0) then
-              if (present(msg)) call check_error_and_write(ierr, msg=msg)
+              if (present(msg)) call extend_check(ierr, msg=msg)
               if (present(stat)) stat = ierr
               return
             endif
@@ -224,9 +224,9 @@
             allocate(temp(newsize), stat=ierr)
             if(.not. present(stat)) then
               if(present(msg)) then
-                call check_error_and_write(ierr, msg=msg)
+                call extend_check(ierr, msg=msg)
               else
-                call check_error_and_write(ierr)
+                call extend_check(ierr)
               end if
             end if
             if(present(stat)) stat = ierr
@@ -243,7 +243,7 @@
 !||====================================================================
 !||    extend_array_integer_2d   ../common_source/tools/memory/extend_array.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write     ../common_source/tools/memory/my_alloc.F90
+!||    extend_check     ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine extend_array_integer_2d(a, oldsize1, oldsize2, newsize1, newsize2, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -267,7 +267,7 @@
           if (.not. allocated(a)) then
             allocate(a(newsize1, newsize2), stat=ierr)
             if (ierr /= 0) then
-              if (present(msg)) call check_error_and_write(ierr, msg=msg)
+              if (present(msg)) call extend_check(ierr, msg=msg)
               if (present(stat)) stat = ierr
               return
             endif
@@ -282,7 +282,7 @@
               ! Extend only the second dimension (use move_alloc)
               allocate(temp(size(a, 1), newsize2), stat=ierr)
               if (ierr /= 0) then
-                if (present(msg)) call check_error_and_write(ierr, msg=msg)
+                if (present(msg)) call extend_check(ierr, msg=msg)
                 if (present(stat)) stat = ierr
                 return
               end if
@@ -294,7 +294,7 @@
               ! Extend in the first dimension or both dimensions (fallback to temporary array)
               allocate(temp(newsize1, newsize2), stat=ierr)
               if (ierr /= 0) then
-                if (present(msg)) call check_error_and_write(ierr, msg=msg)
+                if (present(msg)) call extend_check(ierr, msg=msg)
                 if (present(stat)) stat = ierr
                 return
               end if
@@ -335,7 +335,7 @@
 !||====================================================================
 !||    extend_array_integer_3d   ../common_source/tools/memory/extend_array.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write     ../common_source/tools/memory/my_alloc.F90
+!||    extend_check     ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine extend_array_integer_3d(a, oldsize1, oldsize2, oldsize3, newsize1, newsize2, newsize3, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -365,7 +365,7 @@
               ! Extend only the third dimension (use move_alloc)
               allocate(temp(size(a, 1), size(a, 2), newsize3), stat=ierr)
               if (ierr /= 0) then
-                if (present(msg)) call check_error_and_write(ierr, msg=msg)
+                if (present(msg)) call extend_check(ierr, msg=msg)
                 if (present(stat)) stat = ierr
                 return
               end if
@@ -374,7 +374,7 @@
             else
               allocate(temp(newsize1, newsize2, newsize3), stat=ierr)
               if (ierr /= 0) then
-                if (present(msg)) call check_error_and_write(ierr, msg=msg)
+                if (present(msg)) call extend_check(ierr, msg=msg)
                 if (present(stat)) stat = ierr
                 return
               end if
@@ -414,7 +414,7 @@
 !||====================================================================
 !||    extend_array_real_1d    ../common_source/tools/memory/extend_array.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    extend_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine extend_array_real_1d(a, oldsize, newsize, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -437,7 +437,7 @@
           if (.not. allocated(a)) then
             allocate(a(newsize), stat=ierr)
             if (ierr /= 0) then
-              if (present(msg)) call check_error_and_write(ierr, msg=msg)
+              if (present(msg)) call extend_check(ierr, msg=msg)
               if (present(stat)) stat = ierr
               return
             endif
@@ -450,9 +450,9 @@
             allocate(temp(newsize), stat=ierr)
             if(.not. present(stat)) then
               if(present(msg)) then
-                call check_error_and_write(ierr, msg=msg)
+                call extend_check(ierr, msg=msg)
               else
-                call check_error_and_write(ierr)
+                call extend_check(ierr)
               end if
             end if
             if(present(stat)) stat = ierr
@@ -469,7 +469,7 @@
 !||====================================================================
 !||    extend_array_real_2d    ../common_source/tools/memory/extend_array.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    extend_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine extend_array_real_2d(a, oldsize1, oldsize2, newsize1, newsize2, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -493,7 +493,7 @@
           if (.not. allocated(a)) then
             allocate(a(newsize1, newsize2), stat=ierr)
             if (ierr /= 0) then
-              if (present(msg)) call check_error_and_write(ierr, msg=msg)
+              if (present(msg)) call extend_check(ierr, msg=msg)
               if (present(stat)) stat = ierr
               return
             endif
@@ -507,7 +507,7 @@
               ! Extend only the second dimension (use move_alloc)
               allocate(temp(size(a, 1), newsize2), stat=ierr)
               if (ierr /= 0) then
-                if (present(msg)) call check_error_and_write(ierr, msg=msg)
+                if (present(msg)) call extend_check(ierr, msg=msg)
                 if (present(stat)) stat = ierr
                 return
               end if
@@ -519,7 +519,7 @@
               ! Extend in the first dimension or both dimensions (fallback to temporary array)
               allocate(temp(newsize1, newsize2), stat=ierr)
               if (ierr /= 0) then
-                if (present(msg)) call check_error_and_write(ierr, msg=msg)
+                if (present(msg)) call extend_check(ierr, msg=msg)
                 if (present(stat)) stat = ierr
                 return
               end if
@@ -560,7 +560,7 @@
 !||====================================================================
 !||    extend_array_real_3d    ../common_source/tools/memory/extend_array.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    extend_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine extend_array_real_3d(a, oldsize1, oldsize2, oldsize3, newsize1, newsize2, newsize3, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -590,7 +590,7 @@
               ! Extend only the third dimension (use move_alloc)
               allocate(temp(size(a, 1), size(a, 2), newsize3), stat=ierr)
               if (ierr /= 0) then
-                if (present(msg)) call check_error_and_write(ierr, msg=msg)
+                if (present(msg)) call extend_check(ierr, msg=msg)
                 if (present(stat)) stat = ierr
                 return
               end if
@@ -599,7 +599,7 @@
             else
               allocate(temp(newsize1, newsize2, newsize3), stat=ierr)
               if (ierr /= 0) then
-                if (present(msg)) call check_error_and_write(ierr, msg=msg)
+                if (present(msg)) call extend_check(ierr, msg=msg)
                 if (present(stat)) stat = ierr
                 return
               end if
@@ -641,7 +641,7 @@
 !||====================================================================
 !||    extend_array_double_1d   ../common_source/tools/memory/extend_array.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write    ../common_source/tools/memory/my_alloc.F90
+!||    extend_check    ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine extend_array_double_1d(a, oldsize, newsize, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -664,7 +664,7 @@
           if (.not. allocated(a)) then
             allocate(a(newsize), stat=ierr)
             if (ierr /= 0) then
-              if (present(msg)) call check_error_and_write(ierr, msg=msg)
+              if (present(msg)) call extend_check(ierr, msg=msg)
               if (present(stat)) stat = ierr
               return
             endif
@@ -677,9 +677,9 @@
             allocate(temp(newsize), stat=ierr)
             if(.not. present(stat)) then
               if(present(msg)) then
-                call check_error_and_write(ierr, msg=msg)
+                call extend_check(ierr, msg=msg)
               else
-                call check_error_and_write(ierr)
+                call extend_check(ierr)
               end if
             end if
             if(present(stat)) stat = ierr
@@ -696,7 +696,7 @@
 !||====================================================================
 !||    extend_array_double_2d   ../common_source/tools/memory/extend_array.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write    ../common_source/tools/memory/my_alloc.F90
+!||    extend_check    ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine extend_array_double_2d(a, oldsize1, oldsize2, newsize1, newsize2, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -720,7 +720,7 @@
           if (.not. allocated(a)) then
             allocate(a(newsize1, newsize2), stat=ierr)
             if (ierr /= 0) then
-              if (present(msg)) call check_error_and_write(ierr, msg=msg)
+              if (present(msg)) call extend_check(ierr, msg=msg)
               if (present(stat)) stat = ierr
               return
             endif
@@ -735,7 +735,7 @@
               ! Extend only the second dimension (use move_alloc)
               allocate(temp(size(a, 1), newsize2), stat=ierr)
               if (ierr /= 0) then
-                if (present(msg)) call check_error_and_write(ierr, msg=msg)
+                if (present(msg)) call extend_check(ierr, msg=msg)
                 if (present(stat)) stat = ierr
                 return
               end if
@@ -747,7 +747,7 @@
               ! Extend in the first dimension or both dimensions (fallback to temporary array)
               allocate(temp(newsize1, newsize2), stat=ierr)
               if (ierr /= 0) then
-                if (present(msg)) call check_error_and_write(ierr, msg=msg)
+                if (present(msg)) call extend_check(ierr, msg=msg)
                 if (present(stat)) stat = ierr
                 return
               end if
@@ -788,7 +788,7 @@
 !||====================================================================
 !||    extend_array_double_3d   ../common_source/tools/memory/extend_array.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write    ../common_source/tools/memory/my_alloc.F90
+!||    extend_check    ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine extend_array_double_3d(a, oldsize1, oldsize2, oldsize3, newsize1, newsize2, newsize3, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -818,7 +818,7 @@
               ! Extend only the third dimension (use move_alloc)
               allocate(temp(size(a, 1), size(a, 2), newsize3), stat=ierr)
               if (ierr /= 0) then
-                if (present(msg)) call check_error_and_write(ierr, msg=msg)
+                if (present(msg)) call extend_check(ierr, msg=msg)
                 if (present(stat)) stat = ierr
                 return
               end if
@@ -827,7 +827,7 @@
             else
               allocate(temp(newsize1, newsize2, newsize3), stat=ierr)
               if (ierr /= 0) then
-                if (present(msg)) call check_error_and_write(ierr, msg=msg)
+                if (present(msg)) call extend_check(ierr, msg=msg)
                 if (present(stat)) stat = ierr
                 return
               end if
@@ -868,7 +868,7 @@
 !||====================================================================
 !||    reallocate_array_integer_1d   ../common_source/tools/memory/extend_array.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write         ../common_source/tools/memory/my_alloc.F90
+!||    extend_check         ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine reallocate_array_integer_1d(a, newsize, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -891,17 +891,17 @@
             if(allocated(a)) deallocate(a, stat=ierr)
             if(.not. present(stat)) then
               if(present(msg)) then
-                call check_error_and_write(ierr, msg=msg)
+                call extend_check(ierr, msg=msg)
               else
-                call check_error_and_write(ierr)
+                call extend_check(ierr)
               end if
             end if
             allocate(a(newsize), stat=ierr)
             if(.not. present(stat)) then
               if(present(msg)) then
-                call check_error_and_write(ierr, msg=msg)
+                call extend_check(ierr, msg=msg)
               else
-                call check_error_and_write(ierr)
+                call extend_check(ierr)
               end if
             end if
           end if

--- a/common_source/tools/memory/my_alloc.F90
+++ b/common_source/tools/memory/my_alloc.F90
@@ -422,7 +422,7 @@
 
 !! \brief Check if the allocation was successful and print an error message if it was noti
 !||====================================================================
-!||    check_error_and_write         ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check         ../common_source/tools/memory/my_alloc.F90
 !||--- called by ------------------------------------------------------
 !||    extend_array_double_1d        ../common_source/tools/memory/extend_array.F90
 !||    extend_array_double_2d        ../common_source/tools/memory/extend_array.F90
@@ -488,7 +488,7 @@
 !||--- calls      -----------------------------------------------------
 !||    arret                         ../engine/source/system/arret.F
 !||====================================================================
-        subroutine check_error_and_write(stat,msg)
+        subroutine my_alloc_check(stat,msg)
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                     Arguments
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -505,7 +505,7 @@
             end if
             call arret(2)
           end if
-        end subroutine check_error_and_write
+        end subroutine my_alloc_check
 
 
 ! ======================================================================================================================
@@ -516,7 +516,7 @@
 !||====================================================================
 !||    my_alloc_real_1d        ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_real_1d(a, n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -536,9 +536,9 @@
           allocate(a(n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -549,7 +549,7 @@
 !||====================================================================
 !||    my_alloc_real_2d        ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_real_2d(a, n,m, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -570,9 +570,9 @@
           allocate(a(n,m), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -582,7 +582,7 @@
 !||====================================================================
 !||    my_alloc_real_3d        ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_real_3d(a,l,m,n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -605,9 +605,9 @@
           allocate(a(l,m,n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -621,7 +621,7 @@
 !||====================================================================
 !||    my_alloc_double_1d      ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_double_1d(a, n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -641,9 +641,9 @@
           allocate(a(n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -654,7 +654,7 @@
 !||====================================================================
 !||    my_alloc_double_2d      ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_double_2d(a, n,m, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -675,9 +675,9 @@
           allocate(a(n,m), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -687,7 +687,7 @@
 !||====================================================================
 !||    my_alloc_double_3d      ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_double_3d(a,l,m,n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -710,9 +710,9 @@
           allocate(a(l,m,n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -727,7 +727,7 @@
 !||====================================================================
 !||    my_alloc_integer_1d     ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_integer_1d(a, n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -747,9 +747,9 @@
           allocate(a(n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -760,7 +760,7 @@
 !||====================================================================
 !||    my_alloc_integer_2d     ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_integer_2d(a, n,m, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -781,9 +781,9 @@
           allocate(a(n,m), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -794,7 +794,7 @@
 !||====================================================================
 !||    my_alloc_integer_3d     ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_integer_3d(a,l,m,n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -817,9 +817,9 @@
           allocate(a(l,m,n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -833,7 +833,7 @@
 !||====================================================================
 !||    my_alloc_preal_1d       ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_preal_1d(a, n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -853,9 +853,9 @@
           allocate(a(n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -866,7 +866,7 @@
 !||====================================================================
 !||    my_alloc_preal_2d       ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_preal_2d(a, n,m, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -887,9 +887,9 @@
           allocate(a(n,m), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -899,7 +899,7 @@
 !||====================================================================
 !||    my_alloc_preal_3d       ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_preal_3d(a,l,m,n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -922,9 +922,9 @@
           allocate(a(l,m,n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -938,7 +938,7 @@
 !||====================================================================
 !||    my_alloc_pdouble_1d     ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_pdouble_1d(a, n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -958,9 +958,9 @@
           allocate(a(n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -971,7 +971,7 @@
 !||====================================================================
 !||    my_alloc_pdouble_2d     ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_pdouble_2d(a, n,m, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -992,9 +992,9 @@
           allocate(a(n,m), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1004,7 +1004,7 @@
 !||====================================================================
 !||    my_alloc_pdouble_3d     ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_pdouble_3d(a,l,m,n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1027,9 +1027,9 @@
           allocate(a(l,m,n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1044,7 +1044,7 @@
 !||====================================================================
 !||    my_alloc_pinteger_1d    ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_pinteger_1d(a, n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1064,9 +1064,9 @@
           allocate(a(n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1077,7 +1077,7 @@
 !||====================================================================
 !||    my_alloc_pinteger_2d    ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_pinteger_2d(a, n,m, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1098,9 +1098,9 @@
           allocate(a(n,m), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1111,7 +1111,7 @@
 !||====================================================================
 !||    my_alloc_pinteger_3d    ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_pinteger_3d(a,l,m,n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1134,9 +1134,9 @@
           allocate(a(l,m,n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1153,7 +1153,7 @@
 !||====================================================================
 !||    my_alloc_8_real_1d      ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_real_1d(a, n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1173,9 +1173,9 @@
           allocate(a(n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1186,7 +1186,7 @@
 !||====================================================================
 !||    my_alloc_8_real_2d      ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_real_2d(a, n,m, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1207,9 +1207,9 @@
           allocate(a(n,m), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1219,7 +1219,7 @@
 !||====================================================================
 !||    my_alloc_8_real_3d      ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_real_3d(a,l,m,n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1242,9 +1242,9 @@
           allocate(a(l,m,n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1258,7 +1258,7 @@
 !||====================================================================
 !||    my_alloc_8_double_1d    ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_double_1d(a, n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1278,9 +1278,9 @@
           allocate(a(n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1291,7 +1291,7 @@
 !||====================================================================
 !||    my_alloc_8_double_2d    ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_double_2d(a, n,m, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1312,9 +1312,9 @@
           allocate(a(n,m), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1324,7 +1324,7 @@
 !||====================================================================
 !||    my_alloc_8_double_3d    ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_double_3d(a,l,m,n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1347,9 +1347,9 @@
           allocate(a(l,m,n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1364,7 +1364,7 @@
 !||====================================================================
 !||    my_alloc_8_integer_1d   ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_integer_1d(a, n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1384,9 +1384,9 @@
           allocate(a(n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1397,7 +1397,7 @@
 !||====================================================================
 !||    my_alloc_8_integer_2d   ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_integer_2d(a, n,m, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1418,9 +1418,9 @@
           allocate(a(n,m), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1431,7 +1431,7 @@
 !||====================================================================
 !||    my_alloc_8_integer_3d   ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_integer_3d(a,l,m,n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1454,9 +1454,9 @@
           allocate(a(l,m,n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1469,7 +1469,7 @@
 !||====================================================================
 !||    my_alloc_8_preal_1d     ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_preal_1d(a, n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1489,9 +1489,9 @@
           allocate(a(n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1502,7 +1502,7 @@
 !||====================================================================
 !||    my_alloc_8_preal_2d     ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_preal_2d(a, n,m, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1523,9 +1523,9 @@
           allocate(a(n,m), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1535,7 +1535,7 @@
 !||====================================================================
 !||    my_alloc_8_preal_3d     ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_preal_3d(a,l,m,n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1558,9 +1558,9 @@
           allocate(a(l,m,n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1574,7 +1574,7 @@
 !||====================================================================
 !||    my_alloc_8_pdouble_1d   ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_pdouble_1d(a, n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1594,9 +1594,9 @@
           allocate(a(n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1607,7 +1607,7 @@
 !||====================================================================
 !||    my_alloc_8_pdouble_2d   ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_pdouble_2d(a, n,m, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1628,9 +1628,9 @@
           allocate(a(n,m), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1640,7 +1640,7 @@
 !||====================================================================
 !||    my_alloc_8_pdouble_3d   ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_pdouble_3d(a,l,m,n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1663,9 +1663,9 @@
           allocate(a(l,m,n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1680,7 +1680,7 @@
 !||====================================================================
 !||    my_alloc_8_pinteger_1d   ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write    ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check    ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_pinteger_1d(a, n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1700,9 +1700,9 @@
           allocate(a(n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1713,7 +1713,7 @@
 !||====================================================================
 !||    my_alloc_8_pinteger_2d   ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write    ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check    ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_pinteger_2d(a, n,m, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1734,9 +1734,9 @@
           allocate(a(n,m), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1747,7 +1747,7 @@
 !||====================================================================
 !||    my_alloc_8_pinteger_3d   ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write    ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check    ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_pinteger_3d(a,l,m,n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1770,9 +1770,9 @@
           allocate(a(l,m,n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1785,7 +1785,7 @@
 !||====================================================================
 !||    my_alloc_logical_1d     ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_logical_1d(a, n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1805,9 +1805,9 @@
           allocate(a(n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1818,7 +1818,7 @@
 !||====================================================================
 !||    my_alloc_logical_2d     ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_logical_2d(a, n,m, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1839,9 +1839,9 @@
           allocate(a(n,m), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1851,7 +1851,7 @@
 !||====================================================================
 !||    my_alloc_logical_3d     ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_logical_3d(a,l,m,n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1874,9 +1874,9 @@
           allocate(a(l,m,n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1886,7 +1886,7 @@
 !||====================================================================
 !||    my_alloc_plogical_1d    ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_plogical_1d(a, n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1906,9 +1906,9 @@
           allocate(a(n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1919,7 +1919,7 @@
 !||====================================================================
 !||    my_alloc_plogical_2d    ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_plogical_2d(a, n,m, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1940,9 +1940,9 @@
           allocate(a(n,m), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1952,7 +1952,7 @@
 !||====================================================================
 !||    my_alloc_plogical_3d    ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_plogical_3d(a,l,m,n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -1975,9 +1975,9 @@
           allocate(a(l,m,n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -1990,7 +1990,7 @@
 !||====================================================================
 !||    my_alloc_8_logical_1d   ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_logical_1d(a, n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -2010,9 +2010,9 @@
           allocate(a(n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -2023,7 +2023,7 @@
 !||====================================================================
 !||    my_alloc_8_logical_2d   ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_logical_2d(a, n,m, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -2044,9 +2044,9 @@
           allocate(a(n,m), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -2056,7 +2056,7 @@
 !||====================================================================
 !||    my_alloc_8_logical_3d   ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_logical_3d(a,l,m,n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -2079,9 +2079,9 @@
           allocate(a(l,m,n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -2091,7 +2091,7 @@
 !||====================================================================
 !||    my_alloc_8_plogical_1d   ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write    ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check    ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_plogical_1d(a, n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -2111,9 +2111,9 @@
           allocate(a(n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -2124,7 +2124,7 @@
 !||====================================================================
 !||    my_alloc_8_plogical_2d   ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write    ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check    ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_plogical_2d(a, n,m, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -2145,9 +2145,9 @@
           allocate(a(n,m), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr
@@ -2157,7 +2157,7 @@
 !||====================================================================
 !||    my_alloc_8_plogical_3d   ../common_source/tools/memory/my_alloc.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write    ../common_source/tools/memory/my_alloc.F90
+!||    my_alloc_check    ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine my_alloc_8_plogical_3d(a,l,m,n, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -2180,9 +2180,9 @@
           allocate(a(l,m,n), stat=ierr)
           if(.not. present(stat)) then
             if(present(msg)) then
-              call check_error_and_write(ierr, msg=msg)
+              call my_alloc_check(ierr, msg=msg)
             else
-              call check_error_and_write(ierr)
+              call my_alloc_check(ierr)
             end if
           end if
           if(present(stat)) stat = ierr

--- a/common_source/tools/memory/shrink_array.F90
+++ b/common_source/tools/memory/shrink_array.F90
@@ -31,7 +31,7 @@
         private :: shrink_array_integer_1d
         private :: shrink_array_real_1d
         private :: shrink_array_double_1d
-        private :: check_error_and_write
+        private :: shrink_check
         public :: shrink_array
 
         !\shrink the array, copy the values
@@ -45,7 +45,7 @@
 
 
 !||====================================================================
-!||    check_error_and_write         ../common_source/tools/memory/my_alloc.F90
+!||    shrink_check         ../common_source/tools/memory/my_alloc.F90
 !||--- called by ------------------------------------------------------
 !||    extend_array_double_1d        ../common_source/tools/memory/extend_array.F90
 !||    extend_array_double_2d        ../common_source/tools/memory/extend_array.F90
@@ -111,7 +111,7 @@
 !||--- calls      -----------------------------------------------------
 !||    arret                         ../engine/source/system/arret.F
 !||====================================================================
-        subroutine check_error_and_write(stat,msg)
+        subroutine shrink_check(stat,msg)
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                     Arguments
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -128,14 +128,14 @@
             end if
             call arret(2)
           end if
-        end subroutine check_error_and_write
+        end subroutine shrink_check
 
 
 !! \brief resize a 1D array of integer, copy the values
 !||====================================================================
 !||    shrink_array_integer_1d   ../common_source/tools/memory/shrink_array.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write     ../common_source/tools/memory/my_alloc.F90
+!||    shrink_check     ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine shrink_array_integer_1d(a,  newsize, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -165,9 +165,9 @@
             allocate(temp(newsize), stat=ierr)
             if(.not. present(stat)) then
               if(present(msg)) then
-                call check_error_and_write(ierr, msg=msg)
+                call shrink_check(ierr, msg=msg)
               else
-                call check_error_and_write(ierr)
+                call shrink_check(ierr)
               end if
             end if
             if(present(stat)) stat = ierr
@@ -183,7 +183,7 @@
 !||====================================================================
 !||    shrink_array_real_1d    ../common_source/tools/memory/shrink_array.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write   ../common_source/tools/memory/my_alloc.F90
+!||    shrink_check   ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine shrink_array_real_1d(a,  newsize, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -213,9 +213,9 @@
             allocate(temp(newsize), stat=ierr)
             if(.not. present(stat)) then
               if(present(msg)) then
-                call check_error_and_write(ierr, msg=msg)
+                call shrink_check(ierr, msg=msg)
               else
-                call check_error_and_write(ierr)
+                call shrink_check(ierr)
               end if
             end if
             if(present(stat)) stat = ierr
@@ -230,7 +230,7 @@
 !||====================================================================
 !||    shrink_array_double_1d   ../common_source/tools/memory/shrink_array.F90
 !||--- calls      -----------------------------------------------------
-!||    check_error_and_write    ../common_source/tools/memory/my_alloc.F90
+!||    shrink_check    ../common_source/tools/memory/my_alloc.F90
 !||====================================================================
         subroutine shrink_array_double_1d(a, newsize, msg, stat)
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -259,9 +259,9 @@
             allocate(temp(newsize), stat=ierr)
             if(.not. present(stat)) then
               if(present(msg)) then
-                call check_error_and_write(ierr, msg=msg)
+                call shrink_check(ierr, msg=msg)
               else
-                call check_error_and_write(ierr)
+                call shrink_check(ierr)
               end if
             end if
             if(present(stat)) stat = ierr


### PR DESCRIPTION


#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
This pull request refactors the error handling in the `extend_array` module by renaming the `check_error_and_write` subroutine to `extend_check` throughout `common_source/tools/memory/extend_array.F90`. All references, calls, and documentation comments have been updated to use the new name, ensuring consistency and clarity in the codebase.

**Error handling refactor:**

* Renamed the subroutine `check_error_and_write` to `extend_check` and updated its implementation and all references accordingly. This includes changing the subroutine definition, all calls to it in allocation error handling, and all related documentation comments and private declarations. [[1]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L55-R55) [[2]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L168-R168) [[3]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L185-R192) [[4]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L215-R215) [[5]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L227-R229) [[6]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L246-R246) [[7]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L270-R270) [[8]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L285-R285) [[9]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L297-R297) [[10]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L338-R338) [[11]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L368-R368) [[12]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L377-R377) [[13]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L417-R417) [[14]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L440-R440) [[15]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L453-R455) [[16]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L472-R472) [[17]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L496-R496) [[18]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L510-R510) [[19]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L522-R522) [[20]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L563-R563) [[21]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L593-R593) [[22]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L602-R602) [[23]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L644-R644) [[24]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L667-R667) [[25]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L680-R682) [[26]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L699-R699) [[27]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L723-R723) [[28]](diffhunk://#diff-bad60417cbdfefc3dfd448d1a93dfca5cced2d6e802c925188207524d9125569L102-R102)

No logic was changed aside from the subroutine renaming; this is a straightforward, consistency-focused refactor.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
