### PR TITLE
h3d issue with ORTHD angles in case no LAYER specified

### DIFF
--- a/engine/source/output/h3d/h3d_results/h3d_solid_scalar_1.F
+++ b/engine/source/output/h3d/h3d_results/h3d_solid_scalar_1.F
@@ -1008,6 +1008,7 @@ C--------------------------------------------------
 C--------------------------------------------------
 C           EULER ANGLE : rotation of ORTHOTROPIC SYSTEM wrt GLOBAL SYSTEM
 c ILAYER=NULL NPT=NULL
+                IF(ILAY == -1) ILAY = 1
                 IF ( (ILAY <= NLAY .AND. ILAY > 0) .AND.
      .              IR <= NPTR .AND. IR > 0 .AND.  IS <= NPTS .AND. IS > 0 .AND. IT <= NPTT .AND. IT > 0) THEN
                   IF ( IGTYP == 6 .OR. IGTYP == 21 .OR. IGTYP == 22 ) THEN
@@ -1064,6 +1065,7 @@ C--------------------------------------------------
 C--------------------------------------------------
 C           EULER ANGLE : rotation of ORTHOTROPIC SYSTEM wrt GLOBAL SYSTEM
 c ILAYER=NULL NPT=NULL
+                IF(ILAY == -1) ILAY = 1
                 IF ( (ILAY <= NLAY .AND. ILAY > 0) .AND.
      .              IR <= NPTR .AND. IR > 0 .AND.  IS <= NPTS .AND. IS > 0 .AND. IT <= NPTT .AND. IT > 0) THEN
                   IF ( IGTYP == 6 .OR. IGTYP == 21 .OR. IGTYP == 22 ) THEN
@@ -1119,6 +1121,7 @@ C--------------------------------------------------
 C--------------------------------------------------
 C           EULER ANGLE : rotation of ORTHOTROPIC SYSTEM wrt GLOBAL SYSTEM
 c ILAYER=NULL NPT=NULL
+                IF(ILAY == -1) ILAY = 1
                 IF ( (ILAY <= NLAY .AND. ILAY > 0) .AND.
      .              IR <= NPTR .AND. IR > 0 .AND.  IS <= NPTS .AND. IS > 0 .AND. IT <= NPTT .AND. IT > 0) THEN
                   IF ( IGTYP == 6 .OR. IGTYP == 21 .OR. IGTYP == 22 ) THEN


### PR DESCRIPTION
This pull request introduces a small but important fix to the `H3D_SOLID_SCALAR_1` subroutine in `h3d_solid_scalar_1.F`. The change ensures that if the variable `ILAY` is set to `-1`, it is reset to `1` before proceeding with further logic. This adjustment is made in three locations within the subroutine to prevent potential issues with invalid layer indices.

- Logic correction:
  * Added a check to set `ILAY = 1` if `ILAY == -1` at three points in the `H3D_SOLID_SCALAR_1` subroutine, ensuring valid layer indexing and preventing errors when `ILAY` is uninitialized or set to `-1`. [[1]](diffhunk://#diff-14dd8262a915b83b609a4bcdf01d4bdba37ba1c25c7f3a466e92f34953c9ca27R1011) [[2]](diffhunk://#diff-14dd8262a915b83b609a4bcdf01d4bdba37ba1c25c7f3a466e92f34953c9ca27R1068) [[3]](diffhunk://#diff-14dd8262a915b83b609a4bcdf01d4bdba37ba1c25c7f3a466e92f34953c9ca27R1124)
