### PR TITLE
 Fix SPMD /TH/SURF reduction for all channels

### DIFF
--- a/common_source/modules/interfaces/th_surf_mod.F
+++ b/common_source/modules/interfaces/th_surf_mod.F
@@ -94,7 +94,8 @@ C---------------------------------------------
           INTEGER, DIMENSION(:), ALLOCATABLE :: LOADP_KSEGS  !< ids of th surfaces to which each segment of load pressure is included
           INTEGER, DIMENSION(:), ALLOCATABLE :: LOADP_SEGS   !< list of th surfaces to which each segment of load pressure is included
 
-          my_real, DIMENSION(:,:), ALLOCATABLE :: CHANNELS   !< channels for /TH/SURF output (1:TH_SURF_NUM_CHANNEL, 1:NSURF)
+          my_real, DIMENSION(:,:), ALLOCATABLE :: CHANNELS        !< Local /TH/SURF accumulator
+          my_real, DIMENSION(:,:), ALLOCATABLE :: CHANNELS_OUTPUT !< MPI-reduced /TH/SURF output snapshot
           !
         END TYPE TH_SURF_
 

--- a/engine/source/engine/resol_alloc.F90
+++ b/engine/source/engine/resol_alloc.F90
@@ -346,8 +346,12 @@
           if(nsurf > 0) then
             call my_alloc(output%th%th_surf%channels, th_surf_num_channel, nsurf, "output%th%th_surf%channels")
             output%th%th_surf%channels(1:th_surf_num_channel,1:nsurf)=zero
+            call my_alloc(output%th%th_surf%channels_output, th_surf_num_channel, nsurf, &
+              "output%th%th_surf%channels_output")
+            output%th%th_surf%channels_output(1:th_surf_num_channel,1:nsurf)=zero
           else
             call my_alloc(output%th%th_surf%channels, 0, 0, "output%th%th_surf%channels")
+            call my_alloc(output%th%th_surf%channels_output, 0, 0, "output%th%th_surf%channels_output")
           endif
           if(output%th%th_surf%iok > 0 ) then
             if(output%th%th_surf%loadp_flag > 0 ) then
@@ -1436,4 +1440,3 @@
 
         end subroutine resol_alloc_python
       end module resol_alloc_mod
-

--- a/engine/source/output/th/hist2.F
+++ b/engine/source/output/th/hist2.F
@@ -119,6 +119,7 @@ C-----------------------------------------------
       USE MATPARAM_DEF_MOD
       USE EBCS_MOD , only : t_ebcs_tab
       USE TH_SURF_MOD , only : TH_SURF_NUM_CHANNEL
+      USE SPMD_MOD , only : SPMD_REDUCE, SPMD_SUM
       use glob_therm_mod
       USE OUTPUT_MOD , ONLY : OUTPUT_
       use thsechecksum_mod
@@ -675,20 +676,29 @@ C---------------------------------------------------------
        ENDIF !NSURF > 0
 
 C---------------------------------------------------------
-C      /TH/SURF : SPMD EXCHANGE
+C      /TH/SURF : OUTPUT SNAPSHOT
 C---------------------------------------------------------
-       IF(NSPMD > 1)CALL SPMD_GLOB_DSUM9(FSAVSURF,5*NSURF)
+       IF(NSURF > 0)THEN
+         IF(NSPMD > 1)THEN
+           CALL SPMD_REDUCE(FSAVSURF,
+     .                      OUTPUT%TH%TH_SURF%CHANNELS_OUTPUT,
+     .                      TH_SURF_NUM_CHANNEL*NSURF,SPMD_SUM,IT_SPMD(1))
+         ELSE
+           OUTPUT%TH%TH_SURF%CHANNELS_OUTPUT = FSAVSURF
+         ENDIF
+       ENDIF
 
 C---------------------------------------------------------
-C      /TH/SURF (PRESSURE mean velues)
+C      /TH/SURF (PRESSURE mean values)
 C---------------------------------------------------------
        IF(ISPMD ==0 ) THEN
          DO I=1,NSURF
            IF(IGRSURF(I)%TH_SURF == 1) THEN
-             IF( FSAVSURF(5,I) > ZERO )THEN
-               FSAVSURF(4,I) = FSAVSURF(4,I) / FSAVSURF(5,I) ! The pressure in an average pressure
+             IF( OUTPUT%TH%TH_SURF%CHANNELS_OUTPUT(5,I) > ZERO )THEN
+               OUTPUT%TH%TH_SURF%CHANNELS_OUTPUT(4,I) =
+     .           OUTPUT%TH%TH_SURF%CHANNELS_OUTPUT(4,I) / OUTPUT%TH%TH_SURF%CHANNELS_OUTPUT(5,I)
              ELSE
-               FSAVSURF(4,I) = ZERO
+               OUTPUT%TH%TH_SURF%CHANNELS_OUTPUT(4,I) = ZERO
              ENDIF
            ENDIF
          ENDDO
@@ -696,19 +706,23 @@ C---------------------------------------------------------
 
 C---------------------------------------------------------
 C      /TH/SURF (EBCS mean values)
-C        total surface FSAVSURF(1,:) are here gathered and
+C        total surface output channels are gathered and
 C        they can be used here to divide
 C---------------------------------------------------------
-       IF (EBCS_TAB%nebcs > 0)THEN
+       IF (ISPMD == 0 .AND. EBCS_TAB%nebcs > 0)THEN
          DO K=1,EBCS_TAB%nebcs
            IF(.NOT.EBCS_TAB%need_to_compute(K)) CYCLE
            HAS_TH = EBCS_TAB%TAB(K)%poly%has_th
            IF(has_th) THEN
              SURF_ID = EBCS_TAB%TAB(K)%poly%surf_id
              NN = IGRSURF(SURF_ID)%NSEG
-             IF(FSAVSURF(1,SURF_ID) > ZERO)THEN
-               FSAVSURF(3,SURF_ID) =  FSAVSURF(3,SURF_ID) / FSAVSURF(1,SURF_ID)  !mean velocity
-               FSAVSURF(4,SURF_ID) =  FSAVSURF(4,SURF_ID) / FSAVSURF(1,SURF_ID)  !mean pressure
+             IF(OUTPUT%TH%TH_SURF%CHANNELS_OUTPUT(1,SURF_ID) > ZERO)THEN
+               OUTPUT%TH%TH_SURF%CHANNELS_OUTPUT(3,SURF_ID) =
+     .           OUTPUT%TH%TH_SURF%CHANNELS_OUTPUT(3,SURF_ID) /
+     .           OUTPUT%TH%TH_SURF%CHANNELS_OUTPUT(1,SURF_ID)
+               OUTPUT%TH%TH_SURF%CHANNELS_OUTPUT(4,SURF_ID) =
+     .           OUTPUT%TH%TH_SURF%CHANNELS_OUTPUT(4,SURF_ID) /
+     .           OUTPUT%TH%TH_SURF%CHANNELS_OUTPUT(1,SURF_ID)
              ENDIF
            ENDIF
          ENDDO!next K
@@ -1330,7 +1344,8 @@ C-----------------------------
 C-----------------------------
 C           /TH/SURF
 C-----------------------------
-            CALL THSURF(IAD,IAD+NN-1,IADV,IADV+NVAR-1,ITHBUF,WA ,FSAVSURF,ITTYP,NSURF)
+            CALL THSURF(IAD,IAD+NN-1,IADV,IADV+NVAR-1,ITHBUF,WA,
+     .                  OUTPUT%TH%TH_SURF%CHANNELS_OUTPUT,ITTYP,NSURF)
 C
           ELSEIF (ITYP==118) THEN
 C-----------------------------
@@ -1539,4 +1554,3 @@ C             Aout, Aout1, Uout, Mout, Hout
       END DO
       RETURN
       END SUBROUTINE BUFMONV
-


### PR DESCRIPTION
Fixes #5169.

## Summary

This change fixes silently incorrect `/TH/SURF` pressure and applied-area time
histories in MPI/SPMD runs. The defect depended on the surface's global index:
some surfaces were reduced across domains correctly, while later surfaces could
report zero pressure and area even when loads were applied on another MPI rank.

The fix also handles the persistent cumulative-mass channel safely. It performs
one MPI reduction of all six channels into a dedicated output snapshot, leaving
the per-rank accumulation state unchanged.

## Root cause

`FSAVSURF` is stored as:

```fortran
FSAVSURF(TH_SURF_NUM_CHANNEL, NSURF)
```

where `TH_SURF_NUM_CHANNEL = 6`:

| Channel | `/TH/SURF` variable | Meaning |
| --- | --- | --- |
| 1 | `AREA` | Surface area |
| 2 | `MASSFLOW` | Instantaneous mass flow |
| 3 | `VELOCITY` | Mean flow velocity |
| 4 | `P` | Mean pressure numerator / pressure |
| 5 | `A` | Area with applied pressure |
| 6 | `MASS` | Cumulative mass crossing the surface |

Before this change, `HIST2` used:

```fortran
CALL SPMD_GLOB_DSUM9(FSAVSURF, 5*NSURF)
```

The reduction wrapper treats the buffer as contiguous memory. In Fortran
column-major order, channel `c` of surface `i` is stored at:

```text
6 * (i - 1) + c
```

Consequently, `5*NSURF` reduces a prefix of the complete array; it does **not**
reduce channels 1 through 5 for every surface.

For example, with two surfaces, the reduction length is 10:

```text
surface 1: channels 1..6  -> positions 1..6
surface 2: channels 1..4  -> positions 7..10
surface 2: channel 5      -> position 11, not reduced
surface 2: channel 6      -> position 12, not reduced
```

Pressure for surface 2 can be reduced, but its applied-pressure area is not.
When rank 0 owns no loaded segments, the zero applied area triggers the existing
pressure guard and the reported pressure becomes zero. Later surfaces can have
both pressure and applied area omitted from the MPI sum.

## Why a one-line `6*NSURF` replacement is insufficient

Changing the existing call to `6*NSURF` would include every channel, but
`SPMD_GLOB_DSUM9` writes the reduced result back into its input buffer on rank 0.
That is unsafe for channel 6:

- `MASS` is a local, cumulative state value.
- Unlike channels 1:5, it is intentionally not reset after time-history output.
- If rank 0 retains a global sum and uses it as input to the next reduction, prior
  contributions are included again and cumulative mass can be double counted.

The old partial reduction already had inconsistent channel-6 behavior for early
surfaces because the contiguous prefix could include their sixth channel.

## Implementation

`TH_SURF_` now contains two arrays:

- `CHANNELS`: the existing rank-local accumulator used by loads, EBCS, and
  airbag calculations.
- `CHANNELS_OUTPUT`: a transient output snapshot with the same
  `(6, NSURF)` layout.

The snapshot is allocated once with the existing channel storage. In `HIST2`:

1. Local computations continue to update `CHANNELS`.
2. MPI runs call `SPMD_REDUCE` once to sum all `6*NSURF` values from
   `CHANNELS` into `CHANNELS_OUTPUT` on rank 0.
3. Serial runs copy `CHANNELS` into `CHANNELS_OUTPUT`.
4. Pressure averaging, EBCS normalization, and `THSURF` output use only
   `CHANNELS_OUTPUT`.

The local accumulator is therefore never overwritten by a global result.

## Performance

The implementation uses **one contiguous MPI reduction per `HIST2` call**. It
does not add six reductions, per-channel reductions, or per-surface reductions.

Compared with the previous incorrect call, the payload increases from
`5*NSURF` to `6*NSURF` values (20%), while preserving a single collective and
avoiding packing overhead. Reducing only channels 1:5 would require a strided
array section in the current layout; a correct implementation would need
packing plus a separate channel-6 reduction, adding both memory traffic and
collective latency.

## Compatibility

- Single-rank behavior is preserved through a local snapshot copy.
- The restart format is unchanged: `CHANNELS_OUTPUT` is derived scratch storage
  allocated at engine initialization and is not serialized.
- Channels 1:5 retain their existing reset behavior; channel 6 remains a
  rank-local cumulative accumulator between output writes.

## Validation

The MPI engine build completed successfully. The intended runtime regression
case is a multi-rank model with a pressure-loaded late-index surface and a
cumulative-mass `/TH/SURF` output; its pressure, applied area, and cumulative
mass should match the corresponding single-rank results.