### PR TITLE
LAW70 + XREF memory issue correction

### DIFF
--- a/starter/source/materials/mat_share/mulaw.F
+++ b/starter/source/materials/mat_share/mulaw.F
@@ -279,7 +279,7 @@ C ====================================================================
 
       ELSEIF(MTN==70)THEN
         CALL SIGEPS70(LLT ,NPAR,NUVAR,NFUNC,IFUNC,
-     2                  NPF ,TF  ,TIME,TIMESTEP,BUFMAT(IADBUF),
+     2                  NPF ,TF  ,TIME,TIMESTEP,BUFMAT,
      3                  RHO0,RHO ,VOLN,EINT,NVARTMP ,VARTMP  ,
      4                  DE1 ,DE2 ,DE3 ,DE4  ,DE5  ,DE6 ,
      5                  ES1 ,ES2 ,ES3 ,ES4  ,ES5  ,ES6 ,


### PR DESCRIPTION
This pull request makes a minor change to the `MULAW` subroutine in `mat_share/mulaw.F`. The change updates the arguments passed to the `SIGEPS70` subroutine to simplify the buffer handling.

- Simplified buffer argument: The `SIGEPS70` subroutine is now called with the entire `BUFMAT` array rather than a specific offset (`BUFMAT(IADBUF)`), which likely improves clarity and reduces potential indexing errors.