### PR TITLE
CFG updates (labels)

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2026/LOADS/detpointnode.cfg
+++ b/hm_cfg_files/config/CFG/radioss2026/LOADS/detpointnode.cfg
@@ -21,7 +21,7 @@ ATTRIBUTES(COMMON) {
   // Data
   rad_det_node1       = VALUE(NODE,  "Node identifier defining ignition coordinates");
   rad_det_time        = VALUE(FLOAT, "Detonation time");
-  radius              = VALUE(FLOAT, "initialization radius");
+  radius              = VALUE(FLOAT, "Optional initialization radius");
   rad_det_materialid  = VALUE(MAT, "Explosive material number concerned by detonation time")  {SUBTYPES=(/MAT/MAT_ALE_JWL);}
   rad_det_Ishadow     = VALUE(INT, "Flag for shadowing effects");
   sym_frame1          = VALUE(SYSTEM, "Optional Symmetry Frame 1");
@@ -36,22 +36,27 @@ DEFAULTS(COMMON)
 }
 
 GUI(COMMON) {
-  SCALAR(rad_det_time, "TDET") { DIMENSION="t"; }
+  RADIO(rad_det_Ishadow) {
+    ADD(0,"0: Direct Radial distance");
+    ADD(1,"1: Shadowing effect");
+  }
+  graphical TOOL(sym_frame1) {ORIGIN=MANDATORY;}
+  graphical TOOL(sym_frame2) {ORIGIN=MANDATORY;}
   SCALAR(radius, "R0_shadow") { DIMENSION="l"; }
+  SCALAR(rad_det_time, "TDET") { DIMENSION="t"; }
   DATA(rad_det_materialid, "mat_ID");
-  DATA(rad_det_node1, "node_ID1");
 
-    RADIO(rad_det_Ishadow) {
-      ADD(0,"0: Direct Radial distance");
-      ADD(1,"1: Shadowing effect");
-    }
-
+ mandatory:
+  graphical SUPPORT("Support") {
+    OBJECTS=(NODE);
+    ADD(rad_det_node1,"Node group");
+  }
 }
 
 //  File Format
 FORMAT(radioss2026) {
   HEADER("/DFS/DETPOINT/NODE/%-d",_ID_);
-  COMMENT("#  Ishadow   Iframe1   Iframe2           R0_shadow                          TDET    mat_ID  node_ID1");
+  COMMENT("#  Ishadow frame_ID1 frame_ID2           R0_shadow                          TDET    mat_ID  node_ID1");
   CARD("%10d%10d%10d%20lg%10s%20lg%10d%10d", rad_det_Ishadow,   sym_frame1, sym_frame2, radius, _BLANK_, rad_det_time, rad_det_materialid, rad_det_node1);
 }
 

--- a/hm_cfg_files/config/CFG/radioss2026/LOADS/detpointset.cfg
+++ b/hm_cfg_files/config/CFG/radioss2026/LOADS/detpointset.cfg
@@ -22,7 +22,7 @@ ATTRIBUTES(COMMON) {
   rad_det_grnod1     = VALUE(SETS,  "Group of Nodes identifier") { SUBTYPES = (/SETS/GRNOD);}
   rad_det_time       = VALUE(FLOAT, "Detonation time");
   radius             = VALUE(FLOAT, "Optional initialization radius");
-  rad_det_materialid = VALUE(MAT,   "Explosive material number") {SUBTYPES=(/MAT/MAT_ALE_JWL);}
+  rad_det_materialid = VALUE(MAT,   "Explosive material number concerned by detonation time") {SUBTYPES=(/MAT/MAT_ALE_JWL);}
   rad_det_Ishadow    = VALUE(INT,   "Flag for shadowing effects");
   sym_frame1         = VALUE(SYSTEM, "Optional Symmetry Frame 1");
   sym_frame2         = VALUE(SYSTEM, "Optional Symmetry Frame 2");
@@ -36,22 +36,28 @@ DEFAULTS(COMMON)
 }
 
 GUI(COMMON) {
-  SCALAR(rad_det_time, "TDET") { DIMENSION="t"; }
+  RADIO(rad_det_Ishadow) {
+    ADD(0,"0: Direct Radial distance");
+    ADD(1,"1: Shadowing effect");
+  }
+  graphical TOOL(sym_frame1) {ORIGIN=MANDATORY;}
+  graphical TOOL(sym_frame2) {ORIGIN=MANDATORY;}
   SCALAR(radius, "R0_shadow") { DIMENSION="l"; }
+  SCALAR(rad_det_time, "TDET") { DIMENSION="t"; }
   DATA(rad_det_materialid, "mat_ID");
-  DATA(rad_det_grnod1, "grnod_ID1");
 
-    RADIO(rad_det_Ishadow) {
-      ADD(0,"0: Direct Radial distance");
-      ADD(1,"1: Shadowing effect");
-    }
+ mandatory:
+  graphical SUPPORT("Support") {
+    OBJECTS=(NODE,ELEMENTS,COMPONENT);
+    ADD(rad_det_grnod1,"Node Group");
+  }
 }
 
 
 //  File Format
 FORMAT(radioss2026) {
   HEADER("/DFS/DETPOINT/SET/%-d",_ID_);
-  COMMENT("#  Ishadow   Iframe1   Iframe2           R0_shadow                          TDET    mat_ID grnod_ID1");
+  COMMENT("#  Ishadow frame_ID1 frame_ID2           R0_shadow                          TDET    mat_ID grnod_ID1");
   CARD("%10d%10d%10d%20lg%10s%20lg%10d%10d", rad_det_Ishadow, sym_frame1, sym_frame2, radius, _BLANK_, rad_det_time, rad_det_materialid, rad_det_grnod1);
 }
 


### PR DESCRIPTION
#### CFG updates (labels)


#### Description of the changes
Labels were updated in the CFG reader files for /DFS/DETPOINT/NODE and /DFS/DETPOINT/SET:
- iframe1 -> frame_ID1
- iframe2 -> frame_ID2

This now matches the notation commonly used in the user manual.
