### PR TITLE
layer_string was missing in case solid tensor with ir=0 & it=0

### DIFF
--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_solid_tensor_datatype.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_create_solid_tensor_datatype.cpp
@@ -199,6 +199,15 @@ void c_h3d_create_solid_tensor_datatype_(int *cpt_data, char *name1, int *size1,
              LAYERPOOL = strcat(LAYERPOOL,LAYER_STRING);
 #endif
         }
+        else if(*ir < 0 && *is > 0 && *it < 0)
+        {
+             sprintf(LAYER_STRING, "IS %d " ,*is);
+#ifdef _WIN64
+             strcat_s(LAYERPOOL,100,LAYER_STRING);
+#else
+             LAYERPOOL = strcat(LAYERPOOL,LAYER_STRING);
+#endif
+        }
     }
     else if(*layer < -1 )
     {


### PR DESCRIPTION
This pull request adds support for a new case when building the `LAYERPOOL` string in the `c_h3d_create_solid_tensor_datatype_` function. Specifically, it handles the situation where only the `is` parameter is positive while `ir` and `it` are negative.

Enhancement to string construction logic:

* Added a new conditional branch to handle the case where `*ir < 0`, `*is > 0`, and `*it < 0`, appending the `"IS %d "` string to `LAYERPOOL` accordingly.