### PR TITLE
Add missing initialization

### DIFF
--- a/common_source/modules/connectivity.F90
+++ b/common_source/modules/connectivity.F90
@@ -82,7 +82,7 @@
           real, dimension(:), allocatable :: dist_to_center !< maximum distance of a node to the center of the element
           integer, dimension(:), allocatable :: permutation !< permutation of the shell element in order to have the shells sorted by user_id
           integer :: offset
-          type(C_PTR) :: loc2glob
+          type(C_PTR) :: loc2glob = C_NULL_PTR
         end type shell_
 
         type list_of_shells_
@@ -96,7 +96,7 @@
           integer, dimension(:), allocatable :: addcnel !< address for the node to elemenent (shell) connectivity
           integer, dimension(:), allocatable :: cnel ! element index in nodes arrays
           integer, dimension(:), allocatable :: uid !< user id of the shell element
-          type(C_PTR) :: glob2loc !< map global id to local id
+          type(C_PTR) :: glob2loc = C_NULL_PTR !< map global id to local id
         end type ghost_shell_
 
 
@@ -111,7 +111,7 @@
           integer, dimension(:), allocatable :: pid !< pid(i) :  PID of the i-th solid element
           integer, dimension(:), allocatable :: matid !< matid(i) :  Material ID of the i-th solid element
           integer, dimension(:), allocatable :: user_id !< user_id(i) :  user id of the solid element
-          type(C_PTR) :: loc2glob
+          type(C_PTR) :: loc2glob = C_NULL_PTR
         end type solid_
 
         type connectivity_


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

This pull request makes small but important changes to the initialization of pointer members in several derived types in the `connectivity_mod` module. Specifically, it ensures that all `C_PTR` type pointers are explicitly initialized to `C_NULL_PTR`, which helps prevent the use of uninitialized pointers and potential runtime errors.

Initialization improvements for pointer members:

* In the `shell_` type, the `loc2glob` pointer is now initialized to `C_NULL_PTR` at declaration.
* In the `ghost_shell_` type, the `glob2loc` pointer is now initialized to `C_NULL_PTR` at declaration.
* In the `solid_` type, the `loc2glob` pointer is now initialized to `C_NULL_PTR` at declaration.
#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
