### PR TITLE
/H3D/COMP_LEVEL option

### DIFF
--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_open_file.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_open_file.cpp
@@ -236,9 +236,8 @@ void c_h3d_open_file_(char *name, int *size, my_real *percentage_error, int *com
     //mode |= H3D_NOZLIB;
     //mode |= H3D_NOSORT;
     h3d_file = Hyper3DExportOpen(cname, mode, NULL, ReportErrorMsg);
-
-    //h3d_file -> quantize_error = *percentage_error / 100.f ;
-    //h3d_file -> compression_level = *comp_level ;
+    
+    Hyper3DCompressionLevel(h3d_file, *comp_level);
 
     // define pool names that will be used
     char* creating_application;

--- a/engine/source/output/h3d/h3d_build_cpp/h3d_dl.c
+++ b/engine/source/output/h3d/h3d_build_cpp/h3d_dl.c
@@ -78,6 +78,8 @@ char * H3D_open_file="Hyper3DExportOpen";
  bool (*DLHyper3DExportClearError)  (H3DFileInfo* h3d_file);
 
  bool (*DLHyper3DExportClose)  (H3DFileInfo* h3d_file);
+ 
+ bool (*DLHyper3DCompressionLevel)  (H3DFileInfo* h3d_file, unsigned int level);
 
 /***********************/
 /* String Table Blocks */
@@ -372,6 +374,8 @@ void h3dlib_load_(int * IERROR)
   DLHyper3DExportClose=(void*)GetProcAddress(h3dhandle,"Hyper3DExportClose");
   if( !DLHyper3DExportClose) ierr=ierr+1;
 
+ DLHyper3DCompressionLevel=(void*)GetProcAddress(h3dhandle,"Hyper3DCompressionLevel");
+  if( !DLHyper3DCompressionLevel) ierr=ierr+1;
 /***********************/ 
 /* String Table Blocks */
 /***********************/ 
@@ -675,6 +679,9 @@ void h3dlib_load_(int * IERROR)
 
   DLHyper3DExportClose=dlsym(h3dhandle,"Hyper3DExportClose");
   if( !DLHyper3DExportClose) ierr=ierr+1;
+  
+  DLHyper3DCompressionLevel=dlsym(h3dhandle,"Hyper3DCompressionLevel");
+  if( !DLHyper3DCompressionLevel) ierr=ierr+1;
 
 /***********************/ 
 /* String Table Blocks */
@@ -943,6 +950,12 @@ H3DFileInfo* Hyper3DExportOpen(const char* filename, H3D_FileMode mode,
  bool Hyper3DExportClose(H3DFileInfo* h3d_file)
 {  bool return_value;
    return_value = DLHyper3DExportClose(h3d_file);
+   return return_value ;
+}
+
+ bool Hyper3DCompressionLevel(H3DFileInfo* h3d_file, unsigned int level)
+{  bool return_value;
+   return_value = DLHyper3DCompressionLevel(h3d_file, level);
    return return_value ;
 }
 

--- a/engine/source/output/h3d/h3d_build_fortran/h3d_read.F
+++ b/engine/source/output/h3d/h3d_build_fortran/h3d_read.F
@@ -170,6 +170,7 @@ c           ENDDO
         ELSEIF(KEY2=='COMP_LEVEL')THEN
           CALL WRIUSC2(IREC,1,KEY0(KCUR))
           READ(IUSC2,*,ERR=9990)H3D_DATA%COMP_LEVEL
+          
         ELSEIF(KEY2=='TITLE')THEN
           H3D_DATA%N_TITLE = NBC
           call my_alloc(H3D_DATA%ITITLE, NBC, "H3D_DATA%ITITLE")


### PR DESCRIPTION
This pull request introduces support for setting the compression level in the Hyper3D export workflow. The main changes involve adding a new function to set the compression level, updating dynamic linking logic to load this function, and modifying the C++ code to use it.

**Hyper3D compression level support:**

* Added a new function, `Hyper3DCompressionLevel`, which sets the compression level for a given `H3DFileInfo` object by calling the dynamically loaded function pointer. (`engine/source/output/h3d/h3d_build_cpp/h3d_dl.c`, [engine/source/output/h3d/h3d_build_cpp/h3d_dl.cR956-R961](diffhunk://#diff-b64f4a5e0e8d0711e2a9b75c79af7228fcb3a6b44b920d71179906f2e88a93c6R956-R961))
* Updated dynamic loading logic to retrieve the `Hyper3DCompressionLevel` function pointer using `GetProcAddress` and `dlsym`, and increment the error counter if loading fails. (`engine/source/output/h3d/h3d_build_cpp/h3d_dl.c`, [[1]](diffhunk://#diff-b64f4a5e0e8d0711e2a9b75c79af7228fcb3a6b44b920d71179906f2e88a93c6R377-R378) [[2]](diffhunk://#diff-b64f4a5e0e8d0711e2a9b75c79af7228fcb3a6b44b920d71179906f2e88a93c6R683-R685)
* Declared the function pointer `DLHyper3DCompressionLevel` for dynamic linking. (`engine/source/output/h3d/h3d_build_cpp/h3d_dl.c`, [engine/source/output/h3d/h3d_build_cpp/h3d_dl.cR82-R83](diffhunk://#diff-b64f4a5e0e8d0711e2a9b75c79af7228fcb3a6b44b920d71179906f2e88a93c6R82-R83))

**C++ integration:**

* Updated `c_h3d_open_file.cpp` to call `Hyper3DCompressionLevel` when opening a file, replacing previous commented-out code for setting compression level directly. (`engine/source/output/h3d/h3d_build_cpp/c_h3d_open_file.cpp`, [engine/source/output/h3d/h3d_build_cpp/c_h3d_open_file.cppL240-R240](diffhunk://#diff-405bbf1da9c6077b78d10401b364f3cc027c1df5e8812e6ff99b9715c088c59dL240-R240))

**Fortran integration:**

* Minor formatting change in the Fortran code related to reading the compression level, likely to improve readability. (`engine/source/output/h3d/h3d_build_fortran/h3d_read.F`, [engine/source/output/h3d/h3d_build_fortran/h3d_read.FR173](diffhunk://#diff-f3777ba04a781880a7bee74017e78476cb4bb45ffcc75e8ee45fb20b0b7e70d7R173))