### PR TITLE
correction cfg file mat LAW4 missing Tr field

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2020/MAT/matl4_hyd_jcook.cfg
+++ b/hm_cfg_files/config/CFG/radioss2020/MAT/matl4_hyd_jcook.cfg
@@ -318,7 +318,7 @@ FORMAT(radioss2018) {
     CARD("%20lg",MAT_PC);
     COMMENT("#                  C           EPS_DOT_0                   M               Tmelt                Tmax");
     CARD("%20lg%20lg%20lg%20lg%20lg",MAT_SRC,MAT_SRP,MAT_M,MAT_TMELT,MAT_TMAX);  
-    COMMENT("#              RHOCP");
+    COMMENT("#              RHOCP                                                          Tr");
     CARD("%20lg                                        %20lg",MAT_SPHEAT,MAT_T0);
     if(ALE_Form == 2)
     {


### PR DESCRIPTION
This pull request makes a minor update to the `matl4_hyd_jcook.cfg` configuration file to clarify the comment describing the data fields. The change adds `Tr` to the comment line to accurately reflect the parameters present in the data.

* Documentation update:
  * [`hm_cfg_files/config/CFG/radioss2020/MAT/matl4_hyd_jcook.cfg`](diffhunk://#diff-a1468c42df783dcd304ad0c58ebde0a7220c61266534722ef2243b84f68b432dL321-R321): Added `Tr` to the comment line describing the `RHOCP` field to clarify that the `Tr` parameter is included.