### PR TITLE
DAMP_FUNC : fix of default for alpha

### DIFF
--- a/starter/source/general_controls/damping/hm_read_damp.F
+++ b/starter/source/general_controls/damping/hm_read_damp.F
@@ -342,7 +342,7 @@ C--------------------------------------------------
           TSTART = ZERO
           TSTOP=EP30
           FULL_FORMAT = .TRUE. 
-          IF (ALPHA==ZERO) ALPHA = ONE ! default =1 to add in manual
+          IF ((FUNC_ID /= 0).AND.(ALPHA==ZERO)) ALPHA = ONE ! default =1 if function is defined
           FACTB = ALPHA
           ALPHA = ALPHA_X
 !---------FUNC ID user-----------------------------


### PR DESCRIPTION
/DAMP/FUNCT - fix of default value of alpha when function is not defined
