### PR TITLE
QAPRINT : add /BCS/NRF keyword

### DIFF
--- a/common_source/includes/qaprint_c.inc
+++ b/common_source/includes/qaprint_c.inc
@@ -23,35 +23,35 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 
 C========================================================================
 C     List of available keywords for QAPRINT
-      parameter (NQAKEYLIST_AVAIL=127)
+      parameter (NQAKEYLIST_AVAIL=128)
       CHARACTER (len=64), DIMENSION(NQAKEYLIST_AVAIL) :: QAKEYLIST_AVAIL
       DATA QAKEYLIST_AVAIL/
-     .  'PROPERTIES'  , 'MATERIALS' ,'VELOCITIES','GRID_VELOCITIES','/RBODY'      , 
-     .  '/LOAD/PFLUID','/CLOAD'     ,'/PLOAD'    ,'/GRAV'          ,'/RADIATION'  ,
-     .  '/CONVEC'     ,'/IMPTEMP'   ,'/IMPFLUX'  ,'/BCS'           ,'/LOAD/CENTRI',
-     .  '/DAMP'       ,'/DAMP/INTER','/INITEMP'  ,'/BCS/LAGMUL'    ,'INTERFACES'  ,
-     .  '/CLUSTER'    ,'/BOX'       ,'/ADMAS'    ,'/IMPACC'        ,'/ACCEL'      ,
-     .  'SECTIONS'    ,'SKEWS'      ,'FRAMES'    ,'/MONVOL'        ,'/TYPE2'      ,
-     .  'FRICTION'    ,'/XREF'      ,'/RWALL'    ,'/TH'            ,'DETONATORS'  ,
-     .  '/IMPDISP'    ,'/IMPVEL'    ,'/DT'       ,'/BCS/CYCLIC'    ,'/STOP'       ,
-     .  '/ANIM'       ,'/TFILE'     ,'/RUN'      ,'/RFILE'         ,'/VERS'       ,                   
-     .  'TABLE'       ,'/FUNCT'     ,'/MOVE_FUNCT','/RBE3'         ,'/MERGE'      ,
-     .  '/DEF_SOLID'  ,'ELEMENTS'   ,'/SET'      ,'/SPHBCS'        ,'/ALE/BCS'    ,
-     .  '/INTER/SUB'  ,'/TRANSFORM' ,'/RANDOM'   ,'/IMPLICIT'      ,'/SPMD'       ,
-     .  '/CAA'        ,'/SPHGLO'    ,'/ANALY'    ,'LASERS'         ,'/IOFLAG'     ,
-     .  '/AMS'        ,'/RBE2'      ,'/DRAPE'    ,'/ALE/MUSCL'     ,'/ACTIV'      ,
-     .  '/UNIT'       ,'/INIVOL'    ,'/REFSTA'   ,'/DEFAULT/INTER' ,'/EBCS'       ,
-     .  'GROUPS'      ,'NODES'      ,'SENSOR'    ,'/LINE'          ,'/SURF'       ,
-     .  '/DEF_SHELL'  ,'/INIGRAV'   ,'/INISTA'   ,'/INICRACK'      ,'/LAGMUL'     ,
-     .  '/EREF'       ,'/PRELOAD'   ,'/INTTHICK' ,'/LOAD/PBLAST'   ,'/MPC'        ,
-     .  '/CYL_JOINT'  ,'/RLINK'     ,'/BEM'      ,'/ALE/GRID'      ,'/SHFRA'      ,
-     .  'ADMESH'      ,'/UPWIND'    ,'/PERTURB'  ,'/ALE/LINK'      ,'/GJOINT'     ,
-     .  '/GAUGE'      ,'/STAMPING'  ,'/MADYMO'   ,'/FXBODY'        ,'/EIG'        ,
-     .  '/SPH/INOUT'  ,'/ANIM/VERS' ,'INIMAP'    ,'/SLIPRING'      ,'/LOAD/PRESSURE',
-     .  '/INIBRI'     ,'/INISHE'    ,'/INISH3'   ,'/INIQUA'        ,'/INIBEAM'    ,
-     .  '/INITRUSS'   ,'/INISPRING' ,'/RETRACTOR','/SUBDOMAIN'     ,'/EXT/LINK'   ,
-     .  '/USERWI'     ,'IPARG'      ,'ALE'       ,'/PARITH'        ,'NODES_MASS'  ,
-     .  '/BCS/WALL'   ,'/DAMP/FREQ_RANGE'
+     .  'PROPERTIES'  , 'MATERIALS'      ,'VELOCITIES','GRID_VELOCITIES','/RBODY'      ,
+     .  '/LOAD/PFLUID','/CLOAD'          ,'/PLOAD'    ,'/GRAV'          ,'/RADIATION'  ,
+     .  '/CONVEC'     ,'/IMPTEMP'        ,'/IMPFLUX'  ,'/BCS'           ,'/LOAD/CENTRI',
+     .  '/DAMP'       ,'/DAMP/INTER'     ,'/INITEMP'  ,'/BCS/LAGMUL'    ,'INTERFACES'  ,
+     .  '/CLUSTER'    ,'/BOX'            ,'/ADMAS'    ,'/IMPACC'        ,'/ACCEL'      ,
+     .  'SECTIONS'    ,'SKEWS'           ,'FRAMES'    ,'/MONVOL'        ,'/TYPE2'      ,
+     .  'FRICTION'    ,'/XREF'           ,'/RWALL'    ,'/TH'            ,'DETONATORS'  ,
+     .  '/IMPDISP'    ,'/IMPVEL'         ,'/DT'       ,'/BCS/CYCLIC'    ,'/STOP'       ,
+     .  '/ANIM'       ,'/TFILE'          ,'/RUN'      ,'/RFILE'         ,'/VERS'       ,
+     .  'TABLE'       ,'/FUNCT'          ,'/MOVE_FUNCT','/RBE3'         ,'/MERGE'      ,
+     .  '/DEF_SOLID'  ,'ELEMENTS'        ,'/SET'      ,'/SPHBCS'        ,'/ALE/BCS'    ,
+     .  '/INTER/SUB'  ,'/TRANSFORM'      ,'/RANDOM'   ,'/IMPLICIT'      ,'/SPMD'       ,
+     .  '/CAA'        ,'/SPHGLO'         ,'/ANALY'    ,'LASERS'         ,'/IOFLAG'     ,
+     .  '/AMS'        ,'/RBE2'           ,'/DRAPE'    ,'/ALE/MUSCL'     ,'/ACTIV'      ,
+     .  '/UNIT'       ,'/INIVOL'         ,'/REFSTA'   ,'/DEFAULT/INTER' ,'/EBCS'       ,
+     .  'GROUPS'      ,'NODES'           ,'SENSOR'    ,'/LINE'          ,'/SURF'       ,
+     .  '/DEF_SHELL'  ,'/INIGRAV'        ,'/INISTA'   ,'/INICRACK'      ,'/LAGMUL'     ,
+     .  '/EREF'       ,'/PRELOAD'        ,'/INTTHICK' ,'/LOAD/PBLAST'   ,'/MPC'        ,
+     .  '/CYL_JOINT'  ,'/RLINK'          ,'/BEM'      ,'/ALE/GRID'      ,'/SHFRA'      ,
+     .  'ADMESH'      ,'/UPWIND'         ,'/PERTURB'  ,'/ALE/LINK'      ,'/GJOINT'     ,
+     .  '/GAUGE'      ,'/STAMPING'       ,'/MADYMO'   ,'/FXBODY'        ,'/EIG'        ,
+     .  '/SPH/INOUT'  ,'/ANIM/VERS'      ,'INIMAP'    ,'/SLIPRING'      ,'/LOAD/PRESSURE',
+     .  '/INIBRI'     ,'/INISHE'         ,'/INISH3'   ,'/INIQUA'        ,'/INIBEAM'    ,
+     .  '/INITRUSS'   ,'/INISPRING'      ,'/RETRACTOR','/SUBDOMAIN'     ,'/EXT/LINK'   ,
+     .  '/USERWI'     ,'IPARG'           ,'ALE'       ,'/PARITH'        ,'NODES_MASS'  ,
+     .  '/BCS/WALL'   ,'/DAMP/FREQ_RANGE','/BCS/NRF'
      ./
 C========================================================================
 


### PR DESCRIPTION
#### Description of the feature or the bug
Following Commit 05b9c93, QAPRINT keyword /BCS/NRF is added.
