### PR TITLE
add checksum title

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2026/CARDS/checksum_start.cfg
+++ b/hm_cfg_files/config/CFG/radioss2026/CARDS/checksum_start.cfg
@@ -17,8 +17,9 @@
 
 ATTRIBUTES(COMMON)
 {
+    TITLE                                   = VALUE(STRING, "TITLE");
     //Card 1
-    CHECKSUM_data                              = VALUE(STRING, "CHECKSUM format data");
+    CHECKSUM_data                           = VALUE(STRING, "CHECKSUM format data");
 
     //HM INTERNAL
     KEYWORD_STR                             = VALUE(STRING, "Solver Keyword");
@@ -44,6 +45,7 @@ GUI(COMMON)
 FORMAT(radioss2019)
 {
     HEADER("/CHECKSUM/START");
+    CARD("%-100s", TITLE);
 
     //Card 1
     COMMENT("#CHECK_data                                                                                        ");


### PR DESCRIPTION
This pull request updates the `checksum_start.cfg` configuration file to add support for a `TITLE` attribute and ensure it is included in the output format for the `radioss2019` version.

**Configuration enhancements:**

* Added a `TITLE` attribute to the `ATTRIBUTES(COMMON)` section, allowing users to specify a title string for the configuration.
* Updated the `FORMAT(radioss2019)` section in `GUI(COMMON)` to include the `TITLE` in the output using the `CARD("%-100s", TITLE);` format.