### PR TITLE
/INIVEL/NODE : issue with rotation of //SUBMODEL

### DIFF
--- a/starter/source/initial_conditions/general/inivel/hm_read_inivel.F
+++ b/starter/source/initial_conditions/general/inivel/hm_read_inivel.F
@@ -350,6 +350,12 @@ C--------------------------------------------------
             CALL HM_GET_FLOAT_ARRAY_INDEX('VXRA', VR1, N, IS_AVAILABLE, LSUBMODEL, UNITAB)
             CALL HM_GET_FLOAT_ARRAY_INDEX('VYRA', VR2, N, IS_AVAILABLE, LSUBMODEL, UNITAB)
             CALL HM_GET_FLOAT_ARRAY_INDEX('VZRA', VR3, N, IS_AVAILABLE, LSUBMODEL, UNITAB)
+            ! Submodel rotation in case no skew is provided 
+            IF(ISK == 0 .AND. SUB_INDEX  /=  0) THEN 
+              CALL SUBROTVECT(VL1,VL2,VL3,RTRANS,SUB_ID,LSUBMODEL)
+              CALL SUBROTVECT(VR1,VR2,VR3,RTRANS,SUB_ID,LSUBMODEL)
+            END IF
+
             IF(N2D /= 0 .AND. ISK == 0)THEN
               IF(VL1 /=0 .OR. VR2 /= 0 .OR. VR3 /= 0)THEN
                 !plane strain warning about X-direction


### PR DESCRIPTION
This pull request introduces an enhancement to the initial conditions handling in the `hm_read_inivel.F` subroutine. The main change ensures that, when no skew is provided but a submodel is present, velocity vectors are properly rotated according to the submodel's transformation, improving the accuracy of initial velocity assignments for submodels.

Enhancement to submodel velocity initialization:

* Added logic to rotate velocity vectors (`VL1`, `VL2`, `VL3`, `VR1`, `VR2`, `VR3`) using the `SUBROTVECT` routine when no skew is provided (`ISK == 0`) and a submodel is active (`SUB_INDEX /= 0`). This ensures correct orientation of initial velocities in submodels.