### PR TITLE
fix the defintion of orthotropy direction  for Prop type11 and type10…

### DIFF
--- a/starter/source/elements/shell/coque/corthini.F
+++ b/starter/source/elements/shell/coque/corthini.F
@@ -206,13 +206,13 @@ C---    read property data
         ELSEIF (IGTYP == 10) THEN
           DO I=JFT,JLT
             DO J=1,NLAY
-              PHI1(J,I)= GEO(IPANG+J,PID)
+              PHI1(J,I)= ANGLE(I) +  GEO(IPANG+J,PID)
             ENDDO
           ENDDO
         ELSEIF (IGTYP == 11) THEN
           DO I=JFT,JLT
             DO J=1,NLAY
-              PHI1(J,I)= GEO(IPANG+J,PID)
+              PHI1(J,I)= ANGLE(I) + GEO(IPANG+J,PID)
             ENDDO
           ENDDO
          ELSEIF (IGTYP == 17 .AND. IRP /= 24) THEN !


### PR DESCRIPTION
… when angle is defined at element level

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

The angne of orthotropy defined in /SHELL or /SH3N are not considered in the computing of
orthotropic direction of composite wiht /PROP/TYPE10 and TYPE11
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

The issue is Fixed
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
