### PR TITLE
correction /MERGE/RBODY cfg file

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2020/RBODY/merge_rbody.cfg
+++ b/hm_cfg_files/config/CFG/radioss2020/RBODY/merge_rbody.cfg
@@ -20,7 +20,7 @@
 // MCDS attributes description
 ATTRIBUTES(COMMON) {
 // INPUT ATTRIBUTES
-    NAME                = VALUE(STRING,"Merge rigid body title","TITLE");
+    TITLE               = VALUE(STRING,"Merge rigid body title","TITLE");
 //
     NB_SUBOBJVE      =   SIZE("No. Main/Secondary pairs");
     SUPP_SUBGRPVE    =   ARRAY[NB_SUBOBJVE](SUBOBJECT, "Main/Secondary pairs"); 
@@ -38,7 +38,7 @@ SKEYWORDS_IDENTIFIER(COMMON)
     CommentEnumField      = 7951;
     NUM_COMMENTS          = 5110;
 //
-    NAME                  = 8057;
+    TITLE                 = 8057;
     NB_SUBOBJVE           = -1;
     SUPP_SUBGRPVE         = -1;
 }
@@ -88,7 +88,7 @@ mandatory:
 FORMAT(radioss2020) 
 {
     HEADER("/MERGE/RBODY/%d",_ID_);
-    CARD("%-100s", NAME);
+    CARD("%-100s", TITLE);
     COMMENT("#  Main_ID    M_type  Secon_ID    S_type     Iflag");
     SUBOBJECTS(SUPP_SUBGRPVE,/SUBOBJECT/MERGE_RBODY_SUBOBJ);   
 }


### PR DESCRIPTION
This pull request updates the attribute naming for the merge rigid body configuration in `merge_rbody.cfg` to use `TITLE` instead of `NAME`, ensuring consistency across the file. The changes affect the attribute definition, keyword mapping, and output formatting.

**Attribute renaming for consistency:**

* Replaced the `NAME` attribute with `TITLE` in the attributes section, keyword identifier mapping, and the output card format in `merge_rbody.cfg` to standardize the naming convention. [[1]](diffhunk://#diff-d4a80e57e8ca04f25a98039dddabe2f9e2c060d50b75c0f235ed600678320915L23-R23) [[2]](diffhunk://#diff-d4a80e57e8ca04f25a98039dddabe2f9e2c060d50b75c0f235ed600678320915L41-R41) [[3]](diffhunk://#diff-d4a80e57e8ca04f25a98039dddabe2f9e2c060d50b75c0f235ed600678320915L91-R91)