### PR TITLE
Guard LAW151 submaterial count

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2019/MAT/mat_law151.cfg
+++ b/hm_cfg_files/config/CFG/radioss2019/MAT/mat_law151.cfg
@@ -58,7 +58,7 @@ SKEYWORDS_IDENTIFIER(COMMON)
 CHECK
 {
     NIP                       >=0;
-    NIP                       <=100;
+    NIP                       <=21;
 }
 
 DEFAULTS(COMMON)

--- a/starter/source/materials/mat/mat151/hm_read_mat151.F
+++ b/starter/source/materials/mat/mat151/hm_read_mat151.F
@@ -74,23 +74,24 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       LOGICAL :: IS_AVAILABLE
+      INTEGER, PARAMETER :: MAX_NBMAT = 21
       INTEGER :: NBMAT, MAT_ID  ! Number of declared materials
       INTEGER :: II
       my_real :: FRAC_VOL, SUM_FRAC_VOL
-      my_real :: VFRAC(21)
-      INTEGER :: IMID(21)
+      my_real :: VFRAC(MAX_NBMAT)
+      INTEGER :: IMID(MAX_NBMAT)
 C-----------------------------------------------
 C     B o d y
 C-----------------------------------------------
       IS_AVAILABLE = .FALSE.
       NBMAT = 0
       CALL HM_GET_INTV('NIP',NBMAT,IS_AVAILABLE,LSUBMODEL)
-      MULTI_FVM%NBMAT = MAX(MULTI_FVM%NBMAT, NBMAT)
 
-      IF (NBMAT > 21) THEN
-         !! Limitation to 20 material
+      IF (NBMAT > MAX_NBMAT) THEN
          CALL ANCMSG(MSGID = 87, MSGTYPE = MSGERROR, ANMODE = ANINFO)
+         NBMAT = MAX_NBMAT
       ENDIF
+      MULTI_FVM%NBMAT = MAX(MULTI_FVM%NBMAT, NBMAT)
 
       ! Storing number of materials
       IPM(20) = NBMAT


### PR DESCRIPTION
## Summary

- keep LAW151 processing within its existing 21-submaterial implementation limit after reporting error 87
- update `MULTI_FVM%NBMAT` only after validating and clamping the input count
- align the LAW151 authoring CFG limit with the runtime limit

## Problem

When `/MAT/LAW151` declares more than 21 submaterials, Starter reports error 87 but continues processing with the unadjusted count. The reader then uses that count to index fixed 21-entry arrays. With 100 entries, the official `latest-20260615` GNU double-precision Starter records a segmentation violation and error 760 after error 87.

This change does not raise or remove the existing solver limit. It keeps invalid-input error handling memory-safe and deterministic until the existing final error termination.

## Root cause

`hm_read_mat151.F` stores the unchecked input count in `MULTI_FVM%NBMAT` and only records an error for counts above 21. Subsequent loops still use the original count with fixed-size LAW151 and multimaterial state.

## Verification

Built from `ce019428a` plus this patch with gfortran 13.3 and CMake 3.28.3.

| Build | Submaterials | Result |
| --- | ---: | --- |
| ASan/UBSan | 21 | exit 0, restart created, no sanitizer diagnostics |
| ASan/UBSan | 22 and 100 | error 87, stored count 21, no restart, clean `ERROR TERMINATION` |
| Release | 21 | exit 0, restart created |
| Release | 22 and 100 | error 87, stored count 21, no restart, clean `ERROR TERMINATION` |

Additional checks:

- the official Engine consumed both patched 21-entry restarts and terminated normally after 16,796 cycles, with `ERR=-0.0%`, `DM/M=0`, and three animation files
- the unmodified repository `SMOKE_TEST` passed with the patched release Starter and official Engine
- intended-run scans found no sanitizer diagnostic, abnormal end, segmentation, error 760, runtime error, NaN, or Inf
- `git diff --check` and fixed-form Fortran style checks passed

## QA note

I have not added a tracked regression case yet because the legacy mini-QA runner treats the intended Starter `ERROR TERMINATION` as a serious failure, while its expected-error path does not directly assert the numeric exit code. A 21-entry success-only case would not catch this invalid-input crash.

Maintainer guidance would be welcome on whether to add Starter-only 22/100 cases that require error 87 and forbid segmentation/error 760, or first extend the QA harness to assert the expected Starter exit code.
