### PR TITLE
check VALID flag from MPI_COMM_GET_ATTR before using MPI_APPNUM

### DIFF
--- a/engine/source/mpi/init/inipar.F
+++ b/engine/source/mpi/init/inipar.F
@@ -73,7 +73,7 @@ C-----------------------------------------------
       INTEGER NSPMDx2
       INTEGER :: COLOUR
       INTEGER (kind=MPI_ADDRESS_KIND) :: COLOUR_ADDR
-      INTEGER :: VALID
+      LOGICAL :: VALID
       CHARACTER FILNAM*100
 #if defined(_OPENMP)
       INTEGER OMP_GET_MAX_THREADS
@@ -88,7 +88,7 @@ C--------------------------------------------------
 C
         KEY = 0
         CALL MPI_INITIALIZED(KEY, IERR)
-        VALID = 0
+        VALID  = .FALSE.
         COLOUR_ADDR = 0
 
         CALL MPI_INIT(IERROR)
@@ -96,10 +96,10 @@ C
         CALL MPI_COMM_GET_ATTR(MPI_COMM_WORLD, MPI_APPNUM,
      *                            COLOUR_ADDR, VALID, IERROR)
 
-        IF (IERROR == MPI_SUCCESS) THEN
+        IF (IERROR == MPI_SUCCESS .AND. VALID) THEN
            COLOUR = INT(COLOUR_ADDR)
         ELSE
-           COLOUR = 0  ! Default color if attribute not found
+           COLOUR = 0
         ENDIF
         call coupling_configure(coupling, TRIM(coupling%FILNAM))  
 


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

MPI_COMM_GET_ATTR can return MPI_SUCCESS while the attribute is not
attached (VALID=0), leaving COLOUR_ADDR undefined. Without checking
VALID, profiling tools like mpiP that may not propagate MPI_APPNUM
could cause each rank to get a different colour in MPI_COMM_SPLIT,
creating per-rank communicators of size 1.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
