### PR TITLE
/TRANSFORM/TRA unexpected behavior for SKEW and NODE definitions

### DIFF
--- a/starter/source/model/submodel/lecsubmod.F
+++ b/starter/source/model/submodel/lecsubmod.F
@@ -255,7 +255,7 @@ C-------------------------
                 NODESSUB(CNT) = K
               ENDIF
             ENDDO
-            CALL transform_translate_in_local_skew(
+            IF (CNT > 0) CALL transform_translate_in_local_skew(
      .            NODESSUB     ,CNT        ,X   ,NUMNOD     , ISK  ,
      .            TX           ,TY         ,TZ  ,SKEW       , LSKEW,
      .            SSKEW        )
@@ -378,5 +378,5 @@ c     .'  NODAL TRANSFORMATIONS       '/,
 c     .'  ---------------------- ')
 c 1000 FORMAT(/10X,'NEW NODE COORDINATES',14X,'X',24X,'Y',24X,'Z')
 c 1500 FORMAT( 17X,I10,3(5X,E20.13))
-      RETURN
+       RETURN
       END

--- a/starter/source/model/submodel/lectranssub.F
+++ b/starter/source/model/submodel/lectranssub.F
@@ -295,6 +295,10 @@ C
           ROT(1) = ONE
           ROT(5) = ONE
           ROT(9) = ONE
+
+          DO K=1,9
+            RTRANS(I,K+2) = ROT(K)
+          ENDDO
 C
           WRITE(IOUT,500) ID,ID_TRANSSUB   
           IF (N0 > 0 .AND. N1 > 0) WRITE(IOUT,200) N0,N1


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->

Uninitialized transformation array (rotation matrix) in SUBMODEL for translational transformation

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->

Initialization of rotation matrix for SUBMODEL translational transformation.

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
