### PR TITLE
correction segmentation issue FEXT

### DIFF
--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -1176,7 +1176,7 @@ C End Parith/ON specific
               my_real DT3
               INTEGER  IGROUPFLG(2)
               INTEGER, DIMENSION(:),ALLOCATABLE :: IGROUPC,IGROUPTG,IGROUPS
-              INTEGER  IOLDSECT
+              INTEGER  IOLDSECT,S_NODA_FEXT
               ! TETRA4 : SMOOTH FINITE ELEMENT FORMULATIONS now in SFEM%
 C-----------------------------------------------------------------------------------
 C Parith/OFF + AMS
@@ -1833,13 +1833,13 @@ C ---------------------
 C Allocating FEXT Array
 C ---------------------
               IF(ANIM_V(5)+OUTP_V(5)+H3D_DATA%N_VECT_FINT+
-     .           ANIM_V(6)+OUTP_V(6)+H3D_DATA%N_VECT_FEXT >0 .or. ViperCoupling) THEN
-                ALLOCATE(NODA_FEXT(3*NUMNOD))
-                NODA_FEXT(1:3*NUMNOD)=ZERO
+     .           ANIM_V(6)+OUTP_V(6)+H3D_DATA%N_VECT_FEXT >0 .or. ViperCoupling .OR. NFLOW>0 ) THEN
+                S_NODA_FEXT = NUMNOD
               ELSE
-                ALLOCATE(NODA_FEXT(3))
-                NODA_FEXT(1:3)=ZERO
+                S_NODA_FEXT = 1
               ENDIF
+              ALLOCATE(NODA_FEXT(3*S_NODA_FEXT))
+              NODA_FEXT(1:3*S_NODA_FEXT)=ZERO
 C ---------------------
 C Allocating PEXT Array
 C ---------------------
@@ -3095,7 +3095,7 @@ C
      .                     NODES%V,     NODES%A,       NPC,    TF,     SENSORS%SENSOR_TAB,
      .                     NBGAUGE,LGAUGE,  GAUGE , NSENSOR,  IGRV,   
      .                     AGRV  ,NFUNCT  ,NUMNOD   ,PYTHON, OUTPUT%TH%WFEXT,
-     .                     NODA_FEXT, OUTPUT%DATA%NODA_SURF, OUTPUT%DATA%NODA_PEXT)
+     .                     S_NODA_FEXT, NODA_FEXT, OUTPUT%DATA%NODA_SURF, OUTPUT%DATA%NODA_PEXT)
               ENDIF
 
 C----------------------------------------

--- a/engine/source/fluid/daasolv.F
+++ b/engine/source/fluid/daasolv.F
@@ -40,7 +40,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .                   MFLE,   ACCF,   PM,    PTI,   X, V, A, NPC, TF, 
      .                   NBGAUGE,LGAUGE, GAUGE, NSENSOR, SENSOR_TAB, IGRV, AGRV,
      .                   CBEM   ,IPIV  , NFUNCT, PYTHON,WFEXT,
-     .                   NODA_FEXT, NODA_SURF, NODA_PEXT, OUTPUT)
+     .                   S_NODA_FEXT, NODA_FEXT, NODA_SURF, NODA_PEXT, OUTPUT)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------  
@@ -61,14 +61,14 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER NDIM, NNO, NEL, NUMNOD, NBGAUGE, NSENSOR, NFUNCT
+      INTEGER NDIM, NNO, NEL, NUMNOD, NBGAUGE, NSENSOR, NFUNCT, S_NODA_FEXT
       INTEGER IFLOW(*), IBUF(*), ELEM(NDIM,*), SHELL_GA(*), NPC(*), LGAUGE(3,*)
       INTEGER IGRV(NIGRV,*), IPIV(*)
       my_real X(3,*), V(3,*), A(3,*), TF(*), RFLOW(*)
       my_real NORMAL(3,*), TA(*), AREAF(*), COSG(*), DIST(*), PM(*), ACCF(*), PTI(*)
       my_real MFLE(NEL,*), GAUGE(LLGAUGE,*),AGRV(LFACGRV,*)
       my_real CBEM(NEL,*)
-      my_real,INTENT(INOUT) :: NODA_FEXT(3,NUMNOD), NODA_SURF(NUMNOD), NODA_PEXT(NUMNOD)
+      my_real,INTENT(INOUT) :: NODA_FEXT(3,S_NODA_FEXT), NODA_SURF(NUMNOD), NODA_PEXT(NUMNOD)
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) :: SENSOR_TAB
       TYPE (PYTHON_), INTENT(INOUT) :: PYTHON
       TYPE (OUTPUT_), INTENT(INOUT) :: OUTPUT

--- a/engine/source/fluid/daasolvp.F
+++ b/engine/source/fluid/daasolvp.F
@@ -43,7 +43,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .                    NBGAUGE,LGAUGE, GAUGE, NSENSOR, SENSOR_TAB, IGRV, AGRV,
      .                    CBEM   ,IPIV_L, MFLE_L,IBUFELR, IBUFELC,NFUNCT,
      .                    PYTHON ,WFEXT,
-     .                    NODA_FEXT, NODA_SURF, NODA_PEXT, OUTPUT)
+     .                    S_NODA_FEXT, NODA_FEXT, NODA_SURF, NODA_PEXT, OUTPUT)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------  
@@ -66,7 +66,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      INTEGER NDIM, NNO, NEL, NBGAUGE, NSENSOR, NEL_LOC, NUMNOD, NFUNCT
+      INTEGER NDIM, NNO, NEL, NBGAUGE, NSENSOR, NEL_LOC, NUMNOD, NFUNCT, S_NODA_FEXT
       INTEGER IFLOW(*), IBUF(*), ELEM(NDIM,*), SHELL_GA(*), NPC(*), LGAUGE(3,*)
       INTEGER IBUFL(*), CNP(*), IGRV(NIGRV,*)
       INTEGER IPIV_L(*), IBUFELR(NEL), IBUFELC(NEL)
@@ -74,7 +74,7 @@ C-----------------------------------------------
       my_real NORMAL(3,*), TA(*), AREAF(*), COSG(*), DIST(*), PM(*), ACCF(*), PTI(*)
       my_real MFLE(NEL,*), GAUGE(LLGAUGE,*), AGRV(LFACGRV,*)
       my_real CBEM(NEL,*), MFLE_L(NEL_LOC,*)
-      my_real,INTENT(INOUT) :: NODA_FEXT(3,NUMNOD), NODA_SURF(NUMNOD), NODA_PEXT(NUMNOD)
+      my_real,INTENT(INOUT) :: NODA_FEXT(3,S_NODA_FEXT), NODA_SURF(NUMNOD), NODA_PEXT(NUMNOD)
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) :: SENSOR_TAB
       TYPE (PYTHON_), INTENT(INOUT) :: PYTHON
       TYPE (OUTPUT_), INTENT(INOUT) :: OUTPUT

--- a/engine/source/fluid/flow0.F
+++ b/engine/source/fluid/flow0.F
@@ -37,7 +37,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .                 V      , A      , NPC    , TF    , SENSOR_TAB,
      .                 NBGAUGE, LGAUGE , GAUGE  , NSENSOR, IGRV   ,
      .                 AGRV   , NFUNCT , NUMNOD , PYTHON, WFEXT,
-     .                 NODA_FEXT, NODA_SURF, NODA_PEXT)
+     .                 S_NODA_FEXT, NODA_FEXT, NODA_SURF, NODA_PEXT)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------  
@@ -60,11 +60,11 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       TYPE(OUTPUT_), INTENT(INOUT) :: OUTPUT
-      INTEGER ,INTENT(IN) :: NSENSOR,NBGAUGE,NFUNCT,NUMNOD
+      INTEGER ,INTENT(IN) :: NSENSOR,NBGAUGE,NFUNCT,NUMNOD,S_NODA_FEXT
       INTEGER IFLOW(*), WIFLOW(*), NPC(*),LGAUGE(3,*)
       INTEGER IGRV(NIGRV,*)
       my_real RFLOW(*), WRFLOW(*), X(3,*), V(3,*), A(3,*), TF(*), GAUGE(LLGAUGE,*), AGRV(LFACGRV,*)
-      my_real,INTENT(INOUT) :: NODA_FEXT(3,*), NODA_SURF(*), NODA_PEXT(*)
+      my_real,INTENT(INOUT) :: NODA_FEXT(3,S_NODA_FEXT), NODA_SURF(NUMNOD), NODA_PEXT(NUMNOD)
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) :: SENSOR_TAB
       TYPE (PYTHON_), INTENT(INOUT) :: PYTHON
       DOUBLE PRECISION,INTENT(INOUT) :: WFEXT
@@ -192,7 +192,7 @@ C-------------------------------------------------------------------------------
      .      IFLOW(II10), IFLOW(II6),  IFLOW(II13), IFLOW(II14), WIFLOW(IADIP), 
      .      WRFLOW(IADH),WRFLOW(IADG),IFLOW(II11), IFLOW(II12), IPINT,
      .      PYTHON      ,WFEXT,
-     .      NODA_FEXT, NODA_SURF, NODA_PEXT, OUTPUT)
+     .      S_NODA_FEXT,NODA_FEXT, NODA_SURF, NODA_PEXT, OUTPUT)
 
          ELSEIF(ITYP == 3) THEN
             JFORM    = IFLOW(IADI+4)
@@ -227,7 +227,7 @@ C-------------------------------------------------------------------------------
      .                     RFLOW(IR7), RFLOW(IR8), RFLOW(IR9), RFLOW(IR10),X, V, A, NPC, TF,  
      .                     NBGAUGE, LGAUGE, GAUGE, NSENSOR, SENSOR_TAB, IGRV, AGRV,
      .                     RFLOW(IR11),IFLOW(II7), NFUNCT, PYTHON, WFEXT,
-     .                     NODA_FEXT, NODA_SURF, NODA_PEXT, OUTPUT)
+     .                     S_NODA_FEXT, NODA_FEXT, NODA_SURF, NODA_PEXT, OUTPUT)
             ELSE
               II7=II6+NNO
               II8=II7+NEL
@@ -242,7 +242,7 @@ C-------------------------------------------------------------------------------
      .                      NBGAUGE, LGAUGE, GAUGE, NSENSOR, SENSOR_TAB, IGRV, AGRV,
      .                      RFLOW(IR11),WIFLOW(IADIP), WRFLOW(IADH), IFLOW(II8), IFLOW(II9),
      .                      NFUNCT, PYTHON, WFEXT,
-     .                      NODA_FEXT, NODA_SURF, NODA_PEXT, OUTPUT)
+     .                      S_NODA_FEXT, NODA_FEXT, NODA_SURF, NODA_PEXT, OUTPUT)
             ENDIF
          ENDIF
          IADR=IADR+IFLOW(IADI+15)

--- a/engine/source/fluid/incpflow.F
+++ b/engine/source/fluid/incpflow.F
@@ -47,7 +47,7 @@ Copyright>        commercial version may interest you: https://www.altair.com/ra
      .                    CNP   , ITAGEL, IBUFELR, IBUFELC, IPIV   ,
      .                    HBEM  , GBEM  , IBUFIL , CNPI   , IPINT  ,
      .                    PYTHON, WFEXT ,
-     .                    NODA_FEXT, NODA_SURF, NODA_PEXT, OUTPUT)
+     .                    S_NODA_FEXT,NODA_FEXT, NODA_SURF, NODA_PEXT, OUTPUT)
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------  
@@ -78,12 +78,12 @@ C-----------------------------------------------
      .        IINOUT(NIIOFLOW,*), IBUFI(*), IBUFR(*), IBUFC(*), 
      .        IBUFL(*), NPC(*),CNP(*),
      .        ITAGEL(*), IBUFELR(*), IBUFELC(*), IPIV(*), IBUFIL(*),
-     .        CNPI(*), IPINT, ISMOOTH
+     .        CNPI(*), IPINT, ISMOOTH,S_NODA_FEXT
       my_real
      .        RFLOW(*), PHI(*), PRES(*), U(3,*), RINOUT(NRIOFLOW,*),
      .        X(3,*), V(3,*), A(3,*), TF(*), HBEM(*),
      .        GBEM(*)
-      my_real,INTENT(INOUT) :: NODA_FEXT(3,NUMNOD), NODA_SURF(NUMNOD), NODA_PEXT(NUMNOD)
+      my_real,INTENT(INOUT) :: NODA_FEXT(3,S_NODA_FEXT), NODA_SURF(NUMNOD), NODA_PEXT(NUMNOD)
       TYPE (SENSOR_STR_) ,DIMENSION(NSENSOR) :: SENSOR_TAB
       TYPE(PYTHON_) , INTENT(INOUT) :: PYTHON
       TYPE(OUTPUT_) , INTENT(INOUT) :: OUTPUT


### PR DESCRIPTION
This pull request updates the handling of the `NODA_FEXT` array across several fluid and structural solver routines to allow for a flexible size, rather than always allocating it with the number of nodes. The main change is introducing a new argument, `S_NODA_FEXT`, which specifies the size of the second dimension of `NODA_FEXT`. This improves memory allocation and ensures consistency for cases where the number of nodes may not match the required size for `NODA_FEXT`. All related subroutines and their calls have been updated accordingly.

**Dynamic sizing of `NODA_FEXT`:**

* In `resol.F`, the allocation of `NODA_FEXT` is changed to use a variable size (`S_NODA_FEXT`), which is set based on runtime conditions, and all allocations and initializations are updated to use this size. The subroutine call to the fluid solver is updated to pass `S_NODA_FEXT` as an argument. [[1]](diffhunk://#diff-2eaeb6f8dcb8a2cba073099065e617edc2117c7ef01372c7d59c096fa81124c1L1179-R1179) [[2]](diffhunk://#diff-2eaeb6f8dcb8a2cba073099065e617edc2117c7ef01372c7d59c096fa81124c1L1836-R1842) [[3]](diffhunk://#diff-2eaeb6f8dcb8a2cba073099065e617edc2117c7ef01372c7d59c096fa81124c1L3098-R3098)

**Interface and argument updates in fluid solver routines:**

* The subroutines `DAASOLV`, `DAASOLVP`, `FLOW0`, and `INCPFLOW` in the fluid solver source files are updated to accept the new `S_NODA_FEXT` argument, and all calls to these subroutines are updated to pass this argument. [[1]](diffhunk://#diff-3e2ac2d2f6cfc87f76fe6d38618893d7f21aeb07b67fe397b8920ba873999581L43-R43) [[2]](diffhunk://#diff-3e2ac2d2f6cfc87f76fe6d38618893d7f21aeb07b67fe397b8920ba873999581L64-R71) [[3]](diffhunk://#diff-4367657a32d4388d3e2a718a272e290c5de137642a13d8c4920ff4bf804603f6L46-R46) [[4]](diffhunk://#diff-4367657a32d4388d3e2a718a272e290c5de137642a13d8c4920ff4bf804603f6L69-R77) [[5]](diffhunk://#diff-c05e51895c2aed2403a8115e13a5547486eb47c95e2e6177895c8bbca0b3fea1L40-R40) [[6]](diffhunk://#diff-c05e51895c2aed2403a8115e13a5547486eb47c95e2e6177895c8bbca0b3fea1L63-R67) [[7]](diffhunk://#diff-c05e51895c2aed2403a8115e13a5547486eb47c95e2e6177895c8bbca0b3fea1L195-R195) [[8]](diffhunk://#diff-c05e51895c2aed2403a8115e13a5547486eb47c95e2e6177895c8bbca0b3fea1L230-R230) [[9]](diffhunk://#diff-c05e51895c2aed2403a8115e13a5547486eb47c95e2e6177895c8bbca0b3fea1L245-R245) [[10]](diffhunk://#diff-23011ac2ee4b790c501d90ac851024a4e2f2164219b12ec84498694e4538ae70L50-R50) [[11]](diffhunk://#diff-23011ac2ee4b790c501d90ac851024a4e2f2164219b12ec84498694e4538ae70L81-R86)

**Array declaration and intent changes:**

* The declaration of `NODA_FEXT` in all affected subroutines is changed from a fixed size (`NUMNOD`) to use the runtime-determined size (`S_NODA_FEXT`), ensuring that the second dimension matches the allocated size. [[1]](diffhunk://#diff-3e2ac2d2f6cfc87f76fe6d38618893d7f21aeb07b67fe397b8920ba873999581L64-R71) [[2]](diffhunk://#diff-4367657a32d4388d3e2a718a272e290c5de137642a13d8c4920ff4bf804603f6L69-R77) [[3]](diffhunk://#diff-c05e51895c2aed2403a8115e13a5547486eb47c95e2e6177895c8bbca0b3fea1L63-R67) [[4]](diffhunk://#diff-23011ac2ee4b790c501d90ac851024a4e2f2164219b12ec84498694e4538ae70L81-R86)

These changes improve the flexibility and correctness of the code when dealing with varying numbers of nodes or external force vector requirements.