### PR TITLE
improve Itetra10=2 (dynamic condensation) kinematic condition treatment including the case of Itetra4=10

### DIFF
--- a/starter/source/elements/solid/solide10/dim_s10edg.F
+++ b/starter/source/elements/solid/solide10/dim_s10edg.F
@@ -689,7 +689,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER N,ND,N1,N2,ID,IPR
+      INTEGER N,ND,N1,N2,ID,IPR,IPR1
       INTEGER IS1,IS2,ISMIN,NSL,M,K,KK
       INTEGER, ALLOCATABLE, DIMENSION(:) :: ICODEM
 C     REAL
@@ -719,8 +719,9 @@ C------treatment for /BCS ----------------------------
         ENDDO
       ENDDO
       IPR = 0
+      IPR1 = 0
       DO N=1,NUMNOD
-       IF (ICODEM(N)>0 .AND. ITAGND(N) /=0 ) THEN
+       IF (ITAGND(N) /=0 ) THEN
          ID = IABS(ITAGND(N))
          ND = ICNDS10(1,ID)
          N1 = ICNDS10(2,ID)
@@ -728,7 +729,8 @@ C------treatment for /BCS ----------------------------
          IS1 = ICODEM(N1)
          IS2 = ICODEM(N2)
          ISMIN = MIN(IS1,IS2)
-         IF (IS1/=ICODEM(N).AND.IS2/=ICODEM(N).AND.ISMIN<ICODEM(N)) THEN
+         IF (ICODEM(N)>0) THEN
+           IF (IS1/=ICODEM(N).AND.IS2/=ICODEM(N).AND.ISMIN<ICODEM(N)) THEN
 C----error out  ND has more /BCS than edge node
             CALL ANCMSG(MSGID=1208,
      .                MSGTYPE=MSGERROR,
@@ -736,26 +738,41 @@ C----error out  ND has more /BCS than edge node
      .                I1=ITAB(ND),
      .                C1='Boundary conditions ',
      .                C2='Boundary conditions')
-         ELSE
+           ELSE
 C----remove Nd from /BCS +degenerating
-           ICODE(N) = 0
-           IPR = 1
-           IF (ITAGND(N)>0)ITAGND(N) = -ITAGND(N) 
-           IF (IPRI>=5)
-     .     CALL ANCMSG(MSGID=1207,
+             ICODE(N) = 0
+             IPR = 1
+             IF (ITAGND(N)>0)ITAGND(N) = -ITAGND(N) 
+             IF (IPRI>=5)
+     .       CALL ANCMSG(MSGID=1207,
      .                MSGTYPE=MSGINFO,
      .                ANMODE=ANINFO_BLIND_1,
      .                I1=ITAB(ND),
      .                PRMOD=MSG_CUMU)
-         END IF
+           END IF
+         ELSEIF (ISMIN>0) THEN   ! case w/ Itetra4=10
+             IPR1 = 1
+             IF (ITAGND(N)>0)ITAGND(N) = -ITAGND(N) 
+             IF (IPRI>=5)
+     .       CALL ANCMSG(MSGID=3162,
+     .                MSGTYPE=MSGINFO,
+     .                ANMODE=ANINFO_BLIND_1,
+     .                I1=ITAB(ND),
+     .                PRMOD=MSG_CUMU)
+         END IF !(ICODEM(N)>0) THEN
        END IF
       ENDDO 
-      IF (IPR >0.AND.IPRI>=5) THEN
-          CALL ANCMSG(MSGID=1207,
+      IF (IPRI>=5) THEN
+        IF (IPR>0)  CALL ANCMSG(MSGID=1207,
      .                MSGTYPE=MSGINFO,
      .                ANMODE=ANINFO_BLIND_1,
      .                C1='Boundary conditions ',
      .                C2='Boundary conditions',
+     .                PRMOD=MSG_PRINT)
+        IF (IPR1>0)  CALL ANCMSG(MSGID=3162,
+     .                MSGTYPE=MSGINFO,
+     .                ANMODE=ANINFO_BLIND_1,
+     .                C1='Boundary conditions ',
      .                PRMOD=MSG_PRINT)
       END IF 
       CALL MY_DEALLOC(ICODEM)
@@ -772,7 +789,7 @@ C
 !||--- uses       -----------------------------------------------------
 !||    message_mod   ../starter/share/message_module/message_mod.F
 !||====================================================================
-      SUBROUTINE FIXMODIF_ND(IBFV, ITAGND,ICNDS10,ITAB)
+      SUBROUTINE FIXMODIF_ND(IBFV, ITAGND,ICNDS10,ITAB,IKINE)
 C=======================================================================
       USE MESSAGE_MOD
 C-----------------------------------------------
@@ -789,11 +806,12 @@ C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
       INTEGER IBFV(NIFV,*), ITAGND(*),ICNDS10(3,*),ITAB(*)
+      INTEGER, DIMENSION(NUMNOD)      ,INTENT (IN) :: IKINE
 C     REAL
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
-      INTEGER I,N,ND,N1,N2,K,ID,IPR
+      INTEGER I,N,ND,N1,N2,K,ID,IPR,IPR1
       LOGICAL IS1,IS2
 C-----------------------------------------------
 C   External function
@@ -846,6 +864,30 @@ C
      .                ANMODE=ANINFO_BLIND_1,
      .                C1='Imposed VEL/DISP/ACC',
      .                C2='Imposed VEL/DISP/ACC',
+     .                PRMOD=MSG_PRINT)
+       END IF 
+! add degenerating nd for special case of kinematic two edge nodes including Itetra4=10
+      IPR1 = 0
+       DO I = 1,NS10E
+         N = IABS(ICNDS10(1,I))
+         N1 = ICNDS10(2,I)
+         N2 = ICNDS10(3,I)
+         IF (IKINE(N1)/=0.AND.IKINE(N2)/=0.AND.ITAGND(N)>0) THEN 
+            ITAGND(N) = -ITAGND(N)
+            IPR1 = 1
+            IF (IPRI>=5)
+     .       CALL ANCMSG(MSGID=3162,
+     .                   MSGTYPE=MSGINFO,
+     .                   ANMODE=ANINFO_BLIND_1,
+     .                   I1=ITAB(N),
+     .                   PRMOD=MSG_CUMU)
+         END IF  !(IS1/=0.AND.IS2/=0.AND.ITAGND(N)>0) THEN 
+       END DO 
+       IF (IPR1 >0.AND.IPRI>=5) THEN
+          CALL ANCMSG(MSGID=3162,
+     .                MSGTYPE=MSGINFO,
+     .                ANMODE=ANINFO_BLIND_1,
+     .                C1='Kinematic conditions',
      .                PRMOD=MSG_PRINT)
        END IF 
 C

--- a/starter/source/output/message/starter_message_description.txt
+++ b/starter/source/output/message/starter_message_description.txt
@@ -16214,6 +16214,14 @@ Parameter ALPHA should be lower than square root of 2/3 (0.8164965809)
    %i1="/MAT"
  BBC2005 failed to converge for obtaining BBC2005 yield criterion coefficient, Please check material input parameters
 
+/MESSAGE/3162/TITLE
+** INFO: KINEMATIC CONDITIONS TREATMENT FOR TETRA10 and ITETRA10=2
+/MESSAGE/3162/DESCRIPTION
+   Middle node of TETRA10 will be degenerated from TETRA10 edge which had the %s
+   
+/MESSAGE/3162/DATA
+   Middle node: %d 
+
 /MESSAGE/9998/TITLE
 ** MESSAGE WITH NO CATEGORY
 /MESSAGE/9999/TITLE

--- a/starter/source/starter/lectur.F
+++ b/starter/source/starter/lectur.F
@@ -10100,7 +10100,7 @@ C--------------------------------------------
        CALL BCSMODIF_ND(ICODE, ITAGND,ICNDS10,ITAB,
      .                  NNPBY,SLRBODY,NRBE2L ,SLRBE2,
      .                  NPBY ,LPBY   ,IRBE2  ,LRBE2 )
-       CALL FIXMODIF_ND(IBFV , ITAGND,ICNDS10,ITAB)
+       CALL FIXMODIF_ND(IBFV , ITAGND,ICNDS10,ITAB,D )
        CALL BCSCYCMODIF_ND(IBCSCYC,LBCSCYC,ITAGND,ITAB)
       END IF
 C--------------------------------------------


### PR DESCRIPTION

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
new itetra4=10 option uses dynamic condensation (Itetra10=2) which need the kinematic condition compatibility treatments, it's necessary to include itetra4=10 (conversion to tetra10) in these treatments

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
improve Itetra10=2 (dynamic condensation) kinematic condition treatments including the case of itetra4=10

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
