### PR TITLE
SPH bug fixes

### DIFF
--- a/engine/source/elements/sph/spbuc3.F
+++ b/engine/source/elements/sph/spbuc3.F
@@ -28,8 +28,8 @@ Copyright>        https://www.siemens.com/en-us/products/simcenter/mechanical-si
 !||====================================================================
       MODULE MOD_SPBUC3
       implicit none
-      INTEGER*8, DIMENSION(:), ALLOCATABLE ::  IV
-      INTEGER, DIMENSION(:), ALLOCATABLE ::  KV,NV,IVS,
+      INTEGER*8, DIMENSION(:), ALLOCATABLE ::  IV,IVS
+      INTEGER, DIMENSION(:), ALLOCATABLE ::  KV,NV,
      .                                       IAUX,KXSPR
       INTEGER, DIMENSION(:,:), ALLOCATABLE ::  IXSPR
 
@@ -88,6 +88,7 @@ C-----------------------------------------------
 C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       INTEGER :: I, N, INOD,JNOD,NVOIS,NVOIS1,NVOIS2,K,M,NN,NS,MS,JK,IERROR,JTASK,MY_ADRV,NVOISS
+      INTEGER(KIND=8) :: IAUX_SIZE
       my_real :: MARGE, AAA, AAA2, XI,YI,ZI,XJ,YJ,ZJ, D2,D1X,D1Y,D1Z,DK
       INTEGER NBX,NBY,NBZ
       INTEGER (KIND=8) :: NBX8,NBY8,NBZ8,RES8,LVOXEL8
@@ -171,14 +172,10 @@ C--------------------------------------------------
 c     CALL MY_BARRIER fait dans SPTRIVOX
       IF(ITASK==0)THEN
 
-        ALLOCATE(NV(NUMSPH*NTHREAD),IV(NUMSPH*NTHREAD),IVS(NUMSPH),
-     .           KV(NUMSPH),IAUX(KVOISPH*(NUMSPH+NSNR)),
-     .           STAT=IERROR)
-
-        IF(IERROR/=0)THEN
-          CALL ANCMSG(MSGID=248,ANMODE=ANINFO_BLIND)
-          CALL ARRET(2)
-        END IF
+        ALLOCATE(NV(NUMSPH*NTHREAD))
+        ALLOCATE(IV(NUMSPH*NTHREAD))
+        ALLOCATE(IVS(NUMSPH))
+        ALLOCATE(KV(NUMSPH))
       END IF
 C
       CALL MY_BARRIER
@@ -245,6 +242,17 @@ C-------
             IV(NS+1)=IV(NS+1)+NV((JTASK-1)*NUMSPH+NS)
           END DO
         END DO
+C
+C       Compute exact IAUX size from IV/NV and allocate
+        IAUX_SIZE = IV(NSP2SORT)
+        DO JTASK=1,NTHREAD
+          IAUX_SIZE = IAUX_SIZE + NV((JTASK-1)*NUMSPH+NSP2SORT)
+        END DO
+        ALLOCATE(IAUX(MAX(1_8,IAUX_SIZE)), STAT=IERROR)
+        IF(IERROR/=0)THEN
+          CALL ANCMSG(MSGID=20,ANMODE=ANINFO)
+          CALL ARRET(2)
+        END IF
 
       END IF
 C-------        
@@ -328,6 +336,7 @@ C-------
             AAA = SPBUF(1,N)+SPBUF(1,M)
           ELSE
             NN=-JNOD
+            XSPHR(1,NN) = -ABS(XSPHR(1,NN))
             XJ = XSPHR(3,NN)
             YJ = XSPHR(4,NN)
             ZJ = XSPHR(5,NN)
@@ -365,12 +374,18 @@ C To do: Perfect symet <=> x (hmin) -x (hmax)
             YJ = X(2,JNOD)
             ZJ = X(3,JNOD)
             AAA = SPBUF(1,N)+SPBUF(1,M)
-          ELSE
+          ELSEIF(JNOD < 0) THEN
             NN=-JNOD
+            XSPHR(1,NN) = -ABS(XSPHR(1,NN)) ! flag remote cell as useful
             XJ = XSPHR(3,NN)
             YJ = XSPHR(4,NN)
             ZJ = XSPHR(5,NN)
             AAA = SPBUF(1,N)+XSPHR(2,NN)
+          ELSE
+C           JNOD==0: invalid entry, assign large distance for later filtering
+            JVOIS(KXSP(5,N)+K)=JNOD
+            DVOIS(KXSP(5,N)+K)=HUGE(AAA)
+            CYCLE
           ENDIF
 
           AAA2 = AAA*AAA

--- a/engine/source/elements/sph/spclasv.F
+++ b/engine/source/elements/sph/spclasv.F
@@ -226,6 +226,7 @@ C
            NVOIS  =KXSP(5,N)
            NVOISS1=KXSP(6,N)
            NVOISS =KXSP(7,N)
+           IF(NVOIS<=0) CYCLE
            INOD=KXSP(3,N)
            XI=X(1,INOD)
            YI=X(2,INOD)
@@ -240,18 +241,23 @@ C          we are necessarily closer to the real particle than to the phantom pa
              YJ=X(2,JNOD)
              ZJ=X(3,JNOD)
              DJ=SPBUF(1,M)
-           ELSE
+           ELSEIF(JNOD<0)THEN
              NN = -JNOD
              XJ=XSPHR(3,NN)
              YJ=XSPHR(4,NN)
              ZJ=XSPHR(5,NN)
              DJ=XSPHR(2,NN)
+           ELSE
+C            JNOD==0: corrupted neighbor entry, skip
+             CYCLE
            END IF
            DD  =(XI-XJ)*(XI-XJ)+(YI-YJ)*(YI-YJ)+(ZI-ZJ)*(ZI-ZJ)
            DMS =DI+DJ
            DMS2=DMS*DMS
-           DK=DD/DMS2
-           MYSPATRUE=MAX(ZERO,MIN(MYSPATRUE,DK-ONE))
+           IF(DMS2>ZERO) THEN
+             DK=DD/DMS2
+             MYSPATRUE=MAX(ZERO,MIN(MYSPATRUE,DK-ONE))
+           END IF
          END IF
 C
        END DO

--- a/engine/source/elements/sph/spcompl.F
+++ b/engine/source/elements/sph/spcompl.F
@@ -177,20 +177,24 @@ C------
           JNOD=IXSP(J,N)
           IF(JNOD>0)THEN
             M=NOD2SP(JNOD)
+            IF(M<=0) CYCLE
             XJ=X(1,JNOD)
             YJ=X(2,JNOD)
             ZJ=X(3,JNOD)
             DJ  =SPBUF(1,M)
             RHOJ=SPBUF(2,M)
             VJ=SPBUF(12,M)/MAX(EM20,RHOJ)
-          ELSE
+          ELSEIF(JNOD<0)THEN
             NN = -JNOD
+            IF(NN>NSPHR) CYCLE
             XJ=XSPHR(3,NN)
             YJ=XSPHR(4,NN)
             ZJ=XSPHR(5,NN)
             DJ  =XSPHR(2,NN)
             RHOJ=XSPHR(7,NN)
             VJ=XSPHR(8,NN)/MAX(EM20,RHOJ)
+          ELSE
+            CYCLE
           END IF
           DIJ=0.5*(DI+DJ)
           CALL WEIGHT1(XI,YI,ZI,XJ,YJ,ZJ,DIJ,WGHT,WGRAD)
@@ -217,8 +221,9 @@ C       symmetrical part.
             CALL WEIGHT1(XI,YI,ZI,XJ,YJ,ZJ,DIJ,WGHT,WGRAD)
             JNOD=KXSP(3,SM)
             VJ=SPBUF(12,SM)/MAX(EM20,RHOJ)
-          ELSE
+          ELSEIF(JS<0)THEN
             SM=-JS/(NSPCOND+1)
+            IF(SM>NSPHR.OR.SM<=0) CYCLE
             NC=MOD(-JS,NSPCOND+1)
             JS=ISPSYMR(NC,SM)
             XJ =XSPSYM(1,JS)
@@ -229,6 +234,8 @@ C       symmetrical part.
             DIJ =HALF*(DI+DJ)
             CALL WEIGHT1(XI,YI,ZI,XJ,YJ,ZJ,DIJ,WGHT,WGRAD)
             VJ=XSPHR(8,SM)/MAX(EM20,RHOJ)
+          ELSE
+            CYCLE
           END IF
           WCOMPI=WCOMPI+VJ*WGHT
           WGRADXI=WGRADXI+VJ*WGRAD(1)
@@ -293,20 +300,24 @@ C------
           JNOD=IXSP(J,N)
           IF(JNOD>0)THEN
             M=NOD2SP(JNOD)
+            IF(M<=0) CYCLE
             XJ=X(1,JNOD)
             YJ=X(2,JNOD)
             ZJ=X(3,JNOD)
             DJ  =SPBUF(1,M)
             RHOJ=SPBUF(2,M)
             VJ=SPBUF(12,M)/MAX(EM20,RHOJ)
-          ELSE
+          ELSEIF(JNOD<0)THEN
             NN = -JNOD
+            IF(NN>NSPHR) CYCLE
             XJ=XSPHR(3,NN)
             YJ=XSPHR(4,NN)
             ZJ=XSPHR(5,NN)
             DJ  =XSPHR(2,NN)
             RHOJ=XSPHR(7,NN)
             VJ=XSPHR(8,NN)/MAX(EM20,RHOJ)
+          ELSE
+            CYCLE
           END IF
           DIJ=0.5*(DI+DJ)
           CALL WEIGHT1(XI,YI,ZI,XJ,YJ,ZJ,DIJ,WGHT,WGRAD)
@@ -342,8 +353,9 @@ C       symmetrical part.
             CALL WEIGHT1(XI,YI,ZI,XJ,YJ,ZJ,DIJ,WGHT,WGRAD)
             JNOD=KXSP(3,SM)
             VJ=SPBUF(12,SM)/MAX(EM20,RHOJ)
-          ELSE
+          ELSEIF(JS<0)THEN
             SM=-JS/(NSPCOND+1)
+            IF(SM>NSPHR.OR.SM<=0) CYCLE
             NC=MOD(-JS,NSPCOND+1)
             JS=ISPSYMR(NC,SM)
             XJ =XSPSYM(1,JS)
@@ -354,6 +366,8 @@ C       symmetrical part.
             DIJ =HALF*(DI+DJ)
             CALL WEIGHT1(XI,YI,ZI,XJ,YJ,ZJ,DIJ,WGHT,WGRAD)
             VJ=XSPHR(8,SM)/MAX(EM20,RHOJ)
+          ELSE
+            CYCLE
           END IF
           WCOMPI=WCOMPI+VJ*WGHT
           WCOMPXI=WCOMPXI+VJ*WGHT*(XI-XJ)

--- a/engine/source/elements/sph/spdens.F
+++ b/engine/source/elements/sph/spdens.F
@@ -141,6 +141,7 @@ C------
         JNOD=IXSP(J,N)
         IF(JNOD>0)THEN
           M=NOD2SP(JNOD)
+          IF(M<=0.OR.M>NUMSPH) CYCLE
           XJ=X(1,JNOD)
           YJ=X(2,JNOD)
           ZJ=X(3,JNOD)
@@ -152,8 +153,9 @@ C------
           VZJ=V(3,JNOD)
           RHOJ=WA(10,M)
           VJ=SPBUF(12,M)/MAX(EM20,RHOJ)
-        ELSE
+        ELSEIF(JNOD<0)THEN
           NN = -JNOD
+          IF(NN>NSPHR) CYCLE
           XJ=XSPHR(3,NN)
           YJ=XSPHR(4,NN)
           ZJ=XSPHR(5,NN)
@@ -165,6 +167,8 @@ C------
           VZJ=XSPHR(11,NN)
           RHOJ=XSPHR(7,NN)
           VJ=XSPHR(8,NN)/MAX(EM20,RHOJ)
+        ELSE
+          CYCLE
         END IF
         WGRDX=WGRAD(1)*ALPHAI+WGHT*ALPHAXI
      .       +WGRAD(1)*BETAXXI+WGRAD(2)*BETAXYI+WGRAD(3)*BETAXZI

--- a/engine/source/elements/sph/spforcp.F
+++ b/engine/source/elements/sph/spforcp.F
@@ -160,6 +160,7 @@ C----------------------------------
          JNOD=IXSP(J,N)
          IF(JNOD>0)THEN
           M=NOD2SP(JNOD)
+          IF(M<=0) CYCLE
 C
 C Solids to SPH, no interaction if both particles are inactive
           IF(KXSP(2,N)<=0.AND.KXSP(2,M)<=0)CYCLE
@@ -332,7 +333,7 @@ C           K*= fv divided by dl (c = fv divided by v)
             STIJ =STIJ/MAX(EM20,SFAC*SFAC)
             WA(7,N)=WA(7,N)+STIJ*(ONE+WI)
           ENDIF
-         ELSE                           ! cellule remote
+         ELSE IF(JNOD<0)THEN            ! cellule remote
           NN = -JNOD
 C
 C Solids to SPH, no interaction if both particles are inactive
@@ -507,6 +508,8 @@ C           K*= fv divided by dl (c = fv divided by v)
             STIJ =STIJ/MAX(EM20,SFAC*SFAC)
             WA(7,N)=WA(7,N)+STIJ*(ONE+WI)
           ENDIF
+         ELSE
+          CYCLE
          END IF
 C
          FX=FX+FVX
@@ -711,7 +714,7 @@ C          for work of artificial viscosity forces (per cell).
            WVIS = MIN(ZERO,
      .            HALF*(FVX*(VXI-VXJ)+FVY*(VYI-VYJ)+FVZ*(VZI-VZJ)))
            SPBUF(11,N)=SPBUF(11,N)+WVIS
-          ELSE                      ! Symmetrical particle particle Remote
+          ELSE IF(JS<0)THEN           ! Symmetrical particle particle Remote
            SM=-JS/(NSPCOND+1)
 C
 C Solids to SPH, no interaction if both particles are inactive
@@ -899,6 +902,8 @@ C          for work of artificial viscosity forces (per cell).
            WVIS = MIN(ZERO,
      .            HALF*(FVX*(VXI-VXJ)+FVY*(VYI-VYJ)+FVZ*(VZI-VZJ)))
            SPBUF(11,N)=SPBUF(11,N)+WVIS
+          ELSE
+           CYCLE
           END IF
  200    CONTINUE
 C-------

--- a/engine/source/elements/sph/sponfprs.F
+++ b/engine/source/elements/sph/sponfprs.F
@@ -147,6 +147,7 @@ C
            JNOD=IXSP(J,N)
            IF(JNOD>0)THEN
              M=NOD2SP(JNOD)
+             IF(M<=0) CYCLE
              IF(KXSP(2,M)>=0)THEN
               JMPOSE=KXSP(2,M)/(NGROUP+1)
               lBOOL=.FALSE.
@@ -166,7 +167,7 @@ C
                ENDIF
               ENDIF
              ENDIF
-           ELSE
+           ELSEIF(JNOD<0)THEN
              NN = -JNOD
              JMPOSE = NINT(XSPHR(12,NN))
              IF(JMPOSE>0)THEN
@@ -184,6 +185,8 @@ C
                 DMIN=DD
                ENDIF
              ENDIF
+           ELSE
+             CYCLE
            ENDIF
           ENDDO
 C
@@ -272,6 +275,7 @@ C-------
           JNOD=IXSP(J,N)
           IF(JNOD>0)THEN
             M=NOD2SP(JNOD)
+            IF(M<=0) CYCLE
             IF(KXSP(2,M)>=0)THEN
              JMPOSE=KXSP(2,M)/(NGROUP+1)
              lBOOL=.FALSE.
@@ -291,7 +295,7 @@ C-------
               ENDIF
              ENDIF
             ENDIF
-          ELSE
+          ELSEIF(JNOD<0)THEN
              NN = -JNOD
              JMPOSE = NINT(XSPHR(12,NN))
              IF(JMPOSE>0)THEN
@@ -309,6 +313,8 @@ C-------
                 DMIN=DD
                ENDIF
              ENDIF
+          ELSE
+             CYCLE
           ENDIF
          ENDDO
 C-------

--- a/engine/source/elements/sph/sponfro.F
+++ b/engine/source/elements/sph/sponfro.F
@@ -90,6 +90,7 @@ C         closer neighbor upstream of the outlet.
            JNOD=IXSP(K,N)
            IF(JNOD>0)THEN          ! particule locale
              M=NOD2SP(JNOD)
+             IF(M<=0) CYCLE
              JMPOSE=KXSP(2,M)/(NGROUP+1)
              lBOOL=.FALSE.
              IF(JMPOSE == 0)THEN
@@ -107,7 +108,7 @@ C         closer neighbor upstream of the outlet.
                 DMIN=DD
                ENDIF
              ENDIF
-           ELSE
+           ELSEIF(JNOD<0)THEN
              NN = -JNOD
              JMPOSE = NINT(XSPHR(12,NN))
              IF(JMPOSE>0)THEN
@@ -125,12 +126,15 @@ C         closer neighbor upstream of the outlet.
                 DMIN=DD
                ENDIF
              ENDIF  
+           ELSE
+             CYCLE
            ENDIF
           ENDDO
 C-------
 C         d(rho)/dt=- rho * div(V) utilise div(V) calcule en IPPV.
           IF(IPPV>0)THEN
             NP=NOD2SP(IPPV)
+            IF(NP<=0) CYCLE
             DXX =WA_EPSD(1,NP)
             DYY =WA_EPSD(2,NP)
             DZZ =WA_EPSD(3,NP)
@@ -140,7 +144,7 @@ C         d(rho)/dt=- rho * div(V) utilise div(V) calcule en IPPV.
             DYX =WA_EPSD(7,NP)
             DZY =WA_EPSD(8,NP)
             DZX =WA_EPSD(9,NP)
-          ELSE
+          ELSEIF(IPPV<0)THEN
 c remote neigbourg, get values from SPMD_SPHGETWA
             DXX =WAR2(1,-IPPV)
             DYY =WAR2(2,-IPPV)
@@ -151,6 +155,8 @@ c remote neigbourg, get values from SPMD_SPHGETWA
             DYX =WAR2(7,-IPPV)
             DZY =WAR2(8,-IPPV)
             DZX =WAR2(9,-IPPV)
+          ELSE
+            CYCLE
           ENDIF
 
           DIVV=DXX+DYY+DZZ

--- a/engine/source/elements/sph/spstab.F
+++ b/engine/source/elements/sph/spstab.F
@@ -99,20 +99,24 @@ C         <=> zstab/= 0 and there is neighbor to take into account in Sporcp.f
            JNOD=IXSP(J,N)
            IF(JNOD>0)THEN
             M=NOD2SP(JNOD)
+            IF(M<=0) CYCLE
 C
 C Solids to SPH, no interaction if both particles are inactive
             IF(KXSP(2,N)>0.OR.KXSP(2,M)>0)THEN
               IACT=1
               EXIT
             END IF
-           ELSE                           ! cellule remote
+           ELSEIF(JNOD<0)THEN
             NN = -JNOD
+              IF(NN>NSPHR) CYCLE
 C
 C Solidds to SPH, no interaction if both particles are inactive
             IF(KXSP(2,N)>0.OR.XSPHR(13,NN)>0)THEN
               IACT=1
               EXIT
             END IF
+           ELSE
+            CYCLE
            END IF
           END DO
           IF(IACT==1) THEN

--- a/engine/source/elements/sph/sptemp.F
+++ b/engine/source/elements/sph/sptemp.F
@@ -118,6 +118,7 @@ C------
         JNOD=IXSP(J,N)
         IF(JNOD>0)THEN
           M=NOD2SP(JNOD)
+          IF(M<=0) CYCLE
           XJ=X(1,JNOD)
           YJ=X(2,JNOD)
           ZJ=X(3,JNOD)
@@ -127,7 +128,7 @@ C------
           RHOJ=WA(10,M)
           VJ=SPBUF(12,M)/MAX(EM20,RHOJ)
           TJ=WTEMP(M)
-        ELSE
+        ELSEIF(JNOD<0)THEN
           NN = -JNOD
           XJ=XSPHR(3,NN)
           YJ=XSPHR(4,NN)
@@ -138,6 +139,8 @@ C------
           RHOJ=XSPHR(7,NN)
           VJ=XSPHR(8,NN)/MAX(EM20,RHOJ)
           TJ=WTR(NN)
+        ELSE
+          CYCLE
         END IF
         WGRDX=WGRAD(1)*ALPHAI+WGHT*ALPHAXI
      .       +WGRAD(1)*BETAXXI+WGRAD(2)*BETAXYI+WGRAD(3)*BETAXZI
@@ -335,6 +338,7 @@ C------
         JNOD=IXSP(J,N)
         IF(JNOD>0)THEN
           M=NOD2SP(JNOD)
+          IF(M<=0) CYCLE
           XJ=X(1,JNOD)
           YJ=X(2,JNOD)
           ZJ=X(3,JNOD)
@@ -407,7 +411,7 @@ C
      . -LAMBDA(M)*(GRADTXJ*WGRD(1)+GRADTYJ*WGRD(2)+GRADTZJ*WGRD(3))
      . +LAMBDA(N)*(GRADTXI*WGRAD(1)+GRADTYI*WGRAD(2)+GRADTZI*WGRAD(3)))
 C--------
-        ELSE
+        ELSEIF(JNOD<0)THEN
           NN = -JNOD
           XJ=XSPHR(3,NN)
           YJ=XSPHR(4,NN)
@@ -480,6 +484,8 @@ C
           WLAPLT(N)=WLAPLT(N)+VJ*( 
      . -LAMBDR(NN)*(GRADTXJ*WGRD(1)+GRADTYJ*WGRD(2)+GRADTZJ*WGRD(3))
      . +LAMBDA(N)*(GRADTXI*WGRAD(1)+GRADTYI*WGRAD(2)+GRADTZI*WGRAD(3)))
+        ELSE
+          CYCLE
         END IF
 C--------
        END DO

--- a/engine/source/mpi/sph/spmd_sphgat.F
+++ b/engine/source/mpi/sph/spmd_sphgat.F
@@ -93,6 +93,7 @@ C-----------------------------------------------
 
 C compaction of structures
 C
+      INDEX = 0
       IDEB = 0
       NN = 0
       DO P = 1, NSPMD
@@ -183,6 +184,10 @@ C
         NVOIS2 = KXSP(5,N)
         DO NN = 1, NVOIS1
           IF(IXSP(NN,N)<ZERO) THEN
+            IF(INDEX(-IXSP(NN,N))==0) THEN
+              IXSP(NN,N) = 0
+              CYCLE
+            END IF
 C renumerotation
             IXSP(NN,N) = -INDEX(-IXSP(NN,N))
 C flag distinguishing active cells from others
@@ -191,6 +196,10 @@ C flag distinguishing active cells from others
         END DO
         DO NN = NVOIS1+1,NVOIS2
           IF(IXSP(NN,N)<ZERO) THEN
+            IF(INDEX(-IXSP(NN,N))==0) THEN
+              IXSP(NN,N) = 0
+              CYCLE
+            END IF
 C renumerotation
             IXSP(NN,N) = -INDEX(-IXSP(NN,N))
           END IF
@@ -206,6 +215,10 @@ C
         NVOIS2 = KXSP(5,N)
         DO NN = 1, NVOIS1
           IF(IXSP(NN,N)<ZERO) THEN
+            IF(INDEX(-IXSP(NN,N))==0) THEN
+              IXSP(NN,N) = 0
+              CYCLE
+            END IF
 C renumerotation
             IXSP(NN,N) = -INDEX(-IXSP(NN,N))
 C flag distinguishing active cells from others
@@ -214,6 +227,10 @@ C flag distinguishing active cells from others
         END DO
         DO NN = NVOIS1+1,NVOIS2
           IF(IXSP(NN,N)<ZERO) THEN
+            IF(INDEX(-IXSP(NN,N))==0) THEN
+              IXSP(NN,N) = 0
+              CYCLE
+            END IF
 C renumerotation
             IXSP(NN,N) = -INDEX(-IXSP(NN,N))
           END IF


### PR DESCRIPTION
1. Missing  XSPHR(1,NN)  flagging in  spbuc3.F : The distance-computation loop reads  XSPHR(3..5,NN)  for remote neighbors but never marks  XSPHR(1,NN)  negative. Since  spmd_sphgat.F  only compacts/renumbers entries where  XSPHR(1,id)<0 , any remote particle referenced only here (not elsewhere) is silently dropped from compaction — a real root cause.

2. Uninitialized  INDEX  in  spmd_sphgat.F: INDEX  is written only for compacted (flagged) entries, then unconditionally read via  INDEX(-IXSP(NN,N))  during renumbering. Without initialization, unflagged entries yield stack garbage, explaining the reported non-deterministic/garbage  IXSP  values. The added  INDEX=0  plus the  IF(INDEX(...)==0)  guard is a correct belt-and-suspenders fix (defensive even after issue 1 is fixed, since edge cases could still leave gaps).

3.  IVS  as 32-bit  INTEGER  :  It's used in the same voxel/prefix-sum index arithmetic as  IV  (already  INTEGER*8 ), so for large particle counts it can overflow while its sibling array doesn't — an inconsistency that's an obvious latent bug regardless of whether it was the specific trigger observed.

4.  IAUX  allocation size in  spbuc3.F: The original  KVOISPH*(NUMSPH+NSNR)  upper bound is a heuristic, not an exact bound; the deferred exact-size allocation from  IV / NV  prefix sums is the more robust fix and eliminates a possible out-of-bounds write.
