### PR TITLE
change Ismstr<0 (Auto) for law50 with compaction

### DIFF
--- a/starter/source/materials/mat/mat050/hm_read_mat50.F90
+++ b/starter/source/materials/mat/mat050/hm_read_mat50.F90
@@ -429,7 +429,11 @@
 ! ----------------------------------------------------------------------------------------------------------------------
           call init_mat_keyword(mat_param,"HOOK")
           call init_mat_keyword(mat_param,"COMPRESSIBLE")
-          call init_mat_keyword(mat_param,"SMALL_STRAIN")
+          if (icompact == 1) then
+            call init_mat_keyword(mat_param,"LARGE_STRAIN")
+          else
+            call init_mat_keyword(mat_param,"SMALL_STRAIN")
+          end if
           call init_mat_keyword(mat_param,"ORTHOTROPIC")
           ! properties compatibility
           call init_mat_keyword(mat_param,"SOLID_ISOTROPIC")


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
When law50 (Honeycomb) with compaction, small strain option (ismstr=1) might get too soft behaviors during compaction state.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
Change automatic value (when input ismstr=-1,-2) for law50 with compaction

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
