### PR TITLE
correction ply.cfg group types

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2024/PLY/ply.cfg
+++ b/hm_cfg_files/config/CFG/radioss2024/PLY/ply.cfg
@@ -28,8 +28,8 @@ ATTRIBUTES(COMMON)
     orientangle2                               = VALUE(FLOAT,"Angle between first and second material direction for ply i");
     table                                      = VALUE(TABLE,"Drape identifier");
     def_orth                                   = VALUE(INT,"The orthotropy angle");
-    grsh4n_ID                                  = VALUE(SETS,"Temp variable Shell 4-nodes group identifier")    { SUBTYPES = (/SETS/GRSH3N); }
-    grsh3n_ID                                  = VALUE(SETS,"Temp variable Shell 3-nodes group identifier")    { SUBTYPES = (/SETS/GRSHEL); }
+    grsh4n_ID                                  = VALUE(SETS,"Temp variable Shell 4-nodes group identifier")    { SUBTYPES = (/SETS/GRSHEL); }
+    grsh3n_ID                                  = VALUE(SETS,"Temp variable Shell 3-nodes group identifier")    { SUBTYPES = (/SETS/GRSH3N); }
     Product_Name                               = VALUE(STRING,"Product name");
         
 // HM INTERNAL


### PR DESCRIPTION
This pull request corrects the subtype assignments for temporary shell group identifiers in the `ply.cfg` configuration file for Radioss 2024. The change ensures that the `grsh4n_ID` and `grsh3n_ID` attributes reference the correct shell group subtypes, which is important for accurate configuration and processing of ply definitions.

Configuration corrections:

* [`hm_cfg_files/config/CFG/radioss2024/PLY/ply.cfg`](diffhunk://#diff-b9755b8b7da5d1ef7fafe22667c54a600099e8f9f6bb360eef9581e1f2ab791dL31-R32): Fixed the `SUBTYPES` assignments for `grsh4n_ID` and `grsh3n_ID` so that `grsh4n_ID` now uses `/SETS/GRSHEL` and `grsh3n_ID` uses `/SETS/GRSH3N`, correcting the previous swapped references.