### PR TITLE
correction def_shell.cfg radioss2026

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2026/CARDS/def_shell.cfg
+++ b/hm_cfg_files/config/CFG/radioss2026/CARDS/def_shell.cfg
@@ -141,7 +141,7 @@ FORMAT(radioss2026)
 {
 
     HEADER("/DEF_SHELL");
-    COMMENT("#   ISHELL    Ismstr    Ithick     Iplas   Istrain   Ioffset               ISH3N    Idrill Ithin_drape");
+    COMMENT("#   ISHELL    Ismstr    Ithick     Iplas   Istrain   Ioffset               ISH3N    Idrill    Islice");
     CARD("%10d%10d%10d%10d%10d%10d          %10d%10d%10d", ISHELL, Ismstr, Ithick, Iplas, Istrain,Ioffset,ISH3N, Idrill,Ithin_drape);
 }
 // File format


### PR DESCRIPTION
This pull request makes a minor update to the comment describing the fields in the `/DEF_SHELL` section of the `def_shell.cfg` configuration file for Radioss 2026. The field name in the comment was changed from `Ithin_drape` to `Islice` to better reflect the actual data being represented.

- Updated the comment in `def_shell.cfg` to replace the `Ithin_drape` field name with `Islice` for clarity and accuracy.