### PR TITLE
fix the issue of orthotropic direction for prop type09 when we have a…

### DIFF
--- a/starter/source/elements/shell/coque/corthini.F
+++ b/starter/source/elements/shell/coque/corthini.F
@@ -201,7 +201,7 @@ C--         y' of cylintrical sys (using xc,yc,zc)
 C---    read property data
         IF (IGTYP == 9) THEN
           DO I=JFT,JLT
-            PHI1(1,I)= GEO(10,PID)
+            PHI1(1,I)= ANGLE(I) + GEO(10,PID)
           ENDDO
         ELSEIF (IGTYP == 10) THEN
           DO I=JFT,JLT


### PR DESCRIPTION

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
the angle defined at element level is not considered in orthotropic direction for prop type 09

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

It's fixed
<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
