### PR TITLE
update h3d API 2026.1 version

### DIFF
--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_1d_scalar_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_1d_scalar_datatype.cpp
@@ -169,7 +169,7 @@ void c_h3d_create_1d_scalar_datatype_(int *cpt_data, char *name, int *size, int 
 
         sprintf(edata_type,  cname, H3D_DT_DELIMITER); 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_SCALAR, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         if (strlen(ccomment) != 0) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_1d_tensor_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_1d_tensor_datatype.cpp
@@ -146,7 +146,7 @@ void c_h3d_create_1d_tensor_datatype_(int *cpt_data, char *name, int *size, int 
         sprintf(edata_type,  cname, H3D_DT_DELIMITER); 
 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_TENSOR3D, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         if (strlen(ccomment) != 0) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_1d_torsor_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_1d_torsor_datatype.cpp
@@ -114,7 +114,7 @@ void c_h3d_create_1d_torsor_datatype_(int *cpt_data, char *name, int *size, int 
         dt_id++; 
         sprintf(edata_type,  cname, H3D_DT_DELIMITER); 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_SCALAR, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         if (strlen(ccomment) != 0) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_1d_vector_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_1d_vector_datatype.cpp
@@ -132,7 +132,7 @@ void c_h3d_create_1d_vector_datatype_(int *cpt_data, char *name, int *size, int 
         sprintf(edata_type,  cname, H3D_DT_DELIMITER); 
 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_VECTOR, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         if (strlen(ccomment) != 0) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_beams.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_beams.cpp
@@ -95,7 +95,7 @@ void c_h3d_create_beams_(int *ITAB, int *NUMNOD, int *IXP, int *NIXP, int *NUMEL
                  comp_id = IPART[*LIPART1 * (IPARTP[i] - 1) + 3];
 
                  rc = Hyper3DElementBegin(h3d_file, elem_count, beam_poolname_id, 
-                                    H3D_ELEM_CONFIG_ROD, comp_id, 
+                                    H3D_ELEM_CONFIG_ROD, H3D_NULL_ID, comp_id, 
                                     onedelem_poolname_id, node_poolname_id);
                  if( !rc ) throw rc;
                  rc = Hyper3DElementWrite(h3d_file, elem_id, conn);

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_displacement_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_displacement_datatype.cpp
@@ -81,13 +81,13 @@ void c_h3d_create_displacement_datatype_()
         dt_id = 1;     // the displacement data type
 
         rc = Hyper3DDatatypeWrite(h3d_file, "Animation", dt_id, H3D_DS_NONE, 
-                                    H3D_DS_UNKNOWN, pool_count);
+                                    H3D_DS_UNKNOWN, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         dt_id ++;  
         pool_count = 1; 
         rc = Hyper3DDatatypeWrite(h3d_file, "Displacement", dt_id, H3D_DS_VECTOR, 
-                                    H3D_DS_NODE, pool_count);
+                                    H3D_DS_NODE, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
         rc = Hyper3DDatatypePools(h3d_file, dt_id, node_poolname_id, layer_count, 
                                     layername_ids, has_corners, tensor_type, poisson);

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_nodal_scalar_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_nodal_scalar_datatype.cpp
@@ -136,7 +136,7 @@ void c_h3d_create_nodal_scalar_datatype_(int *cpt_data, char *name, int *size, i
 #endif
 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_SCALAR, 
-                                    H3D_DS_NODE, pool_count);
+                                    H3D_DS_NODE, H3D_NF_REAL, pool_count);
                                     
         free(edata_type);
         

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_nodal_tensor_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_nodal_tensor_datatype.cpp
@@ -124,7 +124,7 @@ void c_h3d_create_nodal_tensor_datatype_(int *cpt_data, char *name, int *size, i
         dt_id++; 
         sprintf(edata_type, cname, H3D_DT_DELIMITER); 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_TENSOR3D, 
-                                    H3D_DS_NODE, pool_count);
+                                    H3D_DS_NODE, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         rc = Hyper3DDatatypeDescriptionWrite(h3d_file, *cpt_data, ccomment);

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_nodal_vector_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_nodal_vector_datatype.cpp
@@ -108,7 +108,7 @@ void c_h3d_create_nodal_vector_datatype_(int *cpt_data, char *name, int *size, i
         dt_id++; 
         sprintf(edata_type, cname, H3D_DT_DELIMITER); 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_VECTOR, 
-                                    H3D_DS_NODE, pool_count);
+                                    H3D_DS_NODE, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_quad_scalar_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_quad_scalar_datatype.cpp
@@ -155,7 +155,7 @@ void c_h3d_create_quad_scalar_datatype_(int *cpt_data, char *name1, int *size1, 
         sprintf(edata_type,  RES_STRING, H3D_DT_DELIMITER); 
 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_SCALAR, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         if (strlen(ccomment) != 0) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_quad_tensor_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_quad_tensor_datatype.cpp
@@ -156,7 +156,7 @@ void c_h3d_create_quad_tensor_datatype_(int *cpt_data, char *name1, int *size1, 
         sprintf(edata_type,  cname, H3D_DT_DELIMITER); 
 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_TENSOR3D, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         if (strlen(ccomment) != 0) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_quad_vector_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_quad_vector_datatype.cpp
@@ -151,7 +151,7 @@ void c_h3d_create_quad_vector_datatype_(int *cpt_data, char *name1, int *size1, 
         sprintf(edata_type,  RES_STRING, H3D_DT_DELIMITER); 
 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_VECTOR, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         if (strlen(ccomment) != 0) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_quads.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_quads.cpp
@@ -136,7 +136,7 @@ void c_h3d_create_quads_(int *ITAB, int *NUMNOD, int *IPART, int *LIPART1,int *H
              	  comp_id = IPART[*LIPART1 * (IPARTQ[i] - 1) + 3];
 
              	  rc = Hyper3DElementBegin(h3d_file, nbelemwrite, quad_poolname_id, 
-             			H3D_ELEM_CONFIG_QUAD4, comp_id, 
+             			H3D_ELEM_CONFIG_QUAD4, H3D_NULL_ID, comp_id, 
              			quad_poolname_id, node_poolname_id);
              	  if( !rc ) throw rc;
              }

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_rbe2.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_rbe2.cpp
@@ -92,7 +92,7 @@ void c_h3d_create_rbe2_(int *ITAB, int *NUMNOD, int *IRBE2, int *NRBE2L, int *LR
         if(*COMPID_RBE2S != 0 && *NRBE2 != 0)
         {
              rc = Hyper3DElement2Begin(h3d_file, *NRBE2, rbe2_poolname_id, 
-                                    H3D_ELEM_CONFIG_RIGIDLINK, *COMPID_RBE2S, 
+                                    H3D_ELEM_CONFIG_RIGIDLINK, H3D_NULL_ID, *COMPID_RBE2S, 
                                     rbe2_poolname_id, node_poolname_id);
             for(i=0;i<*NRBE2;i++)  
             {
@@ -147,7 +147,7 @@ void c_h3d_create_rbe2_(int *ITAB, int *NUMNOD, int *IRBE2, int *NRBE2L, int *LR
 
 
                  rc = Hyper3DElement2Begin(h3d_file, elem_count, rbe2_poolname_id, 
-                                        H3D_ELEM_CONFIG_RIGIDLINK, RigidElem, 
+                                        H3D_ELEM_CONFIG_RIGIDLINK, H3D_NULL_ID, RigidElem, 
                                         rbe2_poolname_id, node_poolname_id);
                  if( !rc ) throw rc;
                  rc = Hyper3DElement2Write(h3d_file, elem_id, conn1, dof1 , coef1 , 1 ,conn, dof, coef, nsn);
@@ -214,7 +214,7 @@ void c_h3d_create_rbe2_impi_(int *ITAB,int *NRBE2,int *IADRBE2,int *MASTERNODS,i
         if(*COMPID_RBE2S != 0 && *NRBE2 != 0)
         {
             rc = Hyper3DElement2Begin(h3d_file, *NRBE2, rbe2_poolname_id, 
-                                    H3D_ELEM_CONFIG_RIGIDLINK, *COMPID_RBE2S, 
+                                    H3D_ELEM_CONFIG_RIGIDLINK, H3D_NULL_ID, *COMPID_RBE2S, 
                                     rbe2_poolname_id, node_poolname_id);
             for(i=0;i<*NRBE2;i++)  
             {
@@ -277,7 +277,7 @@ void c_h3d_create_rbe2_impi_(int *ITAB,int *NRBE2,int *IADRBE2,int *MASTERNODS,i
 
 
                  rc = Hyper3DElement2Begin(h3d_file, elem_count, rbe2_poolname_id, 
-                                        H3D_ELEM_CONFIG_RIGIDLINK, elem_id, 
+                                        H3D_ELEM_CONFIG_RIGIDLINK, H3D_NULL_ID, elem_id, 
                                         rbe2_poolname_id, node_poolname_id);
                  if( !rc ) throw rc;
                  rc = Hyper3DElement2Write(h3d_file, elem_id, conn1, dof1 , coef1 , 1 ,conn, dof, coef, nsn);

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_rbe3.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_rbe3.cpp
@@ -92,7 +92,7 @@ void c_h3d_create_rbe3_(int *ITAB, int *NUMNOD, int *IRBE3, int *NRBE3L, int *LR
         if(*COMPID_RBE3S != 0 && *NRBE3 != 0)
         {
             rc = Hyper3DElement2Begin(h3d_file, *NRBE3, rbe3_poolname_id, 
-                                    H3D_ELEM_CONFIG_RIGIDLINK, *COMPID_RBE3S, 
+                                    H3D_ELEM_CONFIG_RIGIDLINK, H3D_NULL_ID, *COMPID_RBE3S,
                                     rbe3_poolname_id, node_poolname_id);
             for(i=0;i<*NRBE3;i++)  
             {
@@ -148,7 +148,7 @@ void c_h3d_create_rbe3_(int *ITAB, int *NUMNOD, int *IRBE3, int *NRBE3L, int *LR
 
 
                  rc = Hyper3DElement2Begin(h3d_file, elem_count, rbe3_poolname_id, 
-                                        H3D_ELEM_CONFIG_RIGIDLINK, RigidElem, 
+                                        H3D_ELEM_CONFIG_RIGIDLINK, H3D_NULL_ID, RigidElem, 
                                         rbe3_poolname_id, node_poolname_id);
                  if( !rc ) throw rc;
                  rc = Hyper3DElement2Write(h3d_file, elem_id, conn1, dof1 , coef1 , 1 ,conn, dof, coef, nsn);
@@ -214,7 +214,7 @@ void c_h3d_create_rbe3_impi_(int *ITAB,int *NRBE3,int *IADRBE3,int *SLAVENODS,in
         if(*COMPID_RBE3S != 0 && *NRBE3 != 0)
         {
              rc = Hyper3DElement2Begin(h3d_file, *NRBE3, rbe3_poolname_id, 
-                                    H3D_ELEM_CONFIG_RIGIDLINK, *COMPID_RBE3S, 
+                                    H3D_ELEM_CONFIG_RIGIDLINK, H3D_NULL_ID, *COMPID_RBE3S, 
                                     rbe3_poolname_id, node_poolname_id);
             for(i=0;i<*NRBE3;i++)  
             {
@@ -276,7 +276,7 @@ void c_h3d_create_rbe3_impi_(int *ITAB,int *NRBE3,int *IADRBE3,int *SLAVENODS,in
 
 
                  rc = Hyper3DElement2Begin(h3d_file, elem_count, rbe3_poolname_id, 
-                                        H3D_ELEM_CONFIG_RIGIDLINK, elem_id, 
+                                        H3D_ELEM_CONFIG_RIGIDLINK, H3D_NULL_ID, elem_id, 
                                         rbe3_poolname_id, node_poolname_id);
                  if( !rc ) throw rc;
                  rc = Hyper3DElement2Write(h3d_file, elem_id, conn1, dof1 , coef1 , 1 ,conn, dof, coef, nsn);

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_rbodies.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_rbodies.cpp
@@ -92,7 +92,7 @@ void c_h3d_create_rbodies_(int *ITAB, int *NUMNOD, int *NPBY, int *NNPBY, int *L
         if(*COMPID_RBODIES != 0 && *NRBODY != 0)
         {
             rc = Hyper3DElement2Begin(h3d_file, *NRBODY, rbody_poolname_id, 
-                                   H3D_ELEM_CONFIG_RIGIDLINK, *COMPID_RBODIES, 
+                                   H3D_ELEM_CONFIG_RIGIDLINK, H3D_NULL_ID, *COMPID_RBODIES, 
                                    rbody_poolname_id, node_poolname_id);
             for(i=0;i<*NRBODY;i++)  
             {
@@ -161,7 +161,7 @@ void c_h3d_create_rbodies_(int *ITAB, int *NUMNOD, int *NPBY, int *NNPBY, int *L
 
 
                  rc = Hyper3DElement2Begin(h3d_file, elem_count, rbody_poolname_id, 
-                                        H3D_ELEM_CONFIG_RIGIDLINK, RigidElem, 
+                                        H3D_ELEM_CONFIG_RIGIDLINK, H3D_NULL_ID, RigidElem, 
                                         rbody_poolname_id, node_poolname_id);
                  if( !rc ) throw rc;
                  rc = Hyper3DElement2Write(h3d_file, elem_id, conn1, dof1 , coef1 , 1 ,conn, dof, coef, nsn);
@@ -232,7 +232,7 @@ void c_h3d_create_rbodies_impi_(int *ITAB, int *NRBYKIN, int *MASTERND, int *ID_
         if(*COMPID_RBODIES != 0 && *NRBYKIN != 0)
         {
             rc = Hyper3DElement2Begin(h3d_file, *NRBYKIN, rbody_poolname_id, 
-                                   H3D_ELEM_CONFIG_RIGIDLINK, *COMPID_RBODIES, 
+                                   H3D_ELEM_CONFIG_RIGIDLINK, H3D_NULL_ID, *COMPID_RBODIES, 
                                    rbody_poolname_id, node_poolname_id);
             for(i=0;i<*NRBYKIN;i++)  
             {
@@ -362,7 +362,7 @@ void c_h3d_create_rbodies_impi_(int *ITAB, int *NRBYKIN, int *MASTERND, int *ID_
 
 
                  rc = Hyper3DElement2Begin(h3d_file, elem_count, rbody_poolname_id, 
-                                        H3D_ELEM_CONFIG_RIGIDLINK, elem_id, 
+                                        H3D_ELEM_CONFIG_RIGIDLINK, H3D_NULL_ID, elem_id, 
                                         rbody_poolname_id, node_poolname_id);
                  if( !rc ) throw rc;
                  rc = Hyper3DElement2Write(h3d_file, elem_id, conn1, dof1 , coef1 , 1 ,conn, dof, coef, nsn);

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_rwalls.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_rwalls.cpp
@@ -182,7 +182,7 @@ void c_h3d_create_rwalls_(int *NOM_OPT, int *LNOPT1, int *I16D, int *NPRW, int *
                  nbelemwrite = 1;
 
                  rc = Hyper3DElementBegin(h3d_file, nbelemwrite, rwall_poolname_id, 
-                        	   H3D_ELEM_CONFIG_QUAD4, RigidElem, 
+                       	   H3D_ELEM_CONFIG_QUAD4, H3D_NULL_ID, RigidElem, 
                         	   rwall_poolname_id, node_poolname_id);
                  if( !rc ) throw rc;
 
@@ -248,7 +248,7 @@ void c_h3d_create_rwalls_(int *NOM_OPT, int *LNOPT1, int *I16D, int *NPRW, int *
                      nbelemwrite = 1;
 
                      rc = Hyper3DElementBegin(h3d_file, nbelemwrite, rwall_poolname_id, 
-                     	   H3D_ELEM_CONFIG_QUAD4, RigidElem, 
+                     	   H3D_ELEM_CONFIG_QUAD4, H3D_NULL_ID, RigidElem, 
                      	   rwall_poolname_id, node_poolname_id);
     		     if( !rc ) throw rc;
 
@@ -268,7 +268,7 @@ void c_h3d_create_rwalls_(int *NOM_OPT, int *LNOPT1, int *I16D, int *NPRW, int *
                  nbelemwrite = 1;
 
                  rc = Hyper3DElementBegin(h3d_file, nbelemwrite, rwall_poolname_id, 
-                       H3D_ELEM_CONFIG_QUAD4, RigidElem, 
+                       H3D_ELEM_CONFIG_QUAD4, H3D_NULL_ID, RigidElem, 
                        rwall_poolname_id, node_poolname_id);
     		 if( !rc ) throw rc;
 
@@ -347,7 +347,7 @@ void c_h3d_create_rwalls_(int *NOM_OPT, int *LNOPT1, int *I16D, int *NPRW, int *
                              nbelemwrite = 1;
 
                              rc = Hyper3DElementBegin(h3d_file, nbelemwrite, rwall_poolname_id, 
-                        	   H3D_ELEM_CONFIG_QUAD4, RigidElem, 
+                       	   H3D_ELEM_CONFIG_QUAD4, H3D_NULL_ID, RigidElem, 
                         	   rwall_poolname_id, node_poolname_id);
     		             if( !rc ) throw rc;
 
@@ -424,7 +424,7 @@ void c_h3d_create_rwalls_(int *NOM_OPT, int *LNOPT1, int *I16D, int *NPRW, int *
                  nbelemwrite = 1;
 
                  rc = Hyper3DElementBegin(h3d_file, nbelemwrite, rwall_poolname_id, 
-                        	   H3D_ELEM_CONFIG_QUAD4, RigidElem, 
+                        	   H3D_ELEM_CONFIG_QUAD4, H3D_NULL_ID, RigidElem, 
                         	   rwall_poolname_id, node_poolname_id);
                  if( !rc ) throw rc;
 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_sh3ns.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_sh3ns.cpp
@@ -126,7 +126,7 @@ void c_h3d_create_sh3ns_(int *ITAB, int *NUMNOD, int *IXTG, int *NIXTG, int *NUM
                   comp_id = IPART[*LIPART1 * (IPARTTG[i] - 1) + 3] ;
 
                   rc = Hyper3DElementBegin(h3d_file, nbelemwrite, sh3n_poolname_id, 
-                                    H3D_ELEM_CONFIG_TRIA3, comp_id, 
+                                    H3D_ELEM_CONFIG_TRIA3, H3D_NULL_ID, comp_id, 
                                     shell_poolname_id, node_poolname_id);
                   if( !rc ) throw rc;
              }

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_shell_scalar_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_shell_scalar_datatype.cpp
@@ -329,7 +329,7 @@ extern "C"
                         strcpy(edata_type, RES_STRING);
 #endif
                         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data, H3D_DS_SCALAR,
-                                                  H3D_DS_ELEM, pool_count);
+                                                  H3D_DS_ELEM, H3D_NF_REAL, pool_count);
                         if (!rc)
                                 throw rc;
 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_shell_tensor_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_shell_tensor_datatype.cpp
@@ -285,7 +285,7 @@ void c_h3d_create_shell_tensor_datatype_(int *cpt_data, char *name1, int *size1,
 //          sprintf(edata_type,  cname, H3D_DT_DELIMITER); 
 //        }
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_TENSOR2D, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         if (strlen(ccomment) != 0) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_shell_vector_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_shell_vector_datatype.cpp
@@ -247,7 +247,7 @@ void c_h3d_create_shell_vector_datatype_(int *cpt_data, char *name1, int *size1,
         sprintf(edata_type,  RES_STRING, H3D_DT_DELIMITER); 
 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_VECTOR, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         if (strlen(ccomment) != 0) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_shells.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_shells.cpp
@@ -126,7 +126,7 @@ void c_h3d_create_shells_(int *ITAB, int *NUMNOD, int *IXC, int *NIXC, int *NUME
                   comp_id = IPART[*LIPART1 * (IPARTC[i] - 1) + 3] ;
 
                   rc = Hyper3DElementBegin(h3d_file, nbelemwrite, sh4n_poolname_id, 
-                                    H3D_ELEM_CONFIG_QUAD4, comp_id, 
+                                    H3D_ELEM_CONFIG_QUAD4, H3D_NULL_ID, comp_id,
                                     shell_poolname_id, node_poolname_id);
                   if( !rc ) throw rc;
              }

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_skin_scalar_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_skin_scalar_datatype.cpp
@@ -149,7 +149,7 @@ void c_h3d_create_skin_scalar_datatype_(int *cpt_data, char *name1, int *size1, 
         sprintf(edata_type,  RES_STRING, H3D_DT_DELIMITER); 
 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_SCALAR, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         if (strlen(ccomment) != 0) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_skin_tensor_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_skin_tensor_datatype.cpp
@@ -221,7 +221,7 @@ void c_h3d_create_skin_tensor_datatype_(int *cpt_data, char *name1, int *size1, 
         sprintf(edata_type,  cname, H3D_DT_DELIMITER); 
 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_TENSOR2D, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         if (strlen(ccomment) != 0) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_skin_vector_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_skin_vector_datatype.cpp
@@ -149,7 +149,7 @@ void c_h3d_create_skin_vector_datatype_(int *cpt_data, char *name1, int *size1, 
         sprintf(edata_type,  RES_STRING, H3D_DT_DELIMITER); 
 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_VECTOR, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         if (strlen(ccomment) != 0) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_skins.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_skins.cpp
@@ -143,13 +143,13 @@ void c_h3d_create_skins_(int *ITAB, int *NUMNOD, int *IPART, int *LIPART1,int *H
                   if(conn4[3] == conn4[2])
                       {  
              	         rc = Hyper3DElementBegin(h3d_file, nbelemwrite, skin_poolname_id, 
-             			H3D_ELEM_CONFIG_TRIA3, comp_id, 
+             			H3D_ELEM_CONFIG_TRIA3, H3D_NULL_ID, comp_id, 
              			skin_poolname_id, node_poolname_id);
                       }
                   else
                       {  
              	         rc = Hyper3DElementBegin(h3d_file, nbelemwrite, skin_poolname_id, 
-             			H3D_ELEM_CONFIG_QUAD4, comp_id, 
+             			H3D_ELEM_CONFIG_QUAD4, H3D_NULL_ID, comp_id, 
              			skin_poolname_id, node_poolname_id);
                       }
              	  if( !rc ) throw rc;                  

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_solid8n.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_solid8n.cpp
@@ -296,7 +296,7 @@ void c_h3d_create_solid8n_(int *ITAB, int *NUMNOD, int *IXS, int *NIXS, int *NUM
                       comp_id = IPART[*LIPART1 * (IPARTS[i] - 1) + 3];
 
                       rc = Hyper3DElementBegin(h3d_file, nbelemwrite, solid_poolname_id, 
-                                    H3D_ELEM_CONFIG_TETRA4, comp_id, 
+                                    H3D_ELEM_CONFIG_TETRA4, H3D_NULL_ID, comp_id, 
                                     solid_poolname_id, node_poolname_id);
                       if( !rc ) throw rc;
                  }
@@ -326,7 +326,7 @@ void c_h3d_create_solid8n_(int *ITAB, int *NUMNOD, int *IXS, int *NIXS, int *NUM
                       comp_id = IPART[*LIPART1 * (IPARTS[i] - 1) + 3];
 
                       rc = Hyper3DElementBegin(h3d_file, nbelemwrite, solid_poolname_id, 
-                                    H3D_ELEM_CONFIG_PENTA5, comp_id, 
+                                    H3D_ELEM_CONFIG_PENTA5, H3D_NULL_ID, comp_id, 
                                     solid_poolname_id, node_poolname_id);
                       if( !rc ) throw rc;
                  }
@@ -435,7 +435,7 @@ void c_h3d_create_solid8n_(int *ITAB, int *NUMNOD, int *IXS, int *NIXS, int *NUM
                       comp_id = IPART[*LIPART1 * (IPARTS[i] - 1) + 3];
 
                       rc = Hyper3DElementBegin(h3d_file, nbelemwrite, solid_poolname_id, 
-                                    H3D_ELEM_CONFIG_PENTA6, comp_id, 
+                                    H3D_ELEM_CONFIG_PENTA6, H3D_NULL_ID, comp_id, 
                                     solid_poolname_id, node_poolname_id);
                       if( !rc ) throw rc;
                  }
@@ -471,7 +471,7 @@ void c_h3d_create_solid8n_(int *ITAB, int *NUMNOD, int *IXS, int *NIXS, int *NUM
                       comp_id = IPART[*LIPART1 * (IPARTS[i] - 1) + 3];
 
                       rc = Hyper3DElementBegin(h3d_file, nbelemwrite, solid_poolname_id, 
-                                    H3D_ELEM_CONFIG_HEX8, comp_id, 
+                                    H3D_ELEM_CONFIG_HEX8, H3D_NULL_ID, comp_id, 
                                     solid_poolname_id, node_poolname_id);
                       if( !rc ) throw rc;
                  }
@@ -544,7 +544,7 @@ void c_h3d_create_solid8n_(int *ITAB, int *NUMNOD, int *IXS, int *NIXS, int *NUM
              	  comp_id = IPART[*LIPART1 * (IPARTS10[i] - 1) + 3];
 
              	  rc = Hyper3DElementBegin(h3d_file, nbelemwrite, solid_poolname_id, 
-             			H3D_ELEM_CONFIG_TETRA10, comp_id, 
+             			H3D_ELEM_CONFIG_TETRA10, H3D_NULL_ID, comp_id, 
              			solid_poolname_id, node_poolname_id);
              	  if( !rc ) throw rc;
              }
@@ -618,7 +618,7 @@ void c_h3d_create_solid8n_(int *ITAB, int *NUMNOD, int *IXS, int *NIXS, int *NUM
              	  comp_id = IPART[*LIPART1 * (IPARTS16[i] - 1) + 3];
 
              	  rc = Hyper3DElementBegin(h3d_file, nbelemwrite, solid_poolname_id, 
-             			H3D_ELEM_CONFIG_HEX8, comp_id, 
+             			H3D_ELEM_CONFIG_HEX8, H3D_NULL_ID, comp_id, 
              			solid_poolname_id, node_poolname_id);
              	  if( !rc ) throw rc;
              }
@@ -701,7 +701,7 @@ void c_h3d_create_solid8n_(int *ITAB, int *NUMNOD, int *IXS, int *NIXS, int *NUM
              	  comp_id = IPART[*LIPART1 * (IPARTS20[i] - 1) + 3];
 
              	  rc = Hyper3DElementBegin(h3d_file, nbelemwrite, solid_poolname_id, 
-             			H3D_ELEM_CONFIG_HEX20, comp_id, 
+             			H3D_ELEM_CONFIG_HEX20, H3D_NULL_ID, comp_id, 
              			solid_poolname_id, node_poolname_id);
              	  if( !rc ) throw rc;
              }

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_solid_scalar_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_solid_scalar_datatype.cpp
@@ -275,7 +275,7 @@ extern "C"
                         sprintf(edata_type, RES_STRING, H3D_DT_DELIMITER);
 
                         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data, H3D_DS_SCALAR,
-                                                  H3D_DS_ELEM, pool_count);
+                                                  H3D_DS_ELEM, H3D_NF_REAL, pool_count);
                         if (!rc)
                                 throw rc;
 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_solid_tensor_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_solid_tensor_datatype.cpp
@@ -252,7 +252,7 @@ void c_h3d_create_solid_tensor_datatype_(int *cpt_data, char *name1, int *size1,
 #endif
 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_TENSOR3D, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         if (strlen(ccomment) != 0) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_solid_vector_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_solid_vector_datatype.cpp
@@ -239,7 +239,7 @@ void c_h3d_create_solid_vector_datatype_(int *cpt_data, char *name1, int *size1,
         sprintf(edata_type,  RES_STRING, H3D_DT_DELIMITER); 
 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_VECTOR, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         if (strlen(ccomment) != 0) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_sph.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_sph.cpp
@@ -156,7 +156,7 @@ void c_h3d_create_sph_(int *ITAB, int *NUMNOD, int *KXSP, int *NISP, int *NUMSPH
                   comp_id = IPART[*LIPART1 * (IPARTSP[i] - 1) + 3] ;
 
                   rc = Hyper3DElementBegin(h3d_file, nbelemwrite, sphcell_poolname_id, 
-             		   H3D_ELEM_CONFIG_MASS, comp_id, 
+             		   H3D_ELEM_CONFIG_MASS, H3D_NULL_ID, comp_id, 
              		   sphcell_poolname_id, node_poolname_id);
                   if( !rc ) throw rc;
              }

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_sph_scalar_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_sph_scalar_datatype.cpp
@@ -153,7 +153,7 @@ void c_h3d_create_sph_scalar_datatype_(int *cpt_data, char *name1, int *size1, i
         sprintf(edata_type,  RES_STRING, H3D_DT_DELIMITER); 
 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_SCALAR, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         if (strlen(ccomment) != 0) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_sph_tensor_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_sph_tensor_datatype.cpp
@@ -129,7 +129,7 @@ void c_h3d_create_sph_tensor_datatype_(int *cpt_data, char *name1, int *size1, i
         sprintf(edata_type,  cname, H3D_DT_DELIMITER); 
 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_TENSOR3D, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         if (strlen(ccomment) != 0) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_springs.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_springs.cpp
@@ -96,7 +96,7 @@ void c_h3d_create_springs_(int *ITAB, int *NUMNOD, int *IXR, int *NIXR, int *NUM
                  comp_id = IPART[*LIPART1 * (IPARTR[i] - 1) + 3];
 
                  rc = Hyper3DElementBegin(h3d_file, elem_count, spring_poolname_id, 
-                                    H3D_ELEM_CONFIG_SPRING, comp_id, 
+                                    H3D_ELEM_CONFIG_SPRING, H3D_NULL_ID, comp_id, 
                                     onedelem_poolname_id, node_poolname_id);
                  if( !rc ) throw rc;
                  rc = Hyper3DElementWrite(h3d_file, elem_id, conn);

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_truss.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_truss.cpp
@@ -97,7 +97,7 @@ void c_h3d_create_truss_(int *ITAB, int *NUMNOD, int *IXT, int *NIXT, int *NUMEL
                  comp_id = IPART[*LIPART1 * (IPARTT[i] - 1) + 3];
 
                  rc = Hyper3DElementBegin(h3d_file, elem_count, truss_poolname_id, 
-                                    H3D_ELEM_CONFIG_ROD, comp_id, 
+                                    H3D_ELEM_CONFIG_ROD, H3D_NULL_ID, comp_id, 
                                     onedelem_poolname_id, node_poolname_id);
                  if( !rc ) throw rc;
                  rc = Hyper3DElementWrite(h3d_file, elem_id, conn);

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_eroded_oned.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_eroded_oned.cpp
@@ -103,8 +103,8 @@ void c_h3d_eroded_oned_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, int *IXT,
         if(*NUMELT != 0)
         {
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELT, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_EROSION, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, truss_poolname_id, complex); 
+                                        H3D_DS_EROSION, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, truss_poolname_id); 
           if( !rc ) fflush(stdout);
           if( !rc ) throw rc;
 
@@ -134,8 +134,8 @@ void c_h3d_eroded_oned_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, int *IXT,
         if(*NUMELP != 0)
         {
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELP, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_EROSION, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, beam_poolname_id, complex); 
+                                        H3D_DS_EROSION, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, beam_poolname_id); 
           if( !rc ) fflush(stdout);
           if( !rc ) throw rc;
 
@@ -160,8 +160,8 @@ void c_h3d_eroded_oned_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, int *IXT,
         if(*NUMELR != 0)
         {
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELR, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_EROSION, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, spring_poolname_id, complex); 
+                                        H3D_DS_EROSION, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, spring_poolname_id); 
           if( !rc ) fflush(stdout);
           if( !rc ) throw rc;
 
@@ -250,7 +250,7 @@ void c_h3d_create_oned_eroded_(int *cpt_data, char *name, int *size, int *info, 
         sprintf(edata_type,  cname, H3D_DT_DELIMITER); 
        // snprintf(edata_type, sizeof(edata_type), cname, H3D_DT_DELIMITER); 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_EROSION, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         rc = Hyper3DDatatypeDescriptionWrite(h3d_file,dt_id, "N/A : element not deleted");

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_eroded_quad.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_eroded_quad.cpp
@@ -103,8 +103,8 @@ void c_h3d_eroded_quad_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, int *IXQ,
         if(*NUMELQ != 0)
         {
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELQ, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_EROSION, num_corners, num_modes, *CPT_DATATYPE, 
-                                       0, quad_poolname_id, complex); 
+                                        H3D_DS_EROSION, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                       0, quad_poolname_id); 
           if( !rc ) fflush(stdout);
           if( !rc ) throw rc;
 
@@ -184,7 +184,7 @@ void c_h3d_create_quad_eroded_(int *cpt_data, char *name, int *size, int *info, 
         sprintf(edata_type,  cname, H3D_DT_DELIMITER); 
        // snprintf(edata_type, sizeof(edata_type), cname, H3D_DT_DELIMITER); 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_EROSION, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         rc = Hyper3DDatatypeDescriptionWrite(h3d_file,dt_id, "N/A : element not deleted");

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_eroded_shell.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_eroded_shell.cpp
@@ -103,8 +103,8 @@ void c_h3d_eroded_shell_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, int *IXC
         if(*NUMELC != 0)
         {
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELC, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_EROSION, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, sh4n_poolname_id, complex); 
+                                        H3D_DS_EROSION, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, sh4n_poolname_id); 
           if( !rc ) fflush(stdout);
           if( !rc ) throw rc;
 
@@ -134,8 +134,8 @@ void c_h3d_eroded_shell_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, int *IXC
         if(*NUMELTG != 0)
         {
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELTG, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_EROSION, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, sh3n_poolname_id, complex); 
+                                        H3D_DS_EROSION, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, sh3n_poolname_id); 
           if( !rc ) fflush(stdout);
           if( !rc ) throw rc;
 
@@ -224,7 +224,7 @@ void c_h3d_create_shell_eroded_(int *cpt_data, char *name, int *size, int *info,
         sprintf(edata_type,  cname, H3D_DT_DELIMITER); 
        // snprintf(edata_type, sizeof(edata_type), cname, H3D_DT_DELIMITER); 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_EROSION, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         rc = Hyper3DDatatypeDescriptionWrite(h3d_file,dt_id, "N/A : element not deleted");

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_eroded_skin.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_eroded_skin.cpp
@@ -101,8 +101,8 @@ void c_h3d_eroded_skin_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, my_real *
         if(*NUMELQ != 0)
         {
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELQ, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_EROSION, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, skin_poolname_id, complex); 
+                                        H3D_DS_EROSION, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, skin_poolname_id); 
           if( !rc ) fflush(stdout);
           if( !rc ) throw rc;
 
@@ -190,7 +190,7 @@ void c_h3d_create_skin_eroded_(int *cpt_data, char *name, int *size, int *info, 
         sprintf(edata_type,  cname, H3D_DT_DELIMITER); 
        // snprintf(edata_type, sizeof(edata_type), cname, H3D_DT_DELIMITER); 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_EROSION, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         rc = Hyper3DDatatypeDescriptionWrite(h3d_file,dt_id, "N/A : element not deleted");

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_eroded_solid.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_eroded_solid.cpp
@@ -106,8 +106,8 @@ void c_h3d_eroded_solid_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, int *IXS
         if(*NUMELS != 0)
         {
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELS, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_EROSION, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, solid_poolname_id, complex); 
+                                        H3D_DS_EROSION, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, solid_poolname_id); 
           if( !rc ) fflush(stdout);
           if( !rc ) throw rc;
 
@@ -208,7 +208,7 @@ void c_h3d_create_solid_eroded_(int *cpt_data, char *name, int *size, int *info,
         //snprintf(edata_type, sizeof(edata_type), cname, H3D_DT_DELIMITER); 
         sprintf(edata_type,  cname, H3D_DT_DELIMITER); 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_EROSION, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         rc = Hyper3DDatatypeDescriptionWrite(h3d_file,dt_id, "N/A : element not deleted");

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_eroded_sph.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_eroded_sph.cpp
@@ -104,8 +104,8 @@ void c_h3d_eroded_sph_(my_real *TT,int *IH3D, int *NUMSPH, my_real *FUNC , int *
         if(*NUMSPH != 0)
         {
           rc = Hyper3DDatasetBegin(h3d_file, *NUMSPH, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_EROSION, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, sphcell_poolname_id, complex); 
+                                        H3D_DS_EROSION, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, sphcell_poolname_id); 
           if( !rc ) fflush(stdout);
           if( !rc ) throw rc;
 
@@ -194,7 +194,7 @@ void c_h3d_create_sph_eroded_(int *cpt_data, char *name, int *size, int *info, c
         //snprintf(edata_type, sizeof(edata_type), cname, H3D_DT_DELIMITER); 
         sprintf(edata_type,  cname, H3D_DT_DELIMITER); 
         rc = Hyper3DDatatypeWrite(h3d_file, edata_type, *cpt_data , H3D_DS_EROSION, 
-                                    H3D_DS_ELEM, pool_count);
+                                    H3D_DS_ELEM, H3D_NF_REAL, pool_count);
         if( !rc ) throw rc;
 
         rc = Hyper3DDatatypeDescriptionWrite(h3d_file,dt_id, "N/A : element not deleted");

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_open_file.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_open_file.cpp
@@ -232,10 +232,13 @@ void c_h3d_open_file_(char *name, int *size, my_real *percentage_error, int *com
 //
 //  open h3d file
 //
-    h3d_file = Hyper3DExportOpen(cname, H3D_SINGLEFILE, NULL, ReportErrorMsg);
+    int mode(H3D_SINGLEFILE);
+    //mode |= H3D_NOZLIB;
+    //mode |= H3D_NOSORT;
+    h3d_file = Hyper3DExportOpen(cname, mode, NULL, ReportErrorMsg);
 
-    h3d_file -> quantize_error = *percentage_error / 100.f ;
-    h3d_file -> compression_level = *comp_level ;
+    //h3d_file -> quantize_error = *percentage_error / 100.f ;
+    //h3d_file -> compression_level = *comp_level ;
 
     // define pool names that will be used
     char* creating_application;

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_fvmbag_nodes.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_fvmbag_nodes.cpp
@@ -100,8 +100,8 @@ void c_h3d_update_fvmbag_nodes_(char *name, int *size, int *IH3D, int *ITAB, int
         if( *NUMNOD != 0)
         {
             rc = Hyper3DDatasetBegin(h3d_file, *NUMNOD , sim_idx, subcase_id, H3D_DS_NODE,
-           				H3D_DS_VECTOR, num_corners, num_modes, dt_id, 
-           				H3D_DS_NO_LAYER, node_poolname_id, complex);
+           			H3D_DS_VECTOR, H3D_NF_REAL, num_corners, num_modes, dt_id, 
+           			H3D_DS_NO_LAYER, node_poolname_id);
             if( !rc ) throw rc;
 
             for( i = 0; i < *NUMNOD; i++ ) {

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_nodal_fvmbag_scalar.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_nodal_fvmbag_scalar.cpp
@@ -105,8 +105,8 @@ void c_h3d_update_nodal_fvmbag_scalar_(my_real *TT,int *IH3D, int *NUMNOD, my_re
         //fflush(stdout);
 
         rc = Hyper3DDatasetBegin(h3d_file, *NUMNOD, sim_idx, subcase_id, H3D_DS_NODE, 
-                                        H3D_DS_SCALAR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, node_poolname_id, complex); 
+                                        H3D_DS_SCALAR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, node_poolname_id); 
         if( !rc ) throw rc;
 
         offset = 0;

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_nodal_scalar.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_nodal_scalar.cpp
@@ -105,8 +105,8 @@ void c_h3d_update_nodal_scalar_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, m
         //fflush(stdout);
 
         rc = Hyper3DDatasetBegin(h3d_file, *NUMNOD, sim_idx, subcase_id, H3D_DS_NODE, 
-                                        H3D_DS_SCALAR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, node_poolname_id, complex); 
+                                        H3D_DS_SCALAR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, node_poolname_id); 
         if( !rc ) throw rc;
 
         offset = 0;

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_nodal_tensor.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_nodal_tensor.cpp
@@ -103,8 +103,8 @@ void c_h3d_update_nodal_tensor_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, m
 
 
         rc = Hyper3DDatasetBegin(h3d_file, *NUMNOD, sim_idx, subcase_id, H3D_DS_NODE, 
-                                        H3D_DS_TENSOR3D, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, node_poolname_id, complex); 
+                                        H3D_DS_TENSOR3D, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, node_poolname_id); 
         if( !rc ) throw rc;
 
         offset = 0;

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_nodal_vector.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_nodal_vector.cpp
@@ -103,8 +103,8 @@ void c_h3d_update_nodal_vector_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, m
 
 
         rc = Hyper3DDatasetBegin(h3d_file, *NUMNOD, sim_idx, subcase_id, H3D_DS_NODE, 
-                                        H3D_DS_VECTOR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, node_poolname_id, complex); 
+                                        H3D_DS_VECTOR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, node_poolname_id); 
         if( !rc ) throw rc;
 
         offset = 0;

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_nodes.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_nodes.cpp
@@ -126,8 +126,8 @@ void c_h3d_update_nodes_(char *name, int *size, my_real *TT,int *IH3D, int *ITAB
         if( *NUMNOD != 0)
         {
             rc = Hyper3DDatasetBegin(h3d_file, *NUMNOD , sim_idx, subcase_id, H3D_DS_NODE,
-           				H3D_DS_VECTOR, num_corners, num_modes, dt_id, 
-           				H3D_DS_NO_LAYER, node_poolname_id, complex);
+           			H3D_DS_VECTOR, H3D_NF_REAL, num_corners, num_modes, dt_id, 
+           			H3D_DS_NO_LAYER, node_poolname_id);
             if( !rc ) throw rc;
 
             for( i = 0; i < *NUMNOD; i++ ) {
@@ -155,8 +155,8 @@ void c_h3d_update_nodes_(char *name, int *size, my_real *TT,int *IH3D, int *ITAB
                 {
 
                      rc = Hyper3DDatasetBegin(h3d_file, 4 , sim_idx, subcase_id, H3D_DS_NODE,
-           				H3D_DS_VECTOR, num_corners, num_modes, dt_id, 
-           				H3D_DS_NO_LAYER, node_poolname_id, complex);
+           			H3D_DS_VECTOR, H3D_NF_REAL, num_corners, num_modes, dt_id, 
+           			H3D_DS_NO_LAYER, node_poolname_id);
 
            	     node[0] =  XWL[i] + V1[i];
                      node[1] =  YWL[i] + V2[i];
@@ -197,8 +197,8 @@ void c_h3d_update_nodes_(char *name, int *size, my_real *TT,int *IH3D, int *ITAB
                 else if(ityp == 2)
                 {
                     rc = Hyper3DDatasetBegin(h3d_file, 48 , sim_idx, subcase_id, H3D_DS_NODE,
-           				H3D_DS_VECTOR, num_corners, num_modes, dt_id, 
-           				H3D_DS_NO_LAYER, node_poolname_id, complex);
+           			H3D_DS_VECTOR, H3D_NF_REAL, num_corners, num_modes, dt_id, 
+           			H3D_DS_NO_LAYER, node_poolname_id);
                     for(int ii=0;ii<48;ii++) 
                     {
            	        node[0] =  XWL[i] + V1[i];
@@ -218,8 +218,8 @@ void c_h3d_update_nodes_(char *name, int *size, my_real *TT,int *IH3D, int *ITAB
                 else if(ityp == 3)
                 {
                     rc = Hyper3DDatasetBegin(h3d_file, 294 , sim_idx, subcase_id, H3D_DS_NODE,
-           				H3D_DS_VECTOR, num_corners, num_modes, dt_id, 
-           				H3D_DS_NO_LAYER, node_poolname_id, complex);
+           			H3D_DS_VECTOR, H3D_NF_REAL, num_corners, num_modes, dt_id, 
+           			H3D_DS_NO_LAYER, node_poolname_id);
                     for(int ii=0;ii<294;ii++) 
                     {
            	        node[0] =  XWL[i] + V1[i];

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_oned_scalar.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_oned_scalar.cpp
@@ -120,8 +120,8 @@ void c_h3d_update_oned_scalar_(my_real *TT,int *IH3D, int *ITAB, int *NUMELT, in
           {
 
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELT, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_SCALAR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, truss_poolname_id, complex); 
+                                        H3D_DS_SCALAR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, truss_poolname_id); 
           if( !rc ) throw rc;
 
           offset = 0;
@@ -144,8 +144,8 @@ void c_h3d_update_oned_scalar_(my_real *TT,int *IH3D, int *ITAB, int *NUMELT, in
           {
 
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELP, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_SCALAR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, beam_poolname_id, complex); 
+                                        H3D_DS_SCALAR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, beam_poolname_id); 
           if( !rc ) throw rc;
 
           for( i = 0; i < *NUMELT + *NUMELP + *NUMELR; i++ ) 
@@ -165,8 +165,8 @@ void c_h3d_update_oned_scalar_(my_real *TT,int *IH3D, int *ITAB, int *NUMELT, in
           {
 
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELR, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_SCALAR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, spring_poolname_id, complex); 
+                                        H3D_DS_SCALAR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, spring_poolname_id); 
           if( !rc ) throw rc;
 
           for( i = 0; i < *NUMELT + *NUMELP + *NUMELR; i++ ) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_oned_tensor.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_oned_tensor.cpp
@@ -120,8 +120,8 @@ void c_h3d_update_oned_tensor_(my_real *TT,int *IH3D, int *ITAB, int *NUMELT, in
           {
 
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELT, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_TENSOR3D, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, truss_poolname_id, complex); 
+                                        H3D_DS_TENSOR3D, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, truss_poolname_id); 
           if( !rc ) throw rc;
 
           offset = 0;
@@ -149,10 +149,9 @@ void c_h3d_update_oned_tensor_(my_real *TT,int *IH3D, int *ITAB, int *NUMELT, in
           {
 
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELP, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_TENSOR3D, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, beam_poolname_id, complex); 
+                                        H3D_DS_TENSOR3D, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, beam_poolname_id); 
           if( !rc ) throw rc;
-
           for( i = 0; i < *NUMELT + *NUMELP + *NUMELR; i++ ) 
           {
             if( ITY_ELEM[i] == 5 && IS_WRITTEN[i] == 1) 
@@ -175,8 +174,8 @@ void c_h3d_update_oned_tensor_(my_real *TT,int *IH3D, int *ITAB, int *NUMELT, in
           {
 
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELR, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_TENSOR3D, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, spring_poolname_id, complex); 
+                                        H3D_DS_TENSOR3D, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, spring_poolname_id); 
           if( !rc ) throw rc;
 
           for( i = 0; i < *NUMELT + *NUMELP + *NUMELR; i++ ) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_oned_torsor.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_oned_torsor.cpp
@@ -119,11 +119,8 @@ void c_h3d_update_oned_torsor_(my_real *TT,int *IH3D, int *ITAB, int *NUMELT, in
             offset = 0;
 
      	    rc = Hyper3DDatasetBegin(h3d_file, *NUMELT, sim_idx, subcase_id, H3D_DS_ELEM, 
-     	 				    H3D_DS_SCALAR, num_corners, num_modes, *CPT_DATATYPE, 
-     	 				    0, truss_poolname_id, complex); 
-     	    if( !rc ) throw rc;
-
-     	    for( i = 0; i < *NUMELT + *NUMELP + *NUMELR; i++ ) 
+     	 			    H3D_DS_SCALAR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+     	 			    0, truss_poolname_id); 
      	    {
      	      if( ITY_ELEM[i] == 4  && IS_WRITTEN[i] == 1) 
      	      { 
@@ -145,11 +142,8 @@ void c_h3d_update_oned_torsor_(my_real *TT,int *IH3D, int *ITAB, int *NUMELT, in
             offset = 0;
 
      	    rc = Hyper3DDatasetBegin(h3d_file, *NUMELP, sim_idx, subcase_id, H3D_DS_ELEM, 
-     	 				    H3D_DS_SCALAR, num_corners, num_modes, *CPT_DATATYPE, 
-     	 				    0, beam_poolname_id, complex); 
-     	    if( !rc ) throw rc;
-
-     	    for( i = 0; i < *NUMELT + *NUMELP + *NUMELR; i++ ) 
+     	 			    H3D_DS_SCALAR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+     	 			    0, beam_poolname_id); 
      	    {
      	      if( ITY_ELEM[i] == 5  && IS_WRITTEN[i] == 1) 
      	      { 
@@ -171,11 +165,8 @@ void c_h3d_update_oned_torsor_(my_real *TT,int *IH3D, int *ITAB, int *NUMELT, in
             offset = 0;
 
      	    rc = Hyper3DDatasetBegin(h3d_file, *NUMELR, sim_idx, subcase_id, H3D_DS_ELEM, 
-     	 				    H3D_DS_SCALAR, num_corners, num_modes, *CPT_DATATYPE, 
-     	 				    0, spring_poolname_id, complex); 
-     	    if( !rc ) throw rc;
-
-     	    for( i = 0; i < *NUMELT + *NUMELP + *NUMELR; i++ ) 
+     	 			    H3D_DS_SCALAR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+     	 			    0, spring_poolname_id); 
      	    {
      	      if( ITY_ELEM[i] == 6  && IS_WRITTEN[i] == 1) 
      	      { 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_oned_vector.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_oned_vector.cpp
@@ -120,12 +120,12 @@ void c_h3d_update_oned_vector_(my_real *TT,int *IH3D, int *ITAB, int *NUMELT, in
           {
 
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELT, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_VECTOR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, truss_poolname_id, complex); 
+                                        H3D_DS_VECTOR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, truss_poolname_id); 
           if( !rc ) throw rc;
 
           offset = 0;
-
+          
           for( i = 0; i < *NUMELT + *NUMELP + *NUMELR; i++ ) 
           {
             if( ITY_ELEM[i] == 4  && IS_WRITTEN[i] == 1) 
@@ -146,8 +146,8 @@ void c_h3d_update_oned_vector_(my_real *TT,int *IH3D, int *ITAB, int *NUMELT, in
           {
 
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELP, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_VECTOR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, beam_poolname_id, complex); 
+                                        H3D_DS_VECTOR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, beam_poolname_id); 
           if( !rc ) throw rc;
 
           for( i = 0; i < *NUMELT + *NUMELP + *NUMELR; i++ ) 
@@ -169,8 +169,8 @@ void c_h3d_update_oned_vector_(my_real *TT,int *IH3D, int *ITAB, int *NUMELT, in
           {
 
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELR, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_VECTOR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, spring_poolname_id, complex); 
+                                        H3D_DS_VECTOR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, spring_poolname_id); 
           if( !rc ) throw rc;
 
           for( i = 0; i < *NUMELT + *NUMELP + *NUMELR; i++ ) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_quad_scalar.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_quad_scalar.cpp
@@ -107,8 +107,8 @@ void c_h3d_update_quad_scalar_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, in
           {
 
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELQ, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_SCALAR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, quad_poolname_id, complex); 
+                                        H3D_DS_SCALAR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, quad_poolname_id); 
           if( !rc ) throw rc;
 
           offset = 0;

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_quad_tensor.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_quad_tensor.cpp
@@ -101,8 +101,8 @@ void c_h3d_update_quad_tensor_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, in
         sim_idx = *IH3D;
 
         rc = Hyper3DDatasetBegin(h3d_file, *NUMELQ, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_TENSOR3D, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, quad_poolname_id, complex); 
+                                        H3D_DS_TENSOR3D, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, quad_poolname_id); 
 
         if( !rc ) throw rc;
  

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_quad_vector.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_quad_vector.cpp
@@ -107,8 +107,8 @@ void c_h3d_update_quad_vector_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, in
           {
 
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELQ, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_VECTOR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, quad_poolname_id, complex); 
+                                        H3D_DS_VECTOR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, quad_poolname_id); 
           if( !rc ) throw rc;
 
           offset = 0;

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_shell_scalar.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_shell_scalar.cpp
@@ -108,8 +108,8 @@ void c_h3d_update_shell_scalar_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, i
           {
 
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELC, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_SCALAR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, sh4n_poolname_id, complex); 
+                                        H3D_DS_SCALAR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, sh4n_poolname_id); 
           if( !rc ) throw rc;
 
           offset = 0;
@@ -137,8 +137,8 @@ void c_h3d_update_shell_scalar_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, i
           {
 
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELTG, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_SCALAR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, sh3n_poolname_id, complex); 
+                                        H3D_DS_SCALAR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, sh3n_poolname_id); 
           if( !rc ) throw rc;
 
           for( i = 0; i < *SHELL_STACKSIZE; i++ ) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_shell_tensor.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_shell_tensor.cpp
@@ -104,8 +104,8 @@ void c_h3d_update_shell_tensor_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, i
         if( *NUMELC != 0 )
         {
             rc = Hyper3DDatasetBegin(h3d_file, *NUMELC, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                            H3D_DS_TENSOR2D, num_corners, num_modes, *CPT_DATATYPE, 
-                                            0, sh4n_poolname_id, complex); 
+                                            H3D_DS_TENSOR2D, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                            0, sh4n_poolname_id); 
 
             if( !rc ) throw rc;
             offset = 0;
@@ -134,11 +134,8 @@ void c_h3d_update_shell_tensor_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, i
             offset = *NUMELC;
 
      	    rc = Hyper3DDatasetBegin(h3d_file, *NUMELTG, sim_idx, subcase_id, H3D_DS_ELEM, 
-     	 				    H3D_DS_TENSOR2D, num_corners, num_modes, *CPT_DATATYPE, 
-     	 				    0, sh3n_poolname_id, complex); 
-     	    if( !rc ) throw rc;
-
-     	    for( i = 0; i < *NUMELC + *NUMELTG; i++ ) 
+     	 			    H3D_DS_TENSOR2D, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+     	 			    0, sh3n_poolname_id); 
      	    {
               if( ITY_ELEM[i] == 7  && IS_WRITTEN[i] == 1) 
      	      { 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_shell_vector.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_shell_vector.cpp
@@ -108,8 +108,8 @@ void c_h3d_update_shell_vector_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, i
           {
 
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELC, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_VECTOR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, sh4n_poolname_id, complex); 
+                                        H3D_DS_VECTOR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, sh4n_poolname_id); 
           if( !rc ) throw rc;
 
           offset = 0;
@@ -137,8 +137,8 @@ void c_h3d_update_shell_vector_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, i
           {
 
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELTG, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_VECTOR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, sh3n_poolname_id, complex); 
+                                        H3D_DS_VECTOR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, sh3n_poolname_id); 
           if( !rc ) throw rc;
 
           for( i = 0; i < *NUMELC + *NUMELTG; i++ ) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_skin_scalar.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_skin_scalar.cpp
@@ -107,8 +107,8 @@ void c_h3d_update_skin_scalar_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD,
           {
 
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELQ, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_SCALAR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, skin_poolname_id, complex); 
+                                        H3D_DS_SCALAR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, skin_poolname_id); 
           if( !rc ) throw rc;
 
           offset = 0;

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_skin_tensor.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_skin_tensor.cpp
@@ -101,8 +101,8 @@ void c_h3d_update_skin_tensor_(my_real *TT,int *IH3D, int *NUMEL,
         sim_idx = *IH3D;
 
         rc = Hyper3DDatasetBegin(h3d_file, *NUMEL, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_TENSOR2D, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, skin_poolname_id, complex); 
+                                        H3D_DS_TENSOR2D, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, skin_poolname_id); 
 
         if( !rc ) throw rc;
 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_skin_vector.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_skin_vector.cpp
@@ -106,8 +106,8 @@ void c_h3d_update_skin_vector_(my_real *TT,int *IH3D, int *NUMEL,
           {
 
           rc = Hyper3DDatasetBegin(h3d_file, *NUMEL, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_VECTOR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, skin_poolname_id, complex); 
+                                        H3D_DS_VECTOR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, skin_poolname_id); 
           if( !rc ) throw rc;
 
           offset = 0;

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_solid_scalar.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_solid_scalar.cpp
@@ -103,8 +103,8 @@ void c_h3d_update_solid_scalar_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, i
         if( *NUMELS != 0)
         {
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELS, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_SCALAR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, solid_poolname_id, complex); 
+                                        H3D_DS_SCALAR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, solid_poolname_id); 
           if( !rc ) throw rc;
   
           for( i = 0; i < *NUMELS; i++ ) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_solid_tensor.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_solid_tensor.cpp
@@ -115,8 +115,8 @@ void c_h3d_update_solid_tensor_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, i
              if(*NUMELS != 0)
              {
                   rc = Hyper3DDatasetBegin(h3d_file, *NUMELS, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                              H3D_DS_TENSOR3D, NNOD  , num_modes, *CPT_DATATYPE, 
-                                              0, solid_poolname_id, complex); 
+                                              H3D_DS_TENSOR3D, H3D_NF_REAL, NNOD  , num_modes, *CPT_DATATYPE, 
+                                              0, solid_poolname_id); 
                   if( !rc ) throw rc;
 
                   for( i = 0; i < *NUMELS; i++ ) 
@@ -221,8 +221,8 @@ void c_h3d_update_solid_tensor_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, i
         if(*NUMELS != 0)
         {
             rc = Hyper3DDatasetBegin(h3d_file, *NUMELS, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_TENSOR3D, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, solid_poolname_id, complex); 
+                                        H3D_DS_TENSOR3D, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, solid_poolname_id); 
             if( !rc ) throw rc;
 
      	    for( i = 0; i < *NUMELS; i++ ) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_solid_vector.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_solid_vector.cpp
@@ -103,8 +103,8 @@ void c_h3d_update_solid_vector_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, i
         if( *NUMELS != 0)
         {
           rc = Hyper3DDatasetBegin(h3d_file, *NUMELS, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_VECTOR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, solid_poolname_id, complex); 
+                                        H3D_DS_VECTOR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, solid_poolname_id); 
           if( !rc ) throw rc;
   
           for( i = 0; i < *NUMELS; i++ ) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_sph_scalar.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_sph_scalar.cpp
@@ -103,8 +103,8 @@ void c_h3d_update_sph_scalar_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, int
         if( *NUMSPH != 0)
         {
           rc = Hyper3DDatasetBegin(h3d_file, *NUMSPH, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_SCALAR, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, sphcell_poolname_id, complex); 
+                                        H3D_DS_SCALAR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, sphcell_poolname_id); 
           if( !rc ) throw rc;
   
           for( i = 0; i < *NUMSPH; i++ ) 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_sph_tensor.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_sph_tensor.cpp
@@ -103,8 +103,8 @@ void c_h3d_update_sph_tensor_(my_real *TT,int *IH3D, int *ITAB,int *NUMSPH, int 
         if(*NUMSPH != 0)
         {
             rc = Hyper3DDatasetBegin(h3d_file, *NUMSPH, sim_idx, subcase_id, H3D_DS_ELEM, 
-                                        H3D_DS_TENSOR3D, num_corners, num_modes, *CPT_DATATYPE, 
-                                        0, sphcell_poolname_id, complex); 
+                                        H3D_DS_TENSOR3D, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
+                                        0, sphcell_poolname_id); 
             if( !rc ) throw rc;
 
      	    for( i = 0; i < *NUMSPH; i++ ) 

--- a/engine/source/output/h3d/h3d_build_cpp/h3d_dl.c
+++ b/engine/source/output/h3d/h3d_build_cpp/h3d_dl.c
@@ -166,18 +166,15 @@ char * H3D_open_file="Hyper3DExportOpen";
 
  bool (*DLHyper3DElementBegin)  (H3DFileInfo* h3d_file, unsigned int count, 
  	   H3D_ID poolname_id, H3D_ElementConfig config, 
-                    H3D_ID parent_id, H3D_ID parent_poolname_id, 
-                    H3D_ID node_poolname_id);
+                    H3D_ID type_id, H3D_ID parent_id, 
+                    H3D_ID parent_poolname_id, H3D_ID node_poolname_id);
+ bool (*DLHyper3DElement2Begin)  (H3DFileInfo* h3d_file, unsigned int count, 
+ 	   H3D_ID poolname_id, H3D_ElementConfig config, 
+           H3D_ID type_id, H3D_ID parent_id, 
+           H3D_ID parent_poolname_id, H3D_ID node_poolname_id);
 
  bool (*DLHyper3DElementWrite)  (H3DFileInfo* h3d_file, 
  	   H3D_ID id, H3D_ID* connectivity);
-
- bool (*DLHyper3DElementEnd)  (H3DFileInfo* h3d_file);
-
- bool (*DLHyper3DElement2Begin)  (H3DFileInfo* h3d_file, unsigned int count, 
- 	   H3D_ID poolname_id, H3D_ElementConfig config, 
-           H3D_ID parent_id, H3D_ID parent_poolname_id, 
-           H3D_ID node_poolname_id);
 
  bool (*DLHyper3DElement2Write)  (H3DFileInfo* h3d_file, H3D_ID id, 
                     unsigned int* inode, int* idof, double* icoeff, 
@@ -185,6 +182,7 @@ char * H3D_open_file="Hyper3DExportOpen";
                     unsigned int* dnode, int* ddof, double* dcoeff, 
                     unsigned int num_dnodes);
 
+ bool (*DLHyper3DElementEnd)  (H3DFileInfo* h3d_file);
  bool (*DLHyper3DElement2End)  (H3DFileInfo* h3d_file);
 
 /*************************************/
@@ -254,7 +252,7 @@ char * H3D_open_file="Hyper3DExportOpen";
 
  bool (*DLHyper3DDatatypeWrite) (H3DFileInfo* h3d_file, const char* label, 
            H3D_ID dt_id, H3D_DS_FORMAT format, H3D_DS_TYPE type, 
- 	   unsigned int num_pools);
+ 	   unsigned int num_pools, H3D_NF_FORMAT nf_format);
 
  bool (*DLHyper3DDatatypeDescriptionWrite)  (H3DFileInfo* h3d_file, 
  	   H3D_ID dt_id, const char* description);
@@ -275,7 +273,7 @@ char * H3D_open_file="Hyper3DExportOpen";
  	   H3D_DS_TYPE type, H3D_DS_FORMAT format, 
  	   unsigned int num_corners, unsigned int num_modes, 
  	   H3D_ID dt_id, int layer_idx, H3D_ID data_poolname_id,
- 	   bool complex);
+ 	   H3D_NF_FORMAT nf_format);
 
  bool (*DLHyper3DDatasetWriteParent)  (H3DFileInfo* h3d_file, H3D_ID comp_id, 
  	   H3D_ID component_poolname_id);
@@ -1136,11 +1134,11 @@ H3DFileInfo* Hyper3DExportOpen(const char* filename, H3D_FileMode mode,
 
  bool Hyper3DElementBegin(H3DFileInfo* h3d_file, unsigned int count, 
  	   H3D_ID poolname_id, H3D_ElementConfig config, 
- 	   H3D_ID parent_id, H3D_ID parent_poolname_id, 
- 	   H3D_ID node_poolname_id)
+ 	   H3D_ID type_id, H3D_ID parent_id, 
+ 	   H3D_ID parent_poolname_id, H3D_ID node_poolname_id)
 {  bool return_value;
    return_value = DLHyper3DElementBegin(h3d_file, count, poolname_id, config, 
- 	   parent_id, parent_poolname_id, node_poolname_id);
+ 	   type_id, parent_id, parent_poolname_id, node_poolname_id);
    return return_value ;
 }
 
@@ -1159,11 +1157,11 @@ H3DFileInfo* Hyper3DExportOpen(const char* filename, H3D_FileMode mode,
 
  bool Hyper3DElement2Begin(H3DFileInfo* h3d_file, unsigned int count, 
  	   H3D_ID poolname_id, H3D_ElementConfig config, 
- 	   H3D_ID parent_id, H3D_ID parent_poolname_id, 
- 	   H3D_ID node_poolname_id)
+ 	   H3D_ID type_id, H3D_ID parent_id, 
+ 	   H3D_ID parent_poolname_id, H3D_ID node_poolname_id)
 {  bool return_value;
    return_value = DLHyper3DElement2Begin(h3d_file, count, poolname_id, config, 
- 	   parent_id, parent_poolname_id, node_poolname_id);
+ 	   type_id, parent_id, parent_poolname_id, node_poolname_id);
    return return_value ;
 }
 
@@ -1315,9 +1313,9 @@ H3DFileInfo* Hyper3DExportOpen(const char* filename, H3D_FileMode mode,
 
  bool Hyper3DDatatypeWrite(H3DFileInfo* h3d_file, const char* label, 
  	   H3D_ID dt_id, H3D_DS_FORMAT format, H3D_DS_TYPE type, 
- 	   unsigned int num_pools)
+ 	   unsigned int num_pools, H3D_NF_FORMAT nf_format)
 {  bool return_value;
-   return_value = DLHyper3DDatatypeWrite(h3d_file, label, dt_id, format, type, num_pools);
+   return_value = DLHyper3DDatatypeWrite(h3d_file, label, dt_id, format, type, num_pools, nf_format);
    return return_value ;
 }
 
@@ -1354,11 +1352,11 @@ H3DFileInfo* Hyper3DExportOpen(const char* filename, H3D_FileMode mode,
  	   H3D_DS_TYPE type, H3D_DS_FORMAT format, 
  	   unsigned int num_corners, unsigned int num_modes, 
  	   H3D_ID dt_id, int layer_idx, H3D_ID data_poolname_id,
- 	   bool complex)
+ 	   H3D_NF_FORMAT nf_format)
 {  bool return_value;
    return_value = DLHyper3DDatasetBegin(h3d_file,count, idx,subcase_id, 
  	   type, format, num_corners, num_modes, 
- 	   dt_id, layer_idx, data_poolname_id, complex);
+ 	   dt_id, layer_idx, data_poolname_id, nf_format);
    return return_value ;
 }
 


### PR DESCRIPTION
This pull request updates the way data types and element configurations are written to the Hyper3D output files, standardizing the specification of numeric formats and element IDs across multiple routines. The main goals are to ensure that all data types use the correct numeric format (`H3D_NF_REAL`) and to consistently pass `H3D_NULL_ID` where appropriate for element configuration functions, improving clarity and correctness in the Hyper3D export logic.

The most important changes are:

**Standardization of numeric format in datatype creation:**
* Updated all calls to `Hyper3DDatatypeWrite` in various datatype creation functions (scalar, vector, tensor, torsor, displacement, etc.) to explicitly specify `H3D_NF_REAL` as the numeric format argument, ensuring consistency and correctness for real-valued data types. [[1]](diffhunk://#diff-632c896f5442e2e1b29b224f31a3519df4337715ce4c54936760dfdd465fbf28L172-R172) [[2]](diffhunk://#diff-21b3bf0f98fc72fdebaab3638d5888fe2badb2e5db53a6a1a598f2341d53a6f8L149-R149) [[3]](diffhunk://#diff-d20838c1fa5599e6894c06b6e5c5d889511afec641e2819419a3c71c42f4b262L117-R117) [[4]](diffhunk://#diff-dfe63caf582c5d8e11b709c678e2b91f0f9666775af47bd59fce8ff7b6a8726aL135-R135) [[5]](diffhunk://#diff-f7fe3ee66169ee741c1c784e197aaac93abff20fc6e25b79f5ee300a5beef03dL84-R90) [[6]](diffhunk://#diff-408bc03e5663714c9d3ca817344073893d1d6a5b8ad2bf5d2bba09ebefbc196cL139-R139) [[7]](diffhunk://#diff-a1f2a8d895277458a37160c40c53fb9b939223835576a1f87b40eb841e1885a1L127-R127) [[8]](diffhunk://#diff-eb9c96672fccd5b54f76453b297614d94f7fd1612f38b03922131cad7de53f23L111-R111) [[9]](diffhunk://#diff-14b4a3d95afc47d94d4c5795779d515a675db48c96c958041f770af21d2134ffL158-R158) [[10]](diffhunk://#diff-e4143f2646912b8a8ff26a42f6376c9bffb00345fa2b6a0224fb902eab446996L159-R159) [[11]](diffhunk://#diff-8d5fc62e040341753aef8a42630e3469489caf53ffb1462a2cda56218d66156dL154-R154)

**Consistent use of `H3D_NULL_ID` for element configuration:**
* Modified all calls to `Hyper3DElementBegin` and `Hyper3DElement2Begin` to pass `H3D_NULL_ID` as the second argument (element ID) instead of a component or element identifier, aligning with the expected API usage for these functions. This affects beam, quad, RBE2, RBE3, rigid body, and rigid wall element creation routines. [[1]](diffhunk://#diff-3a7229d24e494ddde773fe0b10f9bb0e6c2b27579f5613d7a8d619ee342566aaL98-R98) [[2]](diffhunk://#diff-3504aeb9814d0dd5c3f058302418dd523d95601fc243da7640993e93fb221ef3L139-R139) [[3]](diffhunk://#diff-d7a54de54e3e0928100f46553a0c3b6082586af1c2b775ee142e0c56d0d4c513L95-R95) [[4]](diffhunk://#diff-d7a54de54e3e0928100f46553a0c3b6082586af1c2b775ee142e0c56d0d4c513L150-R150) [[5]](diffhunk://#diff-d7a54de54e3e0928100f46553a0c3b6082586af1c2b775ee142e0c56d0d4c513L217-R217) [[6]](diffhunk://#diff-d7a54de54e3e0928100f46553a0c3b6082586af1c2b775ee142e0c56d0d4c513L280-R280) [[7]](diffhunk://#diff-e5d262161ac6fe5fbe4a48d74064ac15c9b3bdce0ef4ee33e595530b5e2e03f7L95-R95) [[8]](diffhunk://#diff-e5d262161ac6fe5fbe4a48d74064ac15c9b3bdce0ef4ee33e595530b5e2e03f7L151-R151) [[9]](diffhunk://#diff-e5d262161ac6fe5fbe4a48d74064ac15c9b3bdce0ef4ee33e595530b5e2e03f7L217-R217) [[10]](diffhunk://#diff-e5d262161ac6fe5fbe4a48d74064ac15c9b3bdce0ef4ee33e595530b5e2e03f7L279-R279) [[11]](diffhunk://#diff-dca00159afaa22889f7a09e95f310a426c2b7525865f466aef65c77e3316c268L95-R95) [[12]](diffhunk://#diff-dca00159afaa22889f7a09e95f310a426c2b7525865f466aef65c77e3316c268L164-R164) [[13]](diffhunk://#diff-dca00159afaa22889f7a09e95f310a426c2b7525865f466aef65c77e3316c268L235-R235) [[14]](diffhunk://#diff-dca00159afaa22889f7a09e95f310a426c2b7525865f466aef65c77e3316c268L365-R365) [[15]](diffhunk://#diff-2352c136ee032246f106a65a712aebf03f0c7a42249f8e7b6561f050907cfe02L185-R185) [[16]](diffhunk://#diff-2352c136ee032246f106a65a712aebf03f0c7a42249f8e7b6561f050907cfe02L251-R251) [[17]](diffhunk://#diff-2352c136ee032246f106a65a712aebf03f0c7a42249f8e7b6561f050907cfe02L271-R271)

These changes improve the reliability and maintainability of the Hyper3D export routines by making data type and element configuration handling more explicit and uniform.