### PR TITLE
CHECKSUM issue corrections : title was wrong / writing of T01a T01b .…... , missing info in report and .out files about T01a T01b .....

### DIFF
--- a/common_source/modules/output/time_history_mod.F
+++ b/common_source/modules/output/time_history_mod.F
@@ -45,6 +45,7 @@ Copyright>        https://www.siemens.com/en-us/products/simcenter/mechanical-si
           INTEGER, DIMENSION(:), ALLOCATABLE :: ITHGRP
           INTEGER  SITHGRP
           character (len=2048) :: TH_FILENAME
+          character (len=2048), dimension(9) :: AUX_TH_FILENAME
           INTEGER :: TH_WRITE_TYPE
           !
           INTEGER, DIMENSION(:), ALLOCATABLE :: ITHBUFA

--- a/engine/source/engine/radioss2.F
+++ b/engine/source/engine/radioss2.F
@@ -1646,6 +1646,7 @@ C------------------------------------------------
           WA(1:SWA) = ZERO
           ! Store filename for eventuel checksum computation
           OUTPUT%TH%TH_FILENAME(1:LEN_TRIM(FILNAMTH))=FILNAMTH(1:LEN_TRIM(FILNAMTH))
+          OUTPUT%TH%AUX_TH_FILENAME = ''
 
 C   Multiple th files
             IF(NTHGRP01(1)/=0)THEN
@@ -1669,6 +1670,7 @@ C   Multiple th files
      4                    IPM      ,IPART(1+LIPART1*(NPART+NTHPART)) ,2  ,1    ,
      5                    1       ,AFORM(1)           ,ITHFLAG       ,ITHVAR,
      6                    IFILTITL,OUTPUT%TH%SITHBUFA ,NAMES_AND_TITLES)
+        OUTPUT%TH%AUX_TH_FILENAME(1) = FILNAMTH
             END IF
 
             IF(NTHGRP01(2)/=0)THEN
@@ -1692,6 +1694,7 @@ C   Multiple th files
      4                   IPM     ,IPART(1+LIPART1*(NPART+NTHPART)+2*(NPART+NTHPART)),2,1,
      5                   1       ,AFORM(2)          ,ITHFLAG          ,ITHVAR,
      6                   IFILTITL,OUTPUT%TH%SITHBUFB,NAMES_AND_TITLES)
+        OUTPUT%TH%AUX_TH_FILENAME(2) = FILNAMTH
             END IF
 
             IF(NTHGRP01(3)/=0)THEN
@@ -1715,6 +1718,7 @@ C   Multiple th files
      4                   IPM     ,IPART(1+LIPART1*(NPART+NTHPART)+4*(NPART+NTHPART)) ,2 ,1,
      5                   1       ,AFORM(3)          ,ITHFLAG           ,ITHVAR,
      6                   IFILTITL,OUTPUT%TH%SITHBUFC,NAMES_AND_TITLES)
+        OUTPUT%TH%AUX_TH_FILENAME(3) = FILNAMTH
             END IF
 
             IF(NTHGRP01(4)/=0)THEN
@@ -1738,6 +1742,7 @@ C   Multiple th files
      4                   IPM     ,IPART(1+LIPART1*(NPART+NTHPART)+6*(NPART+NTHPART)) ,2 ,1,
      5                   1       ,AFORM(4)          ,ITHFLAG           ,ITHVAR,
      6                   IFILTITL ,OUTPUT%TH%SITHBUFD,NAMES_AND_TITLES)
+        OUTPUT%TH%AUX_TH_FILENAME(4) = FILNAMTH
             END IF
 
             IF(NTHGRP01(5)/=0)THEN
@@ -1761,6 +1766,7 @@ C   Multiple th files
      4                   IPM     ,IPART(1+LIPART1*(NPART+NTHPART)+8*(NPART+NTHPART)),2,1,
      5                   1       ,AFORM(5)          ,ITHFLAG           ,ITHVAR,
      6                   IFILTITL,OUTPUT%TH%SITHBUFE,NAMES_AND_TITLES)
+        OUTPUT%TH%AUX_TH_FILENAME(5) = FILNAMTH
             END IF
 
             IF(NTHGRP01(6)/=0)THEN
@@ -1784,6 +1790,7 @@ C   Multiple th files
      4                   IPM     ,IPART(1+LIPART1*(NPART+NTHPART)+10*(NPART+NTHPART)),2,1,
      5                   1       ,AFORM(6)          ,ITHFLAG           ,ITHVAR,
      6                   IFILTITL,OUTPUT%TH%SITHBUFF,NAMES_AND_TITLES)
+        OUTPUT%TH%AUX_TH_FILENAME(6) = FILNAMTH
             END IF
 
             IF(NTHGRP01(7)/=0)THEN
@@ -1807,6 +1814,7 @@ C   Multiple th files
      4                   IPM,IPART(1+LIPART1*(NPART+NTHPART)+12*(NPART+NTHPART)),2,1,
      5                   1       ,AFORM(7)          ,ITHFLAG           ,ITHVAR,
      6                   IFILTITL,OUTPUT%TH%SITHBUFG ,NAMES_AND_TITLES)
+        OUTPUT%TH%AUX_TH_FILENAME(7) = FILNAMTH
             END IF
 
             IF(NTHGRP01(8)/=0)THEN
@@ -1830,6 +1838,7 @@ C   Multiple th files
      4                   IPM      ,IPART(1+LIPART1*(NPART+NTHPART)+14*(NPART+NTHPART)),2,1,
      5                   1       ,AFORM(8)           ,ITHFLAG           ,ITHVAR,
      6                   IFILTITL,OUTPUT%TH%SITHBUFH,NAMES_AND_TITLES)
+        OUTPUT%TH%AUX_TH_FILENAME(8) = FILNAMTH
             END IF
 
             IF(NTHGRP01(9)/=0)THEN
@@ -1853,6 +1862,7 @@ C   Multiple th files
      4                   IPM     ,IPART(1+LIPART1*(NPART+NTHPART)+16*(NPART+NTHPART)),2,1,
      5                   1       ,AFORM(9)          ,ITHFLAG           ,ITHVAR,
      6                   IFILTITL,OUTPUT%TH%SITHBUFI,NAMES_AND_TITLES)
+        OUTPUT%TH%AUX_TH_FILENAME(9) = FILNAMTH
             END IF
         ELSE
           WRITE(CHR_OLD,'(I2.2)')IRUNN

--- a/engine/source/system/arret.F
+++ b/engine/source/system/arret.F
@@ -472,6 +472,7 @@ C   L o c a l   V a r i a b l e s
 C-----------------------------------------------
       CHARACTER*2048 INAME
       INTEGER IFIL
+      INTEGER I
       INTEGER :: LEN_TMP_NAME
       CHARACTER(len=2148) :: TMP_NAME
       INTEGER :: LEN_TMP_NAME_H3D
@@ -529,6 +530,13 @@ C -----------------------------------------------
      *                                      C_LOC(OUTPUT_PTR%TH%TH_FILENAME),
      *                                      LEN_TRIM(OUTPUT_PTR%TH%TH_FILENAME),
      *                                      IZIP)
+               DO I=1,9
+                 IF(LEN_TRIM(OUTPUT_PTR%TH%AUX_TH_FILENAME(I)) > 0) THEN
+                   CALL COMPUTE_BINARY_CHECKSUM(OUTPUT_PTR%CHECKSUM%files_checksum,
+     *              C_LOC(OUTPUT_PTR%TH%AUX_TH_FILENAME(I)),
+     *              LEN_TRIM(OUTPUT_PTR%TH%AUX_TH_FILENAME(I)),IZIP)
+                 ENDIF
+               ENDDO
             ENDIF
        ENDIF
 C -----------------------------------------------

--- a/starter/source/output/checksum/checksum_list.cpp
+++ b/starter/source/output/checksum/checksum_list.cpp
@@ -169,10 +169,14 @@ bool List_checksum::is_integer(const std::string s) {
           anim_file_list.push_back(fname);
       }
       string th_pattern=rootname+ "T";
-      string file_T=fname.substr(0,fname.length()-2);
-      rd_run = fname.substr(fname.length()-2);
-      if ( is_integer(rd_run)  && th_pattern == file_T){
-          th_file_list.push_back(fname);
+      string th_suffix=fname.substr(th_pattern.length());
+      bool is_base_th_file = th_suffix.length() == 2 && is_integer(th_suffix);
+      bool is_aux_th_file = th_suffix.length() == 3 &&
+                  is_integer(th_suffix.substr(0,2)) &&
+                  th_suffix[2] >= 'a' && th_suffix[2] <= 'i';
+      if (fname.compare(0,th_pattern.length(),th_pattern) == 0 &&
+        (is_base_th_file || is_aux_th_file)) {
+        th_file_list.push_back(fname);
       }
 
         if (fname == rootname + ".h3d") {
@@ -504,6 +508,8 @@ bool List_checksum::is_integer(const std::string s) {
       for (const auto& checksum : get<3>(item)){
           size_t pos = checksum.find_last_of("_");
           string title=checksum.substr(0,pos); // Remove the checksum value
+          // trim end of title
+          title.erase(title.find_last_not_of(" \n\r\t")+1); 
           string digest=checksum.substr(pos+1);  // Keep only the checksum value
           string checksum_line="                  "+title+": "+digest;
           write_out(fd,checksum_line);

--- a/starter/source/output/th/hm_read_thgrou.F
+++ b/starter/source/output/th/hm_read_thgrou.F
@@ -3170,7 +3170,7 @@ c
       ! /TH/CHECKSUM ( activated automaticaly if /CHECKSUM is used )
       !-------------------------------------------
       HM_NTHCHECKSUM=CHECKSUM%checksum_count
-      IF (HM_NTHCHECKSUM > 0) THEN 
+      IF (HM_NTHCHECKSUM > 0) THEN
         HM_NTHGRP = HM_NTHGRP + 1
         IGS = IGS+1
         CHECKSUM_TITLE = ''

--- a/starter/source/starter/lectur.F
+++ b/starter/source/starter/lectur.F
@@ -9395,7 +9395,7 @@ c
 c
       IF(OUTPUT%CHECKSUM%checksum_count > 0) NTHGRP0 = NTHGRP0 + 1
       DO I=1,9
-        IF(OUTPUT%CHECKSUM%checksum_count > 0) NTHGRP01(I) = NTHGRP01(I) + 1  
+        IF(NTHGRP01(I) > 0 .AND. OUTPUT%CHECKSUM%checksum_count > 0) NTHGRP01(I) = NTHGRP01(I) + 1
         NTHGRPMX = MAX(NTHGRP0,NTHGRP01(I))
       ENDDO
 c


### PR DESCRIPTION
This pull request introduces support for handling multiple auxiliary time history filenames in the output module, ensuring that each group of time history files has its filename tracked and included in checksum computations. It also improves the logic for updating group counters and enhances output formatting for checksums.

**Time history filename management:**
* Added a new array `AUX_TH_FILENAME` (size 9) to `OUTPUT%TH` for storing auxiliary time history filenames for each group. (`common_source/modules/output/time_history_mod.F` [common_source/modules/output/time_history_mod.FR48](diffhunk://#diff-38232b7d409896f1bb37e70bcd442a4bae2cc81b93d896bca316b542e811ae08R48))
* In `RADIOSS2`, initializes all entries of `AUX_TH_FILENAME` to empty strings and assigns the correct filename to each group when present. (`engine/source/engine/radioss2.F` [[1]](diffhunk://#diff-38b9a911dcffdc2de110bd9b5c317a10eb9b0eb4b61c978684758af881262048R1649) [[2]](diffhunk://#diff-38b9a911dcffdc2de110bd9b5c317a10eb9b0eb4b61c978684758af881262048R1673) [[3]](diffhunk://#diff-38b9a911dcffdc2de110bd9b5c317a10eb9b0eb4b61c978684758af881262048R1697) [[4]](diffhunk://#diff-38b9a911dcffdc2de110bd9b5c317a10eb9b0eb4b61c978684758af881262048R1721) [[5]](diffhunk://#diff-38b9a911dcffdc2de110bd9b5c317a10eb9b0eb4b61c978684758af881262048R1745) [[6]](diffhunk://#diff-38b9a911dcffdc2de110bd9b5c317a10eb9b0eb4b61c978684758af881262048R1769) [[7]](diffhunk://#diff-38b9a911dcffdc2de110bd9b5c317a10eb9b0eb4b61c978684758af881262048R1793) [[8]](diffhunk://#diff-38b9a911dcffdc2de110bd9b5c317a10eb9b0eb4b61c978684758af881262048R1817) [[9]](diffhunk://#diff-38b9a911dcffdc2de110bd9b5c317a10eb9b0eb4b61c978684758af881262048R1841) [[10]](diffhunk://#diff-38b9a911dcffdc2de110bd9b5c317a10eb9b0eb4b61c978684758af881262048R1865)

**Checksum computation improvements:**
* In `ARRET`, iterates through all entries in `AUX_TH_FILENAME` and calls `COMPUTE_BINARY_CHECKSUM` for each non-empty filename, ensuring checksums are computed for all auxiliary time history files. (`engine/source/system/arret.F` [engine/source/system/arret.FR521-R527](diffhunk://#diff-af2296455e39a69c78a8ea1ca34739c9fcfc7f6443913b19ff40275262841e4aR521-R527))
* Added variable `I` for loop iteration in `ARRET`. (`engine/source/system/arret.F` [engine/source/system/arret.FR475](diffhunk://#diff-af2296455e39a69c78a8ea1ca34739c9fcfc7f6443913b19ff40275262841e4aR475))

**Logic and formatting enhancements:**
* In `LECTUR`, only increments `NTHGRP01(I)` if it is already greater than zero and checksums are present, preventing unintended group count increases. (`starter/source/starter/lectur.F` [starter/source/starter/lectur.FL9400-R9400](diffhunk://#diff-b7cfbd6038ee923f835b05bcea0774e4375066ddc226b80bdd2f2cc8442f7ebdL9400-R9400))
* In `checksum_list.cpp`, trims whitespace from the end of titles before outputting checksum lines for improved formatting. (`starter/source/output/checksum/checksum_list.cpp` [starter/source/output/checksum/checksum_list.cppR503-R504](diffhunk://#diff-9fdadfa5b6923c4af24703d26952961895a802135d9e151532f198f06277e9b9R503-R504))