### PR TITLE
remove incorrect comment line in mat119 cfg file

### DIFF
--- a/hm_cfg_files/config/CFG/radioss2022/MAT/mat119_sh_seatbelt.cfg
+++ b/hm_cfg_files/config/CFG/radioss2022/MAT/mat119_sh_seatbelt.cfg
@@ -148,7 +148,6 @@ FORMAT(radioss2022)
     //
     COMMENT("#                  K                   C                  RE");
     CARD("%20lg%20lg%20lg",STIFF1,DAMP1,RE);
-    COMMENT("#---1----|----2----|----3----|----4----|----5----|----6----|----7----|----8----|----9----|---10----|");
     COMMENT("# fct_load fct_uload             Fscale1             Fscale2   Ireload");
     CARD("%10d%10d%20lg%20lg%10d",FUN_L,FUN_UL,Fcoeft1,Fcoeft2,Ireload);
     COMMENT("#                E22                 V12                 G12            Fscale22");


### PR DESCRIPTION
This pull request makes a minor change to the `mat119_sh_seatbelt.cfg` configuration file for Radioss 2022. The change removes a comment line that was likely redundant or unnecessary.

* Removed a comment line showing column markers from the `mat119_sh_seatbelt.cfg` file to clean up the configuration.