### PR TITLE
LAW51 submat internal ids in IPM(21:24)

### DIFF
--- a/starter/source/materials/mat/mat051/fill_buffer_51.F
+++ b/starter/source/materials/mat/mat051/fill_buffer_51.F
@@ -276,6 +276,7 @@ C-----------------------------------------------
        DO I=1,NBMAT
          IMID     = NINTRI(MID(I),IPM,NPROPMI,NUMMAT,1)
          MAT_PARAM(INTERNAL_ID)%MULTIMAT%MID(I) = IMID !user ID -> internal ID
+         IPM(20+I,INTERNAL_ID) = IMID
          EOS_TYPE = IPM(4,IMID)
          MLN      = IPM(2,IMID)
          IF(EOS_TYPE == 0 .AND. MLN /= 5)THEN


### PR DESCRIPTION
#### LAW51 submat internal ids in IPM(21:24)

#### Description of the changes
Potential issue in Eikonal solver when computing detonation velocity in mixed cells.
Material identifier were not yet updated into internal identifiers. It is now fixed
