### PR TITLE
/INTER/TYPE25 bug fix for 1D-element edges

### DIFF
--- a/starter/source/restart/ddsplit/inter_tools.F
+++ b/starter/source/restart/ddsplit/inter_tools.F
@@ -7378,7 +7378,11 @@ C---  Split of KERMNODE -> IBUF1
            IF(KM1 /= 0.OR.KM2/=0) IK_LOC =.TRUE.
          ELSE
            EM1=INTBUF_TAB%LEDGE(15+(K-1)*NLEDGE)
-           IF(CEP(EM1)==PROC) IK_LOC =.TRUE.
+           IF(CEP(EM1)==PROC) THEN
+             IK_LOC =.TRUE.
+             KM1 = 1
+             KM2 = 1
+           ENDIF
          ENDIF 
          IF(IK_LOC)THEN
             SIZ = INTBUF_TAB%KREMNODE_EDG(K+1)-INTBUF_TAB%KREMNODE_EDG(K)
@@ -7437,7 +7441,11 @@ C---  Split of ERMNODE -> IBUF2
             IF(KM1 /= 0.OR.KM2/=0) IK_LOC =.TRUE.
          ELSE
             EM1=INTBUF_TAB%LEDGE(15+(K-1)*NLEDGE)
-            IF(CEP(EM1)==PROC) IK_LOC =.TRUE.
+            IF(CEP(EM1)==PROC) THEN
+              IK_LOC =.TRUE.
+              KM1 = 1
+              KM2 = 1
+            ENDIF
          ENDIF 
          IF(IK_LOC)THEN
 C


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
This pull request makes a small but important update to the logic in the `SPLIT_REMNODE_I25_EDGE` subroutine. The main change ensures that when a certain condition is met (`CEP(EM1)==PROC`), not only is `IK_LOC` set to `.TRUE.`, but both `KM1` and `KM2` are also set to `1`. This change initializes otherwise uninitialized variables
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
