### PR TITLE
/LAW92 Starter - NU Computation Update

### DIFF
--- a/starter/source/materials/mat/mat092/hm_read_mat92.F
+++ b/starter/source/materials/mat/mat092/hm_read_mat92.F
@@ -165,7 +165,7 @@ C
        NFUNC = 1
        IF (NU == ZERO) NU= 0.495
       ELSEIF(D == ZERO) THEN
-        NU = 0.495
+        IF (NU==ZERO) NU = 0.495
         RBULK = TWO_THIRD*(ONE + NU)*G/(ONE - TWO*NU)
         D  = TWO/RBULK 
       ELSE


### PR DESCRIPTION
#### Description of the feature or the bug
NU was set to 0.495 whenever D = 0, even if the user had defined a value for NU

#### Description of the changes
To let users define the material compressibility using either D or NU, a new conditional is added to check if NU is also zero before setting it to 0.495