### PR TITLE
h3d nodal vector FEXT & nodal scalar PEXT was wrong in some cases

### DIFF
--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -3093,8 +3093,9 @@ C
               IF (NFLOW>0) THEN
                 CALL FLOW0(OUTPUT,IFLOW, RFLOW,   WIFLOW, WRFLOW, NODES%X,
      .                     NODES%V,     NODES%A,       NPC,    TF,     SENSORS%SENSOR_TAB,
-     .                     NBGAUGE,LGAUGE,  GAUGE , NSENSOR,
-     .                     IGRV,   AGRV  ,NFUNCT  ,PYTHON, OUTPUT%TH%WFEXT)
+     .                     NBGAUGE,LGAUGE,  GAUGE , NSENSOR,  IGRV,   
+     .                     AGRV  ,NFUNCT  ,NUMNOD   ,PYTHON, OUTPUT%TH%WFEXT,
+     .                     NODA_FEXT, OUTPUT%DATA%NODA_SURF, OUTPUT%DATA%NODA_PEXT)
               ENDIF
 
 C----------------------------------------

--- a/engine/source/fluid/daasolv.F
+++ b/engine/source/fluid/daasolv.F
@@ -32,17 +32,20 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !||    python_funct_mod       ../common_source/modules/python_mod.F90
 !||    sensor_mod             ../common_source/modules/sensor_mod.F90
 !||====================================================================
-      SUBROUTINE DAASOLV(NDIM,   NNO,    NEL,   
+      SUBROUTINE DAASOLV(NDIM,   NNO,    NEL,   NUMNOD,
      .                   IFLOW,  IBUF,   ELEM,  SHELL_GA,
      .                   RFLOW,  NORMAL, TA,    AREAF, COSG,  DIST,  
      .                   MFLE,   ACCF,   PM,    PTI,   X, V, A, NPC, TF, 
      .                   NBGAUGE,LGAUGE, GAUGE, NSENSOR, SENSOR_TAB, IGRV, AGRV,
-     .                   CBEM   ,IPIV  , NFUNCT, PYTHON,WFEXT)
+     .                   CBEM   ,IPIV  , NFUNCT, PYTHON,WFEXT,
+     .                   NODA_FEXT, NODA_SURF, NODA_PEXT, OUTPUT)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------  
       USE SENSOR_MOD
       USE PYTHON_FUNCT_MOD
+      USE TH_MOD , ONLY : TH_HAS_NODA_PEXT
+      USE OUTPUT_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -56,15 +59,17 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER NDIM, NNO, NEL, NBGAUGE, NSENSOR, NFUNCT
+      INTEGER NDIM, NNO, NEL, NUMNOD, NBGAUGE, NSENSOR, NFUNCT
       INTEGER IFLOW(*), IBUF(*), ELEM(NDIM,*), SHELL_GA(*), NPC(*), LGAUGE(3,*)
       INTEGER IGRV(NIGRV,*), IPIV(*)
       my_real X(3,*), V(3,*), A(3,*), TF(*), RFLOW(*)
       my_real NORMAL(3,*), TA(*), AREAF(*), COSG(*), DIST(*), PM(*), ACCF(*), PTI(*)
       my_real MFLE(NEL,*), GAUGE(LLGAUGE,*),AGRV(LFACGRV,*)
       my_real CBEM(NEL,*)
+      my_real,INTENT(INOUT) :: NODA_FEXT(3,NUMNOD), NODA_SURF(NUMNOD), NODA_PEXT(NUMNOD)
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) :: SENSOR_TAB
       TYPE (PYTHON_), INTENT(INOUT) :: PYTHON
+      TYPE (OUTPUT_), INTENT(INOUT) :: OUTPUT
       DOUBLE PRECISION,INTENT(INOUT) :: WFEXT
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
@@ -583,8 +588,11 @@ C-----------------------------------------------
          PTOT = PP(I)+PS(I)+PR(I)+RHO*HH(I)*ABS(GRAVITY)
          FEL(I) = AREAF(I)*MAX(PTOT,PMIN)
       ENDDO
-C    
+C-----------------------------------------------------------
+C     Compute forces and populate A and NODA_FEXT arrays
+C-----------------------------------------------------------
       IF(JFORM == 1) THEN
+C Triangular elements
          DO I=1,NEL
              I1 = ELEM(1,I)
              I2 = ELEM(2,I)
@@ -600,14 +608,24 @@ C
              A(1,N1) = A(1,N1) + FF*NRX
              A(2,N1) = A(2,N1) + FF*NRY
              A(3,N1) = A(3,N1) + FF*NRZ
+             NODA_FEXT(1,N1) = NODA_FEXT(1,N1) + FF*NRX
+             NODA_FEXT(2,N1) = NODA_FEXT(2,N1) + FF*NRY
+             NODA_FEXT(3,N1) = NODA_FEXT(3,N1) + FF*NRZ
              A(1,N2) = A(1,N2) + FF*NRX
              A(2,N2) = A(2,N2) + FF*NRY
              A(3,N2) = A(3,N2) + FF*NRZ
+             NODA_FEXT(1,N2) = NODA_FEXT(1,N2) + FF*NRX
+             NODA_FEXT(2,N2) = NODA_FEXT(2,N2) + FF*NRY
+             NODA_FEXT(3,N2) = NODA_FEXT(3,N2) + FF*NRZ
              A(1,N3) = A(1,N3) + FF*NRX
              A(2,N3) = A(2,N3) + FF*NRY
              A(3,N3) = A(3,N3) + FF*NRZ
+             NODA_FEXT(1,N3) = NODA_FEXT(1,N3) + FF*NRX
+             NODA_FEXT(2,N3) = NODA_FEXT(2,N3) + FF*NRY
+             NODA_FEXT(3,N3) = NODA_FEXT(3,N3) + FF*NRZ
          ENDDO
       ELSEIF(JFORM == 2) THEN
+C Quadrangular elements
          WF(1)=FAC1*FOURTH
          WF(2)=FAC1*THIRD
          DO I=1,NEL
@@ -628,17 +646,89 @@ C
              A(1,N1) = A(1,N1) + FF*NRX
              A(2,N1) = A(2,N1) + FF*NRY
              A(3,N1) = A(3,N1) + FF*NRZ
+             NODA_FEXT(1,N1) = NODA_FEXT(1,N1) + FF*NRX
+             NODA_FEXT(2,N1) = NODA_FEXT(2,N1) + FF*NRY
+             NODA_FEXT(3,N1) = NODA_FEXT(3,N1) + FF*NRZ
              A(1,N2) = A(1,N2) + FF*NRX
              A(2,N2) = A(2,N2) + FF*NRY
              A(3,N2) = A(3,N2) + FF*NRZ
+             NODA_FEXT(1,N2) = NODA_FEXT(1,N2) + FF*NRX
+             NODA_FEXT(2,N2) = NODA_FEXT(2,N2) + FF*NRY
+             NODA_FEXT(3,N2) = NODA_FEXT(3,N2) + FF*NRZ
              A(1,N3) = A(1,N3) + FF*NRX
              A(2,N3) = A(2,N3) + FF*NRY
              A(3,N3) = A(3,N3) + FF*NRZ
+             NODA_FEXT(1,N3) = NODA_FEXT(1,N3) + FF*NRX
+             NODA_FEXT(2,N3) = NODA_FEXT(2,N3) + FF*NRY
+             NODA_FEXT(3,N3) = NODA_FEXT(3,N3) + FF*NRZ
              IF(I5 == 2) CYCLE
              A(1,N4) = A(1,N4) + FF*NRX
              A(2,N4) = A(2,N4) + FF*NRY
              A(3,N4) = A(3,N4) + FF*NRZ
+             NODA_FEXT(1,N4) = NODA_FEXT(1,N4) + FF*NRX
+             NODA_FEXT(2,N4) = NODA_FEXT(2,N4) + FF*NRY
+             NODA_FEXT(3,N4) = NODA_FEXT(3,N4) + FF*NRZ
          ENDDO
+      ENDIF
+C-----------------------------------------------------------
+C     Populate NODA_PEXT output array for H3D/NODA/PEXT
+C-----------------------------------------------------------
+      IF(TH_HAS_NODA_PEXT > 0 .OR. OUTPUT%DATA%ANIM_HAS_NODA_PEXT > 0 .OR. OUTPUT%DATA%H3D_HAS_NODA_PEXT > 0) THEN
+        IF(JFORM == 1) THEN
+          DO I=1,NEL
+             I1 = ELEM(1,I)
+             I2 = ELEM(2,I)
+             I3 = ELEM(3,I)
+             N1 = IBUF(I1)
+             N2 = IBUF(I2)
+             N3 = IBUF(I3)
+             PTOT = PP(I)+PS(I)+PR(I)+RHO*HH(I)*ABS(GRAVITY)
+             PTOT = MAX(PTOT,PMIN)
+             AREA2 = AREAF(I)*THIRD
+             NODA_SURF(N1) = NODA_SURF(N1) + AREA2
+             NODA_PEXT(N1) = NODA_PEXT(N1) + PTOT*AREA2
+             NODA_SURF(N2) = NODA_SURF(N2) + AREA2
+             NODA_PEXT(N2) = NODA_PEXT(N2) + PTOT*AREA2
+             NODA_SURF(N3) = NODA_SURF(N3) + AREA2
+             NODA_PEXT(N3) = NODA_PEXT(N3) + PTOT*AREA2
+          ENDDO
+        ELSEIF(JFORM == 2) THEN
+          WI(1,1)=FOURTH
+          WI(2,1)=FOURTH
+          WI(3,1)=FOURTH
+          WI(4,1)=FOURTH
+          WI(1,2)=THIRD
+          WI(2,2)=THIRD
+          WI(3,2)=THIRD
+          WI(4,2)=ZERO
+          DO I=1,NEL
+             I1 = ELEM(1,I)
+             I2 = ELEM(2,I)
+             I3 = ELEM(3,I)
+             I4 = ELEM(4,I)
+             I5 = ELEM(5,I)
+             N1 = IBUF(I1)
+             N2 = IBUF(I2)
+             N3 = IBUF(I3)
+             N4 = IBUF(I4)
+             PTOT = PP(I)+PS(I)+PR(I)+RHO*HH(I)*ABS(GRAVITY)
+             PTOT = MAX(PTOT,PMIN)
+             AREA2 = AREAF(I)*WI(1,I5)
+             NODA_SURF(N1) = NODA_SURF(N1) + AREA2
+             NODA_PEXT(N1) = NODA_PEXT(N1) + PTOT*AREA2
+             AREA2 = AREAF(I)*WI(2,I5)
+             NODA_SURF(N2) = NODA_SURF(N2) + AREA2
+             NODA_PEXT(N2) = NODA_PEXT(N2) + PTOT*AREA2
+             AREA2 = AREAF(I)*WI(3,I5)
+             NODA_SURF(N3) = NODA_SURF(N3) + AREA2
+             NODA_PEXT(N3) = NODA_PEXT(N3) + PTOT*AREA2
+             AREA2 = AREAF(I)*WI(4,I5)
+             IF(I5 == 1) THEN
+                NODA_SURF(N4) = NODA_SURF(N4) + AREA2
+                NODA_PEXT(N4) = NODA_PEXT(N4) + PTOT*AREA2
+             ENDIF
+          ENDDO
+        ENDIF
       ENDIF
 C-----------------------------------------------------------
 C     5. Gauge

--- a/engine/source/fluid/daasolvp.F
+++ b/engine/source/fluid/daasolvp.F
@@ -34,18 +34,21 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !||    python_funct_mod       ../common_source/modules/python_mod.F90
 !||    sensor_mod             ../common_source/modules/sensor_mod.F90
 !||====================================================================
-      SUBROUTINE DAASOLVP(NDIM,   NNO,    NEL,   NEL_LOC,
+      SUBROUTINE DAASOLVP(NDIM,   NNO,    NEL,   NEL_LOC, NUMNOD,
      .                    IFLOW,  IBUF,   ELEM,  IBUFL,   SHELL_GA,  CNP,
      .                    RFLOW,  NORMAL, TA,    AREAF,   COSG,      DIST,  
      .                    MFLE,   ACCF,   PM,    PTI, X,  V, A, NPC, TF, 
      .                    NBGAUGE,LGAUGE, GAUGE, NSENSOR, SENSOR_TAB, IGRV, AGRV,
      .                    CBEM   ,IPIV_L, MFLE_L,IBUFELR, IBUFELC,NFUNCT,
-     .                    PYTHON ,WFEXT)
+     .                    PYTHON ,WFEXT,
+     .                    NODA_FEXT, NODA_SURF, NODA_PEXT, OUTPUT)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------  
       USE SENSOR_MOD
       USE PYTHON_FUNCT_MOD
+      USE TH_MOD , ONLY : TH_HAS_NODA_PEXT
+      USE OUTPUT_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -61,7 +64,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER NDIM, NNO, NEL, NBGAUGE, NSENSOR, NEL_LOC,NFUNCT
+      INTEGER NDIM, NNO, NEL, NBGAUGE, NSENSOR, NEL_LOC, NUMNOD, NFUNCT
       INTEGER IFLOW(*), IBUF(*), ELEM(NDIM,*), SHELL_GA(*), NPC(*), LGAUGE(3,*)
       INTEGER IBUFL(*), CNP(*), IGRV(NIGRV,*)
       INTEGER IPIV_L(*), IBUFELR(NEL), IBUFELC(NEL)
@@ -69,8 +72,10 @@ C-----------------------------------------------
       my_real NORMAL(3,*), TA(*), AREAF(*), COSG(*), DIST(*), PM(*), ACCF(*), PTI(*)
       my_real MFLE(NEL,*), GAUGE(LLGAUGE,*), AGRV(LFACGRV,*)
       my_real CBEM(NEL,*), MFLE_L(NEL_LOC,*)
+      my_real,INTENT(INOUT) :: NODA_FEXT(3,NUMNOD), NODA_SURF(NUMNOD), NODA_PEXT(NUMNOD)
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) :: SENSOR_TAB
       TYPE (PYTHON_), INTENT(INOUT) :: PYTHON
+      TYPE (OUTPUT_), INTENT(INOUT) :: OUTPUT
       DOUBLE PRECISION,INTENT(INOUT) :: WFEXT
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
@@ -701,8 +706,11 @@ C-----------------------------------------------
          PTOT = PP(I)+PS(I)+PR(I)+RHO*HH(I)*ABS(GRAVITY)
          FEL(I) = AREAF(I)*MAX(PTOT,PMIN)
       ENDDO
-C    
+C-----------------------------------------------------------
+C     Compute forces and populate A and NODA_FEXT arrays
+C-----------------------------------------------------------
       IF(JFORM == 1) THEN
+C Triangular elements
         NEL_L=0
         DO I=1,NEL
            I1 = ELEM(1,I)
@@ -732,22 +740,32 @@ C
               A(1,N1) = A(1,N1) + FF*NRX
               A(2,N1) = A(2,N1) + FF*NRY
               A(3,N1) = A(3,N1) + FF*NRZ
+              NODA_FEXT(1,N1) = NODA_FEXT(1,N1) + FF*NRX
+              NODA_FEXT(2,N1) = NODA_FEXT(2,N1) + FF*NRY
+              NODA_FEXT(3,N1) = NODA_FEXT(3,N1) + FF*NRZ
               WFEXT   = WFEXT+FF*DT1*(NRX*V(1,N1)+NRY*V(2,N1)+NRZ*V(3,N1))/CNP(I1)
            ENDIF
            IF(N2/=0) THEN
               A(1,N2) = A(1,N2) + FF*NRX
               A(2,N2) = A(2,N2) + FF*NRY
               A(3,N2) = A(3,N2) + FF*NRZ
+              NODA_FEXT(1,N2) = NODA_FEXT(1,N2) + FF*NRX
+              NODA_FEXT(2,N2) = NODA_FEXT(2,N2) + FF*NRY
+              NODA_FEXT(3,N2) = NODA_FEXT(3,N2) + FF*NRZ
               WFEXT   = WFEXT+FF*DT1*(NRX*V(1,N2)+NRY*V(2,N2)+NRZ*V(3,N2))/CNP(I2)
            ENDIF
            IF(N3/=0) THEN
               A(1,N3) = A(1,N3) + FF*NRX
               A(2,N3) = A(2,N3) + FF*NRY
               A(3,N3) = A(3,N3) + FF*NRZ
+              NODA_FEXT(1,N3) = NODA_FEXT(1,N3) + FF*NRX
+              NODA_FEXT(2,N3) = NODA_FEXT(2,N3) + FF*NRY
+              NODA_FEXT(3,N3) = NODA_FEXT(3,N3) + FF*NRZ
               WFEXT   = WFEXT+FF*DT1*(NRX*V(1,N3)+NRY*V(2,N3)+NRZ*V(3,N3))/CNP(I3)
            ENDIF
         ENDDO
       ELSEIF(JFORM == 2) THEN
+C Quadrangular elements
         NEL_L=0
         DO I=1,NEL
            I1 = ELEM(1,I)
@@ -784,27 +802,113 @@ C
               A(1,N1) = A(1,N1) + FF*NRX
               A(2,N1) = A(2,N1) + FF*NRY
               A(3,N1) = A(3,N1) + FF*NRZ
+              NODA_FEXT(1,N1) = NODA_FEXT(1,N1) + FF*NRX
+              NODA_FEXT(2,N1) = NODA_FEXT(2,N1) + FF*NRY
+              NODA_FEXT(3,N1) = NODA_FEXT(3,N1) + FF*NRZ
               WFEXT   = WFEXT+FF*DT1*(NRX*V(1,N1)+NRY*V(2,N1)+NRZ*V(3,N1))/CNP(I1)
            ENDIF
            IF(N2/=0) THEN
               A(1,N2) = A(1,N2) + FF*NRX
               A(2,N2) = A(2,N2) + FF*NRY
               A(3,N2) = A(3,N2) + FF*NRZ
+              NODA_FEXT(1,N2) = NODA_FEXT(1,N2) + FF*NRX
+              NODA_FEXT(2,N2) = NODA_FEXT(2,N2) + FF*NRY
+              NODA_FEXT(3,N2) = NODA_FEXT(3,N2) + FF*NRZ
               WFEXT   = WFEXT+FF*DT1*(NRX*V(1,N2)+NRY*V(2,N2)+NRZ*V(3,N2))/CNP(I2)
            ENDIF
            IF(N3/=0) THEN
               A(1,N3) = A(1,N3) + FF*NRX
               A(2,N3) = A(2,N3) + FF*NRY
               A(3,N3) = A(3,N3) + FF*NRZ
+              NODA_FEXT(1,N3) = NODA_FEXT(1,N3) + FF*NRX
+              NODA_FEXT(2,N3) = NODA_FEXT(2,N3) + FF*NRY
+              NODA_FEXT(3,N3) = NODA_FEXT(3,N3) + FF*NRZ
               WFEXT   = WFEXT+FF*DT1*(NRX*V(1,N3)+NRY*V(2,N3)+NRZ*V(3,N3))/CNP(I3)
            ENDIF
            IF(N4/=0.AND.I5==1) THEN
               A(1,N4) = A(1,N4) + FF*NRX
               A(2,N4) = A(2,N4) + FF*NRY
               A(3,N4) = A(3,N4) + FF*NRZ
+              NODA_FEXT(1,N4) = NODA_FEXT(1,N4) + FF*NRX
+              NODA_FEXT(2,N4) = NODA_FEXT(2,N4) + FF*NRY
+              NODA_FEXT(3,N4) = NODA_FEXT(3,N4) + FF*NRZ
               WFEXT   = WFEXT+FF*DT1*(NRX*V(1,N4)+NRY*V(2,N4)+NRZ*V(3,N4))/CNP(I4)
            ENDIF
         ENDDO
+      ENDIF
+C-----------------------------------------------------------
+C     Populate NODA_PEXT output array for H3D/NODA/PEXT
+C-----------------------------------------------------------
+      IF(TH_HAS_NODA_PEXT > 0 .OR. OUTPUT%DATA%ANIM_HAS_NODA_PEXT > 0 .OR. OUTPUT%DATA%H3D_HAS_NODA_PEXT > 0) THEN
+        IF(JFORM == 1) THEN
+          DO I=1,NEL
+             I1 = ELEM(1,I)
+             I2 = ELEM(2,I)
+             I3 = ELEM(3,I)
+             N1 = IBUF(I1)
+             N2 = IBUF(I2)
+             N3 = IBUF(I3)
+             IF(N1==0.AND.N2==0.AND.N3==0) CYCLE
+             PTOT = PP(I)+PS(I)+PR(I)+RHO*HH(I)*ABS(GRAVITY)
+             PTOT = MAX(PTOT,PMIN)
+             AREA2 = AREAF(I)*THIRD
+             IF(N1/=0) THEN
+                NODA_SURF(N1) = NODA_SURF(N1) + AREA2
+                NODA_PEXT(N1) = NODA_PEXT(N1) + PTOT*AREA2
+             ENDIF
+             IF(N2/=0) THEN
+                NODA_SURF(N2) = NODA_SURF(N2) + AREA2
+                NODA_PEXT(N2) = NODA_PEXT(N2) + PTOT*AREA2
+             ENDIF
+             IF(N3/=0) THEN
+                NODA_SURF(N3) = NODA_SURF(N3) + AREA2
+                NODA_PEXT(N3) = NODA_PEXT(N3) + PTOT*AREA2
+             ENDIF
+          ENDDO
+        ELSEIF(JFORM == 2) THEN
+          WI(1,1)=FOURTH
+          WI(2,1)=FOURTH
+          WI(3,1)=FOURTH
+          WI(4,1)=FOURTH
+          WI(1,2)=THIRD
+          WI(2,2)=THIRD
+          WI(3,2)=THIRD
+          WI(4,2)=ZERO
+          DO I=1,NEL
+             I1 = ELEM(1,I)
+             I2 = ELEM(2,I)
+             I3 = ELEM(3,I)
+             I4 = ELEM(4,I)
+             I5 = ELEM(5,I)
+             N1 = IBUF(I1)
+             N2 = IBUF(I2)
+             N3 = IBUF(I3)
+             N4 = IBUF(I4)
+             IF(N1==0.AND.N2==0.AND.N3==0.AND.N4==0) CYCLE
+             PTOT = PP(I)+PS(I)+PR(I)+RHO*HH(I)*ABS(GRAVITY)
+             PTOT = MAX(PTOT,PMIN)
+             AREA2 = AREAF(I)*WI(1,I5)
+             IF(N1/=0) THEN
+                NODA_SURF(N1) = NODA_SURF(N1) + AREA2
+                NODA_PEXT(N1) = NODA_PEXT(N1) + PTOT*AREA2
+             ENDIF
+             AREA2 = AREAF(I)*WI(2,I5)
+             IF(N2/=0) THEN
+                NODA_SURF(N2) = NODA_SURF(N2) + AREA2
+                NODA_PEXT(N2) = NODA_PEXT(N2) + PTOT*AREA2
+             ENDIF
+             AREA2 = AREAF(I)*WI(3,I5)
+             IF(N3/=0) THEN
+                NODA_SURF(N3) = NODA_SURF(N3) + AREA2
+                NODA_PEXT(N3) = NODA_PEXT(N3) + PTOT*AREA2
+             ENDIF
+             AREA2 = AREAF(I)*WI(4,I5)
+             IF(N4/=0.AND.I5==1) THEN
+                NODA_SURF(N4) = NODA_SURF(N4) + AREA2
+                NODA_PEXT(N4) = NODA_PEXT(N4) + PTOT*AREA2
+             ENDIF
+          ENDDO
+        ENDIF
       ENDIF
 C-----------------------------------------------------------
 C     5. Gauge

--- a/engine/source/fluid/flow0.F
+++ b/engine/source/fluid/flow0.F
@@ -35,8 +35,9 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
 !||====================================================================
       SUBROUTINE FLOW0(OUTPUT,IFLOW  , RFLOW  , WIFLOW , WRFLOW, X      ,
      .                 V      , A      , NPC    , TF    , SENSOR_TAB,
-     .                 NBGAUGE, LGAUGE , GAUGE  , NSENSOR, 
-     .                 IGRV   , AGRV   , NFUNCT , PYTHON, WFEXT)
+     .                 NBGAUGE, LGAUGE , GAUGE  , NSENSOR, IGRV   ,
+     .                 AGRV   , NFUNCT , NUMNOD , PYTHON, WFEXT,
+     .                 NODA_FEXT, NODA_SURF, NODA_PEXT)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------  
@@ -59,10 +60,11 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       TYPE(OUTPUT_), INTENT(INOUT) :: OUTPUT
-      INTEGER ,INTENT(IN) :: NSENSOR,NBGAUGE,NFUNCT
+      INTEGER ,INTENT(IN) :: NSENSOR,NBGAUGE,NFUNCT,NUMNOD
       INTEGER IFLOW(*), WIFLOW(*), NPC(*),LGAUGE(3,*)
       INTEGER IGRV(NIGRV,*)
       my_real RFLOW(*), WRFLOW(*), X(3,*), V(3,*), A(3,*), TF(*), GAUGE(LLGAUGE,*), AGRV(LFACGRV,*)
+      my_real,INTENT(INOUT) :: NODA_FEXT(3,*), NODA_SURF(*), NODA_PEXT(*)
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) :: SENSOR_TAB
       TYPE (PYTHON_), INTENT(INOUT) :: PYTHON
       DOUBLE PRECISION,INTENT(INOUT) :: WFEXT
@@ -189,7 +191,8 @@ C-------------------------------------------------------------------------------
      .      NPC,         TF        ,  NSENSOR    , SENSOR_TAB ,
      .      IFLOW(II10), IFLOW(II6),  IFLOW(II13), IFLOW(II14), WIFLOW(IADIP), 
      .      WRFLOW(IADH),WRFLOW(IADG),IFLOW(II11), IFLOW(II12), IPINT,
-     .      PYTHON      ,WFEXT)
+     .      PYTHON      ,WFEXT,
+     .      NODA_FEXT, NODA_SURF, NODA_PEXT, OUTPUT)
 
          ELSEIF(ITYP == 3) THEN
             JFORM    = IFLOW(IADI+4)
@@ -218,12 +221,13 @@ C-------------------------------------------------------------------------------
 
             IF(NSPMD == 1) THEN
               II7=II6
-              CALL DAASOLV(NDIM, NNO, NEL,
+              CALL DAASOLV(NDIM, NNO, NEL, NUMNOD,
      .                     IFLOW(II1), IFLOW(II2), IFLOW(II3), IFLOW(II5), 
      .                     RFLOW(IR1), RFLOW(IR2), RFLOW(IR3), RFLOW(IR4), RFLOW(IR5), RFLOW(IR6), 
      .                     RFLOW(IR7), RFLOW(IR8), RFLOW(IR9), RFLOW(IR10),X, V, A, NPC, TF,  
      .                     NBGAUGE, LGAUGE, GAUGE, NSENSOR, SENSOR_TAB, IGRV, AGRV,
-     .                     RFLOW(IR11),IFLOW(II7), NFUNCT, PYTHON, WFEXT)
+     .                     RFLOW(IR11),IFLOW(II7), NFUNCT, PYTHON, WFEXT,
+     .                     NODA_FEXT, NODA_SURF, NODA_PEXT, OUTPUT)
             ELSE
               II7=II6+NNO
               II8=II7+NEL
@@ -231,13 +235,14 @@ C-------------------------------------------------------------------------------
               NEL_LOC =IFLOW(IADI+20)
               IADIP =IFLOW(IADI+10)
               IADH  =IFLOW(IADI+11)
-              CALL DAASOLVP(NDIM, NNO, NEL, NEL_LOC,
+              CALL DAASOLVP(NDIM, NNO, NEL, NEL_LOC, NUMNOD,
      .                      IFLOW(II1), IFLOW(II2), IFLOW(II3), IFLOW(II4), IFLOW(II5), IFLOW(II6), 
      .                      RFLOW(IR1), RFLOW(IR2), RFLOW(IR3), RFLOW(IR4), RFLOW(IR5), RFLOW(IR6), 
      .                      RFLOW(IR7), RFLOW(IR8), RFLOW(IR9), RFLOW(IR10),X, V, A, NPC, TF,  
      .                      NBGAUGE, LGAUGE, GAUGE, NSENSOR, SENSOR_TAB, IGRV, AGRV,
      .                      RFLOW(IR11),WIFLOW(IADIP), WRFLOW(IADH), IFLOW(II8), IFLOW(II9),
-     .                      NFUNCT, PYTHON, WFEXT)
+     .                      NFUNCT, PYTHON, WFEXT,
+     .                      NODA_FEXT, NODA_SURF, NODA_PEXT, OUTPUT)
             ENDIF
          ENDIF
          IADR=IADR+IFLOW(IADI+15)

--- a/engine/source/fluid/incpflow.F
+++ b/engine/source/fluid/incpflow.F
@@ -44,12 +44,15 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .                    NPC   , TF    , NSENSOR,SENSOR_TAB,
      .                    CNP   , ITAGEL, IBUFELR, IBUFELC, IPIV   ,
      .                    HBEM  , GBEM  , IBUFIL , CNPI   , IPINT  ,
-     .                    PYTHON, WFEXT )
+     .                    PYTHON, WFEXT ,
+     .                    NODA_FEXT, NODA_SURF, NODA_PEXT, OUTPUT)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------  
       USE SENSOR_MOD
       USE PYTHON_FUNCT_MOD
+      USE TH_MOD , ONLY : TH_HAS_NODA_PEXT
+      USE OUTPUT_MOD
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -78,8 +81,10 @@ C-----------------------------------------------
      .        RFLOW(*), PHI(*), PRES(*), U(3,*), RINOUT(NRIOFLOW,*),
      .        X(3,*), V(3,*), A(3,*), TF(*), HBEM(*),
      .        GBEM(*)
+      my_real,INTENT(INOUT) :: NODA_FEXT(3,NUMNOD), NODA_SURF(NUMNOD), NODA_PEXT(NUMNOD)
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) :: SENSOR_TAB
       TYPE(PYTHON_) , INTENT(INOUT) :: PYTHON
+      TYPE(OUTPUT_) , INTENT(INOUT) :: OUTPUT
       DOUBLE PRECISION,INTENT(INOUT) :: WFEXT
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
@@ -108,7 +113,8 @@ C-----------------------------------------------
      .        SFPA, SFPRES, RHO, PA, PIO, PHI_OLD(NNO+NNI), UU,
      .        COEF, AREA2, W, KSI, ETA, VAL1, VAL2, VAL3, X0, Y0, Z0,
      .        R2, D2, VGX_OLD, VGY_OLD, VGZ_OLD, VGX, VGY, VGZ, AGX,
-     .        AGY, AGZ, SFVINI, VV, PHIP(NNO+NNI), PHI_INF(NNO+NNI)
+     .        AGY, AGZ, SFVINI, VV, PHIP(NNO+NNI), PHI_INF(NNO+NNI),
+     .        PRES_AVG
       INTEGER NPG
       my_real PG(50), WPG(25)
       DATA PG  /.33333333,.33333333,
@@ -1140,7 +1146,7 @@ C pressure imposed at inlet/outlet
          ENDDO
       ENDIF   
 C---------------------------------------------------
-C 5- Force on the boundary
+C 5- Force on the boundary and populate FEXT arrays
 C---------------------------------------------------
       IF (NSPMD == 1) THEN
          DO I=1,NEL
@@ -1157,18 +1163,27 @@ C---------------------------------------------------
             A(1,NN1)=A(1,NN1)+COEF*NRX
             A(2,NN1)=A(2,NN1)+COEF*NRY
             A(3,NN1)=A(3,NN1)+COEF*NRZ
-            A(1,NN2)=A(1,NN2)+COEF*NRX
-            A(2,NN2)=A(2,NN2)+COEF*NRY
-            A(3,NN2)=A(3,NN2)+COEF*NRZ
-            A(1,NN3)=A(1,NN3)+COEF*NRX
-            A(2,NN3)=A(2,NN3)+COEF*NRY
-            A(3,NN3)=A(3,NN3)+COEF*NRZ
+            NODA_FEXT(1,NN1) = NODA_FEXT(1,NN1) + COEF*NRX
+            NODA_FEXT(2,NN1) = NODA_FEXT(2,NN1) + COEF*NRY
+            NODA_FEXT(3,NN1) = NODA_FEXT(3,NN1) + COEF*NRZ
             WFEXT=WFEXT+COEF*NRX*V(1,NN1)*DT1
      .                 +COEF*NRY*V(2,NN1)*DT1
      .                 +COEF*NRZ*V(3,NN1)*DT1
+            A(1,NN2)=A(1,NN2)+COEF*NRX
+            A(2,NN2)=A(2,NN2)+COEF*NRY
+            A(3,NN2)=A(3,NN2)+COEF*NRZ
+            NODA_FEXT(1,NN2) = NODA_FEXT(1,NN2) + COEF*NRX
+            NODA_FEXT(2,NN2) = NODA_FEXT(2,NN2) + COEF*NRY
+            NODA_FEXT(3,NN2) = NODA_FEXT(3,NN2) + COEF*NRZ
             WFEXT=WFEXT+COEF*NRX*V(1,NN2)*DT1
      .                 +COEF*NRY*V(2,NN2)*DT1
      .                 +COEF*NRZ*V(3,NN2)*DT1
+            A(1,NN3)=A(1,NN3)+COEF*NRX
+            A(2,NN3)=A(2,NN3)+COEF*NRY
+            A(3,NN3)=A(3,NN3)+COEF*NRZ
+            NODA_FEXT(1,NN3) = NODA_FEXT(1,NN3) + COEF*NRX
+            NODA_FEXT(2,NN3) = NODA_FEXT(2,NN3) + COEF*NRY
+            NODA_FEXT(3,NN3) = NODA_FEXT(3,NN3) + COEF*NRZ
             WFEXT=WFEXT+COEF*NRX*V(1,NN3)*DT1
      .                 +COEF*NRY*V(2,NN3)*DT1
      .                 +COEF*NRZ*V(3,NN3)*DT1
@@ -1198,6 +1213,9 @@ C---------------------------------------------------
                A(1,NN1)=A(1,NN1)+COEF*NRX
                A(2,NN1)=A(2,NN1)+COEF*NRY
                A(3,NN1)=A(3,NN1)+COEF*NRZ
+               NODA_FEXT(1,NN1) = NODA_FEXT(1,NN1) + COEF*NRX
+               NODA_FEXT(2,NN1) = NODA_FEXT(2,NN1) + COEF*NRY
+               NODA_FEXT(3,NN1) = NODA_FEXT(3,NN1) + COEF*NRZ
                WFEXT=WFEXT+COEF*NRX*V(1,NN1)*DT1
      .                    +COEF*NRY*V(2,NN1)*DT1
      .                    +COEF*NRZ*V(3,NN1)*DT1
@@ -1207,6 +1225,9 @@ C---------------------------------------------------
                A(1,NN2)=A(1,NN2)+COEF*NRX
                A(2,NN2)=A(2,NN2)+COEF*NRY
                A(3,NN2)=A(3,NN2)+COEF*NRZ
+               NODA_FEXT(1,NN2) = NODA_FEXT(1,NN2) + COEF*NRX
+               NODA_FEXT(2,NN2) = NODA_FEXT(2,NN2) + COEF*NRY
+               NODA_FEXT(3,NN2) = NODA_FEXT(3,NN2) + COEF*NRZ
                WFEXT=WFEXT+COEF*NRX*V(1,NN2)*DT1
      .                    +COEF*NRY*V(2,NN2)*DT1
      .                    +COEF*NRZ*V(3,NN2)*DT1
@@ -1216,12 +1237,64 @@ C---------------------------------------------------
                A(1,NN3)=A(1,NN3)+COEF*NRX
                A(2,NN3)=A(2,NN3)+COEF*NRY
                A(3,NN3)=A(3,NN3)+COEF*NRZ
+               NODA_FEXT(1,NN3) = NODA_FEXT(1,NN3) + COEF*NRX
+               NODA_FEXT(2,NN3) = NODA_FEXT(2,NN3) + COEF*NRY
+               NODA_FEXT(3,NN3) = NODA_FEXT(3,NN3) + COEF*NRZ
                WFEXT=WFEXT+COEF*NRX*V(1,NN3)*DT1
      .                    +COEF*NRY*V(2,NN3)*DT1
      .                    +COEF*NRZ*V(3,NN3)*DT1
             ENDIF
          ENDDO      
-      ENDIF 
+      ENDIF
+C---------------------------------------------------
+C     Populate NODA_PEXT output array for H3D/NODA/PEXT
+C---------------------------------------------------
+      IF(TH_HAS_NODA_PEXT > 0 .OR. OUTPUT%DATA%ANIM_HAS_NODA_PEXT > 0 .OR. OUTPUT%DATA%H3D_HAS_NODA_PEXT > 0) THEN
+        IF (NSPMD == 1) THEN
+          DO I=1,NEL
+             N1=ELEM(1,I)
+             N2=ELEM(2,I)
+             N3=ELEM(3,I)
+             NN1=IBUF(N1)
+             NN2=IBUF(N2)
+             NN3=IBUF(N3)
+             AREA=SQRT(NORM(1,I)**2+NORM(2,I)**2+NORM(3,I)**2)
+             AREA2=AREA*THIRD
+             PRES_AVG=THIRD*(PRES(N1)+PRES(N2)+PRES(N3))
+             NODA_SURF(NN1) = NODA_SURF(NN1) + AREA2
+             NODA_PEXT(NN1) = NODA_PEXT(NN1) + PRES_AVG*AREA2
+             NODA_SURF(NN2) = NODA_SURF(NN2) + AREA2
+             NODA_PEXT(NN2) = NODA_PEXT(NN2) + PRES_AVG*AREA2
+             NODA_SURF(NN3) = NODA_SURF(NN3) + AREA2
+             NODA_PEXT(NN3) = NODA_PEXT(NN3) + PRES_AVG*AREA2
+          ENDDO
+        ELSE
+          DO I=1,NEL
+             N1=ELEM(1,I)
+             N2=ELEM(2,I)
+             N3=ELEM(3,I)
+             IF(IBUF(N1)==0.AND.IBUF(N2)==0.AND.IBUF(N3)==0) CYCLE
+             AREA=SQRT(NORM(1,I)**2+NORM(2,I)**2+NORM(3,I)**2)
+             AREA2=AREA*THIRD
+             PRES_AVG=THIRD*(PRES(N1)+PRES(N2)+PRES(N3))
+             IF (IBUF(N1)/=0) THEN
+                NN1=IBUF(N1)
+                NODA_SURF(NN1) = NODA_SURF(NN1) + AREA2
+                NODA_PEXT(NN1) = NODA_PEXT(NN1) + PRES_AVG*AREA2
+             ENDIF
+             IF (IBUF(N2)/=0) THEN
+                NN2=IBUF(N2)
+                NODA_SURF(NN2) = NODA_SURF(NN2) + AREA2
+                NODA_PEXT(NN2) = NODA_PEXT(NN2) + PRES_AVG*AREA2
+             ENDIF
+             IF (IBUF(N3)/=0) THEN
+                NN3=IBUF(N3)
+                NODA_SURF(NN3) = NODA_SURF(NN3) + AREA2
+                NODA_PEXT(NN3) = NODA_PEXT(NN3) + PRES_AVG*AREA2
+             ENDIF
+          ENDDO
+        ENDIF
+      ENDIF
 
       RETURN
       END


### PR DESCRIPTION
This pull request extends the fluid solver functionality to compute and output per-node external force and pressure data, enabling enhanced post-processing and visualization capabilities (such as H3D/NODA/PEXT output). The changes add new arrays for nodal forces and pressures, propagate them through the solver routines, and conditionally compute their values for both triangular and quadrangular elements.

Key changes:

**Per-node output arrays and argument propagation**
- Added new arrays `NODA_FEXT`, `NODA_SURF`, and `NODA_PEXT` to store per-node external force vectors, nodal surface areas, and nodal external pressures, respectively. These arrays are now passed as arguments through `FLOW0`, `DAASOLV`, and `DAASOLVP` subroutines, with corresponding updates to their signatures and calls. (`engine/source/fluid/flow0.F`, `engine/source/fluid/daasolv.F`, `engine/source/fluid/daasolvp.F`, `engine/source/engine/resol.F`) [[1]](diffhunk://#diff-c05e51895c2aed2403a8115e13a5547486eb47c95e2e6177895c8bbca0b3fea1L38-R40) [[2]](diffhunk://#diff-c05e51895c2aed2403a8115e13a5547486eb47c95e2e6177895c8bbca0b3fea1L62-R67) [[3]](diffhunk://#diff-c05e51895c2aed2403a8115e13a5547486eb47c95e2e6177895c8bbca0b3fea1L192-R195) [[4]](diffhunk://#diff-c05e51895c2aed2403a8115e13a5547486eb47c95e2e6177895c8bbca0b3fea1L221-R245) [[5]](diffhunk://#diff-3e2ac2d2f6cfc87f76fe6d38618893d7f21aeb07b67fe397b8920ba873999581L35-R48) [[6]](diffhunk://#diff-3e2ac2d2f6cfc87f76fe6d38618893d7f21aeb07b67fe397b8920ba873999581L59-R72) [[7]](diffhunk://#diff-4367657a32d4388d3e2a718a272e290c5de137642a13d8c4920ff4bf804603f6L37-R51) [[8]](diffhunk://#diff-4367657a32d4388d3e2a718a272e290c5de137642a13d8c4920ff4bf804603f6L64-R78) [[9]](diffhunk://#diff-2eaeb6f8dcb8a2cba073099065e617edc2117c7ef01372c7d59c096fa81124c1L3095-R3097)

**Computation of nodal forces and pressures**
- Updated the element assembly loops in `DAASOLV` and `DAASOLVP` to accumulate external forces into the new `NODA_FEXT` array for each node, for both triangular and quadrangular elements. (`engine/source/fluid/daasolv.F`, `engine/source/fluid/daasolvp.F`) [[1]](diffhunk://#diff-3e2ac2d2f6cfc87f76fe6d38618893d7f21aeb07b67fe397b8920ba873999581L586-R595) [[2]](diffhunk://#diff-3e2ac2d2f6cfc87f76fe6d38618893d7f21aeb07b67fe397b8920ba873999581R611-R628) [[3]](diffhunk://#diff-3e2ac2d2f6cfc87f76fe6d38618893d7f21aeb07b67fe397b8920ba873999581R649-R733) [[4]](diffhunk://#diff-4367657a32d4388d3e2a718a272e290c5de137642a13d8c4920ff4bf804603f6L704-R713) [[5]](diffhunk://#diff-4367657a32d4388d3e2a718a272e290c5de137642a13d8c4920ff4bf804603f6R743-R768) [[6]](diffhunk://#diff-4367657a32d4388d3e2a718a272e290c5de137642a13d8c4920ff4bf804603f6R805-R913)

- Added logic to conditionally accumulate nodal surface areas and pressures into `NODA_SURF` and `NODA_PEXT` arrays, based on output flags (e.g., for H3D/NODA/PEXT output), for both element types. (`engine/source/fluid/daasolv.F`, `engine/source/fluid/daasolvp.F`) [[1]](diffhunk://#diff-3e2ac2d2f6cfc87f76fe6d38618893d7f21aeb07b67fe397b8920ba873999581R649-R733) [[2]](diffhunk://#diff-4367657a32d4388d3e2a718a272e290c5de137642a13d8c4920ff4bf804603f6R805-R913)

**Module usage and intent specifications**
- Updated subroutines to use relevant modules (`TH_MOD`, `OUTPUT_MOD`) and added appropriate `INTENT(INOUT)` specifications for the new arrays and output structures. (`engine/source/fluid/daasolv.F`, `engine/source/fluid/daasolvp.F`) [[1]](diffhunk://#diff-3e2ac2d2f6cfc87f76fe6d38618893d7f21aeb07b67fe397b8920ba873999581L35-R48) [[2]](diffhunk://#diff-3e2ac2d2f6cfc87f76fe6d38618893d7f21aeb07b67fe397b8920ba873999581L59-R72) [[3]](diffhunk://#diff-4367657a32d4388d3e2a718a272e290c5de137642a13d8c4920ff4bf804603f6L37-R51) [[4]](diffhunk://#diff-4367657a32d4388d3e2a718a272e290c5de137642a13d8c4920ff4bf804603f6L64-R78)

These changes enable the codebase to compute and export per-node external force and pressure data, facilitating advanced visualization and analysis in downstream tools.