### PR TITLE
/EOS/TILLOTSON : 2612 format updated for backward compatibility

### DIFF
--- a/common_source/eos/tillotson.F
+++ b/common_source/eos/tillotson.F
@@ -86,6 +86,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
             REAL(KIND=WP) :: I12, I4, KK, TMP3
             REAL(KIND=WP) :: DVV, DENOM
             REAL(KIND=WP) :: P_LOC, DPDM_LOC, DPDE_LOC
+            REAL(KIND=WP) :: P0
 
             C1      = EOS_STRUCT%UPARAM(1)
             C2_VAL  = EOS_STRUCT%UPARAM(2)
@@ -107,6 +108,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
             ENDIF
 
             PSH(1:NEL) = EOS_STRUCT%PSH
+            P0 = EOS_STRUCT%P0
 
             ! ================================================================
             ! IFLAG = 0 : first staggered pass
@@ -171,8 +173,6 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 
                 ! ------------------------------------------------------------
                 ! Regions 1, 2 and 3: Tillotson compressed / cold branch.
-                ! Original semantics preserved:
-                ! P12 is floored and multiplied by OFF before DPDM12.
                 ! ------------------------------------------------------------
                 IF (REG <= 3) THEN
 
@@ -182,7 +182,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
                     C2I = ZERO
                   ENDIF
 
-                  P12 = ABW * ETAE + C1 * MU_I + C2I * MU2_I
+                  P12 = P0 + ABW * ETAE + C1 * MU_I + C2I * MU2_I
                   P12 = MAX(P12, PMIN) * OFF_I
 
                   DE_P12 = -B * DE_W * ETAE * INV_W2 + ABW * ETA
@@ -204,7 +204,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
                   C1EBEAX  = C1EB * EAX
                   ABWX     = A + B * EAX * INV_W
 
-                  P4 = C1EBEAX * MU_I + ABWX * ETAE
+                  P4 = P0 + C1EBEAX * MU_I + ABWX * ETAE
                   P4 = MAX(P4, PMIN) * OFF_I
 
                   DE_P4 = -B * EAX * DE_W * ETAE * INV_W2 + ABWX * ETA
@@ -301,7 +301,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
                     C2I = ZERO
                   ENDIF
 
-                  P12 = ABW * ETAE + C1 * MU_I + C2I * MU2_I
+                  P12 = P0 + ABW * ETAE + C1 * MU_I + C2I * MU2_I
 
                   DE_P12 = -B * DE_W * ETAE * INV_W2 + ABW * ETA
 
@@ -324,7 +324,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
                   C1EBEAX  = C1EB * EAX
                   ABWX     = A + B * EAX * INV_W
 
-                  P4 = C1EBEAX * MU_I + ABWX * ETAE
+                  P4 = P0 + C1EBEAX * MU_I + ABWX * ETAE
 
                   DE_P4 = -B * EAX * DE_W * ETAE * INV_W2 + ABWX * ETA
 
@@ -353,13 +353,13 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
                   C1EBEAX  = C1EB * EAX
                   ABWX     = A + B * EAX * INV_W
 
-                  P12 = ABW * ETAE + C1 * MU_I
+                  P12 = P0 + ABW * ETAE + C1 * MU_I
 
                   DE_P12 = -B * DE_W * ETAE * INV_W2 + ABW * ETA
 
                   DM_P12 = -B * DN_W * ETAE * INV_W2 + ABW * E_I + C1
 
-                  P4 = C1EBEAX * MU_I + ABWX * ETAE
+                  P4 = P0 + C1EBEAX * MU_I + ABWX * ETAE
 
                   DE_P4 = -B * EAX * DE_W * ETAE * INV_W2 + ABWX * ETA
 

--- a/hm_cfg_files/config/CFG/radioss2612/MAT/mat_EOS.cfg
+++ b/hm_cfg_files/config/CFG/radioss2612/MAT/mat_EOS.cfg
@@ -52,7 +52,7 @@ ATTRIBUTES(COMMON)
     TILLOTSON_C2        = VALUE(FLOAT,"C2 Coefficient");
     MAT_B               = VALUE(FLOAT,"b Coefficient");
     E_R                 = VALUE(FLOAT,"Internal Energy Per Unit");
-    Vs                  = VALUE(FLOAT,"Sublimation Relative Volume");
+    Viv                 = VALUE(FLOAT,"Incipient Vaporization Relative Volume");
     TILLOTSON_E0        = VALUE(FLOAT,"Initial Energy per Unit");
     TILLOTSON_Rho_0     = VALUE(FLOAT,"Reference Density");
     Alpha               = VALUE(FLOAT,"Alpha Coefficient");
@@ -155,7 +155,7 @@ SKEYWORDS_IDENTIFIER(COMMON)
     SESAME_RHO          = 2905;
     MAT_B               = 995;
     E_R                 = 4765;
-    Vs                  = 4767;
+    Viv                 = 4767;
     Alpha               = 982;
     Beta                = 983;  
     ISRTY               = 7039;
@@ -247,7 +247,7 @@ GUI(COMMON) {
         SCALAR(E_R)           { DIMENSION="energydensity"; }
         SCALAR(E_CV)          { DIMENSION="energydensity"; }
         SCALAR(E_IV)          { DIMENSION="energydensity"; }
-        SCALAR(Vs)            { DIMENSION="DIMENSIONLESS"; }
+        SCALAR(Viv)           { DIMENSION="DIMENSIONLESS"; }
         SCALAR(MAT_EA)        { DIMENSION="energydensity"; }
         SCALAR(Refer_Rho)     { DIMENSION="density"; }
         SCALAR(Alpha)         { DIMENSION="DIMENSIONLESS"; }
@@ -629,10 +629,10 @@ FORMAT(radioss2612) {
     {
         COMMENT("#                 C1                  C2                   a                   b");
         CARD("%20lg%20lg%20lg%20lg",EOS_C1,EOS_C2,MAT_A,MAT_B);
-        COMMENT("#                 ER                 ECV                 VIV                  EO");
-        CARD("%20lg%20lg%20lg%20lg",E_R,E_CV,Vs,MAT_EA);
-        COMMENT("#              Alpha                Beta                 EIV                 PSH                  P0");
-        CARD("%20lg%20lg%20lg%20lg%20lg",Alpha,Beta,E_IV,MAT_PSH,LAW5_P0);
+        COMMENT("#                 ER                 EIV                 VIV                  EO                 ECV");
+        CARD("%20lg%20lg%20lg%20lg%20lg",E_R,E_IV,Viv,MAT_EA,E_CV);
+        COMMENT("#              Alpha                Beta                 PSH                  P0");
+        CARD("%20lg%20lg%20lg%20lg",Alpha,Beta,MAT_PSH,LAW5_P0);
     }
     else if(EOS_Options == 7)
     {
@@ -965,8 +965,8 @@ FORMAT(radioss2026) {
     {
         COMMENT("#                 C1                  C2                   a                   b");
         CARD("%20lg%20lg%20lg%20lg",EOS_C1,EOS_C2,MAT_A,MAT_B);
-        COMMENT("#                 ER                  ES                  VS                  EO");
-        CARD("%20lg%20lg%20lg%20lg",E_R,E_CV,Vs,MAT_EA);
+        COMMENT("#                 ER                 EIV                 VIV                  EO");
+        CARD("%20lg%20lg%20lg%20lg",E_R,E_IV,Viv,MAT_EA);
         COMMENT("#              Alpha                Beta");
         CARD("%20lg%20lg",Alpha,Beta);
     }
@@ -1292,8 +1292,8 @@ FORMAT(radioss2025) {
     {
         COMMENT("#                 C1                  C2                   a                   b");
         CARD("%20lg%20lg%20lg%20lg",EOS_C1,EOS_C2,MAT_A,MAT_B);
-        COMMENT("#                 ER                  ES                  VS                  EO");
-        CARD("%20lg%20lg%20lg%20lg",E_R,E_CV,Vs,MAT_EA);
+        COMMENT("#                 ER                 EIV                 VIV                  EO");
+        CARD("%20lg%20lg%20lg%20lg",E_R,E_IV,Viv,MAT_EA);
         COMMENT("#              Alpha                Beta");
         CARD("%20lg%20lg",Alpha,Beta);
     }
@@ -1597,8 +1597,8 @@ FORMAT(radioss2024) {
     {
         COMMENT("#                 C1                  C2                   a                   b");
         CARD("%20lg%20lg%20lg%20lg",EOS_C1,EOS_C2,MAT_A,MAT_B);
-        COMMENT("#                 ER                  ES                  VS                  EO");
-        CARD("%20lg%20lg%20lg%20lg",E_R,E_CV,Vs,MAT_EA);
+        COMMENT("#                 ER                 EIV                 VIV                  EO");
+        CARD("%20lg%20lg%20lg%20lg",E_R,E_IV,Viv,MAT_EA);
         COMMENT("#              Alpha                Beta");
         CARD("%20lg%20lg",Alpha,Beta);
     }
@@ -1857,8 +1857,8 @@ FORMAT(radioss2023) {
     {
         COMMENT("#                 C1                  C2                   a                   b");
         CARD("%20lg%20lg%20lg%20lg",EOS_C1,EOS_C2,MAT_A,MAT_B);
-        COMMENT("#                 ER                  ES                  VS                  EO");
-        CARD("%20lg%20lg%20lg%20lg",E_R,E_CV,Vs,MAT_EA);
+        COMMENT("#                 ER                  ES                 VIV                  EO");
+        CARD("%20lg%20lg%20lg%20lg",E_R,E_CV,Viv,MAT_EA);
         COMMENT("#              Alpha                Beta");
         CARD("%20lg%20lg",Alpha,Beta);
     }
@@ -2112,8 +2112,8 @@ FORMAT(radioss2022) {
     {
         COMMENT("#                 C1                  C2                   a                   b");
         CARD("%20lg%20lg%20lg%20lg",EOS_C1,EOS_C2,MAT_A,MAT_B);
-        COMMENT("#                 ER                  ES                  VS                  EO               RHO_0");
-        CARD("%20lg%20lg%20lg%20lg%20lg",E_R,E_CV,Vs,MAT_EA,Refer_Rho);
+        COMMENT("#                 ER                 EIV                 VIV                  EO               RHO_0");
+        CARD("%20lg%20lg%20lg%20lg%20lg",E_R,E_IV,Viv,MAT_EA,Refer_Rho);
         COMMENT("#              Alpha                Beta");
         CARD("%20lg%20lg",Alpha,Beta);
     }
@@ -2358,8 +2358,8 @@ FORMAT(radioss2020) {
     {
         COMMENT("#                 C1                  C2                   a                   b");
         CARD("%20lg%20lg%20lg%20lg",EOS_C1,EOS_C2,MAT_A,MAT_B);
-        COMMENT("#                 ER                  ES                  VS                  EO               RHO_0");
-        CARD("%20lg%20lg%20lg%20lg%20lg",E_R,E_CV,Vs,MAT_EA,Refer_Rho);
+        COMMENT("#                 ER                  ES                 VIV                  EO               RHO_0");
+        CARD("%20lg%20lg%20lg%20lg%20lg",E_R,E_CV,Viv,MAT_EA,Refer_Rho);
         COMMENT("#              Alpha                Beta");
         CARD("%20lg%20lg",Alpha,Beta);
     }
@@ -2581,8 +2581,8 @@ FORMAT(radioss2019) {
     {
         COMMENT("#                 C1                  C2                   a                   b");
         CARD("%20lg%20lg%20lg%20lg",EOS_C1,EOS_C2,MAT_A,MAT_B);
-        COMMENT("#                 ER                  ES                  VS                  EO               RHO_0");
-        CARD("%20lg%20lg%20lg%20lg%20lg",E_R,E_CV,Vs,MAT_EA,Refer_Rho);
+        COMMENT("#                 ER                  ES                 VIV                  EO               RHO_0");
+        CARD("%20lg%20lg%20lg%20lg%20lg",E_R,E_CV,Viv,MAT_EA,Refer_Rho);
         COMMENT("#              Alpha                Beta");
         CARD("%20lg%20lg",Alpha,Beta);
     }
@@ -2779,8 +2779,8 @@ FORMAT(radioss2018) {
     {
         COMMENT("#                 C1                  C2                   a                   b");
         CARD("%20lg%20lg%20lg%20lg",EOS_C1,EOS_C2,MAT_A,MAT_B);
-        COMMENT("#                 ER                  ES                  VS                  EO               RHO_0");
-        CARD("%20lg%20lg%20lg%20lg%20lg",E_R,E_CV,Vs,MAT_EA,Refer_Rho);
+        COMMENT("#                 ER                 EIV                  VIV                 EO               RHO_0");
+        CARD("%20lg%20lg%20lg%20lg%20lg",E_R,E_IV,Viv,MAT_EA,Refer_Rho);
         COMMENT("#              Alpha                Beta");
         CARD("%20lg%20lg",Alpha,Beta);
     }
@@ -2911,8 +2911,8 @@ FORMAT(radioss110) {
     {
         COMMENT("#                 C1                  C2                   a                   b");
         CARD("%20lg%20lg%20lg%20lg",EOS_C1,EOS_C2,MAT_A,MAT_B);
-        COMMENT("#                 ER                  ES                  VS                  EO               RHO_0");
-        CARD("%20lg%20lg%20lg%20lg%20lg",E_R,E_CV,Vs,MAT_EA,Refer_Rho);
+        COMMENT("#                 ER                 EIV                 VIV                  EO               RHO_0");
+        CARD("%20lg%20lg%20lg%20lg%20lg",E_R,E_IV,Viv,MAT_EA,Refer_Rho);
         COMMENT("#              Alpha                Beta");
         CARD("%20lg%20lg",Alpha,Beta);
     }

--- a/starter/source/materials/eos/hm_read_eos_tillotson.F
+++ b/starter/source/materials/eos/hm_read_eos_tillotson.F
@@ -105,8 +105,9 @@ C-----------------------------------------------
       CALL HM_GET_FLOATV('MAT_B', B, IS_AVAILABLE,LSUBMODEL,UNITAB)
 
       CALL HM_GET_FLOATV('E_R',EREF, IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV('E_IV', EIV, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('E_CV', ECV, IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_FLOATV('Vs', VSUBL, IS_AVAILABLE,LSUBMODEL,UNITAB)
+      CALL HM_GET_FLOATV('Viv', VSUBL, IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('MAT_EA', E0 ,IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('Refer_Rho', RHO0 ,IS_AVAILABLE_RHO0,LSUBMODEL,UNITAB)
 
@@ -115,7 +116,6 @@ C-----------------------------------------------
 
       CALL HM_GET_FLOATV('MAT_PSH', PSH ,IS_AVAILABLE,LSUBMODEL,UNITAB)
       CALL HM_GET_FLOATV('LAW5_P0', P0 ,IS_AVAILABLE,LSUBMODEL,UNITAB)
-      CALL HM_GET_FLOATV('E_IV', EIV, IS_AVAILABLE,LSUBMODEL,UNITAB)
 
       RHOR = MAT_PARAM%RHO
       RHOI = MAT_PARAM%RHO0
@@ -127,8 +127,23 @@ C-----------------------------------------------
         RHO0=RHOR                   
       ENDIF
 
-      IF(EIV == ZERO)THEN
-        EIV = ECV
+      IF(ECV == ZERO .OR. ECV == EIV)THEN
+        ECV = EIV
+          call ancmsg(MSGID=140,MSGTYPE=msgwarning,ANMODE=aninfo,I1=imideos,
+     .                C1='/EOS/TILLOTSON',C2='TRANSITION AREA IS RECOMMENDED FOR STABILITY PURPOSES (ECV > EIV)')
+      ENDIF
+
+      IF(E0 /= ZERO)THEN
+          call ancmsg(MSGID=140,MSGTYPE=msgwarning,ANMODE=aninfo,I1=imideos,
+     .                C1='/EOS/TILLOTSON',C2='E0 IS EXPECTED TO BE ZERO. NON ZERO VALUE SHOULD LEAD TO UPDATED PARAMETERS')
+      ENDIF
+
+      IF(EIV < ZERO)THEN
+        call ancmsg(MSGID=67,MSGTYPE=msgerror,ANMODE=aninfo,I1=imideos,
+     .              C1='/EOS/TILLOTSON',C2='EIV MUST BE STRICTLY POSITIVE')
+      ELSEIF(ECV < EIV)THEN
+        call ancmsg(MSGID=67,MSGTYPE=msgerror,ANMODE=aninfo,I1=imideos,
+     .              C1='/EOS/TILLOTSON',C2='ECV MUST BE GREATER THAN EIV')
       ENDIF
 
       IF (ABS(EREF) < EM20)THEN
@@ -158,6 +173,7 @@ C-----------------------------------------------
       MAT_PARAM%EOS%UPARAM(10) = EIV
       MAT_PARAM%EOS%PSH = PSH
       MAT_PARAM%EOS%E0 = E0
+      MAT_PARAM%EOS%P0 = P0
 !
       IF (MAT_PARAM%THERM%TINI == ZERO) THEN
         MAT_PARAM%THERM%TINI =THREE100
@@ -214,7 +230,7 @@ C-----------------------------------------------
       DPDM12 = ZERO ; DPDM4 = ZERO
       DE_P12 = ZERO ; DE_P4 = ZERO
       IF(REGION <= 3)THEN
-        P12 = ABW*ETAE+C1*MU0+C2*MU2
+        P12 = P0+ABW*ETAE+C1*MU0+C2*MU2
         P12 = MAX(P12,PMIN)
         DE_P12 = (-b*DE_W*ETAE)/W2 + ABW*ETA
         DM_P12 = (-B*DN_W*ETAE)/W2 + ABW*E0 + C1 + TWO*C2*MU0
@@ -227,7 +243,7 @@ C-----------------------------------------------
         EAX = exp(-alpha*XX*XX)
         C1EBEAX = C1EB*EAX
         ABWX = (A+B*EAX/W)
-        P4 = C1EB*EAX*MU0+ ABWX*ETAE
+        P4 = P0+C1EB*EAX*MU0+ ABWX*ETAE
         P4 = MAX(P4,PMIN)
         DE_P4 = -B*EAX*DE_W*ETAE/W2 + ABWX*ETA
         DM_P4 = BETA/ETA2*C1EBEAX*MU0 - TWO*C1EBEAX*ALPHA*XX*MU0/ETA2 + C1EBEAX
@@ -270,19 +286,19 @@ C-----------------------------------------------
      & 5X,'  TILLOTSON EOS',/,
      & 5X,'  -------------',/)
  1500 FORMAT(
-     & 5X,'C1. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'C2. . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
+     & 5X,'C1  . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
+     & 5X,'C2  . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'A . . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'B . . . . . . . . . . . . . . . . . . . .=',1PG20.13/,
      & 5X,'ALPHA . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'BETA. . . . . . . . . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'EREF:REFERENCE INTERNAL ENERGY. . . . . .=',1PG20.13/,
+     & 5X,'BETA  . . . . . . . . . . . . . . . . . .=',1PG20.13/,
+     & 5X,'EREF:REFERENCE INTERNAL ENERGY  . . . . .=',1PG20.13/,
      & 5X,'EIV:INCIPIENT VAPORIZATION ENERGY . . . .=',1PG20.13/,
-     & 5X,'ECV:COMPLETE VAPORIZATION ENERGY. . . . .=',1PG20.13/,
-     & 5X,'VSUBL:SUBLIMATION RELATIVE VOLUME . . . .=',1PG20.13/,
-     & 5X,'E0:INITIAL INTERNAL ENERGY. . . . . . . .=',1PG20.13/,
-     & 5X,'PSH:PRESSURE SHIFT. . . . . . . . . . . .=',1PG20.13/,
-     & 5X,'INITIAL PRESSURE. . . . . . . . . . . . .=',1PG20.13)
+     & 5X,'ECV:COMPLETE VAPORIZATION ENERGY  . . . .=',1PG20.13/,
+     & 5X,'VIV:VAPORIZATION RELATIVE VOLUME  . . . .=',1PG20.13/,
+     & 5X,'E0:INITIAL INTERNAL ENERGY  . . . . . . .=',1PG20.13/,
+     & 5X,'PSH:PRESSURE SHIFT  . . . . . . . . . . .=',1PG20.13/,
+     & 5X,'INITIAL PRESSURE  . . . . . . . . . . . .=',1PG20.13)
 
  1501 FORMAT(     
      & 5X,'EOS REFERENCE DENSITY . . . . . . . . . .=',1PG20.13)     

--- a/starter/source/output/message/starter_message_description.txt
+++ b/starter/source/output/message/starter_message_description.txt
@@ -1516,7 +1516,14 @@
 
 
 
+/MESSAGE/140/TITLE
+** WARNING IN EOS DEFINITION
 
+/MESSAGE/140/DESCRIPTION
+   -- EOS ID          : %d
+   -- EOS KEY         : %s
+   %i1="/EOS"
+   %s
 
 
 


### PR DESCRIPTION
#### /EOS/TILLOTSON : 2612 format updated for backward compatibility

#### Description of the changes
The 'Es' parameter has been replaced with a transition interval defined by Eiv and Ecv. For backward compatibility, the legacy Es value is now interpreted as Eiv. The new Ecv parameter defaults to Eiv, ensuring behavior consistent with earlier versions.
_Eiv : incipient vaporization energy
Ecv : complete vaporization energy_

<img width="2029" height="283" alt="image" src="https://github.com/user-attachments/assets/c2620231-9170-4d43-a640-44ae30231d65" />



<img width="1975" height="485" alt="image" src="https://github.com/user-attachments/assets/117be1f7-e351-4dd1-8850-b6409cc54f5a" />

