### PR TITLE
/MAT/LAW76 : correct input table error check in starter

### DIFF
--- a/starter/source/materials/mat/mat076/hm_read_mat76.F
+++ b/starter/source/materials/mat/mat076/hm_read_mat76.F
@@ -315,7 +315,7 @@ c-----------------------------------------------------------------------------
               if (ndim == 1) then
                 if (minval(mat_param%table(i)%y1d) <= zero) ierror = 1
               else if (ndim == 2) then
-                if (minval(mat_param%table(i)%y2d) <= zero) ierror = 1
+                if (minval(mat_param%table(i)%y2d(1,:)) <= zero) ierror = 1
               end if
               if (ierror == 1) then
                 CALL ANCMSG(MSGID=2063, MSGTYPE=MSGERROR, ANMODE=ANINFO_BLIND_1,


### PR DESCRIPTION
Correction of error check in starter concerning 2D tables containing yield functions. Only first dimension should be tested for non-zero first function value.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
