### PR TITLE
STOP starter computation when surface defined only by 1D elements Int…

### DIFF
--- a/starter/source/interfaces/int07/hm_read_inter_type07.F
+++ b/starter/source/interfaces/int07/hm_read_inter_type07.F
@@ -468,7 +468,7 @@ C
         IF(N1D == IGRSURF(ISU2)%NSEG) THEN
             CALL ANCMSG(MSGID=3160,
      .                  MSGTYPE=MSGERROR,
-     .                  ANMODE=ANINFO_BLIND_1,
+     .                  ANMODE=ANSTOP,
      .                  I1=NOINT,
      .                  C1=TITR,
      .                  I2=ISU2_USER)


### PR DESCRIPTION
…er7 and Inter19

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
Stop starter computation when surface is defined only by 1D elements for interface 7 and 19

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
Stop starter computation when surface is defined only by 1D elements for interface 7 and 19


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
