### PR TITLE
/INTER/TYPE10: fix crash on restart with PARITH/ON

### DIFF
--- a/engine/source/output/restart/wrrestp.F
+++ b/engine/source/output/restart/wrrestp.F
@@ -348,6 +348,8 @@ C-----------------------------------------------
 C-----------------------------------------------
 C     Restart size
       INTEGER,INTENT(INOUT) :: RESTSIZE
+      integer :: N
+      my_real, allocatable :: DIST_SAV(:)
 C-----------------------------------------------
       DATA IJK/'I','J','K','L','M','N','O','P','Q','R',
      .         'S','T','U','V','W','X','Y','Z','A','B',
@@ -753,7 +755,24 @@ c        CALL WRITE_I_C(INBUF,SINBUF)
         CALL W_BUFBRIC_22() !inter22
 
         !write new structure INTBUF_TAB
+        ! Ensure type10 distance is negative so next run triggers a sort
+        ALLOCATE(DIST_SAV(NINTER))
+        DO N = 1, NINTER
+          IF (IPARI(NPARI*(N-1)+7)==10 .AND.
+     .        INTBUF_TAB(N)%S_VARIABLES >= distance_index) THEN
+            DIST_SAV(N) = INTBUF_TAB(N)%VARIABLES(distance_index)
+            INTBUF_TAB(N)%VARIABLES(distance_index) =
+     .        -ABS(DIST_SAV(N))
+          ENDIF
+        ENDDO
         CALL WRITE_INTBUF(INTBUF_TAB)
+        DO N = 1, NINTER
+          IF (IPARI(NPARI*(N-1)+7)==10 .AND.
+     .        INTBUF_TAB(N)%S_VARIABLES >= distance_index) THEN
+            INTBUF_TAB(N)%VARIABLES(distance_index) = DIST_SAV(N)
+          ENDIF
+        ENDDO
+        DEALLOCATE(DIST_SAV)
 
         CALL WRITE_I_C(RWALL%NPRW,RWALL%NNPRW*RWALL%NRWALL)
 


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
hen writing a restart file, the contact sort distance criterion (VARIABLES(5)) can be saved as a positive value for type 10 interfaces. This happens when the detection radius (Tzinf) becomes smaller than the user-defined contact gap — a normal situation in crash simulations with dense contact.

On the next engine run, this positive distance tells the sort to skip ("nodes are far apart, no need to re-sort"). But the PARITH/ON skyline arrays (ISKYFI/FSKYFI) are only allocated inside the sort routine (SPMD_TRI10GAT). When the sort is skipped, these arrays are never allocated, and the force phase crashes with "MEMORY PROBLEM IN PARITH OPTION".

The fix forces the distance criterion negative before writing the restart file, so the next run always performs a sort on its first cycle and properly allocates the skyline arrays.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
