### PR TITLE
correction issue adinertia_non_uniform.cfg

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2612/ADMAS/adinertia_non_uniform.cfg
+++ b/hm_cfg_files/config/CFG/radioss2612/ADMAS/adinertia_non_uniform.cfg
@@ -20,7 +20,6 @@
 ATTRIBUTES {
     entityidsmax        = SIZE("Number of entities");
     entityids           = ARRAY[entityidsmax](NODE, "entity to which the mass is added");
-    type                = VALUE(INT,   "Type");
     masses              = ARRAY[entityidsmax](FLOAT, "Added mass");
     ixx                 = ARRAY[entityidsmax](FLOAT, "xx component of inertia tensor");
     ixy                 = ARRAY[entityidsmax](FLOAT, "xy component of inertia tensor");


### PR DESCRIPTION
This pull request makes a small change to the `adinertia_non_uniform.cfg` configuration file by removing the unused `type` attribute from the `ATTRIBUTES` block.