### PR TITLE
In case of solid distortion control with law1 reduce the actual stiffness of contact

### DIFF
--- a/starter/source/materials/mat/hm_read_mat.F90
+++ b/starter/source/materials/mat/hm_read_mat.F90
@@ -1504,7 +1504,7 @@
             endif ! ilaw>=28
 !-------    high stiffness for contact
             pm(107,i) = two*max(pm(32,i),pm(100,i))
-            if (ilaw==1)  pm(107,i) = thirty*pm(107,i)
+            if (ilaw==1)  pm(107,i) = five*pm(107,i)
             if (ilaw==62) pm(107,i) = hundred*pm(107,i)
 !
 !---------------------------------------------------------


### PR DESCRIPTION


#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
In some cases, actual stiffness used for solid distortion control (Icontrol>0) seems to be too high which resulted out energy error and high added mass error

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
We recommend to use Icontrol>0 only for soft materials, but they are not always the case, reducing the contact stiffness increasing avoid this kind of issues.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
