### PR TITLE
Possible regression after GPU vesion of /MAT/LAW2

### DIFF
--- a/engine/CMake_Compilers/cmake_linux64_nvidia.txt
+++ b/engine/CMake_Compilers/cmake_linux64_nvidia.txt
@@ -241,7 +241,7 @@ if ( debug STREQUAL "1" )
 
 # Fortran (debug)
 set_source_files_properties( ${source_files} PROPERTIES COMPILE_FLAGS
-  "-Wall -g -O0 -Mbounds ${fort_flags} ${wo_linalg} ${precision_flag} ${cppmach} ${cpprel} -DCPP_comp=f90 -DCOMP_NVFORTRAN=1 ${mpi_flag} ${ADF}" )
+  "-Wall -g -O0 ${fort_flags} ${wo_linalg} ${precision_flag} ${cppmach} ${cpprel} -DCPP_comp=f90 -DCOMP_NVFORTRAN=1 ${mpi_flag} ${ADF}" )
 
 # C source files
 set_source_files_properties(${c_source_files} PROPERTIES COMPILE_FLAGS

--- a/engine/source/elements/forintc.F
+++ b/engine/source/elements/forintc.F
@@ -61,7 +61,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !||    timer_mod                   ../engine/source/system/timer_mod.F90
 !||    ush_force3_mod              ../engine/source/user_interface/ushforce3.F90
 !||====================================================================
-      SUBROUTINE FORINTC(TIMERS, GPU, IPRI,
+      SUBROUTINE FORINTC(TIMERS, GPU,
      1    PM        ,GEO       ,X         ,A         ,AR        ,
      2    V         ,VR        ,MS        ,IN        ,NLOC_DMG  ,
      3    WA        ,STIFN     ,STIFR     ,FSKY      ,CRKSKY    ,
@@ -173,7 +173,6 @@ C     REAL
      .   MS_PLY(*), ZI_PLY(*),GRESAV(*),
      .   MSTG(*), DMELTG(*), MSC(*), DMELC(*),CONDN(*),CONDNSKY(*),
      .   PTG(3,*),MSZ2(*),APINCH(3,*),STIFPINCH(*),VPINCH(3,*)
-      integer, intent(inout) :: ipri
       DOUBLE PRECISION :: XDP(3,*)
       TYPE (TTABLE) TABLE(*)
       TYPE (ELBUF_STRUCT_), DIMENSION(NGROUP)      :: ELBUF_TAB
@@ -200,7 +199,7 @@ C-----------------------------------------------
       INTEGER I,II,J,N, NG, NVC, MLW, JFT, JLT,ISOLNOD,ITHK,IPLA,
      .    K2, NF1, OFFSET,TYP,
      .   K0, K5, K9, NSG, NEL, KFTS,IOFC, ISTRA,
-     .   ICNOD,NFT1,ISENS_ENERGY,
+     .   ICNOD,NFT1,ISENS_ENERGY,IPRI,
      .   IEXPAN, IG,ITG1,ITG2,ITG3,NLEVXF,ISEATBELT
       INTEGER IPARSENS,ISECT
       INTEGER ISH3N,ISHPLYXFEM,IXFEM

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -4093,7 +4093,7 @@ C Init var parallel SMP
 
               NDTSKR=NDTSK ; IF(IRODDL == 0)NDTSKR=1
 
-              CALL FORINTC(TIMERS, GPU, IPRI,
+              CALL FORINTC(TIMERS, GPU,
      1           PM           ,GEO             ,NODES%X               ,NODES%A(1,NDTSK)     ,NODES%AR(1,NDTSK)  ,
      2           NODES%V            ,NODES%VR              ,NODES%MS              ,NODES%IN             ,NLOC_DMG     ,
      3           WA(NWAFTSK)  ,NODES%STIFN(NDTSK)    ,NODES%STIFR(NDTSKR)    ,ELEMENT%PON%FSKY           ,CRKSKY       ,
@@ -4230,6 +4230,19 @@ C
               IF (IMON>0) CALL STOPTIME(TIMERS,TIMER_ELEMENT)
 
               IF(GPU == 1) THEN
+C     Compute print-flag for GPU shell sync: same logic as FORINTC IPRI.
+C     (GPU elements are only offloaded when ISENS_ENERGY==0, so the
+C     SENSOR_ENERGY_PART side-effect is not relevant here.)
+                IPRI = 0
+                IF (MOD(NCYCLE,IABS(NCPRI))==0.OR.TT >= OUTPUT%TH%THIS.OR.
+     .               MDESS /= 0.OR.TT >= OUTPUT%TH%THIS1(1).OR.TT >= OUTPUT%TH%THIS1(2)
+     .               .OR.TT >= OUTPUT%TH%THIS1(3).OR.TT >= OUTPUT%TH%THIS1(4).OR.TT >= OUTPUT%TH%THIS1(5)
+     .               .OR.TT >= OUTPUT%TH%THIS1(6).OR.TT >= OUTPUT%TH%THIS1(7).OR.TT >= OUTPUT%TH%THIS1(8)
+     .               .OR.TT >= OUTPUT%TH%THIS1(9).OR.NTH /= 0.OR.NANIM/=0
+     .               .OR.TT >= TABFIS(1).OR.TT >= TABFIS(2)
+     .               .OR.TT >= TABFIS(3).OR.TT >= TABFIS(4).OR.TT >= TABFIS(5)
+     .               .OR.TT >= TABFIS(6).OR.TT >= TABFIS(7).OR.TT >= TABFIS(8)
+     .               .OR.TT >= TABFIS(9).OR.TT >= TABFIS(10).OR.ISTAT==3) IPRI=1
 C     GPU SHELL: synchronize + scatter results now that FORINTC + FORINT
 C     have completed on the CPU.  By this point the GPU pipeline has had
 C     time to finish, so the sync call should return near-instantly.


### PR DESCRIPTION
OpenMP data race: IPRI was declared in resol.F outside the OMP PARALLEL region and was not listed in any PRIVATE(...) clause, making it a shared variable.Inside FORINTC, SENSOR_ENERGY_PART(..., IPRI, ...) sets IPRI=1 as a side-effect when energy sensors are active. With all threads sharing the same memorylocation, one thread's write would corrupt the check IF (ISENS_ENERGY==1 .AND. IPRI==0) in other threads, causing missed energy accumulations into PARTSAV.

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
