### PR TITLE
correction issue with commit 486f84b92f24c4272e42effb00406069dede3dca

### DIFF
--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_oned_torsor.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_oned_torsor.cpp
@@ -121,6 +121,9 @@ void c_h3d_update_oned_torsor_(my_real *TT,int *IH3D, int *ITAB, int *NUMELT, in
      	    rc = Hyper3DDatasetBegin(h3d_file, *NUMELT, sim_idx, subcase_id, H3D_DS_ELEM, 
      	 			    H3D_DS_SCALAR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
      	 			    0, truss_poolname_id); 
+     	    if( !rc ) throw rc;
+
+     	    for( i = 0; i < *NUMELT + *NUMELP + *NUMELR; i++ ) 
      	    {
      	      if( ITY_ELEM[i] == 4  && IS_WRITTEN[i] == 1) 
      	      { 
@@ -144,6 +147,9 @@ void c_h3d_update_oned_torsor_(my_real *TT,int *IH3D, int *ITAB, int *NUMELT, in
      	    rc = Hyper3DDatasetBegin(h3d_file, *NUMELP, sim_idx, subcase_id, H3D_DS_ELEM, 
      	 			    H3D_DS_SCALAR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
      	 			    0, beam_poolname_id); 
+     	    if( !rc ) throw rc;
+
+     	    for( i = 0; i < *NUMELT + *NUMELP + *NUMELR; i++ ) 
      	    {
      	      if( ITY_ELEM[i] == 5  && IS_WRITTEN[i] == 1) 
      	      { 
@@ -167,6 +173,9 @@ void c_h3d_update_oned_torsor_(my_real *TT,int *IH3D, int *ITAB, int *NUMELT, in
      	    rc = Hyper3DDatasetBegin(h3d_file, *NUMELR, sim_idx, subcase_id, H3D_DS_ELEM, 
      	 			    H3D_DS_SCALAR, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
      	 			    0, spring_poolname_id); 
+     	    if( !rc ) throw rc;
+
+     	    for( i = 0; i < *NUMELT + *NUMELP + *NUMELR; i++ ) 
      	    {
      	      if( ITY_ELEM[i] == 6  && IS_WRITTEN[i] == 1) 
      	      { 

--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_shell_tensor.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_update_shell_tensor.cpp
@@ -136,6 +136,9 @@ void c_h3d_update_shell_tensor_(my_real *TT,int *IH3D, int *ITAB, int *NUMNOD, i
      	    rc = Hyper3DDatasetBegin(h3d_file, *NUMELTG, sim_idx, subcase_id, H3D_DS_ELEM, 
      	 			    H3D_DS_TENSOR2D, H3D_NF_REAL, num_corners, num_modes, *CPT_DATATYPE, 
      	 			    0, sh3n_poolname_id); 
+     	    if( !rc ) throw rc;
+
+     	    for( i = 0; i < *NUMELC + *NUMELTG; i++ ) 
      	    {
               if( ITY_ELEM[i] == 7  && IS_WRITTEN[i] == 1) 
      	      { 


### PR DESCRIPTION
This pull request improves error handling and iteration logic in the H3D output routines for both 1D torsor and shell tensor data. The main changes ensure that errors in dataset creation are properly caught and that the iteration over elements is consistent and correct.

**Error handling improvements:**

* Added checks after each call to `Hyper3DDatasetBegin` in both `c_h3d_update_oned_torsor.cpp` and `c_h3d_update_shell_tensor.cpp`, throwing an exception if the dataset creation fails. [[1]](diffhunk://#diff-4ca201890997f61384c75b587cf49b5b0b2503444470f7df3d8ad8705ca5a984R124-R126) [[2]](diffhunk://#diff-4ca201890997f61384c75b587cf49b5b0b2503444470f7df3d8ad8705ca5a984R150-R152) [[3]](diffhunk://#diff-4ca201890997f61384c75b587cf49b5b0b2503444470f7df3d8ad8705ca5a984R176-R178) [[4]](diffhunk://#diff-ae970e3826f28ba4d189d4068e4699711d612211438c4e7976f6897a289de9a2R139-R141)

**Iteration logic updates:**

* Updated the loops following dataset creation to iterate over the sum of relevant element counts, ensuring all applicable elements are processed in both 1D torsor and shell tensor routines. [[1]](diffhunk://#diff-4ca201890997f61384c75b587cf49b5b0b2503444470f7df3d8ad8705ca5a984R124-R126) [[2]](diffhunk://#diff-4ca201890997f61384c75b587cf49b5b0b2503444470f7df3d8ad8705ca5a984R150-R152) [[3]](diffhunk://#diff-4ca201890997f61384c75b587cf49b5b0b2503444470f7df3d8ad8705ca5a984R176-R178) [[4]](diffhunk://#diff-ae970e3826f28ba4d189d4068e4699711d612211438c4e7976f6897a289de9a2R139-R141)