### PR TITLE
not initialized value in stress tensor output per ply for shells

### DIFF
--- a/engine/source/output/h3d/h3d_results/h3d_shell_tensor.F
+++ b/engine/source/output/h3d/h3d_results/h3d_shell_tensor.F
@@ -387,6 +387,7 @@ c
               ELSEIF (ILAY == -1 .AND. IPLY > 0 .AND. IPT > 0) THEN 
 c               /TENS/STRESS/PLY=.../NPT=...
                 DO J=1,NLAY                          ! shells type 17,19,51 and 52 only
+                  ID_PLY = 0
                   IF (IGTYP == 17 .OR. IGTYP == 19 .OR. IGTYP == 51) THEN
                     ID_PLY = IGEO(1,STACK%IGEO(2+J,ISUBSTACK))
                   ELSE IF (IGTYP == 52) THEN
@@ -533,6 +534,7 @@ c
               IF (ILAY == -1 .AND. IPLY > 0 .AND. IPT > 0) THEN 
 c               /TENS/MSTRESS/PLY=.../NPT=...
                 DO J=1,NLAY                          ! shells type 17,19,51 and 52 only
+                  ID_PLY = 0
                   IF (IGTYP == 17 .OR. IGTYP == 19 .OR. IGTYP == 51) THEN
                     ID_PLY = IGEO(1,STACK%IGEO(2+J,ISUBSTACK))
                   ELSE IF (IGTYP == 52) THEN
@@ -708,6 +710,7 @@ c               PLY=IPLY NPT=IPT
                   DO J=1,NLAY
                     BUFLY => ELBUF_TAB(NG)%BUFLY(J)
                     NPTT = BUFLY%NPTT
+                    ID_PLY = 0
                     IF (IGTYP == 17 .OR. IGTYP == 51) THEN
                       ID_PLY = IGEO(1,STACK%IGEO(2+J,ISUBSTACK))
                     ELSEIF (IGTYP == 52) THEN
@@ -849,6 +852,7 @@ c
                   DO J=1,NLAY
                     BUFLY => ELBUF_TAB(NG)%BUFLY(J)
                     NPTT = BUFLY%NPTT
+                    ID_PLY = 0
                     IF (IGTYP == 17 .OR. IGTYP == 19 .OR. IGTYP == 51) THEN
                       ID_PLY = IGEO(1,STACK%IGEO(2+J,ISUBSTACK))
                     ELSEIF (IGTYP == 52) THEN
@@ -1039,8 +1043,9 @@ c                 PLY=IPLY NPT=IPT
                   IPTHK  = IPANG + NLAY
                   IPPOS  = IPTHK + NLAY
                   DO J=1,NLAY
+                    ID_PLY = 0
                     IF (IGTYP == 17 .OR. IGTYP == 51) THEN
-                        ID_PLY = IGEO(1,STACK%IGEO(2+J,ISUBSTACK))
+                      ID_PLY = IGEO(1,STACK%IGEO(2+J,ISUBSTACK))
                     ELSEIF (IGTYP == 52) THEN
                       ID_PLY = PLY_INFO(1,STACK%IGEO(2+J,ISUBSTACK)-NUMSTACK) 
                     ENDIF


### PR DESCRIPTION
This pull request makes several small but important changes to the `H3D_SHELL_TENSOR` subroutine in `h3d_shell_tensor.F`. The main update is the explicit initialization of the `ID_PLY` variable to zero at the start of several loops. This ensures that `ID_PLY` always has a defined value before being potentially reassigned, which helps prevent bugs from using uninitialized variables.

Variable initialization improvements:

* Added `ID_PLY = 0` initialization at the start of all relevant loops before conditional assignment, ensuring `ID_PLY` is always set to a known value before use. [[1]](diffhunk://#diff-7dffe2d3a36b62dcc4bf67d89724da031612cda157b1aa0193f36e3fa82f1835R390) [[2]](diffhunk://#diff-7dffe2d3a36b62dcc4bf67d89724da031612cda157b1aa0193f36e3fa82f1835R537) [[3]](diffhunk://#diff-7dffe2d3a36b62dcc4bf67d89724da031612cda157b1aa0193f36e3fa82f1835R713) [[4]](diffhunk://#diff-7dffe2d3a36b62dcc4bf67d89724da031612cda157b1aa0193f36e3fa82f1835R855) [[5]](diffhunk://#diff-7dffe2d3a36b62dcc4bf67d89724da031612cda157b1aa0193f36e3fa82f1835R1046)