### PR TITLE
bug fixing of fully integration quad (Isolid=17) for 2D axisymmetry

### DIFF
--- a/engine/source/elements/solid_2d/quad4/q4forc2.F
+++ b/engine/source/elements/solid_2d/quad4/q4forc2.F
@@ -659,8 +659,8 @@ C
      2   Y2,      Y3,      Y4,      Z1,
      3   Z2,      Z3,      Z4,      VY1,
      4   VY2,     VY3,     VY4,     VZ1,
-     5   VZ2,     VZ3,     VZ4,     PY1,
-     6   PY2,     PZ1,     PZ2,     FY1,
+     5   VZ2,     VZ3,     VZ4,    PYC1,
+     6   PYC2,    PZC1,    PZC2,    FY1,
      7   FY2,     FY3,     FY4,     FZ1,
      8   FZ2,     FZ3,     FZ4,     AIRE,
      9   SSP,     NEL)

--- a/engine/source/elements/solid_2d/quad4/q4vis2.F
+++ b/engine/source/elements/solid_2d/quad4/q4vis2.F
@@ -84,9 +84,8 @@ C
         DO I=1,NEL
          HY=Y1(I)-Y2(I)+Y3(I)-Y4(I)
          HZ=Z1(I)-Z2(I)+Z3(I)-Z4(I)
-         FAC=ONE/MAX(EM20,AREA(I))
-         PX1H1=FAC*(PY1(I)*HY+PZ1(I)*HZ)
-         PX2H1=FAC*(PY2(I)*HY+PZ2(I)*HZ)
+         PX1H1=PY1(I)*HY+PZ1(I)*HZ
+         PX2H1=PY2(I)*HY+PZ2(I)*HZ
          G11(I)= ONE -PX1H1
          G21(I)=-ONE -PX2H1
          G31(I)= ONE +PX1H1


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
may get instability issue for 2D Axisymetric analyse using Isolid=17 with fine mesh

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

bug fixing of quad4 (isolid=17) with 2D Axisymetric
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
