### PR TITLE
Problem PON IPSTIF Option Inter25

### DIFF
--- a/engine/source/interfaces/int25/i25cor3.F
+++ b/engine/source/interfaces/int25/i25cor3.F
@@ -789,7 +789,7 @@ C
      K               Y3        ,Z3    ,X4      ,Y4     ,Z4          ,
      L               INTTH     ,TEMP  ,TEMPI   ,IELES  ,IELESI      ,
      M               IELEM     ,IELEMI,ISTIF_MSDT,DTSTIF,STIFMSDT_S ,
-     N               STIFMSDT_M,NRTM  ,PARAMETERS) 
+     N               STIFMSDT_M,NRTM  ,PARAMETERS,NCYCLE) 
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
@@ -821,6 +821,7 @@ C-----------------------------------------------
      .        IREP_FRICM(*),IREP_FRICMI(MVSIZ),IELESI(MVSIZ),IELEMI(MVSIZ)
       INTEGER , INTENT(IN) :: ISTIF_MSDT
       INTEGER , INTENT(IN) :: NRTM
+      INTEGER , INTENT(IN) :: NCYCLE
 C     REAL
       my_real
      .   X(3,*), STF(*), STFN(*), MS(*), V(3,*), 
@@ -1074,7 +1075,7 @@ c          STIF(I)=MAX(KMIN,MIN(STIF(I),KMAX))
 C------------------------------------------
 C   Stiffness based on mass and time step
 C------------------------------------------
-      IF(ISTIF_MSDT > 0) THEN
+      IF(ISTIF_MSDT > 0.AND.NCYCLE >= 1) THEN
          IF(DTSTIF > ZERO) THEN
             DTS = DTSTIF
          ELSE

--- a/engine/source/interfaces/int25/i25mainf.F
+++ b/engine/source/interfaces/int25/i25mainf.F
@@ -617,7 +617,7 @@ C         Extraction of global data to local arrays
      K  Y3         ,Z3       ,X4          ,Y4          ,Z4      ,
      L  INTTH      ,TEMP     ,TEMPI       ,INTBUF_TAB%IELES     ,IELESI      ,
      M  INTBUF_TAB%IELEM,IELEMI,ISTIF_MSDT,DTSTIF      ,INTBUF_TAB%STIFMSDT_S,
-     N  INTBUF_TAB%STIFMSDT_M,NRTM        ,INTERFACES%PARAMETERS)
+     N  INTBUF_TAB%STIFMSDT_M,NRTM        ,INTERFACES%PARAMETERS,NCYCLE      )
           IKNON(1:JLT) = 0
           CALL I_CORPFIT3(
      1               JLT      ,INTBUF_TAB%STFM  ,INTBUF_TAB%STFNS,STIF      ,NSN    ,


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
Using Ipstif option can lead to PON differences as DTstif the time step at time 0 is not computed in PON way at cycle 0.
=> to avoid that IPSTIF option is taken into account if NCYCLE >=1

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
Using Ipstif option can lead to PON differences as DTstif the time step at time 0 is not computed in PON way at cycle 0.
=> to avoid that IPSTIF option is taken into account if NCYCLE >=1

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
