### PR TITLE
Add case Surface defined by 1D element inter25

### DIFF
--- a/starter/source/interfaces/int25/hm_read_inter_type25.F
+++ b/starter/source/interfaces/int25/hm_read_inter_type25.F
@@ -446,7 +446,7 @@ C            3 : ISU1=0,ISU2>0;IS3>0
             IS1=-1
             IS2=-3
 
-            IF(NSLIN >0.AND.IEDGE >0) THEN
+            IF(NSLIN >0) THEN
               INGR2USR => IGRSLIN(1:NSLIN)%ID
               ISU3=NGR2USRNN(ISU3,INGR2USR,NSLIN)
               IF (ISU3==0) THEN
@@ -481,7 +481,7 @@ C----------------if we copy int7--
             IS1=-1
             IS2=-1
 
-            IF(NSLIN >0.AND.IEDGE >0) THEN
+            IF(NSLIN >0) THEN
               INGR2USR => IGRSLIN(1:NSLIN)%ID
               ISU3=NGR2USRNN(ISU3,INGR2USR,NSLIN)
               IF (ISU3==0) THEN
@@ -493,7 +493,7 @@ C----------------if we copy int7--
               ISU3 = 0
             ENDIF
 
-            IF(NSLIN >0.AND.IEDGE >0) THEN
+            IF(NSLIN >0) THEN
               INGR2USR => IGRSLIN(1:NSLIN)%ID
               ISU4=NGR2USRNN(ISU4,INGR2USR,NSLIN)
               IF (ISU4==0) THEN

--- a/starter/source/interfaces/inter3d1/i25surfi.F
+++ b/starter/source/interfaces/inter3d1/i25surfi.F
@@ -481,6 +481,18 @@ c-----------------------------------------------------------------
           ENDDO
         ENDDO
       ENDIF
+
+      IF (ISU4 /= 0.AND..NOT.LINE_SEG) THEN
+        DO J=1,IGRSLIN(ISU4)%NSEG
+          LINE_TYP = IGRSLIN(ISU4)%ELTYP(J)
+          IF(LINE_TYP /= 1.AND.LINE_TYP /= 3.AND.LINE_TYP /= 7.AND.LINE_TYP /= 0) THEN
+            DO K=1,2
+              TAG(IGRSLIN(ISU4)%NODES(J,K)) = 2
+            ENDDO
+          ENDIF
+        ENDDO
+      ENDIF
+
       IF(ISU1 /= 0.AND..NOT.LINE_SEG_M)THEN
         DO J=1,IGRSURF(ISU1)%NSEG
           DO K=1,4
@@ -491,6 +503,22 @@ c-----------------------------------------------------------------
               TAG(I) = 3
             ENDIF
           ENDDO
+        ENDDO
+      ENDIF
+
+      IF (ISU3 /= 0.AND..NOT.LINE_SEG) THEN
+        DO J=1,IGRSLIN(ISU3)%NSEG
+          LINE_TYP = IGRSLIN(ISU3)%ELTYP(J)
+          IF(LINE_TYP /= 1.AND.LINE_TYP /= 3.AND.LINE_TYP /= 7.AND.LINE_TYP /= 0) THEN
+            DO K=1,2 
+              I=IGRSLIN(ISU3)%NODES(J,K)
+              IF(TAG(I) == 0)THEN
+                  TAG(I) = 1
+              ELSEIF(TAG(I) == 2)THEN
+                  TAG(I) = 3
+              ENDIF
+            ENDDO
+          ENDIF
         ENDDO
       ENDIF
 C for inteply activation needed for Plyxfem + Type24      
@@ -530,14 +558,35 @@ c-----------------------------------------------------------------
 c     taged nodes on S2 -> negative value
             IF(TAG(I) == 2 .OR. TAG(I) == 3)THEN
               TAG(I) = - TAG(I)
-                IF ( ILEV == 2.AND.TAGS(I) == 0 ) THEN
+              IF ( ILEV == 2.AND.TAGS(I) == 0 ) THEN
                 NSN = NSN + 1
                 TAGS(I) = NSN
                 IF(IALLO == 2) THEN
                  NSV(NSN) = I
                  IF(ILEV == 2)NBINFLG(NSN) = BITSET(NBINFLG(NSN),1)
                 END IF
+              END IF !( ILEV == 2 ) THEN
+            ENDIF
+          ENDDO
+        ENDDO
+      ENDIF
+      IF(ISU4 /= 0.AND..NOT.LINE_SEG)THEN
+        DO J=1,IGRSLIN(ISU4)%NSEG
+          DO K=1,2
+            I=IGRSLIN(ISU4)%NODES(J,K)
+            LINE_TYP = IGRSLIN(ISU4)%ELTYP(J)
+            IF(LINE_TYP /= 1.AND.LINE_TYP /= 3.AND.LINE_TYP /= 7.AND.LINE_TYP /= 0) THEN
+              IF(TAG(I) == 2 .OR. TAG(I) == 3)THEN
+                TAG(I) = - TAG(I)
+                IF ( ILEV == 2.AND.TAGS(I) == 0 ) THEN
+                  NSN = NSN + 1
+                  TAGS(I) = NSN
+                  IF(IALLO == 2) THEN
+                    NSV(NSN) = I
+                    IF(ILEV == 2)NBINFLG(NSN) = BITSET(NBINFLG(NSN),1)
+                  END IF
                 END IF !( ILEV == 2 ) THEN
+              ENDIF
             ENDIF
           ENDDO
         ENDDO
@@ -569,6 +618,30 @@ c     taged nodes on S1 -> negative value, ->+3 for nodes on both
               IF(IALLO == 2)MSR(NMN) = I
             ENDIF
           ENDDO
+        ENDDO
+      ENDIF
+
+      IF(ISU3 /= 0.AND..NOT.LINE_SEG)THEN
+        DO J=1,IGRSLIN(ISU3)%NSEG
+          LINE_TYP = IGRSLIN(ISU4)%ELTYP(J)
+          IF(LINE_TYP /= 1.AND.LINE_TYP /= 3.AND.LINE_TYP /= 7.AND.LINE_TYP /= 0) THEN
+            DO K=1,2
+              I=IGRSLIN(ISU3)%NODES(J,K)
+              IF(TAGS(I) == 0 .AND. ILEV /= 3 ) THEN
+                NSN = NSN + 1
+                TAGS(I) = NSN
+                IF(IALLO == 2) THEN
+                  NSV(NSN) = I
+                  IF(ILEV == 2)NBINFLG(NSN) = BITSET(NBINFLG(NSN),0)
+                END IF
+              ELSEIF(ILEV==2)THEN
+                IF(IALLO == 2) THEN
+                  ISN=TAGS(I)
+                  NBINFLG(ISN) = BITSET(NBINFLG(ISN),0)
+                ENDIF
+              ENDIF
+            ENDDO
+          ENDIF
         ENDDO
       ENDIF
 c-----------------------------------------------------------------


### PR DESCRIPTION
#### Description of the feature or the bug
<!--- Describe the problem, ideally from the user's viewpoint -->
Add the capability to extract 1D elements nodes from sets and defining it as secondary nodes of interface type25. 
Before 1D element nodes can be defined only using group of nodes

#### Description of the changes
<!--- Say how you fixed the problem.  Please describe your code changes in detail for the reviewer -->
In addition to surfaces, use new extracted lines from  sets defined in inter25 to define 1D secondary nodes. 
It can be done with or without Iedge

<!--- Pull requests will be accepted only if:  -->
<!--- - they contain one commit (squash your commits) --> 
<!--- - they do not contain merge commits (pull with rebase) --> 
<!--- - the changes satisfy the DOS and DON'TS of the CONTRIBUTING.md file -->
