### PR TITLE
/DFS/DET* : check detonator compatibility with law 105

### DIFF
--- a/starter/source/initial_conditions/detonation/read_dfs_detcord.F
+++ b/starter/source/initial_conditions/detonation/read_dfs_detcord.F
@@ -150,7 +150,7 @@ C-----------------------------------------------
         ELSEIF (UNUSED==2) THEN
           CALL ANCMSG(MSGID=102,MSGTYPE=MSGERROR,ANMODE=ANINFO,
      .                I1=DET_ID,
-     .                C1='DETONATOR MUST REFER TO A JWL MATERIAL LAW (LAWS 5, 51, 97, 151)',
+     .                C1='DETONATOR MUST REFER TO AN EXPLOSIVE COMPATIBLE MATERIAL (LAWS 5, 51, 97, 105, 151)',
      .                C2='/DFS/DETCORD',
      .                I2=MDET)
         ELSEIF (NNOD == 0) THEN

--- a/starter/source/initial_conditions/detonation/read_dfs_detline.F
+++ b/starter/source/initial_conditions/detonation/read_dfs_detline.F
@@ -174,7 +174,7 @@ C-----------------------------------------------
         ELSEIF (UNUSED == 2) THEN
           CALL ANCMSG(MSGID=102,MSGTYPE=MSGERROR,ANMODE=ANINFO,
      .                I1=DET_ID,
-     .                C1='DETONATOR MUST REFER TO A JWL MATERIAL LAW (LAWS 5, 51, 97, 151)',
+     .                C1='DETONATOR MUST REFER TO AN EXPLOSIVE COMPATIBLE MATERIAL (LAWS 5, 51, 97, 105, 151)',
      .                C2='/DFS/DETLINE',
      .                I2=MDET)
         ELSE

--- a/starter/source/initial_conditions/detonation/read_dfs_detplan.F
+++ b/starter/source/initial_conditions/detonation/read_dfs_detplan.F
@@ -176,7 +176,7 @@ C-----------------------------------------------
         ELSEIF (UNUSED==2) THEN
           CALL ANCMSG(MSGID=102,MSGTYPE=MSGERROR,ANMODE=ANINFO,
      .                I1=DET_ID,
-     .                C1='DETONATOR MUST REFER TO A JWL MATERIAL LAW (LAWS 5, 51, 97, 151)',
+     .                C1='DETONATOR MUST REFER TO AN EXPLOSIVE COMPATIBLE MATERIAL (LAWS 5, 51, 97, 105, 151)',
      .                C2='/DFS/DETPLANE',
      .                I2=MDET)
         ELSEIF((NX == ZERO).AND.(NY == ZERO).AND.(NZ == ZERO))THEN

--- a/starter/source/initial_conditions/detonation/read_dfs_detpoint.F
+++ b/starter/source/initial_conditions/detonation/read_dfs_detpoint.F
@@ -336,7 +336,7 @@ C-----------------------------------------------
         ELSEIF (UNUSED == 2) THEN
           CALL ANCMSG(MSGID=102,MSGTYPE=MSGERROR,ANMODE=ANINFO,
      .                I1=DET_ID,
-     .                C1='DETONATOR MUST REFER TO A JWL MATERIAL LAW (LAWS 5, 51, 97, 151)',
+     .                C1='DETONATOR MUST REFER TO AN EXPLOSIVE COMPATIBLE MATERIAL (LAWS 5, 51, 97, 105, 151)',
      .                C2='/DFS/DETPOINT',
      .                I2=MDET)
         ELSE

--- a/starter/source/initial_conditions/detonation/read_dfs_wave_shaper.F
+++ b/starter/source/initial_conditions/detonation/read_dfs_wave_shaper.F
@@ -146,7 +146,7 @@ C-----------------------------------------------
         ELSEIF (UNUSED==2) THEN
           CALL ANCMSG(MSGID=102,MSGTYPE=MSGERROR,ANMODE=ANINFO,
      .                I1=DET_ID,
-     .                C1='DETONATOR MUST REFER TO A JWL MATERIAL LAW (LAWS 5, 51, 97, 151)',
+     .                C1='DETONATOR MUST REFER TO AN EXPLOSIVE COMPATIBLE MATERIAL (LAWS 5, 51, 97, 105, 151)',
      .                C2='/DFS/WAV_SHA',
      .                I2=MDET)
         ELSE

--- a/starter/source/initial_conditions/detonation/unused_mat_detonator.F
+++ b/starter/source/initial_conditions/detonation/unused_mat_detonator.F
@@ -63,7 +63,7 @@ C-----------------------------------------------
               MID= LISTMAT(1,I)
               MLN= LISTMAT(2,I)
               IF (MDET == MID) THEN !MDET refer to an used material
-                IF(MLN /= 5 .AND. MLN /= 51 .AND. MLN /= 97 .AND. MLN /= 151)THEN
+                IF(MLN /= 5 .AND. MLN /= 51 .AND. MLN /= 97 .AND. MLN /= 105 .AND. MLN /= 151)THEN
                   UNUSED_MAT_DETONATOR=2
                   RETURN
                 ENDIF


### PR DESCRIPTION
#### /DFS/DET* : check detonator compatibility with law 105


#### Description of the changes
When providing a material identifier in detonators, it is now checked if it is also compatible with new law 105 (powder-burn) :

```
ERROR ID :    102
** ERROR IN DETONATOR INPUT
DESCRIPTION :  
   DETONATOR MUST REFER TO AN EXPLOSIVE COMPATIBLE MATERIAL (LAWS 5, 51, 97, 105, 151)
   -- DETONATOR TYPE: /DFS/DETPOINT
   -- DETONATOR ID  : 1
   -- MATERIAL ID   : 5

```
