### PR TITLE
/INTER/TYPE7:  More asynchronism on contact interface

### DIFF
--- a/engine/share/modules/inter_struct_mod.F
+++ b/engine/share/modules/inter_struct_mod.F
@@ -81,6 +81,22 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
                 integer, dimension(:), allocatable :: next_nod !< next_node(i) is the next node of node i in the same voxel cell
                 integer, dimension(:), allocatable ::  last_nod
                 integer :: istart !< next available space in next_nod and last_nod
+                ! inverse nsv map: inv_nsv(global_node) = local secondary index (0 if not secondary)
+                integer, dimension(:), allocatable :: inv_nsv
+                ! remote voxel structure (separate from local for overlapped search)
+                integer, dimension(:), allocatable :: voxel_remote
+                integer :: voxel_remote_size = 0
+                integer :: size_node_remote = 0 !< size of remote node arrays
+                integer, dimension(:), allocatable :: next_nod_remote !< next node in remote voxel (1-based)
+                integer, dimension(:), allocatable :: last_nod_remote
+                integer :: nb_voxel_on_remote = 0
+                integer, dimension(:), allocatable :: list_nb_voxel_on_remote
+                ! cumulative timing (seconds) for overlap analysis
+                double precision :: t_fill_local = 0.0d0    !< time in FILL_VOXEL_LOCAL
+                double precision :: t_mpi_wait = 0.0d0      !< time waiting in MPI_WAITANY
+                double precision :: t_fill_remote = 0.0d0   !< time in FILL_VOXEL_REMOTE
+                double precision :: t_candidate_pairs = 0.0d0 !< time in INTER7_CANDIDATE_PAIRS
+                integer :: n_calls = 0                       !< number of sort calls (for averaging)
             END TYPE inter_struct_type  
         END MODULE INTER_STRUCT_MOD
 

--- a/engine/source/interfaces/generic/inter_prepare_sort.F
+++ b/engine/source/interfaces/generic/inter_prepare_sort.F
@@ -132,8 +132,8 @@ C-----------------------------------------------
  
  
         integer :: nsn, nsnr, nrtm, nmn
-        integer :: DUMMY(1)
         my_real :: tzinf,curv        
+        integer(8) :: t0_clock, t1_clock, clock_rate
 !   ----------------------------------------
         nsn = 0
         nsnr = 0
@@ -250,6 +250,23 @@ C-----------------------------------------------
                 nsnr = IPARI(24,N)
                 nmn = IPARI(6,N)
                 call compute_voxel_dimensions(nmn, nrtm, inter_struct(N))
+                call system_clock(t0_clock, clock_rate)
+                CALL FILL_VOXEL_LOCAL(1, nsn, nsnr,
+     .            inter_struct(N)%nbx, inter_struct(N)%nby,
+     .            inter_struct(N)%nbz,
+     .            nrtm, numnod, intbuf_tab(N)%nsv,
+     .            inter_struct(N)%voxel,
+     .            inter_struct(N)%next_nod,
+     .            inter_struct(N)%size_node,
+     .            inter_struct(N)%nb_voxel_on,
+     .            inter_struct(N)%list_nb_voxel_on,
+     .            inter_struct(N)%last_nod,
+     .            x, intbuf_tab(N)%stfns,
+     .            inter_struct(N)%box_limit_main)
+                call system_clock(t1_clock)
+                inter_struct(N)%t_fill_local =
+     .            inter_struct(N)%t_fill_local +
+     .            dble(t1_clock - t0_clock) / dble(clock_rate)
               endif
               ! -----------------------------
               ! creation of voxel of secondary nodes 
@@ -259,13 +276,7 @@ C-----------------------------------------------
               CALL SPMD_CELL_LIST_EXCHANGE(IRECVFROM,ISENDTO,mode,WEIGHT,IAD_ELEM,
      .                 FR_ELEM,X,V,MS,TEMP,
      .                 KINET,NODNX_SMS,ITAB,INTBUF_TAB,IPARI,
-     .                 N,INTER_STRUCT,SORT_COMM,NODNX_SMS_SIZ,TEMP_SIZ, GOT_PREVIEW,component) !   mpi wait size of cell list
-
-              ! -----------------------------
-              if(GOT_PREVIEW == 1) THEN
-                CALL FILL_VOXEL_LOCAL_PARTIAL(nsn,intbuf_tab(n)%nsv,nsnr,nrtm,numnod,x,intbuf_tab(N)%stfns,INTER_STRUCT(N),
-     .                   sort_comm(n)%request_cell_rcv, sort_comm(n)%NB_REQUEST_CELL_RCV)
-              endif            
+     .                 N,INTER_STRUCT,SORT_COMM,NODNX_SMS_SIZ,TEMP_SIZ, GOT_PREVIEW,component) !   mpi wait size of cell list            
               ! -----------------------------
               ! wait comm R "send/rcv the colored cells" 
               ! and compute the number of secondary nodes needed by remote proc 
@@ -284,8 +295,23 @@ C-----------------------------------------------
               if(GOT_PREVIEW == 1) THEN
                 nrtm = IPARI(4,N) ;   nsn = IPARI(5,N) ; nsnr = IPARI(24,N) ; nmn = IPARI(6,N)
                 call compute_voxel_dimensions(nmn, nrtm, inter_struct(N))
-                CALL FILL_VOXEL_LOCAL_PARTIAL(nsn,intbuf_tab(n)%nsv,nsnr,nrtm,numnod,x,
-     .                                           intbuf_tab(N)%stfns,INTER_STRUCT(N),DUMMY,0) 
+                call system_clock(t0_clock, clock_rate)
+                CALL FILL_VOXEL_LOCAL(1, nsn, nsnr,
+     .            inter_struct(N)%nbx, inter_struct(N)%nby,
+     .            inter_struct(N)%nbz,
+     .            nrtm, numnod, intbuf_tab(N)%nsv,
+     .            inter_struct(N)%voxel,
+     .            inter_struct(N)%next_nod,
+     .            inter_struct(N)%size_node,
+     .            inter_struct(N)%nb_voxel_on,
+     .            inter_struct(N)%list_nb_voxel_on,
+     .            inter_struct(N)%last_nod,
+     .            x, intbuf_tab(N)%stfns,
+     .            inter_struct(N)%box_limit_main)
+                call system_clock(t1_clock)
+                inter_struct(N)%t_fill_local =
+     .            inter_struct(N)%t_fill_local +
+     .            dble(t1_clock - t0_clock) / dble(clock_rate)
               ENDIF
             ENDDO
           ENDIF
@@ -310,11 +336,7 @@ C-----------------------------------------------
      .                 KINET,NODNX_SMS,ITAB,INTBUF_TAB,IPARI,
      .                 N,INTER_STRUCT,SORT_COMM,NODNX_SMS_SIZ,TEMP_SIZ, GOT_PREVIEW,component)
                     ! wait "number of secondary nodes needed by remote proc"
-              if(GOT_PREVIEW == 1) THEN
-                nrtm = IPARI(4,N) ;   nsn = IPARI(5,N) ; nsnr = IPARI(24,N) ; nmn = IPARI(6,N)
-                CALL FILL_VOXEL_LOCAL_PARTIAL(nsn,intbuf_tab(n)%nsv,nsnr,nrtm,numnod,x,intbuf_tab(N)%stfns,INTER_STRUCT(N),
-     .                     SORT_COMM(N)%REQUEST_NB_R, SORT_COMM(N)%NBRECV_NB)
-              endif
+
 
               CALL SPMD_WAIT_NB(IRECVFROM,ISENDTO,N,SORT_COMM)    
             ENDIF

--- a/engine/source/interfaces/int07/inter_sort_07.F
+++ b/engine/source/interfaces/int07/inter_sort_07.F
@@ -74,6 +74,7 @@ C-----------------------------------------------
         USE INTBUFDEF_MOD 
         USE INTER7_COLLISION_DETECTION_MOD
         use check_sorting_criteria_mod , only : check_sorting_criteria
+        USE EXTEND_ARRAY_MOD, ONLY : extend_array
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -137,6 +138,7 @@ C-----------------------------------------------
         INTEGER :: NSN,NMN,NTY,NRTM
         logical :: need_computation
         real:: T1
+        INTEGER :: OLD_NCONTACT
 C-----------------------------------------------
         ! --------------
         ! check if the current interface needs to be sorted
@@ -201,16 +203,23 @@ C -------------------------------------------------------------
         RESULT = 0
         NMN_G = INTER_STRUCT(NIN)%NMN_G
 !$OMP END SINGLE
+        CAND_N_OLD = INTBUF_TAB%I_STOK(1)
+        OLD_NCONTACT = NCONTACT
 
         IF(NSPMD > 1) THEN
         ! ---------------------------
             IF(ITASK==0)THEN
             ! ---------------------------
             ! send/rcv the secondary node data
-                CALL SPMD_CELL_EXCHANGE(TIMERS, NIN,ISENDTO,IRCVFROM,NSN,NSNR,IPARI(21,NIN),
+                CALL SPMD_CELL_EXCHANGE(IPARI(23,NIN), TIMERS, NIN,ISENDTO,IRCVFROM,NSN,NSNR,IPARI(21,NIN),
      1                                   IFQ,INACTI,NSNFIOLD,IPARI(47,NIN),NTY, intbuf_tab%stfns, intbuf_tab%nsv,
-     2                                   NRTM, X,
-     2                                   ITIED,NMN,INTER_STRUCT,SORT_COMM, GOT_PREVIEW)
+     2                                   NRTM, X,I_MEM,
+     2                                   ITIED,NMN,INTER_STRUCT,SORT_COMM, GOT_PREVIEW,
+     3                                   INTBUF_TAB, ESHIFT, NCONTACT,
+     4                                   NSNROLD, IPARI(63,NIN),
+     5                                   GAP, GAPMIN, GAPMAX,
+     6                                   TZINF, INTBUF_TAB%VARIABLES(bgapsmx_index),
+     7                                   DRAD, DGAPLOADP)
 C
                 IF(INACTI==5.OR.INACTI==6.OR.INACTI==7.OR.
      +               IFQ>0.OR.ITIED/=0)THEN
@@ -223,7 +232,6 @@ C
         END IF
         ! Voxel remote secondary nodes
         ! ---------------------------
-        CAND_N_OLD = INTBUF_TAB%I_STOK(1)
  40     CONTINUE
 C
         ILD = 0
@@ -235,7 +243,7 @@ C
             ALLOCATE( LIST_REMOTE_S_NODE(NSNR) )
             REMOTE_S_NODE = 0
         ENDIF
-        CALL MY_BARRIER                          
+        CALL MY_BARRIER
 
         IF(IPARI(63,NIN) ==2 ) INTBUF_TAB%METRIC%ALGO = ALGO_VOXEL 
  
@@ -250,7 +258,8 @@ C
         IF (IMONM > 0 .AND. ITASK == 0) CALL STARTIME(TIMERS,30)
 C
         IF(GOT_PREVIEW == 1) THEN
-            CALL INTER7_COLLISION_DETECTION(
+!           IF(I_MEM == 0) THEN
+            CALL INTER7_COLLISION_DETECTION(IPARI(23,NIN) ,
      1      X      ,INTBUF_TAB%IRECTM,INTBUF_TAB%NSV       ,INACTI    ,INTBUF_TAB%CAND_P,
      2      NRTM           ,NSN                  ,INTBUF_TAB%CAND_E,INTBUF_TAB%CAND_N,
      3      GAP    ,NOINT            ,INTBUF_TAB%I_STOK(1) ,NCONTACT ,INTER_STRUCT(NIN)%BOX_LIMIT_MAIN,
@@ -265,6 +274,45 @@ C
      F      INTER_STRUCT(NIN)%SIZE_CAND_A,
      .      INTBUF_TAB%S_KREMNODE, INTBUF_TAB%S_REMNODE, NSPMD, NUMNOD, INTER_STRUCT(nin),
      .      INTHEAT, IDT_THERM, NODADT_THERM)
+
+
+      ! -----------------------------------------------
+      ! reallocate other arrays if needed
+      ! (if extend_array was called in collision detection)
+      ! Use SIZE(CAND_N) as authoritative size since
+      ! different threads may have different NCONTACT values
+      ! after the OMP DO in the REMOTE search.
+      ! -----------------------------------------------
+            CALL MY_BARRIER
+            IF (ITASK == 0) THEN
+              NCONTACT = SIZE(INTBUF_TAB%CAND_N)
+              IF (NCONTACT /= OLD_NCONTACT) THEN
+                ! extend ftsavx/ftsavy/ftsavz (only if friction active)
+                IF (IFQ /= 0) THEN
+                  CALL extend_array(INTBUF_TAB%FTSAVX,OLD_NCONTACT,
+     .                              NCONTACT)
+                  CALL extend_array(INTBUF_TAB%FTSAVY,OLD_NCONTACT,
+     .                              NCONTACT)
+                  CALL extend_array(INTBUF_TAB%FTSAVZ,OLD_NCONTACT,
+     .                              NCONTACT)
+                  INTBUF_TAB%S_FTSAVX = NCONTACT
+                  INTBUF_TAB%S_FTSAVY = NCONTACT
+                  INTBUF_TAB%S_FTSAVZ = NCONTACT
+                ENDIF
+                ! update size metadata
+                INTBUF_TAB%S_CAND_N = NCONTACT
+                INTBUF_TAB%S_CAND_E = NCONTACT
+                IF (IFQ /= 0) INTBUF_TAB%S_IFPEN = NCONTACT
+                IF (INACTI==5.OR.INACTI==6.OR.INACTI==7)
+     .            INTBUF_TAB%S_CAND_P = NCONTACT
+                IF (ITIED /= 0) INTBUF_TAB%S_CAND_F = 8*NCONTACT
+                MULTIMP = IPARI(23,NIN)
+              ENDIF
+            ENDIF
+            CALL MY_BARRIER
+            ! All threads sync NCONTACT from actual array size
+            NCONTACT = SIZE(INTBUF_TAB%CAND_N)
+!           ENDIF
 
         ELSE IF(INTBUF_TAB%METRIC%ALGO == ALGO_VOXEL .OR.  INTBUF_TAB%METRIC%ALGO == TRY_ALGO_VOXEL) THEN
             FIRST = 1 + ITASK*(NRTM/NTHREAD)

--- a/engine/source/interfaces/int07/preview.md
+++ b/engine/source/interfaces/int07/preview.md
@@ -1,0 +1,113 @@
+# `-preview` Command Line Option: MPI/Computation Overlap for Broad Phase Collision Detection
+
+## Overview
+
+When the `-preview` flag is passed on the command line to the engine, it activates an optimized broad phase collision detection path that overlaps candidate pair search with MPI communication. The goal is to hide the latency of MPI exchanges by performing the local candidate pair search while waiting for remote secondary node data to arrive.
+
+## Activation
+
+The flag is parsed in [`execargcheck.F`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/source/engine/execargcheck.F) and stored in the module-level integer variable `GOT_PREVIEW` (defined in [`COMMAND_LINE_ARGS_MOD`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/share/modules/command_line_args.F)):
+
+- `GOT_PREVIEW = 0` — default behavior (legacy sorting algorithm)
+- `GOT_PREVIEW = 1` — overlap mode enabled
+
+## Behavior
+
+### Without `-preview` (legacy path)
+
+1. The segment list (NRTM) is split across OpenMP threads (`ESHIFT` partitioning).
+2. MPI exchange of secondary node data ([`SPMD_CELL_EXCHANGE`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/source/mpi/generic/spmd_cell_exchange.F)) completes fully before the sorting begins.
+3. The broad phase uses the [`I7BUCE_VOX`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/source/interfaces/intsort/i7buce.F) / `I7BUCE` bucket sort routine, which allocates and fills the voxel in a single pass after all data is available.
+
+### With `-preview` (overlap path)
+
+The key idea is to **overlap the local candidate pair search with the MPI exchange of remote secondary node data**. Since the local voxel is complete before the exchange starts, the local search can proceed immediately while remote data is in transit. Remote nodes are inserted into a **separate remote voxel** as messages arrive, and the remote candidate pair search runs after all data is received.
+
+1. **Pre-sort phase** ([`inter_prepare_sort.F`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/source/interfaces/generic/inter_prepare_sort.F)):
+   - Voxel dimensions are computed as soon as the bounding box information is known ([`compute_voxel_dimensions`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/source/interfaces/intsort/voxel_dimensions.F90)).
+   - [`FILL_VOXEL_LOCAL`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/source/interfaces/intsort/fill_voxel.F90) is called to insert **all** local secondary nodes into the local voxel in a single pass. This completes before the MPI exchange begins.
+
+2. **MPI exchange + local search phase** ([`spmd_cell_exchange.F`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/source/mpi/generic/spmd_cell_exchange.F)):
+   - Non-blocking sends (`MPI_ISEND`) and receives (`MPI_IRECV`) of secondary node data (coordinates, integer data) are posted.
+   - [`INTER7_CANDIDATE_PAIRS_LOCAL`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/source/interfaces/intsort/inter7_candidate_pairs.F90) is called immediately after posting the sends/receives. This performs the **full local candidate pair search** using the pre-built local voxel, while MPI transfers are in flight. This is the main source of overlap — the local search (which is the bulk of the computation) runs concurrently with network communication.
+   - After the local search completes, a `MPI_WAITANY` loop processes receives as they complete: each time a message arrives, [`FILL_VOXEL_REMOTE_SEPARATE`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/source/interfaces/intsort/fill_voxel.F90) immediately inserts the received remote secondary nodes into a **separate remote voxel** structure — overlapping communication of subsequent messages with voxel insertion of already-received data.
+
+3. **Remote collision detection** ([`inter_sort_07.F`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/source/interfaces/int07/inter_sort_07.F)):
+   - The full segment list is passed to all threads (`ESHIFT = 0`, `NRTM_T = NRTM`) rather than being statically pre-partitioned by the caller. This is because the candidate pair routines use `!$OMP DO SCHEDULE(DYNAMIC)` internally to distribute the loop over segments across threads. Dynamic scheduling provides better load balancing since the work per segment varies (different number of neighboring voxels and candidate nodes).
+   - [`INTER7_COLLISION_DETECTION`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/source/interfaces/intsort/inter7_collision_detection.F90) is called to perform the **remote candidate pair search** using the separate remote voxel via [`INTER7_CANDIDATE_PAIRS_REMOTE`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/source/interfaces/intsort/inter7_candidate_pairs.F90).
+
+## Data Flow
+
+1. **`inter_prepare_sort`** — voxel structure preparation
+   - `compute_voxel_dimensions`
+   - `FILL_VOXEL_LOCAL` (all local nodes, single pass)
+
+2. **`spmd_cell_exchange`** — MPI exchange + local candidate search
+   - `MPI_ISEND` / `MPI_IRECV` (secondary node coordinates + integer data) — posted, non-blocking
+   - `INTER7_CANDIDATE_PAIRS_LOCAL` (`!$OMP DO SCHEDULE(DYNAMIC)` over segments, local voxel) — **overlaps with MPI transfers**
+   - Loop: `MPI_WAITANY` (receives)
+     - `FILL_VOXEL_REMOTE_SEPARATE` (insert received remote nodes into separate remote voxel) — overlaps with remaining receives
+
+3. **`inter_sort_07`** — remote candidate pair enumeration
+   - `INTER7_COLLISION_DETECTION`
+     - `INTER7_CANDIDATE_PAIRS_REMOTE` (`!$OMP DO SCHEDULE(DYNAMIC)` over segments, remote voxel)
+
+## Timeline
+
+```
+[FILL_VOXEL_LOCAL]
+                   [MPI_IRECV + MPI_ISEND (non-blocking) ══════════════════]
+                   [INTER7_CANDIDATE_PAIRS_LOCAL ═════════]
+                                                           [WAITANY → FILL_VOXEL_REMOTE ═══]
+                                                                                             [CANDIDATE_PAIRS_REMOTE]
+```
+
+## Key Subroutines
+
+| Subroutine | File | Role |
+|---|---|---|
+| `FILL_VOXEL_LOCAL` | [`fill_voxel.F90`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/source/interfaces/intsort/fill_voxel.F90) | Inserts all local secondary nodes into the local voxel (full single pass) |
+| `FILL_VOXEL_REMOTE_SEPARATE` | [`fill_voxel.F90`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/source/interfaces/intsort/fill_voxel.F90) | Inserts a batch of received remote secondary nodes into a separate remote voxel (1-based indexing) |
+| `INTER7_CANDIDATE_PAIRS_LOCAL` | [`inter7_candidate_pairs.F90`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/source/interfaces/intsort/inter7_candidate_pairs.F90) | Enumerates node–segment candidate pairs from the local voxel (called during MPI exchange) |
+| `INTER7_CANDIDATE_PAIRS_REMOTE` | [`inter7_candidate_pairs.F90`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/source/interfaces/intsort/inter7_candidate_pairs.F90) | Enumerates node–segment candidate pairs from the remote voxel |
+| `INTER7_COLLISION_DETECTION` | [`inter7_collision_detection.F90`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/source/interfaces/intsort/inter7_collision_detection.F90) | Calls the remote candidate pair search after MPI exchange is complete |
+| `SPMD_CELL_EXCHANGE` | [`spmd_cell_exchange.F`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/source/mpi/generic/spmd_cell_exchange.F) | MPI exchange of secondary node data + local candidate pair search (overlapped) |
+
+## Data Structures
+
+The `inter_struct_type` (defined in [`inter_struct_mod.F`](https://github.com/OpenRadioss/OpenRadioss/blob/main/engine/share/modules/inter_struct_mod.F)) holds both local and remote voxel data:
+
+- **Local voxel**: `voxel`, `next_nod`, `last_nod`, `nb_voxel_on`, `list_nb_voxel_on`
+- **Remote voxel** (separate): `voxel_remote`, `next_nod_remote`, `last_nod_remote`, `nb_voxel_on_remote`, `list_nb_voxel_on_remote`, `size_node_remote`
+
+Remote nodes are indexed 1..NSNR in the remote voxel arrays. The search subroutine maps `jj -> nsn+jj` for downstream compatibility with the candidate pair arrays.
+
+### Timing fields (for performance analysis)
+
+| Field | Description |
+|---|---|
+| `t_fill_local` | Cumulative time in `FILL_VOXEL_LOCAL` |
+| `t_mpi_wait` | Cumulative time waiting in `MPI_WAITANY` |
+| `t_fill_remote` | Cumulative time in `FILL_VOXEL_REMOTE_SEPARATE` |
+| `t_candidate_pairs` | Cumulative time in `INTER7_CANDIDATE_PAIRS_LOCAL` + `INTER7_CANDIDATE_PAIRS_REMOTE` |
+| `n_calls` | Number of sort calls (for averaging) |
+
+## Performance Rationale
+
+In SPMD (distributed memory) runs, each process needs remote secondary node positions to perform collision detection on its local main segments. The traditional approach serializes the steps:
+
+```
+[MPI exchange] ──► [voxel fill] ──► [candidate search]
+```
+
+With `-preview`, the local candidate pair search runs while MPI transfers are in flight:
+
+```
+[FILL_VOXEL_LOCAL]
+                   [MPI Isend/Irecv ═══════════════════════════]
+                   [CANDIDATE_PAIRS_LOCAL ═══════]
+                                                  [WAITANY → FILL_REMOTE]
+                                                                         [CANDIDATE_PAIRS_REMOTE]
+```
+
+This reduces the wall-clock time of the broad phase sorting step by hiding the local candidate pair search (the most expensive computation) behind MPI communication latency. The separation of local and remote voxels is essential: the local voxel is complete and searchable immediately, while the remote voxel is built incrementally as messages arrive.

--- a/engine/source/interfaces/intsort/fill_voxel.F90
+++ b/engine/source/interfaces/intsort/fill_voxel.F90
@@ -477,4 +477,116 @@
           !deallocate(last_nod)
         END SUBROUTINE FILL_VOXEL_REMOTE
 
+!! \brief Fill a separate remote voxel grid with remote nodes using 1-based indexing
+!! \details Remote nodes are indexed 1..nsnr in voxel_remote/next_nod_remote/last_nod_remote
+!!          The search subroutine maps jj -> nsn+jj for downstream compatibility
+        SUBROUTINE FILL_VOXEL_REMOTE_SEPARATE( &
+        & istart,&
+        & iend,&
+        & nsnr,&
+        & nbx,&
+        & nby,&
+        & nbz,&
+        & s_xrem,&
+        & voxel_remote,&
+        & next_nod_remote,&
+        & size_nod_remote, &
+        & nb_voxel_on_remote,&
+        & list_nb_voxel_on_remote,&
+        & last_nod_remote, &
+        & xrem,&
+        & box_limit_main)
+          USE PRECISION_MOD, ONLY : WP
+          USE CONSTANT_MOD
+          USE EXTEND_ARRAY_MOD, ONLY : extend_array
+! ----------------------------------------------------------------------------------------------------------------------
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          integer, intent(in), value :: istart !< starting index (1-based into xrem)
+          integer, intent(in), value :: iend !< ending index (1-based into xrem)
+          integer, intent(in), value :: nsnr !< number of remote secondary nodes
+          integer, intent(in), value :: nbx !< number of cells in x direction
+          integer, intent(in), value :: nby !< number of cells in y direction
+          integer, intent(in), value :: nbz !< number of cells in z direction
+          integer, intent(in), value :: s_xrem !< number of double data for remote nodes
+          integer, intent(inout) :: voxel_remote((nbx+2)*(nby+2)*(nbz+2)) !< remote voxel data structure
+          integer, dimension(:), allocatable, intent(inout) :: next_nod_remote !< next node in the remote voxel
+          integer, intent(inout) :: size_nod_remote !< size of the remote nod arrays
+          integer, intent(inout) :: nb_voxel_on_remote !< number of remote voxels with nodes
+          integer, dimension(:), allocatable, intent(inout) :: list_nb_voxel_on_remote !< list of remote voxels with nodes
+          real(kind=WP), intent(in) :: xrem(s_xrem,nsnr) !< remote node data
+          real(kind=WP), intent(in) :: box_limit_main(12) !< bounding box of the main segments
+          integer, dimension(:), allocatable, intent(inout) :: last_nod_remote
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   local variables
+! ----------------------------------------------------------------------------------------------------------------------
+          integer :: j
+          real(kind=WP) :: xmin, xmax, ymin, ymax, zmin, zmax
+          real(kind=WP) :: xminb, xmaxb, yminb, ymaxb, zminb, zmaxb
+          integer :: ix, iy, iz
+          integer :: first, last
+          integer :: cellid
+
+! Bounding box of the model
+          xmin = box_limit_main(4)
+          ymin = box_limit_main(5)
+          zmin = box_limit_main(6)
+          xmax = box_limit_main(1)
+          ymax = box_limit_main(2)
+          zmax = box_limit_main(3)
+
+! Reduced bounding box
+          xminb = box_limit_main(10)
+          yminb = box_limit_main(11)
+          zminb = box_limit_main(12)
+          xmaxb = box_limit_main(7)
+          ymaxb = box_limit_main(8)
+          zmaxb = box_limit_main(9)
+
+! Ensure arrays are large enough
+          call extend_array(last_nod_remote, size_nod_remote, nsnr)
+          call extend_array(next_nod_remote, size_nod_remote, nsnr)
+          call extend_array(list_nb_voxel_on_remote, size_nod_remote, nsnr)
+          size_nod_remote = max(size_nod_remote, nsnr)
+
+! Add remote nodes to the remote voxel grid (1-based indexing: j goes from 1..nsnr)
+          do j = istart, iend
+            if(xrem(1,j) < xmin)  cycle
+            if(xrem(1,j) > xmax)  cycle
+            if(xrem(2,j) < ymin)  cycle
+            if(xrem(2,j) > ymax)  cycle
+            if(xrem(3,j) < zmin)  cycle
+            if(xrem(3,j) > zmax)  cycle
+            ix=int(nbx*(xrem(1,j)-xminb)/(xmaxb-xminb))
+            iy=int(nby*(xrem(2,j)-yminb)/(ymaxb-yminb))
+            iz=int(nbz*(xrem(3,j)-zminb)/(zmaxb-zminb))
+            ix=max(1,2+min(nbx,ix))
+            iy=max(1,2+min(nby,iy))
+            iz=max(1,2+min(nbz,iz))
+
+            cellid = (iz-1)*(nbx+2)*(nby+2)+(iy-1)*(nbx+2)+ix
+
+            first = voxel_remote(cellid)
+
+            if(first == 0)then
+              nb_voxel_on_remote = nb_voxel_on_remote + 1
+              list_nb_voxel_on_remote(nb_voxel_on_remote) = cellid
+              voxel_remote(cellid) = j ! first (1-based)
+              next_nod_remote(j) = 0   ! last one
+              last_nod_remote(j) = 0   ! no last
+            else if(last_nod_remote(first) == 0)then
+              next_nod_remote(first) = j ! next
+              last_nod_remote(first) = j ! last
+              next_nod_remote(j) = 0     ! last one
+            else
+              last = last_nod_remote(first) ! last node in this voxel
+              next_nod_remote(last) = j    ! next
+              last_nod_remote(first) = j   ! last
+              next_nod_remote(j) = 0       ! last one
+            end if
+          end do
+        END SUBROUTINE FILL_VOXEL_REMOTE_SEPARATE
+
       END MODULE FILL_VOXEL_MOD

--- a/engine/source/interfaces/intsort/inter7_candidate_pairs.F90
+++ b/engine/source/interfaces/intsort/inter7_candidate_pairs.F90
@@ -25,29 +25,16 @@
 !||--- called by ------------------------------------------------------
 !||    inter7_collision_detection   ../engine/source/interfaces/intsort/inter7_collision_detection.F90
 !||    main                         ../engine/unit_test/unit_test1.F
-!||====================================================================
+!||====================================================================/
       MODULE INTER7_CANDIDATE_PAIRS_MOD
       implicit none
       CONTAINS
 
-!! \brief get the list of candidates pairs for all main segments
-!||====================================================================
-!||    inter7_candidate_pairs       ../engine/source/interfaces/intsort/inter7_candidate_pairs.F90
-!||--- called by ------------------------------------------------------
-!||    inter7_collision_detection   ../engine/source/interfaces/intsort/inter7_collision_detection.F90
-!||--- calls      -----------------------------------------------------
-!||    inter7_filter_cand           ../engine/source/interfaces/intsort/inter7_filter_cand.F90
-!||--- uses       -----------------------------------------------------
-!||    collision_mod                ../engine/source/interfaces/intsort/collision_mod.F
-!||    constant_mod                 ../common_source/modules/constant_mod.F
-!||    inter7_filter_cand_mod       ../engine/source/interfaces/intsort/inter7_filter_cand.F90
-!||    precision_mod                ../common_source/modules/precision_mod.F90
-!||====================================================================
-        SUBROUTINE INTER7_CANDIDATE_PAIRS(&
+!! \brief Search for candidate pairs using ONLY LOCAL nodes (voxel contains local nodes only)
+!! \details Called before MPI_WAITANY to overlap computation with communication.
+!!          Uses the local voxel (indices 1..nsn). No remote node processing.
+        SUBROUTINE INTER7_CANDIDATE_PAIRS_LOCAL(multimp_param ,&
         &                                    nsn          ,&
-        &                                    oldnum       ,&
-        &                                    nsnr         ,&
-        &                                    isznsnr      ,&
         &                                    i_mem        ,&
         &                                    irect        ,&
         &                                    x            ,&
@@ -72,7 +59,6 @@
         &                                    cand_p       ,&
         &                                    ifpen        ,&
         &                                    nrtm         ,&
-        &                                    nsnrold      ,&
         &                                    igap         ,&
         &                                    gap          ,&
         &                                    gap_s        ,&
@@ -93,114 +79,108 @@
         &                                    dgapload     ,&
         &                                    s_cand_a     ,&
         &                                    numnod       ,&
-        &                                    xrem         ,&
-        &                                    s_xrem       ,&
-        &                                    irem         ,&
-        &                                    s_irem       ,&
-        &                                    next_nod      )
+        &                                    next_nod     ,&
+        &                                    inv_nsv       )
           USE PRECISION_MOD, ONLY : WP
           USE COLLISION_MOD , ONLY : GROUP_SIZE
           USE INTER7_FILTER_CAND_MOD
           USE CONSTANT_MOD
+          USE EXTEND_ARRAY_MOD, ONLY : extend_array
 ! ----------------------------------------------------------------------------------------------------------------------
           implicit none
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   arguments
 ! ----------------------------------------------------------------------------------------------------------------------
-          integer, intent(inout) :: i_mem !< error code when not enough memory
-          integer, intent(in), value :: eshift !< openmp shift for main segments
-          integer, intent(in), value :: nsn !< number of secondary nodes
-          integer, intent(in), value :: nsnr !< current number of remote secondary nodes
-          integer, intent(in), value :: nsnrold !< old number of remote secondary nodes
-          integer, intent(in), value :: isznsnr !< size of oldnum
-          integer, intent(in), value :: nrtm !< number of considered segment
-          integer, intent(in), value :: nbx !< number of voxels in x
-          integer, intent(in), value :: nby !< number of voxels in y
-          integer, intent(in), value :: nbz !< number of voxels in z
-          integer, intent(in), value :: inacti !< inactivation of initial penetrations
-          integer, intent(in), value :: ifq !< friction model ?
-          integer, intent(in), value :: igap !< gap model ?
-          integer, intent(in), value :: flagremnode !< flag for removed nodes?
-          integer, intent(in), value :: itied !< tied contact ?
-          integer, intent(in), value :: numnod !< total number of nodes of the model
-          integer, intent(in), value :: s_xrem !< size of xrem
-          integer, intent(in), value :: s_irem !< size of xrem
-          integer, intent(in), value :: s_cand_a !< size of cand_a
-          integer, intent(in), value :: s_kremnod !< 2 * nrtm + 1 if option is used
-          integer, intent(in), value :: s_remnod !< size of remnod
-          integer, intent(in), value :: mulnsn !< maximum numbrer of candidates (size of cand_n)
-          integer, intent(inout) :: ii_stok !< number of candidates found
+          integer, intent(inout) :: multimp_param 
+          integer, intent(inout) :: i_mem
+          integer, intent(in), value :: eshift
+          integer, intent(in), value :: nsn
+          integer, intent(in), value :: nrtm
+          integer, intent(in), value :: nbx
+          integer, intent(in), value :: nby
+          integer, intent(in), value :: nbz
+          integer, intent(in), value :: inacti
+          integer, intent(in), value :: ifq
+          integer, intent(in), value :: igap
+          integer, intent(in), value :: flagremnode
+          integer, intent(in), value :: itied
+          integer, intent(in), value :: numnod
+          integer, intent(in), value :: s_cand_a
+          integer, intent(in), value :: s_kremnod
+          integer, intent(in), value :: s_remnod
+          integer, intent(inout) :: mulnsn
+          integer, intent(inout) :: ii_stok
 
-          integer, intent(in) :: nsv(nsn) !< global secondary node numbers
-          integer, intent(in) :: oldnum(isznsnr) !< renumbering ?
-          integer, intent(in) :: kremnod(s_kremnod) !< list of removed nodes
-          integer, intent(in) :: remnod(s_remnod) !< list of removed nodes
-          integer, intent(in) :: irect(4,nrtm) !< node id (from 1 to NUMNOD) for each segment (1:nrtm)
+          integer, intent(in) :: nsv(nsn)
+          integer, intent(in) :: kremnod(s_kremnod)
+          integer, intent(in) :: remnod(s_remnod)
+          integer, intent(in) :: irect(4,nrtm)
 
-          integer, intent(inout) :: cand_n(mulnsn) !< list of candidates (secondary)
-          integer, intent(inout) :: cand_e(mulnsn) !< list of candidates (main)
-          integer, intent(inout) :: ifpen(mulnsn) !< something related to friction (???)
-          integer, intent(inout) :: cand_a(s_cand_a) !< (???)
-          integer, intent(inout) :: irem(s_irem,nsnr) !< remote (spmd) integer data
-          integer, intent(inout) :: voxel((nbx+2)*(nby+2)*(nbz+2)) !< contain the first node of each voxel
-          integer, intent(inout) :: next_nod(nsn+nsnr) !< next node in the same voxel
+          integer, intent(inout), allocatable :: cand_n(:)
+          integer, intent(inout), allocatable :: cand_e(:)
+          integer, intent(inout), allocatable :: ifpen(:)
+          integer, intent(inout) :: cand_a(s_cand_a)
+          integer, intent(inout) :: voxel((nbx+2)*(nby+2)*(nbz+2))
+          integer, intent(inout) :: next_nod(nsn)
+          integer, intent(in) :: inv_nsv(numnod)
 
-          real(kind=WP), intent(in), value :: gap !< gap (???)
-          real(kind=WP), intent(in), value :: gapmin !< minimum gap
-          real(kind=WP), intent(in), value :: gapmax !< maximum gap
-          real(kind=WP), intent(in), value :: bgapsmx!< overestimation of gap_s
-          real(kind=WP), intent(in), value :: marge !< margin
-          real(kind=WP), intent(in), value :: tzinf !< some kind of length for "zone of influence" ?
-          real(kind=WP), intent(in), value :: drad !< radiation distance (thermal analysis)
-          real(kind=WP), intent(in), value :: dgapload !< gap load (???)
-          real(kind=WP), intent(in) :: x(3,numnod) !< coordinates of nodes all
-          real(kind=WP), intent(in) :: gap_s(nsn) !< gap for secondary nodes
-          real(kind=WP), intent(in) :: gap_m(nrtm) !< gap for main nodes
-          real(kind=WP), intent(in) :: gap_s_l(nsn) !< gap for secondary nodes (???)
-          real(kind=WP), intent(in) :: gap_m_l(nrtm) !< gap for main nodes (???)
-          real(kind=WP), intent(in) :: curv_max(nrtm) !< maximum curvature
-          real(kind=WP), intent(in) :: xyzm(12) !< bounding box
+          real(kind=WP), intent(in), value :: gap
+          real(kind=WP), intent(in), value :: gapmin
+          real(kind=WP), intent(in), value :: gapmax
+          real(kind=WP), intent(in), value :: bgapsmx
+          real(kind=WP), intent(in), value :: marge
+          real(kind=WP), intent(in), value :: tzinf
+          real(kind=WP), intent(in), value :: drad
+          real(kind=WP), intent(in), value :: dgapload
+          real(kind=WP), intent(in) :: x(3,numnod)
+          real(kind=WP), intent(in) :: gap_s(nsn)
+          real(kind=WP), intent(in) :: gap_m(nrtm)
+          real(kind=WP), intent(in) :: gap_s_l(nsn)
+          real(kind=WP), intent(in) :: gap_m_l(nrtm)
+          real(kind=WP), intent(in) :: curv_max(nrtm)
+          real(kind=WP), intent(in) :: xyzm(12)
 
-          real(kind=WP), intent(inout) :: cand_p(mulnsn) !< penetration (???)
-          real(kind=WP), intent(inout) :: cand_f(8*mulnsn) !< related to tied contact, cand force (???)
-          real(kind=WP), intent(in) :: stf(nrtm) !< stiffness of segments (quadrangles or triangles)
-          real(kind=WP), intent(inout) :: xrem(s_xrem,nsnr) !< remote (spmd) real data
+          real(kind=WP), intent(inout), allocatable :: cand_p(:)
+          real(kind=WP), intent(inout), allocatable :: cand_f(:)
+          real(kind=WP), intent(in) :: stf(nrtm)
 
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   local variables
 ! ----------------------------------------------------------------------------------------------------------------------
-          integer :: i,j, nn, ne, k, l, j_stok, jj, delnod, m
+          integer :: i,j, nn, ne, k, l, j_stok, jj, m
           integer, dimension(:), allocatable :: tagremnode
           real(kind=WP) :: xs, ys, zs, sx, sy, sz, s2
           real(kind=WP) :: xmin, xmax, ymin, ymax, zmin, zmax
           real(kind=WP) :: xx1, xx2, xx3, xx4, yy1, yy2, yy3, yy4, zz1, zz2, zz3, zz4
           real(kind=WP) :: d1x, d1y, d1z, d2x, d2y, d2z, dd1, dd2, d2, a2
- 
+          real(kind=WP) :: aaa
+
           integer :: ix, iy, iz, m1, m2, m3, m4, ix1, iy1, iz1, ix2, iy2, iz2
- 
-          real(kind=WP) :: xminb, yminb, zminb, xmaxb, ymaxb, zmaxb, xmine, ymine, zmine, xmaxe, ymaxe, zmaxe, aaa
- 
-          integer, dimension(GROUP_SIZE) :: prov_n, prov_e !< temporary list of candidates
+          integer :: jj_m1, jj_m2, jj_m3, jj_m4
+
+          real(kind=WP) :: xminb, yminb, zminb, xmaxb, ymaxb, zmaxb, xmine, ymine, zmine, xmaxe, ymaxe, zmaxe
+
+          integer, dimension(GROUP_SIZE) :: prov_n, prov_e
           integer :: cellid
+          integer :: old_mulnsn !< old mulnsn value before reallocation
+          ! Dummy variables for inter7_filter_cand compatibility (no remote nodes)
+          integer :: nsnr_dummy, nsnrold_dummy, isznsnr_dummy
+          integer, dimension(1) :: oldnum_dummy
+          real(kind=WP), dimension(1,1) :: xrem_dummy
 
-!$OMP BARRIER
+          nsnr_dummy = 0
+          nsnrold_dummy = 0
+          isznsnr_dummy = 1
+          !write(*,*) "Number of local nodes to process: ", nsn, ii_stok
 
-! The global bounding box contains all the nodes
-! Some nodes may by highly distant from the impact zone
-! The domain is subdivided in cells (voxel)
-! All the cells have the sime size, except the first and the last one in each direction
 
-! bounding box of the model
+
           xmin = xyzm(1)
           ymin = xyzm(2)
           zmin = xyzm(3)
           xmax = xyzm(4)
           ymax = xyzm(5)
           zmax = xyzm(6)
-
-! reduced bounding box of the model
-! The reduced bounding box corresponds to voxel(2:nbx+1,2:nby+1,2:nbz+1), it contains cells of the same size
-
           xminb = xyzm(7)
           yminb = xyzm(8)
           zminb = xyzm(9)
@@ -208,11 +188,6 @@
           ymaxb = xyzm(11)
           zmaxb = xyzm(12)
 
-
-
-! ======================================================================================================================
-! 3   FACE RECOVERY AND ENUMERATION OF CANDIDATE COUPLES
-! ======================================================================================================================
           j_stok = 0
           if(flagremnode == 2) then
             allocate(tagremnode(numnod))
@@ -220,16 +195,12 @@
               tagremnode(i) = 0
             end do
           end if
-!$OMP BARRIER
-!$OMP DO SCHEDULE(DYNAMIC)
           do ne=1,nrtm
-            if(stf(ne) == zero)cycle ! the segment is deleted/eroded
+            if(stf(ne) == zero)cycle
             if(flagremnode == 2) then
               k = kremnod(2*(ne-1)+1)+1
               l = kremnod(2*(ne-1)+2)
               do i=k,l
-                ! the segment ne cannot be in contact with the node remnod(i)
-                ! typically, remnod(i) contains nodes of neighboring elements
                 tagremnode(remnod(i)) = 1
               end do
             end if
@@ -243,6 +214,11 @@
             m2 = irect(2,ne)
             m3 = irect(3,ne)
             m4 = irect(4,ne)
+
+            jj_m1 = inv_nsv(m1)
+            jj_m2 = inv_nsv(m2)
+            jj_m3 = inv_nsv(m3)
+            jj_m4 = inv_nsv(m4)
 
             xx1=x(1,m1)
             xx2=x(1,m2)
@@ -265,13 +241,11 @@
             zmaxe=max(zz1,zz2,zz3,zz4)
             zmine=min(zz1,zz2,zz3,zz4)
 
-            ! surface (to trim candidate list)
             sx = (yy3-yy1)*(zz4-zz2) - (zz3-zz1)*(yy4-yy2)
             sy = (zz3-zz1)*(xx4-xx2) - (xx3-xx1)*(zz4-zz2)
             sz = (xx3-xx1)*(yy4-yy2) - (yy3-yy1)*(xx4-xx2)
             s2 = sx*sx + sy*sy + sz*sz
 
-            !find voxels containing the bounding box of the segment
             if(nbx>1) then
               ix1=int(nbx*(xmine-aaa-xminb)/(xmaxb-xminb))
               ix2=int(nbx*(xmaxe+aaa-xminb)/(xmaxb-xminb))
@@ -307,61 +281,34 @@
             do iz = iz1,iz2
               do iy = iy1,iy2
                 do ix = ix1,ix2
-                  if(i_mem==2) cycle
                   cellid = (iz-1)*(nbx+2)*(nby+2)+(iy-1)*(nbx+2)+ix
                   jj = voxel(cellid)
                   do while(jj > 0)
+                    ! Self-node rejection
+                    if(jj == jj_m1) goto 300
+                    if(jj == jj_m2) goto 300
+                    if(jj == jj_m3) goto 300
+                    if(jj == jj_m4) goto 300
 
-                    if(jj<=nsn)then
-                      ! local node
-                      nn=nsv(jj)
+                    ! Local node only
+                    nn=nsv(jj)
 
-                      if(nn == m1)goto 200
-                      if(nn == m2)goto 200
-                      if(nn == m3)goto 200
-                      if(nn == m4)goto 200
-
-                      if(flagremnode == 2) then
-                        if( tagremnode(nsv(jj)) == 1) goto 200
-                      end if
-                      xs = x(1,nn)
-                      ys = x(2,nn)
-                      zs = x(3,nn)
-                      if(igap /= 0)then
-                        aaa = marge+curv_max(ne)+max(min(gapmax,max(gapmin,gap_s(jj)+gap_m(ne)))+dgapload,drad)
-                      end if
-                    else
-                      ! remote (SPMD) node: data are stored in irem/xrem (communicated earlier)
-                      j=jj-nsn
-                      delnod = 0
-                      if(flagremnode == 2) then
-                        k = kremnod(2*(ne-1)+2) + 1
-                        l = kremnod(2*(ne-1)+3)
-                        do m=k,l
-                          if(remnod(m) == -irem(2,j) ) then
-                            delnod = delnod + 1
-                            exit
-                          end if
-                        end do
-                        if(delnod /= 0)goto 200
-                      end if
-
-                      xs = xrem(1,j)
-                      ys = xrem(2,j)
-                      zs = xrem(3,j)
-                      if(igap /= 0)then
-                        aaa = marge+curv_max(ne)+max(min(gapmax,max(gapmin,xrem(9,j)+gap_m(ne)))+dgapload,drad)
-                      end if
+                    if(flagremnode == 2) then
+                      if( tagremnode(nn) == 1) goto 300
+                    end if
+                    xs = x(1,nn)
+                    ys = x(2,nn)
+                    zs = x(3,nn)
+                    if(igap /= 0)then
+                      aaa = marge+curv_max(ne)+max(min(gapmax,max(gapmin,gap_s(jj)+gap_m(ne)))+dgapload,drad)
                     end if
 
-                    if(xs<=xmine-aaa)goto 200
-                    if(xs>=xmaxe+aaa)goto 200
-                    if(ys<=ymine-aaa)goto 200
-                    if(ys>=ymaxe+aaa)goto 200
-                    if(zs<=zmine-aaa)goto 200
-                    if(zs>=zmaxe+aaa)goto 200
-
-                    ! underestimation of the distance**2 to eliminate candidates
+                    if(xs<=xmine-aaa)goto 300
+                    if(xs>=xmaxe+aaa)goto 300
+                    if(ys<=ymine-aaa)goto 300
+                    if(ys>=ymaxe+aaa)goto 300
+                    if(zs<=zmine-aaa)goto 300
+                    if(zs>=zmaxe+aaa)goto 300
 
                     d1x = xs - xx1
                     d1y = ys - yy1
@@ -374,7 +321,7 @@
                     if(dd1*dd2 > zero)then
                       d2 = min(dd1*dd1,dd2*dd2)
                       a2 = aaa*aaa*s2
-                      if(d2 > a2)goto 200
+                      if(d2 > a2)goto 300
                     end if
 
                     j_stok = j_stok + 1
@@ -382,11 +329,404 @@
                     prov_e(j_stok) = ne
 
                     if(j_stok == GROUP_SIZE) then
-                      ! filter prov_n, prov_e and append to cand_n, cand_e
-                      if(i_mem == 0) call inter7_filter_cand(&
+                      if(j_stok + ii_stok > mulnsn) then
+                        old_mulnsn = mulnsn
+                        multimp_param = multimp_param +4
+                        mulnsn = mulnsn * multimp_param
+                        ! Reallocate candidate arrays to the new size
+                        call extend_array(cand_n, old_mulnsn, mulnsn)
+                        call extend_array(cand_e, old_mulnsn, mulnsn)
+                        if (ifq /= 0) call extend_array(ifpen, old_mulnsn, mulnsn)
+                        if (inacti == 5 .or. inacti == 6 .or. inacti == 7) call extend_array(cand_p, old_mulnsn, mulnsn)
+                        if (itied /= 0) call extend_array(cand_f, 8*old_mulnsn, 8*mulnsn)
+                      end if
+                      call inter7_filter_cand(&
                       &                   j_stok,irect  ,x     ,nsv   ,ii_stok,&
                       &                   cand_n,cand_e ,mulnsn,marge  ,&
-                      &                   i_mem ,prov_n ,prov_e,eshift,inacti ,&
+                      &                   prov_n ,prov_e,eshift,inacti ,&
+                      &                   ifq   ,cand_a ,cand_p,ifpen ,nsn    ,&
+                      &                   oldnum_dummy,nsnrold_dummy,igap  ,gap   ,gap_s  ,&
+                      &                   gap_m ,gapmin ,gapmax,curv_max,&
+                      &                   gap_s_l,gap_m_l,drad,itied    ,&
+                      &                   cand_f ,dgapload, numnod,&
+                      &                   nsnr_dummy, nrtm, isznsnr_dummy,&
+                      &                   xrem_dummy ,1)
+                      j_stok = 0
+                    end if
+
+300                 continue
+                    jj = next_nod(jj)
+                  end do
+                end do
+              end do
+            end do
+            if(flagremnode == 2) then
+              k = kremnod(2*(ne-1)+1)+1
+              l = kremnod(2*(ne-1)+2)
+              do i=k,l
+                tagremnode(remnod(i)) = 0
+              end do
+            end if
+          end do
+          if(j_stok > 0) then 
+            if(j_stok + ii_stok > mulnsn) then
+              old_mulnsn = mulnsn
+              multimp_param = multimp_param +4
+              mulnsn = mulnsn * multimp_param
+              ! Reallocate candidate arrays to the new size
+              call extend_array(cand_n, old_mulnsn, mulnsn)
+              call extend_array(cand_e, old_mulnsn, mulnsn)
+              if (ifq /= 0) call extend_array(ifpen, old_mulnsn, mulnsn)
+              if (inacti == 5 .or. inacti == 6 .or. inacti == 7) call extend_array(cand_p, old_mulnsn, mulnsn)
+              if (itied /= 0) call extend_array(cand_f, 8*old_mulnsn, 8*mulnsn)
+            end if
+            call inter7_filter_cand(&
+          &                   j_stok,irect  ,x     ,nsv   ,ii_stok,&
+          &                   cand_n,cand_e ,mulnsn,marge  ,&
+          &                   prov_n ,prov_e,eshift,inacti ,&
+          &                   ifq   ,cand_a ,cand_p,ifpen ,nsn    ,&
+          &                   oldnum_dummy,nsnrold_dummy,igap  ,gap   ,gap_s  ,&
+          &                   gap_m ,gapmin ,gapmax,curv_max,&
+          &                   gap_s_l,gap_m_l,drad,itied    ,&
+          &                   cand_f ,dgapload, numnod,&
+          &                   nsnr_dummy, nrtm, isznsnr_dummy,&
+          &                   xrem_dummy ,1)
+        endif
+
+          if(flagremnode == 2) then
+            if(allocated(tagremnode)) deallocate(tagremnode)
+          end if
+          if(i_mem == 2) then
+            !write(*,*) "Memory mode 2: Not enough memory (local)",mulnsn
+          endif
+          !write(*,*) "Number of candidate pairs found in local search: ", ii_stok
+          return
+        end subroutine INTER7_CANDIDATE_PAIRS_LOCAL
+
+!! \brief Search for candidate pairs using ONLY REMOTE nodes (voxel_remote contains remote nodes only)
+!! \details Called after MPI receives are complete. Walks voxel_remote (1-based indexing).
+!!          Maps jj -> nsn+jj for downstream cand_n compatibility.
+        SUBROUTINE INTER7_CANDIDATE_PAIRS_REMOTE(multimp_param, &
+        &                                    nsn          ,&
+        &                                    oldnum       ,&
+        &                                    nsnr         ,&
+        &                                    isznsnr      ,&
+        &                                    i_mem        ,&
+        &                                    irect        ,&
+        &                                    x            ,&
+        &                                    stf          ,&
+        &                                    xyzm         ,&
+        &                                    nsv          ,&
+        &                                    ii_stok      ,&
+        &                                    cand_n       ,&
+        &                                    eshift       ,&
+        &                                    cand_e       ,&
+        &                                    mulnsn       ,&
+        &                                    tzinf        ,&
+        &                                    gap_s_l      ,&
+        &                                    gap_m_l      ,&
+        &                                    voxel_remote ,&
+        &                                    nbx          ,&
+        &                                    nby          ,&
+        &                                    nbz          ,&
+        &                                    inacti       ,&
+        &                                    ifq          ,&
+        &                                    cand_a       ,&
+        &                                    cand_p       ,&
+        &                                    ifpen        ,&
+        &                                    nrtm         ,&
+        &                                    nsnrold      ,&
+        &                                    igap         ,&
+        &                                    gap          ,&
+        &                                    gap_s        ,&
+        &                                    gap_m        ,&
+        &                                    gapmin       ,&
+        &                                    gapmax       ,&
+        &                                    marge        ,&
+        &                                    curv_max     ,&
+        &                                    bgapsmx      ,&
+        &                                    s_kremnod    ,&
+        &                                    kremnod      ,&
+        &                                    s_remnod     ,&
+        &                                    remnod       ,&
+        &                                    flagremnode  ,&
+        &                                    drad         ,&
+        &                                    itied        ,&
+        &                                    cand_f       ,&
+        &                                    dgapload     ,&
+        &                                    s_cand_a     ,&
+        &                                    numnod       ,&
+        &                                    xrem         ,&
+        &                                    s_xrem       ,&
+        &                                    irem         ,&
+        &                                    s_irem       ,&
+        &                                    next_nod_remote )
+          USE PRECISION_MOD, ONLY : WP
+          USE COLLISION_MOD , ONLY : GROUP_SIZE
+          USE INTER7_FILTER_CAND_MOD
+          USE EXTEND_ARRAY_MOD, ONLY : extend_array
+          USE CONSTANT_MOD
+! ----------------------------------------------------------------------------------------------------------------------
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          integer, intent(inout) :: multimp_param
+          integer, intent(inout) :: i_mem
+          integer, intent(in), value :: eshift
+          integer, intent(in), value :: nsn
+          integer, intent(in), value :: nsnr
+          integer, intent(in), value :: nsnrold
+          integer, intent(in), value :: isznsnr
+          integer, intent(in), value :: nrtm
+          integer, intent(in), value :: nbx
+          integer, intent(in), value :: nby
+          integer, intent(in), value :: nbz
+          integer, intent(in), value :: inacti
+          integer, intent(in), value :: ifq
+          integer, intent(in), value :: igap
+          integer, intent(in), value :: flagremnode
+          integer, intent(in), value :: itied
+          integer, intent(in), value :: numnod
+          integer, intent(in), value :: s_xrem
+          integer, intent(in), value :: s_irem
+          integer, intent(in), value :: s_cand_a
+          integer, intent(in), value :: s_kremnod
+          integer, intent(in), value :: s_remnod
+          integer, intent(inout) :: mulnsn
+          integer, intent(inout) :: ii_stok
+
+          integer, intent(in) :: nsv(nsn)
+          integer, intent(in) :: oldnum(isznsnr)
+          integer, intent(in) :: kremnod(s_kremnod)
+          integer, intent(in) :: remnod(s_remnod)
+          integer, intent(in) :: irect(4,nrtm)
+
+          integer, intent(inout), allocatable :: cand_n(:)
+          integer, intent(inout), allocatable :: cand_e(:)
+          integer, intent(inout), allocatable :: ifpen(:)
+          integer, intent(inout) :: cand_a(s_cand_a)
+          integer, intent(inout) :: voxel_remote((nbx+2)*(nby+2)*(nbz+2))
+          integer, intent(inout) :: next_nod_remote(nsnr)
+          integer, intent(inout) :: irem(s_irem,nsnr)
+
+          real(kind=WP), intent(in), value :: gap
+          real(kind=WP), intent(in), value :: gapmin
+          real(kind=WP), intent(in), value :: gapmax
+          real(kind=WP), intent(in), value :: bgapsmx
+          real(kind=WP), intent(in), value :: marge
+          real(kind=WP), intent(in), value :: tzinf
+          real(kind=WP), intent(in), value :: drad
+          real(kind=WP), intent(in), value :: dgapload
+          real(kind=WP), intent(in) :: x(3,numnod)
+          real(kind=WP), intent(in) :: gap_s(nsn)
+          real(kind=WP), intent(in) :: gap_m(nrtm)
+          real(kind=WP), intent(in) :: gap_s_l(nsn)
+          real(kind=WP), intent(in) :: gap_m_l(nrtm)
+          real(kind=WP), intent(in) :: curv_max(nrtm)
+          real(kind=WP), intent(in) :: xyzm(12)
+
+          real(kind=WP), intent(inout), allocatable :: cand_p(:)
+          real(kind=WP), intent(inout), allocatable :: cand_f(:)
+          real(kind=WP), intent(in) :: stf(nrtm)
+          real(kind=WP), intent(inout) :: xrem(s_xrem,nsnr)
+
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   local variables
+! ----------------------------------------------------------------------------------------------------------------------
+          integer :: i,j, ne, k, l, j_stok, jj, delnod, m
+          integer, dimension(:), allocatable :: tagremnode
+          real(kind=WP) :: xs, ys, zs, sx, sy, sz, s2
+          real(kind=WP) :: xmin, xmax, ymin, ymax, zmin, zmax
+          real(kind=WP) :: xx1, xx2, xx3, xx4, yy1, yy2, yy3, yy4, zz1, zz2, zz3, zz4
+          real(kind=WP) :: d1x, d1y, d1z, d2x, d2y, d2z, dd1, dd2, d2, a2
+          real(kind=WP) :: aaa
+
+          integer :: ix, iy, iz, m1, m2, m3, m4, ix1, iy1, iz1, ix2, iy2, iz2
+
+          real(kind=WP) :: xminb, yminb, zminb, xmaxb, ymaxb, zmaxb, xmine, ymine, zmine, xmaxe, ymaxe, zmaxe
+
+          integer, dimension(GROUP_SIZE) :: prov_n, prov_e
+          integer :: cellid
+          integer :: old_mulnsn !< old mulnsn value before reallocation
+
+          !write(*,*) "Number of remote nodes to process: ", nsnr, ii_stok
+
+          if(nsnr == 0) return
+
+!$OMP BARRIER
+
+          xmin = xyzm(1)
+          ymin = xyzm(2)
+          zmin = xyzm(3)
+          xmax = xyzm(4)
+          ymax = xyzm(5)
+          zmax = xyzm(6)
+          xminb = xyzm(7)
+          yminb = xyzm(8)
+          zminb = xyzm(9)
+          xmaxb = xyzm(10)
+          ymaxb = xyzm(11)
+          zmaxb = xyzm(12)
+
+          j_stok = 0
+          if(flagremnode == 2) then
+            allocate(tagremnode(numnod))
+            do i=1,numnod
+              tagremnode(i) = 0
+            end do
+          end if
+!$OMP BARRIER
+!$OMP DO SCHEDULE(DYNAMIC)
+          do ne=1,nrtm
+            if(stf(ne) == zero)cycle
+            if(flagremnode == 2) then
+              k = kremnod(2*(ne-1)+1)+1
+              l = kremnod(2*(ne-1)+2)
+              do i=k,l
+                tagremnode(remnod(i)) = 1
+              end do
+            end if
+            if(igap == 0)then
+              aaa = tzinf+curv_max(ne)
+            else
+              aaa = marge+curv_max(ne)+max(min(gapmax,max(gapmin,bgapsmx+gap_m(ne)))+dgapload,drad)
+            end if
+
+            m1 = irect(1,ne)
+            m2 = irect(2,ne)
+            m3 = irect(3,ne)
+            m4 = irect(4,ne)
+
+            xx1=x(1,m1)
+            xx2=x(1,m2)
+            xx3=x(1,m3)
+            xx4=x(1,m4)
+            xmaxe=max(xx1,xx2,xx3,xx4)
+            xmine=min(xx1,xx2,xx3,xx4)
+
+            yy1=x(2,m1)
+            yy2=x(2,m2)
+            yy3=x(2,m3)
+            yy4=x(2,m4)
+            ymaxe=max(yy1,yy2,yy3,yy4)
+            ymine=min(yy1,yy2,yy3,yy4)
+
+            zz1=x(3,m1)
+            zz2=x(3,m2)
+            zz3=x(3,m3)
+            zz4=x(3,m4)
+            zmaxe=max(zz1,zz2,zz3,zz4)
+            zmine=min(zz1,zz2,zz3,zz4)
+
+            sx = (yy3-yy1)*(zz4-zz2) - (zz3-zz1)*(yy4-yy2)
+            sy = (zz3-zz1)*(xx4-xx2) - (xx3-xx1)*(zz4-zz2)
+            sz = (xx3-xx1)*(yy4-yy2) - (yy3-yy1)*(xx4-xx2)
+            s2 = sx*sx + sy*sy + sz*sz
+
+            if(nbx>1) then
+              ix1=int(nbx*(xmine-aaa-xminb)/(xmaxb-xminb))
+              ix2=int(nbx*(xmaxe+aaa-xminb)/(xmaxb-xminb))
+            else
+              ix1=-2
+              ix2=1
+            end if
+
+            if(nby>1) then
+              iy1=int(nby*(ymine-aaa-yminb)/(ymaxb-yminb))
+              iy2=int(nby*(ymaxe+aaa-yminb)/(ymaxb-yminb))
+            else
+              iy1=-2
+              iy2=1
+            end if
+
+            if(nbz>1) then
+              iz1=int(nbz*(zmine-aaa-zminb)/(zmaxb-zminb))
+              iz2=int(nbz*(zmaxe+aaa-zminb)/(zmaxb-zminb))
+            else
+              iz1=-2
+              iz2=1
+            end if
+
+            ix1=max(1,2+min(nbx,ix1))
+            iy1=max(1,2+min(nby,iy1))
+            iz1=max(1,2+min(nbz,iz1))
+
+            ix2=max(1,2+min(nbx,ix2))
+            iy2=max(1,2+min(nby,iy2))
+            iz2=max(1,2+min(nbz,iz2))
+
+            do iz = iz1,iz2
+              do iy = iy1,iy2
+                do ix = ix1,ix2
+                  cellid = (iz-1)*(nbx+2)*(nby+2)+(iy-1)*(nbx+2)+ix
+                  jj = voxel_remote(cellid)
+                  do while(jj > 0)
+                    ! jj is 1-based remote index; actual remote data is at xrem(:,jj)/irem(:,jj)
+                    j = jj
+
+                    delnod = 0
+                    if(flagremnode == 2) then
+                      k = kremnod(2*(ne-1)+2) + 1
+                      l = kremnod(2*(ne-1)+3)
+                      do m=k,l
+                        if(remnod(m) == -irem(2,j) ) then
+                          delnod = delnod + 1
+                          exit
+                        end if
+                      end do
+                      if(delnod /= 0)goto 400
+                    end if
+
+                    xs = xrem(1,j)
+                    ys = xrem(2,j)
+                    zs = xrem(3,j)
+                    if(igap /= 0)then
+                      aaa = marge+curv_max(ne)+max(min(gapmax,max(gapmin,xrem(9,j)+gap_m(ne)))+dgapload,drad)
+                    end if
+
+                    if(xs<=xmine-aaa)goto 400
+                    if(xs>=xmaxe+aaa)goto 400
+                    if(ys<=ymine-aaa)goto 400
+                    if(ys>=ymaxe+aaa)goto 400
+                    if(zs<=zmine-aaa)goto 400
+                    if(zs>=zmaxe+aaa)goto 400
+
+                    d1x = xs - xx1
+                    d1y = ys - yy1
+                    d1z = zs - zz1
+                    d2x = xs - xx2
+                    d2y = ys - yy2
+                    d2z = zs - zz2
+                    dd1 = d1x*sx+d1y*sy+d1z*sz
+                    dd2 = d2x*sx+d2y*sy+d2z*sz
+                    if(dd1*dd2 > zero)then
+                      d2 = min(dd1*dd1,dd2*dd2)
+                      a2 = aaa*aaa*s2
+                      if(d2 > a2)goto 400
+                    end if
+
+                    j_stok = j_stok + 1
+                    ! Store nsn+jj so cand_n is compatible with downstream (remote nodes > nsn)
+                    prov_n(j_stok) = nsn + jj
+                    prov_e(j_stok) = ne
+
+                    if(j_stok == GROUP_SIZE) then
+                      if(j_stok + ii_stok > mulnsn) then
+                        old_mulnsn = mulnsn
+                        multimp_param = multimp_param +4
+                        mulnsn = mulnsn * multimp_param
+                        ! Reallocate candidate arrays to the new size
+                        call extend_array(cand_n, old_mulnsn, mulnsn)
+                        call extend_array(cand_e, old_mulnsn, mulnsn)
+                        if (ifq /= 0) call extend_array(ifpen, old_mulnsn, mulnsn)
+                        if (inacti == 5 .or. inacti == 6 .or. inacti == 7) call extend_array(cand_p, old_mulnsn, mulnsn)
+                        if (itied /= 0) call extend_array(cand_f, 8*old_mulnsn, 8*mulnsn)
+                      end if
+                      call inter7_filter_cand(&
+                      &                   j_stok,irect  ,x     ,nsv   ,ii_stok,&
+                      &                   cand_n,cand_e ,mulnsn,marge  ,&
+                      &                   prov_n ,prov_e,eshift,inacti ,&
                       &                   ifq   ,cand_a ,cand_p,ifpen ,nsn    ,&
                       &                   oldnum,nsnrold,igap  ,gap   ,gap_s  ,&
                       &                   gap_m ,gapmin ,gapmax,curv_max,&
@@ -397,12 +737,12 @@
                       j_stok = 0
                     end if
 
-200                 continue
-                    jj = next_nod(jj)
-                  end do ! while(jj /= 0)
-                end do ! x
-              end do  ! y
-            end do   ! z
+400                 continue
+                    jj = next_nod_remote(jj)
+                  end do
+                end do
+              end do
+            end do
             if(flagremnode == 2) then
               k = kremnod(2*(ne-1)+1)+1
               l = kremnod(2*(ne-1)+2)
@@ -412,10 +752,22 @@
             end if
           end do
 !$OMP END DO
-          if(j_stok > 0 .and. i_mem == 0) call inter7_filter_cand(&
+          if(j_stok > 0) then 
+            if(j_stok + ii_stok > mulnsn) then
+              old_mulnsn = mulnsn
+              multimp_param = multimp_param +4
+              mulnsn = mulnsn * multimp_param
+              ! Reallocate candidate arrays to the new size
+              call extend_array(cand_n, old_mulnsn, mulnsn)
+              call extend_array(cand_e, old_mulnsn, mulnsn)
+              if (ifq /= 0) call extend_array(ifpen, old_mulnsn, mulnsn)
+              if (inacti == 5 .or. inacti == 6 .or. inacti == 7) call extend_array(cand_p, old_mulnsn, mulnsn)
+              if (itied /= 0) call extend_array(cand_f, 8*old_mulnsn, 8*mulnsn)
+            end if
+             call inter7_filter_cand(&
           &                   j_stok,irect  ,x     ,nsv   ,ii_stok,&
           &                   cand_n,cand_e ,mulnsn,marge  ,&
-          &                   i_mem ,prov_n ,prov_e,eshift,inacti ,&
+          &                   prov_n ,prov_e,eshift,inacti ,&
           &                   ifq   ,cand_a ,cand_p,ifpen ,nsn    ,&
           &                   oldnum,nsnrold,igap  ,gap   ,gap_s  ,&
           &                   gap_m ,gapmin ,gapmax,curv_max,&
@@ -423,747 +775,23 @@
           &                   cand_f ,dgapload, numnod,&
           &                   nsnr, nrtm, isznsnr,&
           &                   xrem ,s_xrem)
+          endif
 
-!!=======================================================================
-!! 5   VOXEL RESET
-!!=======================================================================
-!!$OMP BARRIER
-!          if(total_nb_nrtm>0 .and. itask == 0 .and. i_mem == 0) then
-!            do jj = 1, nb_voxel_on
-!              cellid = list_nb_voxel_on(jj)
-!              voxel(cellid) = 0
-!            enddo
-!          endif
 !$OMP BARRIER
-! ======================================================================================================================
-! 7   DEALLOCATE
-! ======================================================================================================================
           if(flagremnode == 2) then
             if(allocated(tagremnode)) deallocate(tagremnode)
           end if
-!         if(itask == 0) deallocate(list_nb_voxel_on)
-
-!#ifndef NO_SERIALIZE
-!        if(nsn > 13602 .and. nrtm > 1800) then
-!        call INTER7_SERIALIZE(      "t10m.dat",
-!     &                                    nsn          ,
-!     &                                    oldnum       ,
-!     &                                    nsnr         ,
-!     &                                    isznsnr      ,
-!     &                                    irect        ,
-!     &                                    x            ,
-!     &                                    stf          ,
-!     &                                    stfn         ,
-!     &                                    xyzm         ,
-!     &                                    nsv          ,
-!     &                                    ii_stok      ,
-!     &                                    cand_n       ,
-!     &                                    cand_e       ,
-!     &                                    mulnsn       ,
-!     &                                    tzinf        ,
-!     &                                    gap_s_l      ,
-!     &                                    gap_m_l      ,
-!     &                                    nbx          ,
-!     &                                    nby          ,
-!     &                                    nbz          ,
-!     &                                    inacti       ,
-!     &                                    ifq          ,
-!     &                                    cand_a       ,
-!     &                                    nrtm         ,
-!     &                                    nsnrold      ,
-!     &                                    igap         ,
-!     &                                    gap          ,
-!     &                                    gap_s        ,
-!     &                                    gap_m        ,
-!     &                                    gapmin       ,
-!     &                                    gapmax       ,
-!     &                                    marge        ,
-!     &                                    curv_max     ,
-!     &                                    bgapsmx      ,
-!     &                                    s_kremnod    ,
-!     &                                    kremnod      ,
-!     &                                    s_remnod     ,
-!     &                                    remnod       ,
-!     &                                    flagremnode  ,
-!     &                                    drad         ,
-!     &                                    itied        ,
-!     &                                    dgapload     ,
-!     &                                    s_cand_a     ,
-!     &                                    total_nb_nrtm,
-!     &                                    numnod       )
-!        stop
-!        endif
-!#endif
+          if(i_mem == 2) then
+             ! In memory mode 2, we only search for candidates but do not store them (no filtering).
+             ! This is used to overlap communication with computation. Candidate pairs will be searched again after MPI_WAITANY.
+          !    write(*,*) "Memory mode 2: Not enough memory (remote)",mulnsn
+          endif
+         ! write(*,*) "Number of candidate pairs found in remote search: ", ii_stok
 
           return
-        end subroutine INTER7_CANDIDATE_PAIRS
+        end subroutine INTER7_CANDIDATE_PAIRS_REMOTE
 
 !! \brief write the data to a file
-!||====================================================================
-!||    inter7_serialize   ../engine/source/interfaces/intsort/inter7_candidate_pairs.F90
-!||--- calls      -----------------------------------------------------
-!||--- uses       -----------------------------------------------------
-!||    precision_mod      ../common_source/modules/precision_mod.F90
-!||====================================================================
-        SUBROUTINE INTER7_SERIALIZE(      filename     ,&
-        &                                    nsn          ,&
-        &                                    oldnum       ,&
-        &                                    nsnr         ,&
-        &                                    isznsnr      ,&
-        &                                    irect        ,&
-        &                                    x            ,&
-        &                                    stf          ,&
-        &                                    stfn         ,&
-        &                                    xyzm         ,&
-        &                                    nsv          ,&
-        &                                    ii_stok      ,&
-        &                                    cand_n       ,&
-        &                                    cand_e       ,&
-        &                                    mulnsn       ,&
-        &                                    tzinf        ,&
-        &                                    gap_s_l      ,&
-        &                                    gap_m_l      ,&
-        &                                    nbx          ,&
-        &                                    nby          ,&
-        &                                    nbz          ,&
-        &                                    inacti       ,&
-        &                                    ifq          ,&
-        &                                    cand_a       ,&
-        &                                    nrtm         ,&
-        &                                    nsnrold      ,&
-        &                                    igap         ,&
-        &                                    gap          ,&
-        &                                    gap_s        ,&
-        &                                    gap_m        ,&
-        &                                    gapmin       ,&
-        &                                    gapmax       ,&
-        &                                    marge        ,&
-        &                                    curv_max     ,&
-        &                                    bgapsmx      ,&
-        &                                    s_kremnod    ,&
-        &                                    kremnod      ,&
-        &                                    s_remnod     ,&
-        &                                    remnod       ,&
-        &                                    flagremnode  ,&
-        &                                    drad         ,&
-        &                                    itied        ,&
-        &                                    dgapload     ,&
-        &                                    s_cand_a     ,&
-        &                                    total_nb_nrtm,&
-        &                                    numnod       )
-          USE PRECISION_MOD, ONLY : WP
-          implicit none
-! ----------------------------------------------------------------------------------------------------------------------
-!                                                   arguments
-! ----------------------------------------------------------------------------------------------------------------------
-          character(len =*), intent(in) :: filename
-
-          integer, intent(in), value :: nsn !< number of secondary nodes
-          integer, intent(in), value :: nsnr !< current number of remote secondary nodes
-          integer, intent(in), value :: nsnrold !< old number of remote secondary nodes
-          integer, intent(in), value :: isznsnr !< size of oldnum
-          integer, intent(in), value :: nrtm !< number of considered segment
-          integer, intent(in), value :: total_nb_nrtm !< total number of segments
-          integer, intent(in), value :: inacti !< inactivation of initial penetrations
-          integer, intent(in), value :: ifq !< friction model ?
-          integer, intent(in), value :: igap !< gap model ?
-          integer, intent(in), value :: flagremnode !< flag for removed nodes?
-          integer, intent(in), value :: itied !< tied contact ?
-          integer, intent(in), value :: numnod !< total number of nodes of the model
-          integer, intent(in), value :: s_cand_a !< size of cand_a
-          integer, intent(in), value :: s_kremnod ! 2 * nrtm + 1 if option is used
-          integer, intent(in), value :: s_remnod !< size of remnod
-          integer, intent(in), value :: mulnsn !< maximum numbrer of candidates (size of cand_n)
-          integer, intent(in), value :: nbx !< number of voxels in x
-          integer, intent(in), value :: nby !< number of voxels in y
-          integer, intent(in), value :: nbz !< number of voxels in z
-
-          integer, intent(in) :: ii_stok !< number of candidates found
-
-          integer, intent(in) :: nsv(nsn) !< global secondary node numbers
-          integer, intent(in) :: oldnum(isznsnr) !< renumbering ?
-          integer, intent(in) :: kremnod(s_kremnod) !< list of removed nodes
-          integer, intent(in) :: remnod(s_remnod) !< list of removed nodes
-          integer, intent(in) :: irect(4,nrtm) !< node id (from 1 to NUMNOD) for each segment (1:nrtm)
-          integer, intent(in) :: cand_a(s_cand_a) !< (???)
-
-          integer, intent(in) :: cand_n(mulnsn) !< list of candidates (secondary)
-          integer, intent(in) :: cand_e(mulnsn) !< list of candidates (main)
-
-          real(kind=WP), intent(in), value :: gap !< gap (???)
-          real(kind=WP), intent(in), value :: gapmin !< minimum gap
-          real(kind=WP), intent(in), value :: gapmax !< maximum gap
-          real(kind=WP), intent(in), value :: bgapsmx!< overestimation of gap_s
-          real(kind=WP), intent(in), value :: marge !< margin
-          real(kind=WP), intent(in), value :: tzinf !< some kind of length for "zone of influence" ?
-          real(kind=WP), intent(in), value :: drad !< radiation distance (thermal analysis)
-          real(kind=WP), intent(in), value :: dgapload !< gap load (???)
-          real(kind=WP), intent(in) :: x(3,numnod) !< coordinates of nodes all
-          real(kind=WP), intent(in) :: gap_s(nsn) !< gap for secondary nodes
-          real(kind=WP), intent(in) :: gap_m(nrtm) !< gap for main nodes
-          real(kind=WP), intent(in) :: gap_s_l(nsn) !< gap for secondary nodes (???)
-          real(kind=WP), intent(in) :: gap_m_l(nrtm) !< gap for main nodes (???)
-          real(kind=WP), intent(in) :: curv_max(nrtm) !< maximum curvature
-          real(kind=WP), intent(in) :: xyzm(12) !< bounding box
-          real(kind=WP), intent(in) :: stf(nrtm) !< stiffness of segments (quadrangles or triangles)
-          real(kind=WP), intent(in) :: stfn(nsn) !< stiffness secondary nodes
-! ----------------------------------------------------------------------------------------------------------------------
-!                                                   local variables
-! ----------------------------------------------------------------------------------------------------------------------
-          integer :: i, j, iostat, unitNum
- 
-
-          open(NEWUNIT=unitNum, FILE=filename, FORM="UNFORMATTED", STATUS="REPLACE", IOSTAT=iostat)
-          if (iostat /= 0) then
-            write(6,*) "error opening file: ", filename
-            return
-          end if
-
-          ! Relevant input
-          write(unitNum) nsn !< number of secondary nodes
-          write(unitNum) nsnr !< current number of remote secondary nodes
-          write(unitNum) nsnrold !< old number of remote secondary nodes
-          write(unitNum) isznsnr !< size of oldnum
-          write(unitNum) nrtm !< number of considered segment
-          write(unitNum) total_nb_nrtm !< total number of segments
-          write(unitNum) inacti !< inactivation of initial penetrations
-          write(unitNum) ifq !< friction model ?
-          write(unitNum) igap !< gap model ?
-          write(unitNum) flagremnode !< flag for removed nodes?
-          write(unitNum) itied !< tied contact ?
-          write(unitNum) numnod !< total number of nodes of the model
-          write(unitNum) s_cand_a !< size of cand_a
-          write(unitNum) s_kremnod !< 2 * nrtm + 1 if option is used
-          write(unitNum) s_remnod !< size of remnod
-          write(unitNum) mulnsn !< maximum numbrer of candidates (size of cand_n)
-          write(unitNum) nbx !< number of voxels in x
-          write(unitNum) nby !< number of voxels in y
-          write(unitNum) nbz !< number of voxels in z
-
-
-          write(unitNum) nsv(1:nsn) !< global secondary node numbers
-          write(unitNum) oldnum(1:isznsnr) !< renumbering ?
-          write(unitNum) kremnod(1:s_kremnod) !< list of removed nodes
-          write(unitNum) remnod(1:s_remnod) !< list of removed nodes
-
-          do i = 1, nrtm
-            write(unitNum) (irect(j, i), j = 1, 4)
-          end do
-          write(unitNum) cand_a(1:s_cand_a) !< (???)
-          write(unitNum) gap !< gap (???)
-          write(unitNum) gapmin !< minimum gap
-          write(unitNum) gapmax !< maximum gap
-          write(unitNum) bgapsmx!< overestimation of gap_s
-          write(unitNum) marge !< margin
-          write(unitNum) tzinf !< some kind of length for "zone of influence" ?
-          write(unitNum) drad !< radiation distance (thermal analysis)
-          write(unitNum) dgapload !< gap load (???)
-          do i = 1, numnod
-            write(unitnum) (x(j, i), j = 1, 3)
-          end do
-          write(unitNum) gap_s(1:nsn) !< gap for secondary nodes
-          write(unitNum) gap_m(1:nrtm) !< gap for main nodes
-          write(unitNum) gap_s_l(1:nsn) !< gap for secondary nodes (???)
-          write(unitNum) gap_m_l(1:nrtm) !< gap for main nodes (???)
-
-          write(unitNum) curv_max(1:nrtm) !< maximum curvature
-          write(unitNum) xyzm(1:12) !< bounding box
-          write(unitNum) stf(1:nrtm) !< stiffness of segments (quadrangles or triangles)
-          write(unitNum) stfn(1:nsn) !< stiffness secondary nodes
-
-          !relevant output
-          !mumnsn is the maximum number of candidates, ii_stok is the number of candidates found
-          write(unitNum) ii_stok !< number of candidates found
-          write(unitNum) cand_n(1:ii_stok) !< list of candidates (secondary)
-          write(unitNum) cand_e(1:ii_stok) !< list of candidates (main)
-          write(6,*)  "nsn          ",nsn
-          write(6,*)  "nsnr         ",nsnr
-          write(6,*)  "nsnrold      ",nsnrold
-          write(6,*)  "isznsnr      ",isznsnr
-          write(6,*)  "nrtm         ",nrtm
-          write(6,*)  "total_nb_nrtm",total_nb_nrtm
-          write(6,*)  "inacti       ",inacti
-          write(6,*)  "ifq          ",ifq
-          write(6,*)  "igap         ",igap
-          write(6,*)  "flagremnode  ",flagremnode
-          write(6,*)  "itied        ",itied
-          write(6,*)  "numnod       ",numnod
-          write(6,*)  "s_cand_a     ",s_cand_a
-          write(6,*)  "s_kremnod    ",s_kremnod
-          write(6,*)  "s_remnod     ",s_remnod
-          write(6,*)  "mulnsn       ",mulnsn
-          write(6,*)  "nbx          ",nbx
-          write(6,*)  "nby          ",nby
-          write(6,*)  "nbz          ",nbz
-          write(6,*)  "ii_stok      ",ii_stok
-
-          call flush(unitNum)
-          close(unitNum)
-        end subroutine INTER7_SERIALIZE
-!! \brief write the data to a file
-!||====================================================================
-!||    inter7_deserialize   ../engine/source/interfaces/intsort/inter7_candidate_pairs.F90
-!||--- uses       -----------------------------------------------------
-!||    precision_mod        ../common_source/modules/precision_mod.F90
-!||====================================================================
-        SUBROUTINE INTER7_DESERIALIZE(    filename     ,&
-        &                                    nsn          ,&
-        &                                    oldnum       ,&
-        &                                    nsnr         ,&
-        &                                    isznsnr      ,&
-        &                                    irect        ,&
-        &                                    x            ,&
-        &                                    stf          ,&
-        &                                    stfn         ,&
-        &                                    xyzm         ,&
-        &                                    nsv          ,&
-        &                                    ii_stok      ,&
-        &                                    cand_n       ,&
-        &                                    cand_e       ,&
-        &                                    mulnsn       ,&
-        &                                    tzinf        ,&
-        &                                    gap_s_l      ,&
-        &                                    gap_m_l      ,&
-        &                                    nbx          ,&
-        &                                    nby          ,&
-        &                                    nbz          ,&
-        &                                    inacti       ,&
-        &                                    ifq          ,&
-        &                                    cand_a       ,&
-        &                                    nrtm         ,&
-        &                                    nsnrold      ,&
-        &                                    igap         ,&
-        &                                    gap          ,&
-        &                                    gap_s        ,&
-        &                                    gap_m        ,&
-        &                                    gapmin       ,&
-        &                                    gapmax       ,&
-        &                                    marge        ,&
-        &                                    curv_max     ,&
-        &                                    bgapsmx      ,&
-        &                                    s_kremnod    ,&
-        &                                    kremnod      ,&
-        &                                    s_remnod     ,&
-        &                                    remnod       ,&
-        &                                    flagremnode  ,&
-        &                                    drad         ,&
-        &                                    itied        ,&
-        &                                    dgapload     ,&
-        &                                    s_cand_a     ,&
-        &                                    total_nb_nrtm,&
-        &                                    numnod       )
-          USE PRECISION_MOD, ONLY : WP
-          implicit none
-! ----------------------------------------------------------------------------------------------------------------------
-!                                                   arguments
-! ----------------------------------------------------------------------------------------------------------------------
-          character(len =*), intent(in) :: filename
-          integer, intent(out) :: nsn !< number of secondary nodes
-          integer, intent(out) :: nsnr !< current number of remote secondary nodes
-          integer, intent(out) :: nsnrold !< old number of remote secondary nodes
-          integer, intent(out) :: isznsnr !< size of oldnum
-          integer, intent(out) :: nrtm !< number of considered segment
-          integer, intent(out) :: total_nb_nrtm !< total number of segments
-          integer, intent(out) :: inacti !< inactivation of initial penetrations
-          integer, intent(out) :: ifq !< friction model ?
-          integer, intent(out) :: igap !< gap model ?
-          integer, intent(out) :: flagremnode !< flag for removed nodes?
-          integer, intent(out) :: itied !< tied contact ?
-          integer, intent(out) :: numnod !< total number of nodes of the model
-          integer, intent(out) :: s_cand_a !< size of cand_a
-          integer, intent(out) :: s_kremnod ! 2 * nrtm + 1 if option is used
-          integer, intent(out) :: s_remnod !< size of remnod
-          integer, intent(out) :: mulnsn !< maximum numbrer of candidates (size of cand_n)
-          integer, intent(out) :: nbx !< number of voxels in x
-          integer, intent(out) :: nby !< number of voxels in y
-          integer, intent(out) :: nbz !< number of voxels in z
-
-          integer, intent(out) :: ii_stok !< number of candidates found
-
-          integer, intent(out), dimension(:), allocatable :: nsv !< global secondary node numbers
-          integer, intent(out), dimension(:), allocatable :: oldnum !< renumbering ?
-          integer, intent(out), dimension(:), allocatable :: kremnod !< list of removed nodes
-          integer, intent(out), dimension(:), allocatable :: remnod !< list of removed nodes
-          integer, intent(out), dimension(:,:), allocatable :: irect !< node id (from 1 to NUMNOD) for each segment (1:nrtm)
-          integer, intent(out), dimension(:), allocatable :: cand_a !< (???)
-
-          integer, intent(out), dimension(:), allocatable :: cand_n !< list of candidates (secondary)
-          integer, intent(out), dimension(:), allocatable :: cand_e !< list of candidates (main)
-
-          real(kind=WP), intent(out) :: gap !< gap (???)
-          real(kind=WP), intent(out) :: gapmin !< minimum gap
-          real(kind=WP), intent(out) :: gapmax !< maximum gap
-          real(kind=WP), intent(out) :: bgapsmx!< overestimation of gap_s
-          real(kind=WP), intent(out) :: marge !< margin
-          real(kind=WP), intent(out) :: tzinf !< some kind of length for "zone of influence" ?
-          real(kind=WP), intent(out) :: drad !< radiation distance (thermal analysis)
-          real(kind=WP), intent(out) :: dgapload !< gap load (???)
-
-          real(kind=WP), intent(out), dimension(:,:), allocatable :: x !< coordinates of nodes all
-          real(kind=WP), intent(out), dimension(:), allocatable :: gap_s !< gap for secondary nodes
-          real(kind=WP), intent(out), dimension(:), allocatable :: gap_m !< gap for main nodes
-          real(kind=WP), intent(out), dimension(:), allocatable :: gap_s_l !< gap for secondary nodes (???)
-          real(kind=WP), intent(out), dimension(:), allocatable :: gap_m_l !< gap for main nodes (???)
-          real(kind=WP), intent(out), dimension(:), allocatable :: curv_max !< maximum curvature
-          real(kind=WP), intent(out), dimension(:), allocatable :: stf !< stiffness of segments (quadrangles or triangles)
-          real(kind=WP), intent(out), dimension(:), allocatable :: stfn !< stiffness secondary nodes
-          real(kind=WP), intent(out) :: xyzm(12) !< bounding box
-
-! ----------------------------------------------------------------------------------------------------------------------
-!                                                   local variables
-! ----------------------------------------------------------------------------------------------------------------------
-          integer :: i, j, iostat, unitNum
- 
-          open(NEWUNIT=unitNum, FILE=filename, FORM="UNFORMATTED", STATUS="OLD", IOSTAT=iostat)
-          if (iostat /= 0) then
-            write(6,*) "error opening file: ", filename
-            return
-          end if
-
-          ! Relevant input
-          read(unitNum) nsn !< number of secondary nodes
-          read(unitNum) nsnr !< current number of remote secondary nodes
-          read(unitNum) nsnrold !< old number of remote secondary nodes
-          read(unitNum) isznsnr !< size of oldnum
-          read(unitNum) nrtm !< number of considered segment
-          read(unitNum) total_nb_nrtm !< total number of segments
-          read(unitNum) inacti !< inactivation of initial penetrations
-          read(unitNum) ifq !< friction model ?
-          read(unitNum) igap !< gap model ?
-          read(unitNum) flagremnode !< flag for removed nodes?
-          read(unitNum) itied !< tied contact ?
-          read(unitNum) numnod !< total number of nodes of the model
-          read(unitNum) s_cand_a !< size of cand_a
-          read(unitNum) s_kremnod !< 2 * nrtm + 1 if option is used
-          read(unitNum) s_remnod !< size of remnod
-          read(unitNum) mulnsn !< maximum numbrer of candidates (size of cand_n)
-          read(unitNum) nbx !< number of voxels in x
-          read(unitNum) nby !< number of voxels in y
-          read(unitNum) nbz !< number of voxels in z
-
-          write(6,*)  "nsn          ",nsn
-          write(6,*)  "nsnr         ",nsnr
-          write(6,*)  "nsnrold      ",nsnrold
-          write(6,*)  "isznsnr      ",isznsnr
-          write(6,*)  "nrtm         ",nrtm
-          write(6,*)  "total_nb_nrtm",total_nb_nrtm
-          write(6,*)  "inacti       ",inacti
-          write(6,*)  "ifq          ",ifq
-          write(6,*)  "igap         ",igap
-          write(6,*)  "flagremnode  ",flagremnode
-          write(6,*)  "itied        ",itied
-          write(6,*)  "numnod       ",numnod
-          write(6,*)  "s_cand_a     ",s_cand_a
-          write(6,*)  "s_kremnod    ",s_kremnod
-          write(6,*)  "s_remnod     ",s_remnod
-          write(6,*)  "mulnsn       ",mulnsn
-          write(6,*)  "nbx          ",nbx
-          write(6,*)  "nby          ",nby
-          write(6,*)  "nbz          ",nbz
-
-
-          allocate(nsv(nsn))
-          allocate(oldnum(isznsnr))
-          allocate(kremnod(s_kremnod))
-          allocate(remnod(s_remnod))
-          allocate(irect(4, nrtm))
-          allocate(cand_a(s_cand_a))
-          allocate(x(3, numnod))
-          allocate(gap_s(nsn))
-          allocate(gap_m(nrtm))
-          allocate(gap_s_l(nsn))
-          allocate(gap_m_l(nrtm))
-          allocate(curv_max(nrtm))
-          allocate(stf(nrtm))
-          allocate(stfn(nsn))
-
-          read(unitNum) nsv(1:nsn) !< global secondary node numbers
-          read(unitNum) oldnum(1:isznsnr) !< renumbering ?
-          read(unitNum) kremnod(1:s_kremnod) !< list of removed nodes
-          read(unitNum) remnod(1:s_remnod) !< list of removed nodes
-          do i = 1, nrtm
-            read(unitNum) (irect(j, i), j = 1, 4)
-          end do
-          read(unitNum) cand_a(1:s_cand_a) !< (???)
-
-          read(unitNum) gap !< gap (???)
-          read(unitNum) gapmin !< minimum gap
-          read(unitNum) gapmax !< maximum gap
-          read(unitNum) bgapsmx!< overestimation of gap_s
-          read(unitNum) marge !< margin
-          read(unitNum) tzinf !< some kind of length for "zone of influence" ?
-          read(unitNum) drad !< radiation distance (thermal analysis)
-          read(unitNum) dgapload !< gap load (???)
-
-          do i = 1, numnod
-            read(unitnum) (x(j, i), j = 1, 3)
-          end do
-          read(unitNum) gap_s(1:nsn) !< gap for secondary nodes
-          read(unitNum) gap_m(1:nrtm) !< gap for main nodes
-          read(unitNum) gap_s_l(1:nsn) !< gap for secondary nodes (???)
-          read(unitNum) gap_m_l(1:nrtm) !< gap for main nodes (???)
-
-          read(unitNum) curv_max(1:nrtm) !< maximum curvature
-          read(unitNum) xyzm(1:12) !< bounding box
-          read(unitNum) stf(1:nrtm) !< stiffness of segments (quadrangles or triangles)
-          read(unitNum) stfn(1:nsn) !< stiffness secondary nodes
-
-          !relevant output
-          !mumnsn is the maximum number of candidates, ii_stok is the number of candidates found
-          read(unitNum) ii_stok !< number of candidates found
-          allocate(cand_n(mulnsn))
-          allocate(cand_e(mulnsn))
-          cand_n = 0
-          cand_e = 0
-          read(unitNum) cand_n(1:ii_stok) !< list of candidates (secondary)
-          read(unitNum) cand_e(1:ii_stok) !< list of candidates (main)
-          close(unitNum)
-          write(6,*)  "ii_stok_ref   ",ii_stok
-        end subroutine INTER7_DESERIALIZE
-
-
-!        !!\brief compare the couple cand_n(i) cand_e(i) with the couple cand_n_ref/cand_e_ref
-!        !!\details check if there exist i and j such as cand_n(i)=cand_n_ref(j) and cand_e(i)=cand_e_ref(j)
-!      !||====================================================================
-!      !||    test_candidates          ../engine/source/interfaces/intsort/inter7_candidate_pairs.F90
-!      !||--- called by ------------------------------------------------------
-!      !||    main                     ../engine/unit_test/unit_test1.F
-!      !||--- calls      -----------------------------------------------------
-!      !||    compare_cand             ../engine/source/interfaces/intsort/compare_cand.cpp
-!      !||    inter7_candidate_pairs   ../engine/source/interfaces/intsort/inter7_candidate_pairs.F90
-!      !||    inter7_deserialize       ../engine/source/interfaces/intsort/inter7_candidate_pairs.F90
-!      !||--- uses       -----------------------------------------------------
-!      !||====================================================================
-!        subroutine test_candidates(filename)
-!          use iso_c_binding , only : c_int
-!                                                     Implicit none
-!          interface
-!          subroutine compare_cand(cand_n, cand_e, ii_stok, cand_n_ref, cand_e_ref, ii_stok_ref) bind(C, name="compare_cand")
-!              import :: c_int
-!              integer(c_int), intent(in) :: cand_n(*), cand_e(*), cand_n_ref(*), cand_e_ref(*)
-!              integer(c_int), intent(in), value :: ii_stok_ref, ii_stok
-!          end subroutine compare_cand
-!          end interface
-!!-----------------------------------------------
-!!   D u m m y   A r g u m e n t s
-!!-----------------------------------------------
-!          character(len =*), intent(in) :: filename
-!!-----------------------------------------------
-!!   L o c a l   V a r i a b l e s
-!!-----------------------------------------------
-!          integer :: nsn !< number of secondary nodes
-!          integer :: nsnr !< current number of remote secondary nodes
-!          integer :: nsnrold !< old number of remote secondary nodes
-!          integer :: isznsnr !< size of oldnum
-!          integer :: nrtm !< number of considered segment
-!          integer :: total_nb_nrtm !< total number of segments
-!          integer :: inacti !< inactivation of initial penetrations
-!          integer :: ifq !< friction model ?
-!          integer :: igap !< gap model ?
-!          integer :: flagremnode !< flag for removed nodes?
-!          integer :: itied !< tied contact ?
-!          integer :: numnod !< total number of nodes of the model
-!          integer :: s_cand_a !< size of cand_a
-!          integer :: s_kremnod ! 2 * nrtm + 1 if option is used
-!          integer :: s_remnod !< size of remnod
-!          integer :: mulnsn !< maximum numbrer of candidates (size of cand_n)
-!          integer :: nbx !< number of voxels in x
-!          integer :: nby !< number of voxels in y
-!          integer :: nbz !< number of voxels in z
-!          integer :: ii_stok, ii_stok_ref !< number of candidates found
-!          integer, dimension(:), allocatable :: nsv !< global secondary node numbers
-!          integer, dimension(:), allocatable :: oldnum !< renumbering ?
-!          integer, dimension(:), allocatable :: kremnod !< list of removed nodes
-!          integer, dimension(:), allocatable :: remnod !< list of removed nodes
-!          integer, dimension(:,:), allocatable :: irect !< node id (from 1 to NUMNOD) for each segment (1:nrtm)
-!          integer, dimension(:), allocatable :: cand_a !< (???)
-!          integer, dimension(:), allocatable :: cand_n, cand_n_ref !< list of candidates (secondary)
-!          integer, dimension(:), allocatable :: cand_e, cand_e_ref !< list of candidates (main)
-!          real(kind=WP) :: gap !< gap (???)
-!          real(kind=WP) :: gapmin !< minimum gap
-!          real(kind=WP) :: gapmax !< maximum gap
-!          real(kind=WP) :: bgapsmx!< overestimation of gap_s
-!          real(kind=WP) :: marge !< margin
-!          real(kind=WP) :: tzinf !< some kind of length for "zone of influence" ?
-!          real(kind=WP) :: drad !< radiation distance (thermal analysis)
-!          real(kind=WP) :: dgapload !< gap load (???)
-!          real(kind=WP), dimension(:,:), allocatable :: x !< coordinates of nodes all
-!          real(kind=WP), dimension(:), allocatable :: gap_s !< gap for secondary nodes
-!          real(kind=WP), dimension(:), allocatable :: gap_m !< gap for main nodes
-!          real(kind=WP), dimension(:), allocatable :: gap_s_l !< gap for secondary nodes (???)
-!          real(kind=WP), dimension(:), allocatable :: gap_m_l !< gap for main nodes (???)
-!          real(kind=WP), dimension(:), allocatable :: curv_max !< maximum curvature
-!          real(kind=WP), dimension(:), allocatable :: stf !< stiffness of segments (quadrangles or triangles)
-!          real(kind=WP), dimension(:), allocatable :: stfn !< stiffness secondary nodes
-!          real(kind=WP), dimension(:), allocatable :: cand_f,cand_p
-!          integer :: nb_voxel_on
-!          integer, dimension(:), allocatable :: list_nb_voxel_on
-!
-!          integer OMP_GET_THREAD_NUM, OMP_GET_NUM_THREADS
-!          external OMP_GET_THREAD_NUM, OMP_GET_NUM_THREADS
-!
-!          real(kind=WP) ::  xyzm(12) !< bounding box
-!!         integer :: voxel(8000000)
-!          integer, dimension(:), allocatable :: voxel
-!          integer, dimension(:), allocatable :: next_nod,ifpen
-!          integer :: eshift,i_mem,i, itask, s_irem, s_xrem
-!          real(kind=WP), dimension(:,:), allocatable :: xrem
-!          integer, dimension(:,:), allocatable :: irem
-!          double precision :: start_time, end_time, elapsed_time
-!          double precision OMP_GET_WTIME
-!          external OMP_GET_WTIME
-!          i_mem = 0
-!          eshift = 0
-!          ii_stok_ref = 0
-!
-!          allocate(voxel(8000000))
-!
-!          call INTER7_DESERIALIZE(        filename     ,&
-!     &                                    nsn          ,&
-!     &                                    oldnum       ,&
-!     &                                    nsnr         ,&
-!     &                                    isznsnr      ,&
-!     &                                    irect        ,&
-!     &                                    x            ,&
-!     &                                    stf          ,&
-!     &                                    stfn         ,&
-!     &                                    xyzm         ,&
-!     &                                    nsv          ,&
-!     &                                    ii_stok_ref  ,&
-!     &                                    cand_n_ref   ,&
-!     &                                    cand_e_ref   ,&
-!     &                                    mulnsn       ,&
-!     &                                    tzinf        ,&
-!     &                                    gap_s_l      ,&
-!     &                                    gap_m_l      ,&
-!     &                                    nbx          ,&
-!     &                                    nby          ,&
-!     &                                    nbz          ,&
-!     &                                    inacti       ,&
-!     &                                    ifq          ,&
-!     &                                    cand_a       ,&
-!     &                                    nrtm         ,&
-!     &                                    nsnrold      ,&
-!     &                                    igap         ,&
-!     &                                    gap          ,&
-!     &                                    gap_s        ,&
-!     &                                    gap_m        ,&
-!     &                                    gapmin       ,&
-!     &                                    gapmax       ,&
-!     &                                    marge        ,&
-!     &                                    curv_max     ,&
-!     &                                    bgapsmx      ,&
-!     &                                    s_kremnod    ,&
-!     &                                    kremnod      ,&
-!     &                                    s_remnod     ,&
-!     &                                    remnod       ,&
-!     &                                    flagremnode  ,&
-!     &                                    drad         ,&
-!     &                                    itied        ,&
-!     &                                    dgapload     ,&
-!     &                                    s_cand_a     ,&
-!     &                                    total_nb_nrtm,&
-!     &                                    numnod       )
-!
-!        allocate(cand_n(mulnsn))
-!        allocate(cand_e(mulnsn))
-!        allocate(cand_f(8*mulnsn))
-!        allocate(cand_p(mulnsn))
-!        allocate(ifpen(mulnsn))
-!        s_xrem = 1
-!        s_irem = 1
-!        allocate(xrem(s_xrem, nsnr))
-!        allocate(irem(s_irem, nsnr))
-!        ifpen = 0
-!        cand_n = 0
-!        cand_e = 0
-!        cand_f = 0
-!        cand_p = 0
-!        ii_stok = 0
-!        allocate(next_nod(nsn+nsnr))
-!        start_time = OMP_GET_WTIME()
-!!$OMP PARALLEL PRIVATE(i,itask)
-!!$OMP SINGLE
-!        do i=1,(nbx+2)*(nby+2)*(nbz+2)
-!          voxel(i)=0
-!        enddo
-!        allocate(list_nb_voxel_on((nbx+2)*(nby+2)*(nbz+2)))
-!        nb_voxel_on = 0
-!!$OMP END SINGLE
-!         ITASK = OMP_GET_THREAD_NUM()
-!
-!
-!        call INTER7_CANDIDATE_PAIRS(&
-!     &                                    nsn          ,&
-!     &                                    oldnum       ,&
-!     &                                    nsnr         ,&
-!     &                                    isznsnr      ,&
-!     &                                    i_mem        ,&
-!     &                                    irect        ,&
-!     &                                    x            ,&
-!     &                                    stf          ,&
-!     &                                    xyzm         ,&
-!     &                                    nsv          ,&
-!     &                                    ii_stok      ,&
-!     &                                    cand_n       ,&
-!     &                                    eshift       ,&
-!     &                                    cand_e       ,&
-!     &                                    mulnsn       ,&
-!     &                                    tzinf        ,&
-!     &                                    gap_s_l      ,&
-!     &                                    gap_m_l      ,&
-!     &                                    voxel        ,&
-!     &                                    nbx          ,&
-!     &                                    nby          ,&
-!     &                                    nbz          ,&
-!     &                                    inacti       ,&
-!     &                                    ifq          ,&
-!     &                                    cand_a       ,&
-!     &                                    cand_p       ,&
-!     &                                    ifpen        ,&
-!     &                                    nrtm         ,&
-!     &                                    nsnrold      ,&
-!     &                                    igap         ,&
-!     &                                    gap          ,&
-!     &                                    gap_s        ,&
-!     &                                    gap_m        ,&
-!     &                                    gapmin       ,&
-!     &                                    gapmax       ,&
-!     &                                    marge        ,&
-!     &                                    curv_max     ,&
-!     &                                    itask        ,&
-!     &                                    bgapsmx      ,&
-!     &                                    s_kremnod    ,&
-!     &                                    kremnod      ,&
-!     &                                    s_remnod     ,&
-!     &                                    remnod       ,&
-!     &                                    flagremnode  ,&
-!     &                                    drad         ,&
-!     &                                    itied        ,&
-!     &                                    cand_f       ,&
-!     &                                    dgapload     ,&
-!     &                                    s_cand_a     ,&
-!     &                                    total_nb_nrtm,&
-!     &                                    numnod       ,&
-!     &                                    xrem         ,&
-!     &                                    s_xrem       ,&
-!     &                                    irem         ,&
-!     &                                    s_irem       ,&
-!     &                                    next_nod     ,&
-!     &                                    nb_voxel_on, &
-!     &                                    list_nb_voxel_on);
-!
-!!$OMP END PARALLEL
-!          end_time = OMP_GET_WTIME()
-!
-!          write(6,*) "Elapsed time =", end_time - start_time
-!
-!          call compare_cand(cand_n, cand_e, ii_stok, cand_n_ref, cand_e_ref, ii_stok_ref)
-!
-!          deallocate(voxel)
-!
-!        end subroutine
-
 
       end module INTER7_CANDIDATE_PAIRS_MOD
 

--- a/engine/source/interfaces/intsort/inter7_collision_detection.F90
+++ b/engine/source/interfaces/intsort/inter7_collision_detection.F90
@@ -47,7 +47,7 @@
 !||    tri7box                      ../engine/share/modules/tri7box.F
 !||    voxel_dimensions_mod         ../engine/source/interfaces/intsort/voxel_dimensions.F90
 !||====================================================================
-        SUBROUTINE INTER7_COLLISION_DETECTION(&
+        SUBROUTINE INTER7_COLLISION_DETECTION(multimp_param,&
         &X        ,IRECT   ,NSV     ,INACTI   ,CAND_P  ,&
         &NRTM    ,NSN     ,CAND_E   ,CAND_N  ,&
         &GAP      ,NOINT   ,II_STOK ,NCONTACT ,BMINMA  ,&
@@ -87,6 +87,7 @@
           INTEGER :: INACTI !< inacti option
           INTEGER :: IFQ !< friction option
           INTEGER :: NSNR !< number of remote nodes
+          integer, intent(inout) :: multimp_param
           INTEGER :: NSNROLD !< number of old secondary nodes
           INTEGER :: RENUM_SIZ !< size of renum array
           INTEGER, INTENT(IN) :: NUMNOD !< global number of nodes
@@ -98,9 +99,9 @@
           INTEGER :: RENUM(RENUM_SIZ) !< ?
           INTEGER :: NUM_IMP           !<
           INTEGER :: ITASK            !< OpenMP task id
-          INTEGER :: CAND_E(NCONTACT) !< segment id of the contact candidate
-          INTEGER :: CAND_N(NCONTACT) !< node id of the contact candidate
-          INTEGER :: IFPEN(NCONTACT)
+          INTEGER, INTENT(INOUT), ALLOCATABLE :: CAND_E(:) !< segment id of the contact candidate
+          INTEGER, INTENT(INOUT), ALLOCATABLE :: CAND_N(:) !< node id of the contact candidate
+          INTEGER, INTENT(INOUT), ALLOCATABLE :: IFPEN(:)
           INTEGER :: KREMNOD(*) !< remnode option
           INTEGER :: REMNOD(*) !< remnode option
           INTEGER :: NCONTACT !< number of contact candidates
@@ -131,17 +132,18 @@
           real(kind=WP) , INTENT(IN) :: DRAD
           real(kind=WP) , INTENT(IN) :: DGAPLOAD
           real(kind=WP) :: X(3,NUMNOD)
-          real(kind=WP) :: CAND_P(NCONTACT)
+          real(kind=WP), INTENT(INOUT), ALLOCATABLE :: CAND_P(:)
           real(kind=WP) :: STF(NRTM)
           real(kind=WP) :: GAP_S(NSN)
           real(kind=WP) :: GAP_M(NRTM)
           real(kind=WP) :: GAP_S_L(NSN)
           real(kind=WP) :: GAP_M_L(NRTM)
-          real(kind=WP) :: CAND_F(NCONTACT)
+          real(kind=WP), INTENT(INOUT), ALLOCATABLE :: CAND_F(:)
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   local variables
 ! ----------------------------------------------------------------------------------------------------------------------
-          INTEGER :: S_PREV_REMOTE_NUMBER
+          INTEGER :: S_PREV_REMOTE_NUMBER, I
+          INTEGER(8) :: t0_clock, t1_clock, clock_rate
 !     REAL
           real(kind=WP) :: XYZM(6,2), MARGE
 
@@ -165,7 +167,7 @@
           XYZM(5,2) = BMINMA(8)
           XYZM(6,2) = BMINMA(9)
 
-          I_MEM = 0
+!         I_MEM = 0
 !
           IF(INACTI==5.OR.INACTI==6.OR.INACTI==7.OR.&
           &IFQ>0.OR.NUM_IMP>0.OR.ITIED/=0) THEN
@@ -234,71 +236,206 @@
 !       &                    xrem,&
 !       &                    inter_struct%box_limit_main)
           END IF
+          ! Build inverse NSV map: global node number -> local secondary index
+          ! Allows fast self-node rejection without nsv(jj) memory access
+          if(.not. allocated(inter_struct%inv_nsv)) then
+            allocate(inter_struct%inv_nsv(numnod))
+            inter_struct%inv_nsv(:) = 0
+            do i = 1, nsn
+              inter_struct%inv_nsv(nsv(i)) = i
+            end do
+          end if
+
 !$OMP END SINGLE
 
 
+          call system_clock(t0_clock, clock_rate)
 
-          CALL INTER7_CANDIDATE_PAIRS( &
-          & NSN, &
-          & PREV_REMOTE_NUMBER, &
-          & NSNR, &
-          & S_PREV_REMOTE_NUMBER, &
-          & I_MEM, &
-          & IRECT, &
-          & X, &
-          & STF, &
-          & XYZM, &
-          & NSV, &
-          & II_STOK, &
-          & CAND_N, &
-          & ESHIFT, &
-          & CAND_E, &
-          & NCONTACT, &
-          & TZINF, &
-          & GAP_S_L, &
-          & GAP_M_L, &
-          & inter_struct%VOXEL, &
-          & inter_struct%NBX, &
-          & inter_struct%NBY, &
-          & inter_struct%NBZ, &
-          & INACTI, &
-          & IFQ, &
-          & CAND_A, &
-          & CAND_P, &
-          & IFPEN, &
-          & NRTM, &
-          & NSNROLD, &
-          & IGAP, &
-          & GAP, &
-          & GAP_S, &
-          & GAP_M, &
-          & GAPMIN, &
-          & GAPMAX, &
-          & MARGE, &
-          & CURV_MAX, &
-          & BGAPSMX, &
-          & S_KREMNOD, &
-          & KREMNOD, &
-          & S_REMNOD, &
-          & REMNOD, &
-          & FLAGREMNODE, &
-          & DRAD, &
-          & ITIED, &
-          & CAND_F, &
-          & DGAPLOAD, &
-          & s_cand_a, &
-          & NUMNOD, &
-          & XREM, &
-          & SIZE(XREM, 1), &
-          & IREM, &
-          & SIZE(IREM, 1), &
-          & inter_struct%NEXT_NOD)
+          if(NSPMD > 1) then
+            ! NSPMD==1: no MPI, do local search here (no remote nodes exist)
+!           CALL INTER7_CANDIDATE_PAIRS_LOCAL(multimp_param,&
+!           & NSN, &
+!           & I_MEM, &
+!           & IRECT, &
+!           & X, &
+!           & STF, &
+!           & XYZM, &
+!           & NSV, &
+!           & II_STOK, &
+!           & CAND_N, &
+!           & ESHIFT, &
+!           & CAND_E, &
+!           & NCONTACT, &
+!           & TZINF, &
+!           & GAP_S_L, &
+!           & GAP_M_L, &
+!           & inter_struct%VOXEL, &
+!           & inter_struct%NBX, &
+!           & inter_struct%NBY, &
+!           & inter_struct%NBZ, &
+!           & INACTI, &
+!           & IFQ, &
+!           & CAND_A, &
+!           & CAND_P, &
+!           & IFPEN, &
+!           & NRTM, &
+!           & IGAP, &
+!           & GAP, &
+!           & GAP_S, &
+!           & GAP_M, &
+!           & GAPMIN, &
+!           & GAPMAX, &
+!           & MARGE, &
+!           & CURV_MAX, &
+!           & BGAPSMX, &
+!           & S_KREMNOD, &
+!           & KREMNOD, &
+!           & S_REMNOD, &
+!           & REMNOD, &
+!           & FLAGREMNODE, &
+!           & DRAD, &
+!           & ITIED, &
+!           & CAND_F, &
+!           & DGAPLOAD, &
+!           & s_cand_a, &
+!           & NUMNOD, &
+!           & inter_struct%NEXT_NOD, &
+!           & inter_struct%INV_NSV)
+
+
+            ! Local search was already done in SPMD_CELL_EXCHANGE (overlapped with MPI)
+            ! Here we only do the remote search using the separate remote voxel
+            CALL INTER7_CANDIDATE_PAIRS_REMOTE(multimp_param,&
+            & NSN, &
+            & PREV_REMOTE_NUMBER, &
+            & NSNR, &
+            & S_PREV_REMOTE_NUMBER, &
+            & I_MEM, &
+            & IRECT, &
+            & X, &
+            & STF, &
+            & XYZM, &
+            & NSV, &
+            & II_STOK, &
+            & CAND_N, &
+            & ESHIFT, &
+            & CAND_E, &
+            & NCONTACT, &
+            & TZINF, &
+            & GAP_S_L, &
+            & GAP_M_L, &
+            & inter_struct%VOXEL_REMOTE, &
+            & inter_struct%NBX, &
+            & inter_struct%NBY, &
+            & inter_struct%NBZ, &
+            & INACTI, &
+            & IFQ, &
+            & CAND_A, &
+            & CAND_P, &
+            & IFPEN, &
+            & NRTM, &
+            & NSNROLD, &
+            & IGAP, &
+            & GAP, &
+            & GAP_S, &
+            & GAP_M, &
+            & GAPMIN, &
+            & GAPMAX, &
+            & MARGE, &
+            & CURV_MAX, &
+            & BGAPSMX, &
+            & S_KREMNOD, &
+            & KREMNOD, &
+            & S_REMNOD, &
+            & REMNOD, &
+            & FLAGREMNODE, &
+            & DRAD, &
+            & ITIED, &
+            & CAND_F, &
+            & DGAPLOAD, &
+            & s_cand_a, &
+            & NUMNOD, &
+            & XREM, &
+            & SIZE(XREM, 1), &
+            & IREM, &
+            & SIZE(IREM, 1), &
+            & inter_struct%NEXT_NOD_REMOTE)
+          else
+            ! NSPMD==1: no MPI, do local search here (no remote nodes exist)
+            CALL INTER7_CANDIDATE_PAIRS_LOCAL(multimp_param, &
+            & NSN, &
+            & I_MEM, &
+            & IRECT, &
+            & X, &
+            & STF, &
+            & XYZM, &
+            & NSV, &
+            & II_STOK, &
+            & CAND_N, &
+            & ESHIFT, &
+            & CAND_E, &
+            & NCONTACT, &
+            & TZINF, &
+            & GAP_S_L, &
+            & GAP_M_L, &
+            & inter_struct%VOXEL, &
+            & inter_struct%NBX, &
+            & inter_struct%NBY, &
+            & inter_struct%NBZ, &
+            & INACTI, &
+            & IFQ, &
+            & CAND_A, &
+            & CAND_P, &
+            & IFPEN, &
+            & NRTM, &
+            & IGAP, &
+            & GAP, &
+            & GAP_S, &
+            & GAP_M, &
+            & GAPMIN, &
+            & GAPMAX, &
+            & MARGE, &
+            & CURV_MAX, &
+            & BGAPSMX, &
+            & S_KREMNOD, &
+            & KREMNOD, &
+            & S_REMNOD, &
+            & REMNOD, &
+            & FLAGREMNODE, &
+            & DRAD, &
+            & ITIED, &
+            & CAND_F, &
+            & DGAPLOAD, &
+            & s_cand_a, &
+            & NUMNOD, &
+            & inter_struct%NEXT_NOD, &
+            & inter_struct%INV_NSV)
+          end if
+
+          call system_clock(t1_clock)
+!$OMP ATOMIC
+          inter_struct%t_candidate_pairs = inter_struct%t_candidate_pairs + &
+            dble(t1_clock - t0_clock) / dble(clock_rate)
+!$OMP ATOMIC
+          inter_struct%n_calls = inter_struct%n_calls + 1
 
           IF(ITASK==0)  THEN
 !           IF(ALLOCATED(inter_struct%NEXT_NOD)) DEALLOCATE(inter_struct%NEXT_NOD)
             IF(ALLOCATED(PREV_REMOTE_NUMBER)) DEALLOCATE(PREV_REMOTE_NUMBER)
 !           if(allocated(inter_struct%list_nb_voxel_on)) deallocate(inter_struct%list_nb_voxel_on)
-
+            ! Print cumulative timing every 1000 sort calls
+            if(mod(inter_struct%n_calls, 100) == 0) then
+              write(6,'(A,I8,A)') ' [PREVIEW TIMING] after ', &
+                inter_struct%n_calls, ' calls (cumulative seconds):'
+              write(6,'(A,F12.4)') '   fill_local      = ', &
+                inter_struct%t_fill_local
+              write(6,'(A,F12.4)') '   mpi_wait        = ', &
+                inter_struct%t_mpi_wait
+              write(6,'(A,F12.4)') '   fill_remote     = ', &
+                inter_struct%t_fill_remote
+              write(6,'(A,F12.4)') '   candidate_pairs = ', &
+                inter_struct%t_candidate_pairs
+            end if
           END IF
 !     I_MEM = 2 ==> Not enough memory
           IF (I_MEM ==2) RETURN

--- a/engine/source/interfaces/intsort/inter7_filter_cand.F90
+++ b/engine/source/interfaces/intsort/inter7_filter_cand.F90
@@ -47,7 +47,7 @@
         SUBROUTINE INTER7_FILTER_CAND(&
         &j_stok,irect  ,x     ,nsv   ,ii_stok,&
         &cand_n,cand_e ,mulnsn,margin  ,&
-        &i_mem ,prov_n ,prov_e,eshift,inacti ,&
+        &prov_n ,prov_e,eshift,inacti ,&
         &ifq   ,cand_a ,cand_p,ifpen ,nsn    ,&
         &oldnum,nsnrold,igap  ,gap   ,gap_s  ,&
         &gap_m ,gapmin ,gapmax,curv_max,&
@@ -69,7 +69,6 @@
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   arguments
 ! ----------------------------------------------------------------------------------------------------------------------
-          integer, intent(inout) :: i_mem !< memory error flag
           integer, intent(in) :: nrtm !< number of main segments
           integer, intent(in) :: isznsnr !< size of oldnum
           integer, intent(in) :: nsn  !< number secondary nodes
@@ -187,21 +186,10 @@
             if(pene(i)/=zero) k_stok = k_stok + 1
           end do
           if(k_stok==0)return
-          exit_flag = .false.
 !$omp critical
           i_stok = ii_stok
-          if (i_stok + k_stok > mulnsn) then
-            i_mem = 2
-            exit_flag = .true.
-          else
-            ii_stok = i_stok + k_stok
-          end if
+          ii_stok = i_stok + k_stok
 !$omp end critical
-
-          if (exit_flag) then
-            return
-          end if
-
           inacti_l = inacti
           itied_l = itied
           ifq_l = ifq

--- a/engine/source/interfaces/intsort/voxel_dimensions.F90
+++ b/engine/source/interfaces/intsort/voxel_dimensions.F90
@@ -134,6 +134,17 @@
             do i=1,inter_struct%voxel_size
               inter_struct%voxel(i)=0
             end do
+            ! Allocate remote voxel (same size as local)
+            if(allocated(inter_struct%voxel_remote) .and. inter_struct%voxel_remote_size < res8) &
+              deallocate(inter_struct%voxel_remote)
+            if(.not.allocated(inter_struct%voxel_remote)) then
+              call my_alloc(inter_struct%voxel_remote,res8)
+              inter_struct%voxel_remote_size = res8
+            end if
+            do i=1,inter_struct%voxel_remote_size
+              inter_struct%voxel_remote(i)=0
+            end do
+            inter_struct%nb_voxel_on_remote = 0
             inter_struct%nbx = nbx
             inter_struct%nby = nby
             inter_struct%nbz = nbz

--- a/engine/source/mpi/generic/spmd_cell_exchange.F
+++ b/engine/source/mpi/generic/spmd_cell_exchange.F
@@ -41,10 +41,15 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !||    timer_mod                  ../engine/source/system/timer_mod.F90
 !||    tri7box                    ../engine/share/modules/tri7box.F
 !||====================================================================
-      SUBROUTINE SPMD_CELL_EXCHANGE(TIMERS, NIN,ISENDTO,IRCVFROM,NSN,NSNR,IGAP,
+      SUBROUTINE SPMD_CELL_EXCHANGE(multimp_param, TIMERS, NIN,ISENDTO,IRCVFROM,NSN,NSNR,IGAP,
      1                               IFQ,INACTI,NSNFIOLD,INTTH,ITYP,STFNS, NSV,
-     2                               NRTM, X,
-     2                               ITIED,NMN,INTER_STRUCT,SORT_COMM, GOT_PREVIEW)
+     2                               NRTM, X,I_MEM_LOCAL,
+     2                               ITIED,NMN,INTER_STRUCT,SORT_COMM, GOT_PREVIEW,
+     3                               INTBUF_TAB, ESHIFT_ARG, NCONTACT_ARG,
+     4                               NSNROLD_ARG, FLAGREMNODE_ARG,
+     5                               GAP_ARG, GAPMIN_ARG, GAPMAX_ARG,
+     6                               TZINF_ARG, BGAPSMX_ARG, DRAD_ARG,
+     7                               DGAPLOAD_ARG)
 !$COMMENT
 !       SPMD_CELL_EXCHANGE description :
 !       exchange of secondary node data (x, v, temp...)
@@ -63,6 +68,8 @@ C-----------------------------------------------
         USE MULTI_FVM_MOD
         USE INTER_SORTING_MOD
         USE INTER_STRUCT_MOD
+        USE INTBUFDEF_MOD
+        USE INTER7_CANDIDATE_PAIRS_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -88,6 +95,7 @@ C-----------------------------------------------
      .        NSNFIOLD(NSPMD),
      .        ISENDTO(NINTER+1,NSPMD+1), IRCVFROM(NINTER+1,NSPMD+1),
      .        ITYP
+        integer :: multimp_param
         INTEGER :: GOT_PREVIEW !< flag to indicate if -preview is available
         INTEGER :: NMN
         TYPE(inter_struct_type), DIMENSION(NINTER), INTENT(inout) :: INTER_STRUCT   !   structure for interface
@@ -96,6 +104,16 @@ C-----------------------------------------------
         INTEGER :: NSV(NSN)
         INTEGER :: NRTM
         my_real :: X(3,NUMNOD)
+        TYPE(INTBUF_STRUCT_), INTENT(INOUT) :: INTBUF_TAB
+        INTEGER, INTENT(IN) :: ESHIFT_ARG
+        INTEGER, intent(inout) :: NCONTACT_ARG
+        INTEGER, INTENT(IN) :: NSNROLD_ARG, FLAGREMNODE_ARG
+        my_real, INTENT(IN) :: GAP_ARG, GAPMIN_ARG, GAPMAX_ARG
+        my_real, INTENT(IN) :: TZINF_ARG, BGAPSMX_ARG, DRAD_ARG
+        my_real, INTENT(IN) :: DGAPLOAD_ARG
+        INTEGER :: I_MEM_LOCAL
+
+
 C-----------------------------------------------
 C   L o c a l  V a r i a b l e s
 C-----------------------------------------------
@@ -112,7 +130,10 @@ C-----------------------------------------------
       DATA MSGOFF5/6027/ 
       INTEGER :: SIZE_S
       INTEGER :: OFFSET(NSPMD)
-      INTEGER :: DUMMY(1)
+      INTEGER(8) :: t0_clock, t1_clock, clock_rate
+      INTEGER :: II_STOK_LOCAL
+      my_real :: MARGE_LOCAL
+      my_real :: XYZM_LOCAL(12)
 C-----------------------------------------------
 C   S o u r c e  L i n e s
 C-----------------------------------------------
@@ -198,40 +219,135 @@ C================================================================
       ENDDO
 
 
-        ! -----------------------------
-        if(GOT_PREVIEW == 1) THEN
-        ! finish the last groups of secondary nodes, if any
-            CALL FILL_VOXEL_LOCAL_PARTIAL(nsn,nsv,nsnr,nrtm,numnod,x,stfns,INTER_STRUCT(NIN),DUMMY,0) 
-        ENDIF
- 
 
-      ! ---------------------------------------
-      ! wait the rcv comm
+      ! ============================================================
+      ! LOCAL SEARCH: overlap with MPI communication
+      ! All sends posted, receives pending. Use all threads for local search.
+      ! ============================================================
+      IF(GOT_PREVIEW==1 .AND. NRTM > 0) THEN
+        MARGE_LOCAL = TZINF_ARG - MAX(GAP_ARG+DGAPLOAD_ARG,DRAD_ARG)
+        I_MEM_LOCAL = 0
+        II_STOK_LOCAL = INTBUF_TAB%I_STOK(1)
+        ! Remap BOX_LIMIT_MAIN to xyzm layout expected by candidate_pairs
+        ! BOX_LIMIT_MAIN: (1:3)=max, (4:6)=min, (7:9)=reduced_max, (10:12)=reduced_min
+        ! xyzm expected:  (1:3)=min, (4:6)=max, (7:9)=reduced_min, (10:12)=reduced_max
+        XYZM_LOCAL(1) = INTER_STRUCT(NIN)%BOX_LIMIT_MAIN(4)
+        XYZM_LOCAL(2) = INTER_STRUCT(NIN)%BOX_LIMIT_MAIN(5)
+        XYZM_LOCAL(3) = INTER_STRUCT(NIN)%BOX_LIMIT_MAIN(6)
+        XYZM_LOCAL(4) = INTER_STRUCT(NIN)%BOX_LIMIT_MAIN(1)
+        XYZM_LOCAL(5) = INTER_STRUCT(NIN)%BOX_LIMIT_MAIN(2)
+        XYZM_LOCAL(6) = INTER_STRUCT(NIN)%BOX_LIMIT_MAIN(3)
+        XYZM_LOCAL(7) = INTER_STRUCT(NIN)%BOX_LIMIT_MAIN(10)
+        XYZM_LOCAL(8) = INTER_STRUCT(NIN)%BOX_LIMIT_MAIN(11)
+        XYZM_LOCAL(9) = INTER_STRUCT(NIN)%BOX_LIMIT_MAIN(12)
+        XYZM_LOCAL(10) = INTER_STRUCT(NIN)%BOX_LIMIT_MAIN(7)
+        XYZM_LOCAL(11) = INTER_STRUCT(NIN)%BOX_LIMIT_MAIN(8)
+        XYZM_LOCAL(12) = INTER_STRUCT(NIN)%BOX_LIMIT_MAIN(9)
+        ! Build inverse NSV map if not done yet
+!$OMP PARALLEL
+!$OMP SINGLE
+        if(.not. allocated(inter_struct(nin)%inv_nsv)) then
+          allocate(inter_struct(nin)%inv_nsv(NUMNOD))
+          inter_struct(nin)%inv_nsv(:) = 0
+          do L = 1, NSN
+            inter_struct(nin)%inv_nsv(NSV(L)) = L
+          end do
+        end if
+!$OMP END SINGLE
+        call system_clock(t0_clock, clock_rate)
+         CALL INTER7_CANDIDATE_PAIRS_LOCAL(multimp_param,
+     &    NSN,
+     &    I_MEM_LOCAL,
+     &    INTBUF_TAB%IRECTM,
+     &    X,
+     &    INTBUF_TAB%STFM,
+     &    XYZM_LOCAL,
+     &    NSV,
+     &    II_STOK_LOCAL,
+     &    INTBUF_TAB%CAND_N,
+     &    ESHIFT_ARG,
+     &    INTBUF_TAB%CAND_E,
+     &    NCONTACT_ARG,
+     &    TZINF_ARG,
+     &    INTBUF_TAB%GAP_SL,
+     &    INTBUF_TAB%GAP_ML,
+     &    INTER_STRUCT(NIN)%VOXEL,
+     &    INTER_STRUCT(NIN)%NBX,
+     &    INTER_STRUCT(NIN)%NBY,
+     &    INTER_STRUCT(NIN)%NBZ,
+     &    INACTI,
+     &    IFQ,
+     &    INTER_STRUCT(NIN)%CAND_A,
+     &    INTBUF_TAB%CAND_P,
+     &    INTBUF_TAB%IFPEN,
+     &    NRTM,
+     &    IGAP,
+     &    GAP_ARG,
+     &    INTBUF_TAB%GAP_S,
+     &    INTBUF_TAB%GAP_M,
+     &    GAPMIN_ARG,
+     &    GAPMAX_ARG,
+     &    MARGE_LOCAL,
+     &    INTER_STRUCT(NIN)%CURV_MAX,
+     &    BGAPSMX_ARG,
+     &    INTBUF_TAB%S_KREMNODE,
+     &    INTBUF_TAB%KREMNODE,
+     &    INTBUF_TAB%S_REMNODE,
+     &    INTBUF_TAB%REMNODE,
+     &    FLAGREMNODE_ARG,
+     &    DRAD_ARG,
+     &    ITIED,
+     &    INTBUF_TAB%CAND_F,
+     &    DGAPLOAD_ARG,
+     &    INTER_STRUCT(NIN)%SIZE_CAND_A,
+     &    NUMNOD,
+     &    INTER_STRUCT(NIN)%NEXT_NOD,
+     &    INTER_STRUCT(NIN)%INV_NSV)
+         INTBUF_TAB%I_STOK(1) = II_STOK_LOCAL
+
+        call system_clock(t1_clock)
+!$OMP SINGLE
+        inter_struct(nin)%t_candidate_pairs =
+     .    inter_struct(nin)%t_candidate_pairs +
+     .    dble(t1_clock - t0_clock) / dble(clock_rate)
+!$OMP END SINGLE
+!$OMP END PARALLEL
+      ENDIF
+
       IF(IRCVFROM(NIN,LOC_PROC)/=0) THEN  !   nmn > 0
        IF(NSNR>0) THEN   !   nsnr>0 only on proc with nmn>0
          DO L = 1, SORT_COMM(NIN)%NBIRECV
+          call system_clock(t0_clock, clock_rate)
           CALL MPI_WAITANY(SORT_COMM(NIN)%NBIRECV,REQ_RD,INDEXI,STATUS,IERROR) !XREM
+          call system_clock(t1_clock)
+          inter_struct(nin)%t_mpi_wait =
+     .      inter_struct(nin)%t_mpi_wait +
+     .      dble(t1_clock - t0_clock) / dble(clock_rate)
 
          ! CALL MPI_WAITANY(SORT_COMM(NIN)%NBIRECV,REQ_RD2,INDEXI,STATUS,IERROR)
 
           if(GOT_PREVIEW==1) then
-          call fill_voxel_remote(
+          call system_clock(t0_clock)
+          call fill_voxel_remote_separate(
      .                    OFFSET(INDEXI), 
      .                    OFFSET(INDEXI+1)-1, 
-     .                    nsn,
      .                    nsnr,
      .                    inter_struct(nin)%nbx,
      .                    inter_struct(nin)%nby,
      .                    inter_struct(nin)%nbz,
      .                    size(XREM,1),
-     .                    inter_struct(nin)%voxel,
-     .                    inter_struct(nin)%next_nod,
-     .                    inter_struct(nin)%size_node,
-     .                    inter_struct(nin)%nb_voxel_on,
-     .                    inter_struct(nin)%list_nb_voxel_on,
-     .                    inter_struct(nin)%last_nod,
+     .                    inter_struct(nin)%voxel_remote,
+     .                    inter_struct(nin)%next_nod_remote,
+     .                    inter_struct(nin)%size_node_remote,
+     .                    inter_struct(nin)%nb_voxel_on_remote,
+     .                    inter_struct(nin)%list_nb_voxel_on_remote,
+     .                    inter_struct(nin)%last_nod_remote,
      .                    xrem,
      .                    inter_struct(nin)%box_limit_main)
+          call system_clock(t1_clock)
+          inter_struct(nin)%t_fill_remote =
+     .      inter_struct(nin)%t_fill_remote +
+     .      dble(t1_clock - t0_clock) / dble(clock_rate)
           endif
           CALL MPI_WAIT(REQ_RD2(INDEXI),STATUS,IERROR) !IREM
 
@@ -266,12 +382,6 @@ C================================================================
         ENDDO
       ENDIF
       ! ---------------------------------------
-      ELSE 
-
-        if(GOT_PREVIEW == 1) THEN
-        ! finish the last groups of secondary nodes, if any
-            CALL FILL_VOXEL_LOCAL_PARTIAL(nsn,nsv,nsnr,nrtm,numnod,x,stfns,INTER_STRUCT(NIN),DUMMY,0) 
-        ENDIF
 
        ENDIF
 


### PR DESCRIPTION
Local and remote broad phase search separated
Run the engine with -preview option. Useful only for large number of MPI

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
This pull request introduces a new `-preview` command line option and implements significant changes to enable overlapping of MPI communication with computation in the broad phase collision detection. The main improvements include separating local and remote voxel structures, refactoring the sorting and collision detection routines to support overlap, and adding detailed timing and documentation for the new code path. These changes are designed to reduce wall-clock time by hiding MPI latency behind the local candidate pair search.

The most important changes are:

**Overlap Mode Implementation and Data Structures**
* Added new fields to `inter_struct_type` in `inter_struct_mod.F` to support separate storage for local and remote voxels (`voxel_remote`, `next_nod_remote`, etc.), as well as timing fields for performance analysis.
* The local voxel is now always filled in a single pass before the MPI exchange, and a separate remote voxel is incrementally filled as remote data is received. [[1]](diffhunk://#diff-8e5bd183a8421c6d81189fc0f241be509cf99abbc1314f9d7e2541c68dedf65dR253-R269) [[2]](diffhunk://#diff-8e5bd183a8421c6d81189fc0f241be509cf99abbc1314f9d7e2541c68dedf65dL287-R314)

**Sorting and Collision Detection Refactoring**
* Refactored `inter_prepare_sort.F` to always use `FILL_VOXEL_LOCAL` for local voxel construction, removing the partial fill path, and added high-resolution timing around voxel fill operations. [[1]](diffhunk://#diff-8e5bd183a8421c6d81189fc0f241be509cf99abbc1314f9d7e2541c68dedf65dR253-R269) [[2]](diffhunk://#diff-8e5bd183a8421c6d81189fc0f241be509cf99abbc1314f9d7e2541c68dedf65dL287-R314) [[3]](diffhunk://#diff-8e5bd183a8421c6d81189fc0f241be509cf99abbc1314f9d7e2541c68dedf65dL135-R136)
* Updated `inter_sort_07.F` to support the new overlap mode, including passing additional arguments to `SPMD_CELL_EXCHANGE` and `INTER7_COLLISION_DETECTION`, and synchronizing/reallocating arrays after collision detection to handle dynamic resizing in OpenMP. [[1]](diffhunk://#diff-7c82dc7d366d5365bb86f8bf7b367217e79b83487d2a6fe0c8bfd60f363780b8R206-R222) [[2]](diffhunk://#diff-7c82dc7d366d5365bb86f8bf7b367217e79b83487d2a6fe0c8bfd60f363780b8R278-R316)

**Documentation**
* Added a comprehensive `preview.md` file documenting the `-preview` option, its activation, behavior, data flow, timeline, key routines, and rationale for the overlap approach.

**Code Cleanup and Minor Changes**
* Removed unused variables and obsolete code paths, such as the `FILL_VOXEL_LOCAL_PARTIAL` calls and dummy variables. [[1]](diffhunk://#diff-8e5bd183a8421c6d81189fc0f241be509cf99abbc1314f9d7e2541c68dedf65dL263-L268) [[2]](diffhunk://#diff-8e5bd183a8421c6d81189fc0f241be509cf99abbc1314f9d7e2541c68dedf65dL313-R339) [[3]](diffhunk://#diff-8e5bd183a8421c6d81189fc0f241be509cf99abbc1314f9d7e2541c68dedf65dL135-R136)
* Added missing module imports and local variables for new logic. [[1]](diffhunk://#diff-7c82dc7d366d5365bb86f8bf7b367217e79b83487d2a6fe0c8bfd60f363780b8R77) [[2]](diffhunk://#diff-7c82dc7d366d5365bb86f8bf7b367217e79b83487d2a6fe0c8bfd60f363780b8R141)

These changes collectively enable the engine to overlap computation and communication during broad phase collision detection, improving parallel efficiency in distributed-memory runs.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
