### PR TITLE
/INTERFACE/TYPE9  correct group search start index

### DIFF
--- a/engine/source/interfaces/int09/i9grd3.F
+++ b/engine/source/interfaces/int09/i9grd3.F
@@ -74,7 +74,7 @@ C-----------------------------------------------
 C---------------------------------
 C         search for the element in the buffer
 C---------------------------------
-          DO 200 NG=II/NVSIZ+1,NGROUP
+          DO 200 NG=(II-1)/NVSIZ+1,NGROUP
           CALL INITBUF(IPARG    ,NG      ,                    
      2          MTN     ,LLT     ,NFT     ,IAD     ,ITY     ,  
      3          NPT     ,JALE    ,ISMSTR  ,JEUL    ,JTUR    ,  
@@ -83,6 +83,7 @@ C---------------------------------
      6          IREP    ,IINT    ,IGTYP   ,ISRAT   ,ISROT   ,  
      7          ICSEN   ,ISORTH  ,ISORTHG ,IFAILURE,JSMS    )
             IF(ITY/=1)          GO TO 200
+            IF(II<=NFT)        GO TO 200
             IF(II>NFT+LLT)     GO TO 200
             IF(IPARG(8,NG)==1.OR.JTHE/=1)THEN
               IERR = 1

--- a/engine/source/interfaces/int09/rgwat2.F
+++ b/engine/source/interfaces/int09/rgwat2.F
@@ -112,7 +112,7 @@ C----------------------
 C---------------------------------
 C         search for the element in the buffer
 C---------------------------------
-          DO 200 NG=II/NVSIZ,NGROUP
+          DO 200 NG=(II-1)/NVSIZ+1,NGROUP
             CALL INITBUF(IPARG    ,NG      ,                   
      2            MTN     ,LLT     ,NFT     ,IAD     ,ITY     , 
      3            NPT     ,JALE    ,ISMSTR  ,JEUL    ,JTUR    , 
@@ -121,6 +121,7 @@ C---------------------------------
      6            IREP    ,IINT    ,IGTYP   ,ISRAT   ,ISROT   , 
      7            ICSEN   ,ISORTH  ,ISORTHG ,IFAILURE,JSMS    )
             IF(ITY/=2)          GO TO 200
+            IF(II<=NFT)        GO TO 200
             IF(II>NFT+LLT)     GO TO 200
             IF(IPARG(8,NG)==1)  GO TO 600
             IF(JTHE/=1)         GO TO 600

--- a/engine/source/interfaces/int09/rgwat3.F
+++ b/engine/source/interfaces/int09/rgwat3.F
@@ -122,7 +122,7 @@ C----------------------
 C---------------------------------
 C         search for the element in the buffer
 C---------------------------------
-          DO 200 NG=II/NVSIZ,NGROUP
+          DO 200 NG=(II-1)/NVSIZ+1,NGROUP
             CALL INITBUF(IPARG    ,NG      ,                   
      2            MTN     ,LLT     ,NFT     ,IAD     ,ITY     , 
      3            NPT     ,JALE    ,ISMSTR  ,JEUL    ,JTUR    , 
@@ -131,6 +131,7 @@ C---------------------------------
      6            IREP    ,IINT    ,IGTYP   ,ISRAT   ,ISROT   , 
      7            ICSEN   ,ISORTH  ,ISORTHG ,IFAILURE,JSMS    )
             IF(ITY/=1)          GO TO 200
+            IF(II<=NFT)        GO TO 200
             IF(II>NFT+LLT)     GO TO 200
             IF(IPARG(8,NG)==1)  GO TO 600
             IF(JTHE/=1)         GO TO 600


### PR DESCRIPTION
This pull request updates the buffer search logic in three interface routines to improve element range handling and consistency. The main changes adjust the calculation of the buffer group index and add additional range checks to ensure elements are processed only when they fall within valid bounds.

**Buffer search logic improvements:**

* Updated the loop index calculation in `I9GRD3`, `RGWAT2`, and `RGWAT3` to use `(II-1)/NVSIZ+1` instead of `II/NVSIZ` or `II/NVSIZ+1`, ensuring correct group selection for element searches. [[1]](diffhunk://#diff-4edb8d9981fb2253a3c20065241ff165ac0a37169db86f2a6ca8b8a64a318b8eL77-R77) [[2]](diffhunk://#diff-6c30cd3079ae2a527298d930b44306a834f33225125b2661960109b2caddb629L115-R115) [[3]](diffhunk://#diff-1ba35251ecce8ff358e80d64bce3cb4cbab88fc4f109a6838406bf2e2590c317L125-R125)

**Element range validation:**

* Added checks in all three routines to skip processing if `II <= NFT`, preventing out-of-bounds element handling. [[1]](diffhunk://#diff-4edb8d9981fb2253a3c20065241ff165ac0a37169db86f2a6ca8b8a64a318b8eR86) [[2]](diffhunk://#diff-6c30cd3079ae2a527298d930b44306a834f33225125b2661960109b2caddb629R124) [[3]](diffhunk://#diff-1ba35251ecce8ff358e80d64bce3cb4cbab88fc4f109a6838406bf2e2590c317R134)

These changes enhance the robustness and correctness of buffer element searches across the affected subroutines.