### PR TITLE
improve hourglass control of HEPH (Isolid=24) with different plastic …

### DIFF
--- a/engine/source/elements/solid/solidez/szforc3.F
+++ b/engine/source/elements/solid/solidez/szforc3.F
@@ -986,7 +986,7 @@ C
      O   SIGO,         ICP,          LBUF%PLA,     IMATVIS,
      P   ET,           R3_DAM,       NEL,          GBUF%STRHG,
      Q   ISTRAIN,      MTN,          ISMSTR,       JLAG,
-     R   IINT)
+     R   IINT, MAT_ELEM%MAT_PARAM(IMAT))
       END IF !(ISORTH>0) THEN
       IF (CNS2 > ZERO) 
      .     CALL NSVIS_SM12(GBUF%OFF ,CNS2,CXX  ,VOLN ,DXX     ,

--- a/engine/source/elements/solid/solidez/szhour3.F
+++ b/engine/source/elements/solid/solidez/szhour3.F
@@ -59,11 +59,12 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      O   SIGOLD,   ICP,      DEFP,     MATVIS,
      P   ET,       D_MAX,    NEL,      STRHG,
      Q   ISTRAIN,  MTN,      ISMSTR,   JLAG,
-     R   IINT)
+     R   IINT,     MAT_PARAM)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
       USE ELBUFDEF_MOD
+      use matparam_def_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -108,10 +109,11 @@ C-----------------------------------------------
      .   D_MAX(*),STRHG(NEL,18)
       INTEGER MAT(*),PID(*),IPARTS(*),ICP,MATVIS
       TYPE (ELBUF_STRUCT_), TARGET :: ELBUF_STR
+      type(matparam_struct_)  , intent(in) :: mat_param
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I, MX, J,IET, MT,IPLAST
+      INTEGER I, MX, J,IET, MT,IPLAST,ICRIT_VM,L_SEQ
       my_real
      .   CAQ(MVSIZ), FCL(MVSIZ),DEINT(MVSIZ),
      .   H11(MVSIZ), H22(MVSIZ), H33(MVSIZ),
@@ -132,27 +134,30 @@ C-----------------------------------------------
      .   DFHOUR(MVSIZ,3,4),FHOURT(3,4),DT05,RHO0,
      .   NU1(MVSIZ),NU2(MVSIZ),NU3(MVSIZ),NU4(MVSIZ),E0(MVSIZ),
      .   E_R,E_S,E_T,FAC,FAC1,FAC2,COEFH,HQ13P,HQ13N,HQ24P,HQ24N,FF,
-     .   DAMA_G(MVSIZ,6),G0,C1
+     .   DAMA_G(MVSIZ,6),G0,C1,SIGYM(NEL),SS(3),SVM2_0(NEL),
+     .   SEQ,FAC_MAX,FACI(NEL),SMN
 C-----------------------------------------------
        IET =IINT
        COEFH = ZEP9999   
 C---- note: r->eta; s->zeta; t->ksi------------
 
-C +++ MAT Visco-----
-!      DO I=1,NEL
-!        SIG0V(I,1) = SIG0(I,1)
-!        SIG0V(I,2) = SIG0(I,2)
-!        SIG0V(I,3) = SIG0(I,3)
-!        SIG0V(I,4) = SIG0(I,4)
-!        SIG0V(I,5) = SIG0(I,5)
-!        SIG0V(I,6) = SIG0(I,6)
-!      ENDDO
       MX = MAT(1)
       RHO0=PM(1,MX)
       NU=PM(21,MX)
       G0=PM(22,MX)
       C1=PM(32,MX)
       IPLAST = ELBUF_STR%GBUF%G_PLA
+      ICRIT_VM = mat_param%crit_plas  ! =1 Von Mises
+      L_SEQ = ELBUF_STR%BUFLY(1)%L_SEQ
+      IF (IPLAST==1) THEN
+        DO I=1,NEL 
+          SS(1) =SIG0(I,1)-SIG0(I,2)
+          SS(2) =SIG0(I,2)-SIG0(I,3)
+          SS(3) =SIG0(I,1)-SIG0(I,3)
+          SVM2_0(I) = (SS(1)*SS(1)+SS(2)*SS(2)+SS(3)*SS(3))*HALF + THREE*
+     .      (SIG0(I,4)*SIG0(I,4)+SIG0(I,5)*SIG0(I,5)+SIG0(I,6)*SIG0(I,6))
+        END DO
+      END IF
       SELECT CASE (MTN)
 C  +++ MAT Hydro---
         CASE (3,4,6,70) 
@@ -262,7 +267,7 @@ C------ w/ Prony, use Icpre=0 anyway
         NU3(I) =ZEP444
         NU4(I) =ZERO
        ENDDO
-      ELSEIF(ICP==2.AND.IPLAST>0.AND.MTN/=104)THEN
+      ELSEIF(ICP==2.AND.IPLAST>0.AND.ICRIT_VM==1)THEN
        DO I=1,NEL
         FAC1 = SIGY(I)/E0(I)+DEFP(I)
         FAC2=ONE-DEFP(I)/FAC1
@@ -402,7 +407,7 @@ C         SIGY(I) = 1.0E+30
       IF (IPLAST==1) 
      .   CALL SZSVM(
      1   JR0,     JS0,     JT0,     FHOUR,
-     2   SIGY,    SIGOLD,  NU4,     SMO1,
+     2   SIGY,    SVM2_0,  NU4,     SMO1,
      3   SMO2,    NEL,     IINT)
       !-----------For energy calculation------------
       IF(JLAG==1)THEN
@@ -500,25 +505,57 @@ C
       IF (IPLAST==1) 
      .    CALL SZSVM(
      1   JR0,     JS0,     JT0,     FHOUR,
-     2   SIGY,    SIG0,    NU4,     SM1,
+     2   SIGY,    SVM2_0,  NU4,     SM1,
      3   SM2,     NEL,     IINT)
       !-----------ELASTIC-PLASTIC yield criterion------------
       IF (IPLAST==1) THEN
+        SIGYM(1:NEL) =SIGY(1:NEL)
+        SVM2_0(1:NEL) = SQRT(SVM2_0(1:NEL))
+        FACI(1:NEL) = ZERO
+        IF (ICRIT_VM/=1.AND.L_SEQ>0) THEN 
+          DO I=1,NEL 
+            SEQ = ELBUF_STR%BUFLY(1)%LBUF(1,1,1)%SEQ(I)
+            IF (SEQ>EM20) THEN
+              SIGYM(I) = SIGYM(I)*SVM2_0(I)/SEQ 
+            END IF
+          END DO
+        END IF
+        IF (ICP==2.AND.ICRIT_VM==1) THEN     ! old formulation
+           DO I=1,NEL
+             IF (SM1(I)>SIGYM(I).AND.DEINT(I)>0) THEN
+              SMO  = ZEP9*SMO1(I)+EM01*SMO2(I)
+              FAC1 = SIGYM(I)-SMO
+              FAC2 = SM1(I)-SMO
+              IF (FAC2<=EM20) THEN
+                FAC=ZERO
+              ELSE
+                FAC = ONE - MAX(EM20,FAC1/FAC2)
+              ENDIF
+              IF (SM2(I)<SIGYM(I)) THEN ! for coarse mesh?
+                FAC1 =(SM1(I)-SIGYM(I))/MAX((SM1(I)-SM2(I)),EM20)
+                FAC1 =HALF + SQRT(FAC1)
+                FAC = MIN(FAC1,ONE)*FAC
+              ENDIF
+              FACI(I)=FAC
+             ENDIF
+           ENDDO
+        ELSE 
+           FAC_MAX = TWO*EM03
+           DO I=1,NEL
+             IF (SM1(I)>SIGYM(I).AND.DEINT(I)>0) THEN
+               FAC = SIGYM(I)/SM1(I)
+               SMO  = ZEP9*SMO1(I)+EM01*SMO2(I)
+               IF (SMO>SIGYM(I).AND.SM1(I)>SMO) THEN ! already too high at previous step
+                 FAC1 = (SMO-SIGYM(I))/(SM1(I)-SMO)
+                 FAC = FAC* MIN(ONE,FAC1)
+               END IF
+               FACI(I) = ONE - FAC
+             ENDIF
+           ENDDO
+        END IF
       DO I=1,NEL
-        IF (SM1(I)>SIGY(I).AND.DEINT(I)>0) THEN
-         SMO  = ZEP9*SMO1(I)+EM01*SMO2(I)
-         FAC1 = SIGY(I)-SMO
-         FAC2 = SM1(I)-SMO
-         IF (FAC2<=EM20) THEN
-           FAC=ZERO
-         ELSE
-           FAC = ONE - MAX(EM20,FAC1/FAC2)
-         ENDIF
-         IF (SM2(I)<SIGY(I)) THEN
-           FAC1 =(SM1(I)-SIGY(I))/MAX((SM1(I)-SM2(I)),EM20)
-           FAC1 =HALF + SQRT(FAC1)
-           FAC = MIN(FAC1,ONE)*FAC
-         ENDIF  
+        IF (SM1(I)>SIGYM(I).AND.DEINT(I)>0) THEN
+         FAC = FACI(I)
          FHOUR(I,1,1) = FHOUR(I,1,1) - FAC*DFHOUR(I,1,1)
          FHOUR(I,1,2) = FHOUR(I,1,2) - FAC*DFHOUR(I,1,2)
          FHOUR(I,1,3) = FHOUR(I,1,3) - FAC*DFHOUR(I,1,3)

--- a/engine/source/elements/solid/solidez/szhour3_or.F
+++ b/engine/source/elements/solid/solidez/szhour3_or.F
@@ -120,7 +120,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I, MX, J, IET, MT, IPLAST
+      INTEGER I, MX, J, IET, MT, IPLAST,ICRIT_VM,L_SEQ
       my_real
      . CAQ(MVSIZ), FCL(MVSIZ),DEINT(MVSIZ),
      .   H11(MVSIZ), H22(MVSIZ), H33(MVSIZ),
@@ -142,22 +142,24 @@ C-----------------------------------------------
      . NUS(MVSIZ),NU2(MVSIZ),NU4(MVSIZ),E0(MVSIZ),
      .   E_R,E_S,E_T,FAC,FAC1,FAC2,COEFH,HQ13P,HQ13N,HQ24P,HQ24N,FF
       my_real
-     .   CC(MVSIZ,3,3),CG(MVSIZ,3,3),G33(MVSIZ,3,3),GM,GMIN,DAMA_G(MVSIZ,3)
+     .   CC(MVSIZ,3,3),CG(MVSIZ,3,3),G33(MVSIZ,3,3),GM,GMIN,DAMA_G(MVSIZ,3),
+     .   SIGYM(NEL),SS(3),SVM2_0(NEL),SEQ,FACI(NEL)
 C-----------------------------------------------
        IET =IINT
        COEFH = ZEP9999   
        IPLAST = ELBUF_STR%GBUF%G_PLA
 C---- note: r->eta; s->zeta; t->ksi------------
-
-C +++ MAT Visco-----
-!      DO I=1,NEL
-!        SIG0V(I,1) = SIG0(I,1)
-!        SIG0V(I,2) = SIG0(I,2)
-!        SIG0V(I,3) = SIG0(I,3)
-!        SIG0V(I,4) = SIG0(I,4)
-!        SIG0V(I,5) = SIG0(I,5)
-!        SIG0V(I,6) = SIG0(I,6)
-!      ENDDO
+      ICRIT_VM = mat_param%crit_plas  ! =1 Von Mises
+      L_SEQ = ELBUF_STR%BUFLY(1)%L_SEQ
+      IF (IPLAST==1) THEN
+        DO I=1,NEL 
+          SS(1) =SIG0(I,1)-SIG0(I,2)
+          SS(2) =SIG0(I,2)-SIG0(I,3)
+          SS(3) =SIG0(I,1)-SIG0(I,3)
+          SVM2_0(I) = (SS(1)*SS(1)+SS(2)*SS(2)+SS(3)*SS(3))*HALF + THREE*
+     .      (SIG0(I,4)*SIG0(I,4)+SIG0(I,5)*SIG0(I,5)+SIG0(I,6)*SIG0(I,6))
+        END DO
+      END IF
       MX = MAT(1)
       RHO0=PM(1,MX)
       NU=PM(21,MX)
@@ -172,14 +174,6 @@ C----- sometimes GM is too small
        GG(I)=MAX(GG(I),GMIN)   
        E0(I)=TWO*(ONE+NU)*GG(I)
       ENDDO
-C  +++ MAT Hydro---
-c      IF (MTN==3 .OR.MTN==4 .OR.MTN==6) THEN
-c       MX = MAT(1)
-c       DO I=1,NEL
-c        GG(I)=PM(22,MX)
-c        GG(I)=MAX(GG(I),VIS(I))
-c       ENDDO
-c      ENDIF 
 C
       IF (IET > 1 .AND. MATVIS>0 ) THEN
        CALL SZETFAC(1,NEL,IET,MTN,ET,GG )
@@ -237,32 +231,6 @@ C------now when IHKT=2, w.r.t. Isolid=1, fac=0.2*0.006666 ~0.001
        ENDDO
       END IF
 C
-c      IF(ICP==1)THEN
-C-------!!!curieux!!!!!!!!
-c       DO I=1,NEL
-c        NU1(I) =FOUR_OVER_3
-c        NU2(I) =-TWO_THIRD
-c        NU3(I) =ZEP444
-c        NU4(I) =ZERO
-c       ENDDO
-c      ELSEIF(ICP==2)THEN
-c       DO I=1,NEL
-c        FAC1 = SIGY(I)/E0(I)+DEFP(I)
-c        FAC2=ONE-DEFP(I)/FAC1
-c        FF =(ONE +NU)/(ONE -TWO*NU)*FAC2
-c        NU1(I) =TWO_THIRD*(TWO+FF)
-c        NU2(I) =TWO_THIRD*(FF-ONE)
-c        NU3(I) =ZEP222*(TWO+FF)
-c        NU4(I) =ZERO
-c       ENDDO
-c      ELSE
-c       DO I=1,NEL
-c        NU1(I) =TWO/(ONE-NU)
-c        NU2(I) =NU*NU1(I)
-c        NU3(I) =TWO_THIRD*(ONE + NU)
-c        NU4(I) =NU
-c       ENDDO
-c      ENDIF
       IF(ICP==1)THEN
        DO I=1,NEL
         NUS(I) =ZEP499
@@ -405,7 +373,7 @@ C         SIGY(I) = 1.0E+30
      .   CALL SZSVM_OR(
      1   JR0,     JS0,     JT0,     CC,
      2   CG,      G33,     FHOUR,   SIGY,
-     3   SIGOLD,  NU,      SMO1,    SMO2,
+     3   SVM2_0,  NU,      SMO1,    SMO2,
      4   NEL,     IINT)
       !-----------For energy calculation------------
       IF(JLAG==1)THEN
@@ -475,25 +443,55 @@ C
      .    CALL SZSVM_OR(
      1   JR0,     JS0,     JT0,     CC,
      2   CG,      G33,     FHOUR,   SIGY,
-     3   SIG0,    NU,      SM1,     SM2,
+     3   SVM2_0,  NU,      SM1,     SM2,
      4   NEL,     IINT)
       !-----------ELASTIC-PLASTIC yield criterion------------
       IF (IPLAST==1) THEN
+        SIGYM(1:NEL) =SIGY(1:NEL)
+        FACI(1:NEL) = ZERO
+        IF (ICRIT_VM/=1.AND.L_SEQ>0) THEN 
+          DO I=1,NEL 
+            SEQ = ELBUF_STR%BUFLY(1)%LBUF(1,1,1)%SEQ(I)
+            IF (SEQ>EM20) THEN
+              SIGYM(I) = SIGYM(I)*SQRT(SVM2_0(I))/SEQ 
+            END IF
+          END DO
+        END IF
+        IF (ICP==2.AND.ICRIT_VM==1) THEN     ! old formulation
+           DO I=1,NEL
+             IF (SM1(I)>SIGYM(I).AND.DEINT(I)>0) THEN
+              SMO  = ZEP9*SMO1(I)+EM01*SMO2(I)
+              FAC1 = SIGYM(I)-SMO
+              FAC2 = SM1(I)-SMO
+              IF (FAC2<=EM20) THEN
+                FAC=ZERO
+              ELSE
+                FAC = ONE - MAX(EM20,FAC1/FAC2)
+              ENDIF
+              IF (SM2(I)<SIGYM(I)) THEN ! for coarse mesh?
+                FAC1 =(SM1(I)-SIGYM(I))/MAX((SM1(I)-SM2(I)),EM20)
+                FAC1 =HALF + SQRT(FAC1)
+                FAC = MIN(FAC1,ONE)*FAC
+              ENDIF
+              FACI(I)=FAC
+             ENDIF
+           ENDDO
+        ELSE 
+           DO I=1,NEL
+             IF (SM1(I)>SIGYM(I).AND.DEINT(I)>0) THEN
+               FAC = SIGYM(I)/SM1(I)
+               SMO  = ZEP9*SMO1(I)+EM01*SMO2(I)
+               IF (SMO>SIGYM(I).AND.SM1(I)>SMO) THEN ! already too high at previous step
+                 FAC1 = (SMO-SIGYM(I))/(SM1(I)-SMO)
+                 FAC = FAC* MIN(ONE,FAC1)
+               END IF
+               FACI(I) = ONE - FAC
+             ENDIF
+           ENDDO
+        END IF
       DO I=1,NEL
-        IF (SM1(I)>SIGY(I).AND.DEINT(I)>0) THEN
-         SMO  = ZEP9*SMO1(I)+EM01*SMO2(I)
-         FAC1 = SIGY(I)-SMO
-         FAC2 = SM1(I)-SMO
-         IF (FAC2<=EM20) THEN
-           FAC=ZERO
-         ELSE
-           FAC = ONE - MAX(EM20,FAC1/FAC2)
-         ENDIF
-         IF (SM2(I)<SIGY(I)) THEN
-           FAC1 =(SM1(I)-SIGY(I))/MAX((SM1(I)-SM2(I)),EM20)
-           FAC1 =HALF + SQRT(FAC1)
-           FAC = MIN(FAC1,ONE)*FAC
-         ENDIF  
+        IF (SM1(I)>SIGYM(I).AND.DEINT(I)>0) THEN
+         FAC = FACI(I)
          FHOUR(I,1,1) = FHOUR(I,1,1) - FAC*DFHOUR(I,1,1)
          FHOUR(I,1,2) = FHOUR(I,1,2) - FAC*DFHOUR(I,1,2)
          FHOUR(I,1,3) = FHOUR(I,1,3) - FAC*DFHOUR(I,1,3)

--- a/engine/source/elements/solid/solidez/szsvm.F
+++ b/engine/source/elements/solid/solidez/szsvm.F
@@ -29,7 +29,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !||====================================================================
       SUBROUTINE SZSVM(
      1   JR0,     JS0,     JT0,     FHOUR,
-     2   SIGY,    SIG0,    NU,      SVM1,
+     2   SIGY,    SVM2_0,   NU,      SVM1,
      3   SVM2,    NEL,     IINT)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
@@ -45,13 +45,14 @@ C-----------------------------------------------
       INTEGER NEL
       my_real
      .   FHOUR(NEL,3,4),JR0(*),JS0(*),JT0(*) ,
-     .   SIGY(*) ,SIG0(NEL,6),SVM1(*),SVM2(*),NU(*)
+     .   SIGY(*) ,SVM1(*),SVM2(*),NU(*)
+      my_real, dimension(NEL), INTENT(IN) :: SVM2_0
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,IKT
       my_real
-     .   S1,S2,S3,SVM0,SR1,SR2,SR3,SR4,
+     .   SVM0,SR1,SR2,SR3,SR4,
      .   SS1,SS2,SS3,SS4,ST1,ST2,ST3,ST4,SVMR,SVMS,SVMT,
      .   SVMRST,COEF,COEF1, JR_1,JS_1,JT_1,NU1,NU2,
      .   RS,ST,RT,VT2(4),MAX0,MIN0    
@@ -71,11 +72,7 @@ C-----------------------------------------------
        SVM1(I) = ZERO
        SVM2(I) = ZERO
        IF (SIGY(I)<ZEP9EP30) THEN
-        S1 =SIG0(I,1)-SIG0(I,2)
-        S2 =SIG0(I,2)-SIG0(I,3)
-        S3 =SIG0(I,1)-SIG0(I,3)
-        SVM0 = (S1*S1+S2*S2+S3*S3)*HALF + THREE*(SIG0(I,4)*SIG0(I,4)
-     .                +SIG0(I,5)*SIG0(I,5)+SIG0(I,6)*SIG0(I,6))
+        SVM0 = SVM2_0(I)
         NU1 =ONE/(ONE - NU(I))
         NU2 =NU(I)*NU1
         JR_1 = ONE/MAX(EM20,JR0(I))
@@ -127,7 +124,7 @@ C
         SVMRST = SVM0+COEF*(SVMR+SVMS+SVMT)
         SVM1(I) = SQRT(ABS(SVMRST+COEF*MAX0))
         SVM2(I) = SQRT(MAX(SVMRST+COEF*MIN0,ZERO))
-        SVM2(I) = MIN(SVM2(I),SVM0)
+        SVM2(I) = MIN(SVM2(I),SQRT(SVM0))
        ENDIF
       ENDDO 
 C

--- a/engine/source/elements/solid/solidez/szsvm_or.F
+++ b/engine/source/elements/solid/solidez/szsvm_or.F
@@ -29,7 +29,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
       SUBROUTINE SZSVM_OR(
      1   JR0,     JS0,     JT0,     CC,
      2   CG,      G33,     FHOUR,   SIGY,
-     3   SIG0,    NU,      SVM1,    SVM2,
+     3   SVM2_0,   NU,      SVM1,    SVM2,
      4   NEL,     IINT)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
@@ -49,14 +49,15 @@ C-----------------------------------------------
       INTEGER NEL
       my_real
      .   FHOUR(NEL,3,4),JR0(*),JS0(*),JT0(*) ,
-     .   SIGY(*) ,SIG0(NEL,6),SVM1(*),SVM2(*),NU,
+     .   SIGY(*) ,SVM1(*),SVM2(*),NU,
      .   CC(MVSIZ,3,3),CG(MVSIZ,3,3),G33(MVSIZ,3,3)
+      my_real, dimension(NEL), INTENT(IN) :: SVM2_0
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER I,  J,K,IKT
       my_real
-     .   S1,S2,S3,SVM0,SR1,SR2,SR3,SR4,
+     .   SVM0,SR1,SR2,SR3,SR4,
      .   SS1,SS2,SS3,SS4,ST1,ST2,ST3,ST4,SVMR,SVMS,SVMT,
      .   SVMRST,COEF,COEF1, JR_1,JS_1,JT_1,NU1,NU2,T1,T2,
      .   RS,ST,RT,VT2(4),MAX0,MIN0, 
@@ -79,11 +80,7 @@ C         coef= (3*8*0.75)^2 coef1 =1/0.75
        SVM1(I) = ZERO
        SVM2(I) = ZERO
        IF (SIGY(I)<ZEP9EP30) THEN
-        S1 =SIG0(I,1)-SIG0(I,2)
-        S2 =SIG0(I,2)-SIG0(I,3)
-        S3 =SIG0(I,1)-SIG0(I,3)
-        SVM0 = (S1*S1+S2*S2+S3*S3)*HALF + THREE*(SIG0(I,4)*SIG0(I,4)
-     .                +SIG0(I,5)*SIG0(I,5)+SIG0(I,6)*SIG0(I,6))
+        SVM0 = SVM2_0(I)
         JR_1 = ONE/MAX(EM20,JR0(I))
         JS_1 = ONE/MAX(EM20,JS0(I))
         JT_1 = ONE/MAX(EM20,JT0(I))
@@ -214,7 +211,7 @@ C
         SVMRST = SVM0+COEF*(SVMR+SVMS+SVMT)
         SVM1(I) = SQRT(ABS(SVMRST+COEF*MAX0))
         SVM2(I) = SQRT(MAX(SVMRST+COEF*MIN0,ZERO))
-        SVM2(I) = MIN(SVM2(I),SVM0)
+        SVM2(I) = MIN(SVM2(I),SQRT(SVM0))
        ENDIF
       ENDDO 
 C


### PR DESCRIPTION
…criteria

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
Hourglass control of HEPH is optimized for the materials using classical Von-Mises criteria (Plasticity), for other type criteria (Hill,Drucker...), it may be not well computed.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
This development has been done to improve other cases than Von-Mises criteria after the introduction of different plastic criteria by 28b2ef6877109c646fea831c36d2d5db95a3bee0
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
