### PR TITLE
win compil issue

### DIFF
--- a/common_source/output/h3d/h3d_build_cpp/h3dreader_dl.c
+++ b/common_source/output/h3d/h3d_build_cpp/h3dreader_dl.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #define _FCALL
 
@@ -45,7 +46,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <dlfcn.h>
-#include <stdbool.h>
 
 #endif
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the inclusion of the `stdbool.h` header in the `h3dreader_dl.c` file. The header is now included unconditionally at the top of the file, rather than only in certain platform-specific code blocks. This helps ensure that the `bool` type is always available where needed.

* Always include `stdbool.h` at the top of `h3dreader_dl.c` instead of conditionally including it later in the file. [[1]](diffhunk://#diff-d3d7d0ca17932ba6a4acf41be6f989588ed760de50a186fd04af3d05caf2a21bR29) [[2]](diffhunk://#diff-d3d7d0ca17932ba6a4acf41be6f989588ed760de50a186fd04af3d05caf2a21bL48)
