### PR TITLE
INTENT attribute consistency (engine only)

### DIFF
--- a/engine/source/ale/grid/alewdx.F
+++ b/engine/source/ale/grid/alewdx.F
@@ -149,7 +149,8 @@ C-----------------------------------------------
       TYPE(ELBUF_STRUCT_), DIMENSION(NGROUP) :: ELBUF_TAB
       TYPE(INTBUF_STRUCT_) INTBUF_TAB(*)
       TYPE (GROUP_)  , DIMENSION(NGRNOD)  :: IGRNOD
-      TYPE(t_ale_connectivity), INTENT(IN) :: ALE_CONNECTIVITY
+C     ALEWDX_GRID_BCS declares NALE as INTENT(INOUT).
+      TYPE(t_ale_connectivity), INTENT(INOUT) :: ALE_CONNECTIVITY
       INTEGER, INTENT(IN) :: NE_NERCVOIS(*), NE_NESDVOIS(*), NE_LERCVOIS(*), NE_LESDVOIS(*)
       DOUBLE PRECISION, INTENT(INOUT) :: WFEXT
 C-----------------------------------------------

--- a/engine/source/elements/beam/fail_beam18.F
+++ b/engine/source/elements/beam/fail_beam18.F
@@ -101,7 +101,8 @@ C-----------------------------------------------
       my_real ,DIMENSION(NEL,NPT)        ,INTENT(IN)    :: SIGY    
 C
       TYPE (ELBUF_STRUCT_)    ,INTENT(INOUT) :: ELBUF_STR
-      TYPE (FAIL_PARAM_)      ,INTENT(IN)    :: FAIL
+C     FAIL_ENERGY_IB declares FAIL as INTENT(INOUT).
+      TYPE (FAIL_PARAM_)      ,INTENT(INOUT) :: FAIL
       TYPE (MATPARAM_STRUCT_) ,INTENT(IN)    :: MAT_PARAM
       TARGET :: ELBUF_STR
 C-----------------------------------------------

--- a/engine/source/elements/beam/fail_beam3.F
+++ b/engine/source/elements/beam/fail_beam3.F
@@ -104,7 +104,8 @@ C-----------------------------------------------
 C                                                         
       TYPE (ELBUF_STRUCT_)    ,INTENT(INOUT) :: ELBUF_STR
       TYPE (MATPARAM_STRUCT_) ,INTENT(IN)    :: MAT_PARAM
-      TYPE (FAIL_PARAM_)      ,INTENT(IN)    :: FAIL
+C     FAIL_ENERGY_B declares FAIL as INTENT(INOUT).
+      TYPE (FAIL_PARAM_)      ,INTENT(INOUT) :: FAIL
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C----------------------------------------------- 

--- a/engine/source/elements/beam/main_beam18.F
+++ b/engine/source/elements/beam/main_beam18.F
@@ -102,7 +102,8 @@ C-----------------------------------------------
       my_real ,DIMENSION(STF)  ,INTENT(IN)    :: TF
 C
       TYPE (ELBUF_STRUCT_) ,INTENT(INOUT) :: ELBUF_STR
-      TYPE (MATPARAM_STRUCT_) ,INTENT(IN) :: MAT_PARAM
+C     FAIL_BEAM18 declares FAIL as INTENT(INOUT).
+      TYPE (MATPARAM_STRUCT_) ,INTENT(INOUT) :: MAT_PARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/engine/source/elements/beam/main_beam3.F
+++ b/engine/source/elements/beam/main_beam3.F
@@ -100,7 +100,8 @@ C-----------------------------------------------
       my_real ,DIMENSION(NEL)  ,INTENT(OUT)   :: EPSD
       my_real ,DIMENSION(NEL,NUVAR) ,INTENT(INOUT) :: UVAR
       TYPE (ELBUF_STRUCT_) ,INTENT(INOUT) :: ELBUF_STR
-      TYPE (MATPARAM_STRUCT_) ,INTENT(IN) :: MAT_PARAM
+C     FAIL_BEAM3 declares FAIL as INTENT(INOUT).
+      TYPE (MATPARAM_STRUCT_) ,INTENT(INOUT) :: MAT_PARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/engine/source/elements/beam/pforc3.F
+++ b/engine/source/elements/beam/pforc3.F
@@ -134,7 +134,8 @@ C-----------------------------------------------
 C
       TYPE (ELBUF_STRUCT_), TARGET :: ELBUF_STR
       TYPE (H3D_DATABASE) :: H3D_DATA
-      TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(IN) :: MAT_PARAM
+C     MAIN_BEAM3 declares MAT_PARAM as INTENT(INOUT).
+      TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(INOUT) :: MAT_PARAM
       TYPE (DT_), INTENT(IN) :: DT
       type (sensors_),INTENT(INOUT) :: SENSORS
 C-----------------------------------------------

--- a/engine/source/elements/spring/r23law114.F
+++ b/engine/source/elements/spring/r23law114.F
@@ -89,7 +89,8 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
-      type(python_), intent(in) :: PYTHON
+C     REDEF3 declares PYTHON as INTENT(INOUT).
+      type(python_), intent(inout) :: PYTHON
       INTEGER, INTENT(IN) :: STF !< Size of TF
       INTEGER, INTENT(IN) :: SANIN !< Size of ANIM
       INTEGER, INTENT(IN) :: IRESP !< Single Precision flag

--- a/engine/source/input/lectur.F
+++ b/engine/source/input/lectur.F
@@ -207,7 +207,8 @@ C-----------------------------------------------
       CHARACTER MDS_LABEL(1024,MDS_NMAT)
       TYPE (STACK_PLY) :: STACK
       TYPE (SENSORS_) ,INTENT(INOUT) ,TARGET :: SENSORS
-      TYPE (MAT_ELEM_), INTENT(IN) :: MAT_ELEM
+C     LECSTAT declares MAT_PARAM as INTENT(INOUT).
+      TYPE (MAT_ELEM_), INTENT(INOUT) :: MAT_ELEM
       TYPE (DYNAIN_DATABASE), INTENT(INOUT)  :: DYNAIN_DATA
       TYPE (DT_), INTENT(INOUT)              :: DT
       TYPE(OUTPUT_), INTENT(INOUT) :: OUTPUT !< output structure
@@ -3931,4 +3932,3 @@ C
  8700 FORMAT(
      .  ' FREE RIGID MOTION /MRIGM W/ REF_NODE_ID:',2X,3I10/)
       END
-

--- a/engine/source/interfaces/int25/i25mainf.F
+++ b/engine/source/interfaces/int25/i25mainf.F
@@ -162,7 +162,8 @@ C     REAL
       TYPE(INTBUF_STRUCT_) INTBUF_TAB
       TYPE(H3D_DATABASE) :: H3D_DATA
       TYPE(INTBUF_FRIC_STRUCT_), TARGET, DIMENSION(NINTERFRIC) ::  INTBUF_FRIC_TAB
-      TYPE (INTERFACES_) ,INTENT(IN):: INTERFACES
+C     I25COR3_3 declares PARAMETERS as INTENT(INOUT).
+      TYPE (INTERFACES_) ,INTENT(INOUT):: INTERFACES
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------

--- a/engine/source/mpi/anim/spmd_gather_wa.F
+++ b/engine/source/mpi/anim/spmd_gather_wa.F
@@ -51,7 +51,9 @@ C-----------------------------------------------
 !       MODE = 0 --> collect the index array for each proc
 !       MODE = 1 --> collect all the buffer arrays
 !       SIZE_BUFFER_S is the size of the local sended array
-        INTEGER, INTENT(IN) :: MODE,SIZE_BUFFER_S
+        INTEGER, INTENT(IN) :: MODE
+!       SPMD_GATHERV declares RECVBUF as INTENT(INOUT).
+        INTEGER, INTENT(INOUT) :: SIZE_BUFFER_S
 !       SIZE_BUFFER_R is the size of the global received array, proc 0 
         INTEGER, INTENT(INOUT) :: SIZE_BUFFER_R
 !       SINDEX : index buffer array, local on each proc                      
@@ -59,7 +61,8 @@ C-----------------------------------------------
 !       RINDEX_PROC : global index buffer array, only on proc 0
         INTEGER, DIMENSION(NSECT+1,3,NSPMD), INTENT(INOUT) :: RINDEX_PROC
 !       BUFFER_S : sended buffer
-        INTEGER, DIMENSION(SIZE_BUFFER_S), INTENT(IN) :: BUFFER_S
+!       SPMD_GATHERV declares SENDBUF as INTENT(INOUT).
+        INTEGER, DIMENSION(SIZE_BUFFER_S), INTENT(INOUT) :: BUFFER_S
 !       BUFFER_R : received buffer, size = SIZE_BUFFER_R on proc 0
         INTEGER, DIMENSION(*), INTENT(INOUT) :: BUFFER_R
         INTEGER, DIMENSION(NSPMD), INTENT(INOUT) :: SHIFT_R,NB_ELEM_R

--- a/engine/source/mpi/forces/spmd_i7fcom_pon.F
+++ b/engine/source/mpi/forces/spmd_i7fcom_pon.F
@@ -129,7 +129,8 @@ C-----------------------------------------------
       TYPE(INTBUF_STRUCT_) INTBUF_TAB(*)
       TYPE(H3D_DATABASE) :: H3D_DATA
       TYPE(MULTI_FVM_STRUCT) :: MULTI_FVM
-      TYPE (INTERFACES_)    ,INTENT(IN) :: INTERFACES
+C     REALLOCATE_I_SKYLINE declares PON as INTENT(INOUT).
+      TYPE (INTERFACES_)    ,INTENT(INOUT) :: INTERFACES
       TYPE (GLOB_THERM_)    ,INTENT(IN) :: GLOB_THERM
 C-----------------------------------------------
       TYPE (GROUP_)  , DIMENSION(NGRBRIC) :: IGRBRIC

--- a/engine/source/output/h3d/h3d_results/h3d_quad_scalar.F
+++ b/engine/source/output/h3d/h3d_results/h3d_quad_scalar.F
@@ -103,7 +103,8 @@ C-----------------------------------------------
       TYPE(MULTI_FVM_STRUCT), INTENT(IN) :: MULTI_FVM
       TYPE(t_ale_connectivity), INTENT(IN) :: ALE_CONNECT
       my_real, TARGET :: BUFMAT(*)
-      INTEGER, INTENT(in) :: NERCVOIS(*),NESDVOIS(*), LERCVOIS(*),LESDVOIS(*)
+C     SCHLIEREN_BUFFER_GATHERING declares these arrays as INTENT(INOUT).
+      INTEGER, INTENT(INOUT) :: NERCVOIS(*),NESDVOIS(*), LERCVOIS(*),LESDVOIS(*)
       TYPE (MATPARAM_STRUCT_) ,DIMENSION(NUMMAT) ,INTENT(IN) :: MAT_PARAM
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
@@ -144,4 +145,3 @@ C-----------
 C-----------------------------------------------
       RETURN
       END
-


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
This pull request updates the intent of several subroutine arguments across the codebase to ensure consistency with how these variables are used in other routines or to match their usage in called subroutines. The changes primarily affect the `INTENT` specification of arguments, switching many from `IN` to `INOUT` based on their modification in subroutine calls. This helps prevent potential bugs and clarifies data flow in the code.

The most important changes are:

**Beam Elements and Material Parameters:**
* Changed the `FAIL` argument in `FAIL_BEAM18` and `FAIL_BEAM3` from `INTENT(IN)` to `INTENT(INOUT)` to match their usage in `FAIL_ENERGY_IB` and `FAIL_ENERGY_B` respectively. [[1]](diffhunk://#diff-ee7a1f53a6fb7a9ce3466f8f3e019bcefe07ff51d747c76decf78df088a950d7L104-R105) [[2]](diffhunk://#diff-fbf7453acd42558fa7270ffe8de9d977f11a60efcb925eda5385c10bb8a18431L107-R108)
* Updated the `MAT_PARAM` argument in `MAIN_BEAM18`, `MAIN_BEAM3`, and `PFORC3` from `INTENT(IN)` to `INTENT(INOUT)` for consistency with `FAIL_BEAM18` and `MAIN_BEAM3`. [[1]](diffhunk://#diff-7abf198fa3528af778e16701f9343eca7fe8b82cb96711c1869054ba864f2531L105-R106) [[2]](diffhunk://#diff-1d9de5abe6f260ff307de3f398ebc852463f9fc0c34b94b89e23e98d16cd4a08L103-R104) [[3]](diffhunk://#diff-9fe5963c3c592a6b1ffadd3443568094a0e0c9b748ff35ab0b23a39f17d56f04L137-R138)

**Interface and Connectivity Structures:**
* Changed the `INTERFACES` argument in `I25MAINF` and `SPMD_I7FCOM_PON` from `INTENT(IN)` to `INTENT(INOUT)` to match their use in `I25COR3_3` and `REALLOCATE_I_SKYLINE`. [[1]](diffhunk://#diff-7930728faac47eacd1620c481ff194f338a6683539c87c17fef2d7269c8f8752L165-R166) [[2]](diffhunk://#diff-23341a37eddccd577fb1e58b44cd8183622ccfac6580690ef5b1b765b33f8015L132-R133)
* Updated the `ALE_CONNECTIVITY` argument in `ALEWDX` from `INTENT(IN)` to `INTENT(INOUT)` to align with its usage in `ALEWDX_GRID_BCS`.

**Input and Output Handling:**
* Changed the `MAT_ELEM` argument in `LECTUR` from `INTENT(IN)` to `INTENT(INOUT)` based on its usage in `LECSTAT`.
* Updated several neighbor array arguments in `H3D_QUAD_SCALAR` from `INTENT(IN)` to `INTENT(INOUT)` for compatibility with `SCHLIEREN_BUFFER_GATHERING`.

**MPI and Buffer Management:**
* Modified buffer-related arguments in `SPMD_GATHER_WA` from `INTENT(IN)` to `INTENT(INOUT)` to match their use in `SPMD_GATHERV`.
* Changed the `PYTHON` argument in `R23LAW114` from `INTENT(IN)` to `INTENT(INOUT)` to align with `REDEF3`.

These changes improve code clarity, maintainability, and reduce the risk of bugs due to mismatched argument intent specifications.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
