### PR TITLE
avoid negative stiffness of brick element for contact interface

### DIFF
--- a/starter/source/interfaces/inter3d1/volint.F
+++ b/starter/source/interfaces/inter3d1/volint.F
@@ -98,6 +98,7 @@ C
       JAC_48_57 = JAC4 * JAC8 - JAC5 * JAC7 
 C
       VOL =  ZEP015625 * (JAC1 * JAC_59_68 + JAC2 * JAC_67_49 + JAC3 * JAC_48_57)
+      VOL =  ABS(VOL)
 
       RETURN
       END


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
In some special cases, input solid element connectivity isn't consisting with Radioss' convention or elements created by /TRNSFORM/SYM which might result in negative volume of solid element, although Radioss does the correction (connectivity change) automatically at the element initialization phase, but in the contact interface initialization phase which has been done before, negative stiffness (used for contact) could be computed due to the negative volume, then made the run (Engine) failed or generated the NaN value.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
correction to avoid negative stiffness for contact interface

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
