### PR TITLE
h3d check version windows compil error

### DIFF
--- a/engine/source/output/h3d/h3d_build_cpp/c_h3d_export_library_version.cpp
+++ b/engine/source/output/h3d/h3d_build_cpp/c_h3d_export_library_version.cpp
@@ -61,7 +61,7 @@ extern "C"
 void c_h3d_export_library_version_(int *major_version, int *minor_version)
 {
     try {   
-        Hyper3DExportLibraryVersion((u_int32_t*)major_version, (u_int32_t*)minor_version);
+        Hyper3DExportLibraryVersion((uint32_t*)major_version, (uint32_t*)minor_version);
 
     } // end of try
 


### PR DESCRIPTION
This pull request makes a small but important change to the `c_h3d_export_library_version.cpp` file. The change updates the type used for casting version number pointers to ensure consistency and correctness with standard C++ types.

* Changed type cast from `u_int32_t` to `uint32_t` in the call to `Hyper3DExportLibraryVersion` for better portability and adherence to standard integer types.