### PR TITLE
CONSTRAINED_JOINT_STIFFNESS issue with pool Id : it was considered as a property

### DIFF
--- a/hm_cfg_files/config/CFG/Keyword971_R15.0/data_hierarchy.cfg
+++ b/hm_cfg_files/config/CFG/Keyword971_R15.0/data_hierarchy.cfg
@@ -4285,7 +4285,7 @@ HIERARCHY {
     TITLE   = "Properties";
     TYPE    = PROP;
     FLAGS   = (!HM_SUPPORTED | HAS_ID_IN_FIRST_DATA_CARD | CAN_HAVE_TITLE_CARD);
-    USER_NAMES = (*SECTION, *CONSTRAINED_JOINT_STIFFNESS, *DEFINE_ELEMENT_DEATH);
+    USER_NAMES = (*SECTION, *DEFINE_ELEMENT_DEATH);
 
     HIERARCHY {
           KEYWORD    = SECTION_SEATBELT ;
@@ -4406,20 +4406,6 @@ HIERARCHY {
          ID_POOL    = 20;
          USER_NAMES = (SECTION_ALE2D,SectALE2D);
     }
-    */
-    HIERARCHY {
-         KEYWORD    = CONSTRAINED_JOINT_STIFFNESS;
-         TITLE      = "027  PROP";
-         FILE       = "PROPERTY/constrained_joint_stiffness.cfg";
-         SUBTYPE    = USER;
-         USER_ID    = 2314;
-         ID_POOL    = 25;
-         USER_NAMES = (/*CONSTRAINED_JOINT_STIFFNESS,*/
-                       CONSTRAINED_JOINT_STIFFNESS_GENERALIZED,
-                       /*CONSTRAINED_JOINT_STIFFNESS_FLEXION-TORSION,*/
-                       CONSTRAINED_JOINT_STIFFNESS_TRANSLATIONAL/*,JointStff*/);
-    }
-    /*
     HIERARCHY {
          KEYWORD    = DEFINE_CONNECTION_PROPERTIES ;
          TITLE      = "028  PROP";
@@ -6208,9 +6194,23 @@ HIERARCHY {
     KEYWORD = JOINT;
     TYPE    = JOINT;
     TITLE   = "JOINT";
-    FLAGS   = (!HM_SUPPORTED | CAN_HAVE_ID_CARD);
+    FLAGS   = (!HM_SUPPORTED | CAN_HAVE_ID_CARD| CAN_HAVE_TITLE_CARD);
     USER_NAMES = (CONSTRAINED_JOINT);
 
+    
+    HIERARCHY {
+         KEYWORD    = CONSTRAINED_JOINT_STIFFNESS;
+         TITLE      = "027  PROP";
+         FILE       = "PROPERTY/constrained_joint_stiffness.cfg";
+         SUBTYPE    = USER;
+         USER_ID    = 2314;
+         ID_POOL    = 25;
+         USER_NAMES = (CONSTRAINED_JOINT_STIFFNESS,
+                       CONSTRAINED_JOINT_STIFFNESS_GENERALIZED,
+                       /*CONSTRAINED_JOINT_STIFFNESS_FLEXION-TORSION,*/
+                       CONSTRAINED_JOINT_STIFFNESS_TRANSLATIONAL/*,JointStff*/);
+    }
+    
     HIERARCHY {
         KEYWORD    = CONSTRAINED_JOINT_CYLINDRICAL;
         TITLE      = "CONSTRAINED JOINT CYLINDRICAL";


### PR DESCRIPTION
This pull request reorganizes how the `CONSTRAINED_JOINT_STIFFNESS` keyword is handled within the `data_hierarchy.cfg` configuration file. The main change is moving the hierarchy definition for `CONSTRAINED_JOINT_STIFFNESS` from the `PROP` section to the `JOINT` section, which better aligns with its functional grouping. Additionally, some minor flag and user name list adjustments were made.

Hierarchy restructuring:

* Removed `CONSTRAINED_JOINT_STIFFNESS` from the `USER_NAMES` list in the `PROP` section and deleted its hierarchy definition from that section. [[1]](diffhunk://#diff-f517a2e7d81b5488d44bed4219f5e9cce7023dec55a8e47bfb3bf87c117d837cL4288-R4288) [[2]](diffhunk://#diff-f517a2e7d81b5488d44bed4219f5e9cce7023dec55a8e47bfb3bf87c117d837cL4409-L4422)
* Added the hierarchy definition for `CONSTRAINED_JOINT_STIFFNESS` under the `JOINT` section, including its relevant properties and user names.

Flag and metadata updates:

* Modified the `FLAGS` for the `JOINT` section to include `CAN_HAVE_TITLE_CARD` in addition to the existing flags.