### PR TITLE
/MAT/LAW117: add damage criterion and evolution shape options (linear/exponential/Xu-Needleman)

### DIFF
--- a/engine/source/materials/mat/mat117/sigeps117.F
+++ b/engine/source/materials/mat/mat117/sigeps117.F
@@ -1,4 +1,4 @@
-Copyright>        OpenRadioss
+﻿Copyright>        OpenRadioss
 Copyright>        Copyright (C) 1986-2026 Altair Engineering Inc.
 Copyright>
 Copyright>        This program is free software: you can redistribute it and/or modify
@@ -32,7 +32,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      2     UPARAM  ,UVAR    ,AREA    ,OFF     ,OFFL    ,
      3     EPSZZ   ,EPSYZ   ,EPSZX   ,DEPSZZ  ,DEPSYZ  ,DEPSZX  ,
      4     SIGNZZ  ,SIGNYZ  ,SIGNZX  ,STIFM   ,DMELS   ,DMG     ,
-     5     IPG     ,NFAIL   ,NGL     ,NFUNC   ,IFUNC   ,NPF      ,TF)    
+     5     IPG     ,NFAIL   ,NGL     ,NFUNC   ,IFUNC   ,NPF      ,TF)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -61,210 +61,464 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER :: I,II, IRUPT,NINDXF
+      INTEGER :: I,II, IRUPT, NINDXF, ICRITTYP, IEVOSHAP
       INTEGER ,DIMENSION(NEL)  :: INDXF
-      my_real ::   DM,   DAM,  STF,DTB,
-     .   E_ELAS_N,DTINV , T_N,T_S,
-     .   EXP_G   ,     EXP_BK,   DELTA0S_CST, DELTA0N_CST, 
-     .   GIC     ,     GIIC  ,  E_ELAS_S,  UND_CST,  UTD_CST,GAMA
+      my_real ::   DM,   DAM,  STF,DTB, ALPHA, DENOM1, DENOM2, U_NORM,
+     .   E_ELAS_N,DTINV , T_N,T_S, EXP_ALPHA,COEF0, FUNC_ALPHA,
+     .   EXP_G   ,     EXP_BK,   DELTA0S_CST, DELTA0N_CST,D_F,
+     .   GIC     ,     GIIC  ,  E_ELAS_S,  UND_CST,  UTD_CST,GAMA,
+     .   TERM1, TERM2, RATIO, COS2, SIN2, XI, A_COEF, FADE,
+     .   EPSMMAX_PREV, DELTA_PREV, DAM_ENR, E_ELAS, DDELTA
 c
-      my_real, DIMENSION(NEL) :: EPSM,DELTA0M,  BETA,
-     .   DELTAFMAX,EPST,FAC1, FAC2,FAC3,EPSMMAX ,EPSN ,
-     .   DELTA0N,DELTA0S,UND,UTD,DYDX1,DYDX2,LENGTH,TMAX_N,TMAX_S
+      my_real, DIMENSION(NEL) :: EPSM,DELTA0M,  BETA, TMAX_MIX,
+     .   DELTAFMAX,EPST,FAC1, FAC2,FAC3,EPSMMAX ,EPSN,
+     .   DELTA0N,DELTA0S,UND,UTD,DYDX1,DYDX2,LENGTH,TMAX_N,TMAX_S,
+     .   GN,GS,G0,GC, DGI, DGII, DGIII, GTOT
+      
 c-----------------------------------------------
-c     UVAR(1)  =  
-c     UVAR(2)  =  
-c     UVAR(3)  =  
-c     UVAR(4)  =  
-c     UVAR(5)  = 
-c     UVAR(6)  =    
-c     UVAR(7)  =  
-c     UVAR(8)  =  
+
+      
 C=======================================================================
 C     INPUT PARAMETERS INITIALIZATION
-C-----------------------------------------------
-      E_ELAS_N  =  UPARAM(1)  
-      E_ELAS_S  =  UPARAM(2) 
-      GAMA      =  UPARAM(3)
-      T_N       =  UPARAM(4)
-      T_S       =  UPARAM(5)   
-      IRUPT     =  INT(UPARAM(6)  )
-      GIC       =  UPARAM(7) 
-      GIIC      =  UPARAM(8)
-      NFAIL     =  INT(UPARAM(9))
+C=======================================================================
+      
+      E_ELAS_N  =  UPARAM(1)  ! Rigid élastique normale (EN)
+      E_ELAS_S  =  UPARAM(2)  ! Rigid élastique tang (ET)
+      GAMA      =  UPARAM(3)  ! Param de couplage de mode (GAMMA)
+      T_N       =  UPARAM(4)  ! Conrainte normale (TN)
+      T_S       =  UPARAM(5)  ! Contrainte tang de ciss (TT)
+      IRUPT     =  INT(UPARAM(6)  ) ! Modèle (1 = Power law, 2 = BK METHOD) (IRUPT)
+      GIC       =  UPARAM(7)  ! Energie critique de rupture - mode I (GIC)
+      GIIC      =  UPARAM(8)  ! Energie critique de rupture - mode II (GIIC)
+      NFAIL     =  INT(UPARAM(9)) ! IDEL (dft = 1 INT)
       EXP_G     =  UPARAM(10)  
-      EXP_BK    =  UPARAM(11)  
-      DELTA0N_CST   =  UPARAM(13)        !         DISP puremode N
-      DELTA0S_CST   =  UPARAM(14)        !         DISP puremode S
-      UND_CST       =  UPARAM(15)   ! ultimate displacement in normal direction (UND)
-      UTD_CST       =  UPARAM(16)   ! ultimate displacement in tangential direction (UTD)
-
+      EXP_BK    =  UPARAM(11) ! Benzeggage-Kenane exponent for the mixed mode (EXP_BK)
+      DELTA0N_CST   =  UPARAM(13)        !         DISP puremode N - déplacement initial normal
+      DELTA0S_CST   =  UPARAM(14)        !         DISP puremode S - deplacment initial tang
+      UND_CST       =  UPARAM(15)   ! ultimate displacement in normal direction (UND) - depl ultime de rupture norm
+      UTD_CST       =  UPARAM(16)   ! ultimate displacement in tangential direction (UTD) - depl ultime de rupture tang
+      
+      ICRITTYP  = INT(UPARAM(18)) ! 1=displacement-based, 2=energy-based
+      IEVOSHAP  = INT(UPARAM(19)) ! 1=linear, 2=exponential
+      ALPHA     = UPARAM(20)
 c
       DTINV   = ONE / (MAX(TIMESTEP, EM20))
       STF     = E_ELAS_N + E_ELAS_S
       NINDXF  = 0
-c-------------------------
-      IF (TIME == ZERO) THEN
-        DO I=1,NEL
-         EPSMMAX(I)=ZERO      
-        ENDDO 
-      ELSE
-        DO I=1,NEL
-         EPSMMAX(I)    = UVAR(I,4)
-        ENDDO 
-      ENDIF
 
-      DO I=1,NEL             
-        EPSN(I) = MAX(EPSZZ(I) , ZERO)      
-        EPST(I) = SQRT(EPSYZ(I)**2  + EPSZX(I)**2)
-        EPSM(I) = SQRT( EPSN(I)**2  + EPST(I)**2)             
-        EPSMMAX(I) = MAX(EPSM(I),EPSMMAX(I))
-      ENDDO !I=1,NEL
-      !---------------------------------------------------------
-      !      Compute damage initiation and max displacement 
-      !---------------------------------------------------------
-      IF ( IFUNC(1) /= 0.OR. IFUNC(2) /= 0) THEN !depending on mesh size
-         LENGTH(1:NEL) = SQRT(AREA(1:NEL))
+C=======================================================================
+C     UVAR FIELDS DEFINITION
+C=======================================================================
+c     UVAR(1)  = EPSZZ 
+c     UVAR(2)  = EPSZX
+c     UVAR(3)  = EPSYZ
+c     UVAR(4)  = EPSMMAX
+c     UVAR(5)  = DMG
+c     UVAR(6)  = SIGNZZ   
+c     UVAR(7)  = SIGNZX
+c     UVAR(8)  = SIGNYZ 
+c     UVAR(9)  = DELTA0M
+c     UVAR(10) = BETA
+c     UVAR(11) = 
+c     UVAR(12) = DELTAFMAX
+c     UVAR(13) = GN
+c     UVAR(14) = GS
+c     UVAR(15) = GC
+
+C=======================================================================
+C     INIT FIELDS OR RECOVER HISTORY
+C=======================================================================
+      IF (TIME == ZERO) THEN 
+          DO I=1,NEL
+              SIGNZZ(I) = ZERO
+              SIGNZX(I) = ZERO
+              SIGNYZ(I) = ZERO
+              
+              EPSMMAX(I) = ZERO
+              
+              UVAR(I,11) = ZERO
+              
+              GN(I) = ZERO
+              GS(I) = ZERO
+              
+              DMG(I) = ZERO
+          ENDDO
+          
+      ELSE
+          DO I=1,NEL
+              SIGNZZ(I) = UVAR(I,6)
+              SIGNZX(I) = UVAR(I,7)
+              SIGNYZ(I) = UVAR(I,8)
+              
+              EPSMMAX(I) = UVAR(I,4)
+              
+              DMG(I) = UVAR(I,5)
+
+              ! Get energy
+              GN(I) = UVAR(I,13)
+              GS(I) = UVAR(I,14)
+          ENDDO
       ENDIF
+      
+C=======================================================================
+C     COMPUTE DELTA KNOWN AS EPSMMAX (i.e. MAX STRAIN)
+C=======================================================================
+      DO I=1, NEL
+          ! Compute norm and tang strain
+          EPSN(I) = MAX(EPSZZ(I) , ZERO) ! Ignore compressive state
+          EPST(I) = SQRT(EPSYZ(I)**2  + EPSZX(I)**2) ! Combine both plans
+          ! Compute mixt stain state
+          EPSM(I) = SQRT( EPSN(I)**2  + EPST(I)**2) ! Mixt strain
+          
+          ! Compute DELTA_MAX
+          EPSMMAX(I) = MAX(EPSM(I), EPSMMAX(I)) ! 
+      ENDDO ! I=1,NEL
+ 
+C=======================================================================
+C     COMPUTE DELTA0 (INITATION DISPLACMENT) and DELTAFMAX (FAILURE DISPLACEMENT)
+C=======================================================================
+      ! Init params for DELTA_FAILURE calculation
+      IF (IEVOSHAP /= 3) THEN
+          EXP_ALPHA  = EXP(-ALPHA)
+          DENOM1     = ONE - EXP_ALPHA
+          FUNC_ALPHA = (ONE - (ONE + ALPHA) * EXP_ALPHA)/(ALPHA * DENOM1) 
+      ENDIF
+      
+      ! IF Fct_TN !=0 or Fct_TT != 0 starts mesh correction on TN and TT (max traction)
+      IF ( IFUNC(1) /= 0.OR. IFUNC(2) /= 0) THEN
+          LENGTH(1:NEL) = SQRT(AREA(1:NEL))
+      ENDIF
+      
       IF ( IFUNC(1) /= 0) THEN
-         DO I=1,NEL             
-           TMAX_N(I) = T_N * FINTER(IFUNC(1),LENGTH(I),NPF,TF,DYDX1(I))
-           DELTA0N(I)= TMAX_N(I) /E_ELAS_N
-           UND(I)    = TWO*GIC /TMAX_N(I)
-         ENDDO !I=1,NEL
-      ELSE      
-         DO I=1,NEL             
-           DELTA0N(I) =  DELTA0N_CST
-           UND(I)     =  UND_CST
-         ENDDO  
+          DO I=1, NEL
+             TMAX_N(I) = T_N * FINTER(IFUNC(1),LENGTH(I),NPF,TF,DYDX1(I))
+             
+             IF (IEVOSHAP == 1) THEN
+                 DELTA0N(I) = TMAX_N(I) / E_ELAS_N
+                 UND(I) = TWO*GIC/TMAX_N(I)
+             ELSE IF (IEVOSHAP == 2) THEN
+                 DELTA0N(I) = TMAX_N(I) / E_ELAS_N
+                 COEF0  = GIC - TMAX_N(I) * DELTA0N(I) * HALF
+                 UND(I) = DELTA0N(I) + COEF0 / (FUNC_ALPHA*TMAX_N(I))
+             ELSE IF (IEVOSHAP == 3) THEN
+                 DELTA0N(I) = GIC / (EXP(ONE) * TMAX_N(I))
+                 UND(I)     = -DELTA0N(I) * LOG(EM04)
+             ENDIF
+          ENDDO ! I=1,NEL
+      ELSE ! No TN correction
+          DO I=1,NEL
+              DELTA0N(I) =  DELTA0N_CST
+              UND(I)     =  UND_CST
+              TMAX_N(I)  = T_N
+          ENDDO
       ENDIF
+      
       IF ( IFUNC(2) /= 0) THEN
-         DO I=1,NEL             
-           TMAX_S(I) = T_S * FINTER(IFUNC(2),LENGTH(I),NPF,TF,DYDX2(I))
-           DELTA0S(I)= TMAX_S(I) /E_ELAS_S
-           UTD(I)    = TWO*GIIC/TMAX_S(I)
-         ENDDO !I=1,NEL
+          DO I=1,NEL             
+              TMAX_S(I) = T_S * FINTER(IFUNC(2),LENGTH(I),NPF,TF,DYDX2(I))
+           
+              IF (IEVOSHAP == 1) THEN
+                  DELTA0S(I) = TMAX_S(I) /E_ELAS_S
+                  UTD(I) = TWO*GIIC/TMAX_S(I)
+              ELSE IF (IEVOSHAP == 2) THEN
+                  DELTA0S(I) = TMAX_S(I) /E_ELAS_S
+                  COEF0 = GIIC - TMAX_S(I) * DELTA0S(I) * HALF
+                  UTD(I) = DELTA0S(I) + COEF0 / (FUNC_ALPHA*TMAX_S(I)) 
+              ELSE IF (IEVOSHAP == 3) THEN
+                 DELTA0S(I) = GIIC / (EXP(ONE) * TMAX_S(I))
+                 UTD(I)     = -DELTA0S(I) * LOG(EM03)                
+              ENDIF
+          ENDDO !I=1,NEL
       ELSE      
-         DO I=1,NEL             
-           DELTA0S(I) =  DELTA0S_CST
-           UTD(I)     =  UTD_CST
-         ENDDO  
+          DO I=1,NEL             
+              DELTA0S(I) = DELTA0S_CST
+              UTD(I)     = UTD_CST
+              TMAX_S(I)  = T_S
+          ENDDO  
       ENDIF
-        !---------------------------------------------------------
-        !       Update failure initiation strains in mixed mode
-        !---------------------------------------------------------
-      DO I=1,NEL             
-        IF (EPST(I) == ZERO) THEN
-           DELTA0M(I) =  DELTA0N(I)
-        ELSE IF (EPSN(I) == ZERO) THEN
-           DELTA0M(I) = DELTA0S(I)
-        ELSE      ! mixed mode 
-           BETA(I)   = ABS(EPST(I) / EPSN(I))
-           DELTA0M(I)= DELTA0S(I)* DELTA0N(I)*SQRT((ONE + BETA(I)**2)/           
-     .                    ((DELTA0S(I)**2) + (BETA(I)* DELTA0N(I))**2))
-        END IF
-      ENDDO !I=1,NEL
-!------------------------------------------------    
-!             DAMAGE      : ultimate displacement                       
-!------------------------------------------------    
-      ! IRUPT =2  = BK method -----------------
-      IF (IRUPT == 2) THEN
-        DO I=1,NEL
-         IF (EPST(I) == ZERO) THEN
-           DELTAFMAX(I)= UND(I)
-         ELSE IF (EPSN(I) == ZERO) THEN
-           DELTAFMAX(I)= UTD(I)
-         ELSE      ! mixed mode 
-            FAC1(I) = (E_ELAS_N**GAMA)/(ONE + BETA(I)**2)
-            FAC2(I) = (E_ELAS_S**GAMA)*(BETA(I)**2)/(ONE + BETA(I)**2)
-            FAC3(I) = (FAC1(I) + FAC2(I) )**(ONE/GAMA)
-            !ultimate mixed mode displacement           
-            DELTAFMAX(I)= TWO/(DELTA0M(I)*  FAC3(I)   )*
-     .                    (GIC + (GIIC - GIC)*((E_ELAS_S*BETA(I)**2)/
-     .                    (E_ELAS_N + E_ELAS_S*BETA(I)**2))**ABS(EXP_BK))
-         END IF
-        ENDDO
-      ELSE
-        ! IRUPT =1  = power law method-- default---------------
-        DO I=1,NEL
-         IF (EPST(I) == ZERO) THEN
-           DELTAFMAX(I)= UND(I)
-         ELSE IF (EPSN(I) == ZERO) THEN
-           DELTAFMAX(I)= UTD(I)
-         ELSE      ! mixed mode 
-           FAC1(I) = TWO*((ONE+BETA(I)**2))/DELTA0M(I)
-           !ultimate mixed mode displacement
-           DELTAFMAX(I)= FAC1(I)*((E_ELAS_N/GIC)**EXP_G + 
-     .                  (E_ELAS_S*(BETA(I)**2)/GIIC)**EXP_G)**(-ONE/EXP_G)
-         END IF
-        ENDDO
-      ENDIF
-!---------------------------------------------------------------
-!             damage evolution       
-!---------------------------------------------------------------
+      
+      ! Compute DELTA0M (i.e. DELTA0 for the mix mode)
       DO I=1,NEL
-        DM = EPSMMAX(I) - DELTA0M(I)
-        IF (DM > ZERO.AND.EPSMMAX(I) /= ZERO ) THEN
-          DAM =       (DELTAFMAX(I) / EPSMMAX(I))*
-     .                (EPSMMAX(I)   - DELTA0M(I))/
-     .            MAX((DELTAFMAX(I) - DELTA0M(I)), EM20) 
-               
-          DMG(I) = MAX(DMG(I), DAM)!
-          DMG(I) = MIN(DMG(I), ONE)
-          IF (OFFL(I) == ONE .AND. EPSMMAX(I) > DELTAFMAX(I) ) THEN
-            NINDXF = NINDXF+1
-            INDXF(NINDXF) = I
-            OFFL(I) = ZERO
-          END IF
-        END IF
-      ENDDO
-!---------------------------------------------------------------
-!     Stress update
-!---------------------------------------------------------------
-      DO I=1,NEL
-         IF (EPSZZ(I) < ZERO )  THEN 
-            SIGNZZ(I) = E_ELAS_N*EPSZZ(I)            
+          IF (EPST(I) == ZERO) THEN
+              ! Pure mode I
+              DELTA0M(I)  = DELTA0N(I)
+              TMAX_MIX(I) = TMAX_N(I)
+              BETA(I) = ZERO
+          ELSE IF (EPSN(I) == ZERO) THEN
+              ! Pure mode II    
+              DELTA0M(I)  = DELTA0S(I)
+              TMAX_MIX(I) = TMAX_S(I)
+              BETA(I) = ZERO
           ELSE
-            SIGNZZ(I) = (ONE-DMG(I))*E_ELAS_N*EPSZZ(I)
+              BETA(I)     = ABS(EPST(I) / EPSN(I))
+              DELTA0M(I)  = DELTA0S(I)* DELTA0N(I)*SQRT((ONE + BETA(I)**2)/
+     .                    ((DELTA0S(I)**2) + (BETA(I)* DELTA0N(I))**2))
+              ! We should be consistent with the energy G0
+              ! Tmax_mix = T_eff = DELTA_0^m * \mathcal{F}_1
+              TMAX_MIX(I) = DELTA0M(I) * (E_ELAS_N + E_ELAS_S*BETA(I)**2) /
+     .                    (ONE + BETA(I)**2)
           ENDIF
-          ! sigma shear Y   
-          SIGNYZ(I) = (ONE-DMG(I))*E_ELAS_S*(EPSYZ(I))
-          !  sigma shear X  
-          SIGNZX(I) = (ONE-DMG(I))*E_ELAS_S*(EPSZX(I))
-      ENDDO
-     
-      DO I=1,NEL      
-        UVAR(I,1) = EPSZZ(I)
-        UVAR(I,2) = EPSZX(I)
-        UVAR(I,3) = EPSYZ(I)
-        UVAR(I,4)=  EPSMMAX(I)
+          ENDDO !I=1,NEL
+      
+      ! Compute DELTA0FMAX
+      IF (IEVOSHAP == 3) THEN
+          ! Xu-Needleman: delta_f = 9.21 * delta_p_mix (D_crit = 0.9999)
+          DO I=1,NEL
+              DELTAFMAX(I) = -DELTA0M(I) * LOG(EM04)
+          ENDDO
+      ELSE IF (IRUPT == 2) THEN ! IRUPT =2  = BK method
+          DO I=1, NEL
+              IF (EPST(I) == ZERO) THEN
+                  DELTAFMAX(I) = UND(I)
+              ELSE IF (EPSN(I) == ZERO) THEN
+                  DELTAFMAX(I) = UTD(I)
+              ELSE ! Mix mode
+                  FAC1(I) = (E_ELAS_N**GAMA)/(ONE + BETA(I)**2)
+                  FAC2(I) = (E_ELAS_S**GAMA)*(BETA(I)**2)/(ONE + BETA(I)**2)
+                  FAC3(I) = (FAC1(I) + FAC2(I) )**(ONE/GAMA)
+                  
+                  DELTAFMAX(I) = TWO/(DELTA0M(I)*  FAC3(I)   )*
+     .                           (GIC + (GIIC - GIC)*((E_ELAS_S*BETA(I)**2)/
+     .                           (E_ELAS_N + E_ELAS_S*BETA(I)**2))**ABS(EXP_BK))     
+              ENDIF
+          ENDDO ! I=1,NEL
+      ELSE ! IRUPT =1  = power law method-- default
+          DO I=1,NEL
+              IF (EPST(I) == ZERO) THEN
+                  DELTAFMAX(I)= UND(I)
+              ELSE IF (EPSN(I) == ZERO) THEN
+                  DELTAFMAX(I)= UTD(I)
+              ELSE      ! mixed mode 
+                  FAC1(I) = TWO*((ONE+BETA(I)**2))/DELTA0M(I)
+            
+                  DELTAFMAX(I) = FAC1(I)*((E_ELAS_N/GIC)**EXP_G + 
+     .                          (E_ELAS_S*(BETA(I)**2)/GIIC)**EXP_G)**(-ONE/EXP_G)
+              ENDIF
+          ENDDO ! I=1,NEL
+      ENDIF
+      
+C=======================================================================
+C     ENERGY COMPUTATION (UNIQUEMENT POUR LE CRITERE ENERGETIQUE)
+C=======================================================================
+      IF (ICRITTYP == 2) THEN
+          
+          DO I=1, NEL
+              ! Compute the elastic-energy
+              G0(I) = HALF * TMAX_MIX(I) * DELTA0M(I)
+              
+              ! Compute the energy-increment with forward Euler             
+              DGI(I) = ZERO
+              IF (EPSZZ(I) > ZERO) THEN
+                  DGI(I) = SIGNZZ(I) * DEPSZZ(I)
+              ENDIF
+                
+              DGII(I) = (SIGNYZ(I)*DEPSYZ(I) + SIGNZX(I)*DEPSZX(I))
+                
+              ! Update the energy
+              GN(I) = MAX(GN(I) + DGI(I), ZERO)
+              GS(I) = MAX(GS(I) + DGII(I), ZERO)
+              
+              ! Compute the total energy
+              GTOT(I) = GN(I) + GS(I)
+              
+              ! Compute RATIO 
+              IF (GTOT(I) > ZERO) THEN
+                  RATIO = GS(I) / GTOT(I)
+              ELSE
+                  RATIO = ZERO
+              ENDIF
+              RATIO = MAX(ZERO, MIN(ONE, RATIO))
+              
+              ! Critical energy - GC
+              IF (IRUPT == 1) THEN ! Power law model
+                  !TERM1 = (MAX(EPSN(I),ZERO) / EPSMMAX(I))**(2*EXP_G) * (ONE/GIC) ** EXP_G
+                  !TERM2 = (EPST(I)/EPSMMAX(I)) ** (2*EXP_G) * (ONE/GIIC) ** EXP_G
+                  
+                  !GC(I) = (TERM1 + TERM2)**(-ONE/EXP_G)
 
-        UVAR(I,6)=  SIGNZZ(I)
-        UVAR(I,7)=  SIGNZX(I)
-        UVAR(I,8)=  SIGNYZ(I)
-        UVAR(I,9)=  DELTA0M(I)
-        UVAR(I,10)=  BETA(I)
-        UVAR(I,12) = DELTAFMAX(I)
-      ENDDO
+                  GC(I) = ( ((ONE - RATIO) / GIC) ** EXP_G + (RATIO/GIIC)**EXP_G)**(-ONE/EXP_G)
+              ELSE IF (IRUPT == 2) then ! BK model
+                  GC(I) = GIC + (GIIC - GIC) * (RATIO ** EXP_BK)
+              ELSE
+                  GC(I) = GIC
+              ENDIF
+              
+          ENDDO ! I=1,NEL
+      ENDIF ! ICRITTYP == 2
+      
+C=======================================================================
+C     COMPUTE DAMAGE (2nd part of the Traction-separation curve
+C=======================================================================    
+      IF (ICRITTYP == 1) THEN ! Displacement-based
+          DO I=1,NEL
+              IF ( EPSMMAX(I) > DELTA0M(I) .AND. EPSMMAX(I) /= 0 .AND. IEVOSHAP /= 3) THEN
+                  IF (IEVOSHAP == 1) THEN ! Linear
+                      DAM = (DELTAFMAX(I) / EPSMMAX(I)) *
+     .                      (EPSMMAX(I)   - DELTA0M(I)) /
+     .                  MAX((DELTAFMAX(I) - DELTA0M(I)), EM20)
+                  ELSE IF (IEVOSHAP == 2) THEN ! Exponentielle
+                      U_NORM =    (EPSMMAX(I) - DELTA0M(I)) /
+     .                      MAX((DELTAFMAX(I) - DELTA0M(I)), EM20)
+                      
+                      DAM    =          ONE - (DELTA0M(I)/EPSMMAX(I)) *
+     .                  (EXP(-ALPHA*U_NORM) - EXP_ALPHA) / DENOM1       
+                  ENDIF
+                  DMG(I) = MAX(DMG(I), DAM) ! Respecte la monotonie du damage
+                  DMG(I) = MIN(DMG(I), ONE) ! Saturé à 1 par définition
+                  
+                  ! Deactivate EF (Displament Criterion)
+                  IF (OFFL(I) == ONE.AND.EPSMMAX(I) > DELTAFMAX(I)) THEN
+                      NINDXF = NINDXF+1 ! Count
+                      INDXF(NINDXF) = I
+                      OFFL(I) = ZERO
+                  ENDIF
+              ENDIF
+              
+              IF (IEVOSHAP == 3) THEN
+                  ! Xu-Needleman: D = 1 - exp(-delta_max / delta_p)
+                  ! No initiation threshold (damage starts from delta=0)
+                  DAM = ONE - EXP(-EPSMMAX(I) / MAX(DELTA0M(I), EM20))
+                  DMG(I) = MAX(DMG(I), DAM)
+                  DMG(I) = MIN(DMG(I), ONE)
+                  ! Deletion: EPSMMAX > DELTAFMAX (= 6.908 * delta_p)
+                  IF (OFFL(I) == ONE .AND. EPSMMAX(I) > DELTAFMAX(I)) THEN
+                      NINDXF = NINDXF + 1
+                      INDXF(NINDXF) = I
+                      OFFL(I) = ZERO
+                  ENDIF
+              END IF
+          ENDDO ! I=1,NEL
+      ELSE IF (ICRITTYP == 2) THEN ! Energy-based
+          DO I=1,NEL
+              
+              D_F = TWO * GC(I) / TMAX_MIX(I) ! From the OS doc
+              
+              IF ( EPSMMAX(I) > DELTA0M(I) .AND. EPSMMAX(I) /= 0 ) THEN
+                  IF (IEVOSHAP == 1) THEN ! Linear
+                      DAM = (D_F/EPSMMAX(I)) * (EPSMMAX(I) - DELTA0M(I)) /
+     .                                            MAX((D_F - DELTA0M(I)), EM20)
+                      DMG(I) = MAX(DMG(I), DAM)
+                      DMG(I) = MIN(DMG(I), ONE)
+                  ELSE IF (IEVOSHAP == 2) THEN ! La loi merdique - intégration
+                      
+                      !
+                      DENOM2 = MAX(GC(I) - G0(I), EM20)
+                      
+                      EPSMMAX_PREV = UVAR(I,4)
+                      DELTA_PREV   = MAX(EPSMMAX_PREV, DELTA0M(I))
+                      
+                      IF (EPSMMAX(I) > ZERO) THEN
+                          COS2 = EPSN(I)**2 / EPSMMAX(I)**2
+                          SIN2 = EPST(I)**2 / EPSMMAX(I)**2
+                          E_ELAS = E_ELAS_N * COS2 + E_ELAS_S * SIN2
+                      ELSE
+                          E_ELAS = E_ELAS_N
+                      ENDIF
+                      
+                      ! EDO IMPLICIT
+                      DELTA_PREV = UVAR(I,4)
+                      DDELTA = MAX(EPSMMAX(I) - DELTA_PREV, ZERO)
+                      IF (DDELTA > ZERO .AND. EPSMMAX(I) > DELTA0M(I)) THEN
+                         ! A = K * delta^(n+1) / (Gc^(n+1) - G0) * Ddelta
+                         A_COEF = E_ELAS * EPSMMAX(I) * DDELTA
+     .                          / MAX(GC(I) - G0(I), EM20)
+                         ! Schema implicite exact : D = (D^n + A) / (1 + A)
+                         DAM_ENR = (DMG(I) + A_COEF) / (ONE + A_COEF)
+                      ELSE
+                         DAM_ENR = DMG(I)
+                      ENDIF
+                      
+                      DMG(I)  = MAX(DMG(I), DAM_ENR)
+                      DMG(I)  = MIN(DMG(I), ONE)
+                  ENDIF
+              ENDIF
+              
+              IF (OFFL(I) == ONE .AND. (GTOT(I) .GE. GC(I) .OR. DMG(I) .GE. ONE )) THEN
+                  NINDXF = NINDXF + 1
+                  INDXF(NINDXF) = I
+                  OFFL(I) = ZERO
+              ENDIF 
+          ENDDO ! I=1,NEL
+      ENDIF ! ICRITTYP == 1 OR 2
+
+C=======================================================================
+C     STRESS FIELD UPDATE
+C======================================================================= 
+      DO I=1,NEL
+          ! New field
+          IF (EPSZZ(I) < ZERO )  THEN 
+              SIGNZZ(I) = E_ELAS_N*EPSZZ(I) 
+          ELSE
+              SIGNZZ(I) = (ONE-DMG(I))*E_ELAS_N*EPSZZ(I)
+          ENDIF
+          
+          SIGNYZ(I) = (ONE-DMG(I))*E_ELAS_S*EPSYZ(I)
+          SIGNZX(I) = (ONE-DMG(I))*E_ELAS_S*EPSZX(I)
+          
+          ! Smooth C^1 fade-out near deletion (energy-based criterion)
+          ! 3-2 Hermite step on D in [D_fade=0.95, D_crit=0.999]
+          IF (ICRITTYP == 2 .AND. DMG(I) > ZEP95) THEN
+              XI = MIN(MAX((DMG(I) - ZEP95) / (ZEP999 - ZEP95), ZERO), ONE)
+              FADE = ONE - XI*XI*(THREE - TWO*XI)
+              SIGNZZ(I) = SIGNZZ(I) * FADE
+              SIGNYZ(I) = SIGNYZ(I) * FADE
+              SIGNZX(I) = SIGNZX(I) * FADE
+          ENDIF
+      ENDDO ! I=1,NEL
+      
+C=======================================================================
+C     SAVE UVAR FIELDS
+C======================================================================= 
+      DO I=1, NEL
+          UVAR(I,1) = EPSZZ(I) ! Déformation normale
+          UVAR(I,2) = EPSZX(I) ! Cissailement X
+          UVAR(I,3) = EPSYZ(I) ! Cissaillement Y
+          
+          UVAR(I,4) = EPSMMAX(I) ! Déformation max (historique)
+          
+          UVAR(I,5) = DMG(I)
+          
+          UVAR(I,6) = SIGNZZ(I) ! Contrainte normale
+          UVAR(I,7) = SIGNZX(I) ! Contrainte X 
+          UVAR(I,8) = SIGNYZ(I) ! Contrainte Y
+          UVAR(I,9) = DELTA0M(I) ! delta_mix_0
+          UVAR(I,10)= BETA(I) ! Ratio de mode mixte
+        
+          UVAR(I,12)= DELTAFMAX(I) ! delta_f_max
+          
+          IF (ICRITTYP == 2) THEN
+              UVAR(I,13)= GN(I)
+              UVAR(I,14)= GS(I)
+              UVAR(I,15)= GC(I)
+          ENDIF
+      ENDDO ! I=1, NEL
+      
 c-----------------------------------------------------      
 c-----------------------------------------------------      
 c     omega = sqrt(2k/2*dmels), dt=2/omega, 2*dmels=dt**2 * 2k / 4
       IF (IDTMINS==2 .AND. JSMS/=0) THEN
-        DTB = (DTMINS/DTFACS)**2
-        DO I=1,NEL                                                 
-          DMELS(I)=MAX(DMELS(I),HALF*DTB*STF*AREA(I)*OFF(I))
-        ENDDO                                                        
+          ! DTB = (dt ciblé / scaling factor)**2
+          DTB = (DTMINS/DTFACS)**2
+          ! Pour chaque EF, on scale la masse par DMELS(I) ou HALF*DTB*STF*AREA(I)*OFF(I)
+          ! On a ajouté le OFF(I) pour ne pas scaler les éléments qui ont sauté
+          ! HALF*DTB*STF*AREA(I) a pour unité s2.N/m3 * m2 -> s2 N/m = MASSE
+          DO I=1,NEL                                                 
+              DMELS(I) = MAX(DMELS(I),HALF*DTB*STF*AREA(I)*OFF(I))
+          ENDDO                                                        
       END IF
+      
+      ! Update de la raideur des EFs en tenant compte de la raideur cohésive. 
       STIFM(1:NEL) = STIFM(1:NEL) + STF*AREA(1:NEL)*OFF(1:NEL)    
-c-----------------------------------------------------      
+c-----------------------------------------------------     
+      ! Si des elements ont sauté, on print un message.
       IF (NINDXF > 0) THEN
-        DO II=1,NINDXF
-          I = INDXF(II)
+          DO II=1,NINDXF
+              I = INDXF(II)
 #include "lockon.inc"
-          WRITE(IOUT ,1000) NGL(I),IPG,EPSM(I)
-          WRITE(ISTDO,1100) NGL(I),IPG,EPSM(I),TIME
+              WRITE(IOUT ,1000) NGL(I),IPG,EPSM(I)
+              WRITE(ISTDO,1100) NGL(I),IPG,EPSM(I),TIME
 #include "lockoff.inc"
-        END DO
+          END DO
       END IF
 c-----------------------------------------------------      
  1000 FORMAT(5X,'FAILURE COHESIVE ELEMENT ',I10,
@@ -275,3 +529,4 @@ c-----------------------------------------------------
 c-----------
       RETURN
       END
+          

--- a/hm_cfg_files/config/CFG/radioss2026/MAT/mat117.cfg
+++ b/hm_cfg_files/config/CFG/radioss2026/MAT/mat117.cfg
@@ -1,0 +1,192 @@
+//Copyright>    CFG Files and Library ("CFG")
+//Copyright>    Copyright (C) 1986-2026 Altair Engineering Inc.
+//Copyright>
+//Copyright>    Altair Engineering Inc. grants to third parties limited permission to
+//Copyright>    use and modify CFG solely in connection with OpenRadioss software, provided
+//Copyright>    that any modification to CFG by a third party must be provided back to
+//Copyright>    Altair Engineering Inc. and shall be deemed a Contribution under and therefore
+//Copyright>    subject to the CONTRIBUTOR LICENSE AGREEMENT for OpenRadioss software.
+//Copyright>
+//Copyright>    CFG IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//Copyright>    INCLUDING, BUT NOT LIMITED TO, THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+//Copyright>    A PARTICULAR PURPOSE, AND NONINFRINGEMENT.  IN NO EVENT SHALL ALTAIR ENGINEERING
+//Copyright>    INC. OR ITS AFFILIATES BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY,
+//Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
+//Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
+//
+// Material law 117 Setup File
+// 
+
+// MCDS attributes description
+ATTRIBUTES(COMMON) {
+
+    KEYWORD_STR                     = VALUE(STRING,"Solver Keyword");
+    MAT_RHO                         = VALUE(FLOAT, "Initial Density");
+    MAT_E_ELAS_N                    = VALUE(FLOAT, "Stiffness normal to the plane of the cohesive element");
+    MAT_E_ELAS_S                    = VALUE(FLOAT, "Stiffness in to the plane of the cohesive element");
+//
+    MAT_Fct_TN                      = VALUE(FUNCT, "Function identifier of the peak traction in normal direction vs element mesh size");
+    MAT_Fct_TT                      = VALUE(FUNCT, "Function identifier of the peak traction in tangential direction vs element mesh size");
+    MAT_TMAX_N                      = VALUE(FLOAT, "Peak traction in normal direction");
+    MAT_TMAX_S                      = VALUE(FLOAT, "Peak traction in tangential direction");
+    MAT_Fscale_x                    = VALUE(FLOAT, "Scale Factor for abscissa of Fct_TN and FCT_TT");
+//
+    MAT_IRUPT                       = VALUE(INT,   "Choice of propagation criteria ");
+    MAT_IMASS                       = VALUE(INT,   "Density definition flag");
+    MAT_IDEL                        = VALUE(INT,   "Nb integration points to fail");
+// 
+// BEGIN Farouk Contrib
+// 
+    MAT_CRIT_TYPE                   = VALUE(INT,   "Damage criteria energy 2 or displacement based 1");
+    MAT_EVO_SHAPE                   = VALUE(INT,   "Damage evolution shape linear 1 or exponential 2");
+    MAT_DELTA_FN                    = VALUE(FLOAT, "Failure displacement for normal mode");
+    MAT_DELTA_FS                    = VALUE(FLOAT, "Failure displacement for shear mode");
+    MAT_ALPHA                       = VALUE(FLOAT, "Alpha coefficient for expononential law");
+// 
+// END Farouk Contrib
+// 
+//
+    MAT_GIC                         = VALUE(FLOAT, "Energy release rate for mode I");
+    MAT_GIIC                        = VALUE(FLOAT, "Energy release rate for mode II");
+//
+    MAT_EXP_G                     = VALUE(FLOAT, "Mu, Power law exponent ");
+    MAT_EXP_BK                    = VALUE(FLOAT, "Mu, Benzeggagh-Kenane exponent ");
+    MAT_GAMMA                     = VALUE(FLOAT, "Gamma exponent for Benseggagh-Kenane law");
+//
+    
+     //
+    LAW_NO                          = VALUE(STRING, "");
+    Mat_Name_OR_LawNo               = VALUE(INT,  "RADIOSS_COMMENT_FLAG");
+    IO_FLAG                         = VALUE(INT, "");
+    TITLE                           = VALUE(STRING,"");
+}
+CHECK( COMMON)
+{
+    MAT_RHO                            >  0.0   ;
+    MAT_E_ELAS_N                       >  0.0   ;
+    MAT_E_ELAS_S                       >  0.0   ;
+    MAT_TMAX_N                         >  0.0   ;
+    MAT_TMAX_S                         >  0.0   ;
+    MAT_DELTA_FN                       >  0.0   ;
+    MAT_DELTA_FS                       >  0.0   ;
+    MAT_GIC                            >  0.0   ;
+    MAT_GIIC                           >  0.0   ;
+    MAT_EXP_G                          >  0.0   ;
+    MAT_EXP_BK                         >  0.0   ;   
+}
+
+DEFAULTS(COMMON)
+{
+    MAT_IMASS                        = 1    ;
+    MAT_GAMMA                        = 1    ;
+    MAT_IDEL                         = 1    ;
+    MAT_CRIT_TYPE                    = 1    ; // Disp based criterion
+    MAT_EVO_SHAPE                    = 1    ; // Linear shape
+}
+
+// GUI description (Common domain)
+
+GUI(COMMON) {
+ 
+ mandatory:
+    SCALAR(MAT_RHO)         { DIMENSION="density"        ;}
+    SCALAR(MAT_E_ELAS_N)    { DIMENSION="PRESSURE PER UNIT LENGTH";}
+    SCALAR(MAT_E_ELAS_S)    { DIMENSION="PRESSURE PER UNIT LENGTH";}
+    SCALAR(MAT_TMAX_N)      { DIMENSION="pressure"       ;}
+    SCALAR(MAT_TMAX_S)      { DIMENSION="pressure"       ;}
+    SCALAR(MAT_Fscale_x)    { DIMENSION="l"       ;}
+
+    SCALAR(MAT_GIC)         { DIMENSION="lineic_force"   ;}          
+    SCALAR(MAT_GIIC)        { DIMENSION="lineic_force"   ;}          
+          
+    SCALAR(MAT_EXP_G)     { DIMENSION="DIMENSIONLESS"   ;}          
+    SCALAR(MAT_EXP_BK)    { DIMENSION="DIMENSIONLESS"   ;}          
+ optional:
+    RADIO(MAT_IMASS)
+    {
+        ADD(1,"1: Element Mass is Calculated Using Density and mean Area");
+        ADD(2,"0: Element Mass is Calculated Using Density and Volume");
+    }
+
+ optional:
+    RADIO(MAT_IRUPT)
+    {
+        ADD(1,"1: Power law propagation criterion");
+        ADD(2,"2: Benzeggagh-Kenane propagation criterion");
+    }
+}
+
+
+// File format
+FORMAT(radioss2022) {
+
+ASSIGN(IO_FLAG, 0, EXPORT);
+ASSIGN(IO_FLAG, 1,IMPORT);
+if(IO_FLAG == 0)
+{    HEADER("/MAT/LAW117/%d",_ID_);
+    CARD("%-100s", TITLE);
+}        
+    COMMENT("#        Init. dens.");
+    CARD("%20lg",MAT_RHO);
+    //
+    COMMENT("#                 EN                  ES     Imass      Idel     Irupt");
+    CARD("%20lg%20lg%10d%10d%10d",  MAT_E_ELAS_N,MAT_E_ELAS_S,MAT_IMASS,MAT_IDEL,MAT_IRUPT);
+    //
+    COMMENT("#   FCT_TN    FCT_TT                  TN                  TS            Fscale_x");
+    CARD("%10d%10d%20lg%20lg%20lg",MAT_Fct_TN,MAT_Fct_TT, MAT_TMAX_N,MAT_TMAX_S,MAT_Fscale_x);
+    //
+    COMMENT("#                GIC                GIIC               EXP_G              EXP_BK               GAMMA");
+    CARD("%20lg%20lg%20lg%20lg%20lg", MAT_GIC,MAT_GIIC,MAT_EXP_G,MAT_EXP_BK,MAT_GAMMA);
+}
+
+
+// File format
+FORMAT(radioss2026) {
+
+ASSIGN(IO_FLAG, 0, EXPORT);
+ASSIGN(IO_FLAG, 1,IMPORT);
+if(IO_FLAG == 0)
+{    HEADER("/MAT/LAW117/%d",_ID_);
+    CARD("%-100s", TITLE);
+}        
+    COMMENT("#        Init. dens.");
+    CARD("%20lg",MAT_RHO);
+    //
+    COMMENT("#                 EN                  ES     Imass      Idel     Irupt");
+    CARD("%20lg%20lg%10d%10d%10d",  MAT_E_ELAS_N,MAT_E_ELAS_S,MAT_IMASS,MAT_IDEL,MAT_IRUPT);
+    //
+    COMMENT("#   FCT_TN    FCT_TT                  TN                  TS            Fscale_x");
+    CARD("%10d%10d%20lg%20lg%20lg",MAT_Fct_TN,MAT_Fct_TT, MAT_TMAX_N,MAT_TMAX_S,MAT_Fscale_x);
+    //
+    // BEGIN Farouk Contrib
+    //
+    COMMENT("#  CRITTYPE  EVOSHAPE              DELF_N              DELF_S               ALPHA");
+    CARD("%10d%10d%20lg%20lg%20lg",MAT_CRIT_TYPE,MAT_EVO_SHAPE, MAT_DELTA_FN,MAT_DELTA_FS,MAT_ALPHA);
+    //
+    // END Farouk Contrib
+    //
+    COMMENT("#                GIC                GIIC               EXP_G              EXP_BK               GAMMA");
+    CARD("%20lg%20lg%20lg%20lg%20lg", MAT_GIC,MAT_GIIC,MAT_EXP_G,MAT_EXP_BK,MAT_GAMMA);
+}
+
+
+FORMAT(radioss2021) {
+
+ASSIGN(IO_FLAG, 0, EXPORT);
+ASSIGN(IO_FLAG, 1,IMPORT);
+if(IO_FLAG == 0)
+{    HEADER("/MAT/LAW117/%d",_ID_);
+    CARD("%-100s", TITLE);
+}        
+    COMMENT("#        Init. dens.");
+    CARD("%20lg",MAT_RHO);
+    //
+    COMMENT("#                 EN                  ES     Imass      Idel");
+    CARD("%20lg%20lg%10d%10d",  MAT_E_ELAS_N,MAT_E_ELAS_S,MAT_IMASS,MAT_IDEL);
+    //
+    COMMENT("#                 TN                  TS     Irupt     GAMMA");
+    CARD("%20lg%20lg%10d%10d", MAT_TMAX_N,MAT_TMAX_S,MAT_IRUPT,MAT_GAMMA);
+    //
+    COMMENT("#                GIC                GIIC               EXP_G              EXP_BK");
+    CARD("%20lg%20lg%20lg%20lg", MAT_GIC,MAT_GIIC,MAT_EXP_G,MAT_EXP_BK);
+}

--- a/starter/source/materials/mat/mat117/hm_read_mat117.F
+++ b/starter/source/materials/mat/mat117/hm_read_mat117.F
@@ -47,7 +47,7 @@ C-----------------------------------------------
 C   DUMMY ARGUMENTS DESCRIPTION:
 C   ===================
 C
-C     NAME            DESCRIPTION                         
+C     NAME            DESCRIPTION
 C
 C     IPM             MATERIAL ARRAY(INTEGER)
 C     PM              MATERIAL ARRAY(REAL)
@@ -76,7 +76,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      TYPE (UNIT_TYPE_),INTENT(IN) ::UNITAB 
+      TYPE (UNIT_TYPE_),INTENT(IN) ::UNITAB
       INTEGER, INTENT(INOUT)          :: IFUNC(MAXFUNC), NFUNC, MAXFUNC
       INTEGER, INTENT(INOUT)          :: MAXUPARAM,
      .                                   NUPARAM,NUVAR
@@ -85,15 +85,15 @@ C-----------------------------------------------
       CHARACTER(LEN=NCHARTITLE) ,INTENT(IN) :: TITR
       TYPE(SUBMODEL_DATA),INTENT(IN)  :: LSUBMODEL(*)
       TYPE(MLAW_TAG_), INTENT(INOUT)  :: MTAG
-      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM  
+      TYPE(MATPARAM_STRUCT_) ,INTENT(INOUT) :: MATPARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER :: ILAW,IMASS,IDEL,
-     .    IRUPT
-      my_real :: RHO0,FSCALEX,FSCALEX_UNIT,
-     .   E_ELAS_N,E_ELAS_S,TMAX_N,TMAX_S,
-     .                   GIC,GIIC,EXP_G,EXP_BK,DISP_0N,DISP_0S,DELTA0N,DELTA0S,UND,UTD,GAMA
+     .    IRUPT,ICRITTYP,IEVOSHAP
+      my_real :: RHO0,FSCALEX,FSCALEX_UNIT,UDN,UDS,ALPHA,EXP_ALPHA,DENOM,
+     .   E_ELAS_N,E_ELAS_S,TMAX_N,TMAX_S,COEF_N,COEF_T,COEF0,FUNC_ALPHA,
+     .   GIC,GIIC,EXP_G,EXP_BK,DELTA0N,DELTA0S,UND,UTD,GAMA
       LOGICAL :: IS_AVAILABLE,IS_ENCRYPTED
 C=======================================================================
       ILAW = 117
@@ -110,7 +110,7 @@ Card1
       CALL HM_GET_FLOATV('MAT_Fscale_x'   ,FSCALEX      ,IS_AVAILABLE, LSUBMODEL, UNITAB)
       IF(FSCALEX == ZERO) THEN
           CALL HM_GET_FLOATV_DIM('MAT_Fscale_x'  ,FSCALEX_UNIT    ,IS_AVAILABLE, LSUBMODEL, UNITAB)
-          FSCALEX = FSCALEX_UNIT  
+          FSCALEX = FSCALEX_UNIT
       ENDIF
       CALL HM_GET_FLOATV('MAT_E_ELAS_N'   ,E_ELAS_N     ,IS_AVAILABLE, LSUBMODEL, UNITAB)
       CALL HM_GET_FLOATV('MAT_E_ELAS_S'   ,E_ELAS_S     ,IS_AVAILABLE, LSUBMODEL, UNITAB)
@@ -125,6 +125,14 @@ Card1
       CALL HM_GET_FLOATV('MAT_EXP_G'    ,EXP_G      ,IS_AVAILABLE, LSUBMODEL, UNITAB)
       CALL HM_GET_FLOATV('MAT_EXP_BK'   ,EXP_BK     ,IS_AVAILABLE, LSUBMODEL, UNITAB)
       CALL HM_GET_FLOATV('MAT_GAMMA'    ,GAMA       ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+
+      CALL HM_GET_INTV  ('MAT_CRIT_TYPE'    ,ICRITTYP   ,IS_AVAILABLE, LSUBMODEL)
+      CALL HM_GET_INTV  ('MAT_EVO_SHAPE'    ,IEVOSHAP  ,IS_AVAILABLE, LSUBMODEL)
+
+      CALL HM_GET_FLOATV('MAT_DELTA_FN'    ,UDN       ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_DELTA_FS'    ,UDS       ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+      CALL HM_GET_FLOATV('MAT_ALPHA'       ,ALPHA     ,IS_AVAILABLE, LSUBMODEL, UNITAB)
+
 c---------------------------------------------------------------------------------
       PM(1) = RHO0  ! RHOR
       PM(89)= RHO0
@@ -133,64 +141,195 @@ C Number of User Element Variables and Curves
 C-------------------------------------------
       NUVAR = 15
       NFUNC = 2
-      NUPARAM = 18
+      NUPARAM = 20
 c-------------------
 c     Default Values
 c-------------------
-      IF (IDEL  == 0)   IDEL    = 1
-      IF (IMASS == 0)   IMASS   = 1
-      IF (IRUPT == 0)   IRUPT   = 1
-      IF (GAMA  == ZERO)   GAMA   = ONE
+      IF (IDEL  == 0)     IDEL     = 1
+      IF (IMASS == 0)     IMASS    = 1
+      IF (IRUPT == 0)     IRUPT    = 1
+      IF (ICRITTYP == 0)   ICRITTYP  = 1
+      IF (IEVOSHAP == 0)  IEVOSHAP = 1
+      IF (GAMA  == ZERO)  GAMA   = ONE
+      IF (ALPHA == ZERO)  ALPHA  = THREE
       IF (EXP_G  == ZERO) EXP_G   = TWO
       IF (E_ELAS_S == ZERO) E_ELAS_S = E_ELAS_N
-      IF ( GIC < (TMAX_N**2 / TWO/E_ELAS_N )  ) THEN
-        GIC = TMAX_N**2 / TWO/E_ELAS_N
-        CALL ANCMSG(MSGID=3016,MSGTYPE=MSGWARNING,ANMODE=ANINFO_BLIND_1,
-     .                I1 = MAT_ID,
-     .                C1 = TITR )
-      END IF
-      IF ( GIIC < (TMAX_S**2 / TWO/E_ELAS_S )  ) THEN
-        GIIC = TMAX_S**2 / TWO/E_ELAS_S
-        CALL ANCMSG(MSGID=3017,MSGTYPE=MSGWARNING,ANMODE=ANINFO_BLIND_1,
-     .                I1 = MAT_ID,
-     .                C1 = TITR )
-      END IF
 
+      ! INIT PARM
+      IF (IEVOSHAP == 3) THEN
+          !----------------------------------------------------------
+          ! Xu-Needleman exponential potential (IEVOSHAP = 3)
+          ! Mandatory inputs: GIC > 0, GIIC > 0, TMAX_N > 0, TMAX_S > 0
+          ! Derived: K0 = e^2 * Tn^2 / Gc,  delta_p = Gc / (e * Tn)
+          ! User EN, ES, UDN, UDS, ALPHA are ignored
+          !----------------------------------------------------------
+          IF (GIC <= ZERO) THEN
+              CALL ANCMSG(MSGID=3016,MSGTYPE=MSGERROR,
+     .                    ANMODE=ANINFO_BLIND_1,
+     .                    I1=MAT_ID, C1=TITR)
+              GIC = ONE ! DUMMY VALUE
+          ENDIF
+          
+          IF (GIIC <= ZERO) THEN
+              CALL ANCMSG(MSGID=3017,MSGTYPE=MSGERROR,
+     .                    ANMODE=ANINFO_BLIND_1,
+     .                    I1=MAT_ID, C1=TITR)
+              GIIC = ONE ! DUMMY VALUE 2
+          ENDIF
+          IF (TMAX_N <= ZERO) THEN
+              CALL ANCMSG(MSGID=3017,MSGTYPE=MSGERROR,
+     .                    ANMODE=ANINFO_BLIND_1,
+     .                    I1=MAT_ID, C1=TITR) 
+              TMAX_N = ONE
+          ENDIF
+          IF (TMAX_S <= ZERO) THEN
+              CALL ANCMSG(MSGID=3017,MSGTYPE=MSGERROR,
+     .                    ANMODE=ANINFO_BLIND_1,
+     .                    I1=MAT_ID, C1=TITR) 
+              TMAX_S = ONE
+          ENDIF  
+          
+          ! Derive Xu-Needlman params
+          E_ELAS_N = EXP(ONE)**2 * TMAX_N**2 / GIC
+          E_ELAS_S = EXP(ONE)**2 * TMAX_S**2 / GIIC      
+          
+          DELTA0N  = GIC  / (EXP(ONE) * TMAX_N)
+          DELTA0S  = GIIC / (EXP(ONE) * TMAX_S)
+          
+          UDN = -DELTA0N * LOG(EM04)
+          UDS = -DELTA0S * LOG(EM04)
+          
+          ICRITTYP = 1
+      ELSE ! IEVOSHAP = 1 or 2
+          EXP_ALPHA  = EXP(-ALPHA)
+          DENOM      = ONE - EXP_ALPHA
+          FUNC_ALPHA = (ONE - (ONE + ALPHA) * EXP_ALPHA)/(ALPHA * DENOM)
+          ! DFT VALUES for DELTA0
+          DELTA0N  = TMAX_N/E_ELAS_N !single mode damage initiation normal
+          DELTA0S  = TMAX_S/E_ELAS_S !single mode damage initiation tangential
+          ! INIT CHECK FOR GIC and UDN
+          IF (GIC == ZERO) THEN
+              IF (UDN == ZERO) THEN
+                  GIC = TMAX_N**2 / TWO / E_ELAS_N
+                  UDN = DELTA0N
+                  CALL ANCMSG(MSGID=3016,MSGTYPE=MSGWARNING,ANMODE=ANINFO_BLIND_1,
+     .                        I1 = MAT_ID,
+     .                        C1 = TITR)
+              ELSE
+                  ! LINEAR Criterion
+                  IF (IEVOSHAP == 1) THEN
+                      GIC = HALF * UDN * TMAX_N
+                  ! EXPO
+                  ELSE
+                      GIC = TMAX_N*DELTA0N*HALF + TMAX_N*(UDN - DELTA0N)*FUNC_ALPHA
+                  ENDIF
+              ENDIF
+          ELSE
+              IF ( GIC < (TMAX_N**2 / TWO/E_ELAS_N )  ) THEN
+                  GIC = TMAX_N**2 / TWO/ E_ELAS_N
+                  CALL ANCMSG(MSGID=3016,MSGTYPE=MSGWARNING,ANMODE=ANINFO_BLIND_1,
+     .                        I1 = MAT_ID,
+     .                        C1 = TITR )
+              ENDIF
 
+              IF (UDN == ZERO) THEN
+                  IF (IEVOSHAP == 1) THEN
+                      UDN = TWO*GIC / (DELTA0N * E_ELAS_N)
+                  ELSE
+                      COEF0 = GIC - TMAX_N * DELTA0N * HALF
+                      UDN = DELTA0N + COEF0 / (FUNC_ALPHA * TMAX_N)
+                  ENDIF
+              ENDIF
+          ENDIF
+          ! INIT CHECK FOR GIIC and UDS
+          IF (GIIC == ZERO) THEN
+              IF (UDS == ZERO) THEN
+                  GIIC = TMAX_S**2 / TWO / E_ELAS_S
+                  UDS  = DELTA0S
+                  CALL ANCMSG(MSGID=3017,MSGTYPE=MSGWARNING,ANMODE=ANINFO_BLIND_1,
+     .                        I1 = MAT_ID,
+     .                        C1 = TITR)
+              ELSE
+                  ! LINEAR Criterion
+                  IF (IEVOSHAP == 1) THEN
+                      GIIC = HALF * UDS * TMAX_S
+                  ! EXPO
+                  ELSE
+                      GIIC = TMAX_S*DELTA0S*HALF + TMAX_S*(UDS - DELTA0S)*FUNC_ALPHA
+                  ENDIF
+              ENDIF
+          ELSE
+              IF ( GIIC < (TMAX_S**2 / TWO / E_ELAS_S )  ) THEN
+                  GIIC =  TMAX_S**2 / TWO / E_ELAS_S
+                  CALL ANCMSG(MSGID=3017,MSGTYPE=MSGWARNING,ANMODE=ANINFO_BLIND_1,
+     .                        I1 = MAT_ID,
+     .                        C1 = TITR )
+              ENDIF
 
+              IF (UDS == ZERO) THEN
+                  IF (IEVOSHAP == 1) THEN
+                      UDS = TWO*GIIC / (DELTA0S * E_ELAS_S)
+                  ELSE
+                      COEF0 = GIIC - TMAX_S * DELTA0S * HALF
+                      UDS = DELTA0S + COEF0 / (FUNC_ALPHA * TMAX_S)
+                  ENDIF
+              ENDIF
+          ENDIF
+      ENDIF
+      ! IF GIC is empty, init the GIC with elastic energy
+      !IF ( GIC < (TMAX_N**2 / TWO/E_ELAS_N )  ) THEN
+      !  GIC = TMAX_N**2 / TWO/E_ELAS_N
+      !  CALL ANCMSG(MSGID=3016,MSGTYPE=MSGWARNING,ANMODE=ANINFO_BLIND_1,
+      !.                I1 = MAT_ID,
+      !.                C1 = TITR )
+      !END IF
+      !IF ( GIIC < (TMAX_S**2 / TWO/E_ELAS_S )  ) THEN
+      !  GIIC = TMAX_S**2 / TWO/E_ELAS_S
+      !  CALL ANCMSG(MSGID=3017,MSGTYPE=MSGWARNING,ANMODE=ANINFO_BLIND_1,
+      !.                I1 = MAT_ID,
+      !.                C1 = TITR )
+      !END IF
 
-      DELTA0N  = TMAX_N/E_ELAS_N !single mode damage initiation normal
-      DELTA0S  = TMAX_S/E_ELAS_S !single mode damage initiation tangential
-
-      UND  = TWO*GIC /(DELTA0N *E_ELAS_N)! ultimate displacement in normal direction (UND)
-      UTD  = TWO*GIIC/(DELTA0S *E_ELAS_S)! ultimate displacement in tangential direction (UTD)
-
-
+      ! INITIATE DELTA_F depending on the DMG model (lin or exp)
+      !IF (IEVOSHAP == 1) THEN
+      !    UND = TWO*GIC / (DELTA0N * E_ELAS_N) ! ultimate displacement in normal direction (UND) => G = UND*TN*HALF
+      !    UTD = TWO*GIIC / (DELTA0S * E_ELAS_S) ! ultimate displacement in tangential direction (UTD)
+      !ELSE
+      !    COEF_N = GIC - TMAX_N * DELTA0N * HALF
+      !    COEF_T = GIIC - TMAX_S * DELTA0S * HALF
+      !    COEF1 = ONE - (ONE + ALPHA) * EXP(-ALPHA)
+      !    COEF2 = ALPHA * (ONE - EXP(-ALPHA))
+      !
+      !    UND = DELTA0N + (COEF_N * COEF2) / (COEF1 * TMAX_N)
+      !    UTD = DELTA0S + (COEF_T * COEF2) / (COEF1 * TMAX_S)
+      !END IF
 
 
 C-------------------------------------------
 C User Material Parameters Definition
 C-------------------------------------------
 
-      DISP_0N = TMAX_N/E_ELAS_N
-      DISP_0S = TMAX_S/E_ELAS_S
-      UPARAM(1)  = E_ELAS_N 
-      UPARAM(2)  = E_ELAS_S 
+      UPARAM(1)  = E_ELAS_N
+      UPARAM(2)  = E_ELAS_S
       UPARAM(3)  = GAMA
       UPARAM(4)  = TMAX_N
-      UPARAM(5)  = TMAX_S  
-      UPARAM(6)  = IRUPT  
-      UPARAM(7)  = GIC  
+      UPARAM(5)  = TMAX_S
+      UPARAM(6)  = IRUPT
+      UPARAM(7)  = GIC
       UPARAM(8)  = GIIC
-      UPARAM(9)  = IDEL  
+      UPARAM(9)  = IDEL
       UPARAM(10) = EXP_G
-      UPARAM(11) = EXP_BK  
+      UPARAM(11) = EXP_BK
       UPARAM(12) = IMASS
-      UPARAM(13) = DELTA0N        !         DISP puremode 
-      UPARAM(14) = DELTA0S        !         DISP puremode 
-      UPARAM(15) = UND! ultimate displacement in normal direction (UND)
-      UPARAM(16) = UTD! ultimate displacement in tangential direction (UTD)
+      UPARAM(13) = DELTA0N        !         DISP puremode
+      UPARAM(14) = DELTA0S        !         DISP puremode
+      UPARAM(15) = UDN ! ultimate displacement in normal direction (UDN)
+      UPARAM(16) = UDS ! ultimate displacement in tangential direction (UDS)
       UPARAM(17) = FSCALEX
+
+      UPARAM(18) = ICRITTYP
+      UPARAM(19) = IEVOSHAP
+      UPARAM(20) = ALPHA
 
 C-------------------------------------------
 C Interface Contact
@@ -198,7 +337,7 @@ C-------------------------------------------
 C----------------
       PARMAT(1)  = MAX(E_ELAS_N,E_ELAS_S) / THREE
       PARMAT(2)  = MAX(E_ELAS_N,E_ELAS_S)
-      PARMAT(17) = ONE ! (ONE - TWO*NU)/(ONE - NU), NU=0      
+      PARMAT(17) = ONE ! (ONE - TWO*NU)/(ONE - NU), NU=0
 c
       MTAG%L_EPE  = 3
       MTAG%L_DMG  = 1
@@ -206,7 +345,7 @@ c
 c
       ! MATPARAM keywords
       CALL INIT_MAT_KEYWORD(MATPARAM,"HOOK")
-c 
+c
       ! Properties compatibility
       CALL INIT_MAT_KEYWORD(MATPARAM,"SOLID_COHESIVE")
 c-------------------
@@ -216,17 +355,18 @@ c-------------------
       WRITE(IOUT,1000)
       IF (IS_ENCRYPTED) THEN
         WRITE(IOUT,'(5X,A,//)')'CONFIDENTIAL DATA'
-      ELSE                                                     
+      ELSE
         WRITE(IOUT,1200) RHO0,E_ELAS_N,E_ELAS_S,TMAX_N,TMAX_S,
      .                   IFUNC(1),IFUNC(2),FSCALEX,
-     .                   IRUPT,GIC,GIIC,EXP_G,EXP_BK,GAMA
+     .                   IRUPT,GIC,GIIC,UDN,UDS,EXP_G,EXP_BK,GAMA,
+     .                   ICRITTYP,IEVOSHAP,ALPHA
       ENDIF
 c-----------
       RETURN
 C-------------------------------------------
  1000 FORMAT(
      & 10X,' MIXED MODE COHESIVE LAW 117  ',/,
-     & 10X,' ---------------------------  ',/)   
+     & 10X,' ---------------------------  ',/)
  1100 FORMAT(/
      & 5X,A,/,
      & 5X,'MATERIAL NUMBER . . . . . . . . . . . . . . .=',I10/,
@@ -247,10 +387,23 @@ c
 c
      & 5X,'ENERGY RELEASE RATE FOR MODE I. . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'ENERGY RELEASE RATE FOR MODE II . . . . . . . . . . . .=',1PG20.13/,
-
+c
+     & 5X,'MAXIMUM DISPLACEMENT (FAILURE) FOR MODE I . . . . . . .=',1PG20.13/,
+     & 5X,'MAXIMUM DISPLACEMENT (FAILURE) FOR MODE II. . . . . . .=',1PG20.13/,
+c
      & 5X,'POWER LAW EXPONENT MU . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'BENZEGGAGH-KENANE EXPONENT MU . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'BENZEGGAGH-KENANE EXPONENT GAMMA. . . . . . . . . . . .=',1PG20.13/)
-
+     & 5X,'BENZEGGAGH-KENANE EXPONENT GAMMA. . . . . . . . . . . .=',1PG20.13/,
+c
+     & 5X,'CHOICE OF THE FAILURE CRITERION . . . . . . . . . . . .=',I10/,
+     & 5X,'             = 1 => DISP-BASED (COHDISP)                   '/,
+     & 5X,'             = 2 => ENERGY-BASED (COHENRG)                 '/,
+c
+     & 5X,'CHOICE OF THE DAMAGE EVOLUTION. . . . . . . . . . . . .=',I10/,
+     & 5X,'             = 1 => LINEAR (LINEAR-LINEAR)                 '/,
+     & 5X,'             = 2 => EXPONENTIAL (LINEAR-EXPONENTIAL)       '/,
+     & 5X,'             = 3 => XU-NEEDLEMAN EXPONENTIAL (C-INFTY)     '/,
+c
+     & 5X,'EXPONENTIAL DAMAGE EXPONENT ALPHA . . . . . . . . . . .=',1PG20.13/)
 c--------
       END


### PR DESCRIPTION
/MAT/LAW117: add damage criterion and evolution shape options (linear/exponential/Xu-Needleman)

New input parameters in radioss2026 format (CRITTYPE, EVOSHAPE,DELTA_FN, DELTA_FS, ALPHA):
  - CRITTYPE = 1 displacement-based (default), 2 energy-based;
  - EVOSHAPE = 1 linear (default), 2 exponential, 3 Xu-Needleman (basic implementation, I need to work on it to implement the original potential function of Xu-Needleman);
  - DELTA_FN/DELTA_FS: failure displacements (modes I/II);
  - ALPHA: shape parameter for exponential evolution;

For more details, please refer to the draft paper submitted via email on Wednesday, May 6, 2026. 