### PR TITLE
improve tetra10 element under distortion control (icontrol=1)

### DIFF
--- a/engine/source/elements/solid/solide10/s10for_distor.F
+++ b/engine/source/elements/solid/solide10/s10for_distor.F
@@ -42,6 +42,7 @@ Copyright>        https://www.siemens.com/en-us/products/simcenter/mechanical-si
 C-----------------------------------------------
 C   M o d u l e s
 C-----------------------------------------------
+          use tetra_for_trac_mod
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -79,8 +80,9 @@ C-----------------------------------------------
      .   FORC_N1(MVSIZ,3),FORC_N2(MVSIZ,3),FORC_N3(MVSIZ,3),
      .   PENMIN(MVSIZ),PENREF(MVSIZ),MARGE(MVSIZ),
      .   VCX(MVSIZ,4),VCY(MVSIZ,4),VCZ(MVSIZ,4),
+     .   XC0(MVSIZ),YC0(MVSIZ),ZC0(MVSIZ),
      .   FORC_N4(MVSIZ,3),FCX,FCY,FCZ,GAP_MAX,GAP_MIN,
-     .   TOL_C, TOL_V, TOL_E    
+     .   TOL_C, TOL_V, TOL_E,TOL_T    
       INTEGER I,J,NCTL,IFCTL,IFC1(MVSIZ),IFC2(MVSIZ)
 C-----------------------------------------------
 C   P r e - C o n d i t i o n s
@@ -132,17 +134,26 @@ C---- Element center
         XC = ZERO
         YC = ZERO
         ZC = ZERO
+        XC0 = ZERO
+        YC0 = ZERO
+        ZC0 = ZERO
         DO J =1,10
          DO I=1,NEL
            XC(I,5) = XC(I,5)+XX(I,J)
            YC(I,5) = YC(I,5)+YY(I,J)
            ZC(I,5) = ZC(I,5)+ZZ(I,J)
+           XC0(I) = XC0(I)+XX0(I,J)
+           YC0(I) = YC0(I)+YY0(I,J)
+           ZC0(I) = ZC0(I)+ZZ0(I,J)
          ENDDO
         END DO 
         DO I=1,NEL
            XC(I,5) = XC(I,5)*EM01
            YC(I,5) = YC(I,5)*EM01
            ZC(I,5) = ZC(I,5)*EM01
+           XC0(I) = XC0(I)*EM01
+           YC0(I) = YC0(I)*EM01
+           ZC0(I) = ZC0(I)*EM01
         ENDDO
 C---- middle node treatment first
         TOL_E = EM01 ! %
@@ -157,6 +168,19 @@ C---- middle node treatment first
      .          FOR_T10,   TOL_E,   IFC2 ,     
      .           IFCTL ,   NEL  ,E_DISTOR,
      .             DT1 )
+        NCTL = NCTL + IFCTL
+!---- edge extra-tension treatment
+        TOL_T = FOURTH  !25% engineering strain
+        CALL TETRA_FOR_TRAC(
+     .           NEL   ,     STI,   STI_C,
+     .           XX(1:MVSIZ,1:4),YY(1:MVSIZ,1:4) ,ZZ(1:MVSIZ,1:4) ,
+     .           XX0(1:MVSIZ,1:4),YY0(1:MVSIZ,1:4),ZZ0(1:MVSIZ,1:4),
+     .           VX(1:MVSIZ,1:4), VY(1:MVSIZ,1:4) ,VZ(1:MVSIZ,1:4) ,
+     .           XC(1:NEL,5),     YC(1:NEL,5),     ZC(1:NEL,5),
+     .           XC0,     YC0,     ZC0,   
+     .           FOR_T1,  FOR_T2,  FOR_T3,
+     .           FOR_T4,   TOL_T,   IFC1 ,
+     .           IFCTL ,E_DISTOR,      VC,DT1)
         NCTL = NCTL + IFCTL
 c-- contact by sub-segs       
 c-- sorting for each 4 big seg; IFC1 is used for contact only       
@@ -323,9 +347,9 @@ C---- force assemblage and STI update (dt)
 !        IF (NCTL >0) THEN : potential P/ON issue
           DO I=1,NEL
             IF (STI_C(I) ==ZERO) CYCLE
-            IF (STIF(I)>STI_C(I)) STI(I) = MAX(STI(I),STIF(I))
+            IF (STIF(I)>STI_C(I)) STI(I) = STI(I)+STIF(I)
             IF (FORC_N(I,1)==ZERO.AND.FORC_N(I,2)==ZERO
-     .            .AND.FORC_N(I,3)==ZERO) CYCLE
+     .            .AND.FORC_N(I,3)==ZERO.AND.IFC1(I)==0.AND.IFC2(I)==0) CYCLE
              FCX = EM01*FORC_N(I,1)
              FCY = EM01*FORC_N(I,2)
              FCZ = EM01*FORC_N(I,3)

--- a/engine/source/elements/solid/solide10/s10for_edgec.F
+++ b/engine/source/elements/solid/solide10/s10for_edgec.F
@@ -223,12 +223,12 @@ C----
               FN(I,J) = KTS*(LAM-LAM0)*LENG
               FACT = F_T*(THREE*FAC+ONE)
               STIF(I) = MAX(STIF(I),FACT*STI_C(I)) ! will be added to STI not max()
-!			  
+!  
               DDX = VX(I,JJ) - VXM(I,J)
               DDY = VY(I,JJ) - VYM(I,J)
               DDZ = VZ(I,JJ) - VZM(I,J)
               DDN = DT1*(DDX*NJX(I,J)+DDY*NJY(I,J)+DDZ*NJZ(I,J))
-              E_DISTOR(I) = E_DISTOR(I) - FN(I,J)*DDN
+              E_DISTOR(I) = E_DISTOR(I) + FN(I,J)*DDN
             END IF 
           ENDDO
          ENDDO
@@ -368,7 +368,7 @@ C----10(3,4)
          ENDDO
          DO I=1,NEL
            IF (STI_C(I)==ZERO) CYCLE
-           STI(I) = MAX(STI(I),STIF(I))
+           IF (STIF(I)>STI_C(I)) STI(I) = STI(I)+STIF(I)
          ENDDO
         END IF !(IFF >0) THEN
        

--- a/engine/source/elements/solid/solide10/sfor_visn10.F
+++ b/engine/source/elements/solid/solide10/sfor_visn10.F
@@ -67,13 +67,21 @@ C-----------------------------------------------
 C                                                                     12
       my_real
      .   FAC,VNJ,VL,TOL_V2,
-     .   V2MAX(MVSIZ),VC2
+     .   V2MAX(MVSIZ),VC2,V2J(MVSIZ,4),VREF(MVSIZ,3),VR2
 C----------------------------
         TOL_V2 = TOL_V*TOL_V
         IFCTL = 0
         V2MAX(1:NEL) = ZERO
         FAC = ONE + TWO*MU
-         DO J =1,10
+         DO J =1,4
+           DO I=1,NEL
+             IF (STIF(I)==ZERO) CYCLE
+             VNJ = VX(I,J)*VX(I,J) + VY(I,J)*VY(I,J) + VZ(I,J)*VZ(I,J) 
+             V2MAX(I) = MAX(V2MAX(I),VNJ)
+             V2J(I,J) = VNJ
+           ENDDO
+         END DO 
+         DO J =5,10
            DO I=1,NEL
              IF (STIF(I)==ZERO) CYCLE
              VNJ = VX(I,J)*VX(I,J) + VY(I,J)*VY(I,J) + VZ(I,J)*VZ(I,J) 
@@ -83,7 +91,26 @@ C----------------------------
          DO I=1,NEL
            VC2 = VC(I,1)*VC(I,1)+VC(I,2)*VC(I,2)+VC(I,3)*VC(I,3)
            IF (STIF(I)==ZERO.OR.VC2 <EM20) CYCLE
-           VL = TOL_V2*VC2
+!           VL = TOL_V2*VC2
+           VR2 = MIN(V2J(I,1),V2J(I,2),V2J(I,3),V2J(I,4))
+           VL = TOL_V2*VR2
+           IF (VR2 == V2J(I,1)) THEN 
+              VREF(I,1) = VX(I,1)
+              VREF(I,2) = VY(I,1)
+              VREF(I,3) = VZ(I,1) 
+            ELSE IF (VR2 == V2J(I,2)) THEN
+              VREF(I,1) = VX(I,2)
+              VREF(I,2) = VY(I,2)
+              VREF(I,3) = VZ(I,2) 
+            ELSE IF (VR2 == V2J(I,3)) THEN
+              VREF(I,1) = VX(I,3)
+              VREF(I,2) = VY(I,3)
+              VREF(I,3) = VZ(I,3) 
+            ELSE 
+              VREF(I,1) = VX(I,4)
+              VREF(I,2) = VY(I,4)
+              VREF(I,3) = VZ(I,4)
+            END IF
            IF (V2MAX(I) > VL) IFC1(I) = 1
            IF (IFC1(I) > 0)   IFCTL=1
          END DO
@@ -91,67 +118,67 @@ C
        IF (IFCTL==1) THEN
          DO I=1,NEL
            IF (IFC1(I)==0) CYCLE
-           FOR_T1(I,1) = FOR_T1(I,1) - FLD(I)*(VX(I,1)-VC(I,1))
-           FOR_T1(I,2) = FOR_T1(I,2) - FLD(I)*(VY(I,1)-VC(I,2))
-           FOR_T1(I,3) = FOR_T1(I,3) - FLD(I)*(VZ(I,1)-VC(I,3))
-           FOR_T2(I,1) = FOR_T2(I,1) - FLD(I)*(VX(I,2)-VC(I,1))
-           FOR_T2(I,2) = FOR_T2(I,2) - FLD(I)*(VY(I,2)-VC(I,2))
-           FOR_T2(I,3) = FOR_T2(I,3) - FLD(I)*(VZ(I,2)-VC(I,3))
-           FOR_T3(I,1) = FOR_T3(I,1) - FLD(I)*(VX(I,3)-VC(I,1))
-           FOR_T3(I,2) = FOR_T3(I,2) - FLD(I)*(VY(I,3)-VC(I,2))
-           FOR_T3(I,3) = FOR_T3(I,3) - FLD(I)*(VZ(I,3)-VC(I,3))
-           FOR_T4(I,1) = FOR_T4(I,1) - FLD(I)*(VX(I,4)-VC(I,1))
-           FOR_T4(I,2) = FOR_T4(I,2) - FLD(I)*(VY(I,4)-VC(I,2))
-           FOR_T4(I,3) = FOR_T4(I,3) - FLD(I)*(VZ(I,4)-VC(I,3))
-           FOR_T5(I,1) = FOR_T5(I,1) - FLD(I)*(VX(I,5)-VC(I,1))
-           FOR_T5(I,2) = FOR_T5(I,2) - FLD(I)*(VY(I,5)-VC(I,2))
-           FOR_T5(I,3) = FOR_T5(I,3) - FLD(I)*(VZ(I,5)-VC(I,3))
-           FOR_T6(I,1) = FOR_T6(I,1) - FLD(I)*(VX(I,6)-VC(I,1))
-           FOR_T6(I,2) = FOR_T6(I,2) - FLD(I)*(VY(I,6)-VC(I,2))
-           FOR_T6(I,3) = FOR_T6(I,3) - FLD(I)*(VZ(I,6)-VC(I,3))
-           FOR_T7(I,1) = FOR_T7(I,1) - FLD(I)*(VX(I,7)-VC(I,1))
-           FOR_T7(I,2) = FOR_T7(I,2) - FLD(I)*(VY(I,7)-VC(I,2))
-           FOR_T7(I,3) = FOR_T7(I,3) - FLD(I)*(VZ(I,7)-VC(I,3))
-           FOR_T8(I,1) = FOR_T8(I,1) - FLD(I)*(VX(I,8)-VC(I,1))
-           FOR_T8(I,2) = FOR_T8(I,2) - FLD(I)*(VY(I,8)-VC(I,2))
-           FOR_T8(I,3) = FOR_T8(I,3) - FLD(I)*(VZ(I,8)-VC(I,3))
-           FOR_T9(I,1) = FOR_T9(I,1) - FLD(I)*(VX(I,9)-VC(I,1))
-           FOR_T9(I,2) = FOR_T9(I,2) - FLD(I)*(VY(I,9)-VC(I,2))
-           FOR_T9(I,3) = FOR_T9(I,3) - FLD(I)*(VZ(I,9)-VC(I,3))
-           FOR_T10(I,1) = FOR_T10(I,1) - FLD(I)*(VX(I,10)-VC(I,1))
-           FOR_T10(I,2) = FOR_T10(I,2) - FLD(I)*(VY(I,10)-VC(I,2))
-           FOR_T10(I,3) = FOR_T10(I,3) - FLD(I)*(VZ(I,10)-VC(I,3))
+           FOR_T1(I,1) = FOR_T1(I,1) - FLD(I)*(VX(I,1)-VREF(I,1))
+           FOR_T1(I,2) = FOR_T1(I,2) - FLD(I)*(VY(I,1)-VREF(I,2))
+           FOR_T1(I,3) = FOR_T1(I,3) - FLD(I)*(VZ(I,1)-VREF(I,3))
+           FOR_T2(I,1) = FOR_T2(I,1) - FLD(I)*(VX(I,2)-VREF(I,1))
+           FOR_T2(I,2) = FOR_T2(I,2) - FLD(I)*(VY(I,2)-VREF(I,2))
+           FOR_T2(I,3) = FOR_T2(I,3) - FLD(I)*(VZ(I,2)-VREF(I,3))
+           FOR_T3(I,1) = FOR_T3(I,1) - FLD(I)*(VX(I,3)-VREF(I,1))
+           FOR_T3(I,2) = FOR_T3(I,2) - FLD(I)*(VY(I,3)-VREF(I,2))
+           FOR_T3(I,3) = FOR_T3(I,3) - FLD(I)*(VZ(I,3)-VREF(I,3))
+           FOR_T4(I,1) = FOR_T4(I,1) - FLD(I)*(VX(I,4)-VREF(I,1))
+           FOR_T4(I,2) = FOR_T4(I,2) - FLD(I)*(VY(I,4)-VREF(I,2))
+           FOR_T4(I,3) = FOR_T4(I,3) - FLD(I)*(VZ(I,4)-VREF(I,3))
+           FOR_T5(I,1) = FOR_T5(I,1) - FLD(I)*(VX(I,5)-VREF(I,1))
+           FOR_T5(I,2) = FOR_T5(I,2) - FLD(I)*(VY(I,5)-VREF(I,2))
+           FOR_T5(I,3) = FOR_T5(I,3) - FLD(I)*(VZ(I,5)-VREF(I,3))
+           FOR_T6(I,1) = FOR_T6(I,1) - FLD(I)*(VX(I,6)-VREF(I,1))
+           FOR_T6(I,2) = FOR_T6(I,2) - FLD(I)*(VY(I,6)-VREF(I,2))
+           FOR_T6(I,3) = FOR_T6(I,3) - FLD(I)*(VZ(I,6)-VREF(I,3))
+           FOR_T7(I,1) = FOR_T7(I,1) - FLD(I)*(VX(I,7)-VREF(I,1))
+           FOR_T7(I,2) = FOR_T7(I,2) - FLD(I)*(VY(I,7)-VREF(I,2))
+           FOR_T7(I,3) = FOR_T7(I,3) - FLD(I)*(VZ(I,7)-VREF(I,3))
+           FOR_T8(I,1) = FOR_T8(I,1) - FLD(I)*(VX(I,8)-VREF(I,1))
+           FOR_T8(I,2) = FOR_T8(I,2) - FLD(I)*(VY(I,8)-VREF(I,2))
+           FOR_T8(I,3) = FOR_T8(I,3) - FLD(I)*(VZ(I,8)-VREF(I,3))
+           FOR_T9(I,1) = FOR_T9(I,1) - FLD(I)*(VX(I,9)-VREF(I,1))
+           FOR_T9(I,2) = FOR_T9(I,2) - FLD(I)*(VY(I,9)-VREF(I,2))
+           FOR_T9(I,3) = FOR_T9(I,3) - FLD(I)*(VZ(I,9)-VREF(I,3))
+           FOR_T10(I,1) = FOR_T10(I,1) - FLD(I)*(VX(I,10)-VREF(I,1))
+           FOR_T10(I,2) = FOR_T10(I,2) - FLD(I)*(VY(I,10)-VREF(I,2))
+           FOR_T10(I,3) = FOR_T10(I,3) - FLD(I)*(VZ(I,10)-VREF(I,3))
            STIF(I)      = FAC*STIF(I)
-           E_DISTOR(I)=E_DISTOR(I)- DT1*(FOR_T1(I,1)*(VX(I,1)-VC(I,1))+
-     .                                   FOR_T1(I,2)*(VY(I,1)-VC(I,2))+
-     .                                   FOR_T1(I,3)*(VZ(I,1)-VC(I,3))+
-     .                                   FOR_T2(I,1)*(VX(I,2)-VC(I,1))+
-     .                                   FOR_T2(I,2)*(VY(I,2)-VC(I,2))+
-     .                                   FOR_T2(I,3)*(VZ(I,2)-VC(I,3))+
-     .                                   FOR_T3(I,1)*(VX(I,3)-VC(I,1))+
-     .                                   FOR_T3(I,2)*(VY(I,3)-VC(I,2))+
-     .                                   FOR_T3(I,3)*(VZ(I,3)-VC(I,3))+
-     .                                   FOR_T4(I,1)*(VX(I,4)-VC(I,1))+
-     .                                   FOR_T4(I,2)*(VY(I,4)-VC(I,2))+
-     .                                   FOR_T4(I,3)*(VZ(I,4)-VC(I,3))+
-     .                                   FOR_T5(I,1)*(VX(I,5)-VC(I,1))+
-     .                                   FOR_T5(I,2)*(VY(I,5)-VC(I,2))+
-     .                                   FOR_T5(I,3)*(VZ(I,5)-VC(I,3))+
-     .                                   FOR_T6(I,1)*(VX(I,6)-VC(I,1))+
-     .                                   FOR_T6(I,2)*(VY(I,6)-VC(I,2))+
-     .                                   FOR_T6(I,3)*(VZ(I,6)-VC(I,3))+
-     .                                   FOR_T7(I,1)*(VX(I,7)-VC(I,1))+
-     .                                   FOR_T7(I,2)*(VY(I,7)-VC(I,2))+
-     .                                   FOR_T7(I,3)*(VZ(I,7)-VC(I,3))+
-     .                                   FOR_T8(I,1)*(VX(I,8)-VC(I,1))+
-     .                                   FOR_T8(I,2)*(VY(I,8)-VC(I,2))+
-     .                                   FOR_T8(I,3)*(VZ(I,8)-VC(I,3))+
-     .                                   FOR_T9(I,1)*(VX(I,9)-VC(I,1))+
-     .                                   FOR_T9(I,2)*(VY(I,9)-VC(I,2))+
-     .                                   FOR_T9(I,3)*(VZ(I,9)-VC(I,3))+
-     .                                 FOR_T10(I,1)*(VX(I,10)-VC(I,1))+
-     .                                 FOR_T10(I,2)*(VY(I,10)-VC(I,2))+
-     .                                 FOR_T10(I,3)*(VZ(I,10)-VC(I,3)))
+           E_DISTOR(I)=E_DISTOR(I)- DT1*(FOR_T1(I,1)*(VX(I,1)-VREF(I,1))+
+     .                                   FOR_T1(I,2)*(VY(I,1)-VREF(I,2))+
+     .                                   FOR_T1(I,3)*(VZ(I,1)-VREF(I,3))+
+     .                                   FOR_T2(I,1)*(VX(I,2)-VREF(I,1))+
+     .                                   FOR_T2(I,2)*(VY(I,2)-VREF(I,2))+
+     .                                   FOR_T2(I,3)*(VZ(I,2)-VREF(I,3))+
+     .                                   FOR_T3(I,1)*(VX(I,3)-VREF(I,1))+
+     .                                   FOR_T3(I,2)*(VY(I,3)-VREF(I,2))+
+     .                                   FOR_T3(I,3)*(VZ(I,3)-VREF(I,3))+
+     .                                   FOR_T4(I,1)*(VX(I,4)-VREF(I,1))+
+     .                                   FOR_T4(I,2)*(VY(I,4)-VREF(I,2))+
+     .                                   FOR_T4(I,3)*(VZ(I,4)-VREF(I,3))+
+     .                                   FOR_T5(I,1)*(VX(I,5)-VREF(I,1))+
+     .                                   FOR_T5(I,2)*(VY(I,5)-VREF(I,2))+
+     .                                   FOR_T5(I,3)*(VZ(I,5)-VREF(I,3))+
+     .                                   FOR_T6(I,1)*(VX(I,6)-VREF(I,1))+
+     .                                   FOR_T6(I,2)*(VY(I,6)-VREF(I,2))+
+     .                                   FOR_T6(I,3)*(VZ(I,6)-VREF(I,3))+
+     .                                   FOR_T7(I,1)*(VX(I,7)-VREF(I,1))+
+     .                                   FOR_T7(I,2)*(VY(I,7)-VREF(I,2))+
+     .                                   FOR_T7(I,3)*(VZ(I,7)-VREF(I,3))+
+     .                                   FOR_T8(I,1)*(VX(I,8)-VREF(I,1))+
+     .                                   FOR_T8(I,2)*(VY(I,8)-VREF(I,2))+
+     .                                   FOR_T8(I,3)*(VZ(I,8)-VREF(I,3))+
+     .                                   FOR_T9(I,1)*(VX(I,9)-VREF(I,1))+
+     .                                   FOR_T9(I,2)*(VY(I,9)-VREF(I,2))+
+     .                                   FOR_T9(I,3)*(VZ(I,9)-VREF(I,3))+
+     .                                 FOR_T10(I,1)*(VX(I,10)-VREF(I,1))+
+     .                                 FOR_T10(I,2)*(VY(I,10)-VREF(I,2))+
+     .                                 FOR_T10(I,3)*(VZ(I,10)-VREF(I,3)))
          ENDDO
        END IF 
 C

--- a/engine/source/elements/solid/solide10/tetra_for_trac.F90
+++ b/engine/source/elements/solid/solide10/tetra_for_trac.F90
@@ -1,0 +1,276 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 2026 Siemens
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Simcenter Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Siemens also offers Simcenter(TM) Radioss(R)
+!Copyright>        software under a commercial license.  Contact Siemens to discuss further if the
+!Copyright>        commercial version may interest you: 
+!Copyright>        https://www.siemens.com/en-us/products/simcenter/mechanical-simulation/radioss/.
+!||====================================================================
+!||    s10get_x0_mod   ../engine/source/elements/solid/solide10/s10get_x0.F90
+!||--- called by ------------------------------------------------------
+!||    s10forc3        ../engine/source/elements/solid/solide10/s10forc3.F
+!||====================================================================
+      module tetra_for_trac_mod
+      implicit none
+      contains
+! ======================================================================================================================
+! \brief distortion control on extra-traction of tet elements
+! ======================================================================================================================
+        subroutine tetra_for_trac(                                 &
+                   nel,    sti,    sti_c,                          &
+                   xx ,    yy ,     zz ,                           &
+                   xx0,     yy0,     zz0,                          &
+                   vx ,     vy ,     vz ,                          &
+                   xc ,     yc ,     zc ,                          &
+                   xc0,     yc0,     zc0,                          &
+                for_t1,  for_t2,  for_t3,                          &
+                for_t4,  tol_t,   ifce ,                           &
+                ifctl ,   e_distor, vc,dt1)
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Modules
+! ----------------------------------------------------------------------------------------------------------------------
+          use constant_mod, only : zero,one,three,fourth,twenty,third,ten
+          use precision_mod, only : WP
+          use mvsiz_mod , only : mvsiz
+! ----------------------------------------------------------------------------------------------------------------------
+          implicit none
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                     Arguments
+! ----------------------------------------------------------------------------------------------------------------------
+          integer, intent(in)                                    :: nel             !< number of elements
+          integer, intent (out)                                  :: ifctl           ! if control actived
+          integer, dimension(mvsiz), intent(inout)               :: ifce            ! flag to do the control
+          real(kind=WP), intent(in)                              :: tol_t           !< strain tolerance
+          real(kind=WP), intent(in)                              :: dt1             !< time step
+          real(kind=WP), dimension(mvsiz), intent(in   )         :: sti_c           !< control stiffness
+          real(kind=WP), dimension(mvsiz), intent(inout)         :: sti             !< stiffness for time step
+          double precision, dimension(mvsiz,4), intent(in)       :: xx0, yy0, zz0   !< coordinates in initial configuration
+          double precision, dimension(mvsiz,4), intent(in)       :: xx, yy, zz      !< coordinates in current configuration
+          real(kind=WP), dimension(mvsiz,4), intent(in)          :: vx, vy, vz      !< velocities in current configuration
+          real(kind=WP), dimension(nel), intent(in)              :: xc, yc, zc      !< element center coordinates in current configuration
+          real(kind=WP), dimension(nel), intent(in)              :: xc0, yc0, zc0   !< element center coordinates in initial configuration
+          real(kind=WP), dimension(nel,3), intent(in)            :: vc              !< element center velocity
+          real(kind=WP), dimension(nel), intent(inout)           :: e_distor        !< distortion control energy
+          real(kind=WP), dimension(mvsiz,3), intent(inout)       ::          &
+                               for_t1, for_t2, for_t3,for_t4                        !< distortion control forces
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                   Local variables
+! ----------------------------------------------------------------------------------------------------------------------
+          integer :: i,j,jj,ifc1(nel),jmaxi(nel),j2,jmax,iff
+          real(kind=WP), dimension(nel) :: stif        
+          real(kind=WP), dimension(nel,4) :: xl,yl,zl,xl0,yl0,zl0        
+          real(kind=WP), dimension(nel)   :: fn,ll,l0        
+          real(kind=WP) :: fact,norm,alpha,fac,nx,ny,nz,fx,fy,fz,f_t,kts,fnj,ddn,l3(3),v3(3),tol_t2,fac_max,k0
+          real(kind=WP) :: dx,dy,dz,dmax,l0min,tol1,e_e,e_e0,lam2max,l2(4),l02(4),lam2(4),lam2m,tol_d,tol_dm
+! ----------------------------------------------------------------------------------------------------------------------
+!                                                      Body
+! ----------------------------------------------------------------------------------------------------------------------
+!   4 /\   
+!    /  \  \
+!   /    \   \3
+!  /      \  /
+!1/________\/2     12,13,14,23,24,34
+!----1er sorting IFCE(I) 
+         ifctl = 0
+         stif(1:nel) = sti_c(1:nel)
+! algo: 4 edge nodes respect to element center
+!     only the case to do the largest tension strain is extra (much higher than others)
+! one spring per element
+! first sorting : 4 nodes in local coordinates respect to element center
+         tol1=third*tol_t
+         ifc1=0
+        do i=1,nel
+          if (ifce(i)==0) cycle
+          do j=1,4
+            xl0(i,j)= xx0(i,j)-xc0(i)
+            yl0(i,j)= yy0(i,j)-yc0(i)
+            zl0(i,j)= zz0(i,j)-zc0(i)
+            xl(i,j)= xx(i,j)-xc(i)
+            yl(i,j)= yy(i,j)-yc(i)
+            zl(i,j)= zz(i,j)-zc(i)
+            dx =xl(i,j)-xl0(i,j)
+            dy =yl(i,j)-yl0(i,j)
+            dz =zl(i,j)-zl0(i,j)
+            dmax=max(dx,dy,dz)
+            l0min=max(abs(xl0(i,j)),abs(yl0(i,j)),abs(zl0(i,j)))
+            if (dmax>tol1*l0min) ifc1(i)=1
+          end do
+        end do
+! 2nd sorting : largest tension and extra
+         iff = 0
+         tol_t2 = (one+tol_t)*(one+tol_t)
+         tol_d = 1.1*1.1
+         tol_dm = 1.25*1.25
+         do i=1,nel
+           if (ifc1(i)==0) cycle
+           l02(1:4)=xl0(i,1:4)*xl0(i,1:4)+yl0(i,1:4)*yl0(i,1:4)+zl0(i,1:4)*zl0(i,1:4)
+           l2(1:4)=xl(i,1:4)*xl(i,1:4)+yl(i,1:4)*yl(i,1:4)+zl(i,1:4)*zl(i,1:4)
+           lam2(1:4) = l2(1:4)/l02(1:4)
+           lam2max=zero
+           lam2m=zero
+           jmax=0
+           do j = 1,4
+             lam2m=lam2m+lam2(j)
+             if (lam2(j)>lam2max) then
+                lam2max=lam2(j)
+                jmax=j
+             end if
+           end do
+           if (lam2max<tol_t2) then 
+             ifc1(i)=0
+             cycle 
+           end if
+! look at average of reste and 2nd largest one
+           lam2m=third*(lam2m-lam2max)
+           j2=0
+           lam2max=zero
+           do j = 1,4
+             if (j==jmax) cycle
+             if (lam2(j)>lam2max) then
+                lam2max=lam2(j)
+                j2=j
+             end if
+           end do
+           if (lam2(jmax)<tol_d*lam2(j2).or.lam2(jmax)<tol_dm*lam2m ) then 
+             ifc1(i)=0
+             cycle 
+           end if
+           iff = 1
+           ll(i)=sqrt(l2(jmax))
+           l0(i)=sqrt(l02(jmax))
+           jmaxi(i)=jmax
+         end do
+        if (iff >0) then
+         fn = zero
+         f_t = three !quadratic
+         alpha = one
+!         alpha = fourth
+         e_e0 = tol_t
+         fac_max = ten
+         do i=1,nel
+            if (ifc1(i)==0) cycle
+            e_e = (ll(i)-l0(i))/l0(i) -e_e0  ! relative strain
+            fac = min(fac_max,alpha*e_e*e_e)
+            k0 = sti_c(i)
+            kts = (fac+one)*k0
+            fn(i) = kts*e_e*l0(i)
+            fact = f_t*fac+one
+            stif(i) = max(stif(i),fact*k0) 
+         end do
+         do i=1,nel
+           if (fn(i)==zero) cycle
+           j= jmaxi(i)
+           v3(1)=vc(i,1)-vx(i,j)
+           v3(2)=vc(i,2)-vy(i,j)
+           v3(3)=vc(i,3)-vz(i,j)
+           l3(1)=-xl(i,j)
+           l3(2)=-yl(i,j)
+           l3(3)=-zl(i,j)
+           norm = one/sqrt(l3(1)*l3(1)+l3(2)*l3(2)+l3(3)*l3(3))
+           fnj = fn(i)
+           nx = l3(1)*norm
+           ny = l3(2)*norm
+           nz = l3(3)*norm
+           ddn = dt1*(v3(1)*nx+v3(2)*ny+v3(3)*nz)
+           e_distor(i) = e_distor(i) + fnj*ddn
+           fx = fnj*nx
+           fy = fnj*ny
+           fz = fnj*nz
+           select case (j)
+            case (1)
+              for_t1(i,1) = for_t1(i,1) + fx
+              for_t1(i,2) = for_t1(i,2) + fy
+              for_t1(i,3) = for_t1(i,3) + fz
+              fnj = third*fn(i)
+              fx = fnj*nx
+              fy = fnj*ny
+              fz = fnj*nz
+              for_t2(i,1) = for_t2(i,1) - fx
+              for_t2(i,2) = for_t2(i,2) - fy
+              for_t2(i,3) = for_t2(i,3) - fz
+              for_t3(i,1) = for_t3(i,1) - fx
+              for_t3(i,2) = for_t3(i,2) - fy
+              for_t3(i,3) = for_t3(i,3) - fz
+              for_t4(i,1) = for_t4(i,1) - fx
+              for_t4(i,2) = for_t4(i,2) - fy
+              for_t4(i,3) = for_t4(i,3) - fz
+            case (2)
+              for_t2(i,1) = for_t2(i,1) + fx
+              for_t2(i,2) = for_t2(i,2) + fy
+              for_t2(i,3) = for_t2(i,3) + fz
+              fnj = third*fn(i)
+              fx = fnj*nx
+              fy = fnj*ny
+              fz = fnj*nz
+              for_t1(i,1) = for_t1(i,1) - fx
+              for_t1(i,2) = for_t1(i,2) - fy
+              for_t1(i,3) = for_t1(i,3) - fz
+              for_t3(i,1) = for_t3(i,1) - fx
+              for_t3(i,2) = for_t3(i,2) - fy
+              for_t3(i,3) = for_t3(i,3) - fz
+              for_t4(i,1) = for_t4(i,1) - fx
+              for_t4(i,2) = for_t4(i,2) - fy
+              for_t4(i,3) = for_t4(i,3) - fz
+            case (3)
+              for_t3(i,1) = for_t3(i,1) + fx
+              for_t3(i,2) = for_t3(i,2) + fy
+              for_t3(i,3) = for_t3(i,3) + fz
+              fnj = third*fn(i)
+              fx = fnj*nx
+              fy = fnj*ny
+              fz = fnj*nz
+              for_t2(i,1) = for_t2(i,1) - fx
+              for_t2(i,2) = for_t2(i,2) - fy
+              for_t2(i,3) = for_t2(i,3) - fz
+              for_t1(i,1) = for_t1(i,1) - fx
+              for_t1(i,2) = for_t1(i,2) - fy
+              for_t1(i,3) = for_t1(i,3) - fz
+              for_t4(i,1) = for_t4(i,1) - fx
+              for_t4(i,2) = for_t4(i,2) - fy
+              for_t4(i,3) = for_t4(i,3) - fz
+            case (4)
+              for_t4(i,1) = for_t4(i,1) + fx
+              for_t4(i,2) = for_t4(i,2) + fy
+              for_t4(i,3) = for_t4(i,3) + fz
+              fnj = third*fn(i)
+              fx = fnj*nx
+              fy = fnj*ny
+              fz = fnj*nz
+              for_t2(i,1) = for_t2(i,1) - fx
+              for_t2(i,2) = for_t2(i,2) - fy
+              for_t2(i,3) = for_t2(i,3) - fz
+              for_t3(i,1) = for_t3(i,1) - fx
+              for_t3(i,2) = for_t3(i,2) - fy
+              for_t3(i,3) = for_t3(i,3) - fz
+              for_t1(i,1) = for_t1(i,1) - fx
+              for_t1(i,2) = for_t1(i,2) - fy
+              for_t1(i,3) = for_t1(i,3) - fz
+           end select
+         end do
+         do i=1,nel
+           if (ifc1(i)==0) cycle
+           if (stif(i)<=sti_c(i)) cycle
+           sti(i) = sti(i)+stif(i)
+           ifctl=ifctl+1
+         enddo
+        end if !(iff >0) then
+!----------------------------
+        end subroutine tetra_for_trac
+!-------------------
+      end module tetra_for_trac_mod

--- a/starter/source/elements/solid/solide/sgrtails.F
+++ b/starter/source/elements/solid/solide/sgrtails.F
@@ -128,7 +128,7 @@ C-----------------------------------------------
      .   NGR1, MLN, NG, ISSN, ISSN_, N, MID, PID, II,ILOC,IL,NEL, NE1,IREP,IINT,
      .   P, NEL_PREC, IGT, JHBE, I, IKSNOD0,NB,IEOS,NLAY,
      .   MODE, WORK(70000), NN, J, NPTR,NPTS,NPTT,NPG,
-     .   IPLAST,NUVARP, INEG, JIVF,ICPRE,ICSTR,
+     .   IPLAST,NUVARP, INEG, JIVF,ICPRE,ICSTR,ISCTL,
      .   IFAIL,IMATVIS,NLY,NL,ILAW,IM,IPMAT,ITET4,ITET10,
      .   NGP(NSPMD+1),JJ,IFAILMODEL,NFAIL,ISVIS,IVISC,IMAT,
      .   INUM_R2R(1+R2R_SIU*NUMELS),IPARTSPH,IPARTR2R,MFT,IBOLTP,ICP0,ISM0,
@@ -536,6 +536,7 @@ C         GROUP PARAMETER
             ISTRAIN= IGEO(12,PID)
             ITET4  = IGEO(20,PID)
             ITET10  = IGEO(50,PID)
+            ISCTL  = IGEO(97,PID)
 c
             ISVIS  = IGEO(33,PID)                       
             IPARTSPH=IGEO(38,PID)          
@@ -927,7 +928,7 @@ C-------compressible
 C------       
               CASE(2)                                             
                ICPRE = 1
-               IF (MLN == 1.OR.MLN == 92) ICPRE = 3
+               IF (MLN == 1.OR.MLN == 92.OR.ISCTL>0) ICPRE = 3
 C--------elasto-plastic       
               CASE(3)                                             
                ICPRE = 2


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
improvements on tetra10 elements using distortion control: 1)don't use SFEM (average nodal pressure) for in-compressible materials;2) conservative nodal time step with distortion control;3)add extra-tension control 

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
