### PR TITLE
Cmake: missing include in arm+gfortran build

### DIFF
--- a/starter/CMake_Compilers/cmake_linuxa64_gf.txt
+++ b/starter/CMake_Compilers/cmake_linuxa64_gf.txt
@@ -90,10 +90,10 @@ set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS "${FSANIT
 
 
 # C source files
-set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} ${zlib_inc} -O0 -g -fopenmp " )
+set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} ${zlib_inc} ${md5_inc} -O0 -g -fopenmp " )
 
 # CXX source files
-set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} ${zlib_inc}  -O0 -g  -fopenmp -std=c++11  " )
+set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} ${zlib_inc} ${md5_inc} -O0 -g  -fopenmp -std=c++11  " )
 
 elseif ( debug STREQUAL "asan" )
 
@@ -108,10 +108,10 @@ set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS "${FSANIT
 
 
 # C source files
-set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} -O0 -g -fopenmp ${zlib_inc} -march=armv8-a -DARCH_CPU=ARM " )
+set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} -O0 -g -fopenmp ${zlib_inc} ${md5_inc} -march=armv8-a -DARCH_CPU=ARM " )
 
 # CXX source files
-set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${precision_flag} -DMETIS5 ${cppmach} ${cpprel}  -O0 -g  -fopenmp  ${zlib_inc} -std=c++11 -march=armv8-a -DARCH_CPU=ARM" )
+set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "${FSANITIZE} ${precision_flag} -DMETIS5 ${cppmach} ${cpprel}  -O0 -g  -fopenmp  ${zlib_inc} ${md5_inc} -std=c++11 -march=armv8-a -DARCH_CPU=ARM" )
 
 else ()
 
@@ -123,10 +123,10 @@ set_source_files_properties( ${source_files}  PROPERTIES COMPILE_FLAGS " ${preci
 
 
 # C source files
-set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS "-w ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} ${zlib_inc} -O2 -fopenmp -march=armv8-a -DARCH_CPU=ARM  " )
+set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS "-w ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} ${zlib_inc} ${md5_inc} -O2 -fopenmp -march=armv8-a -DARCH_CPU=ARM  " )
 
 # CXX source files
-set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "-w ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} ${zlib_inc} -O2 -fopenmp -std=c++11  " )
+set_source_files_properties(${cpp_source_files} PROPERTIES COMPILE_FLAGS "-w ${precision_flag} -DMETIS5 ${cppmach} ${cpprel} ${zlib_inc} ${md5_inc} -O2 -fopenmp -std=c++11  " )
 
 endif()
 


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
This pull request updates the build configuration in `starter/CMake_Compilers/cmake_linuxa64_gf.txt` to consistently include the `${md5_inc}` variable in the compiler flags for both C and C++ source files. This ensures that the MD5-related include paths or definitions are properly set during compilation for all relevant build types.

**Build system updates:**

* Added `${md5_inc}` to the `COMPILE_FLAGS` property for both `${c_source_files}` and `${cpp_source_files}` in all build configurations, ensuring MD5 support is included during compilation. [[1]](diffhunk://#diff-60ba40f48eb3a1fa4c12f8758efd298d5d7588f594ed18f60e4d535f3f44f917L93-R96) [[2]](diffhunk://#diff-60ba40f48eb3a1fa4c12f8758efd298d5d7588f594ed18f60e4d535f3f44f917L111-R114) [[3]](diffhunk://#diff-60ba40f48eb3a1fa4c12f8758efd298d5d7588f594ed18f60e4d535f3f44f917L126-R129)

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
