### PR TITLE
fix regression of /DT1/BRICK from e678696eedfb37683de3dc59886bb661dcd…

### DIFF
--- a/engine/source/elements/solid/solide8e/s8eforc3.F
+++ b/engine/source/elements/solid/solide8e/s8eforc3.F
@@ -1533,8 +1533,11 @@ C
      .           NC1,NC2,NC3,NC4,NC5,NC6,NC7,NC8,
      .           TEMP,TEMPEL)
       ENDIF 
-      DELTAXI(1:NEL) = DELTAX(1:NEL)   
-      IF (FAC_NU<ONE) DELTAXI(1:NEL) = MAX(DELTAXI(1:NEL),NU_SP*DELTAX(1:NEL))   
+      IF (FAC_NU<ONE) THEN 
+        DELTAXI(1:NEL) = MAX(DELTAXI(1:NEL),NU_SP*DELTAX(1:NEL)) 
+      ELSE 
+        DELTAXI(1:NEL) = DELTAX(1:NEL)   
+      ENDIF	  
 C------------------------------------------------------
 C     CALCUL DES CONTRAINTES SUIVANT LOIS CONSTITUTIVES
 C     TIME STEP EST CALCULE ICI DT2T

--- a/engine/source/elements/solid/solide8z/s8zforc3.F
+++ b/engine/source/elements/solid/solide8z/s8zforc3.F
@@ -1182,8 +1182,11 @@ C
      2               NC1,NC2,NC3,NC4,NC5,NC6,NC7,NC8,
      3               TEMP,TEMPEL)
       ENDIF    
-      DELTAXI(1:NEL) = DELTAX(1:NEL)   
-      IF (FAC_NU<ONE) DELTAXI(1:NEL) = MAX(DELTAXI(1:NEL),NU_SP*DELTAX(1:NEL))   
+      IF (FAC_NU<ONE) THEN 
+        DELTAXI(1:NEL) = MAX(DELTAXI(1:NEL),NU_SP*DELTAX(1:NEL)) 
+      ELSE 
+        DELTAXI(1:NEL) = DELTAX(1:NEL)   
+      ENDIF	  
 C------------------------------------------------------
 C     CALCUL DES CONTRAINTES SUIVANT LOIS CONSTITUTIVES
 C     TIME STEP EST CALCULE ICI DT2T

--- a/engine/source/elements/solid/solidez/szforc3.F
+++ b/engine/source/elements/solid/solidez/szforc3.F
@@ -706,8 +706,11 @@ C Element temperature
         ENDDO
       ENDIF
 C
-      DELTAXI(1:NEL) = DELTAX(1:NEL)   
-      IF (FAC_NU<ONE) DELTAXI(1:NEL) = MAX(DELTAXI(1:NEL),NU_SP*DELTAX(1:NEL))   
+      IF (FAC_NU<ONE) THEN 
+        DELTAXI(1:NEL) = MAX(DELTAXI(1:NEL),NU_SP*DELTAX(1:NEL)) 
+      ELSE 
+        DELTAXI(1:NEL) = DELTAX(1:NEL)   
+      ENDIF	  
 C-----------------------------------------------------------------------
       IF ((ITASK==0).AND.(IMON_MAT==1)) CALL STARTIME(TIMERS,35)
       ILAY = 1 


### PR DESCRIPTION
…dc958

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
may have instability issue (time step) of Hexa element (Isolid=24,14,18) for special case even using /DT1/BRICK

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
fix regression for time step in e678696eedfb37683de3dc59886bb661dcddc958

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
