### PR TITLE
bug fix: /DT/NODA  reproducibility issue for /PARITH/ON

### DIFF
--- a/common_source/tools/sort/cppsort.cpp
+++ b/common_source/tools/sort/cppsort.cpp
@@ -43,7 +43,7 @@ void stlsort_generic_generic(int *len,  K *keys, V *values){
         pairs[i] = std::make_pair(keys[i], values[i]);
     }
 
-    std::sort(pairs.begin(), pairs.end(), [](const std::pair<K, V> &a, const std::pair<K, V> &b) {
+    std::stable_sort(pairs.begin(), pairs.end(), [](const std::pair<K, V> &a, const std::pair<K, V> &b) {
         return a.first < b.first;
     });
 
@@ -51,6 +51,46 @@ void stlsort_generic_generic(int *len,  K *keys, V *values){
         keys[i] = pairs[i].first;
         values[i] = pairs[i].second;
     }
+}
+
+// Sort by two real keys (key1 primary, key2 secondary), tracking a 1-based integer permutation.
+// Used for reproducible /DT/NODA sorting independent of MPI partition order.
+template<typename K>
+void stlsort_real2_int_generic(int *len, K *key1, K *key2, int *perm) {
+    int n = *len;
+    // Build index array (0-based internally, returned as 1-based)
+    std::vector<int> idx(n);
+    for (int i = 0; i < n; ++i) idx[i] = i;
+
+    std::stable_sort(idx.begin(), idx.end(), [&](int a, int b) {
+        if (key1[a] != key1[b]) return key1[a] < key1[b];
+        return key2[a] < key2[b];
+    });
+
+    // Reorder key1 and key2 in place and write 1-based perm
+    std::vector<K> k1(n), k2(n);
+    for (int i = 0; i < n; ++i) { k1[i] = key1[idx[i]]; k2[i] = key2[idx[i]]; }
+    for (int i = 0; i < n; ++i) { key1[i] = k1[i]; key2[i] = k2[i]; perm[i] = idx[i] + 1; }
+}
+
+// Sort by real key (primary) then integer key (secondary), tracking a 1-based integer permutation.
+// Used for reproducible /DT/NODA sorting: primary=DT ratio, secondary=node user ID.
+template<typename K>
+void stlsort_real_int2_int_generic(int *len, K *key1, int *key2, int *perm) {
+    int n = *len;
+    std::vector<int> idx(n);
+    for (int i = 0; i < n; ++i) idx[i] = i;
+
+    std::stable_sort(idx.begin(), idx.end(), [&](int a, int b) {
+        if (key1[a] != key1[b]) return key1[a] < key1[b];
+        return key2[a] < key2[b];
+    });
+
+    // Reorder key1 and key2 in place and write 1-based perm
+    std::vector<K> k1(n);
+    std::vector<int> k2(n);
+    for (int i = 0; i < n; ++i) { k1[i] = key1[idx[i]]; k2[i] = key2[idx[i]]; }
+    for (int i = 0; i < n; ++i) { key1[i] = k1[i]; key2[i] = k2[i]; perm[i] = idx[i] + 1; }
 }
 
 extern "C" {
@@ -108,5 +148,38 @@ extern "C" {
     void STLSORT_REAL_INT_(int *len, my_real* keys,  int *values) {
          stlsort_generic_generic<my_real,int>(len, keys, values); 
     } 
-}
 
+// sort by two real keys (primary, secondary) with 1-based integer permutation output
+    void stlsort_real2_int(int *len, my_real* key1, my_real* key2, int *perm) {
+         stlsort_real2_int_generic<my_real>(len, key1, key2, perm);
+    }
+    void stlsort_real2_int__(int *len, my_real* key1, my_real* key2, int *perm) {
+         stlsort_real2_int_generic<my_real>(len, key1, key2, perm);
+    }
+    void _FCALL stlsort_real2_int_(int *len, my_real* key1, my_real* key2, int *perm) {
+         stlsort_real2_int_generic<my_real>(len, key1, key2, perm);
+    }
+    void _FCALL STLSORT_REAL2_INT(int *len, my_real* key1, my_real* key2, int *perm) {
+         stlsort_real2_int_generic<my_real>(len, key1, key2, perm);
+    }
+    void STLSORT_REAL2_INT_(int *len, my_real* key1, my_real* key2, int *perm) {
+         stlsort_real2_int_generic<my_real>(len, key1, key2, perm);
+    }
+
+// sort by real primary key + integer secondary key (e.g. node user ID) with 1-based permutation output
+    void stlsort_real_int2_int(int *len, my_real* key1, int* key2, int *perm) {
+         stlsort_real_int2_int_generic<my_real>(len, key1, key2, perm);
+    }
+    void stlsort_real_int2_int__(int *len, my_real* key1, int* key2, int *perm) {
+         stlsort_real_int2_int_generic<my_real>(len, key1, key2, perm);
+    }
+    void _FCALL stlsort_real_int2_int_(int *len, my_real* key1, int* key2, int *perm) {
+         stlsort_real_int2_int_generic<my_real>(len, key1, key2, perm);
+    }
+    void _FCALL STLSORT_REAL_INT2_INT(int *len, my_real* key1, int* key2, int *perm) {
+         stlsort_real_int2_int_generic<my_real>(len, key1, key2, perm);
+    }
+    void STLSORT_REAL_INT2_INT_(int *len, my_real* key1, int* key2, int *perm) {
+         stlsort_real_int2_int_generic<my_real>(len, key1, key2, perm);
+    }
+}

--- a/common_source/tools/sort/cppsort_mod.F90
+++ b/common_source/tools/sort/cppsort_mod.F90
@@ -1,0 +1,69 @@
+!Copyright>        OpenRadioss
+!Copyright>        Copyright (C) 2026 Siemens
+!Copyright>
+!Copyright>        This program is free software: you can redistribute it and/or modify
+!Copyright>        it under the terms of the GNU Affero General Public License as published by
+!Copyright>        the Free Software Foundation, either version 3 of the License, or
+!Copyright>        (at your option) any later version.
+!Copyright>
+!Copyright>        This program is distributed in the hope that it will be useful,
+!Copyright>        but WITHOUT ANY WARRANTY; without even the implied warranty of
+!Copyright>        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!Copyright>        GNU Affero General Public License for more details.
+!Copyright>
+!Copyright>        You should have received a copy of the GNU Affero General Public License
+!Copyright>        along with this program.  If not, see <https://www.gnu.org/licenses/>.
+!Copyright>
+!Copyright>
+!Copyright>        Commercial Alternative: Simcenter Radioss Software
+!Copyright>
+!Copyright>        As an alternative to this open-source version, Siemens also offers Simcenter(TM) Radioss(R)
+!Copyright>        software under a commercial license.  Contact Siemens to discuss further if the
+!Copyright>        commercial version may interest you: 
+!Copyright>        https://www.siemens.com/en-us/products/simcenter/mechanical-simulation/radioss/.
+! ----------------------------------------------------------------------------------------------------------------------
+module cppsort_mod
+  use precision_mod, only : wp
+  implicit none
+
+  contains
+
+!! \brief Sort by two real keys (primary key1, secondary key2) with 1-based permutation output.
+!!
+!! \details Uses std::stable_sort with lexicographic (key1, key2) comparator.
+!!
+!! \param[in]     n     Number of elements
+!! \param[inout]  key1  Primary sort key array (real, sorted on output)
+!! \param[inout]  key2  Secondary sort key array (real, sorted on output)
+!! \param[out]    perm  1-based permutation array
+  subroutine sort_real2_perm(n, key1, key2, perm)
+    integer,       intent(in)    :: n
+    real(kind=wp), intent(inout) :: key1(n)
+    real(kind=wp), intent(inout) :: key2(n)
+    integer,       intent(out)   :: perm(n)
+
+    call stlsort_real2_int(n, key1, key2, perm)
+
+  end subroutine sort_real2_perm
+
+!! \brief Sort by real primary key then integer secondary key, with 1-based permutation output.
+!!
+!! \details Enables fully deterministic node ordering for /DT/NODA reproducibility across
+!!          MPI decompositions. When all DT = MS/STIFN ratios are equal (uniform mesh),
+!!          the integer secondary key (node user ID) uniquely determines the sort order.
+!!
+!! \param[in]     n     Number of elements
+!! \param[inout]  key1  Primary sort key array (real, sorted on output)
+!! \param[inout]  key2  Secondary sort key array (integer, sorted on output)
+!! \param[out]    perm  1-based permutation array
+  subroutine sort_real_int2_perm(n, key1, key2, perm)
+    integer,       intent(in)    :: n
+    real(kind=wp), intent(inout) :: key1(n)
+    integer,       intent(inout) :: key2(n)
+    integer,       intent(out)   :: perm(n)
+
+    call stlsort_real_int2_int(n, key1, key2, perm)
+
+  end subroutine sort_real_int2_perm
+
+end module cppsort_mod

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -1554,7 +1554,7 @@ C------------------------------------------
      .                                NGPE,NGRTH,NELEM,NODREAC,GRTH,IGRTH,DXANCG, 
      .                                IGROUPFLG,IGROUPC,IGROUPTG,IGROUPS,NUMMAT,IPM,NPROPMI, 
      .                                NVOLU,NUMELC,NUMELS)
- 
+
 C-----------------------------------------------
 C /IMPDISP/FGEO
               FXVEL_FGEO = 0
@@ -5790,7 +5790,7 @@ C----------------------------------------------------------
                 call spmd_profile_begin(PROF_RWALL)
                 CALL RGWALF(NODES%A ,RWALL%RWBUF ,RWALL%NPRW ,NODES%MS )
                 IF (RWALL%nrwall_pen>0 .AND. IMPL_S==0) THEN 
-                   nsect_offset = nsect + nintsub + ninter 
+                   nsect_offset = nsect + nintsub + ninter
 !$OMP PARALLEL
                   CALL RGWAL0_PEN(
      1            NODES%X           ,NODES%A        ,NODES%V      ,NODES%MS       ,NUMNOD            ,
@@ -5977,7 +5977,7 @@ C----------------------------------------------------------
               IF ((NCYCLE==0).AND.(IDT_PERCENT_ADDMASS > 0).AND.(IDTMIN(11)==3.OR.IDTMIN(11)==8)) THEN
                 CALL FIND_DT_FOR_TARGETED_ADDED_MASS(NODES%MS,NODES%STIFN,DTFAC1(11),IDTGR(11),TARGET_DT,
      .                                               PERCENT_ADDMASS,PERCENT_ADDMASS_OLD,MASS0_START,NODES%WEIGHT_MD,IGRNOD,
-     .                                               ICNDS10)
+     .                                               ICNDS10,NODES%ITAB)
                 DTMIN1(11) = MAX(DTMIN1(11),TARGET_DT)
               ELSEIF ((IDT_PERCENT_ADDMASS == 2).AND.(IDTMIN(11) == 8)) THEN
 C--     For /DT/NODA/STOP + % added mass - IDTMIN switch back to 1 after first cycle

--- a/engine/source/mpi/generic/spmd_gather_dtnoda.F
+++ b/engine/source/mpi/generic/spmd_gather_dtnoda.F
@@ -29,7 +29,7 @@ Copyright>        https://www.siemens.com/en-us/products/simcenter/mechanical-si
 !||--- uses       -----------------------------------------------------
 !||    spmd_comm_world_mod               ../engine/source/mpi/spmd_comm_world.F90
 !||====================================================================
-       SUBROUTINE SPMD_GATHER_DTNODA(TAGN,STIFN,MS,WEIGHT,NUM,DT2_L,STF_L,MS_L)
+       SUBROUTINE SPMD_GATHER_DTNODA(TAGN,STIFN,MS,WEIGHT,ITAB,NUM,DT2_L,STF_L,MS_L,UID_L)
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -47,19 +47,21 @@ C   D u m m y   A r g u m e n t s
 C-----------------------------------------------
        my_real
      .   STIFN(*),MS(*),DT2_L(*),MS_L(*),STF_L(*)
-       INTEGER WEIGHT(*),NUM,TAGN(*)
+       INTEGER WEIGHT(*),NUM,TAGN(*),ITAB(*),UID_L(*)
 C-----------------------------------------------
 C   L O C A L   V A R I A B L E S
 C-----------------------------------------------
 #ifdef MPI
       INTEGER STATUS(MPI_STATUS_SIZE),IERROR,MS_LOFF,ID_G
-      INTEGER SIZ,MS_LTYP,I,K,NREC
+      INTEGER SIZ,MS_LTYP,I,K,NREC,UID_LTYP
 
       DATA MS_LOFF/7014/
        my_real, DIMENSION(:) , ALLOCATABLE :: BUFSR
+       INTEGER, DIMENSION(:) , ALLOCATABLE :: BUFI
 C
 C=======================================================================
-       ALLOCATE (BUFSR(3*NUM))     
+       ALLOCATE (BUFSR(3*NUM))
+       ALLOCATE (BUFI(NUM))
 C  
        IF (ISPMD/=0) THEN     
          SIZ = 0
@@ -68,16 +70,17 @@ C
              SIZ = SIZ + 3
              BUFSR(SIZ-2) = MS(I)/STIFN(I)
              BUFSR(SIZ-1) = STIFN(I) 
-             BUFSR(SIZ  ) = MS(I)  
+             BUFSR(SIZ  ) = MS(I)
+             BUFI(SIZ/3) = ITAB(I)
            END IF
          END DO 
 
-C   Because of the simple precision version, we cannot put the integer
-C   In the floating buffer because there are only 2 24 bits available ~ 16 million
-C   nodes at most
-
+C   Floating buffer (MS/STIFN, STIFN, MS)
          MS_LTYP = MS_LOFF 
          CALL MPI_SEND(BUFSR,SIZ,REAL,IT_SPMD(1),MS_LTYP,
+     .     SPMD_COMM_WORLD,ierror)
+         UID_LTYP = MS_LOFF + 1
+         CALL MPI_SEND(BUFI,SIZ/3,MPI_INTEGER,IT_SPMD(1),UID_LTYP,
      .     SPMD_COMM_WORLD,ierror)
 
        ELSE
@@ -87,7 +90,8 @@ C   nodes at most
               ID_G = ID_G + 1 
               DT2_L(ID_G) = MS(I)/STIFN(I) 
               STF_L(ID_G) = STIFN(I) 
-              MS_L(ID_G) = MS(I) 
+              MS_L(ID_G) = MS(I)
+              UID_L(ID_G) = ITAB(I)
             ENDIF
           ENDDO
 
@@ -99,8 +103,10 @@ C-------------
               CALL MPI_GET_COUNT(STATUS,REAL,SIZ,ierror) 
 
 C------------ Reception of the floating buffer
-
             CALL MPI_RECV(BUFSR,SIZ,REAL,IT_SPMD(I),MS_LTYP,
+     .                  SPMD_COMM_WORLD,STATUS,ierror)
+            UID_LTYP = MS_LOFF + 1
+            CALL MPI_RECV(BUFI,SIZ/3,MPI_INTEGER,IT_SPMD(I),UID_LTYP,
      .                  SPMD_COMM_WORLD,STATUS,ierror)
      
             NREC = SIZ
@@ -108,13 +114,15 @@ C------------ Reception of the floating buffer
               ID_G = ID_G + 1
               DT2_L(ID_G) = BUFSR(K)
               STF_L(ID_G) = BUFSR(K+1)
-              MS_L(ID_G) = BUFSR(K+2) 
+              MS_L(ID_G) = BUFSR(K+2)
+              UID_L(ID_G) = BUFI(K/3+1)
             ENDDO
 C
           ENDDO
 
        ENDIF
        DEALLOCATE(BUFSR)
+       DEALLOCATE(BUFI)
 
 #endif
        RETURN

--- a/engine/source/time_step/find_dt_for_targeted_added_mass.F
+++ b/engine/source/time_step/find_dt_for_targeted_added_mass.F
@@ -27,7 +27,6 @@ Copyright>        https://www.siemens.com/en-us/products/simcenter/mechanical-si
 !||    resol                             ../engine/source/engine/resol.F
 !||--- calls      -----------------------------------------------------
 !||    find_dt_target                    ../common_source/tools/time_step/find_dt_target.F
-!||    myqsort                           ../common_source/tools/sort/myqsort.F
 !||    spmd_gather_dtnoda                ../engine/source/mpi/generic/spmd_gather_dtnoda.F
 !||    spmd_glob_imax9                   ../engine/source/mpi/generic/spmd_glob_imax9.F
 !||    spmd_glob_isum9                   ../engine/source/mpi/interfaces/spmd_th.F
@@ -40,12 +39,13 @@ Copyright>        https://www.siemens.com/en-us/products/simcenter/mechanical-si
 !||====================================================================
       SUBROUTINE FIND_DT_FOR_TARGETED_ADDED_MASS(MS,STIFN,DTSCA,IGRP_USR,TARGET_DT,
      .                                           PERCENT_ADDMASS,PERCENT_ADDMASS_OLD,TOTMAS,WEIGHT,IGRNOD,
-     .                                           ICNDS10)
+     .                                           ICNDS10,ITAB)
 C-----------------------------------------------
 C   A n a l y s e   M o d u l e
 C-----------------------------------------------
       USE GROUPDEF_MOD
       USE MESSAGE_MOD
+      USE CPPSORT_MOD, ONLY : SORT_REAL_INT2_PERM
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -55,7 +55,7 @@ C-----------------------------------------------
 C-----------------------------------------------
 C   D u m m y   A r g u m e n t s
 C----------------------------------------------- 
-      INTEGER WEIGHT(*),IGRP_USR,ICNDS10(3,*)
+      INTEGER WEIGHT(*),IGRP_USR,ICNDS10(3,*),ITAB(*)
       my_real
      .   MS(*),STIFN(*),TARGET_DT,DTSCA,PERCENT_ADDMASS,PERCENT_ADDMASS_OLD,TOTMAS
 C-----------------------------------------------
@@ -75,10 +75,11 @@ C-----------------------------------------------
      .   DT2_L
       my_real, DIMENSION(:),ALLOCATABLE :: 
      .   STF_L,MS_L
+      INTEGER, DIMENSION(:),ALLOCATABLE ::
+     .   UID_L
       my_real, DIMENSION(:),POINTER ::
      .   TMP
       my_real SUMK,SUMM,TARGET_PERCENT
-      INTEGER :: IERROR
       INTEGER, DIMENSION(:), ALLOCATABLE :: PERM
 C=======================================================================
 C
@@ -133,22 +134,25 @@ C---  Counstruction of arrays
           call my_alloc(DT2_L, 2*SIZG, "DT2_L")
           call my_alloc(STF_L, SIZG, "STF_L")
           call my_alloc(MS_L, SIZG, "MS_L")
-          SIZ = SIZ_MAX
-        ENDIF
-        CALL SPMD_GATHER_DTNODA(TAGN,STIFN,MS,WEIGHT,SIZ,DT2_L,STF_L,MS_L)
+          call my_alloc(UID_L, SIZG, "UID_L")
+        SIZ = SIZ_MAX
+      ENDIF
+      CALL SPMD_GATHER_DTNODA(TAGN,STIFN,MS,WEIGHT,ITAB,SIZ,DT2_L,STF_L,MS_L,UID_L)
       ELSE
-        call my_alloc(DT2_L, 2*SIZG, "DT2_L")
-        call my_alloc(STF_L, SIZG, "STF_L")
-        call my_alloc(MS_L, SIZG, "MS_L")
-        COMPT = 0
-        DO I=1,NUMNOD
-          IF (TAGN(I) > 0) THEN
-            COMPT = COMPT + 1
-            DT2_L(COMPT) = MS(I)/STIFN(I)
-            MS_L(COMPT) = MS(I)
-            STF_L(COMPT) = STIFN(I)
-          ENDIF
-        ENDDO
+      call my_alloc(DT2_L, 2*SIZG, "DT2_L")
+      call my_alloc(STF_L, SIZG, "STF_L")
+      call my_alloc(MS_L, SIZG, "MS_L")
+      call my_alloc(UID_L, SIZG, "UID_L")
+      COMPT = 0
+      DO I=1,NUMNOD
+        IF (TAGN(I) > 0) THEN
+          COMPT = COMPT + 1
+          DT2_L(COMPT) = MS(I)/STIFN(I)
+          MS_L(COMPT) = MS(I)
+          STF_L(COMPT) = STIFN(I)
+          UID_L(COMPT) = ITAB(I)
+        ENDIF
+      ENDDO
       ENDIF
 C
       call my_dealloc(TAGN)
@@ -163,13 +167,12 @@ C
         SUMM = ZERO
         SUMK = ZERO
         DO I=1,SIZG
-          TMP(I)=I
           PERM(I) = I
           SUMM = SUMM + MS_L(I)
           SUMK = SUMK + STF_L(I)
         ENDDO
 
-        CALL MYQSORT(SIZG,DT2_L,PERM,IERROR)
+        CALL SORT_REAL_INT2_PERM(SIZG, DT2_L, UID_L, PERM)
         TMP(1:SIZG) = PERM(1:SIZG)
 
         call my_dealloc(PERM)
@@ -190,6 +193,7 @@ C
         call my_dealloc(DT2_L)
         call my_dealloc(STF_L)
         call my_dealloc(MS_L)
+        call my_dealloc(UID_L)
 C
       ENDIF
 C


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
the  /DT/NODA  added-mass target-DT computation was using a sort key based on  DT = MS/STIFN 
when several nodes share the same  DT  and  STIFN , the key does not define a unique order
that leaves the  MS / STIFN  accumulation order MPI-dependent and breaks  /PARITH/ON  reproducibility


#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
make  /DT/NODA  target-DT gathering deterministic across MPI
carry node user IDs through the gather and sort ties with a unique integer key

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
