### PR TITLE
/BCS/WALL:deallocate statement moved out of the loop

### DIFF
--- a/engine/source/multifluid/multi_solve_eint.F90
+++ b/engine/source/multifluid/multi_solve_eint.F90
@@ -100,6 +100,7 @@
 
           !dummy
           VOL = ONE
+          IF(RHO(1) == ZERO) VOL = ZERO ! '/ebcs/inlet'
 
           !Initialization
           TEMP = ZERO

--- a/starter/source/boundary_conditions/init_bcs_wall.F90
+++ b/starter/source/boundary_conditions/init_bcs_wall.F90
@@ -345,9 +345,10 @@
             end if
 
             call my_dealloc(adjacent_elem)
-            call my_dealloc(bcs%iworking_array)
 
           end do !next ii
+
+          call my_dealloc(bcs%iworking_array)
 
 
 


### PR DESCRIPTION
#### /BCS/WALL:deallocate out of the loop

#### Description of the changes
In case of several /BCS/WALL option defined in the input file the Starter failed. This is now fixed as the deallocate statment is moved out of the loop.