### PR TITLE
correction on /INIVEL (starter) with dynamic condensation of tetra10 …

### DIFF
--- a/engine/source/elements/solid/solide10/s10cndf.F
+++ b/engine/source/elements/solid/solide10/s10cndf.F
@@ -396,7 +396,7 @@ C----6---------------------------------------------------------------7---------8
 !||====================================================================
       SUBROUTINE S10CND_INI(ICNDS10,ITAGND,IAD_CNDM,FR_CNDM,FR_NBCCCND,
      1                      ADDCNCND,PROCNCND,VND  ,V   ,ITAB    ,
-     2                      IAD_CNDM1,FR_CNDM1,FR_NBCCCND1)
+     2                      IAD_CNDM1,FR_CNDM1,FR_NBCCCND1,TIME )
 C-----------------------------------------------
 C   I m p l i c i t   T y p e s
 C-----------------------------------------------
@@ -417,6 +417,7 @@ C-----------------------------------------------
 C     REAL
       my_real
      .   V(3,*),VND(3,*)
+      my_real, INTENT(IN) :: TIME
 C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
@@ -431,6 +432,12 @@ C-----------------------------------------------
         VND(2,I) = HALF*(V(2,N1) + V(2,N2))
         VND(3,I) = HALF*(V(3,N1) + V(3,N2))
        END DO
+       IF (TIME==ZERO) THEN 
+         DO I = 1, NS10E
+           NOD = IABS(ICNDS10(1,I))
+           V(1:3,NOD) = VND(1:3,I)
+         END DO
+       END IF
 C       
        IF (IPARIT/=0) THEN
         DO I = 1, NSPMD+1

--- a/engine/source/engine/resol.F
+++ b/engine/source/engine/resol.F
@@ -8988,7 +8988,7 @@ CC
      .                                TT,   IRODDL, LOADS%NINIVELT,LOADS%INIVELT,
      .                             NPARG,   NGROUP,       LENGTH,         IPARG,
      .                         ELBUF_TAB,       NODES%MS,         NODES%IN,        NODES%WEIGHT,
-     .                           NXFRAME,   T_KIN )
+     .                           NXFRAME,   T_KIN ,NS10E      ,ICNDS10 )
                   OUTPUT%TH%WFEXT = OUTPUT%TH%WFEXT + T_KIN
                 END IF
 !

--- a/engine/source/engine/resol_init.F
+++ b/engine/source/engine/resol_init.F
@@ -1145,7 +1145,7 @@ C-----------------------
      .                   FR_CNDS,IAD_CNDS,itab ) 
          CALL S10CND_INI(ICNDS10,ITAGND,IAD_CNDM,FR_CNDM,FR_NBCCCND,
      1                 ADDCNCND,PROCNCND,VND   ,V    ,ITAB ,
-     2                 IAD_CNDM1,FR_CNDM1,FR_NBCCCND1)
+     2                 IAD_CNDM1,FR_CNDM1,FR_NBCCCND1,TT )
         END IF
         CALL MY_BARRIER()
       ENDIF

--- a/engine/source/loads/general/inivel/inivel_start.F90
+++ b/engine/source/loads/general/inivel/inivel_start.F90
@@ -53,13 +53,13 @@
           ngrnod,  ngrbric,    ngrquad,       ngrsh3n,           &
           igrnod,  igrbric,    igrquad,       igrsh3n,           &
           numskw,    lskew,    numfram,       sensors,           &
-          xframe,      skew,          x,             v,           &
-          vr,    numnod,      vflow,         wflow,           &
-          w, multi_fvm,       iale,       ialelag,           &
+          xframe,     skew,          x,             v,           &
+          vr,       numnod,      vflow,         wflow,           &
+          w,     multi_fvm,       iale,       ialelag,           &
           time ,    iroddl,   ninivelt,      inivel_t,           &
           nparg,    ngroup,       lens,         iparg,           &
-          elbuf_tab,         ms,         in,        weight,           &
-          nxframe,      t_kin)
+          elbuf_tab,    ms,         in,        weight,           &
+          nxframe,   t_kin,      ns10e,       icnds10)
 ! ----------------------------------------------------------------------------------------------------------------------
 !                                                   Modules
 ! ----------------------------------------------------------------------------------------------------------------------
@@ -99,6 +99,8 @@
           integer , intent(in   )                          :: ngrquad   !< number quad element group
           integer , intent(in   )                          :: ngrsh3n   !< number tria element group
           integer , intent(in   )                          :: lens      !< dimension of work array itagvel
+          integer , intent(in   )                          :: ns10e     !< number of tetra10 edges
+          integer , intent(in   ) ,dimension(3,ns10e)      :: icnds10   !< tetra10 edge connectivity
           integer , intent(in   ) ,dimension(numnod)       :: weight    !< nodal mass weight array (spmd)
           integer , dimension(nparg,ngroup), intent(in   ) :: iparg     !< element group data array
           type(inivel_), dimension(ninivelt),intent(inout) :: inivel_t  !< inivel_struc
@@ -125,9 +127,9 @@
 !                                                   Local variables
 ! ----------------------------------------------------------------------------------------------------------------------
           integer  :: i,j,id,n,ng,itype,nosys,sens_id,iremain,iupdate
-          integer  :: igrs,igbric,igqd,igtria,isk,ifra,idir,ifm,k1,k2,k3
+          integer  :: igrs,igbric,igqd,igtria,isk,ifra,idir,ifm,k1,k2,k3,n1,n2,nd
           integer  :: mtn,nel,nft,ii,n_ini
-          integer , dimension(:) , allocatable :: itagvel
+          integer , dimension(:) , allocatable :: itagvel,itag_n
           real(kind=WP)  :: tstart,tstart_s,tstart1,vx,vy,vz,vl(3), nixj(6),vlt(3),mas
           real(kind=WP) :: vra, ox, oy, oz
           type(g_bufel_), pointer :: gbuf
@@ -168,6 +170,8 @@
           if (iupdate>0) then
             call my_alloc(itagvel, lens, "itagvel")
             itagvel = 0
+            call my_alloc(itag_n, numnod, "itag_n")
+            itag_n = 0            
           end if
           iremain = 0
           do n =1,ninivelt
@@ -247,6 +251,7 @@
                 do j=1,igrnod(igrs)%nentity
                   nosys=igrnod(igrs)%entity(j)
                   v(1:3,nosys)=vl(1:3)
+                  itag_n(nosys) = 2
                   if(ialelag > 0) then
                     vflow(1:3,nosys) = vl(1:3)
                     wflow(1:3,nosys) = vl(1:3)
@@ -267,6 +272,7 @@
                 do j=1,igrnod(igrs)%nentity
                   nosys=igrnod(igrs)%entity(j)
                   v(1:3,nosys)=vl(1:3)
+                  itag_n(nosys) = 2
                   if(ialelag > 0) then
                     vflow(1:3,nosys) = vl(1:3)
                     wflow(1:3,nosys) = vl(1:3)
@@ -336,6 +342,7 @@
                   v(1,nosys)= vl(1)+vra*(nixj(3)-nixj(4))
                   v(2,nosys)= vl(2)+vra*(nixj(5)-nixj(6))
                   v(3,nosys)= vl(3)+vra*(nixj(1)-nixj(2))
+                  itag_n(nosys) = 2
                   if(ialelag > 0) then
                     vflow(1:3,nosys) = v(1:3,nosys)
                     wflow(1:3,nosys) = v(1:3,nosys)
@@ -440,7 +447,18 @@
                 end do
               end if !(mtn == 151) then
             end do
+            do n = 1, ns10e
+              nd = iabs(icnds10(1,n))
+              if (itag_n(nd)==2) cycle
+              n1 = icnds10(2,n)
+              n2 = icnds10(3,n)
+              if (itag_n(n1)==2 .and. itag_n(n2)==2) then 
+                v(1:3,nd) = half*(v(1:3,n1)+v(1:3,n2))
+              end if
+            end do
+!             
             call my_dealloc(itagvel)
+            call my_dealloc(itag_n)
           end if
 
 ! 1000   FORMAT(3X,'BY SENSOR ON, ACTIVATING INIVEL OF ID =',I10)


### PR DESCRIPTION
…(Itetra10=2)

#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
When /INIVEL are applied only on the vertex nodes (by error or w/ Itetra4=10), unexpected deformations will be created.

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
correction on /INIVEL +Itetra10=2 to avoid unexpected result

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
