### PR TITLE
Tillotson : prevent from potential FPE

### DIFF
--- a/common_source/eos/tillotson.F
+++ b/common_source/eos/tillotson.F
@@ -98,8 +98,13 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
             BETA    = EOS_STRUCT%UPARAM(9)
             EIV     = EOS_STRUCT%UPARAM(10)
 
-            INV_EREF  = ONE / EREF
-            INV_ERANGE = ONE / (ECV - EIV)
+            INV_EREF  = ONE / EREF  ! pre-condition (checked during Starter Reader) : |EREF| > 1E-20
+
+            IF(ECV /= EIV)THEN
+              INV_ERANGE = ONE / (ECV - EIV) ! relevant only in Region=3 if EIV/=ECV
+            ELSE
+              INV_ERANGE = ZERO ! not used otherwise
+            ENDIF
 
             PSH(1:NEL) = EOS_STRUCT%PSH
 

--- a/starter/source/materials/eos/hm_read_eos_tillotson.F
+++ b/starter/source/materials/eos/hm_read_eos_tillotson.F
@@ -130,6 +130,11 @@ C-----------------------------------------------
         EIV = ECV
       ENDIF
 
+      IF (ABS(EREF) < EM20)THEN
+        call ancmsg(MSGID=67,MSGTYPE=msgerror,ANMODE=aninfo,I1=imideos,
+     .              C1='/EOS/TILLOTSON',C2='EREF PARAMETER IS EXPECTED TO BE GREATHER THAN ZERO')
+      ENDIF
+
       PM(23) = E0
       PM(32) = C1+B*E0   !BULK = (1+µ)*dP/dmu (partial derivative at constant E)
       PM(88) = PSH


### PR DESCRIPTION
#### Tillotson : prevent from potential FPE

#### Description of the changes
Division-by-zero issue is now treated correctly. This issue had no impact on the numerical solution.

The expression INV_ERANGE = ONE / (ECV - EIV) is only needed when EIV differs from ECV in Region 3, corresponding to the transition to the vaporization region. It is not used otherwise.

The floating-point exception signal no longer occurs.