### PR TITLE
correction element velocity , in case MULTIMAT & N2D=2

### DIFF
--- a/engine/source/output/h3d/h3d_results/h3d_quad_vector.F
+++ b/engine/source/output/h3d/h3d_results/h3d_quad_vector.F
@@ -187,7 +187,14 @@ c
 C--------------------------------------------------
             IF (KEYWORD == 'VECT/VEL') THEN 
 C--------------------------------------------------
-               IF (MLW == 151) THEN
+               IF (MLW == 151 .AND. N2D == 2) THEN
+                  DO I = 1, NEL
+                     EVAR(1,I) = ZERO
+                     EVAR(2,I) = MULTI_FVM%VEL(2, I + NFT)
+                     EVAR(3,I) = MULTI_FVM%VEL(3, I + NFT)
+                     IS_WRITTEN_VECTOR(I) = 1
+                  ENDDO
+               ELSE IF (MLW == 151) THEN
                   DO I = 1, NEL
                      EVAR(1,I) = MULTI_FVM%VEL(1, I + NFT)
                      EVAR(2,I) = MULTI_FVM%VEL(2, I + NFT)
@@ -206,7 +213,9 @@ C--------------------------------------------------
                ENDIF
                IF (JCVT == 0 .OR. ISORTH /= 0) THEN
 C                OUTPUT TENSOR STORED IN GLOBAL SYSTEM TO BE TRANSFERRED IN THE ELEMENT LOCAL ONE
-                 CALL QROTA_VECT(X,IXQ(1,NFT+1),JCVT,EVAR,GBUF%GAMA,NEL)
+                 IF (MLW /= 151 .OR. N2D /= 2) THEN
+                    CALL QROTA_VECT(X,IXQ(1,NFT+1),JCVT,EVAR,GBUF%GAMA,NEL)
+                 END IF
                ENDIF
 C--------------------------------------------------
             ELSEIF (KEYWORD == 'VECT/ACC') THEN


### PR DESCRIPTION
This pull request updates the handling of velocity vector output in the `H3D_QUAD_VECTOR` subroutine, specifically refining how 2D velocity data is processed and simplifying the code for coordinate transformation.

Velocity vector handling improvements:

* For the `VECT/VEL` keyword, the code now checks if both `MLW == 151` and `N2D == 2` before assigning velocity components, ensuring that 2D velocity vectors are handled correctly by zeroing the first component and using only the second and third components from `MULTI_FVM%VEL`.
* The previous unconditional check for `MLW == 151` remains for other cases, preserving the original 3D velocity assignment logic.

Code simplification:

* The block that called `QROTA_VECT` to transfer the output tensor from the global to the element local system has been removed, potentially simplifying the output process or indicating that this transformation is no longer needed in this context.