### PR TITLE
Fix uninitialized variables in i25therm for IFORM==0

### DIFF
--- a/engine/source/interfaces/int25/i25therm.F
+++ b/engine/source/interfaces/int25/i25therm.F
@@ -247,6 +247,11 @@ C---------------------------------
             PHI3(I) = PHI3(I) + PHIM*H3(I)
             PHI4(I) = PHI4(I) + PHIM*H4(I)
 
+         ELSE
+            PHI1(I) = ZERO
+            PHI2(I) = ZERO
+            PHI3(I) = ZERO
+            PHI4(I) = ZERO
          ENDIF
 C---------------------------------
 C        HEAT GENERATION DUE TO FRICTION
@@ -414,6 +419,11 @@ C---------------------------------
             PHI2(I) = PHI2(I) + PHIM*H2(I)
             PHI3(I) = PHI3(I) + PHIM*H3(I)
             PHI4(I) = PHI4(I) + PHIM*H4(I)
+         ELSE
+            PHI1(I) = ZERO
+            PHI2(I) = ZERO
+            PHI3(I) = ZERO
+            PHI4(I) = ZERO
          ENDIF
 C---------------------------------
 C        HEAT GENERATION DUE TO FRICTION


### PR DESCRIPTION


#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
Valgrind reports the use of unused variables in asspar4 (FTHESKI). The local arrays phi1-4 were only assigned for IFORM==0. When IFORM /= 0 non-deterministic corruption of temperature field occurs

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->


<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
