### PR TITLE
correction issue with /XREF option on solid parts using law 70 or law90

### DIFF
--- a/starter/source/materials/mat_share/mulaw.F
+++ b/starter/source/materials/mat_share/mulaw.F
@@ -278,7 +278,7 @@ C ====================================================================
 
       ELSEIF(MTN==70)THEN
         CALL SIGEPS70(LLT ,NPAR,NUVAR,NFUNC,IFUNC,
-     2                  NPF ,TF  ,TIME,TIMESTEP,BUFMAT,
+     2                  NPF ,TF  ,TIME,TIMESTEP,BUFMAT(IADBUF),
      3                  RHO0,RHO ,VOLN,EINT,NVARTMP ,VARTMP  ,
      4                  DE1 ,DE2 ,DE3 ,DE4  ,DE5  ,DE6 ,
      5                  ES1 ,ES2 ,ES3 ,ES4  ,ES5  ,ES6 ,
@@ -298,7 +298,7 @@ C ====================================================================
      8                ASRATE,EPSD,NVARTMP,VARTMP,DMG,NGL) 
       ELSEIF(MTN==90)THEN
         CALL SIGEPS90(LLT ,NPAR,NUVAR,NFUNC,IFUNC,
-     2                  NPF ,TF  ,TIME,TIMESTEP,BUFMAT,
+     2                  NPF ,TF  ,TIME,TIMESTEP,BUFMAT(IADBUF),
      3                  RHO0,RHO ,VOLN,EINT,
      4                  EP1 ,EP2 ,EP3 ,EP4  ,EP5  ,EP6 ,
      5                  DE1 ,DE2 ,DE3 ,DE4  ,DE5  ,DE6 ,


### PR DESCRIPTION
This pull request makes a targeted fix to how the `BUFMAT` array is passed to subroutines within the `MULAW` subroutine. Specifically, it updates the calls to `SIGEPS70` and `SIGEPS90` to pass a sliced portion of `BUFMAT` starting at `IADBUF`, rather than the entire array. This change ensures that the subroutines receive the correct segment of the buffer, which can help prevent errors related to incorrect memory access.

**Material model subroutine argument fixes:**

* Updated calls to `SIGEPS70` and `SIGEPS90` in `mulaw.F` to pass `BUFMAT(IADBUF)` instead of the whole `BUFMAT` array, ensuring the correct buffer segment is used. [[1]](diffhunk://#diff-2dcb7c2f4beff96c4bdcb8ad3d91bcef9cec83c3de0c7f7c851cfc2d8053b542L281-R281) [[2]](diffhunk://#diff-2dcb7c2f4beff96c4bdcb8ad3d91bcef9cec83c3de0c7f7c851cfc2d8053b542L301-R301)