### PR TITLE
*HASH dyna keyword plug

### DIFF
--- a/hm_cfg_files/config/CFG/Keyword971_R15.0/CONTROL_CARDS/hash.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R15.0/CONTROL_CARDS/hash.cfg
@@ -1,0 +1,52 @@
+//Copyright>    CFG Files and Library ("CFG")
+//Copyright>    Copyright (C) 1986-2026 Altair Engineering Inc.
+//Copyright>
+//Copyright>    Altair Engineering Inc. grants to third parties limited permission to
+//Copyright>    use and modify CFG solely in connection with OpenRadioss software, provided
+//Copyright>    that any modification to CFG by a third party must be provided back to
+//Copyright>    Altair Engineering Inc. and shall be deemed a Contribution under and therefore
+//Copyright>    subject to the CONTRIBUTOR LICENSE AGREEMENT for OpenRadioss software.
+//Copyright>
+//Copyright>    CFG IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//Copyright>    INCLUDING, BUT NOT LIMITED TO, THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+//Copyright>    A PARTICULAR PURPOSE, AND NONINFRINGEMENT.  IN NO EVENT SHALL ALTAIR ENGINEERING
+//Copyright>    INC. OR ITS AFFILIATES BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY,
+//Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
+//Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
+//
+// HASH
+// 
+
+
+ ATTRIBUTES(COMMON) 
+  {
+
+    //INPUT ATTRIBUTES
+
+    //Title
+    TITLE               = VALUE(STRING,    "Title");
+
+    // Data
+    KEYWORD_STR                     = VALUE(STRING, "Solver Keyword");
+
+  
+}
+
+SKEYWORDS_IDENTIFIER(COMMON)
+{
+}
+
+
+GUI(COMMON)
+{
+    ASSIGN(KEYWORD_STR, "*HASH");
+    SCALAR(TITLE, "Title");
+}
+
+// File format
+   FORMAT(Keyword971) {
+
+    HEADER("*HASH");
+    CARD("%-80s", TITLE);
+
+}

--- a/hm_cfg_files/config/CFG/Keyword971_R15.0/CONTROL_CARDS/hash_end.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R15.0/CONTROL_CARDS/hash_end.cfg
@@ -1,0 +1,47 @@
+//Copyright>    CFG Files and Library ("CFG")
+//Copyright>    Copyright (C) 1986-2026 Altair Engineering Inc.
+//Copyright>
+//Copyright>    Altair Engineering Inc. grants to third parties limited permission to
+//Copyright>    use and modify CFG solely in connection with OpenRadioss software, provided
+//Copyright>    that any modification to CFG by a third party must be provided back to
+//Copyright>    Altair Engineering Inc. and shall be deemed a Contribution under and therefore
+//Copyright>    subject to the CONTRIBUTOR LICENSE AGREEMENT for OpenRadioss software.
+//Copyright>
+//Copyright>    CFG IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+//Copyright>    INCLUDING, BUT NOT LIMITED TO, THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+//Copyright>    A PARTICULAR PURPOSE, AND NONINFRINGEMENT.  IN NO EVENT SHALL ALTAIR ENGINEERING
+//Copyright>    INC. OR ITS AFFILIATES BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY,
+//Copyright>    WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR
+//Copyright>    IN CONNECTION WITH CFG OR THE USE OR OTHER DEALINGS IN CFG.
+//
+// HASH_END
+// 
+
+
+ ATTRIBUTES(COMMON) 
+  {
+
+    //INPUT ATTRIBUTES
+
+    // Data
+    KEYWORD_STR                     = VALUE(STRING, "Solver Keyword");
+
+  
+}
+
+SKEYWORDS_IDENTIFIER(COMMON)
+{
+}
+
+
+GUI(COMMON)
+{
+    ASSIGN(KEYWORD_STR, "*HASH_END");
+}
+
+// File format
+   FORMAT(Keyword971) {
+
+    HEADER("*HASH_END");
+
+}

--- a/hm_cfg_files/config/CFG/Keyword971_R15.0/data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R15.0/data_hierarchy.cfg
@@ -6693,7 +6693,7 @@ HIERARCHY {
   KEYWORD = CONTROL_CARD;
   TYPE    = CARD;
   TITLE   = "Control Cards";
-  USER_NAMES = (CONTROL, DATABASE);
+  USER_NAMES = (CONTROL, DATABASE, HASH);
     /*
     HIERARCHY {
          KEYWORD    = TITLE ;
@@ -8001,6 +8001,19 @@ HIERARCHY {
                        CONTROL_MPP_REBALANCE);
     }
   }
+  
+    HIERARCHY {
+         KEYWORD    = HASH ;
+         TITLE      = "HASH";
+         FILE       = "CONTROL_CARDS/hash.cfg";
+         USER_NAMES = (HASH);
+    }
+    HIERARCHY {
+         KEYWORD    = HASH_END ;
+         TITLE      = "HASH_END";
+         FILE       = "CONTROL_CARDS/hash_end.cfg";
+         USER_NAMES = (HASH_END);
+    }
 }
 
    


### PR DESCRIPTION
This pull request introduces support for two new control cards, `HASH` and `HASH_END`, in the configuration for Keyword971_R15.0. It adds their configuration files, updates the data hierarchy to recognize these new cards, and ensures they are properly integrated into the system.

**New control card support:**

* Added new configuration file `hash.cfg` for the `HASH` control card, including attribute definitions, GUI configuration, and file format specification.
* Added new configuration file `hash_end.cfg` for the `HASH_END` control card, including attribute definitions, GUI configuration, and file format specification.

**Data hierarchy updates:**

* Updated the `USER_NAMES` list in the control card hierarchy to include `HASH`, ensuring it is recognized as a valid control card.
* Added new hierarchy entries for `HASH` and `HASH_END` in `data_hierarchy.cfg`, specifying their titles, file locations, and user names.