### PR TITLE
possible starter freeze when non supported KEY_TYPE in MAT/LAW131

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2612/MAT/matl131_elasto_plastic_support.cfg
+++ b/hm_cfg_files/config/CFG/radioss2612/MAT/matl131_elasto_plastic_support.cfg
@@ -614,7 +614,7 @@ FORMAT(radioss2612) {
         COMMENT("#                  E                  NU");
         CARD("%20lg%20lg",ELAS_ISOT_E,ELAS_ISOT_NU);
    }
-   if (KEY_type == "ELAS_ORTHOTROPIC")
+   else if (KEY_type == "ELAS_ORTHOTROPIC")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
@@ -623,7 +623,7 @@ FORMAT(radioss2612) {
         COMMENT("#               NU31                 G12                 G23                 G31");
         CARD("%20lg%20lg%20lg%20lg",ELAS_ORTH_NU31,ELAS_ORTH_G12,ELAS_ORTH_G23,ELAS_ORTH_G31);
    }
-   if (KEY_type == "ELAS_ANISOTROPIC")
+   else if (KEY_type == "ELAS_ANISOTROPIC")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
@@ -638,7 +638,7 @@ FORMAT(radioss2612) {
         COMMENT("#                C66");
         CARD("%20lg",ELAS_ANIS_C66);
    }
-   if (KEY_type == "ELAS_VISC_ISOTROPIC")
+   else if (KEY_type == "ELAS_VISC_ISOTROPIC")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
@@ -647,21 +647,21 @@ FORMAT(radioss2612) {
         COMMENT("#               FCUT                  VP");
         CARD("%20lg%10s%10d",ELAS_VISC_FCUT,_BLANK_,ELAS_VISC_VP);
    }
-   if (KEY_type == "ELAS_TEMP_ISOTROPIC")
+   else if (KEY_type == "ELAS_TEMP_ISOTROPIC")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
         COMMENT("#                  E                  NU         FCT_ID_HEAT         FCT_ID_COOL           FCT_ID_NU");
         CARD("%20lg%20lg%10s%10d%10s%10d%10s%10d",ELAS_TEMP_E,ELAS_TEMP_NU,_BLANK_,ELAS_TEMP_FCTH,_BLANK_,ELAS_TEMP_FCTC,_BLANK_,ELAS_TEMP_FCTN);
    }
-   if (KEY_type == "ELAS_BIMOD_ISOTROPIC")
+   else if (KEY_type == "ELAS_BIMOD_ISOTROPIC")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
         COMMENT("#                 ET                  EC                  NU                  TT                  TC");
         CARD("%20lg%20lg%20lg%20lg%20lg",ELAS_BIMOD_ET,ELAS_BIMOD_EC,ELAS_BIMOD_NU,ELAS_BIMOD_TT,ELAS_BIMOD_TC);
    }
-   if (KEY_type == "ELAS_PLAS_ISOTROPIC")
+   else if (KEY_type == "ELAS_PLAS_ISOTROPIC")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
@@ -669,19 +669,19 @@ FORMAT(radioss2612) {
         CARD("%20lg%20lg%20lg%20lg%10s%10d",ELAS_PLAS_E,ELAS_PLAS_NU,ELAS_PLAS_EINF,ELAS_PLAS_CE,_BLANK_,ELAS_PLAS_FCTE);
    }   
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-   if (KEY_type == "CRIT_VONMISES")
+   else if (KEY_type == "CRIT_VONMISES")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
    }
-   if (KEY_type == "CRIT_HERSHEY")
+   else if (KEY_type == "CRIT_HERSHEY")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
         COMMENT("#                  N");
         CARD("%20lg",CRIT_HERSHEY_N);
    }
-   if (KEY_type == "CRIT_HILL_1")
+   else if (KEY_type == "CRIT_HILL_1")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
@@ -690,7 +690,7 @@ FORMAT(radioss2612) {
         COMMENT("#                R23");
         CARD("%20lg",CRIT_HILL_R23);
    }
-   if (KEY_type == "CRIT_HILL_2")
+   else if (KEY_type == "CRIT_HILL_2")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
@@ -699,21 +699,21 @@ FORMAT(radioss2612) {
         COMMENT("#                  N");
         CARD("%20lg",CRIT_HILL_N);
    }
-   if (KEY_type == "CRIT_HILL_3")
+   else if (KEY_type == "CRIT_HILL_3")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
         COMMENT("#                r00                 r45                 r90                 DIR");
         CARD("%20lg%20lg%20lg%10s%10d",CRIT_HILL_R00,CRIT_HILL_R45,CRIT_HILL_R90,_BLANK_,CRIT_HILL_DIR);
    }
-   if (KEY_type == "CRIT_BARLAT1989")
+   else if (KEY_type == "CRIT_BARLAT1989")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
         COMMENT("#                R00                 R45                 R90                MEXP");
         CARD("%20lg%20lg%20lg%20lg",CRIT_BARL89_R00,CRIT_BARL89_R45,CRIT_BARL89_R90,CRIT_BARL89_M);        
    }
-   if (KEY_type == "CRIT_BARLAT2000_1")
+   else if (KEY_type == "CRIT_BARLAT2000_1")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);      
@@ -722,7 +722,7 @@ FORMAT(radioss2612) {
         COMMENT("#             ALPHA6              ALPHA7              ALPHA8                 AXP");
         CARD("%20lg%20lg%20lg%20lg",CRIT_BARL00_A6,CRIT_BARL00_A7,CRIT_BARL00_A8,CRIT_BARL00_AXP);
    }
-   if (KEY_type == "CRIT_BARLAT2000_2")
+   else if (KEY_type == "CRIT_BARLAT2000_2")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);      
@@ -732,7 +732,7 @@ FORMAT(radioss2612) {
         CARD("%20lg%20lg%20lg%20lg%20lg",CRIT_BARL00_R00,CRIT_BARL00_R45,CRIT_BARL00_R90,CRIT_BARL00_RB,CRIT_BARL00_AXP);
    }
 
-   if (KEY_type == "CRIT_BBC2005")
+   else if (KEY_type == "CRIT_BBC2005")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);      
@@ -742,21 +742,21 @@ FORMAT(radioss2612) {
         CARD("%20lg%20lg%20lg%10s%10d",CRIT_BBC2005_R90,CRIT_BBC2005_YB,CRIT_BBC2005_RB,_BLANK_,CRIT_BBC2005_K);
    }
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-   if (KEY_type == "HARD_POWERLAW")
+   else if (KEY_type == "HARD_POWERLAW")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
         COMMENT("#                  A                   B                   N                EPS0              SIGMAX");
         CARD("%20lg%20lg%20lg%20lg%20lg",HARD_POWERLAW_A,HARD_POWERLAW_B,HARD_POWERLAW_N,HARD_POWERLAW_EPS0,HARD_POWERLAW_SIGMAX);
    }
-   if (KEY_type == "HARD_POWERLAW_ENG")
+   else if (KEY_type == "HARD_POWERLAW_ENG")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
         COMMENT("#               SIGY                 UTS             EPS_UTS                EPS0              SIGMAX");
         CARD("%20lg%20lg%20lg%20lg%20lg",HARD_POWERLAW_SIGY,HARD_POWERLAW_UTS,HARD_POWERLAW_EPSUTS,HARD_POWERLAW_EPS0,HARD_POWERLAW_SIGMAX);
    }
-   if (KEY_type == "HARD_VOCE")
+   else if (KEY_type == "HARD_VOCE")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
@@ -765,21 +765,21 @@ FORMAT(radioss2612) {
         COMMENT("#                 Q3                  B3");
         CARD("%20lg%20lg",HARD_VOCE_Q3,HARD_VOCE_B3);
    }
-   if (KEY_type == "HARD_TAB")
+   else if (KEY_type == "HARD_TAB")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
         COMMENT("#   TAB_ID    IEXTRA        SRATE_XSCALE              YSCALE                FCUT                  VP");
         CARD("%10d%10d%20lg%20lg%20lg%10s%10d",HARD_TAB_ID,HARD_TAB_EXTRAP,HARD_TAB_XSCALE,HARD_TAB_YSCALE,SRATE_FCUT,_BLANK_,SRATE_VFLAG);     
    }   
-   if (KEY_type == "HARD_LINVOCE")
+   else if (KEY_type == "HARD_LINVOCE")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
         COMMENT("#                 R0                   H                   Q                   B");
         CARD("%20lg%20lg%20lg%20lg",HARD_LINVOCE_R0,HARD_LINVOCE_H,HARD_LINVOCE_Q,HARD_LINVOCE_B);
    }   
-   if (KEY_type == "HARD_ZERILLI_FCC")
+   else if (KEY_type == "HARD_ZERILLI_FCC")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
@@ -788,7 +788,7 @@ FORMAT(radioss2612) {
         COMMENT("#               EREF");
         CARD("%20lg",HARD_ZERILLI_EREF);
    }
-   if (KEY_type == "HARD_ZERILLI_BCC")
+   else if (KEY_type == "HARD_ZERILLI_BCC")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
@@ -798,28 +798,28 @@ FORMAT(radioss2612) {
         CARD("%20lg%20lg",HARD_ZERILLI_N,HARD_ZERILLI_EREF);
    }      
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-   if (KEY_type == "SRATE_JOHNSONCOOK")
+   else if (KEY_type == "SRATE_JOHNSONCOOK")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
         COMMENT("#                  C                EREF              SIGSAT                FCUT                  VP");
         CARD("%20lg%20lg%20lg%20lg%10s%10d",SRATE_JCOOK_C,SRATE_JCOOK_EREF,SRATE_JCOOK_SIGSAT,SRATE_FCUT,_BLANK_,SRATE_VFLAG);
    }
-   if (KEY_type == "SRATE_COWPER")
+   else if (KEY_type == "SRATE_COWPER")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
         COMMENT("#                  C                   P                                    FCUT                  VP");
         CARD("%20lg%20lg%20s%20lg%10s%10d",SRATE_COWPER_C,SRATE_COWPER_P,_BLANK_,SRATE_FCUT,_BLANK_,SRATE_VFLAG);
    }
-   if (KEY_type == "SRATE_TAB")
+   else if (KEY_type == "SRATE_TAB")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
         COMMENT("# FUNCT_ID                  SRATE_XSCALE              YSCALE                FCUT                  VP");
         CARD("%10d%10s%20lg%20lg%20lg%10s%10d",SRATE_TAB_ID,_BLANK_,SRATE_TAB_XSCALE,SRATE_TAB_YSCALE,SRATE_FCUT,_BLANK_,SRATE_VFLAG);     
    }
-   if (KEY_type == "SRATE_NLINEAR")
+   else if (KEY_type == "SRATE_NLINEAR")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
@@ -827,21 +827,21 @@ FORMAT(radioss2612) {
         CARD("%20lg%20lg%20s%20lg%10s%10d",SRATE_NLINE_CS,SRATE_NLINE_DPS,_BLANK_,SRATE_FCUT,_BLANK_,SRATE_VFLAG);
    }
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-   if (KEY_type == "THERM_JOHNSONCOOK")
+   else if (KEY_type == "THERM_JOHNSONCOOK")
    {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
         COMMENT("#               TREF               TMELT                   M");
         CARD("%20lg%20lg%20lg",THERM_JCOOK_TREF,THERM_JCOOK_TMELT,THERM_JCOOK_M);
    }
-    if (KEY_type == "THERM_ZHAO")
+    else if (KEY_type == "THERM_ZHAO")
     {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
         COMMENT("#               TREF                  MU");
         CARD("%20lg%20lg",THERM_ZHAO_TREF,THERM_ZHAO_MU);
     }
-    if (KEY_type == "THERM_TAB")
+    else if (KEY_type == "THERM_TAB")
     {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
@@ -849,14 +849,14 @@ FORMAT(radioss2612) {
         CARD("%20lg%10s%10d",THERM_TAB_TREF,_BLANK_,THERM_TAB_ID);
     }
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    if (KEY_type == "HEAT_TAYLOR")
+    else if (KEY_type == "HEAT_TAYLOR")
     {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
         COMMENT("#                 T0                 ETA                  CP                DEIS                DEAD");
         CARD("%20lg%20lg%20lg%20lg%20lg",HEAT_TAYLOR_T0,HEAT_TAYLOR_ETA,HEAT_TAYLOR_CP,HEAT_TAYLOR_DEIS,HEAT_TAYLOR_DEAD);
     }
-    if (KEY_type == "HEAT_TAB")
+    else if (KEY_type == "HEAT_TAB")
     {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
@@ -864,14 +864,14 @@ FORMAT(radioss2612) {
         CARD("%20lg%20lg%20lg%10s%10d%20lg",HEAT_TAYLOR_T0,HEAT_TAYLOR_ETA,HEAT_TAYLOR_CP,_BLANK_,HEAT_TAB_ID,HEAT_TAB_XSCALE);
     }
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    if (KEY_type == "KINE_PRAGER")
+    else if (KEY_type == "KINE_PRAGER")
     {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
         COMMENT("#              CHARD");
         CARD("%20lg",KINE_PRAG_CHARD);
     }
-    if (KEY_type == "KINE_CHABOCHE")
+    else if (KEY_type == "KINE_CHABOCHE")
     {
         COMMENT("#           KEY_TYPE");
         CARD("%-20s",KEY_type);
@@ -879,5 +879,10 @@ FORMAT(radioss2612) {
         CARD("%20lg%20lg%20lg%20lg%20lg",KINE_PRAG_CHARD,KINE_CHAB_CRC1,KINE_CHAB_CRA1,KINE_CHAB_CRC2,KINE_CHAB_CRA2);
         COMMENT("#               CRC3                CRA3                CRC4                CRA4");
         CARD("%20lg%20lg%20lg%20lg",KINE_CHAB_CRC3,KINE_CHAB_CRA3,KINE_CHAB_CRC4,KINE_CHAB_CRA4);
+    }
+    else
+    {
+        COMMENT("#           KEY_TYPE");
+        CARD("%-20s",KEY_type);
     }
 }

--- a/starter/source/materials/mat/mat131/hm_read_elasto_plastic.F90
+++ b/starter/source/materials/mat/mat131/hm_read_elasto_plastic.F90
@@ -383,6 +383,13 @@
                 is_available,unitab,lsubmodel,iout     ,is_encrypted ,       &
                 mtag     ,chard  )
               chard = min(max(chard,zero),one)
+            case default
+              call ancmsg(msgid=3163,                                        &
+                msgtype=msgerror,                                  &
+                anmode=aninfo,                                     &
+                i1=mat_id,                                         &
+                c1=titr,                                           &
+                c2=key)
             end select
           enddo
           !=====================================================================

--- a/starter/source/output/message/starter_message_description.txt
+++ b/starter/source/output/message/starter_message_description.txt
@@ -16213,7 +16213,7 @@ Parameter ALPHA should be lower than square root of 2/3 (0.8164965809)
    -- MATERIAL TITLE: %s
    %i1="/MAT"
  BBC2005 failed to converge for obtaining BBC2005 yield criterion coefficient, Please check material input parameters
-
+ 
 /MESSAGE/3162/TITLE
 ** INFO: KINEMATIC CONDITIONS TREATMENT FOR TETRA10 and ITETRA10=2
 /MESSAGE/3162/DESCRIPTION
@@ -16221,6 +16221,15 @@ Parameter ALPHA should be lower than square root of 2/3 (0.8164965809)
    
 /MESSAGE/3162/DATA
    Middle node: %d 
+
+/MESSAGE/3163/TITLE
+** ERROR IN ELASTO-PLASTIC MATERIAL DEFINITION (LAW131)
+
+/MESSAGE/3163/DESCRIPTION
+   -- MATERIAL ID: %d
+   -- MATERIAL TITLE: %s
+   %i1="/MAT"
+   NOT SUPPORTED %s KEY_TYPE HAS BEEN DEFINED. 
 
 /MESSAGE/9998/TITLE
 ** MESSAGE WITH NO CATEGORY


### PR DESCRIPTION
This pull request improves error handling and code structure for elasto-plastic material support in the Radioss configuration and starter routines. The main change is to ensure that only one `KEY_type` block is executed by converting multiple `if` statements into an `else if` chain, and to add a catch-all error for unsupported `KEY_type` values. Additionally, a new error message is defined for unsupported types.

**Control flow improvements:**

* Changed all `if` statements checking `KEY_type` in `matl131_elasto_plastic_support.cfg` to `else if`, ensuring only one block is executed per call and preventing accidental multiple matches. [[1]](diffhunk://#diff-2fb4c586b6dafeb9cc54b5807e551c40de0b1eed3ba96f9ac8479442f270acebL617-R617) [[2]](diffhunk://#diff-2fb4c586b6dafeb9cc54b5807e551c40de0b1eed3ba96f9ac8479442f270acebL626-R626) [[3]](diffhunk://#diff-2fb4c586b6dafeb9cc54b5807e551c40de0b1eed3ba96f9ac8479442f270acebL641-R641) [[4]](diffhunk://#diff-2fb4c586b6dafeb9cc54b5807e551c40de0b1eed3ba96f9ac8479442f270acebL650-R684) [[5]](diffhunk://#diff-2fb4c586b6dafeb9cc54b5807e551c40de0b1eed3ba96f9ac8479442f270acebL693-R693) [[6]](diffhunk://#diff-2fb4c586b6dafeb9cc54b5807e551c40de0b1eed3ba96f9ac8479442f270acebL702-R716) [[7]](diffhunk://#diff-2fb4c586b6dafeb9cc54b5807e551c40de0b1eed3ba96f9ac8479442f270acebL725-R725) [[8]](diffhunk://#diff-2fb4c586b6dafeb9cc54b5807e551c40de0b1eed3ba96f9ac8479442f270acebL735-R735) [[9]](diffhunk://#diff-2fb4c586b6dafeb9cc54b5807e551c40de0b1eed3ba96f9ac8479442f270acebL745-R759) [[10]](diffhunk://#diff-2fb4c586b6dafeb9cc54b5807e551c40de0b1eed3ba96f9ac8479442f270acebL768-R782) [[11]](diffhunk://#diff-2fb4c586b6dafeb9cc54b5807e551c40de0b1eed3ba96f9ac8479442f270acebL791-R791) [[12]](diffhunk://#diff-2fb4c586b6dafeb9cc54b5807e551c40de0b1eed3ba96f9ac8479442f270acebL801-R874)

* Added a final `else` block in `matl131_elasto_plastic_support.cfg` to handle any unknown `KEY_type` values, ensuring that all cases are covered.

**Error handling:**

* In `hm_read_elasto_plastic.F90`, added a `case default` to the material type selection, which logs a specific error message when an unsupported `KEY_type` is encountered.

* Defined a new error message (`MESSAGE/3163`) in `starter_message_description.txt` to clearly report unsupported `KEY_type` values in elasto-plastic material definitions.