### PR TITLE
check if a part is filled with elements before erroring with not existing material

### DIFF
--- a/starter/source/devtools/hm_reader/hm_is_part_with_elements.F90
+++ b/starter/source/devtools/hm_reader/hm_is_part_with_elements.F90
@@ -1,0 +1,63 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 1986-2026 Altair Engineering Inc.
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Altair Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Altair also offers Altair Radioss
+!Copyright>        software under a commercial license.  Contact Altair to discuss further if the
+!Copyright>        commercial version may interest you: https://www.altair.com/radioss/.
+!||====================================================================
+!||    hm_is_part_with_elements_mod   ../starter/source/devtools/hm_reader/hm_is_part_with_elements.F90
+!||--- called by ------------------------------------------------------
+!||    starter0                       ../starter/source/starter/starter0.F
+!||====================================================================
+        module hm_is_part_with_elements_mod
+         use, intrinsic :: iso_c_binding, only : c_bool
+         implicit none
+      contains
+! ======================================================================================================================
+!                                                   procedures
+! ======================================================================================================================
+!! \brief check if a /PART has elements
+!! \details This routine checks if a /PART has elements.
+!||====================================================================
+!||    hm_is_part_with_elements           ../starter/source/devtools/hm_reader/hm_is_part_with_elements.F90
+!||--- called by ------------------------------------------------------
+!||    starter0                                       ../starter/source/starter/starter0.F
+!||--- calls      -----------------------------------------------------
+!||====================================================================
+        subroutine hm_is_part_with_elements(part_id, is_part_with_elements)
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Modules
+! ----------------------------------------------------------------------------------------------------------------------
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          integer, intent(in) :: part_id
+          logical(c_bool), intent(inout) :: is_part_with_elements
+! ----------------------------------------------------------------------------------------------------------------------
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Body
+! ----------------------------------------------------------------------------------------------------------------------
+          call cpp_is_part_with_elements(part_id, is_part_with_elements)
+! ----------------------------------------------------------------------------------------------------------------------
+        end subroutine hm_is_part_with_elements
+      end module hm_is_part_with_elements_mod

--- a/starter/source/model/assembling/hm_read_part.F
+++ b/starter/source/model/assembling/hm_read_part.F
@@ -77,6 +77,8 @@ C-----------------------------------------------
       USE MAT_ELEM_MOD
       USE NAMES_AND_TITLES_MOD , ONLY : NCHARTITLE
       use glob_therm_mod
+      use hm_is_part_with_elements_mod
+      use, intrinsic :: iso_c_binding , only : c_bool
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -122,6 +124,7 @@ C-----------------------------------------------
      .        ILAW_PLY,IPMAT,NPT,IDPARTSPH,SUB_INDEX, IDS, CNT,
      .        STAT,JALE_FROM_PROP,JALE_FROM_MAT
       my_real BID, THICK,FAC_L,MP,VOL,DIAM
+      logical(c_bool) :: IS_FILLED
 C-----------------------------------------------
 C   E x t e r n a l   F u n c t i o n s
 C-----------------------------------------------
@@ -209,6 +212,9 @@ C--------------------------------------------------
             CALL FRETITL2(TITR1,IGEO(NPROPGI-LTITR+1,IPID),LTITR)
         ENDIF
 
+        IS_FILLED = .FALSE.
+        call hm_is_part_with_elements(ID,IS_FILLED)
+
         IGTYP=NINT(GEO(12,IPID))
         IF(IGTYP == 17 .OR. IGTYP == 51) IPART_STACK = 1
         IF(IGTYP ==  52) IPART_PCOMPP = 1
@@ -221,7 +227,7 @@ C--------------------------------------------------
      .      (IGTYP == 17).OR.(IGTYP == 51).OR.(IGTYP == 52).OR. 
      .      (IGTYP == 23).OR.(IGTYP == 43)) THEN
             IF(MID == 0) THEN
-               CALL ANCMSG(MSGID=179,
+               IF(IS_FILLED) CALL ANCMSG(MSGID=179,
      .                     MSGTYPE=MSGERROR,
      .                     ANMODE=ANINFO,
      .                     I1=ID,
@@ -237,7 +243,7 @@ C--------------------------------------------------
         ELSE
          IMID = NINTRI(MID,IPM,NPROPMI,NUMMAT,1)
          IF(IMID == 0) THEN
-            CALL ANCMSG(MSGID=179,
+            IF(IS_FILLED) CALL ANCMSG(MSGID=179,
      .                  MSGTYPE=MSGERROR,
      .                  ANMODE=ANINFO,
      .                  I1=ID,


### PR DESCRIPTION
This pull request introduces a new utility module to check if a `/PART` has elements and integrates this check into the part reading logic. The main goal is to ensure that certain error messages are only triggered for parts that actually contain elements, improving the accuracy of error handling in the `hm_read_part` routine.

The most important changes are:

**New functionality for part element checking:**
* Added a new module `hm_is_part_with_elements_mod` in `hm_is_part_with_elements.F90`, which provides the `hm_is_part_with_elements` subroutine to determine if a part contains elements. This uses a C binding for interoperability.

**Integration with part reading logic:**
* Imported `hm_is_part_with_elements_mod` and related C interoperability types into `hm_read_part.F`, and declared a new logical variable `IS_FILLED` to store the result. [[1]](diffhunk://#diff-0a49343e74e778d75c741121055ece22d331ca30e78c0e23b1652ea096eb1903R80-R81) [[2]](diffhunk://#diff-0a49343e74e778d75c741121055ece22d331ca30e78c0e23b1652ea096eb1903R127)
* Called `hm_is_part_with_elements` for each part to set `IS_FILLED` before processing, ensuring the check is performed early in the routine.

**Improved error handling:**
* Modified error conditions so that error messages for missing material IDs (`MID == 0`) are only raised if the part actually contains elements (`IS_FILLED` is true), avoiding false positives for empty parts. [[1]](diffhunk://#diff-0a49343e74e778d75c741121055ece22d331ca30e78c0e23b1652ea096eb1903L223-R229) [[2]](diffhunk://#diff-0a49343e74e778d75c741121055ece22d331ca30e78c0e23b1652ea096eb1903L239-R245)
