### PR TITLE
remove incorrect error message in case node group build from TETRA10 elements

### DIFF
--- a/starter/source/groups/hm_elngr.F
+++ b/starter/source/groups/hm_elngr.F
@@ -196,15 +196,5 @@ C               tag nodes connected to the element
         ENDIF
       ENDDO
 C-----------
-      IF (ITETRA10 /= 0)THEN
-        CALL ANCMSG(MSGID=500,
-     .              MSGTYPE=MSGWARNING,
-     .              ANMODE=ANINFO_BLIND_1,
-     .              C1='GRNOD',
-     .              I1=ID,
-     .              C2='GRNOD',
-     .              C3=TITR)
-      ENDIF
-C-----------
       RETURN
       END


### PR DESCRIPTION
This pull request makes a minor change to the `HM_ELNGRS` subroutine by removing an error message that was previously triggered under certain conditions.

- Removal of warning logic:
  * Removed the conditional block that called `ANCMSG` to issue an error message when `ITETRA10` was not zero. (`starter/source/groups/hm_elngr.F`, [starter/source/groups/hm_elngr.FL198-L207](diffhunk://#diff-85ea1e57cf10e1bf7900d7d49366bab0a2f59c01030d9ce0596ce25957ef9748L198-L207))