### PR TITLE
/TH/SURF + /LOAD/PRESSURE correction issue with 3 nodes surfaces

### DIFF
--- a/starter/source/output/th/th_surf_load_pressure.F
+++ b/starter/source/output/th/th_surf_load_pressure.F
@@ -138,7 +138,7 @@ C     ! list of th surfaces to which each segment of PLOAD is included
                    TAG(N1) = 1
                    TAG(N2) = 1
                    TAG(N3) = 1
-                   TAG(N4) = 1
+                   IF(N4 > 0) TAG(N4) = 1
                    NSEGPL = NSEGPL + 1
                    NS = 0
                    ADSEG = TH_SURF%PLOAD_KSEGS(NSEGPL)     
@@ -162,7 +162,7 @@ C     ! list of th surfaces to which each segment of PLOAD is included
                    TAG(N1) = 0
                    TAG(N2) = 0
                    TAG(N3) = 0
-                   TAG(N4) = 0
+                   IF(N4 > 0) TAG(N4) = 0
                 ENDIF
              ENDDO
 C
@@ -182,7 +182,7 @@ C     ! list of th surfaces to which each segment of LOADP (PDFLUID, PBLAST, LOA
                    TAG(N1) = 1
                    TAG(N2) = 1
                    TAG(N3) = 1
-                   TAG(N4) = 1 
+                   IF(N4 > 0) TAG(N4) = 1 
                    NSEGPL = NSEGPL + 1
                    NS = 0
                    ADSEG = TH_SURF%LOADP_KSEGS(NSEGPL)  
@@ -206,7 +206,7 @@ C     ! list of th surfaces to which each segment of LOADP (PDFLUID, PBLAST, LOA
                    TAG(N1) = 0
                    TAG(N2) = 0
                    TAG(N3) = 0
-                   TAG(N4) = 0
+                   IF(N4 > 0) TAG(N4) = 0
                 ENDDO        
              ENDDO 
 C


### PR DESCRIPTION
This pull request updates the `TH_SURF_LOAD_PRESSURE` subroutine in `th_surf_load_pressure.F` to improve how the `TAG` array is set for the fourth node (`N4`). The changes add a conditional check to ensure that assignments to `TAG(N4)` only occur when `N4` is greater than zero, which helps prevent potential out-of-bounds errors or unintended behavior when `N4` is not valid.

Most important changes:

**Bug fix / Robustness improvements:**

* All assignments to `TAG(N4)` are now wrapped in `IF(N4 > 0)` checks to ensure that the code only accesses `TAG(N4)` when `N4` is a valid index. This change applies to both setting and resetting the tag value in multiple places within the subroutine. [[1]](diffhunk://#diff-5e60189d52faab31f910c7cb3ac7252ca640a6c33dd51703d78131ee9d878e9cL141-R141) [[2]](diffhunk://#diff-5e60189d52faab31f910c7cb3ac7252ca640a6c33dd51703d78131ee9d878e9cL165-R165) [[3]](diffhunk://#diff-5e60189d52faab31f910c7cb3ac7252ca640a6c33dd51703d78131ee9d878e9cL185-R185) [[4]](diffhunk://#diff-5e60189d52faab31f910c7cb3ac7252ca640a6c33dd51703d78131ee9d878e9cL209-R209)