### PR TITLE
*MAT_ADD_... POOL_ID change

### DIFF
--- a/hm_cfg_files/config/CFG/Keyword971_R15.0/data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R15.0/data_hierarchy.cfg
@@ -4192,6 +4192,28 @@ HIERARCHY {
          USER_NAMES = (MAT_UNSUPPORTED,MAT_,Unsupported);
     }
     HIERARCHY {
+        KEYWORD    = DEFINE_MATERIAL_HISTORIES;
+        TITLE      = "DEFINE_MATERIAL_HISTORIES";
+        FILE       = "IGNORED/IGNORED.cfg"; 
+        USER_NAMES = (DEFINE_MATERIAL_HISTORIES);
+    }
+    HIERARCHY {
+         KEYWORD    = MAT_NONLOCAL;
+         TITLE      = "MAT_NONLOCAL";
+         FILE       = "MATERIALBEHAVIOR/mat_nonlocal.cfg";
+         SUBTYPE    = USER;
+         USER_ID    = 7025;
+         USER_NAMES = (MAT_NONLOCAL);
+    }
+}
+
+HIERARCHY {
+    KEYWORD = MATERIALBEHAVIOR;
+    TYPE    = MATERIALBEHAVIOR;
+    TITLE   = "MATERIALBEHAVIOR";
+    FLAGS   = (CAN_HAVE_TITLE_CARD);
+        
+    HIERARCHY {
          KEYWORD    = MAT_ADD_EROSION ;
          TITLE      = "MAT_ADD_EROSION";
          FILE       = "MATERIALBEHAVIOR/mat_add_erosion.cfg";
@@ -4226,20 +4248,6 @@ HIERARCHY {
          USER_ID    = 7907;
          //ID_POOL    = 75;
          USER_NAMES = (MAT_ADD_THERMAL_EXPANSION,ADD_THERMAL_EXPANSION);
-    }
-    HIERARCHY {
-        KEYWORD    = DEFINE_MATERIAL_HISTORIES;
-        TITLE      = "DEFINE_MATERIAL_HISTORIES";
-        FILE       = "IGNORED/IGNORED.cfg"; 
-        USER_NAMES = (DEFINE_MATERIAL_HISTORIES);
-    }
-    HIERARCHY {
-         KEYWORD    = MAT_NONLOCAL;
-         TITLE      = "MAT_NONLOCAL";
-         FILE       = "MATERIALBEHAVIOR/mat_nonlocal.cfg";
-         SUBTYPE    = USER;
-         USER_ID    = 7025;
-         USER_NAMES = (MAT_NONLOCAL);
     }
 }
 


### PR DESCRIPTION
This pull request updates the `data_hierarchy.cfg` configuration file by reorganizing and relocating the hierarchy definitions for `DEFINE_MATERIAL_HISTORIES` and `MAT_NONLOCAL`. The main change is moving these keyword definitions from one section of the hierarchy to another, specifically under the new `MATERIALBEHAVIOR` hierarchy node.

Reorganization of hierarchy definitions:

* Moved the `DEFINE_MATERIAL_HISTORIES` and `MAT_NONLOCAL` keyword hierarchy definitions from their previous location to be nested under a new `MATERIALBEHAVIOR` hierarchy node. This helps group material behavior-related keywords together for better organization and maintainability. [[1]](diffhunk://#diff-f517a2e7d81b5488d44bed4219f5e9cce7023dec55a8e47bfb3bf87c117d837cR4194-R4215) [[2]](diffhunk://#diff-f517a2e7d81b5488d44bed4219f5e9cce7023dec55a8e47bfb3bf87c117d837cL4230-L4243)

Addition of a new hierarchy node:

* Added a new top-level `HIERARCHY` node with `KEYWORD = MATERIALBEHAVIOR` to serve as a parent for material behavior-related keyword definitions.